### PR TITLE
Remove package-lock.json from the root folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Don't believe this is used - and will help unlock some security scanning that was failing because of this file.