### PR TITLE
Fix link to 'Edit this Page' for Docs

### DIFF
--- a/website/components/temporary_docs-page/index.jsx
+++ b/website/components/temporary_docs-page/index.jsx
@@ -43,7 +43,7 @@ export default function DocsPage({
           data: data,
           order,
         }}
-        resourceURL={`https://github.com/hashicorp/${productSlug}/blob/master/website/content/docs/${filePath}`}
+        resourceURL={`https://github.com/hashicorp/boundary/blob/master/website/content/docs/${filePath}`}
       >
         {content}
       </DocsPageComponent>


### PR DESCRIPTION
Right now we're using a codename for our product name (which will be updated back to boundary in the near future).  Plugging this hardcoded hotfix to get our "Edit this Page" button working again, while keeping our styles working.