### PR TITLE
Fix unused error in *api/client.Client.Do during redirect

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -767,7 +767,10 @@ func (c *Client) Do(r *retryablehttp.Request) (*Response, error) {
 
 	result, err := client.Do(r)
 	if result != nil && err == nil && result.StatusCode == http.StatusTemporaryRedirect {
-		loc, err := result.Location()
+		// Declare loc here to reuse previous error
+		var loc *url.URL
+
+		loc, err = result.Location()
 		if err != nil {
 			return nil, fmt.Errorf("error getting new location during redirect: %w", err)
 		}


### PR DESCRIPTION
The error declared during the `*retryablehttp.Client.Do` is being "overshadowed" by the error declared when a redirect is missing the result location.

https://github.com/hashicorp/boundary/blob/9372c6c1d99318dca58c6f00cf0b72a8b4b07789/api/client.go#L768-L770

This leads to the next `*retryablehttp.Client.Do` to have an unused error variable, since it's reusing the `err` on line [#L770](https://github.com/hashicorp/boundary/blob/9372c6c1d99318dca58c6f00cf0b72a8b4b07789/api/client.go#L770) and not [#L768](https://github.com/hashicorp/boundary/blob/9372c6c1d99318dca58c6f00cf0b72a8b4b07789/api/client.go#L768), so it's never actually checked:

https://github.com/hashicorp/boundary/blob/9372c6c1d99318dca58c6f00cf0b72a8b4b07789/api/client.go#L783

By declaring the loc outside the call assignment on [#L770](https://github.com/hashicorp/boundary/blob/9372c6c1d99318dca58c6f00cf0b72a8b4b07789/api/client.go#L770), we can properly reuse the error and resulting check after a redirect.