### PR TITLE
Temp: docs link in the nav to getting-started

### DIFF
--- a/website/data/navigation.js
+++ b/website/data/navigation.js
@@ -1,7 +1,7 @@
 export default [
   {
     text: 'Docs',
-    url: '/docs',
+    url: '/docs/getting-started',
     type: 'inbound',
   },
 ]


### PR DESCRIPTION
We don't have a great docs index page right now, and we want to direct
everyone in the beta to the getting started page.

We'll revert this prior to going public.