### PR TITLE
Fix gorm newlines issue

### DIFF
--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -402,6 +402,7 @@ func (b *Server) CreateDevDatabase(dialect string) error {
 	b.Database = dbase
 
 	gorm.LogFormatter = db.GetGormLogFormatter(b.Logger)
+	b.Database.SetLogger(db.GetGormLogger(b.Logger))
 	b.Database.LogMode(true)
 
 	rw := db.New(b.Database)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -182,3 +182,21 @@ func GetGormLogFormatter(log hclog.Logger) func(values ...interface{}) (messages
 		return nil
 	}
 }
+
+type gormLogger struct {
+	logger hclog.Logger
+}
+
+func (g gormLogger) Print(values ...interface{}) {
+	formatted := gorm.LogFormatter(values...)
+	if formatted == nil {
+		return
+	}
+	// Our formatter should elide anything we don't want so this should never
+	// happen, panic if so so we catch/fix
+	panic("unhandled error case")
+}
+
+func GetGormLogger(log hclog.Logger) gormLogger {
+	return gormLogger{logger: log}
+}

--- a/internal/db/read_writer_test.go
+++ b/internal/db/read_writer_test.go
@@ -684,6 +684,7 @@ func TestDb_SearchWhere(t *testing.T) {
 		Level:  hclog.Trace,
 	})
 	gorm.LogFormatter = GetGormLogFormatter(log)
+	db.SetLogger(GetGormLogger(log))
 	db.LogMode(true)
 	defer func() {
 		assert.True(strings.Contains(buf.String(), "syntax error at or near"))


### PR DESCRIPTION
Even if you made a custom formatter for gorm, it would blithely println
anything returned, including nils, resulting in lots of new lines when
we were ignoring output. This also creates a custom logger that doesn't
do anything when newlines are found.