### PR TITLE
Switch connection limit for default target to -1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## vNext
 
+### Changes/Deprecations
+
+* controller: Switch the session connection limit for dev mode and the initial
+  target when doing database initialization to `-1`. This makes it easier for
+  people to start understanding Boundary while not hitting issues related to
+  some programs/protocols needing multiple connections as they may not be easy
+  for new users to understand.
+  ([PR](https://github.com/hashicorp/boundary/pull/814))
+
 ### New and Improved
 
 * controller: Improved error handling in hosts, host catalog and host set

--- a/internal/cmd/commands/database/init.go
+++ b/internal/cmd/commands/database/init.go
@@ -442,6 +442,7 @@ func (c *InitCommand) Run(args []string) (retCode int) {
 		return 0
 	}
 
+	c.srv.DevTargetSessionConnectionLimit = -1
 	t, err := c.srv.CreateInitialTarget(c.Context)
 	if err != nil {
 		c.UI.Error(fmt.Errorf("Error creating initial target: %w", err).Error())

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -144,10 +144,11 @@ func (c *Command) Flags() *base.FlagSets {
 	})
 
 	f.IntVar(&base.IntVar{
-		Name:   "target-session-connection-limit",
-		Target: &c.flagTargetSessionConnectionLimit,
-		EnvVar: "BOUNDARY_DEV_TARGET_SESSION_CONNECTION_LIMIT",
-		Usage:  "Maximum number of connections per session to set on the default target. -1 means unlimited.",
+		Name:    "target-session-connection-limit",
+		Target:  &c.flagTargetSessionConnectionLimit,
+		Default: -1,
+		EnvVar:  "BOUNDARY_DEV_TARGET_SESSION_CONNECTION_LIMIT",
+		Usage:   "Maximum number of connections per session to set on the default target. -1 means unlimited.",
 	})
 
 	f.IntVar(&base.IntVar{


### PR DESCRIPTION
This makes the initial testing workflow less confusing for users