### PR TITLE
website: fix edit this page links on /docs

### DIFF
--- a/website/pages/docs/[[...page]].jsx
+++ b/website/pages/docs/[[...page]].jsx
@@ -12,7 +12,7 @@ function DocsLayout(props) {
   return (
     <DocsPage
       productName={productName}
-      productSlug="red"
+      productSlug="boundary"
       subpath={subpath}
       order={order}
       staticProps={props}


### PR DESCRIPTION
previously, we were using `red` as a codename for the project. this fixes an issue where the "edit this page" links were pointing to a repo that didn't exist based on said codename.