### PR TITLE
Create common errorID generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ dev: build-ui-ifne
 	@echo "==> Building Boundary with dev and UI features enabled"
 	@CGO_ENABLED=$(CGO_ENABLED) BUILD_TAGS='$(BUILD_TAGS)' BOUNDARY_DEV_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
+rand:
+	@echo "==> Generating random boundary error ID"
+	@go run scripts/errorid.go
+
 bin: BUILD_TAGS+=ui
 bin: build-ui
 	@echo "==> Building Boundary with UI features enabled"

--- a/scripts/errorid.go
+++ b/scripts/errorid.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/vault/sdk/helper/base62"
+)
+
+const idLength = 10
+
+func main() {
+	rand, err := base62.Random(idLength)
+	if err != nil {
+		fmt.Printf("failed to generate error ID: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(rand)
+}


### PR DESCRIPTION
### What does this PR do

Small go file to generate unique error IDs (10 digit alpha-numeric)
Adds `make rand` to make file to print above-mentioned IDs

### Testing

The output of successful `make rand`:
```
$ make rand
==> Generating random boundary error ID
7w4DR9AmwJ
$ make rand
==> Generating random boundary error ID
6xLoaB7ocE
```

introducing a `fake error` to show the failure case:
```
$ make rand
==> Generating random boundary error ID
failed to generate errorID: fake error
exit status 1
Makefile:31: recipe for target 'rand' failed
make: *** [rand] Error 1
```
