### PR TITLE
Fix IPv4-only check when no port is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Canonical reference for changes, improvements, and bugfixes for Boundary.
 
+## vNext
+
+### Bug Fixes
+
+* controller, worker: Fix IPv4-only check so `0.0.0.0` specified without a port
+  only listens on IPv4 ([PR](https://github.com/hashicorp/boundary/pull/752))
+
 ## v0.1.1
 
 ### Changes/Deprecations

--- a/internal/cmd/base/listener.go
+++ b/internal/cmd/base/listener.go
@@ -156,7 +156,7 @@ func tcpListenerFactory(purpose string, l *configutil.Listener, logger hclog.Log
 
 	// If they've passed 0.0.0.0, we only want to bind on IPv4
 	// rather than golang's dual stack default
-	if strings.HasPrefix(l.Address, "0.0.0.0:") {
+	if strings.HasPrefix(l.Address, "0.0.0.0:") || l.Address == "0.0.0.0" {
 		bindProto = "tcp4"
 	}
 


### PR DESCRIPTION
We have behavior that causes "0.0.0.0" to only listen on IPv4, however,
it also assumed there was a port suffixed. This changes it so that it
also works with a port-less address.