### PR TITLE
docs: Fix a typo & broken link

### DIFF
--- a/website/content/docs/getting-started/index.mdx
+++ b/website/content/docs/getting-started/index.mdx
@@ -15,7 +15,7 @@ The examples in Getting Started all revolve around running in `dev mode`. There 
 
 1. [Docker](https://docs.docker.com/get-docker/) is installed
 2. A route to download the [Postgres Docker image](https://hub.docker.com/_/postgres) is available or a local image cache is available
-3. A [Boundary binary](https://www.boundaryproject.io/downloads) in your \$PATH
+3. A [Boundary binary](https://www.boundaryproject.io/downloads) in your `$PATH`
 
 ## What is Dev Mode?
 

--- a/website/pages/docs/[[...page]].jsx
+++ b/website/pages/docs/[[...page]].jsx
@@ -12,7 +12,7 @@ function DocsLayout(props) {
   return (
     <DocsPage
       productName={productName}
-      productSlug="red"
+      productSlug="boundary"
       subpath={subpath}
       order={order}
       staticProps={props}

--- a/website/pages/docs/[[...page]].jsx
+++ b/website/pages/docs/[[...page]].jsx
@@ -12,7 +12,7 @@ function DocsLayout(props) {
   return (
     <DocsPage
       productName={productName}
-      productSlug="boundary"
+      productSlug="red"
       subpath={subpath}
       order={order}
       staticProps={props}


### PR DESCRIPTION
The "Edit this page" link actually still links to 'master' branch
but that seems to be a harder problem to solve as the template
seems to be shared.