### PR TITLE
Remove not-set value.

### DIFF
--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -29,9 +29,6 @@ const (
 	// maxLineLength is the maximum width of any line.
 	maxLineLength int = 78
 
-	// NotSetValue is a flag value for a not-set value
-	NotSetValue = "(not set)"
-
 	envToken          = "BOUNDARY_TOKEN"
 	envTokenName      = "BOUNDARY_TOKEN_NAME"
 	envRecoveryConfig = "BOUNDARY_RECOVERY_CONFIG"
@@ -131,8 +128,7 @@ func (c *Command) Client(opt ...Option) (*api.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	if c.flagAddr != NotSetValue {
+	if c.flagAddr != "" {
 		if err := c.client.SetAddr(c.flagAddr); err != nil {
 			return nil, fmt.Errorf("error setting address on client: %w", err)
 		}
@@ -141,23 +137,23 @@ func (c *Command) Client(opt ...Option) (*api.Client, error) {
 	// If we need custom TLS configuration, then set it
 	var modifiedTLS bool
 	tlsConfig := config.TLSConfig
-	if c.flagTLSCACert != NotSetValue {
+	if c.flagTLSCACert != "" {
 		tlsConfig.CACert = c.flagTLSCACert
 		modifiedTLS = true
 	}
-	if c.flagTLSCAPath != NotSetValue {
+	if c.flagTLSCAPath != "" {
 		tlsConfig.CAPath = c.flagTLSCAPath
 		modifiedTLS = true
 	}
-	if c.flagTLSClientCert != NotSetValue {
+	if c.flagTLSClientCert != "" {
 		tlsConfig.ClientCert = c.flagTLSClientCert
 		modifiedTLS = true
 	}
-	if c.flagTLSClientKey != NotSetValue {
+	if c.flagTLSClientKey != "" {
 		tlsConfig.ClientKey = c.flagTLSClientKey
 		modifiedTLS = true
 	}
-	if c.flagTLSServerName != NotSetValue {
+	if c.flagTLSServerName != "" {
 		tlsConfig.ServerName = c.flagTLSServerName
 		modifiedTLS = true
 	}
@@ -265,7 +261,6 @@ func (c *Command) FlagSet(bit FlagSetBit) *FlagSets {
 			f.StringVar(&StringVar{
 				Name:       FlagNameAddr,
 				Target:     &c.flagAddr,
-				Default:    NotSetValue,
 				EnvVar:     api.EnvBoundaryAddr,
 				Completion: complete.PredictAnything,
 				Usage:      "Addr of the Boundary controller, as a complete URL (e.g. https://boundary.example.com:9200).",
@@ -274,7 +269,6 @@ func (c *Command) FlagSet(bit FlagSetBit) *FlagSets {
 			f.StringVar(&StringVar{
 				Name:       FlagNameCACert,
 				Target:     &c.flagTLSCACert,
-				Default:    NotSetValue,
 				EnvVar:     api.EnvBoundaryCACert,
 				Completion: complete.PredictFiles("*"),
 				Usage: "Path on the local disk to a single PEM-encoded CA " +
@@ -285,7 +279,6 @@ func (c *Command) FlagSet(bit FlagSetBit) *FlagSets {
 			f.StringVar(&StringVar{
 				Name:       FlagNameCAPath,
 				Target:     &c.flagTLSCAPath,
-				Default:    NotSetValue,
 				EnvVar:     api.EnvBoundaryCAPath,
 				Completion: complete.PredictDirs("*"),
 				Usage: "Path on the local disk to a directory of PEM-encoded CA " +
@@ -295,7 +288,6 @@ func (c *Command) FlagSet(bit FlagSetBit) *FlagSets {
 			f.StringVar(&StringVar{
 				Name:       FlagNameClientCert,
 				Target:     &c.flagTLSClientCert,
-				Default:    NotSetValue,
 				EnvVar:     api.EnvBoundaryClientCert,
 				Completion: complete.PredictFiles("*"),
 				Usage: "Path on the local disk to a single PEM-encoded CA " +
@@ -306,7 +298,6 @@ func (c *Command) FlagSet(bit FlagSetBit) *FlagSets {
 			f.StringVar(&StringVar{
 				Name:       FlagNameClientKey,
 				Target:     &c.flagTLSClientKey,
-				Default:    NotSetValue,
 				EnvVar:     api.EnvBoundaryClientKey,
 				Completion: complete.PredictFiles("*"),
 				Usage: "Path on the local disk to a single PEM-encoded private key " +
@@ -316,7 +307,6 @@ func (c *Command) FlagSet(bit FlagSetBit) *FlagSets {
 			f.StringVar(&StringVar{
 				Name:       FlagTLSServerName,
 				Target:     &c.flagTLSServerName,
-				Default:    NotSetValue,
 				EnvVar:     api.EnvBoundaryTLSServerName,
 				Completion: complete.PredictAnything,
 				Usage: "Name to use as the SNI host when connecting to the Boundary " +

--- a/internal/cmd/base/logging.go
+++ b/internal/cmd/base/logging.go
@@ -14,7 +14,7 @@ func ProcessLogLevelAndFormat(flagLogLevel, flagLogFormat, configLogLevel, confi
 
 	// If the flag wasn't set, check config; if not set use info
 	logLevel := strings.ToLower(strings.TrimSpace(flagLogLevel))
-	if logLevel == NotSetValue {
+	if logLevel == "" {
 		logLevel = strings.ToLower(strings.TrimSpace(configLogLevel))
 		if logLevel == "" {
 			logLevel = "info"
@@ -38,7 +38,7 @@ func ProcessLogLevelAndFormat(flagLogLevel, flagLogFormat, configLogLevel, confi
 		return level, logFormat, fmt.Errorf("unknown log level: %s", logLevel)
 	}
 
-	if flagLogFormat != NotSetValue {
+	if flagLogFormat != "" {
 		var err error
 		logFormat, err = logging.ParseLogFormat(flagLogFormat)
 		if err != nil {

--- a/internal/cmd/commands/database/init.go
+++ b/internal/cmd/commands/database/init.go
@@ -98,7 +98,6 @@ func (c *InitCommand) Flags() *base.FlagSets {
 	f.StringVar(&base.StringVar{
 		Name:       "log-level",
 		Target:     &c.flagLogLevel,
-		Default:    base.NotSetValue,
 		EnvVar:     "BOUNDARY_LOG_LEVEL",
 		Completion: complete.PredictSet("trace", "debug", "info", "warn", "err"),
 		Usage: "Log verbosity level. Supported values (in order of more detail to less) are " +
@@ -108,7 +107,6 @@ func (c *InitCommand) Flags() *base.FlagSets {
 	f.StringVar(&base.StringVar{
 		Name:       "log-format",
 		Target:     &c.flagLogFormat,
-		Default:    base.NotSetValue,
 		Completion: complete.PredictSet("standard", "json"),
 		Usage:      `Log format. Supported values are "standard" and "json".`,
 	})
@@ -140,10 +138,9 @@ func (c *InitCommand) Flags() *base.FlagSets {
 	})
 
 	f.StringVar(&base.StringVar{
-		Name:    "migration-url",
-		Target:  &c.flagMigrationUrl,
-		Default: base.NotSetValue,
-		Usage:   `If set, overrides a migration URL set in config, and specifies the URL used to connect to the database for initialization. This can allow different permissions for the user running initialization vs. normal operation. This can refer to a file on disk (file://) from which a URL will be read; an env var (env://) from which the URL will be read; or a direct database URL.`,
+		Name:   "migration-url",
+		Target: &c.flagMigrationUrl,
+		Usage:  `If set, overrides a migration URL set in config, and specifies the URL used to connect to the database for initialization. This can allow different permissions for the user running initialization vs. normal operation. This can refer to a file on disk (file://) from which a URL will be read; an env var (env://) from which the URL will be read; or a direct database URL.`,
 	})
 
 	return set
@@ -214,7 +211,7 @@ func (c *InitCommand) Run(args []string) (retCode int) {
 	if c.Config.Controller.Database.MigrationUrl != "" {
 		migrationUrlToParse = c.Config.Controller.Database.MigrationUrl
 	}
-	if c.flagMigrationUrl != "" && c.flagMigrationUrl != base.NotSetValue {
+	if c.flagMigrationUrl != "" {
 		migrationUrlToParse = c.flagMigrationUrl
 	}
 	// Fallback to using database URL for everything

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -78,7 +78,6 @@ func (c *Command) Flags() *base.FlagSets {
 	f.StringVar(&base.StringVar{
 		Name:       "log-level",
 		Target:     &c.flagLogLevel,
-		Default:    base.NotSetValue,
 		EnvVar:     "BOUNDARY_LOG_LEVEL",
 		Completion: complete.PredictSet("trace", "debug", "info", "warn", "err"),
 		Usage: "Log verbosity level. Supported values (in order of more detail to less) are " +
@@ -88,7 +87,6 @@ func (c *Command) Flags() *base.FlagSets {
 	f.StringVar(&base.StringVar{
 		Name:       "log-format",
 		Target:     &c.flagLogFormat,
-		Default:    base.NotSetValue,
 		Completion: complete.PredictSet("standard", "json"),
 		Usage:      `Log format. Supported values are "standard" and "json".`,
 	})

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -89,7 +89,6 @@ func (c *Command) Flags() *base.FlagSets {
 	f.StringVar(&base.StringVar{
 		Name:       "log-level",
 		Target:     &c.flagLogLevel,
-		Default:    base.NotSetValue,
 		EnvVar:     "BOUNDARY_LOG_LEVEL",
 		Completion: complete.PredictSet("trace", "debug", "info", "warn", "err"),
 		Usage: "Log verbosity level. Supported values (in order of more detail to less) are " +
@@ -99,7 +98,6 @@ func (c *Command) Flags() *base.FlagSets {
 	f.StringVar(&base.StringVar{
 		Name:       "log-format",
 		Target:     &c.flagLogFormat,
-		Default:    base.NotSetValue,
 		Completion: complete.PredictSet("standard", "json"),
 		Usage:      `Log format. Supported values are "standard" and "json".`,
 	})


### PR DESCRIPTION
I don't think the conditions exist here that necessitated it being
introduced into Vault, but I do sometimes see a baffling condition where
the address coming from the flag is empty. I don't think we need this so
take it out.