### PR TITLE
ui: bump UI release commit for 0.1.2

### DIFF
--- a/internal/ui/VERSION
+++ b/internal/ui/VERSION
@@ -1,4 +1,4 @@
-e99f3385dad8c0859d6c75cb0f53aca14d3a150b Merge pull request #370 from hashicorp/fix-org-deletion-label
+04770f4e50b84b3ec712ba2b5c09a0c03fdbea8c Merge pull request #372 from hashicorp/chore-alternate-dropdown-radios
 # This file determines the version of the UI to embed in the boundary binary.
 # Update this file by running 'make update-ui-version' from the root of this repo.
 # Set UI_COMMITISH when running the above target to update to a specific version.


### PR DESCRIPTION
This bumps the commit hash for the UI for the upcoming v0.1.2 release.