### PR TITLE
Switch connection limit for default target to -1

### DIFF
--- a/internal/cmd/commands/database/init.go
+++ b/internal/cmd/commands/database/init.go
@@ -442,6 +442,7 @@ func (c *InitCommand) Run(args []string) (retCode int) {
 		return 0
 	}
 
+	c.srv.DevTargetSessionConnectionLimit = -1
 	t, err := c.srv.CreateInitialTarget(c.Context)
 	if err != nil {
 		c.UI.Error(fmt.Errorf("Error creating initial target: %w", err).Error())

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -144,10 +144,11 @@ func (c *Command) Flags() *base.FlagSets {
 	})
 
 	f.IntVar(&base.IntVar{
-		Name:   "target-session-connection-limit",
-		Target: &c.flagTargetSessionConnectionLimit,
-		EnvVar: "BOUNDARY_DEV_TARGET_SESSION_CONNECTION_LIMIT",
-		Usage:  "Maximum number of connections per session to set on the default target. -1 means unlimited.",
+		Name:    "target-session-connection-limit",
+		Target:  &c.flagTargetSessionConnectionLimit,
+		Default: -1,
+		EnvVar:  "BOUNDARY_DEV_TARGET_SESSION_CONNECTION_LIMIT",
+		Usage:   "Maximum number of connections per session to set on the default target. -1 means unlimited.",
 	})
 
 	f.IntVar(&base.IntVar{


### PR DESCRIPTION
This makes the initial testing workflow less confusing for users