### PR TITLE
Don't return error code 1 if saving the value to the keyring

### DIFF
--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -234,7 +234,9 @@ func (c *Command) ReadTokenFromKeyring(tokenName string) *authtokens.AuthToken {
 		if err == keyring.ErrNotFound {
 			c.UI.Info("No saved credential found, continuing without")
 		} else {
+			// TODO: potentially look for dbus-launch in advance and don't issue a warning at all
 			c.UI.Error(fmt.Sprintf("Error reading auth token from system credential store: %s", err))
+			c.UI.Warn("Token must be provided via BOUNDARY_TOKEN env var or -token flag. Reading the token can also be disabled via -token-name=none.")
 		}
 		token = ""
 	}

--- a/internal/cmd/commands/authenticate/password.go
+++ b/internal/cmd/commands/authenticate/password.go
@@ -168,9 +168,10 @@ func (c *PasswordCommand) Run(args []string) int {
 			c.UI.Error(fmt.Sprintf("Error marshaling auth token to save to system credential store: %s", err))
 			return 1
 		}
+		// TODO: potentially look for dbus-launch in advance and don't issue a warning at all
 		if err := keyring.Set("HashiCorp Boundary Auth Token", tokenName, base64.RawStdEncoding.EncodeToString(marshaled)); err != nil {
 			c.UI.Error(fmt.Sprintf("Error saving auth token to system credential store: %s", err))
-			return 1
+			c.UI.Warn("The token printed above must be manually passed in via the BOUNDARY_TOKEN env var or -token flag. Storing the token can also be disabled via -token-name=none.")
 		}
 	}
 


### PR DESCRIPTION
This can break automation even if it's fine. We could adjust this later if it makes sense.