### PR TITLE
Update docker build to 0.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ docker-build:
 	docker build -t $(IMAGE_TAG) \
 	--build-arg VERSION=$(VERSION) \
 	-f $(DOCKER_DIR)/Release.dockerfile docker/ 
+	docker tag $(IMAGE_TAG) hashicorp/boundary:latest
 
 # builds from locally generated binary in bin/
 docker-build-dev: export XC_OSARCH=linux/amd64
@@ -179,6 +180,7 @@ docker-build-dev: dev
 # requires appropriate permissions in dockerhub
 docker-publish:
 	docker push $(IMAGE_TAG)
+	docker push hashicorp/boundary:latest
 
 .PHONY: api tools gen migrations proto website ci-config ci-verify set-ui-version docker docker-build docker-build-dev docker-publish 
 

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ install-go:
 # Docker build and publish variables and targets
 REGISTRY_NAME?=docker.io/hashicorp
 IMAGE_NAME=boundary
-VERSION?=0.1.1
+VERSION?=0.1.2
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
 IMAGE_TAG_DEV=$(REGISTRY_NAME)/$(IMAGE_NAME):latest-$(shell git rev-parse --short HEAD)
 DOCKER_DIR=./docker

--- a/docker/Release.dockerfile
+++ b/docker/Release.dockerfile
@@ -1,6 +1,6 @@
 FROM docker.mirror.hashicorp.services/alpine:3.10
 
-ARG VERSION=0.1.1
+ARG VERSION=0.1.2
 
 LABEL name="Boundary" \
       maintainer="HashiCorp Boundary Team <boundary@hashicorp.com>" \


### PR DESCRIPTION
Updates the docker build to 0.1.2 and adds the docker build step for tagging and publishing `latest`. 