### PR TITLE
tests: add bats tests for CLI-based workflows

### DIFF
--- a/internal/tests/cli/README.md
+++ b/internal/tests/cli/README.md
@@ -1,0 +1,36 @@
+# Boundary CLI Tests
+
+This directory contains [bats tests](https://github.com/bats-core/bats-core) for testing the Boundary CLI against arbitrary Boundary deployments. 
+The tests are meant to mimic common workflows such as creating resources, and connecting to targets. Currently, the tests rely heavily on
+generated resources when running Boundary in `dev` mode. In the future, we hope to remove this dependency and generate all resources through
+the Boundary CLI from the outset. 
+
+The tests are designed to be idempotent.
+
+## Getting Started
+
+#### Dependencies
+
+- [jq](https://stedolan.github.io/jq/)
+- [bats](https://github.com/bats-core/bats-core)
+- [boundary](https://github.com/hashicorp/boundary)
+
+#### Running Tests
+
+1. Start boundary in dev mode
+
+```bash
+boundary dev
+```
+
+or direct the tests towards an existing install by setting
+
+```bash
+export BOUNDARY_ADDR=<your_install>
+```
+
+2. Run the tests
+
+```bash
+bats -p boundary/
+```

--- a/internal/tests/cli/boundary/_accounts.bash
+++ b/internal/tests/cli/boundary/_accounts.bash
@@ -1,0 +1,20 @@
+function create_account() {
+  boundary accounts create password -login-name $1 -password $DEFAULT_PASSWORD -auth-method-id $DEFAULT_AMPW
+}
+
+function read_account() {
+  boundary accounts read -id $1
+}
+
+function delete_account() {
+  boundary accounts delete -id $1
+}
+
+function list_accounts() {
+  boundary accounts list -auth-method-id $DEFAULT_AMPW -format json
+}
+
+function account_id() {
+  local acct=$1
+  strip $(list_accounts | jq -c ".[] | select(.attributes.login_name | contains(\"$acct\")) | .[\"id\"]")
+}

--- a/internal/tests/cli/boundary/_auth.bash
+++ b/internal/tests/cli/boundary/_auth.bash
@@ -1,0 +1,3 @@
+function login() {
+  boundary authenticate password -auth-method-id $DEFAULT_AMPW -login-name $1 -password $DEFAULT_PASSWORD
+}

--- a/internal/tests/cli/boundary/_connect.bash
+++ b/internal/tests/cli/boundary/_connect.bash
@@ -1,0 +1,4 @@
+function connect_nc() {
+  local id=$1
+  echo "foo" | boundary connect -exec nc -target-id $id -- {{boundary.ip}} {{boundary.port}}
+}

--- a/internal/tests/cli/boundary/_helpers.bash
+++ b/internal/tests/cli/boundary/_helpers.bash
@@ -1,0 +1,12 @@
+export BOUNDARY_ADDR='http://127.0.0.1:9200'
+export DEFAULT_PASSWORD='password'
+export DEFAULT_USER='admin'
+export DEFAULT_AMPW='ampw_1234567890'
+export DEFAULT_P_ID='p_1234567890'
+export DEFAULT_O_ID='o_1234567890'
+export DEFAULT_TARGET='ttcp_1234567890'
+export DEFAULT_HOST_SET='hsst_1234567890'
+
+function strip() {
+  echo "$1" | tr -d '"'
+}

--- a/internal/tests/cli/boundary/_hosts.bash
+++ b/internal/tests/cli/boundary/_hosts.bash
@@ -1,0 +1,24 @@
+
+function create_host() {
+  local name=$1
+  local addr=$2
+  boundary hosts create static -name $name -address $addr
+}
+
+function read_host() {
+  boundary hosts read -id $1
+}
+
+function delete_host() {
+  boundary hosts delete -id $1
+}
+
+function list_hosts() {
+  boundary hosts list -scope-id $1 -format json
+}
+
+function host_id() {
+  local sid=$1
+  local name=$2
+  strip $(list_hosts $sid | jq -c ".[] | select(.name | contains(\"$name\")) | .[\"id\"]")
+}

--- a/internal/tests/cli/boundary/_targets.bash
+++ b/internal/tests/cli/boundary/_targets.bash
@@ -1,0 +1,36 @@
+export TGT_NAME='test'
+
+function create_tcp_target() {
+  local sid=$1
+  local port=$2
+  local name=$3
+  boundary targets create tcp \
+    -default-port $port \
+    -name $name \
+    -scope-id $sid \
+    -format json
+}
+
+function read_target() {
+  boundary targets read -id $1
+}
+
+function delete_target() {
+  boundary targets delete -id $1
+}
+
+function list_targets() {
+  boundary targets list -scope-id $1 -format json
+}
+
+function assoc_host_sets() {
+  local id=$1
+  local hst=$2
+  boundary targets add-host-sets -id $id -host-set $hst
+}
+
+function target_id() {
+  local sid=$1
+  local name=$2
+  strip $(list_targets $sid | jq -c ".[] | select(.name | contains(\"$name\")) | .[\"id\"]")
+}

--- a/internal/tests/cli/boundary/_users.bash
+++ b/internal/tests/cli/boundary/_users.bash
@@ -1,0 +1,24 @@
+function create_user() {
+  boundary users create -scope-id global -name $1 -description 'test user'
+}
+
+function read_user() {
+  boundary users read -id $1
+}
+
+function delete_user() {
+  boundary users delete -id $1
+}
+
+function list_users() {
+  boundary users list -format json
+}
+
+function assoc_user_acct() {
+  boundary users add-accounts -account $1 -id $2
+}
+
+function user_id() {
+  local user=$1
+  strip $(list_users | jq -c ".[] | select(.name | contains(\"$user\")) | .[\"id\"]")
+}

--- a/internal/tests/cli/boundary/target.bats
+++ b/internal/tests/cli/boundary/target.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+load _auth
+load _connect
+load _targets
+load _helpers
+
+
+@test "boundary/login: can login as default user" {
+  run login $DEFAULT_USER
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: default user can create target" {
+  run create_tcp_target $DEFAULT_P_ID 22 $TGT_NAME
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: default user can not create already created target" {
+  run create_tcp_target $DEFAULT_P_ID 22 $TGT_NAME
+  [ "$status" -eq 1 ]
+}
+
+@test "boundary/target: default user can read created target" {
+  local id=$(target_id $DEFAULT_P_ID $TGT_NAME)
+  run read_target $id
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: default user can add default host set to created target" {
+  local id=$(target_id $DEFAULT_P_ID $TGT_NAME)
+  run assoc_host_sets $id $DEFAULT_HOST_SET  
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: default user can connect to created target" {
+  local id=$(target_id $DEFAULT_P_ID $TGT_NAME)
+  run connect_nc $id
+  echo "connecting to $id: $output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: default user can delete target" {
+  local id=$(target_id $DEFAULT_P_ID $TGT_NAME)
+  run delete_target $id
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: default user can not read deleted target" {
+  local id=$(target_id $DEFAULT_P_ID $TGT_NAME) 
+  run read_target $id
+  [ "$status" -eq 1 ]
+}

--- a/internal/tests/cli/boundary/user.bats
+++ b/internal/tests/cli/boundary/user.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+
+load _accounts
+load _auth
+load _users
+load _helpers
+
+export NEW_USER='test'
+
+@test "boundary/login: can login as default user" {
+  run login $DEFAULT_USER
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/users: can add $NEW_USER user" {
+	run create_user $NEW_USER
+	[ "$status" -eq 0 ]
+}
+
+@test "boundary/users: can not add already created $NEW_USER user" {
+	run create_user $NEW_USER
+	[ "$status" -eq 1 ]
+}
+
+@test "boundary/users: can read $NEW_USER user" {
+  local uid=$(user_id $NEW_USER)
+	run read_user $uid
+	[ "$status" -eq 0 ]
+}
+
+@test "boundary/account/password: can add $NEW_USER account" {
+	run create_account $NEW_USER
+	[ "$status" -eq 0 ]
+}
+
+@test "boundary/account/password: can not add already created $NEW_USER account" {
+	run create_account $NEW_USER
+	[ "$status" -eq 1 ]
+}
+
+@test "boundary/account/password: can read created $NEW_USER account" {
+  local aid=$(account_id $NEW_USER)
+	run read_account $aid
+	[ "$status" -eq 0 ]
+}
+
+@test "boundary/user/account-add: can associate $NEW_USER account with $NEW_USER user" {	
+  local uid=$(user_id $NEW_USER)
+  local aid=$(account_id $NEW_USER)
+  run assoc_user_acct $aid $uid
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/login: can login as $NEW_USER user" {
+  run login $NEW_USER
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/user: can delete $NEW_USER user" {
+  login $DEFAULT_USER
+  local uid=$(user_id $NEW_USER)
+  run delete_user $uid 
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/user: can not delete already deleted $NEW_USER user" {
+  login $DEFAULT_USER
+  local uid=$(user_id $NEW_USER)
+  run delete_user $uid 
+  [ "$status" -eq 1 ]
+}
+
+@test "boundary/users: can not read deleted $NEW_USER user" {
+  local uid=$(user_id $NEW_USER)
+	run read_user $uid
+	[ "$status" -eq 1 ]
+}
+
+@test "boundary/account/password: can delete $NEW_USER account" {
+  local aid=$(account_id $NEW_USER)
+  run delete_account $aid 
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/account/password: can not delete already deleted $NEW_USER account" {
+  local aid=$(account_id $NEW_USER)
+  run delete_account $aid 
+  [ "$status" -eq 1 ]
+}
+
+@test "boundary/account/password: can not read deleted $NEW_USER account" {
+  local aid=$(account_id $NEW_USER)
+	run read_account $aid
+	[ "$status" -eq 1 ]
+}


### PR DESCRIPTION
This PR is:
- A way to test the CLI
- A way to test common workflows execute as expected

I want to add a lot more stuff to this, mainly around setting up a more complex set of tests and not rely so heavily on dev mode generated resources. That being said, this will at least give us an easy way to test the staged binaries we build next week against basic workflows before the final dropping of the curtain while also providing the basic framework for testing staged binaries before release.

Tests:
```bash
 bats -p boundary
 ✓ boundary/login: can login as default user
 ✓ boundary/target: default user can create target
 ✓ boundary/target: default user can not create already created target
 ✓ boundary/target: default user can read created target
 ✓ boundary/target: default user can add default host set to created target
 ✓ boundary/target: default user can connect to created target
 ✓ boundary/target: default user can delete target
 ✓ boundary/target: default user can not read deleted target
 ✓ boundary/login: can login as default user
 ✓ boundary/users: can add test user
 ✓ boundary/users: can not add already created test user
 ✓ boundary/users: can read test user
 ✓ boundary/account/password: can add test account
 ✓ boundary/account/password: can not add already created test account
 ✓ boundary/account/password: can read created test account
 ✓ boundary/user/account-add: can associate test account with test user
 ✓ boundary/login: can login as test user
 ✓ boundary/user: can delete test user
 ✓ boundary/user: can not delete already deleted test user
 ✓ boundary/users: can not read deleted test user
 ✓ boundary/account/password: can delete test account
 ✓ boundary/account/password: can not delete already deleted test account
 ✓ boundary/account/password: can not read deleted test account

23 tests, 0 failures
```