### PR TITLE
add option db.WithSkipVetForWrite(true) so the db tests don't get intercepted by app validation

### DIFF
--- a/internal/host/static/immutable_fields_test.go
+++ b/internal/host/static/immutable_fields_test.go
@@ -64,7 +64,7 @@ func TestHostCatalog_ImmutableFields(t *testing.T) {
 			err := w.LookupById(context.Background(), orig)
 			require.NoError(err)
 
-			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 
@@ -132,7 +132,7 @@ func TestStaticHost_ImmutableFields(t *testing.T) {
 			err := w.LookupById(context.Background(), orig)
 			require.NoError(err)
 
-			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 
@@ -207,7 +207,7 @@ func TestStaticHostSet_ImmutableFields(t *testing.T) {
 			err := w.LookupById(context.Background(), orig)
 			require.NoError(err)
 
-			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 
@@ -276,7 +276,7 @@ func TestStaticHostSetMember_ImmutableFields(t *testing.T) {
 			err = w.LookupWhere(context.Background(), orig, "host_id = ? and set_id = ?", orig.HostId, orig.SetId)
 			require.NoError(err)
 
-			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 

--- a/internal/iam/immutable_fields_test.go
+++ b/internal/iam/immutable_fields_test.go
@@ -73,7 +73,7 @@ func TestScope_ImmutableFields(t *testing.T) {
 			err := w.LookupById(context.Background(), orig)
 			require.NoError(err)
 
-			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 
@@ -196,7 +196,7 @@ func TestUser_ImmutableFields(t *testing.T) {
 			err := w.LookupById(context.Background(), orig)
 			require.NoError(err)
 
-			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 
@@ -263,7 +263,7 @@ func TestRole_ImmutableFields(t *testing.T) {
 			err := w.LookupById(context.Background(), orig)
 			require.NoError(err)
 
-			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 
@@ -330,7 +330,7 @@ func TestGroup_ImmutableFields(t *testing.T) {
 			err := w.LookupById(context.Background(), orig)
 			require.NoError(err)
 
-			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := w.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 

--- a/internal/kms/immutable_fields_test.go
+++ b/internal/kms/immutable_fields_test.go
@@ -96,7 +96,7 @@ func TestRootKeyVersion_ImmutableFields(t *testing.T) {
 
 			err = tt.update.Encrypt(context.Background(), wrapper)
 			require.NoError(err)
-			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 
@@ -163,7 +163,7 @@ func TestRootKey_ImmutableFields(t *testing.T) {
 			err := rw.LookupById(context.Background(), orig)
 			require.NoError(err)
 
-			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 
@@ -232,7 +232,7 @@ func TestDatabaseKey_ImmutableFields(t *testing.T) {
 			err := rw.LookupById(context.Background(), orig)
 			require.NoError(err)
 
-			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 
@@ -331,7 +331,7 @@ func TestDatabaseKeyVersion_ImmutableFields(t *testing.T) {
 
 			err = tt.update.Encrypt(context.Background(), wrapper)
 			require.NoError(err)
-			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 

--- a/internal/target/immutable_fields_test.go
+++ b/internal/target/immutable_fields_test.go
@@ -70,7 +70,7 @@ func TestTarget_ImmutableFields(t *testing.T) {
 			require.NoError(err)
 
 			tt.update.SetTableName("target")
-			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 
@@ -137,7 +137,7 @@ func TestTcpTarget_ImmutableFields(t *testing.T) {
 			err := rw.LookupById(context.Background(), orig)
 			require.NoError(err)
 
-			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 
@@ -218,7 +218,7 @@ func TestTargetHostSet_ImmutableFields(t *testing.T) {
 			err := rw.LookupWhere(context.Background(), orig, "target_id = ? and host_set_id = ?", new.TargetId, new.HostSetId)
 			require.NoError(err)
 
-			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil)
+			rowsUpdated, err := rw.Update(context.Background(), tt.update, tt.fieldMask, nil, db.WithSkipVetForWrite(true))
 			require.Error(err)
 			assert.Equal(0, rowsUpdated)
 


### PR DESCRIPTION
Should be a 2 min review... ty!