### PR TITLE
Fix segfault with boundary sessions help output

### DIFF
--- a/internal/cmd/commands/sessions/session.go
+++ b/internal/cmd/commands/sessions/session.go
@@ -36,10 +36,34 @@ var flagsMap = map[string][]string{
 
 func (c *Command) Help() string {
 	helpMap := common.HelpMap("session")
-	if c.Func == "" {
-		return helpMap["base"]()
+	var helpStr string
+	switch c.Func {
+	case "":
+		return base.WrapForHelpText([]string{
+			"Usage: boundary sessions [sub command] [options] [args]",
+			"",
+			"  This command allows operations on Boundary sessions.",
+			"",
+			"    Read a session:",
+			"",
+			`      $ boundary sessions read -id s_1234567890`,
+			"",
+			"  Please see the sessions subcommand help for detailed usage information.",
+		})
+	case "cancel":
+		helpStr = base.WrapForHelpText([]string{
+			"Usage: boundary sessions cancel [options] [args]",
+			"",
+			"  Cancel the session specified by ID. Example:",
+			"",
+			`    $ boundary sessions cancel -id s_1234567890`,
+			"",
+			"",
+		})
+	default:
+		helpStr = helpMap[c.Func]()
 	}
-	return helpMap[c.Func]() + c.Flags().Help()
+	return helpStr + c.Flags().Help()
 }
 
 func (c *Command) Flags() *base.FlagSets {


### PR DESCRIPTION
This addresses:
```
▶ boundary sessions -h
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1f5b8df]

goroutine 1 [running]:
github.com/hashicorp/boundary/internal/cmd/commands/sessions.(*Command).Help(0xc000550260, 0xc000554300, 0x232925b)
        /Users/xntrik/go/src/github.com/hashicorp/boundary/internal/cmd/commands/sessions/session.go:48 +0xff
github.com/mitchellh/cli.(*CLI).commandHelp(0xc0002db040, 0x257a260, 0xc000301be0, 0x259a060, 0xc0005dc000)
        /Users/xntrik/go/pkg/mod/github.com/mitchellh/cli@v1.1.1/cli.go:573 +0x815
github.com/mitchellh/cli.(*CLI).Run(0xc0002db040, 0xc0002db040, 0xc0006167a0, 0xc000401500)
        /Users/xntrik/go/pkg/mod/github.com/mitchellh/cli@v1.1.1/cli.go:248 +0x391
github.com/hashicorp/boundary/internal/cmd.RunCustom(0xc0000a40d0, 0x2, 0x2, 0xc00056de60, 0xc00009c058)
        /Users/xntrik/go/src/github.com/hashicorp/boundary/internal/cmd/main.go:172 +0x846
github.com/hashicorp/boundary/internal/cmd.Run(...)
        /Users/xntrik/go/src/github.com/hashicorp/boundary/internal/cmd/main.go:78
main.main()
        /Users/xntrik/go/src/github.com/hashicorp/boundary/cmd/boundary/main.go:13 +0xda
```