### PR TITLE
Environment variable support for DB connection string

### DIFF
--- a/website/content/docs/configuration/controller.mdx
+++ b/website/content/docs/configuration/controller.mdx
@@ -3,7 +3,7 @@ layout: docs
 page_title: Controller - Configuration
 sidebar_title: controller
 description: |-
-  The controller stanza configures controller-specifc parameters.
+  The controller stanza configures controller-specific parameters.
 ---
 
 # `controller` Stanza


### PR DESCRIPTION
This is a small PR to add support for setting the database connection string via environment variable.  I picked up the fact that we currently can't do this when beta testing and i'm confident many would want this ability in the product.  I've also updated the website to reflect this change.  As it's such a small change, I haven't written any tests but let me know if you need me to.