### PR TITLE
Makefile target to remove generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,6 @@ GENERATED_CODE := $(shell  find ${THIS_DIR} -name '*.gen.go' && find ${THIS_DIR}
 
 export GEN_BASEPATH := $(shell pwd)
 
-stuff:
-	@echo ${THIS_DIR}
-
 bootstrap:
 	go generate -tags tools tools/tools.go
 


### PR DESCRIPTION
This CL adds a target to remove all generated files.  It also makes all operations take place relative to the makefile's path instead of the path that make was called from.