### PR TITLE
feat: override PG host Docker-advertised address when set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 * controller: Allow API/Cluster listeners to be Unix domain sockets
   ([Issue](https://github.com/hashicorp/boundary/pull/699))
   ([PR](https://github.com/hashicorp/boundary/pull/705))
+* dev controller: Allow connecting to postgres when using remote docker in dev mode
+  ([Issue](https://github.com/hashicorp/boundary/issues/720)
+  ([PR](https://github.com/hashicorp/boundary/pull/732))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### Bug Fixes
 
-* cli: Fix database init when locale isn't english 
+* cli: Fix database init when locale isn't English 
   ([Issue](https://github.com/hashicorp/boundary/issues/729))
   ([PR](https://github.com/hashicorp/boundary/pull/736))
 * cli: Fix hyphenation in help output for resources with compound names
@@ -32,4 +32,5 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## v0.1.0
 
-v0.1.0 is the first release of Boundary. As a result there are no changes, improvements, or bugfixes from past versions.
+v0.1.0 is the first release of Boundary. As a result there are no changes,
+improvements, or bugfixes from past versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,15 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 * controller: Allow API/Cluster listeners to be Unix domain sockets
   ([Issue](https://github.com/hashicorp/boundary/pull/699))
   ([PR](https://github.com/hashicorp/boundary/pull/705))
-* dev controller: Allow connecting to postgres when using remote docker in dev mode
-  ([Issue](https://github.com/hashicorp/boundary/issues/720)
-  ([PR](https://github.com/hashicorp/boundary/pull/732))
 
 ### Bug Fixes
 
 * cli: Fix hyphenation in help output for resources with compound names
   ([Issue](https://github.com/hashicorp/boundary/issues/686))
   ([PR](https://github.com/hashicorp/boundary/pull/689))
+* controller: Allow connecting to Postgres when using remote Docker in dev mode
+  ([Issue](https://github.com/hashicorp/boundary/issues/720)
+  ([PR](https://github.com/hashicorp/boundary/pull/732))
 * controller, worker: Fix listening on IPv6 addresses
   ([Issue](https://github.com/hashicorp/boundary/issues/701))
   ([PR](https://github.com/hashicorp/boundary/pull/703))

--- a/internal/docker/supported.go
+++ b/internal/docker/supported.go
@@ -29,6 +29,9 @@ func startDbInDockerSupported(dialect string) (cleanup func() error, retURL, con
 	case "postgres":
 		resource, err = pool.Run("postgres", "12", []string{"POSTGRES_PASSWORD=password", "POSTGRES_DB=boundary"})
 		url = "postgres://postgres:password@localhost:%s?sslmode=disable"
+		if err == nil {
+			url = fmt.Sprintf("postgres://postgres:password@%s?sslmode=disable", resource.GetHostPort("5432/tcp"))
+		}
 	default:
 		panic(fmt.Sprintf("unknown dialect %q", dialect))
 	}
@@ -39,8 +42,6 @@ func startDbInDockerSupported(dialect string) (cleanup func() error, retURL, con
 	cleanup = func() error {
 		return cleanupDockerResource(pool, resource)
 	}
-
-	url = fmt.Sprintf(url, resource.GetPort("5432/tcp"))
 
 	if err := pool.Retry(func() error {
 		db, err := sql.Open(dialect, url)


### PR DESCRIPTION
Allows connecting to the postgres container forked in `dev` mode to be accessed from a remote docker host if set. 

Fixes https://github.com/hashicorp/boundary/issues/720