### PR TITLE
docs: fix misleading statement about what scope a role can be created

### DIFF
--- a/website/content/docs/concepts/domain-model/roles.mdx
+++ b/website/content/docs/concepts/domain-model/roles.mdx
@@ -13,7 +13,7 @@ that contains a collection of [permissions][]
 which are granted to any principal assigned to the role.
 [Users][] and [groups][] are principals
 which allows either to be assigned to a role.
-A role can only be defined within a [project][] [scope][].
+A role can be defined within any [scope][].
 A role can be assigned to principals from any scope.
 
 ## Attributes


### PR DESCRIPTION
Fixes misleading documentation surfaced in https://discuss.hashicorp.com/t/documentation-inconsistent-about-roles-at-org-level-project-level/17859.