### PR TITLE
Refactor names to avoid stutter

### DIFF
--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -27,7 +27,7 @@ const (
 // a string.
 var reRemoveWhitespace = regexp.MustCompile(`[\s]+`)
 
-type BaseCommand struct {
+type Command struct {
 	UI      cli.Ui
 	Address string
 	Context context.Context
@@ -47,7 +47,7 @@ type BaseCommand struct {
 	flagOutputCurlString bool
 }
 
-func (c *BaseCommand) SetAddress(addr string) {
+func (c *Command) SetAddress(addr string) {
 	c.Address = addr
 }
 
@@ -62,7 +62,7 @@ const (
 
 // FlagSet creates the flags for this command. The result is cached on the
 // command to save performance on future calls.
-func (c *BaseCommand) FlagSet(bit FlagSetBit) *FlagSets {
+func (c *Command) FlagSet(bit FlagSetBit) *FlagSets {
 	c.flagsOnce.Do(func() {
 		set := NewFlagSets(c.UI)
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -16,8 +16,8 @@ var Commands map[string]cli.CommandFactory
 
 func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 	/*
-		getBaseCommand := func() *base.BaseCommand {
-			return &base.BaseCommand{
+		getBaseCommand := func() *base.Command {
+			return &base.Command{
 				UI:      ui,
 				Address: runOpts.Address,
 			}
@@ -26,8 +26,8 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 
 	Commands = map[string]cli.CommandFactory{
 		"controller": func() (cli.Command, error) {
-			return &controller.ControllerCommand{
-				BaseCommand: &base.BaseCommand{
+			return &controller.Command{
+				Command: &base.Command{
 					UI:      serverCmdUi,
 					Address: runOpts.Address,
 				},
@@ -37,8 +37,8 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 			}, nil
 		},
 		"dev": func() (cli.Command, error) {
-			return &dev.DevCommand{
-				BaseCommand: &base.BaseCommand{
+			return &dev.Command{
+				Command: &base.Command{
 					UI:      serverCmdUi,
 					Address: runOpts.Address,
 				},

--- a/internal/cmd/commands/controller/config/config.go
+++ b/internal/cmd/commands/controller/config/config.go
@@ -17,8 +17,8 @@ type Config struct {
 	*configutil.SharedConfig `hcl:"-"`
 }
 
-// DevConfig is a Config that is used for dev mode of Watchtower
-func DevConfig() (*Config, error) {
+// Dev is a Config that is used for dev mode of Watchtower
+func Dev() (*Config, error) {
 	randBuf := new(bytes.Buffer)
 	n, err := randBuf.ReadFrom(&io.LimitedReader{
 		R: rand.Reader,
@@ -61,28 +61,28 @@ kms "aead" {
 `
 
 	hclStr = fmt.Sprintf(hclStr, controllerKey, workerAuthKey)
-	parsed, err := ParseConfig(hclStr)
+	parsed, err := Parse(hclStr)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing dev config: %w", err)
 	}
 	return parsed, nil
 }
 
-func NewConfig() *Config {
+func New() *Config {
 	return &Config{
 		SharedConfig: new(configutil.SharedConfig),
 	}
 }
 
-// LoadConfigFile loads the configuration from the given file.
-func LoadConfigFile(path string) (*Config, error) {
+// LoadFile loads the configuration from the given file.
+func LoadFile(path string) (*Config, error) {
 	// Read the file
 	d, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	conf, err := ParseConfig(string(d))
+	conf, err := Parse(string(d))
 	if err != nil {
 		return nil, err
 	}
@@ -90,14 +90,14 @@ func LoadConfigFile(path string) (*Config, error) {
 	return conf, nil
 }
 
-func ParseConfig(d string) (*Config, error) {
+func Parse(d string) (*Config, error) {
 	obj, err := hcl.Parse(d)
 	if err != nil {
 		return nil, err
 	}
 
 	// Nothing to do here right now
-	result := NewConfig()
+	result := New()
 	if err := hcl.DecodeObject(result, obj); err != nil {
 		return nil, err
 	}

--- a/internal/cmd/commands/controller/controller_noprofile.go
+++ b/internal/cmd/commands/controller/controller_noprofile.go
@@ -2,5 +2,5 @@
 
 package controller
 
-func (c *ControllerCommand) startMemProfiler() {
+func (c *Command) startMemProfiler() {
 }

--- a/internal/cmd/commands/controller/controller_profile.go
+++ b/internal/cmd/commands/controller/controller_profile.go
@@ -14,7 +14,7 @@ func init() {
 	memProfilerEnabled = true
 }
 
-func (c *ControllerCommand) startMemProfiler() {
+func (c *Command) startMemProfiler() {
 	profileDir := filepath.Join(os.TempDir(), "watchtowerprof")
 	if err := os.MkdirAll(profileDir, 0700); err != nil {
 		c.logger.Debug("could not create profile directory", "error", err)

--- a/internal/cmd/commands/controller/listener/listener.go
+++ b/internal/cmd/commands/controller/listener/listener.go
@@ -18,17 +18,17 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-// ListenerFactory is the factory function to create a listener.
-type ListenerFactory func(*configutil.Listener, io.Writer, cli.Ui) (*alpnmux.ALPNMux, map[string]string, reloadutil.ReloadFunc, error)
+// Factory is the factory function to create a listener.
+type Factory func(*configutil.Listener, io.Writer, cli.Ui) (*alpnmux.ALPNMux, map[string]string, reloadutil.ReloadFunc, error)
 
 // BuiltinListeners is the list of built-in listener types.
-var BuiltinListeners = map[string]ListenerFactory{
+var BuiltinListeners = map[string]Factory{
 	"tcp": tcpListenerFactory,
 }
 
-// NewListener creates a new listener of the given type with the given
+// New creates a new listener of the given type with the given
 // configuration. The type is looked up in the BuiltinListeners map.
-func NewListener(l *configutil.Listener, w io.Writer, ui cli.Ui) (*alpnmux.ALPNMux, map[string]string, reloadutil.ReloadFunc, error) {
+func New(l *configutil.Listener, w io.Writer, ui cli.Ui) (*alpnmux.ALPNMux, map[string]string, reloadutil.ReloadFunc, error) {
 	f, ok := BuiltinListeners[l.Type]
 	if !ok {
 		return nil, nil, nil, fmt.Errorf("unknown listener type: %q", l.Type)

--- a/internal/cmd/commands/dev/dev_noprofile.go
+++ b/internal/cmd/commands/dev/dev_noprofile.go
@@ -2,5 +2,5 @@
 
 package dev
 
-func (d *DevCommand) startMemProfiler() {
+func (d *Command) startMemProfiler() {
 }

--- a/internal/cmd/commands/dev/dev_profile.go
+++ b/internal/cmd/commands/dev/dev_profile.go
@@ -14,7 +14,7 @@ func init() {
 	memProfilerEnabled = true
 }
 
-func (d *DevCommand) startMemProfiler() {
+func (d *Command) startMemProfiler() {
 	profileDir := filepath.Join(os.TempDir(), "watchtowerprof")
 	if err := os.MkdirAll(profileDir, 0700); err != nil {
 		d.logger.Debug("could not create profile directory", "error", err)

--- a/internal/servers/controller/config.go
+++ b/internal/servers/controller/config.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Config struct {
-	*base.BaseServer
+	*base.Server
 	RawConfig   *config.Config
 	BaseContext context.Context
 }

--- a/internal/servers/controller/controller.go
+++ b/internal/servers/controller/controller.go
@@ -16,7 +16,7 @@ type Controller struct {
 	baseCancel  context.CancelFunc
 }
 
-func NewController(conf *Config) (*Controller, error) {
+func New(conf *Config) (*Controller, error) {
 	if conf.Logger == nil {
 		conf.Logger = hclog.New(&hclog.LoggerOptions{
 			Level: hclog.Trace,

--- a/version/version.go
+++ b/version/version.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 )
 
-// VersionInfo
-type VersionInfo struct {
+// Info
+type Info struct {
 	Revision          string
 	Version           string
 	VersionPrerelease string
 	VersionMetadata   string
 }
 
-func GetVersion() *VersionInfo {
+func Get() *Info {
 	ver := Version
 	rel := VersionPrerelease
 	md := VersionMetadata
@@ -24,7 +24,7 @@ func GetVersion() *VersionInfo {
 		rel = "dev"
 	}
 
-	return &VersionInfo{
+	return &Info{
 		Revision:          GitCommit,
 		Version:           ver,
 		VersionPrerelease: rel,
@@ -32,7 +32,7 @@ func GetVersion() *VersionInfo {
 	}
 }
 
-func (c *VersionInfo) VersionNumber() string {
+func (c *Info) VersionNumber() string {
 	if Version == "unknown" && VersionPrerelease == "unknown" {
 		return "(version unknown)"
 	}
@@ -50,7 +50,7 @@ func (c *VersionInfo) VersionNumber() string {
 	return version
 }
 
-func (c *VersionInfo) FullVersionNumber(rev bool) string {
+func (c *Info) FullVersionNumber(rev bool) string {
 	var versionString bytes.Buffer
 
 	if Version == "unknown" && VersionPrerelease == "unknown" {


### PR DESCRIPTION
Since client code uses the package name as a prefix when referring to the package contents, the names for those contents need not repeat the package name.

- Rename `base.BaseCommand` to `base.Command`
- Rename `base.BaseServer` to `base.Server`
- Rename `config.DevConfig()` to `config.Dev()`
- Rename `config.LoadConfigFile()` to `config.LoadFile()`
- Rename `config.NewConfig()` to `config.New()`
- Rename `config.ParseConfig()` to `config.Parse()`
- Rename `controller.ControllerCommand` to `controller.Command`
- Rename `controller.NewController()` to `controller.New()`
- Rename `dev.DevCommand` to `dev.Command`
- Rename `listener.ListenerFactory` to `listener.Factory`
- Rename `listener.NewListener()` to `listener.New()`
- Rename `version.GetVersion()` to `version.Get()`
- Rename `version.VersionInfo` to `version.Info`

See:
- https://golang.org/doc/effective_go.html#package-names
- https://blog.golang.org/package-names#TOC_3.
- https://github.com/golang/go/wiki/CodeReviewComments#package-names