### PR TITLE
Correct assert.Equal actual/expected

### DIFF
--- a/internal/db/read_writer_test.go
+++ b/internal/db/read_writer_test.go
@@ -1120,7 +1120,7 @@ func TestDb_DoTx(t *testing.T) {
 		got, err := w.DoTx(context.Background(), 1, ExpBackoff{}, func(Reader, Writer) error { return stderrors.New("not a retry error") })
 		require.Error(err)
 		assert.Equal(RetryInfo{}, got)
-		assert.NotEqual(err, oplog.ErrTicketAlreadyRedeemed)
+		assert.NotEqual(oplog.ErrTicketAlreadyRedeemed, err)
 	})
 	t.Run("too-many-retries", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)

--- a/internal/db/timestamp/scanners_test.go
+++ b/internal/db/timestamp/scanners_test.go
@@ -28,7 +28,7 @@ func Test_TimestampValue(t *testing.T) {
 		ts := Timestamp{Timestamp: &timestamp.Timestamp{Seconds: maxValidSeconds, Nanos: 0}}
 		v, err := ts.Value()
 		assert.True(err != nil)
-		assert.Equal(err.Error(), "timestamp: seconds:253402300800 after 10000-01-01")
+		assert.Equal("timestamp: seconds:253402300800 after 10000-01-01", err.Error())
 		assert.Equal(v, utcDate(10000, 1, 1))
 	})
 }
@@ -55,14 +55,14 @@ func Test_TimestampScan(t *testing.T) {
 		ts := Timestamp{}
 		err := ts.Scan(v)
 		assert.True(err != nil)
-		assert.Equal(err.Error(), "Not a protobuf Timestamp")
+		assert.Equal("Not a protobuf Timestamp", err.Error())
 	})
 	t.Run("invalid time", func(t *testing.T) {
 		v := time.Unix(maxValidSeconds, 0)
 		ts := Timestamp{}
 		err := ts.Scan(v)
 		assert.True(err != nil)
-		assert.Equal(err.Error(), "error converting the timestamp: timestamp: seconds:253402300800 after 10000-01-01")
+		assert.Equal("error converting the timestamp: timestamp: seconds:253402300800 after 10000-01-01", err.Error())
 	})
 }
 

--- a/internal/kms/repository_test.go
+++ b/internal/kms/repository_test.go
@@ -70,7 +70,7 @@ func TestNewRepository(t *testing.T) {
 			got, err := kms.NewRepository(tt.args.r, tt.args.w)
 			if tt.wantErr {
 				require.Error(err)
-				assert.Equal(err.Error(), tt.wantErrString)
+				assert.Equal(tt.wantErrString, err.Error())
 				return
 			}
 			require.NoError(err)

--- a/internal/oplog/oplog_test.go
+++ b/internal/oplog/oplog_test.go
@@ -183,7 +183,7 @@ func Test_NewEntry(t *testing.T) {
 			ticketer,
 		)
 		require.Error(err)
-		assert.Equal(err.Error(), "error creating entry: entry aggregate name is not set")
+		assert.Equal("error creating entry: entry aggregate name is not set", err.Error())
 	})
 	t.Run("bad cipherer", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
@@ -201,7 +201,7 @@ func Test_NewEntry(t *testing.T) {
 			ticketer,
 		)
 		require.Error(err)
-		assert.Equal(err.Error(), "error creating entry: entry Cipherer is nil")
+		assert.Equal("error creating entry: entry Cipherer is nil", err.Error())
 	})
 	t.Run("bad ticket", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
@@ -217,7 +217,7 @@ func Test_NewEntry(t *testing.T) {
 			nil,
 		)
 		require.Error(err)
-		assert.Equal(err.Error(), "error creating entry: entry Ticketer is nil")
+		assert.Equal("error creating entry: entry Ticketer is nil", err.Error())
 	})
 }
 
@@ -282,7 +282,7 @@ func Test_UnmarshalData(t *testing.T) {
 		entry.Data = queue.Bytes()
 		_, err = entry.UnmarshalData(types)
 		require.Error(err)
-		assert.Equal(err.Error(), "no Data to unmarshal")
+		assert.Equal("no Data to unmarshal", err.Error())
 	})
 
 	t.Run("nil types", func(t *testing.T) {
@@ -307,7 +307,7 @@ func Test_UnmarshalData(t *testing.T) {
 		require.NoError(err)
 		_, err = entry.UnmarshalData(nil)
 		require.Error(err)
-		assert.Equal(err.Error(), "TypeCatalog is nil")
+		assert.Equal("TypeCatalog is nil", err.Error())
 	})
 
 	t.Run("missing type", func(t *testing.T) {
@@ -335,7 +335,7 @@ func Test_UnmarshalData(t *testing.T) {
 		require.NoError(err)
 		_, err = entry.UnmarshalData(types)
 		require.Error(err)
-		assert.Equal(err.Error(), "error removing item from queue: error getting the TypeName for Remove: error typeName is not found for Get")
+		assert.Equal("error removing item from queue: error getting the TypeName for Remove: error typeName is not found for Get", err.Error())
 	})
 }
 
@@ -492,11 +492,11 @@ func Test_Replay(t *testing.T) {
 
 		var foundUser2 oplog_test.TestUser
 		err = tx2.Where("id = ?", userCreate2.Id).First(&foundUser2).Error
-		assert.Equal(err, gorm.ErrRecordNotFound)
+		assert.Equal(gorm.ErrRecordNotFound, err, err.Error())
 
 		var foundReplayedUser2 oplog_test.TestUser
 		err = tx2.Where("id = ?", userCreate2.Id).First(&foundReplayedUser2).Error
-		assert.Equal(err, gorm.ErrRecordNotFound)
+		assert.Equal(gorm.ErrRecordNotFound, err, err.Error())
 
 	})
 }
@@ -572,7 +572,7 @@ func Test_WriteEntryWith(t *testing.T) {
 			&Message{Message: &u, TypeName: "user", OpType: OpType_OP_TYPE_CREATE},
 			&Message{Message: &u2, TypeName: "user", OpType: OpType_OP_TYPE_CREATE})
 		require.Error(err)
-		assert.Equal(err.Error(), "bad writer")
+		assert.Equal("bad writer", err.Error())
 	})
 	t.Run("nil ticket", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
@@ -591,7 +591,7 @@ func Test_WriteEntryWith(t *testing.T) {
 			&Message{Message: &u, TypeName: "user", OpType: OpType_OP_TYPE_CREATE},
 			&Message{Message: &u2, TypeName: "user", OpType: OpType_OP_TYPE_CREATE})
 		require.Error(err)
-		assert.Equal(err.Error(), "bad ticket")
+		assert.Equal("bad ticket", err.Error())
 	})
 	t.Run("nil ticket", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
@@ -608,7 +608,7 @@ func Test_WriteEntryWith(t *testing.T) {
 		require.NoError(err)
 		err = newLogEntry.WriteEntryWith(context.Background(), &GormWriter{db}, ticket, nil)
 		require.Error(err)
-		assert.Equal(err.Error(), "bad message")
+		assert.Equal("bad message", err.Error())
 	})
 }
 

--- a/internal/oplog/queue_test.go
+++ b/internal/oplog/queue_test.go
@@ -104,7 +104,7 @@ func Test_Queue(t *testing.T) {
 		queue := Queue{}
 		_, _, _, _, err = queue.Remove()
 		require.Error(err)
-		assert.Equal(err.Error(), "remove Catalog is nil")
+		assert.Equal("remove Catalog is nil", err.Error())
 	})
 	t.Run("not replayable", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
@@ -115,13 +115,13 @@ func Test_Queue(t *testing.T) {
 		}
 		err = queue.Add(u, "user", OpType_OP_TYPE_CREATE)
 		require.Error(err)
-		assert.Equal(err.Error(), "error *oplog_test.TestNonReplayableUser is not a ReplayableMessage")
+		assert.Equal("error *oplog_test.TestNonReplayableUser is not a ReplayableMessage", err.Error())
 	})
 	t.Run("nil message", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
 		err = queue.Add(nil, "user", OpType_OP_TYPE_CREATE)
 		require.Error(err)
-		assert.Equal(err.Error(), "error <nil> is not a ReplayableMessage")
+		assert.Equal("error <nil> is not a ReplayableMessage", err.Error())
 	})
 	t.Run("missing both field mask and null paths for update", func(t *testing.T) {
 		require.Error(t, queue.Add(userUpdate, "user", OpType_OP_TYPE_UPDATE))

--- a/internal/oplog/ticketer_gorm_test.go
+++ b/internal/oplog/ticketer_gorm_test.go
@@ -22,7 +22,7 @@ func Test_NewGormTicketer(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
 		_, err := NewGormTicketer(nil, WithAggregateNames(true))
 		require.Error(err)
-		assert.Equal(err.Error(), "tx is nil")
+		assert.Equal("tx is nil", err.Error())
 	})
 }
 
@@ -46,7 +46,7 @@ func Test_GetTicket(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
 		ticket, err := ticketer.GetTicket("")
 		require.Error(err)
-		assert.Equal(err.Error(), "bad ticket name")
+		assert.Equal("bad ticket name", err.Error())
 		assert.Nil(ticket)
 	})
 }
@@ -80,7 +80,7 @@ func Test_Redeem(t *testing.T) {
 		require.NoError(err)
 		err = ticketer.Redeem(nil)
 		require.Error(err)
-		assert.Equal(err.Error(), "ticket is nil")
+		assert.Equal("ticket is nil", err.Error())
 	})
 
 	t.Run("detect two redemptions in separate concurrent transactions", func(t *testing.T) {
@@ -104,7 +104,7 @@ func Test_Redeem(t *testing.T) {
 		tx.Commit()
 
 		err = secondTicketer.Redeem(secondTicket)
-		assert.Equal(err.Error(), "ticket already redeemed")
+		assert.Equal("ticket already redeemed", err.Error())
 	})
 
 }

--- a/internal/oplog/type_catalog_test.go
+++ b/internal/oplog/type_catalog_test.go
@@ -61,7 +61,7 @@ func Test_NewTypeCatalog(t *testing.T) {
 		)
 		assert.Nil(types)
 		assert.Error(err)
-		assert.Equal(err.Error(), "error setting the type: typeName is an empty string for Set (in NewTypeCatalog)")
+		assert.Equal("error setting the type: typeName is an empty string for Set (in NewTypeCatalog)", err.Error())
 	})
 	t.Run("missing Type.Interface", func(t *testing.T) {
 		assert := assert.New(t)
@@ -71,7 +71,7 @@ func Test_NewTypeCatalog(t *testing.T) {
 		)
 		assert.Nil(types)
 		assert.Error(err)
-		assert.Equal(err.Error(), "error type is {} (in NewTypeCatalog)")
+		assert.Equal("error type is {} (in NewTypeCatalog)", err.Error())
 	})
 	t.Run("empty Type", func(t *testing.T) {
 		assert := assert.New(t)
@@ -81,7 +81,7 @@ func Test_NewTypeCatalog(t *testing.T) {
 		)
 		assert.Nil(types)
 		assert.Error(err)
-		assert.Equal(err.Error(), "error type is {} (in NewTypeCatalog)")
+		assert.Equal("error type is {} (in NewTypeCatalog)", err.Error())
 	})
 
 }
@@ -114,7 +114,7 @@ func Test_GetTypeName(t *testing.T) {
 		n, err := types.GetTypeName(new(oplog_test.TestCar))
 		require.Error(err)
 		assert.Equal(n, "")
-		assert.Equal(err.Error(), "error unknown name for interface: *oplog_test.TestCar")
+		assert.Equal("error unknown name for interface: *oplog_test.TestCar", err.Error())
 	})
 	t.Run("nil interface", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
@@ -127,7 +127,7 @@ func Test_GetTypeName(t *testing.T) {
 		n, err := types.GetTypeName(nil)
 		require.Error(err)
 		assert.Equal(n, "")
-		assert.Equal(err.Error(), "error interface parameter is nil for GetTypeName")
+		assert.Equal("error interface parameter is nil for GetTypeName", err.Error())
 	})
 }
 
@@ -159,7 +159,7 @@ func Test_Get(t *testing.T) {
 		n, err := types.Get("car")
 		require.Error(err)
 		assert.Equal(n, nil)
-		assert.Equal(err.Error(), "error typeName is not found for Get")
+		assert.Equal("error typeName is not found for Get", err.Error())
 	})
 	t.Run("bad typeName", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
@@ -172,7 +172,7 @@ func Test_Get(t *testing.T) {
 		n, err := types.Get("")
 		require.Error(err)
 		assert.Equal(n, nil)
-		assert.Equal(err.Error(), "error typeName is empty string for Get")
+		assert.Equal("error typeName is empty string for Get", err.Error())
 	})
 }
 
@@ -198,7 +198,7 @@ func Test_Set(t *testing.T) {
 		u := new(oplog_test.TestUser)
 		err = types.Set(u, "")
 		require.Error(err)
-		assert.Equal(err.Error(), "typeName is an empty string for Set")
+		assert.Equal("typeName is an empty string for Set", err.Error())
 		assert.Equal(types, &TypeCatalog{})
 	})
 	t.Run("bad interface", func(t *testing.T) {
@@ -208,7 +208,7 @@ func Test_Set(t *testing.T) {
 		require.NoError(err)
 		err = types.Set(nil, "")
 		require.Error(err)
-		assert.Equal(err.Error(), "error interface parameter is nil for Set")
+		assert.Equal("error interface parameter is nil for Set", err.Error())
 		assert.Equal(types, &TypeCatalog{})
 	})
 }

--- a/internal/oplog/writer_test.go
+++ b/internal/oplog/writer_test.go
@@ -34,7 +34,7 @@ func Test_GormWriterCreate(t *testing.T) {
 		err := w.Create(&oplog_test.TestUser{})
 		require.Error(err)
 
-		assert.Equal(err.Error(), "create Tx is nil")
+		assert.Equal("create Tx is nil", err.Error())
 	})
 	t.Run("nil model", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
@@ -43,7 +43,7 @@ func Test_GormWriterCreate(t *testing.T) {
 		w := GormWriter{tx}
 		err := w.Create(nil)
 		require.Error(err)
-		assert.Equal(err.Error(), "create interface is nil")
+		assert.Equal("create interface is nil", err.Error())
 	})
 }
 
@@ -64,14 +64,14 @@ func Test_GormWriterDelete(t *testing.T) {
 		require.NoError(w.Delete(&user))
 		err := tx.Where("id = ?", user.Id).First(&foundUser).Error
 		require.Error(err)
-		assert.Equal(err, gorm.ErrRecordNotFound)
+		assert.Equal(gorm.ErrRecordNotFound, err)
 	})
 	t.Run("nil tx", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
 		w := GormWriter{nil}
 		err := w.Delete(&oplog_test.TestUser{})
 		require.Error(err)
-		assert.Equal(err.Error(), "delete Tx is nil")
+		assert.Equal("delete Tx is nil", err.Error())
 	})
 	t.Run("nil model", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
@@ -80,7 +80,7 @@ func Test_GormWriterDelete(t *testing.T) {
 		w := GormWriter{tx}
 		err := w.Delete(nil)
 		require.Error(err)
-		assert.Equal(err.Error(), "delete interface is nil")
+		assert.Equal("delete interface is nil", err.Error())
 	})
 }
 
@@ -147,7 +147,7 @@ func Test_GormWriterCreateTable(t *testing.T) {
 		err := w.createTableLike("", newTableName)
 		require.Error(err)
 		assert.Error(err, err.Error(), nil)
-		assert.Equal(err.Error(), "error existingTableName is empty string")
+		assert.Equal("error existingTableName is empty string", err.Error())
 	})
 	t.Run("blank name", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
@@ -156,7 +156,7 @@ func Test_GormWriterCreateTable(t *testing.T) {
 		err := w.createTableLike(u.TableName(), "")
 		require.Error(err)
 		assert.Error(err, err.Error(), nil)
-		assert.Equal(err.Error(), "error newTableName is empty string")
+		assert.Equal("error newTableName is empty string", err.Error())
 	})
 }
 
@@ -181,7 +181,7 @@ func Test_GormWriterDropTableIfExists(t *testing.T) {
 		w := GormWriter{Tx: db}
 		err := w.dropTableIfExists("")
 		require.Error(err)
-		assert.Equal(err.Error(), "cannot drop table whose name is an empty string")
+		assert.Equal("cannot drop table whose name is an empty string", err.Error())
 	})
 }
 

--- a/internal/session/repository_test.go
+++ b/internal/session/repository_test.go
@@ -64,7 +64,7 @@ func TestNewRepository(t *testing.T) {
 			got, err := kms.NewRepository(tt.args.r, tt.args.w)
 			if tt.wantErr {
 				require.Error(err)
-				assert.Equal(err.Error(), tt.wantErrString)
+				assert.Equal(tt.wantErrString, err.Error())
 				return
 			}
 			require.NoError(err)

--- a/internal/target/repository_test.go
+++ b/internal/target/repository_test.go
@@ -91,7 +91,7 @@ func TestNewRepository(t *testing.T) {
 			got, err := NewRepository(tt.args.r, tt.args.w, tt.args.kms)
 			if tt.wantErr {
 				require.Error(err)
-				assert.Equal(err.Error(), tt.wantErrString)
+				assert.Equal(tt.wantErrString, err.Error())
 				return
 			}
 			require.NoError(err)


### PR DESCRIPTION
### What does this PR do

Updates a number of usages of `assert.Equal` where error checks incorrectly had `actual` as the first paramter and `expected` as the second parameter.  This avoids confusing error messages in failed tests such as:
```
Not equal: 
     expected: "actual error string"
     actual  : "expected error string"
```