### PR TITLE
Don't show "Version v" on startup if empty

### DIFF
--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -208,9 +208,11 @@ func (b *Server) SetupMetrics(ui cli.Ui, telemetry *configutil.Telemetry) error 
 }
 
 func (b *Server) PrintInfo(ui cli.Ui) {
-	b.InfoKeys = append(b.InfoKeys, "version")
 	verInfo := version.Get()
-	b.Info["version"] = verInfo.FullVersionNumber(false)
+	if verInfo.Version != "" {
+		b.InfoKeys = append(b.InfoKeys, "version")
+		b.Info["version"] = verInfo.FullVersionNumber(false)
+	}
 	if verInfo.Revision != "" {
 		b.Info["version sha"] = strings.Trim(verInfo.Revision, "'")
 		b.InfoKeys = append(b.InfoKeys, "version sha")


### PR DESCRIPTION
We'll still show the SHA in this case