### PR TITLE
Fix typo in docs

### DIFF
--- a/website/content/docs/installing/high-availability.mdx
+++ b/website/content/docs/installing/high-availability.mdx
@@ -22,7 +22,7 @@ The following ports should be available:
 ## Architecture
 
 The general architecture for the server infrastructure requires 3 controllers
-and 3 workers. Note that it is possible to a controller and worker within the
+and 3 workers. Note that it is possible to run a controller and worker within the
 same process, but the guide here assumes separate deployments. The documentation
 here uses virtual machines running on Amazon EC2 as the example environment, but
 this use case can be extrapolated to almost any cloud platform to suit operator


### PR DESCRIPTION
Fixing typo (missing word in sentence) in high-availability installation guide