### PR TITLE
More Error Cleanup

### DIFF
--- a/internal/servers/controller/handlers/authmethods/authmethod_service.go
+++ b/internal/servers/controller/handlers/authmethods/authmethod_service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/boundary/internal/types/scope"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -185,7 +184,7 @@ func (s Service) createInRepo(ctx context.Context, scopeId string, item *pb.Auth
 	}
 	u, err := password.NewAuthMethod(scopeId, opts...)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to build auth method for creation: %v.", err)
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to build auth method for creation: %v.", err)
 	}
 	repo, err := s.repoFn()
 	if err != nil {
@@ -193,10 +192,10 @@ func (s Service) createInRepo(ctx context.Context, scopeId string, item *pb.Auth
 	}
 	out, err := repo.CreateAuthMethod(ctx, u)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create auth method: %v.", err)
+		return nil,fmt.Errorf("unable to create auth method: %w", err)
 	}
 	if out == nil {
-		return nil, status.Error(codes.Internal, "Unable to create auth method but no error returned from repository.")
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to create auth method but no error returned from repository.")
 	}
 	return toProto(out)
 }
@@ -211,12 +210,13 @@ func (s Service) updateInRepo(ctx context.Context, scopeId, id string, mask []st
 	}
 	u, err := password.NewAuthMethod(scopeId, opts...)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to build auth method for update: %v.", err)
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to build auth method for update: %v.", err)
 	}
 
 	pwAttrs := &pb.PasswordAuthMethodAttributes{}
 	if err := handlers.StructToProto(item.GetAttributes(), pwAttrs); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Provided attributes don't match expected format.")
+		return nil, handlers.InvalidArgumentErrorf("Error in provided request.",
+			map[string]string{"attributes": "Attribute fields do not match the expected format."})
 	}
 	if pwAttrs.GetMinLoginNameLength() != 0 {
 		u.MinLoginNameLength = pwAttrs.GetMinLoginNameLength()
@@ -237,10 +237,10 @@ func (s Service) updateInRepo(ctx context.Context, scopeId, id string, mask []st
 	}
 	out, rowsUpdated, err := repo.UpdateAuthMethod(ctx, u, version, dbMask)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to update auth method: %v.", err)
+		return nil, fmt.Errorf("unable to update auth method: %w", err)
 	}
 	if rowsUpdated == 0 {
-		return nil, handlers.NotFoundErrorf("AuthMethod %q doesn't exist.", id)
+		return nil, handlers.NotFoundErrorf("AuthMethod %q doesn't exist or incorrect version provided.", id)
 	}
 	return toProto(out)
 }
@@ -255,7 +255,7 @@ func (s Service) deleteFromRepo(ctx context.Context, scopeId, id string) (bool, 
 		if errors.Is(err, db.ErrRecordNotFound) {
 			return false, nil
 		}
-		return false, status.Errorf(codes.Internal, "Unable to delete auth method: %v.", err)
+		return false, fmt.Errorf("unable to delete auth method: %w", err)
 	}
 	return rows > 0, nil
 }
@@ -324,7 +324,7 @@ func toProto(in *password.AuthMethod) (*pb.AuthMethod, error) {
 		MinPasswordLength:  in.GetMinPasswordLength(),
 	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed building password attribute struct: %v", err)
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "failed building password attribute struct: %v", err)
 	}
 	out.Attributes = st
 	return &out, nil

--- a/internal/servers/controller/handlers/authtokens/authtoken_service.go
+++ b/internal/servers/controller/handlers/authtokens/authtoken_service.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hashicorp/boundary/internal/types/action"
 	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/boundary/internal/types/scope"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // Service handles request as described by the pbs.AuthTokenServiceServer interface.
@@ -100,7 +98,7 @@ func (s Service) getFromRepo(ctx context.Context, id string) (*pb.AuthToken, err
 		if errors.Is(err, db.ErrRecordNotFound) {
 			return nil, handlers.NotFoundErrorf("AuthToken %q doesn't exist.", id)
 		}
-		return nil, err
+		return nil, fmt.Errorf("unable to list auth tokens: %w", err)
 	}
 	if u == nil {
 		return nil, handlers.NotFoundErrorf("AuthToken %q doesn't exist.", id)
@@ -118,7 +116,7 @@ func (s Service) deleteFromRepo(ctx context.Context, id string) (bool, error) {
 		if errors.Is(err, db.ErrRecordNotFound) {
 			return false, nil
 		}
-		return false, status.Errorf(codes.Internal, "Unable to delete user: %v.", err)
+		return false, fmt.Errorf("unable to delete user: %w", err)
 	}
 	return rows > 0, nil
 }

--- a/internal/servers/controller/handlers/roles/role_service_test.go
+++ b/internal/servers/controller/handlers/roles/role_service_test.go
@@ -1426,6 +1426,15 @@ func TestAddGrants(t *testing.T) {
 		err  error
 	}{
 		{
+			name: "Bad Version",
+			req: &pbs.AddRoleGrantsRequest{
+				Id:           role.GetPublicId(),
+				GrantStrings: []string{"id=*;actions=create"},
+				Version:      role.GetVersion() + 2,
+			},
+			err: handlers.ApiErrorWithCode(codes.Internal),
+		},
+		{
 			name: "Bad Role Id",
 			req: &pbs.AddRoleGrantsRequest{
 				Id:           "bad id",
@@ -1529,6 +1538,15 @@ func TestSetGrants(t *testing.T) {
 		err  error
 	}{
 		{
+			name: "Bad Version",
+			req: &pbs.SetRoleGrantsRequest{
+				Id:           role.GetPublicId(),
+				GrantStrings: []string{"id=*;actions=create"},
+				Version:      role.GetVersion() + 2,
+			},
+			err: handlers.ApiErrorWithCode(codes.Internal),
+		},
+		{
 			name: "Bad Role Id",
 			req: &pbs.SetRoleGrantsRequest{
 				Id:           "bad id",
@@ -1631,6 +1649,15 @@ func TestRemoveGrants(t *testing.T) {
 
 		err error
 	}{
+		{
+			name: "Bad Version",
+			req: &pbs.RemoveRoleGrantsRequest{
+				Id:           role.GetPublicId(),
+				GrantStrings: []string{"id=*;actions=create"},
+				Version:      role.GetVersion() + 2,
+			},
+			err: handlers.ApiErrorWithCode(codes.Internal),
+		},
 		{
 			name: "Bad Role Id",
 			req: &pbs.RemoveRoleGrantsRequest{

--- a/internal/servers/controller/handlers/scopes/scope_service.go
+++ b/internal/servers/controller/handlers/scopes/scope_service.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/boundary/internal/types/scope"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -175,7 +174,7 @@ func (s Service) createInRepo(ctx context.Context, authResults auth.VerifyResult
 		iamScope, err = iam.NewProject(parentScope.GetId(), opts...)
 	}
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to build new scope for creation: %v.", err)
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to build new scope for creation: %v.", err)
 	}
 	repo, err := s.repoFn()
 	if err != nil {
@@ -183,10 +182,10 @@ func (s Service) createInRepo(ctx context.Context, authResults auth.VerifyResult
 	}
 	out, err := repo.CreateScope(ctx, iamScope, authResults.UserId, opts...)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create scope: %v.", err)
+		return nil, fmt.Errorf("unable to create scope: %w", err)
 	}
 	if out == nil {
-		return nil, status.Error(codes.Internal, "Unable to create scope but no error returned from repository.")
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to create scope but no error returned from repository.")
 	}
 	return ToProto(out), nil
 }
@@ -210,7 +209,7 @@ func (s Service) updateInRepo(ctx context.Context, parentScope *scopes.ScopeInfo
 		iamScope, err = iam.NewProject(parentScope.GetId(), opts...)
 	}
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to build scope for update: %v.", err)
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to build scope for update: %v.", err)
 	}
 	iamScope.PublicId = scopeId
 	dbMask := maskManager.Translate(mask)
@@ -223,10 +222,10 @@ func (s Service) updateInRepo(ctx context.Context, parentScope *scopes.ScopeInfo
 	}
 	out, rowsUpdated, err := repo.UpdateScope(ctx, iamScope, version, dbMask)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to update project: %v.", err)
+		return nil, fmt.Errorf("unable to update project: %w", err)
 	}
 	if rowsUpdated == 0 {
-		return nil, handlers.NotFoundErrorf("Scope %q doesn't exist.", scopeId)
+		return nil, handlers.NotFoundErrorf("Scope %q doesn't exist or incorrect version provided.", scopeId)
 	}
 	return ToProto(out), nil
 }
@@ -238,7 +237,7 @@ func (s Service) deleteFromRepo(ctx context.Context, scopeId string) (bool, erro
 	}
 	rows, err := repo.DeleteScope(ctx, scopeId)
 	if err != nil {
-		return false, status.Errorf(codes.Internal, "Unable to delete scope: %v.", err)
+		return false, fmt.Errorf("unable to delete scope: %w", err)
 	}
 	return rows > 0, nil
 }
@@ -264,10 +263,11 @@ func (s Service) listFromRepo(ctx context.Context, scopeId string) ([]*pb.Scope,
 	case strings.HasPrefix(scopeId, scope.Org.Prefix()):
 		scps, err = repo.ListProjects(ctx, scopeId)
 	default:
-		return nil, status.Errorf(codes.InvalidArgument, "Invalid scope ID given for listing")
+		return nil, handlers.InvalidArgumentErrorf("Error in provided request.",
+			map[string]string{"scope_id": "Invalid id for listing."})
 	}
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to list scopes: %v", err)
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to list scopes: %v", err)
 	}
 
 	var outPl []*pb.Scope
@@ -357,7 +357,7 @@ func validateGetRequest(req *pbs.GetScopeRequest) error {
 		badFields["id"] = "Invalidly formatted scope id."
 	}
 	if len(badFields) > 0 {
-		return handlers.InvalidArgumentErrorf("Improperly formatted identifier.", badFields)
+		return handlers.InvalidArgumentErrorf("Error in provided request.", badFields)
 	}
 	return nil
 }
@@ -393,7 +393,7 @@ func validateCreateRequest(req *pbs.CreateScopeRequest) error {
 		badFields["version"] = "This cannot be specified at create time."
 	}
 	if len(badFields) > 0 {
-		return handlers.InvalidArgumentErrorf("Argument errors found in the request.", badFields)
+		return handlers.InvalidArgumentErrorf("Error in provided request.", badFields)
 	}
 	return nil
 }
@@ -427,7 +427,7 @@ func validateUpdateRequest(req *pbs.UpdateScopeRequest) error {
 	item := req.GetItem()
 	if item == nil {
 		if len(badFields) > 0 {
-			return handlers.InvalidArgumentErrorf("Errors in provided fields.", badFields)
+			return handlers.InvalidArgumentErrorf("Error in provided request.", badFields)
 		}
 		// It is legitimate for no item to be specified in an update request as it indicates all fields provided in
 		// the mask will be marked as unset.
@@ -446,7 +446,7 @@ func validateUpdateRequest(req *pbs.UpdateScopeRequest) error {
 		badFields["updated_time"] = "This is a read only field and cannot be specified in an update request."
 	}
 	if len(badFields) > 0 {
-		return handlers.InvalidArgumentErrorf("Errors in provided fields.", badFields)
+		return handlers.InvalidArgumentErrorf("Error in provided request.", badFields)
 	}
 
 	return nil
@@ -470,7 +470,7 @@ func validateDeleteRequest(req *pbs.DeleteScopeRequest) error {
 		badFields["id"] = "Invalidly formatted scope id."
 	}
 	if len(badFields) > 0 {
-		return handlers.InvalidArgumentErrorf("Errors in provided fields.", badFields)
+		return handlers.InvalidArgumentErrorf("Error in provided request.", badFields)
 	}
 	return nil
 }
@@ -478,7 +478,7 @@ func validateDeleteRequest(req *pbs.DeleteScopeRequest) error {
 func validateListRequest(req *pbs.ListScopesRequest) error {
 	badFields := map[string]string{}
 	if len(badFields) > 0 {
-		return handlers.InvalidArgumentErrorf("Improperly formatted identifier.", badFields)
+		return handlers.InvalidArgumentErrorf("Error in provided request.", badFields)
 	}
 	return nil
 }

--- a/internal/servers/controller/handlers/sessions/session_service.go
+++ b/internal/servers/controller/handlers/sessions/session_service.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hashicorp/boundary/internal/types/action"
 	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/boundary/internal/types/scope"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // Service handles request as described by the pbs.SessionServiceServer interface.
@@ -132,7 +130,7 @@ func (s Service) cancelInRepo(ctx context.Context, id string, version uint32) (*
 	}
 	out, err := repo.CancelSession(ctx, id, version)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to update session: %v.", err)
+		return nil, fmt.Errorf("unable to update session: %w", err)
 	}
 	return toProto(out), nil
 }

--- a/internal/servers/controller/handlers/users/user_service.go
+++ b/internal/servers/controller/handlers/users/user_service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/boundary/internal/types/scope"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -161,7 +160,7 @@ func (s Service) createInRepo(ctx context.Context, orgId string, item *pb.User) 
 	}
 	u, err := iam.NewUser(orgId, opts...)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to build user for creation: %v.", err)
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to build user for creation: %v.", err)
 	}
 	repo, err := s.repoFn()
 	if err != nil {
@@ -169,10 +168,10 @@ func (s Service) createInRepo(ctx context.Context, orgId string, item *pb.User) 
 	}
 	out, err := repo.CreateUser(ctx, u)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create user: %v.", err)
+		return nil, fmt.Errorf("unable to create user: %w", err)
 	}
 	if out == nil {
-		return nil, status.Error(codes.Internal, "Unable to create user but no error returned from repository.")
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to create user but no error returned from repository.")
 	}
 	return toProto(out), nil
 }
@@ -188,7 +187,7 @@ func (s Service) updateInRepo(ctx context.Context, orgId, id string, mask []stri
 	version := item.GetVersion()
 	u, err := iam.NewUser(orgId, opts...)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to build user for update: %v.", err)
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to build user for update: %v.", err)
 	}
 	u.PublicId = id
 	dbMask := maskManager.Translate(mask)
@@ -201,10 +200,10 @@ func (s Service) updateInRepo(ctx context.Context, orgId, id string, mask []stri
 	}
 	out, rowsUpdated, err := repo.UpdateUser(ctx, u, version, dbMask)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to update user: %v.", err)
+		return nil, fmt.Errorf("unable to update user: %w", err)
 	}
 	if rowsUpdated == 0 {
-		return nil, handlers.NotFoundErrorf("User %q doesn't exist.", id)
+		return nil, handlers.NotFoundErrorf("User %q doesn't exist or incorrect version provided.", id)
 	}
 	return toProto(out), nil
 }
@@ -219,7 +218,7 @@ func (s Service) deleteFromRepo(ctx context.Context, id string) (bool, error) {
 		if errors.Is(err, db.ErrRecordNotFound) {
 			return false, nil
 		}
-		return false, status.Errorf(codes.Internal, "Unable to delete user: %v.", err)
+		return false, fmt.Errorf("unable to delete user: %w", err)
 	}
 	return rows > 0, nil
 }


### PR DESCRIPTION
This PR removes status.Errors completely from the handlers.
Repo handlers are forwarded directly for the most part (except for the add|set|remove X repo errors since they don't follow standard behavior yet when the incorrect version is provided.
The error handler translates any errors that are not an api Error as internal except for some special cases (like uniqueness errors, db provided update mask errors, and db provided not found errors).