### PR TITLE
Tiny: Rename table from servers to server

### DIFF
--- a/internal/db/migrations/postgres.gen.go
+++ b/internal/db/migrations/postgres.gen.go
@@ -1377,8 +1377,7 @@ commit;
 		bytes: []byte(`
 begin;
 
-  drop table workers;
-  drop table controllers;
+  drop table server;
 
 commit;
 
@@ -1393,7 +1392,7 @@ begin;
 -- to not have to persist some generated ID to worker and controller nodes.
 -- Eventually we may want them to diverge, so we have both here for now.
 
-create table servers (
+create table server (
     private_id text,
     type text,
     name text not null unique
@@ -1408,13 +1407,13 @@ create table servers (
 create trigger 
   immutable_columns
 before
-update on servers
+update on server
   for each row execute procedure immutable_columns('create_time');
   
 create trigger 
   default_create_time_column
 before
-insert on servers
+insert on server
   for each row execute procedure default_create_time();
 
 create table recovery_nonces (

--- a/internal/db/migrations/postgres/08_servers.down.sql
+++ b/internal/db/migrations/postgres/08_servers.down.sql
@@ -1,6 +1,5 @@
 begin;
 
-  drop table workers;
-  drop table controllers;
+  drop table server;
 
 commit;

--- a/internal/db/migrations/postgres/08_servers.up.sql
+++ b/internal/db/migrations/postgres/08_servers.up.sql
@@ -4,7 +4,7 @@ begin;
 -- to not have to persist some generated ID to worker and controller nodes.
 -- Eventually we may want them to diverge, so we have both here for now.
 
-create table servers (
+create table server (
     private_id text,
     type text,
     name text not null unique
@@ -19,13 +19,13 @@ create table servers (
 create trigger 
   immutable_columns
 before
-update on servers
+update on server
   for each row execute procedure immutable_columns('create_time');
   
 create trigger 
   default_create_time_column
 before
-insert on servers
+insert on server
   for each row execute procedure default_create_time();
 
 create table recovery_nonces (

--- a/internal/servers/gorm.go
+++ b/internal/servers/gorm.go
@@ -1,0 +1,5 @@
+package servers
+
+func (s *Server) TableName() string {
+	return "server"
+}

--- a/internal/servers/repository.go
+++ b/internal/servers/repository.go
@@ -73,11 +73,11 @@ func (r *Repository) UpsertServer(ctx context.Context, server *Server, opt ...Op
 	server.PrivateId = server.Name
 	// Build query
 	q := `
-	insert into servers
+	insert into server
 		(private_id, type, name, description, address, update_time)
 	values
 		($1, $2, $3, $4, $5, $6)
-	on conflict on constraint servers_pkey
+	on conflict on constraint server_pkey
 	do update set
 		name = $3,
 		description = $4,


### PR DESCRIPTION
Our table naming convention is to use singular names.