### PR TITLE
ensure make tools executes before build-ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ cleangen:
 
 dev: BUILD_TAGS+=dev
 dev: BUILD_TAGS+=ui
-dev: tools build-ui-ifne
+dev: build-ui-ifne
 	@echo "==> Building Boundary with dev and UI features enabled"
 	@CGO_ENABLED=$(CGO_ENABLED) BUILD_TAGS='$(BUILD_TAGS)' BOUNDARY_DEV_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ cleangen:
 
 dev: BUILD_TAGS+=dev
 dev: BUILD_TAGS+=ui
-dev: build-ui-ifne
+dev: tools build-ui-ifne
 	@echo "==> Building Boundary with dev and UI features enabled"
 	@CGO_ENABLED=$(CGO_ENABLED) BUILD_TAGS='$(BUILD_TAGS)' BOUNDARY_DEV_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
@@ -54,7 +54,7 @@ update-ui-version:
 	fi; \
 	./scripts/uiclone.sh && ./scripts/uiupdate.sh
 
-build-ui: tools
+build-ui:
 	@if [ -z "$(UI_COMMITISH)" ]; then \
 		echo "==> Building default UI version from $(UI_VERSION_FILE): $(UI_CURRENT_COMMIT)"; \
 		export UI_COMMITISH="$(UI_CURRENT_COMMIT)"; \

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ update-ui-version:
 	fi; \
 	./scripts/uiclone.sh && ./scripts/uiupdate.sh
 
-build-ui:
+build-ui: tools
 	@if [ -z "$(UI_COMMITISH)" ]; then \
 		echo "==> Building default UI version from $(UI_VERSION_FILE): $(UI_CURRENT_COMMIT)"; \
 		export UI_COMMITISH="$(UI_CURRENT_COMMIT)"; \

--- a/README.md
+++ b/README.md
@@ -99,14 +99,15 @@ UI assets; which will take a few extra minutes.) Once complete, run Boundary in
 
   ```./$GOPATH/bin/boundary dev```
 
-Please note that building the UI requires `go-bindata`, the easiest way to install
+Please note that building the UI requires `go-bindata`; the easiest way to install
 Boundary's dependent tools is to simply run:
 
   ```make tools```
 
 Without doing so, you may encounter errors while running `make dev`. It is important
-to also mention that installing tools like `go-bindata` may overwrite or take precedence
-of tools that might already be installed on the system.
+to also note that using `make tools` will install various tools used for Boundary
+development to the normal Go binary directory; this may overwrite or take precedence
+over tools that might already be installed on the system.
 
 #### Specify a UI Commitish at Build Time
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ UI assets; which will take a few extra minutes.) Once complete, run Boundary in
 
   ```./$GOPATH/bin/boundary dev```
 
+Please note that building the UI requires `go-bindata`, the easiest way to install
+Boundary's dependent tools is to simply run:
+
+  ```make tools```
+
+Without doing so, you may encounter errors while running `make dev`. It is important
+to also mention that installing tools like `go-bindata` may overwrite or take precedence
+of tools that might already be installed on the system.
+
 #### Specify a UI Commitish at Build Time
 
 By default the UI will be built from a preselected commit ID from [the UI


### PR DESCRIPTION
`make dev` requires `build-ui` which executes a script that requires `go-bindata` binary that isn't installed without executing `make tools`. This pr ensures the `tools` make target is executed first.