### PR TITLE
Simplify worker->controller connection

### DIFF
--- a/internal/cmd/base/listener.go
+++ b/internal/cmd/base/listener.go
@@ -32,7 +32,6 @@ type ServerListener struct {
 }
 
 type WorkerAuthInfo struct {
-	CACertPEM       []byte `json:"ca_cert"`
 	CertPEM         []byte `json:"cert"`
 	KeyPEM          []byte `json:"key"`
 	Name            string `json:"name"`

--- a/internal/servers/controller/worker_tls_config.go
+++ b/internal/servers/controller/worker_tls_config.go
@@ -70,7 +70,7 @@ func (c Controller) v1WorkerAuthConfig(protos []string) (*tls.Config, *base.Work
 	}
 
 	rootCAs := x509.NewCertPool()
-	if ok := rootCAs.AppendCertsFromPEM(info.CACertPEM); !ok {
+	if ok := rootCAs.AppendCertsFromPEM(info.CertPEM); !ok {
 		return nil, info, errors.New("unable to add ca cert to cert pool")
 	}
 	tlsCert, err := tls.X509KeyPair(info.CertPEM, info.KeyPEM)


### PR DESCRIPTION
Go's TLS stack doesn't need a separate CA cert and in fact for sessions
we don't use this. So simplify the worker connection to remove an
unnecessary extra key generation.