### PR TITLE
ci: add slack integration for master branch failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
 jobs:
   build:
     machine:
@@ -14,3 +16,7 @@ jobs:
         name: "Run Acceptance Tests"
         command: |
           make test-ci
+    - slack/status:
+        fail_only: true
+        only_for_branches: master
+        webhook: webhook


### PR DESCRIPTION
This PR adds a CircleCI <> Slack integration that sends failure notifications for the `master` branch to #team-watchtower. 