### PR TITLE
Use 'at' for auth token prefix

### DIFF
--- a/internal/authtoken/authtoken.go
+++ b/internal/authtoken/authtoken.go
@@ -79,7 +79,7 @@ func (s *AuthToken) decrypt(ctx context.Context, cipher wrapping.Wrapper) error 
 }
 
 const (
-	AuthTokenPrefix = "t"
+	AuthTokenPrefix = "at"
 	// The version prefix is used to differentiate token versions just for future proofing.
 	TokenValueVersionPrefix = "0"
 	tokenLength             = 24

--- a/internal/cmd/common/help.go
+++ b/internal/cmd/common/help.go
@@ -35,6 +35,8 @@ func HelpMap(resType string) map[string]func() string {
 		resource.HostCatalog.String(): "hc",
 		resource.HostSet.String():     "hs",
 		resource.Host.String():        "h",
+		resource.Session.String():     "ss",
+		resource.Target.String():      "t",
 	}
 	return map[string]func() string{
 		"base": func() string {


### PR DESCRIPTION
CLI was already expecting this and this disambiguates better from targets