### PR TITLE
refactor clonable to not rely on the resource interface

### DIFF
--- a/internal/db/read_writer.go
+++ b/internal/db/read_writer.go
@@ -105,7 +105,7 @@ type GormReadWriter struct {
 	Tx *gorm.DB
 }
 
-// ensure that GroupRole implements the interfaces of: Resource, ClonableResource, AssignedRole and db.VetForWriter
+// ensure that GormReadWriter implements the interfaces of: Reader and Writer
 var _ Reader = (*GormReadWriter)(nil)
 var _ Writer = (*GormReadWriter)(nil)
 

--- a/internal/iam/resource.go
+++ b/internal/iam/resource.go
@@ -71,8 +71,8 @@ func (r ResourceType) String() string {
 	}[r]
 }
 
-type ClonableResource interface {
-	Clone() Resource
+type Clonable interface {
+	Clone() interface{}
 }
 
 // ResourceWithScope defines an interface for Resources that have a scope

--- a/internal/iam/scope.go
+++ b/internal/iam/scope.go
@@ -40,7 +40,7 @@ type Scope struct {
 // ensure that Scope implements the interfaces of: Resource, ClonableResource, and db.VetForWriter
 var _ Resource = (*Scope)(nil)
 var _ db.VetForWriter = (*Scope)(nil)
-var _ ClonableResource = (*Scope)(nil)
+var _ Clonable = (*Scope)(nil)
 
 func NewOrganization(opt ...Option) (*Scope, error) {
 	return newScope(OrganizationScope, opt...)
@@ -114,7 +114,7 @@ func allocScope() Scope {
 }
 
 // Clone creates a clone of the Scope
-func (s *Scope) Clone() Resource {
+func (s *Scope) Clone() interface{} {
 	cp := proto.Clone(s.Scope)
 	return &Scope{
 		Scope: cp.(*store.Scope),


### PR DESCRIPTION
Working on the users, groups and group members of iam basics, it's clear that we need to support cloning any object that we're writing to the db because of oplog retry requirements.