### PR TITLE
Set vercel config

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "public": true
+}


### PR DESCRIPTION
This will make build logs for deploy previews public which should allow easier troubleshooting for contributors. 

Appending `/_logs` to the deploy preview URL will show the Vercel build logs.