### PR TITLE
Add a passthrough directory feature.

### DIFF
--- a/internal/cmd/commands/controller/dev_flags.go
+++ b/internal/cmd/commands/controller/dev_flags.go
@@ -1,0 +1,18 @@
+// +build dev
+
+package controller
+
+import "github.com/hashicorp/watchtower/internal/cmd/base"
+
+func init() {
+	devOnlyControllerFlags = addDevOnlyControllerFlags
+}
+
+func addDevOnlyControllerFlags(c *Command, f *base.FlagSet) {
+	f.StringVar(&base.StringVar{
+		Name:   "dev-passthrough-directory",
+		Target: &c.flagDevPassthroughDirectory,
+		EnvVar: "WATCHTOWER_DEV_PASSTHROUGH_DIRECTORY",
+		Usage:  "Enables a passthrough directory in the webserver at /passthrough",
+	})
+}

--- a/internal/cmd/commands/dev/dev_flags.go
+++ b/internal/cmd/commands/dev/dev_flags.go
@@ -1,0 +1,18 @@
+// +build dev
+
+package dev
+
+import "github.com/hashicorp/watchtower/internal/cmd/base"
+
+func init() {
+	devOnlyControllerFlags = addDevOnlyControllerFlags
+}
+
+func addDevOnlyControllerFlags(c *Command, f *base.FlagSet) {
+	f.StringVar(&base.StringVar{
+		Name:   "dev-passthrough-directory",
+		Target: &c.flagDevPassthroughDirectory,
+		EnvVar: "WATCHTOWER_DEV_PASSTHROUGH_DIRECTORY",
+		Usage:  "Enables a passthrough directory in the webserver at /passthrough",
+	})
+}

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -65,8 +65,9 @@ listener "tcp" {
 type Config struct {
 	*configutil.SharedConfig `hcl:"-"`
 
-	DevController bool   `hcl:"-"`
-	DefaultOrgId  string `hcl:"default_org_id"`
+	DevController        bool   `hcl:"-"`
+	DefaultOrgId         string `hcl:"default_org_id"`
+	PassthroughDirectory string `hcl:"-"`
 }
 
 // DevWorker is a Config that is used for dev mode of Watchtower

--- a/internal/servers/controller/config.go
+++ b/internal/servers/controller/config.go
@@ -9,6 +9,6 @@ import (
 
 type Config struct {
 	*base.Server
-	RawConfig   *config.Config
-	BaseContext context.Context
+	RawConfig            *config.Config
+	BaseContext          context.Context
 }

--- a/internal/servers/controller/handler.go
+++ b/internal/servers/controller/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -29,6 +30,20 @@ type HandlerProperties struct {
 func (c *Controller) handler(props HandlerProperties) http.Handler {
 	// Create the muxer to handle the actual endpoints
 	mux := http.NewServeMux()
+
+	if c.conf.RawConfig.PassthroughDirectory != "" {
+		// Panic may not be ideal but this is never a production call and it'll
+		// panic on startup. We could also just change the function to return
+		// an error.
+		abs, err := filepath.Abs(c.conf.RawConfig.PassthroughDirectory)
+		if err != nil {
+			panic(err)
+		}
+		c.logger.Warn("serving passthrough files at /passthrough", "path", abs)
+		fs := http.FileServer(http.Dir(abs))
+		prefixHandler := http.StripPrefix("/passthrough/", fs)
+		mux.Handle("/passthrough/", prefixHandler)
+	}
 
 	mux.Handle("/v1/", handleGrpcGateway(c))
 


### PR DESCRIPTION
This is only compiled in when a `dev` build tag is specified (see #75)
for safety. Attempting to use the flag without that tag at build time
will fail. However, it is always available within the codebase itself so
that tests can be written against this functionality in a programmatic
way.

Manual testing was performed; no plans to add automated ones as this
isn't production-necessary nor exported functionality.