### PR TITLE
Check for nil in embedded HostCatalog

### DIFF
--- a/internal/host/static/repository.go
+++ b/internal/host/static/repository.go
@@ -53,6 +53,9 @@ func (r *Repository) CreateCatalog(ctx context.Context, c *HostCatalog, opt ...O
 	if c == nil {
 		return nil, fmt.Errorf("create: static host catalog: %w", db.ErrNilParameter)
 	}
+	if c.HostCatalog == nil {
+		return nil, fmt.Errorf("create: static host catalog: embedded HostCatalog: %w", db.ErrNilParameter)
+	}
 	if c.HostCatalog.ScopeId == "" {
 		return nil, fmt.Errorf("create: static host catalog: no scope id: %w", db.ErrInvalidParameter)
 	}
@@ -108,6 +111,9 @@ func (r *Repository) CreateCatalog(ctx context.Context, c *HostCatalog, opt ...O
 func (r *Repository) UpdateCatalog(ctx context.Context, c *HostCatalog, fieldMask []string, opt ...Option) (*HostCatalog, int, error) {
 	if c == nil {
 		return nil, db.NoRowsAffected, fmt.Errorf("update: static host catalog: %w", db.ErrNilParameter)
+	}
+	if c.HostCatalog == nil {
+		return nil, db.NoRowsAffected, fmt.Errorf("update: static host catalog: embedded HostCatalog: %w", db.ErrNilParameter)
 	}
 	if c.PublicId == "" {
 		return nil, db.NoRowsAffected, fmt.Errorf("update: static host catalog: missing public id: %w", db.ErrInvalidParameter)

--- a/internal/host/static/repository_test.go
+++ b/internal/host/static/repository_test.go
@@ -139,6 +139,11 @@ func TestRepository_CreateCatalog(t *testing.T) {
 			wantIsErr: db.ErrNilParameter,
 		},
 		{
+			name:      "nil-embedded-catalog",
+			in:        &HostCatalog{},
+			wantIsErr: db.ErrNilParameter,
+		},
+		{
 			name: "valid-no-options",
 			in: &HostCatalog{
 				HostCatalog: &store.HostCatalog{},
@@ -183,7 +188,7 @@ func TestRepository_CreateCatalog(t *testing.T) {
 			assert.NoError(err)
 			assert.NotNil(repo)
 			_, prj := iam.TestScopes(t, conn)
-			if tt.in != nil {
+			if tt.in != nil && tt.in.HostCatalog != nil {
 				tt.in.ScopeId = prj.GetPublicId()
 				assert.Empty(tt.in.PublicId)
 			}
@@ -310,6 +315,12 @@ func TestRepository_UpdateCatalog(t *testing.T) {
 		}
 	}
 
+	makeEmbeddedNil := func() func(*HostCatalog) *HostCatalog {
+		return func(c *HostCatalog) *HostCatalog {
+			return &HostCatalog{}
+		}
+	}
+
 	deletePublicId := func() func(*HostCatalog) *HostCatalog {
 		return func(c *HostCatalog) *HostCatalog {
 			c.PublicId = ""
@@ -348,6 +359,15 @@ func TestRepository_UpdateCatalog(t *testing.T) {
 				HostCatalog: &store.HostCatalog{},
 			},
 			chgFn:     makeNil(),
+			masks:     []string{"Name", "Description"},
+			wantIsErr: db.ErrNilParameter,
+		},
+		{
+			name: "nil-embedded-catalog",
+			orig: &HostCatalog{
+				HostCatalog: &store.HostCatalog{},
+			},
+			chgFn:     makeEmbeddedNil(),
 			masks:     []string{"Name", "Description"},
 			wantIsErr: db.ErrNilParameter,
 		},


### PR DESCRIPTION
Addresses @jefferai [comment](https://github.com/hashicorp/watchtower/pull/51/files/50f82b133feb844f67f01dbc2ae32efa547ad2de#r431502012) in PR #51:

> Below you are accessing ScopeId and PublicId without actually validating that `c.HostCatalog` is not nil.
