### PR TITLE
Add ability to skip automatic auth method creation

### DIFF
--- a/internal/cmd/base/option.go
+++ b/internal/cmd/base/option.go
@@ -14,8 +14,9 @@ type Option func(*Options)
 
 // Options - how Options are represented.
 type Options struct {
-	withNoTokenScope bool
-	withNoTokenValue bool
+	withNoTokenScope           bool
+	withNoTokenValue           bool
+	withSkipAuthMethodCreation bool
 }
 
 func getDefaultOptions() Options {
@@ -37,5 +38,13 @@ func WithNoTokenScope() Option {
 func WithNoTokenValue() Option {
 	return func(o *Options) {
 		o.withNoTokenValue = true
+	}
+}
+
+// WithSkipAuthMethodCreation tells the command not to instantiate an auth
+// method on first run.
+func WithSkipAuthMethodCreation() Option {
+	return func(o *Options) {
+		o.withSkipAuthMethodCreation = true
 	}
 }

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -421,7 +421,9 @@ func (b *Server) ConnectToDatabase(dialect string) error {
 	return nil
 }
 
-func (b *Server) CreateDevDatabase(dialect string) error {
+func (b *Server) CreateDevDatabase(dialect string, opt ...Option) error {
+	opts := getOpts(opt...)
+
 	c, url, container, err := db.InitDbInDocker(dialect)
 	// In case of an error, run the cleanup function.  If we pass all errors, c should be set to a noop
 	// function before returning from this method
@@ -467,11 +469,6 @@ func (b *Server) CreateDevDatabase(dialect string) error {
 		return fmt.Errorf("error adding config keys to kms: %w", err)
 	}
 
-	repo, err := iam.NewRepository(rw, rw, kmsCache, iam.WithRandomReader(b.SecureRandomReader))
-	if err != nil {
-		return fmt.Errorf("unable to create repo for org id: %w", err)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		<-b.ShutdownCh
@@ -485,6 +482,13 @@ func (b *Server) CreateDevDatabase(dialect string) error {
 	_, _, err = kmsRepo.CreateRootKey(ctx, b.RootKms, scope.Global.String(), rootKey)
 	if err != nil {
 		return fmt.Errorf("error saving global scope root key: %w", err)
+	}
+
+	if opts.withSkipAuthMethodCreation {
+		// now that we have passed all the error cases, reset c to be a noop so the
+		// defer doesn't do anything.
+		c = func() error { return nil }
+		return nil
 	}
 
 	// Create the dev auth method
@@ -504,6 +508,8 @@ func (b *Server) CreateDevDatabase(dialect string) error {
 	if err != nil {
 		return fmt.Errorf("error saving auth method to the db: %w", err)
 	}
+	b.InfoKeys = append(b.InfoKeys, "dev auth method id")
+	b.Info["dev auth method id"] = amId
 
 	// Create the dev user
 	acctLoginName := b.DevLoginName
@@ -521,6 +527,9 @@ func (b *Server) CreateDevDatabase(dialect string) error {
 			return fmt.Errorf("unable to generate dev password: %w", err)
 		}
 	}
+	b.InfoKeys = append(b.InfoKeys, "dev password")
+	b.Info["dev password"] = pw
+
 	acct, err := password.NewAccount(amId, password.WithLoginName(acctLoginName))
 	if err != nil {
 		return fmt.Errorf("error creating new in memory auth account: %w", err)
@@ -529,29 +538,30 @@ func (b *Server) CreateDevDatabase(dialect string) error {
 	if err != nil {
 		return fmt.Errorf("error saving auth account to the db: %w", err)
 	}
+	b.InfoKeys = append(b.InfoKeys, "dev login name")
+	b.Info["dev login name"] = acct.GetLoginName()
 
 	// Create a role tying them together
+	iamRepo, err := iam.NewRepository(rw, rw, kmsCache, iam.WithRandomReader(b.SecureRandomReader))
+	if err != nil {
+		return fmt.Errorf("unable to create repo for org id: %w", err)
+	}
 	pr, err := iam.NewRole(scope.Global.String())
 	if err != nil {
 		return fmt.Errorf("error creating in memory role for default dev grants: %w", err)
 	}
 	pr.Name = "Dev Mode Global Scope Admin Role"
 	pr.Description = `Provides admin grants to all authenticated users within the "global" scope`
-	defPermsRole, err := repo.CreateRole(ctx, pr)
+	defPermsRole, err := iamRepo.CreateRole(ctx, pr)
 	if err != nil {
 		return fmt.Errorf("error creating role for default dev grants: %w", err)
 	}
-	if _, err := repo.AddRoleGrants(ctx, defPermsRole.PublicId, defPermsRole.Version, []string{"id=*;actions=*"}); err != nil {
+	if _, err := iamRepo.AddRoleGrants(ctx, defPermsRole.PublicId, defPermsRole.Version, []string{"id=*;actions=*"}); err != nil {
 		return fmt.Errorf("error creating grant for default dev grants: %w", err)
 	}
-	if _, err := repo.AddPrincipalRoles(ctx, defPermsRole.PublicId, defPermsRole.Version+1, []string{"u_auth"}, nil); err != nil {
+	if _, err := iamRepo.AddPrincipalRoles(ctx, defPermsRole.PublicId, defPermsRole.Version+1, []string{"u_auth"}, nil); err != nil {
 		return fmt.Errorf("error adding principal to role for default dev grants: %w", err)
 	}
-
-	b.InfoKeys = append(b.InfoKeys, "dev auth method id", "dev login name", "dev password")
-	b.Info["dev auth method id"] = amId
-	b.Info["dev login name"] = acct.GetLoginName()
-	b.Info["dev password"] = pw
 
 	// now that we have passed all the error cases, reset c to be a noop so the
 	// defer doesn't do anything.

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -31,10 +31,10 @@ type Command struct {
 	flagCombineLogs                    bool
 	flagDevLoginName                   string
 	flagDevPassword                    string
-	flagDevOrgId                       string
 	flagDevAuthMethodId                string
 	flagDevControllerAPIListenAddr     string
 	flagDevControllerClusterListenAddr string
+	flagDevSkipAuthMethodCreation      bool
 }
 
 func (c *Command) Synopsis() string {
@@ -81,14 +81,6 @@ func (c *Command) Flags() *base.FlagSets {
 	f = set.NewFlagSet("Dev Options")
 
 	f.StringVar(&base.StringVar{
-		Name:   "dev-org-id",
-		Target: &c.flagDevOrgId,
-		EnvVar: "WATCHTWER_DEV_ORG_ID",
-		Usage: "Auto-created org ID. This only applies when running in \"dev\" " +
-			"mode.",
-	})
-
-	f.StringVar(&base.StringVar{
 		Name:   "dev-auth-method-id",
 		Target: &c.flagDevAuthMethodId,
 		EnvVar: "WATCHTWER_DEV_AUTH_METHOD_ID",
@@ -124,6 +116,12 @@ func (c *Command) Flags() *base.FlagSets {
 		Target: &c.flagDevControllerClusterListenAddr,
 		EnvVar: "BOUNDARY_DEV_CONTROLLER_CLUSTER_LISTEN_ADDRESS",
 		Usage:  "Address to bind to for controller \"cluster\" purpose.",
+	})
+
+	f.BoolVar(&base.BoolVar{
+		Name:   "dev-skip-auth-method-creation",
+		Target: &c.flagDevSkipAuthMethodCreation,
+		Usage:  "If set, an auth method will not be created as part of the dev instance. The recovery KMS will be needed to perform any actions.",
 	})
 
 	f.BoolVar(&base.BoolVar{
@@ -254,7 +252,17 @@ func (c *Command) Run(args []string) int {
 		}
 	}()
 
-	if err := c.CreateDevDatabase("postgres"); err != nil {
+	var opts []base.Option
+	if c.flagDevSkipAuthMethodCreation {
+		opts = append(opts, base.WithSkipAuthMethodCreation())
+		switch {
+		case c.flagDevAuthMethodId != "",
+			c.flagDevLoginName != "",
+			c.flagDevPassword != "":
+			c.UI.Warn("-dev-skip-auth-method-creation set, skipping any auth-method related flags")
+		}
+	}
+	if err := c.CreateDevDatabase("postgres", opts...); err != nil {
 		c.UI.Error(fmt.Errorf("Error creating dev database container: %w", err).Error())
 		return 1
 	}

--- a/internal/servers/controller/testing.go
+++ b/internal/servers/controller/testing.go
@@ -180,6 +180,10 @@ type TestControllerOpts struct {
 	// DefaultPassword is the password used when creating the default account.
 	DefaultPassword string
 
+	// DisableAuthMethodCreation can be set true to disable creating an auth
+	// method automatically.
+	DisableAuthMethodCreation bool
+
 	// DisableDatabaseCreation can be set true to disable creating a dev
 	// database
 	DisableDatabaseCreation bool
@@ -302,7 +306,11 @@ func NewTestController(t *testing.T, opts *TestControllerOpts) *TestController {
 			t.Fatal(err)
 		}
 	} else if !opts.DisableDatabaseCreation {
-		if err := tc.b.CreateDevDatabase("postgres"); err != nil {
+		var createOpts []base.Option
+		if opts.DisableAuthMethodCreation {
+			createOpts = append(createOpts, base.WithSkipAuthMethodCreation())
+		}
+		if err := tc.b.CreateDevDatabase("postgres", createOpts...); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
This is useful if you, for instance, want Terraform to be 100%
responsible for creation of resources (outside of the static ones that
cannot be removed or modified, like u_anon). This will mean using the
recovery mechanism for initial setup, but that isn't an issue once TF
supports that :-)