### PR TITLE
Fix IPv6 binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 * cli: Fix hyphenation in help output for resources with compound names
   ([Issue](https://github.com/hashicorp/boundary/issues/686))
   ([PR](https://github.com/hashicorp/boundary/pull/689))
+* controller, worker: Fix listening on IPv6 addresses ([Issue](https://github.com/hashicorp/boundary/issues/701)) ([PR](https://github.com/hashicorp/boundary/pull/703))
 
 ## v0.1.0
 

--- a/internal/cmd/base/listener.go
+++ b/internal/cmd/base/listener.go
@@ -120,11 +120,11 @@ func tcpListenerFactory(l *configutil.Listener, logger hclog.Logger, ui cli.Ui) 
 		port = ""
 	}
 
-	finalListenAddr := fmt.Sprintf("%s:%s", host, port)
+	finalListenAddr := net.JoinHostPort(host, port)
 
 	ln, err := net.Listen(bindProto, finalListenAddr)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("error creating listener with proto %s and address %s: %w", bindProto, finalListenAddr, err)
 	}
 
 	ln = TCPKeepAliveListener{ln.(*net.TCPListener)}


### PR DESCRIPTION
Annoyingly, I somehow managed to test net.SplitHostPort and account for
IPv6 but then reassemble it for listening in the wrong way, such that it
flat out doesn't work. No idea how. Anyways, fixed.

Fixes #701