### PR TITLE
[Docs only] default login instructions

### DIFF
--- a/website/content/docs/getting-started/run-and-login.mdx
+++ b/website/content/docs/getting-started/run-and-login.mdx
@@ -16,8 +16,7 @@ $ boundary dev
 
 ## Login to Boundary
 
-Boundary uses a predictable login name (`admin`) and password (`password`) in
-dev mode. These can be overridden, or randomly generated, with flags to
+Boundary uses a randomly generated login name and password for the default account which can be found in the output of `boundary dev`. These login name and password values can be overridden with the flags to
 `boundary dev`.
 
 From the CLI:


### PR DESCRIPTION
changing login instructions for default account to note that login and password are randomly generated and can be found in the output of boundary dev.