### PR TITLE
[Website] Bump HSM version to include waypoint

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1642,9 +1642,9 @@
       "integrity": "sha512-a2eWgjLwGAC2LjUHE7Xt6sRGGjyTWfrc4N+qVxsyZw4eE0EiNhMIKDYHWjmtb+tGh8r8j+ca3tSjsuOUePVPUw=="
     },
     "@hashicorp/react-hashi-stack-menu": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.0.6.tgz",
-      "integrity": "sha512-GKUmF6hoPal9mi/y1lVFeQcizQ9Kc1iYVcYwgqEDMi40C84na6Wd/AFYRckC4MNruCFXtuS3Fs8Sv7l5qqW4wA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.0.7.tgz",
+      "integrity": "sha512-WcPD9T2WjjuAlUmCNG3ed6zmroKC0T9LDf5ocL/IWTI5TSnqtjmlC63066v1YCPytG1B/QMkarFP9SYZUrIJrQ==",
       "requires": {
         "@hashicorp/react-inline-svg": "^1.0.2",
         "slugify": "1.3.4"

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "@hashicorp/react-content": "5.2.1",
     "@hashicorp/react-docs-page": "6.3.1",
     "@hashicorp/react-global-styles": "4.6.1",
-    "@hashicorp/react-hashi-stack-menu": "^1.0.6",
+    "@hashicorp/react-hashi-stack-menu": "^1.0.7",
     "@hashicorp/react-head": "1.1.4",
     "@hashicorp/react-hero": "^3.1.9",
     "@hashicorp/react-image": "3.0.1",


### PR DESCRIPTION
This PR updates the `<HashiStackMenu />` 

[🔍  Preview link](https://boundary-git-jmbump-hsm-version-107.hashicorp.vercel.app)