### PR TITLE
Rename db.IsUnique to db.IsUniqueError

### DIFF
--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -42,9 +42,9 @@ var (
 	ErrMultipleRecords = errors.New("multiple records")
 )
 
-// IsUnique returns a boolean indicating whether the error is known to
+// IsUniqueError returns a boolean indicating whether the error is known to
 // report a unique constraint violation.
-func IsUnique(err error) bool {
+func IsUniqueError(err error) bool {
 	if err == nil {
 		return false
 	}

--- a/internal/db/error_test.go
+++ b/internal/db/error_test.go
@@ -38,7 +38,7 @@ func TestError_IsUnique(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			err := tt.in
-			got := IsUnique(err)
+			got := IsUniqueError(err)
 			assert.Equal(tt.want, got)
 		})
 	}

--- a/internal/host/static/repository.go
+++ b/internal/host/static/repository.go
@@ -85,7 +85,7 @@ func (r *Repository) CreateCatalog(ctx context.Context, c *HostCatalog, opt ...O
 	)
 
 	if err != nil {
-		if db.IsUnique(err) {
+		if db.IsUniqueError(err) {
 			return nil, fmt.Errorf("create: static host catalog: in scope: %s: name %s already exists: %w",
 				c.ScopeId, c.Name, db.ErrNotUnique)
 		}
@@ -154,7 +154,7 @@ func (r *Repository) UpdateCatalog(ctx context.Context, c *HostCatalog, fieldMas
 	)
 
 	if err != nil {
-		if db.IsUnique(err) {
+		if db.IsUniqueError(err) {
 			return nil, db.NoRowsAffected, fmt.Errorf("update: static host catalog: %s: name %s already exists: %w",
 				c.PublicId, c.Name, db.ErrNotUnique)
 		}


### PR DESCRIPTION
Addresses @jefferai [comment](https://github.com/hashicorp/watchtower/pull/51#discussion_r431502600) in PR #51:

> Can you call this `IsUniqueError`? Given that this is the `db` package and not an errors package of some kind, `db.IsUnique` is easy to confuse with a function that validates uniqueness of something.

