### PR TITLE
Separate out protocol-specific functions

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -11,13 +11,13 @@ import (
 	"github.com/hashicorp/boundary/internal/cmd/commands/authmethods"
 	"github.com/hashicorp/boundary/internal/cmd/commands/authtokens"
 	"github.com/hashicorp/boundary/internal/cmd/commands/config"
+	"github.com/hashicorp/boundary/internal/cmd/commands/connect"
 	"github.com/hashicorp/boundary/internal/cmd/commands/database"
 	"github.com/hashicorp/boundary/internal/cmd/commands/dev"
 	"github.com/hashicorp/boundary/internal/cmd/commands/groups"
 	"github.com/hashicorp/boundary/internal/cmd/commands/hostcatalogs"
 	"github.com/hashicorp/boundary/internal/cmd/commands/hosts"
 	"github.com/hashicorp/boundary/internal/cmd/commands/hostsets"
-	"github.com/hashicorp/boundary/internal/cmd/commands/proxy"
 	"github.com/hashicorp/boundary/internal/cmd/commands/roles"
 	"github.com/hashicorp/boundary/internal/cmd/commands/scopes"
 	"github.com/hashicorp/boundary/internal/cmd/commands/server"
@@ -57,37 +57,6 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 		"version": func() (cli.Command, error) {
 			return &version.Command{
 				Command: base.NewCommand(ui),
-			}, nil
-		},
-
-		"connect": func() (cli.Command, error) {
-			return &proxy.Command{
-				Command: base.NewCommand(ui),
-				Func:    "connect",
-			}, nil
-		},
-		"connect http": func() (cli.Command, error) {
-			return &proxy.Command{
-				Command: base.NewCommand(ui),
-				Func:    "http",
-			}, nil
-		},
-		"connect ssh": func() (cli.Command, error) {
-			return &proxy.Command{
-				Command: base.NewCommand(ui),
-				Func:    "ssh",
-			}, nil
-		},
-		"connect rdp": func() (cli.Command, error) {
-			return &proxy.Command{
-				Command: base.NewCommand(ui),
-				Func:    "rdp",
-			}, nil
-		},
-		"connect postgres": func() (cli.Command, error) {
-			return &proxy.Command{
-				Command: base.NewCommand(ui),
-				Func:    "postgres",
 			}, nil
 		},
 
@@ -273,6 +242,37 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 			return &config.AutocompleteCommand{
 				Command: base.NewCommand(ui),
 				Func:    "uninstall",
+			}, nil
+		},
+
+		"connect": func() (cli.Command, error) {
+			return &connect.Command{
+				Command: base.NewCommand(ui),
+				Func:    "connect",
+			}, nil
+		},
+		"connect http": func() (cli.Command, error) {
+			return &connect.Command{
+				Command: base.NewCommand(ui),
+				Func:    "http",
+			}, nil
+		},
+		"connect ssh": func() (cli.Command, error) {
+			return &connect.Command{
+				Command: base.NewCommand(ui),
+				Func:    "ssh",
+			}, nil
+		},
+		"connect rdp": func() (cli.Command, error) {
+			return &connect.Command{
+				Command: base.NewCommand(ui),
+				Func:    "rdp",
+			}, nil
+		},
+		"connect postgres": func() (cli.Command, error) {
+			return &connect.Command{
+				Command: base.NewCommand(ui),
+				Func:    "postgres",
 			}, nil
 		},
 

--- a/internal/cmd/commands/connect/funcs.go
+++ b/internal/cmd/commands/connect/funcs.go
@@ -1,4 +1,4 @@
-package proxy
+package connect
 
 import (
 	"time"

--- a/internal/cmd/commands/connect/http.go
+++ b/internal/cmd/commands/connect/http.go
@@ -1,0 +1,95 @@
+package connect
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/posener/complete"
+)
+
+const (
+	httpSynopsis = "Authorize a session against a target and invoke an HTTP client to connect"
+)
+
+func httpOptions(c *Command, set *base.FlagSets) {
+	f := set.NewFlagSet("HTTP Options")
+
+	f.StringVar(&base.StringVar{
+		Name:       "style",
+		Target:     &c.flagHttpStyle,
+		EnvVar:     "BOUNDARY_CONNECT_HTTP_STYLE",
+		Completion: complete.PredictSet("curl"),
+		Default:    "curl",
+		Usage:      `Specifies how the CLI will attempt to invoke an HTTP client. This will also set a suitable default for -exec if a value was not specified. Currently-understood values are "curl".`,
+	})
+
+	f.StringVar(&base.StringVar{
+		Name:       "host",
+		Target:     &c.flagHttpHost,
+		EnvVar:     "BOUNDARY_CONNECT_HTTP_HOST",
+		Completion: complete.PredictNothing,
+		Usage:      `Specifies the host value to use. The specified hostname will be passed through to the client (if supported) for use in the Host header and TLS SNI value.`,
+	})
+
+	f.StringVar(&base.StringVar{
+		Name:       "path",
+		Target:     &c.flagHttpPath,
+		EnvVar:     "BOUNDARY_CONNECT_HTTP_PATH",
+		Completion: complete.PredictNothing,
+		Usage:      `Specifies a path that will be appended to the generated URL.`,
+	})
+
+	f.StringVar(&base.StringVar{
+		Name:       "method",
+		Target:     &c.flagHttpMethod,
+		EnvVar:     "BOUNDARY_CONNECT_HTTP_METHOD",
+		Completion: complete.PredictNothing,
+		Usage:      `Specifies the method to use. If not set, will use the client's default.`,
+	})
+
+	f.StringVar(&base.StringVar{
+		Name:       "scheme",
+		Target:     &c.flagHttpScheme,
+		Default:    "https",
+		EnvVar:     "BOUNDARY_CONNECT_HTTP_SCHEME",
+		Completion: complete.PredictNothing,
+		Usage:      `Specifies the scheme to use.`,
+	})
+}
+
+type httpFlags struct {
+	flagHttpStyle  string
+	flagHttpHost   string
+	flagHttpPath   string
+	flagHttpMethod string
+	flagHttpScheme string
+}
+
+func (h *httpFlags) defaultExec() string {
+	return strings.ToLower(h.flagHttpStyle)
+}
+
+func (h *httpFlags) buildArgs(c *Command, port, ip, addr string) []string {
+	var args []string
+	switch h.flagHttpStyle {
+	case "curl":
+		if h.flagHttpMethod != "" {
+			args = append(args, "-X", h.flagHttpMethod)
+		}
+		var uri string
+		if h.flagHttpHost != "" {
+			h.flagHttpHost = strings.TrimSuffix(h.flagHttpHost, "/")
+			args = append(args, "-H", fmt.Sprintf("Host: %s", h.flagHttpHost))
+			args = append(args, "--resolve", fmt.Sprintf("%s:%s:%s", h.flagHttpHost, port, ip))
+			uri = fmt.Sprintf("%s://%s:%s", h.flagHttpScheme, h.flagHttpHost, port)
+		} else {
+			uri = fmt.Sprintf("%s://%s", h.flagHttpScheme, addr)
+		}
+		if h.flagHttpPath != "" {
+			uri = fmt.Sprintf("%s/%s", uri, strings.TrimPrefix(h.flagHttpPath, "/"))
+		}
+		args = append(args, uri)
+	}
+	return args
+}

--- a/internal/cmd/commands/connect/postgres.go
+++ b/internal/cmd/commands/connect/postgres.go
@@ -1,0 +1,53 @@
+package connect
+
+import (
+	"strings"
+
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/posener/complete"
+)
+
+const (
+	postgresSynopsis = "Authorize a session against a target and invoke a Postgres client to connect"
+)
+
+func postgresOptions(c *Command, set *base.FlagSets) {
+	f := set.NewFlagSet("Postgres Options")
+
+	f.StringVar(&base.StringVar{
+		Name:       "style",
+		Target:     &c.flagPostgresStyle,
+		EnvVar:     "BOUNDARY_CONNECT_POSTGRES_STYLE",
+		Completion: complete.PredictSet("psql"),
+		Default:    "psql",
+		Usage:      `Specifies how the CLI will attempt to invoke a Postgres client. This will also set a suitable default for -exec if a value was not specified. Currently-understood values are "psql".`,
+	})
+
+	f.StringVar(&base.StringVar{
+		Name:       "username",
+		Target:     &c.flagUsername,
+		EnvVar:     "BOUNDARY_CONNECT_USERNAME",
+		Completion: complete.PredictNothing,
+		Usage:      `Specifies the username to pass through to the client`,
+	})
+}
+
+type postgresFlags struct {
+	flagPostgresStyle string
+}
+
+func (p *postgresFlags) defaultExec() string {
+	return strings.ToLower(p.flagPostgresStyle)
+}
+
+func (p *postgresFlags) buildArgs(c *Command, port, ip, addr string) []string {
+	var args []string
+	switch p.flagPostgresStyle {
+	case "psql":
+		args = append(args, "-p", port, "-h", ip)
+		if c.flagUsername != "" {
+			args = append(args, "-U", c.flagUsername)
+		}
+	}
+	return args
+}

--- a/internal/cmd/commands/connect/rdp.go
+++ b/internal/cmd/commands/connect/rdp.go
@@ -1,0 +1,61 @@
+package connect
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/posener/complete"
+)
+
+const (
+	rdpSynopsis = "Authorize a session against a target and invoke an RDP client to connect"
+)
+
+func rdpOptions(c *Command, set *base.FlagSets) {
+	f := set.NewFlagSet("RDP Options")
+
+	f.StringVar(&base.StringVar{
+		Name:       "style",
+		Target:     &c.flagRdpStyle,
+		EnvVar:     "BOUNDARY_CONNECT_RDP_STYLE",
+		Completion: complete.PredictSet("mstsc", "open"),
+		Usage:      `Specifies how the CLI will attempt to invoke an RDP client. This will also set a suitable default for -exec if a value was not specified. Currently-understood values are "mstsc", which is the default on Windows and launches the Windows client, and "open", which is the default on Mac and launches via an rdp:// URL.`,
+	})
+}
+
+type rdpFlags struct {
+	flagRdpStyle string
+}
+
+func (r *rdpFlags) defaultExec() string {
+	r.flagRdpStyle = strings.ToLower(r.flagRdpStyle)
+	switch r.flagRdpStyle {
+	case "":
+		switch runtime.GOOS {
+		case "windows":
+			r.flagRdpStyle = "mstsc"
+		case "darwin":
+			r.flagRdpStyle = "open"
+		default:
+			// We may want to support rdesktop and/or xfreerdp at some point soon
+			r.flagRdpStyle = "mstsc"
+		}
+	}
+	if r.flagRdpStyle == "mstsc" {
+		r.flagRdpStyle = "mstsc.exe"
+	}
+	return r.flagRdpStyle
+}
+
+func (r *rdpFlags) buildArgs(c *Command, port, ip, addr string) []string {
+	var args []string
+	switch r.flagRdpStyle {
+	case "mstsc.exe":
+		args = append(args, "/v", addr)
+	case "open":
+		args = append(args, "-n", "-W", fmt.Sprintf("rdp://full%saddress=s:%s", "%20", addr))
+	}
+	return args
+}

--- a/internal/cmd/commands/connect/ssh.go
+++ b/internal/cmd/commands/connect/ssh.go
@@ -1,0 +1,58 @@
+package connect
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/posener/complete"
+)
+
+const (
+	sshSynopsis = "Authorize a session against a target and invoke an SSH client to connect"
+)
+
+func sshOptions(c *Command, set *base.FlagSets) {
+	f := set.NewFlagSet("SSH Options")
+
+	f.StringVar(&base.StringVar{
+		Name:       "style",
+		Target:     &c.flagSshStyle,
+		EnvVar:     "BOUNDARY_CONNECT_SSH_STYLE",
+		Completion: complete.PredictSet("ssh", "putty"),
+		Default:    "ssh",
+		Usage:      `Specifies how the CLI will attempt to invoke an SSH client. This will also set a suitable default for -exec if a value was not specified. Currently-understood values are "ssh" and "putty".`,
+	})
+
+	f.StringVar(&base.StringVar{
+		Name:       "username",
+		Target:     &c.flagUsername,
+		EnvVar:     "BOUNDARY_CONNECT_USERNAME",
+		Completion: complete.PredictNothing,
+		Usage:      `Specifies the username to pass through to the client`,
+	})
+}
+
+type sshFlags struct {
+	flagSshStyle string
+}
+
+func (s *sshFlags) defaultExec() string {
+	return strings.ToLower(s.flagSshStyle)
+}
+
+func (s *sshFlags) buildArgs(c *Command, port, ip, addr string) []string {
+	// Might want -t for ssh or -tt but seems fine without it for now...
+	var args []string
+	switch s.flagSshStyle {
+	case "ssh":
+		args = append(args, "-p", port, ip)
+		args = append(args, "-o", fmt.Sprintf("HostKeyAlias=%s", c.sessionAuthzData.HostId))
+	case "putty":
+		args = append(args, "-P", port, ip)
+	}
+	if c.flagUsername != "" {
+		args = append(args, "-l", c.flagUsername)
+	}
+	return args
+}


### PR DESCRIPTION
Placing them into separate files slims down the main connect file and
makes it more obvious where things need to be handled for future
integrations.