### PR TITLE
Change 501 errors to 405

### DIFF
--- a/internal/servers/controller/handler_test.go
+++ b/internal/servers/controller/handler_test.go
@@ -41,7 +41,7 @@ func TestHandleGrpcGateway(t *testing.T) {
 		{
 			"Unimplemented path",
 			"v1/orgs/1/projects/2/host-catalogs/3/host-sets/4",
-			http.StatusNotImplemented,
+			http.StatusMethodNotAllowed,
 		},
 	}
 	for _, tc := range cases {

--- a/internal/servers/controller/handlers/errors.go
+++ b/internal/servers/controller/handlers/errors.go
@@ -35,6 +35,10 @@ func InvalidArgumentErrorf(msg string, fields []string) error {
 func statusErrorToApiError(s *status.Status) *pb.Error {
 	apiErr := &pb.Error{}
 	apiErr.Status = int32(runtime.HTTPStatusFromCode(s.Code()))
+	if s.Code() == codes.Unimplemented {
+		// Instead of returning a 501 we always want to return a 405 when a method isn't implemented.
+		apiErr.Status = http.StatusMethodNotAllowed
+	}
 	apiErr.Message = s.Message()
 	// TODO(ICU-193): Decouple from the status codes and instead use codes defined specifically for our API.
 	apiErr.Code = s.Code().String()


### PR DESCRIPTION
The HTTP principle doc says we should use 405 when a method is not implemented.  Updated our error handler to translate the rpc's unimplemented status code to http status of 405.