### PR TITLE
Add env file for vercel vars

### DIFF
--- a/website/.env
+++ b/website/.env
@@ -1,0 +1,1 @@
+HASHI_ENV=production


### PR DESCRIPTION
Vercel will build previews for all PRs (incl forks) as long as we don't include env vars in the Vercel UI. This moves our one and only env var to a `.env` file. 