### PR TITLE
Support for Unix domain socket listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### Improvements
 
+* controller: Allow API/Cluster listeners to be Unix domain sockets
+  ([Issue](https://github.com/hashicorp/boundary/pull/699))
+  ([PR](https://github.com/hashicorp/boundary/pull/705))
+
 ### Bug Fixes
 
 * cli: Fix hyphenation in help output for resources with compound names
   ([Issue](https://github.com/hashicorp/boundary/issues/686))
   ([PR](https://github.com/hashicorp/boundary/pull/689))
+* controller, worker: Fix listening on IPv6 addresses
+  ([Issue](https://github.com/hashicorp/boundary/issues/701))
+  ([PR](https://github.com/hashicorp/boundary/pull/703))
 
 ## v0.1.0
 

--- a/internal/cmd/base/listener.go
+++ b/internal/cmd/base/listener.go
@@ -164,7 +164,7 @@ func tcpListenerFactory(purpose string, l *configutil.Listener, logger hclog.Log
 		port = ""
 	}
 
-	finalListenAddr := fmt.Sprintf("%s:%s", host, port)
+	finalListenAddr := net.JoinHostPort(host, port)
 
 	ln, err := net.Listen(bindProto, finalListenAddr)
 	if err != nil {

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -614,15 +614,23 @@ func (b *Server) SetupWorkerPublicAddress(conf *config.Config, flagValue string)
 			}
 		}
 	}
-	host, port, err := net.SplitHostPort(conf.Worker.PublicAddr)
-	if err != nil {
-		if strings.Contains(err.Error(), "missing port") {
-			port = "9202"
-			host = conf.Worker.PublicAddr
-		} else {
-			return fmt.Errorf("Error splitting public adddress host/port: %w", err)
+	switch {
+	case strings.HasPrefix(conf.Worker.PublicAddr, "/"):
+		conf.Worker.PublicAddr = fmt.Sprintf("unix://%s", conf.Worker.PublicAddr)
+
+	case strings.HasPrefix(conf.Worker.PublicAddr, "unix://"):
+
+	default:
+		host, port, err := net.SplitHostPort(conf.Worker.PublicAddr)
+		if err != nil {
+			if strings.Contains(err.Error(), "missing port") {
+				port = "9202"
+				host = conf.Worker.PublicAddr
+			} else {
+				return fmt.Errorf("Error splitting public adddress host/port: %w", err)
+			}
 		}
+		conf.Worker.PublicAddr = net.JoinHostPort(host, port)
 	}
-	conf.Worker.PublicAddr = fmt.Sprintf("%s:%s", host, port)
 	return nil
 }

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -614,23 +614,15 @@ func (b *Server) SetupWorkerPublicAddress(conf *config.Config, flagValue string)
 			}
 		}
 	}
-	switch {
-	case strings.HasPrefix(conf.Worker.PublicAddr, "/"):
-		conf.Worker.PublicAddr = fmt.Sprintf("unix://%s", conf.Worker.PublicAddr)
-
-	case strings.HasPrefix(conf.Worker.PublicAddr, "unix://"):
-
-	default:
-		host, port, err := net.SplitHostPort(conf.Worker.PublicAddr)
-		if err != nil {
-			if strings.Contains(err.Error(), "missing port") {
-				port = "9202"
-				host = conf.Worker.PublicAddr
-			} else {
-				return fmt.Errorf("Error splitting public adddress host/port: %w", err)
-			}
+	host, port, err := net.SplitHostPort(conf.Worker.PublicAddr)
+	if err != nil {
+		if strings.Contains(err.Error(), "missing port") {
+			port = "9202"
+			host = conf.Worker.PublicAddr
+		} else {
+			return fmt.Errorf("Error splitting public adddress host/port: %w", err)
 		}
-		conf.Worker.PublicAddr = net.JoinHostPort(host, port)
 	}
+	conf.Worker.PublicAddr = fmt.Sprintf("%s:%s", host, port)
 	return nil
 }

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -623,6 +623,6 @@ func (b *Server) SetupWorkerPublicAddress(conf *config.Config, flagValue string)
 			return fmt.Errorf("Error splitting public adddress host/port: %w", err)
 		}
 	}
-	conf.Worker.PublicAddr = fmt.Sprintf("%s:%s", host, port)
+	conf.Worker.PublicAddr = net.JoinHostPort(host, port)
 	return nil
 }

--- a/internal/cmd/commands/connect/connect.go
+++ b/internal/cmd/commands/connect/connect.go
@@ -12,8 +12,10 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -393,6 +395,33 @@ func (c *Command) Run(args []string) (retCode int) {
 	// hijacked, just setting for completeness
 	transport.IdleConnTimeout = 0
 
+	var hostOverride string
+	switch {
+	case strings.HasPrefix(workerAddr, "unix://"):
+		socket := strings.TrimPrefix(workerAddr, "unix://")
+		transport.DialContext = func(context.Context, string, string) (net.Conn, error) {
+			dialer := net.Dialer{}
+			return dialer.DialContext(c.proxyCtx, "unix", socket)
+		}
+		// Necessary to put a host in even though the custom dialer means it's ignored
+		hostOverride = "unixfaker"
+
+	default:
+		workerAddr = fmt.Sprintf("tcp://%s", workerAddr)
+	}
+
+	workerUrl, err := url.Parse(workerAddr)
+	if err != nil {
+		c.UI.Error(fmt.Errorf("Error parsing worker address: %w", err).Error())
+		return 1
+	}
+	workerUrl.Scheme = "https"
+	if hostOverride != "" {
+		workerUrl.Host = hostOverride
+	}
+	workerUrl.Path = path.Join("v1", "proxy")
+	workerAddr = workerUrl.String()
+
 	c.listener, err = net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   listenAddr,
 		Port: c.flagListenPort,
@@ -559,7 +588,7 @@ func (c *Command) handleConnection(
 
 	conn, resp, err := websocket.Dial(
 		c.proxyCtx,
-		fmt.Sprintf("wss://%s/v1/proxy", workerAddr),
+		workerAddr,
 		&websocket.DialOptions{
 			HTTPClient: &http.Client{
 				Transport: transport,

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -123,7 +123,7 @@ func (c *Command) Flags() *base.FlagSets {
 		Name:   "api-listen-address",
 		Target: &c.flagControllerAPIListenAddr,
 		EnvVar: "BOUNDARY_DEV_CONTROLLER_API_LISTEN_ADDRESS",
-		Usage:  "Address to bind to for controller \"api\" purpose.",
+		Usage:  "Address to bind to for controller \"api\" purpose. If this begins with a forward slash, it will be assumed to be a Unix domain socket path.",
 	})
 
 	f.StringVar(&base.StringVar{
@@ -160,14 +160,14 @@ func (c *Command) Flags() *base.FlagSets {
 		Name:   "cluster-listen-address",
 		Target: &c.flagControllerClusterListenAddr,
 		EnvVar: "BOUNDARY_DEV_CONTROLLER_CLUSTER_LISTEN_ADDRESS",
-		Usage:  "Address to bind to for controller \"cluster\" purpose.",
+		Usage:  "Address to bind to for controller \"cluster\" purpose. If this begins with a forward slash, it will be assumed to be a Unix domain socket path.",
 	})
 
 	f.StringVar(&base.StringVar{
 		Name:   "proxy-listen-address",
 		Target: &c.flagWorkerProxyListenAddr,
 		EnvVar: "BOUNDARY_DEV_WORKER_PROXY_LISTEN_ADDRESS",
-		Usage:  "Address to bind to for worker \"proxy\" purpose.",
+		Usage:  "Address to bind to for worker \"proxy\" purpose. If this begins with a forward slash, it will be assumed to be a Unix domain socket path.",
 	})
 
 	f.StringVar(&base.StringVar{
@@ -306,6 +306,9 @@ func (c *Command) Run(args []string) int {
 			if c.flagWorkerProxyListenAddr != "" {
 				l.Address = c.flagWorkerProxyListenAddr
 			}
+		}
+		if strings.HasPrefix(l.Address, "/") {
+			l.Type = "unix"
 		}
 	}
 

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -167,7 +167,7 @@ func (c *Command) Flags() *base.FlagSets {
 		Name:   "proxy-listen-address",
 		Target: &c.flagWorkerProxyListenAddr,
 		EnvVar: "BOUNDARY_DEV_WORKER_PROXY_LISTEN_ADDRESS",
-		Usage:  "Address to bind to for worker \"proxy\" purpose. If this begins with a forward slash, it will be assumed to be a Unix domain socket path.",
+		Usage:  "Address to bind to for worker \"proxy\" purpose.",
 	})
 
 	f.StringVar(&base.StringVar{
@@ -296,20 +296,23 @@ func (c *Command) Run(args []string) int {
 			if c.flagControllerAPIListenAddr != "" {
 				l.Address = c.flagControllerAPIListenAddr
 			}
+			if strings.HasPrefix(l.Address, "/") {
+				l.Type = "unix"
+			}
 
 		case "cluster":
 			if c.flagControllerClusterListenAddr != "" {
 				l.Address = c.flagControllerClusterListenAddr
 				c.Config.Worker.Controllers = []string{l.Address}
 			}
+			if strings.HasPrefix(l.Address, "/") {
+				l.Type = "unix"
+			}
 
 		case "proxy":
 			if c.flagWorkerProxyListenAddr != "" {
 				l.Address = c.flagWorkerProxyListenAddr
 			}
-		}
-		if strings.HasPrefix(l.Address, "/") {
-			l.Type = "unix"
 		}
 	}
 

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -300,6 +300,7 @@ func (c *Command) Run(args []string) int {
 		case "cluster":
 			if c.flagControllerClusterListenAddr != "" {
 				l.Address = c.flagControllerClusterListenAddr
+				c.Config.Worker.Controllers = []string{l.Address}
 			}
 
 		case "proxy":

--- a/internal/servers/worker/handler.go
+++ b/internal/servers/worker/handler.go
@@ -26,12 +26,6 @@ func (w *Worker) handler(props HandlerProperties) http.Handler {
 
 	mux.Handle("/v1/proxy", w.handleProxy())
 
-	mux.Handle("/", func() http.HandlerFunc {
-		return http.HandlerFunc(func(wr http.ResponseWriter, r *http.Request) {
-			w.logger.Error("REQUEST PATH", "path", r.RequestURI)
-		})
-	}())
-
 	genericWrappedHandler := w.wrapGenericHandler(mux, props)
 
 	return genericWrappedHandler
@@ -39,7 +33,6 @@ func (w *Worker) handler(props HandlerProperties) http.Handler {
 
 func (w *Worker) handleProxy() http.HandlerFunc {
 	return http.HandlerFunc(func(wr http.ResponseWriter, r *http.Request) {
-		w.logger.Debug("IN HANDLE PROXY")
 		if r.TLS == nil {
 			w.logger.Error("no request TLS information found")
 			wr.WriteHeader(http.StatusInternalServerError)

--- a/internal/tests/cluster/unix_listener_test.go
+++ b/internal/tests/cluster/unix_listener_test.go
@@ -1,9 +1,15 @@
 package cluster
 
 import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/boundary/api"
+	"github.com/hashicorp/boundary/api/scopes"
 	"github.com/hashicorp/boundary/internal/cmd/config"
 	"github.com/hashicorp/boundary/internal/servers/controller"
 	"github.com/hashicorp/boundary/internal/servers/worker"
@@ -12,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMultiControllerMultiWorkerConnections(t *testing.T) {
+func TestUnixListener(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 	amId := "ampw_1234567890"
 	user := "user"
@@ -24,6 +30,25 @@ func TestMultiControllerMultiWorkerConnections(t *testing.T) {
 	conf, err := config.DevController()
 	require.NoError(err)
 
+	tempDir, err := ioutil.TempDir("", "boundary-unix-listener-test")
+	require.NoError(err)
+
+	defer func() {
+		require.NoError(os.RemoveAll(tempDir))
+	}()
+
+	for _, l := range conf.Listeners {
+		switch l.Purpose[0] {
+		case "api":
+			l.Address = path.Join(tempDir, "api")
+			l.Type = "unix"
+
+		case "cluster":
+			l.Address = path.Join(tempDir, "cluster")
+			l.Type = "unix"
+		}
+	}
+
 	c1 := controller.NewTestController(t, &controller.TestControllerOpts{
 		Config:              conf,
 		DefaultAuthMethodId: amId,
@@ -32,11 +57,6 @@ func TestMultiControllerMultiWorkerConnections(t *testing.T) {
 		Logger:              logger.Named("c1"),
 	})
 	defer c1.Shutdown()
-
-	c2 := c1.AddClusterControllerMember(t, &controller.TestControllerOpts{
-		Logger: c1.Config().Logger.ResetNamed("c2"),
-	})
-	defer c2.Shutdown()
 
 	expectWorkers := func(c *controller.TestController, workers ...*worker.TestWorker) {
 		updateTimes := c.Controller().WorkerStatusUpdateTimes()
@@ -52,7 +72,7 @@ func TestMultiControllerMultiWorkerConnections(t *testing.T) {
 				// expecting it we'll see an out-of-date entry
 				return true
 			}
-			assert.WithinDuration(time.Now(), v.(time.Time), 30*time.Second)
+			assert.WithinDuration(time.Now(), v.(time.Time), 35*time.Second)
 			delete(workerMap, k.(string))
 			return true
 		})
@@ -60,9 +80,12 @@ func TestMultiControllerMultiWorkerConnections(t *testing.T) {
 	}
 
 	expectWorkers(c1)
-	expectWorkers(c2)
+
+	wconf, err := config.DevWorker()
+	require.NoError(err)
 
 	w1 := worker.NewTestWorker(t, &worker.TestWorkerOpts{
+		Config:             wconf,
 		WorkerAuthKms:      c1.Config().WorkerAuthKms,
 		InitialControllers: c1.ClusterAddrs(),
 		Logger:             logger.Named("w1"),
@@ -71,33 +94,27 @@ func TestMultiControllerMultiWorkerConnections(t *testing.T) {
 
 	time.Sleep(10 * time.Second)
 	expectWorkers(c1, w1)
-	expectWorkers(c2, w1)
-
-	w2 := w1.AddClusterWorkerMember(t, &worker.TestWorkerOpts{
-		Logger: logger.Named("w2"),
-	})
-	defer w2.Shutdown()
-
-	time.Sleep(10 * time.Second)
-	expectWorkers(c1, w1, w2)
-	expectWorkers(c2, w1, w2)
 
 	require.NoError(w1.Worker().Shutdown(true))
 	time.Sleep(10 * time.Second)
-	expectWorkers(c1, w2)
-	expectWorkers(c2, w2)
-
-	require.NoError(w1.Worker().Start())
-	time.Sleep(10 * time.Second)
-	expectWorkers(c1, w1, w2)
-	expectWorkers(c2, w1, w2)
+	expectWorkers(c1)
 
 	require.NoError(c1.Controller().Shutdown(true))
 	time.Sleep(10 * time.Second)
-	expectWorkers(c2, w1, w2)
 
 	require.NoError(c1.Controller().Start())
 	time.Sleep(10 * time.Second)
-	expectWorkers(c1, w1, w2)
-	expectWorkers(c2, w1, w2)
+	expectWorkers(c1, w1)
+
+	client, err := api.NewClient(nil)
+	require.NoError(err)
+
+	addrs := c1.ApiAddrs()
+	require.Len(addrs, 1)
+
+	require.NoError(client.SetAddr(addrs[0]))
+
+	sc := scopes.NewClient(client)
+	_, err = sc.List(context.Background(), "global")
+	require.NoError(err)
 }


### PR DESCRIPTION
The client already supports protocol-agnostic transport so handles unix:/// schemes.

Fixes #699 