### PR TITLE
Remove proxy proto documentation for now

### DIFF
--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -57,24 +57,18 @@ kms "aead" {
 listener "tcp" {
 	purpose = "api"
 	tls_disable = true
-	proxy_protocol_behavior = "allow_authorized"
-	proxy_protocol_authorized_addrs = "127.0.0.1"
 	cors_enabled = true
 	cors_allowed_origins = ["*"]
 }
 
 listener "tcp" {
 	purpose = "cluster"
-	proxy_protocol_behavior = "allow_authorized"
-	proxy_protocol_authorized_addrs = "127.0.0.1"
 }
 `
 
 	devWorkerExtraConfig = `
 listener "tcp" {
 	purpose = "proxy"
-	proxy_protocol_behavior = "allow_authorized"
-	proxy_protocol_authorized_addrs = "127.0.0.1"
 }
 
 worker {

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-sockaddr"
 	"github.com/hashicorp/shared-secure-libs/configutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,33 +14,20 @@ func TestDevController(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	addr, err := sockaddr.NewIPAddr("127.0.0.1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	exp := &Config{
 		SharedConfig: &configutil.SharedConfig{
 			DisableMlock: true,
 			Listeners: []*configutil.Listener{
 				{
-					Type:                  "tcp",
-					Purpose:               []string{"api"},
-					TLSDisable:            true,
-					ProxyProtocolBehavior: "allow_authorized",
-					ProxyProtocolAuthorizedAddrs: []*sockaddr.SockAddrMarshaler{
-						{SockAddr: addr},
-					},
+					Type:               "tcp",
+					Purpose:            []string{"api"},
+					TLSDisable:         true,
 					CorsEnabled:        true,
 					CorsAllowedOrigins: []string{"*"},
 				},
 				{
-					Type:                  "tcp",
-					Purpose:               []string{"cluster"},
-					ProxyProtocolBehavior: "allow_authorized",
-					ProxyProtocolAuthorizedAddrs: []*sockaddr.SockAddrMarshaler{
-						{SockAddr: addr},
-					},
+					Type:    "tcp",
+					Purpose: []string{"cluster"},
 				},
 			},
 			Seals: []*configutil.KMS{
@@ -102,22 +88,13 @@ func TestDevWorker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	addr, err := sockaddr.NewIPAddr("127.0.0.1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	exp := &Config{
 		SharedConfig: &configutil.SharedConfig{
 			DisableMlock: true,
 			Listeners: []*configutil.Listener{
 				{
-					Type:                  "tcp",
-					Purpose:               []string{"proxy"},
-					ProxyProtocolBehavior: "allow_authorized",
-					ProxyProtocolAuthorizedAddrs: []*sockaddr.SockAddrMarshaler{
-						{SockAddr: addr},
-					},
+					Type:    "tcp",
+					Purpose: []string{"proxy"},
 				},
 			},
 			Telemetry: &configutil.Telemetry{

--- a/website/content/docs/configuration/controller.mdx
+++ b/website/content/docs/configuration/controller.mdx
@@ -61,8 +61,6 @@ listener "tcp" {
   purpose = "api"
 
   tls_disable = false
-  proxy_protocol_behavior = "allow_authorized"
-  proxy_protocol_authorized_addrs = "127.0.0.1"
 
   # Enable CORS for the Admin UI
   cors_enabled = true
@@ -77,8 +75,6 @@ listener "tcp" {
   purpose = "cluster"
 
   tls_disable = false
-  proxy_protocol_behavior = "allow_authorized"
-  proxy_protocol_authorized_addrs = "127.0.0.1"
 }
 
 # Root KMS configuration block: this is the root key for Boundary

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -61,23 +61,6 @@ advertise the correct address to other nodes.
   request duration allowed before Boundary cancels the request. This overrides
   `default_max_request_duration` for this listener.
 
-- `proxy_protocol_behavior` `(string: "")` – When specified, enables a PROXY
-  protocol version 1 behavior for the listener.
-  Accepted Values:
-
-  - _use_always_ - The client's IP address will always be used.
-  - _allow_authorized_ - If the source IP address is in the
-    `proxy_protocol_authorized_addrs` list, the client's IP address will be used.
-    If the source IP is not in the list, the source IP address will be used.
-  - _deny_unauthorized_ - The traffic will be rejected if the source IP
-    address is not in the `proxy_protocol_authorized_addrs` list.
-
-- `proxy_protocol_authorized_addrs` `(string: <required-if-enabled> or array: <required-if-enabled> )` –
-  Specifies the list of allowed source IP addresses to be used with the PROXY protocol.
-  Not required if `proxy_protocol_behavior` is set to `use_always`. Source IPs should
-  be comma-delimited if provided as a string. At least one source IP must be provided,
-  `proxy_protocol_authorized_addrs` cannot be an empty array or string.
-
 - `tls_disable` `(string: "false")` – Specifies if TLS will be disabled. Boundary
   assumes TLS by default, so you must explicitly disable TLS to opt-in to
   insecure communication.

--- a/website/content/docs/getting-started/installing/production.mdx
+++ b/website/content/docs/getting-started/installing/production.mdx
@@ -73,10 +73,6 @@ listener "tcp" {
 	purpose = "api"
   # Should be enabled for production installs
 	tls_disable = true
-  # TODO
-	# proxy_protocol_behavior = "allow_authorized"
-  # TODO
-	# proxy_protocol_authorized_addrs = "127.0.0.1"
   # Enable CORS for the Admin UI
 	cors_enabled = true
 	cors_allowed_origins = ["*"]
@@ -90,10 +86,6 @@ listener "tcp" {
 	purpose = "cluster"
   # Should be enabled for production installs
 	tls_disable = true
-  # TODO
-	# proxy_protocol_behavior = "allow_authorized"
-  # TODO
-	# proxy_protocol_authorized_addrs = "127.0.0.1"
 }
 
 # Root KMS configuration block: this is the root key for Boundary
@@ -139,8 +131,6 @@ database {
 listener "tcp" {
 	purpose = "proxy"
 	tls_disable = true
-	#proxy_protocol_behavior = "allow_authorized"
-	#proxy_protocol_authorized_addrs = "127.0.0.1"
 }
 
 worker {


### PR DESCRIPTION
We haven't tested it with the new lib yet. We can add this back whenever
we get to testing it.