### PR TITLE
docs: update installation steps with templated account.id grant string

### DIFF
--- a/website/content/docs/installing/no-gen-resources.mdx
+++ b/website/content/docs/installing/no-gen-resources.mdx
@@ -1,16 +1,16 @@
 ---
 layout: docs
 page_title: Installing Boundary Without Generated Resources
-sidebar_title: Without Generated Resources 
+sidebar_title: Without Generated Resources
 description: |-
   How to install boundary without generated resources.
 ---
 
-# Installing Boundary Without Generated Resources 
+# Installing Boundary Without Generated Resources
 
-Initializing Boundary without generated resources for the first time can be a little confusing. How do you 
-create your first user and login to administer a Boundary deployment that has no authentication methods, 
-users, accounts, etc? This section describes how to get your freshly deployed Boundary installation off the 
+Initializing Boundary without generated resources for the first time can be a little confusing. How do you
+create your first user and login to administer a Boundary deployment that has no authentication methods,
+users, accounts, etc? This section describes how to get your freshly deployed Boundary installation off the
 ground.
 
 ## Recovery KMS Workflow
@@ -43,14 +43,14 @@ kms "aead" {
 <truncated>
 ```
 
-In this example, we're using hardcoded AEAD keys, but in a real world non-dev deployment, you 
+In this example, we're using hardcoded AEAD keys, but in a real world non-dev deployment, you
 should use your cloud provider's KMS such as [AWS KMS](https://www.boundaryproject.io/docs/configuration/kms/awskms) to manage the keys Boundary
 uses to encrypt sensitive information.
 
 The KMS block we're focused on is the `recovery` block. This block specifies the key used to "recover" Boundary
 but you can also use it to authenticate to Boundary and manage it as a "global" super user. This allows
-you to authenticate from the CLI or from Terraform in order to manage Boundary without any generated 
-resources. 
+you to authenticate from the CLI or from Terraform in order to manage Boundary without any generated
+resources.
 
 To authenticate to Boundary using the recovery KMS workflow:
 
@@ -83,7 +83,7 @@ To configure your provider to use the recovery KMS workflow, provide the KMS blo
 
 ```hcl
 provider "boundary" {
-  addr             = 'https://boundary.mycorp.com:9200' 
+  addr             = 'https://boundary.mycorp.com:9200'
   recovery_kms_hcl = <<EOT
 kms "aead" {
 	purpose   = "recovery"
@@ -108,7 +108,7 @@ $ boundary database init -h
 ...
 ```
 
-From this command, you can see the flags available to skip the creation of auto-generated resources. 
+From this command, you can see the flags available to skip the creation of auto-generated resources.
 
 To initialize the Boundary database without generated resources:
 
@@ -117,8 +117,8 @@ $ boundary database init -skip-initial-login-role -config /etc/boundary.hcl
 ```
 
 When you start Boundary, you will effectively have a blank sheet to work against. The initial migrations in the database have been run (note that this includes creating special users like `u_anon` and the `global` scope) and the internal keyrings have been initialized. From here, it's required that
-you use the KMS recovery workflow described above to create at a minimum an auth method, a user, an account, and a 
-role with sufficient grants. Otherwise, you need to continue to use the recovery workflow for management. It's important 
+you use the KMS recovery workflow described above to create at a minimum an auth method, a user, an account, and a
+role with sufficient grants. Otherwise, you need to continue to use the recovery workflow for management. It's important
 to realize that this is effectively a global super user type of workflow and comes with security concerns.
 
 ## Creating Your First Login Account
@@ -129,7 +129,7 @@ scopes we create. This will allow our user to configure targets within those sco
 
 ### Create Org and Project Scopes
 
-In this example, we're going to create an org and project scope and skip creating an administrator and admin role 
+In this example, we're going to create an org and project scope and skip creating an administrator and admin role
 for each scope. We're going to specify a role for managing these scopes by selected users in a later step.
 
 <Tabs>
@@ -158,7 +158,7 @@ resource "boundary_scope" "org" {
   name        = "organization"
   description = "Organization scope"
 
-  auto_create_admin_role   = false 
+  auto_create_admin_role   = false
   auto_create_default_role = false
 }
 
@@ -166,7 +166,7 @@ resource "boundary_scope" "project" {
   name                     = "project"
   description              = "My first project"
   scope_id                 = boundary_scope.org.id
-  auto_create_admin_role   = false 
+  auto_create_admin_role   = false
   auto_create_default_role = false
 }
 ```
@@ -229,7 +229,7 @@ resource "boundary_account" "myuser" {
   name           = "myuser"
   description    = "User account for my user"
   type           = "password"
-  login_name     = "myuser" 
+  login_name     = "myuser"
   password       = "foofoofoo"
   auth_method_id = boundary_auth_method.password.id
 }
@@ -273,9 +273,9 @@ resource "boundary_user" "myuser" {
 
 ### Create Roles to Manage Scopes
 
-The following describes the four baseline roles you'll need to create to manage resources within the org and project 
+The following describes the four baseline roles you'll need to create to manage resources within the org and project
 scopes created above. These roles are similar to the roles created for you in if generation had not been skipped during `boundary database init`, but declaring them explicitly
-allows you to manage them independently and fully within Terraform or on the CLI. This is useful if you want to lock 
+allows you to manage them independently and fully within Terraform or on the CLI. This is useful if you want to lock
 them down more or have control over them in a declarative way.
 
 The following example creates 4 roles:
@@ -305,7 +305,7 @@ $ boundary add-grants -id <global_anon_listing_id> \
 
 $ boundary add-principals -id <global_anon_listing_id> \
   -recovery-config /tmp/recovery.hcl \
-  -principal 'u_anon' 
+  -principal 'u_anon'
 ```
 
 </Tab>
@@ -336,17 +336,17 @@ Assumes recovery key export from above steps is still set:
 ```bash
 $ boundary roles create -name 'org_anon_listing' \
   -recovery-config /tmp/recovery.hcl \
-  -scope-id <org_scope_id> 
+  -scope-id <org_scope_id>
 
 $ boundary add-grants -id <org_anon_listing_id> \
   -recovery-config /tmp/recovery.hcl \
   -grant 'id=*;type=auth-method;actions=list,authenticate' \
   -grant 'type=scope;actions=list' \
-  -grant 'id=*;actions=read,change-password'
+  -grant 'id={{account.id}};actions=read,change-password'
 
 $ boundary add-principals -id <org_anon_listing_id> \
   -recovery-config /tmp/recovery.hcl \
-  -principal 'u_anon' 
+  -principal 'u_anon'
 ```
 
 </Tab>
@@ -386,7 +386,7 @@ $ boundary add-grants -id <org_admin_id> \
 
 $ boundary add-principals -id <org_admin_id> \
   -recovery-config /tmp/recovery.hcl \
-  -principal <myuser_user_id> 
+  -principal <myuser_user_id>
 ```
 
 </Tab>
@@ -394,7 +394,7 @@ $ boundary add-principals -id <org_admin_id> \
 
 ```hcl
 resource "boundary_role" "org_admin" {
-  scope_id       = "global" 
+  scope_id       = "global"
   grant_scope_id = boundary_scope.org.id
   grant_strings = [
     "id=*;type=*;actions=*"
@@ -425,7 +425,7 @@ $ boundary add-grants -id <project_admin_id> \
 
 $ boundary add-principals -id <project_admin_id> \
   -recovery-config /tmp/recovery.hcl \
-  -principal <myuser_user_id> 
+  -principal <myuser_user_id>
 ```
 
 </Tab>


### PR DESCRIPTION
My nvim setup appears to have removed a bunch of trailing spaces as well. The only change I was interested in addressing was at line 345.