### PR TITLE
Reverse server's incorrect test for globalUnicast IPs

### DIFF
--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -264,8 +264,8 @@ func (c *Command) Run(args []string) int {
 					errMsg = "an unspecified"
 				case ip.IsMulticast():
 					errMsg = "a multicast"
-				case ip.IsGlobalUnicast():
-					errMsg = "a global unicast"
+				case !ip.IsGlobalUnicast():
+					errMsg = "is not a global unicast"
 				}
 				if errMsg != "" {
 					c.UI.Error(fmt.Sprintf("Controller address %q is invalid: cannot be %s address", controller, errMsg))


### PR DESCRIPTION
Workers will error out on valid IPs shown here: https://www.boundaryproject.io/docs/configuration/worker#complete-configuration-example

```
Dec 23 21:13:25 boundary-worker-1 boundary[377038]: Controller address "10.10.10.1" is invalid: cannot be a global unicast address
Dec 23 21:13:25 boundary-worker-1 systemd[1]: boundary-worker.service: Main process exited, code=exited, status=1/FAILURE
```

The test implemented in e6c98f1454e64b29e5744efa0e4f4090be0d6257 is simply wrong: a global unicast address is required, not a failure. Any valid IP address it can reach must be a global unicast address