### PR TITLE
enable GitHub code scanning workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,10 +1,8 @@
-name: "Code scanning - action"
+name: "Code scanning - scheduled (weekly)"
 
 on:
-  push:
-    branches: [ enable-gh-code-scanning ]
-  pull_request:
-    branches: [ enable-gh-code-scanning ]
+  schedule:
+    - cron: '0 15 * * 0'
 
 jobs:
   CodeQL-Build:


### PR DESCRIPTION
We're in the process of adopting GitHub "Advanced Security", which includes CodeQL code scanning capabilities.

We'll start by enabling just for this PR's branch, then switch to run ~on all PRs/pushes &~ on schedule, similar to https://github.com/hashicorp/consul-enterprise/pull/511.

Results of scans will be available only to users with 'write' access to this repo, via the 'Security' tab (https://github.com/hashicorp/boundary/security/code-scanning).