### PR TITLE
Simplify UI passthrough logic

### DIFF
--- a/internal/servers/controller/handler_test.go
+++ b/internal/servers/controller/handler_test.go
@@ -91,6 +91,13 @@ func TestHandleDevPassthrough(t *testing.T) {
 			"text/html; charset=utf-8",
 		},
 		{
+			"base slash",
+			"",
+			"index.html",
+			http.StatusOK,
+			"text/html; charset=utf-8",
+		},
+		{
 			"no extension",
 			"orgs",
 			"index.html",


### PR DESCRIPTION
I realized we can handle the special case of `/index.html` by ensuring
that `/` does the right thing because that's _also_ standard behavior to
fetch `/index.html`. As a result this allows a lot of simplification.