### PR TITLE
Remove AllLoggers

### DIFF
--- a/internal/cmd/commands/controller/controller.go
+++ b/internal/cmd/commands/controller/controller.go
@@ -411,7 +411,7 @@ func (c *Command) WaitForInterrupt() int {
 					c.Logger.Error("unknown log level found on reload", "level", newConf.LogLevel)
 					goto RUNRELOADFUNCS
 				}
-				c.controller.SetLogLevel(level)
+				c.Logger.SetLevel(level)
 			}
 
 		RUNRELOADFUNCS:

--- a/internal/cmd/commands/worker/worker.go
+++ b/internal/cmd/commands/worker/worker.go
@@ -318,7 +318,7 @@ func (c *Command) WaitForInterrupt() int {
 					c.Logger.Error("unknown log level found on reload", "level", newConf.LogLevel)
 					goto RUNRELOADFUNCS
 				}
-				c.worker.SetLogLevel(level)
+				c.Logger.SetLevel(level)
 			}
 
 		RUNRELOADFUNCS:

--- a/internal/servers/controller/controller.go
+++ b/internal/servers/controller/controller.go
@@ -20,14 +20,7 @@ type Controller struct {
 func New(conf *Config) (*Controller, error) {
 	c := &Controller{
 		conf:   conf,
-		logger: conf.Logger,
-	}
-
-	if c.logger == nil {
-		c.logger = hclog.New(&hclog.LoggerOptions{
-			Level: hclog.Trace,
-		})
-		conf.AllLoggers = append(conf.AllLoggers, c.logger)
+		logger: conf.Logger.Named("controller"),
 	}
 
 	if conf.SecureRandomReader == nil {
@@ -50,8 +43,6 @@ func New(conf *Config) (*Controller, error) {
 		}
 	}
 
-	c.logger = c.logger.Named("controller")
-
 	c.baseContext, c.baseCancel = context.WithCancel(context.Background())
 
 	return c, nil
@@ -69,10 +60,4 @@ func (c *Controller) Shutdown() error {
 		return fmt.Errorf("error stopping controller listeners: %w", err)
 	}
 	return nil
-}
-
-func (c *Controller) SetLogLevel(level hclog.Level) {
-	for _, logger := range c.conf.AllLoggers {
-		logger.SetLevel(level)
-	}
 }

--- a/internal/servers/worker/worker.go
+++ b/internal/servers/worker/worker.go
@@ -20,14 +20,7 @@ type Worker struct {
 func New(conf *Config) (*Worker, error) {
 	c := &Worker{
 		conf:   conf,
-		logger: conf.Logger,
-	}
-
-	if c.logger == nil {
-		c.logger = hclog.New(&hclog.LoggerOptions{
-			Level: hclog.Trace,
-		})
-		conf.AllLoggers = append(conf.AllLoggers, c.logger)
+		logger: conf.Logger.Named("worker"),
 	}
 
 	if conf.SecureRandomReader == nil {
@@ -50,8 +43,6 @@ func New(conf *Config) (*Worker, error) {
 		}
 	}
 
-	c.logger = c.logger.Named("worker")
-
 	c.baseContext, c.baseCancel = context.WithCancel(context.Background())
 
 	return c, nil
@@ -69,10 +60,4 @@ func (c *Worker) Shutdown() error {
 		return fmt.Errorf("error stopping worker listeners: %w", err)
 	}
 	return nil
-}
-
-func (c *Worker) SetLogLevel(level hclog.Level) {
-	for _, logger := range c.conf.AllLoggers {
-		logger.SetLevel(level)
-	}
 }


### PR DESCRIPTION
This was copied from Vault code but shouldn't be necessary any more as a
change in hclog a while back meant that derived loggers share the log
level of the parent.