### PR TITLE
Disallow deletion of r_default

### DIFF
--- a/internal/db/migrations/postgres.gen.go
+++ b/internal/db/migrations/postgres.gen.go
@@ -654,7 +654,6 @@ before
 delete on iam_scope
   for each row execute procedure disallow_global_scope_deletion();
 
-
 create trigger 
   update_time_column 
 before update on iam_scope 
@@ -937,6 +936,24 @@ create trigger
 before
 insert on iam_role_grant
   for each row execute procedure default_create_time();
+
+create or replace function
+  disallow_r_default_deletion()
+  returns trigger
+as $$
+begin
+  if old.public_id = 'r_default' then
+    raise exception 'deletion of r_default not allowed';
+  end if;
+  return old;
+end;
+$$ language plpgsql;
+
+create trigger
+  iam_role_disallow_global_deletion
+before
+delete on iam_role
+  for each row execute procedure disallow_r_default_deletion();
 
 create trigger 
   update_version_column

--- a/internal/db/migrations/postgres/06_iam.up.sql
+++ b/internal/db/migrations/postgres/06_iam.up.sql
@@ -136,7 +136,6 @@ before
 delete on iam_scope
   for each row execute procedure disallow_global_scope_deletion();
 
-
 create trigger 
   update_time_column 
 before update on iam_scope 
@@ -419,6 +418,24 @@ create trigger
 before
 insert on iam_role_grant
   for each row execute procedure default_create_time();
+
+create or replace function
+  disallow_r_default_deletion()
+  returns trigger
+as $$
+begin
+  if old.public_id = 'r_default' then
+    raise exception 'deletion of r_default not allowed';
+  end if;
+  return old;
+end;
+$$ language plpgsql;
+
+create trigger
+  iam_role_disallow_global_deletion
+before
+delete on iam_role
+  for each row execute procedure disallow_r_default_deletion();
 
 create trigger 
   update_version_column

--- a/internal/iam/repository_role_test.go
+++ b/internal/iam/repository_role_test.go
@@ -494,13 +494,26 @@ func TestRepository_DeleteRole(t *testing.T) {
 			name: "no-public-id",
 			args: args{
 				role: func() *Role {
-					g := allocRole()
-					return &g
+					r := allocRole()
+					return &r
 				}(),
 			},
 			wantRowsDeleted: 0,
 			wantErr:         true,
 			wantErrMsg:      "delete role: missing public id invalid parameter",
+		},
+		{
+			name: "r_default",
+			args: args{
+				role: func() *Role {
+					r := allocRole()
+					r.PublicId = "r_default"
+					return &r
+				}(),
+			},
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrMsg:      `deletion of r_default not allowed`,
 		},
 		{
 			name: "not-found",

--- a/internal/servers/controller/handlers/roles/role_service.go
+++ b/internal/servers/controller/handlers/roles/role_service.go
@@ -620,7 +620,14 @@ func validateUpdateRequest(req *pbs.UpdateRoleRequest) error {
 }
 
 func validateDeleteRequest(req *pbs.DeleteRoleRequest) error {
-	return handlers.ValidateDeleteRequest(iam.RolePrefix, req, handlers.NoopValidatorFn)
+	return handlers.ValidateDeleteRequest(iam.RolePrefix, req, func() map[string]string {
+		if req.GetId() == "r_default" {
+			return map[string]string{
+				"id": `Deleting "r_default" is not allowed`,
+			}
+		}
+		return nil
+	})
 }
 
 func validateListRequest(req *pbs.ListRolesRequest) error {

--- a/internal/servers/controller/handlers/roles/role_service_test.go
+++ b/internal/servers/controller/handlers/roles/role_service_test.go
@@ -285,6 +285,14 @@ func TestDelete(t *testing.T) {
 			errCode: codes.NotFound,
 		},
 		{
+			name:    "Delete default role",
+			scopeId: "global",
+			req: &pbs.DeleteRoleRequest{
+				Id: "r_default",
+			},
+			errCode: codes.InvalidArgument,
+		},
+		{
 			name:    "Bad Role Id formatting",
 			scopeId: or.GetPublicId(),
 			req: &pbs.DeleteRoleRequest{


### PR DESCRIPTION
If it's a useful named resource and people accidentally delete it e.g.
with TF, they can't get it back. This doesn't affect TF's ability to
manage it, just delete.