### PR TITLE
Updates link to base releases directory

### DIFF
--- a/website/components/subnav/index.jsx
+++ b/website/components/subnav/index.jsx
@@ -19,7 +19,7 @@ export default function ProductSubnav() {
         },
         {
           text: 'Download',
-          url: 'https://github.com/hashicorp/boundary/releases/tag/beta',
+          url: 'https://github.com/hashicorp/boundary/releases',
         },
       ]}
       currentPath={router.pathname}

--- a/website/pages/home/index.jsx
+++ b/website/pages/home/index.jsx
@@ -9,7 +9,7 @@ export default function HomePage() {
         links={[
           {
             text: 'Download',
-            url: 'https://github.com/hashicorp/boundary/releases/tag/beta',
+            url: 'https://github.com/hashicorp/boundary/releases',
             type: 'download',
           },
           {


### PR DESCRIPTION
We figured out that pointing to the beta releases wouldn't be scalable for when we cut new releases, so just pointing to this base directory here.