### PR TITLE
fix: do not print info in output that could be JSON or YAML format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Canonical reference for changes, improvements, and bugfixes for Boundary.
 
+## vNext
+
+### Bug Fixes
+
+* cli: Ensure errors print to stderr when token is not found
+  ([Issue](https://github.com/hashicorp/boundary/issues/791))
+  ([PR](https://github.com/hashicorp/boundary/pull/799)]
+
 ## v0.1.2
 
 ### New and Improved

--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -314,7 +314,7 @@ func (c *Command) ReadTokenFromKeyring(keyringType, tokenName string) *authtoken
 		token, err = zkeyring.Get("HashiCorp Boundary Auth Token", tokenName)
 		if err != nil {
 			if err == zkeyring.ErrNotFound {
-				c.UI.Info("No saved credential found, continuing without")
+				c.UI.Error("No saved credential found, continuing without")
 			} else {
 				c.UI.Error(fmt.Sprintf("Error reading auth token from keyring: %s", err))
 				c.UI.Warn("Token must be provided via BOUNDARY_TOKEN env var or -token flag. Reading the token can also be disabled via -keyring-type=none.")


### PR DESCRIPTION
Fixes #791 

There were two avenues I considered for this:

1. Check `c.flagFormat` and print the info level statement if the value is not `json` or `yaml`
1. Remove the info level output all together

I went with #2 because it was more simple, but I'm open to other possible paths too.