### PR TITLE
feat: make CLI error handling more clear

### DIFF
--- a/api/apierror.go
+++ b/api/apierror.go
@@ -28,27 +28,24 @@ func AsServerError(in error) *Error {
 
 // Error satisfies the error interface.
 func (e *Error) Error() string {
-	res := fmt.Sprintf("Status: %d, Code: %q, Error: %q", e.Status, e.Code, e.Message)
-	var dets []string
+	msg := []string{fmt.Sprintf("%s\n", e.Message), fmt.Sprintf("  %d, %s\n\n", e.Status, e.Code)}
+
 	if e.Details != nil {
 		if e.Details.ErrorId != "" {
-			dets = append(dets, fmt.Sprintf("error_id: %q", e.Details.ErrorId))
+			msg = append(msg, fmt.Sprintf("  Error ID: %s\n", e.Details.ErrorId))
 		}
 		if e.Details.RequestId != "" {
-			dets = append(dets, fmt.Sprintf("request_id: %q", e.Details.RequestId))
+			msg = append(msg, fmt.Sprintf("  Request ID: %s\n", e.Details.RequestId))
 		}
 		if e.Details.TraceId != "" {
-			dets = append(dets, fmt.Sprintf("TraceId: %q", e.Details.TraceId))
+			msg = append(msg, fmt.Sprintf("  Trace ID: %s\n", e.Details.TraceId))
 		}
 		for _, rf := range e.Details.RequestFields {
-			dets = append(dets, fmt.Sprintf("request_field: {name: %q, desc: %q}", rf.Name, rf.Description))
+			msg = append(msg, fmt.Sprintf("  '-%s': %s\n", strings.ReplaceAll(rf.Name, "_", "-"), rf.Description))
 		}
 	}
-	if len(dets) > 0 {
-		det := strings.Join(dets, ", ")
-		res = fmt.Sprintf("%s, Details: {%s}", res, det)
-	}
-	return res
+
+	return strings.Join(msg, "")
 }
 
 // Errors are considered the same iff they are both api.Errors and their statuses are the same.


### PR DESCRIPTION
This PR refactors how we print CLI output:

- Removes unnecessary characters in the output including quotes from "%q" usage.
- Prints the error message clearly at the top, and indents additional details on new lines

Needs more scrutiny: 
- Parses request fields and reconstructs flag names to give more clear communication about what flag was broken 

I ran through several scenarios and couldn't break the "flag-ifying" of the request field names. Below are a couple of examples of the new output:

<img width="655" alt="Screen Shot 2020-10-05 at 8 04 51 PM" src="https://user-images.githubusercontent.com/4028224/95154868-ad824400-0747-11eb-8273-bfeed8e899e5.png">
<img width="1092" alt="Screen Shot 2020-10-05 at 8 10 29 PM" src="https://user-images.githubusercontent.com/4028224/95154875-ae1ada80-0747-11eb-9e0f-7dc708547992.png">
<img width="628" alt="Screen Shot 2020-10-05 at 8 09 33 PM" src="https://user-images.githubusercontent.com/4028224/95154876-aeb37100-0747-11eb-9880-6e74a12e15ca.png">


