### PR TITLE
add workflow file for backport-assistant github action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -2,7 +2,7 @@
   name: Backport Assistant Runner
   
   on:
-    pull_request:
+    pull_request_target:
       types:
         - closed
   
@@ -10,7 +10,7 @@
     backport:
       if: github.event.pull_request.merged
       runs-on: ubuntu-latest
-      container: hashicorpdev/backport-assistant:0.2.0
+      container: hashicorpdev/backport-assistant:0.2.1
       steps:
         - name: Run Backport Assistant
           run: |

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,21 @@
+---
+  name: Backport Assistant Runner
+  
+  on:
+    pull_request:
+      types:
+        - closed
+  
+  jobs:
+    backport:
+      if: github.event.pull_request.merged
+      runs-on: ubuntu-latest
+      container: hashicorpdev/backport-assistant:0.2.0
+      steps:
+        - name: Run Backport Assistant
+          run: |
+            backport-assistant backport -automerge
+          env:
+            BACKPORT_LABEL_REGEXP: "(?P<target>website)/cherrypick"
+            BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
+            GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
`backport-assistant` enables us to merge documentation around future releases into `main`, and selectively automerge documentation for the current release into `stable-website.`

If there are no merge conflicts it will create and automerge the targeted PR into stable-website - [example automerged PR](https://github.com/krantzinator/waypoint/pull/3)
If there are merge conflicts, it will leave the PR open - [example open PR](https://github.com/krantzinator/waypoint/pull/5)
This action runs if a merged PR has the label `website/cherrypick` (which I created prior to opening this PR), and it targets the branch `stable-website` for automerging.

I also added the referenced secret to the repo Secrets.