### PR TITLE
Add boundary config get-token

### DIFF
--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -30,7 +30,7 @@ const (
 	maxLineLength int = 78
 
 	envToken          = "BOUNDARY_TOKEN"
-	envTokenName      = "BOUNDARY_TOKEN_NAME"
+	EnvTokenName      = "BOUNDARY_TOKEN_NAME"
 	envRecoveryConfig = "BOUNDARY_RECOVERY_CONFIG"
 )
 
@@ -207,6 +207,7 @@ func (c *Command) Client(opt ...Option) (*api.Client, error) {
 		if c.FlagTokenName != "" {
 			tokenName = c.FlagTokenName
 		}
+		os.Setenv(EnvTokenName, tokenName)
 		if tokenName != "none" {
 			token, err := keyring.Get("HashiCorp Boundary Auth Token", tokenName)
 			if err != nil {
@@ -329,7 +330,7 @@ func (c *Command) FlagSet(bit FlagSetBit) *FlagSets {
 			f.StringVar(&StringVar{
 				Name:   "token-name",
 				Target: &c.FlagTokenName,
-				EnvVar: envTokenName,
+				EnvVar: EnvTokenName,
 				Usage:  `If specified, the given value will be used as the name when storing the token in the system credential store. This can allow switching user identities for different commands. Set to "none" to disable storing the token.`,
 			})
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -244,6 +244,12 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 				Func:    "decrypt",
 			}, nil
 		},
+		"config get-token": func() (cli.Command, error) {
+			return &config.TokenCommand{
+				Command: base.NewCommand(ui),
+				Func:    "get-token",
+			}, nil
+		},
 
 		"database": func() (cli.Command, error) {
 			return &database.Command{

--- a/internal/cmd/commands/config/config.go
+++ b/internal/cmd/commands/config/config.go
@@ -12,7 +12,7 @@ type Command struct {
 }
 
 func (c *Command) Synopsis() string {
-	return "Manage sensitive values in Boundary's configuration files"
+	return "Manage resources related to Boundary's local configuration"
 }
 
 func (c *Command) Help() string {
@@ -28,6 +28,10 @@ func (c *Command) Help() string {
 		"    Decrypt sensitive values in a config file:",
 		"",
 		"      $ boundary config decrypt config.hcl",
+		"",
+		"    Read a stored token out:",
+		"",
+		"      $ boundary config get-token",
 		"",
 		"  Please see the individual subcommand help for detailed usage information.",
 	})

--- a/internal/cmd/commands/config/encryptdecrypt.go
+++ b/internal/cmd/commands/config/encryptdecrypt.go
@@ -125,8 +125,6 @@ func (c *EncryptDecryptCommand) Run(args []string) (ret int) {
 		return 1
 	}
 
-	args = f.Args()
-
 	switch c.flagConfig {
 	case "":
 		c.UI.Error(`Missing required parameter -config`)

--- a/internal/cmd/commands/config/token.go
+++ b/internal/cmd/commands/config/token.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"fmt"
+	"net/textproto"
+
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+)
+
+var _ cli.Command = (*TokenCommand)(nil)
+var _ cli.CommandAutocomplete = (*TokenCommand)(nil)
+
+type TokenCommand struct {
+	*base.Command
+
+	Func string
+}
+
+func (c *TokenCommand) Synopsis() string {
+	return fmt.Sprintf("%s sensitive values in Boundary's configuration file", textproto.CanonicalMIMEHeaderKey(c.Func))
+}
+
+func (c *TokenCommand) Help() string {
+	var args []string
+	switch c.Func {
+	case "get-token":
+		args = append(args,
+			"Usage: boundary config get-token [options] [args]",
+			"",
+			"  Fetch a token stored by the Boundary CLI. Example:",
+			"",
+			`    $ boundary config get-token`,
+			"",
+			"  This can be useful in various situations. For example, a line such as the following could be in a shell script shared by developers, such that each developer on their own machine executing the script ends up using their own Boundary token:",
+			"",
+			`    $ curl -H "Authorization: Bearer $(boundary config get-token)" -H "Content-Type: application/json" http://127.0.0.1:9200/v1/roles/r_1234567890`,
+			"",
+			"  Note that this command keeps parity with the behavior of other Boundary commands; if the BOUNDARY_TOKEN environment variable it set, it will override the value loaded from the system store. Not only does this keep parity, but it also allows examples such as the one above to work even if there is no stored token but if an environment variable is specified.",
+			"",
+		)
+	}
+
+	return base.WrapForHelpText(args) + c.Flags().Help()
+}
+
+func (c *TokenCommand) Flags() *base.FlagSets {
+	set := c.FlagSet(base.FlagSetNone)
+
+	f := set.NewFlagSet("Command Options")
+
+	f.StringVar(&base.StringVar{
+		Name:   "token-name",
+		Target: &c.FlagTokenName,
+		EnvVar: base.EnvTokenName,
+		Usage:  `If specified, the given value will be used as the name when loading the token from the system credential store. This must correspond to a name used when authenticating.`,
+	})
+
+	return set
+}
+
+func (c *TokenCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictAnything
+}
+
+func (c *TokenCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *TokenCommand) Run(args []string) (ret int) {
+	f := c.Flags()
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.UI.Output(client.Token())
+
+	return 0
+}


### PR DESCRIPTION
This means that you get immediately executable curl output:

```
$ boundary hosts read -output-curl-string -id hst_1234567890 -token-name foobar
curl -H "Authorization: Bearer $(boundary config get-token -token-name foobar)" -H "Content-Type: application/json" http://127.0.0.1:9200/v1/hosts/hst_1234567890
```