### PR TITLE
Fix global scope lookup

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/boundary/internal/servers/controller/common"
 	"github.com/hashicorp/boundary/internal/servers/controller/handlers"
 	"github.com/hashicorp/boundary/internal/types/action"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/boundary/internal/types/scope"
 	"github.com/hashicorp/boundary/sdk/recovery"
 	"github.com/hashicorp/go-hclog"
@@ -142,6 +143,10 @@ func Verify(ctx context.Context, opt ...Option) (ret VerifyResults) {
 		Id:      opts.withId,
 		Pin:     opts.withPin,
 		Type:    opts.withType,
+	}
+	// Global scope has no parent ID; account for this
+	if opts.withId == scope.Global.String() && opts.withType == resource.Scope {
+		v.res.ScopeId = scope.Global.String()
 	}
 
 	if v.requestInfo.EncryptedToken != "" {

--- a/internal/cmd/commands/scopes/scope.go
+++ b/internal/cmd/commands/scopes/scope.go
@@ -117,7 +117,9 @@ func (c *Command) Run(args []string) int {
 		opts = append(opts, scopes.WithDescription(c.FlagDescription))
 	}
 
-	opts = append(opts, scopes.WithSkipRoleCreation(c.flagSkipRoleCreation))
+	if c.flagSkipRoleCreation {
+		opts = append(opts, scopes.WithSkipRoleCreation(c.flagSkipRoleCreation))
+	}
 
 	scopeClient := scopes.NewClient(client)
 


### PR DESCRIPTION
The changed auth logic + verify logic in the scope handler pass the
parent ID for validation, which is correct, as a scope lives in its
parent ID. However, the global scope has no parent, and the changes
resulted in an empty ID being passed in rather than the global scope
itself. This fixes that lookup.