### PR TITLE
internal/servers/controller/handlers/groups: fix dropped test error

### DIFF
--- a/internal/servers/controller/handlers/groups/group_service_test.go
+++ b/internal/servers/controller/handlers/groups/group_service_test.go
@@ -546,6 +546,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	tested, err := groups.NewService(repoFn)
+	require.NoError(t, err, "Error creating new service")
 	cases := []struct {
 		name    string
 		scopeId string


### PR DESCRIPTION
This fixes a dropped test error.