### PR TITLE
Remove erronious IsGlobalUnicast check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   ([PR](https://github.com/hashicorp/boundary/pull/815))
 
 ### Bug Fixes
+
+* servers: Fix erronious global unicast check that disallowed valid addresses
+  from being assigned ([PR](https://github.com/hashicorp/boundary/pull/845))
   
 ## 0.1.3
 

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -264,8 +264,6 @@ func (c *Command) Run(args []string) int {
 					errMsg = "an unspecified"
 				case ip.IsMulticast():
 					errMsg = "a multicast"
-				case ip.IsGlobalUnicast():
-					errMsg = "a global unicast"
 				}
 				if errMsg != "" {
 					c.UI.Error(fmt.Sprintf("Controller address %q is invalid: cannot be %s address", controller, errMsg))


### PR DESCRIPTION
Fixes the issue raised at https://www.boundaryproject.io/docs/configuration/worker#complete-configuration-example