### PR TITLE
Add public address config option

### DIFF
--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -110,6 +110,7 @@ type Worker struct {
 	Name        string   `hcl:"name"`
 	Description string   `hcl:"description"`
 	Controllers []string `hcl:"controllers"`
+	PublicAddr  string   `hcl:"public_addr"`
 }
 
 type Database struct {

--- a/internal/servers/worker/listeners.go
+++ b/internal/servers/worker/listeners.go
@@ -31,10 +31,6 @@ func (w *Worker) startListeners() error {
 				return fmt.Errorf("unknown listener purpose %q", purpose)
 			}
 
-			if w.listeningAddress != "" {
-				return errors.New("more than one listening address found")
-			}
-
 			handler := w.handler(HandlerProperties{
 				ListenerConfig: ln.Config,
 			})
@@ -81,11 +77,6 @@ func (w *Worker) startListeners() error {
 			servers = append(servers, func() {
 				go server.Serve(l)
 			})
-
-			if w.listeningAddress == "" {
-				w.listeningAddress = l.Addr().String()
-				w.logger.Info("reporting listening address to controllers", "address", w.listeningAddress)
-			}
 		}
 	}
 

--- a/internal/servers/worker/status.go
+++ b/internal/servers/worker/status.go
@@ -85,7 +85,7 @@ func (w *Worker) startStatusTicking(cancelCtx context.Context) {
 						Name:        w.conf.RawConfig.Worker.Name,
 						Type:        resource.Worker.String(),
 						Description: w.conf.RawConfig.Worker.Description,
-						Address:     w.listeningAddress,
+						Address:     w.conf.RawConfig.Worker.PublicAddr,
 					},
 				})
 				if err != nil {

--- a/internal/servers/worker/worker.go
+++ b/internal/servers/worker/worker.go
@@ -27,8 +27,6 @@ type Worker struct {
 	controllerStatusConn *atomic.Value
 	lastStatusSuccess    *atomic.Value
 
-	listeningAddress string
-
 	controllerResolver        *atomic.Value
 	controllerResolverCleanup *atomic.Value
 
@@ -128,7 +126,6 @@ func (w *Worker) Shutdown(skipListeners bool) error {
 			return fmt.Errorf("error stopping worker listeners: %w", err)
 		}
 	}
-	w.listeningAddress = ""
 	w.started.Store(false)
 	return nil
 }


### PR DESCRIPTION
This option controls the address the worker reports to the controller that is then given to clients. If not set, defaults to the address of the listener marked for "proxy" use.