### PR TITLE
Allow dash in account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## vNext
 
+### New and Improved
+
+* controller: Relax account login name constraints to allow dash as valid character 
+  ([Issue](https://github.com/hashicorp/boundary/issues/759))
+  ([PR](https://github.com/hashicorp/boundary/pull/806))
+
 ### Bug Fixes
 
 * cli: Ensure errors print to stderr when token is not found
   ([Issue](https://github.com/hashicorp/boundary/issues/791))
-  ([PR](https://github.com/hashicorp/boundary/pull/799)]
+  ([PR](https://github.com/hashicorp/boundary/pull/799))
 
 ## v0.1.2
 

--- a/internal/auth/password/repository_account.go
+++ b/internal/auth/password/repository_account.go
@@ -42,7 +42,7 @@ func (r *Repository) CreateAccount(ctx context.Context, scopeId string, a *Accou
 		return nil, fmt.Errorf("create: password account: scope id empty: %w", errors.ErrInvalidParameter)
 	}
 	if !validLoginName(a.LoginName) {
-		return nil, fmt.Errorf("create: password account: invalid login name; must be all-lowercase alphanumeric: %w", errors.ErrInvalidParameter)
+		return nil, fmt.Errorf("create: password account: invalid login name; must be all-lowercase alphanumeric, period or hyphen: %w", errors.ErrInvalidParameter)
 	}
 
 	cc, err := r.currentConfig(ctx, a.AuthMethodId)
@@ -236,7 +236,7 @@ func (r *Repository) UpdateAccount(ctx context.Context, scopeId string, a *Accou
 		case strings.EqualFold("Description", f):
 		case strings.EqualFold("LoginName", f):
 			if !validLoginName(a.LoginName) {
-				return nil, db.NoRowsAffected, fmt.Errorf("update: password account: invalid user name: %w", errors.ErrInvalidParameter)
+				return nil, db.NoRowsAffected, fmt.Errorf("update: password account: invalid user name: must be all-lowercase alphanumeric, period or hyphen %w", errors.ErrInvalidParameter)
 			}
 			changeLoginName = true
 		default:

--- a/internal/auth/password/repository_account.go
+++ b/internal/auth/password/repository_account.go
@@ -190,7 +190,7 @@ func (r *Repository) DeleteAccount(ctx context.Context, scopeId, withPublicId st
 	return rowsDeleted, nil
 }
 
-var reInvalidLoginName = regexp.MustCompile("[^a-z0-9.]")
+var reInvalidLoginName = regexp.MustCompile("[^a-z0-9.-]")
 
 func validLoginName(u string) bool {
 	if u == "" {

--- a/internal/auth/password/repository_account_test.go
+++ b/internal/auth/password/repository_account_test.go
@@ -27,6 +27,8 @@ func TestCheckLoginName(t *testing.T) {
 		{"contains spaces", false},
 		{"NotLowerCase", false},
 		{"valid.loginname", true},
+		{"valid-loginname", true},
+		{"validloginname", true},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
### What does this PR do

Resolves #759 
Relaxes the regex constraint to allow `-` (dash) as a valid character in an account login name

### Testing

Updated unit tests
I verified that password do accept all characters mentioned in the issue (hyphen, underscore and period)
Performed manual testing:

Before changes:
```
boundary accounts create password -auth-method-id ampw_1234567890 -login-name admin-tester
Password is not set as flag, please enter it now (will be hidden):
Error from the controller when performing create on password-type account:
Error information:
  Code:                Internal
  Error ID:            YqlVyFuvqc
  Message:
  Status:              500
```
Server logs error:
```
2020-12-01T13:10:23.671-0800 [ERROR] controller: internal error returned: error id=YqlVyFuvqc error="unable to create user: create: password account: invalid login name; must be all-lowercase alphanumeric: invalid parameter: parameter violation: error #100"
```

After changes:
```
boundary accounts create password -auth-method-id ampw_1234567890 -login-name admin-tester
Password is not set as flag, please enter it now (will be hidden):

Account information:
  Auth Method ID:      ampw_1234567890
  Created Time:        Tue, 01 Dec 2020 13:08:55 PST
  ID:                  apw_jQ1DKAWgQk
  Type:                password
  Updated Time:        Tue, 01 Dec 2020 13:08:55 PST
  Version:             1

  Scope:
    ID:                global
    Name:              global
    Type:              global

  Attributes:
    Login Name:        admin-tester
```
