### PR TITLE
Skip curl output when using automatic versioning and reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### Bug Fixes
 
+* cli: When `output-curl-string` is used with `update` or `add-/remove-/set-`
+  commands and automatic versioning is being used (that is, no `-version` flag
+  is given), it will now display the final call instead of the `GET` that
+  fetches the current version
+  ([Issue](https://github.com/hashicorp/boundary/issues/856))
+  ([PR](https://github.com/hashicorp/boundary/pull/858))
 * db: Fix panic in `database init` when controller config block is missing 
   ([Issue](https://github.com/hashicorp/boundary/issues/819)) 
   ([PR](https://github.com/hashicorp/boundary/pull/851))

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ CGO_ENABLED?=0
 
 export GEN_BASEPATH := $(shell pwd)
 
-api:
+api: apigen fmt
+apigen:
 	$(MAKE) --environment-overrides -C internal/api/genapi api
 
 tools:

--- a/api/accounts/account.gen.go
+++ b/api/accounts/account.gen.go
@@ -57,10 +57,8 @@ func (n AccountReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	AccountCreateResult = AccountReadResult
-	AccountUpdateResult = AccountReadResult
-)
+type AccountCreateResult = AccountReadResult
+type AccountUpdateResult = AccountReadResult
 
 type AccountDeleteResult struct {
 	response *api.Response
@@ -176,7 +174,7 @@ func (c *Client) Read(ctx context.Context, accountId string, opt ...Option) (*Ac
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}
@@ -208,7 +206,7 @@ func (c *Client) Update(ctx context.Context, accountId string, version uint32, o
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into Update request and automatic versioning not specified")
 		}
-		existingTarget, existingErr := c.Read(ctx, accountId, opt...)
+		existingTarget, existingErr := c.Read(ctx, accountId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)

--- a/api/accounts/account.gen.go
+++ b/api/accounts/account.gen.go
@@ -57,8 +57,10 @@ func (n AccountReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type AccountCreateResult = AccountReadResult
-type AccountUpdateResult = AccountReadResult
+type (
+	AccountCreateResult = AccountReadResult
+	AccountUpdateResult = AccountReadResult
+)
 
 type AccountDeleteResult struct {
 	response *api.Response

--- a/api/accounts/option.gen.go
+++ b/api/accounts/option.gen.go
@@ -17,6 +17,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -32,6 +33,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -42,6 +46,14 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }
 

--- a/api/authmethods/authmethods.gen.go
+++ b/api/authmethods/authmethods.gen.go
@@ -57,10 +57,8 @@ func (n AuthMethodReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	AuthMethodCreateResult = AuthMethodReadResult
-	AuthMethodUpdateResult = AuthMethodReadResult
-)
+type AuthMethodCreateResult = AuthMethodReadResult
+type AuthMethodUpdateResult = AuthMethodReadResult
 
 type AuthMethodDeleteResult struct {
 	response *api.Response
@@ -181,7 +179,7 @@ func (c *Client) Read(ctx context.Context, authMethodId string, opt ...Option) (
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}
@@ -213,7 +211,7 @@ func (c *Client) Update(ctx context.Context, authMethodId string, version uint32
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into Update request and automatic versioning not specified")
 		}
-		existingTarget, existingErr := c.Read(ctx, authMethodId, opt...)
+		existingTarget, existingErr := c.Read(ctx, authMethodId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)

--- a/api/authmethods/authmethods.gen.go
+++ b/api/authmethods/authmethods.gen.go
@@ -57,8 +57,10 @@ func (n AuthMethodReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type AuthMethodCreateResult = AuthMethodReadResult
-type AuthMethodUpdateResult = AuthMethodReadResult
+type (
+	AuthMethodCreateResult = AuthMethodReadResult
+	AuthMethodUpdateResult = AuthMethodReadResult
+)
 
 type AuthMethodDeleteResult struct {
 	response *api.Response

--- a/api/authmethods/option.gen.go
+++ b/api/authmethods/option.gen.go
@@ -17,6 +17,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -32,6 +33,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -42,6 +46,14 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }
 

--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -57,10 +57,8 @@ func (n AuthTokenReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	AuthTokenCreateResult = AuthTokenReadResult
-	AuthTokenUpdateResult = AuthTokenReadResult
-)
+type AuthTokenCreateResult = AuthTokenReadResult
+type AuthTokenUpdateResult = AuthTokenReadResult
 
 type AuthTokenDeleteResult struct {
 	response *api.Response
@@ -132,7 +130,7 @@ func (c *Client) Read(ctx context.Context, authTokenId string, opt ...Option) (*
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}

--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -57,8 +57,10 @@ func (n AuthTokenReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type AuthTokenCreateResult = AuthTokenReadResult
-type AuthTokenUpdateResult = AuthTokenReadResult
+type (
+	AuthTokenCreateResult = AuthTokenReadResult
+	AuthTokenUpdateResult = AuthTokenReadResult
+)
 
 type AuthTokenDeleteResult struct {
 	response *api.Response

--- a/api/authtokens/option.gen.go
+++ b/api/authtokens/option.gen.go
@@ -17,6 +17,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -32,6 +33,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -42,5 +46,13 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }

--- a/api/groups/group.gen.go
+++ b/api/groups/group.gen.go
@@ -57,10 +57,8 @@ func (n GroupReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	GroupCreateResult = GroupReadResult
-	GroupUpdateResult = GroupReadResult
-)
+type GroupCreateResult = GroupReadResult
+type GroupUpdateResult = GroupReadResult
 
 type GroupDeleteResult struct {
 	response *api.Response
@@ -176,7 +174,7 @@ func (c *Client) Read(ctx context.Context, groupId string, opt ...Option) (*Grou
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}
@@ -208,7 +206,7 @@ func (c *Client) Update(ctx context.Context, groupId string, version uint32, opt
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into Update request and automatic versioning not specified")
 		}
-		existingTarget, existingErr := c.Read(ctx, groupId, opt...)
+		existingTarget, existingErr := c.Read(ctx, groupId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -357,7 +355,7 @@ func (c *Client) AddMembers(ctx context.Context, groupId string, version uint32,
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into AddMembers request")
 		}
-		existingTarget, existingErr := c.Read(ctx, groupId, opt...)
+		existingTarget, existingErr := c.Read(ctx, groupId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -422,7 +420,7 @@ func (c *Client) SetMembers(ctx context.Context, groupId string, version uint32,
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into SetMembers request")
 		}
-		existingTarget, existingErr := c.Read(ctx, groupId, opt...)
+		existingTarget, existingErr := c.Read(ctx, groupId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -489,7 +487,7 @@ func (c *Client) RemoveMembers(ctx context.Context, groupId string, version uint
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into RemoveMembers request")
 		}
-		existingTarget, existingErr := c.Read(ctx, groupId, opt...)
+		existingTarget, existingErr := c.Read(ctx, groupId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)

--- a/api/groups/group.gen.go
+++ b/api/groups/group.gen.go
@@ -57,8 +57,10 @@ func (n GroupReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type GroupCreateResult = GroupReadResult
-type GroupUpdateResult = GroupReadResult
+type (
+	GroupCreateResult = GroupReadResult
+	GroupUpdateResult = GroupReadResult
+)
 
 type GroupDeleteResult struct {
 	response *api.Response

--- a/api/groups/option.gen.go
+++ b/api/groups/option.gen.go
@@ -17,6 +17,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -32,6 +33,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -42,6 +46,14 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }
 

--- a/api/hostcatalogs/host_catalog.gen.go
+++ b/api/hostcatalogs/host_catalog.gen.go
@@ -57,8 +57,10 @@ func (n HostCatalogReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type HostCatalogCreateResult = HostCatalogReadResult
-type HostCatalogUpdateResult = HostCatalogReadResult
+type (
+	HostCatalogCreateResult = HostCatalogReadResult
+	HostCatalogUpdateResult = HostCatalogReadResult
+)
 
 type HostCatalogDeleteResult struct {
 	response *api.Response

--- a/api/hostcatalogs/host_catalog.gen.go
+++ b/api/hostcatalogs/host_catalog.gen.go
@@ -57,10 +57,8 @@ func (n HostCatalogReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	HostCatalogCreateResult = HostCatalogReadResult
-	HostCatalogUpdateResult = HostCatalogReadResult
-)
+type HostCatalogCreateResult = HostCatalogReadResult
+type HostCatalogUpdateResult = HostCatalogReadResult
 
 type HostCatalogDeleteResult struct {
 	response *api.Response
@@ -181,7 +179,7 @@ func (c *Client) Read(ctx context.Context, hostCatalogId string, opt ...Option) 
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}
@@ -213,7 +211,7 @@ func (c *Client) Update(ctx context.Context, hostCatalogId string, version uint3
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into Update request and automatic versioning not specified")
 		}
-		existingTarget, existingErr := c.Read(ctx, hostCatalogId, opt...)
+		existingTarget, existingErr := c.Read(ctx, hostCatalogId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)

--- a/api/hostcatalogs/option.gen.go
+++ b/api/hostcatalogs/option.gen.go
@@ -17,6 +17,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -32,6 +33,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -42,6 +46,14 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }
 

--- a/api/hosts/host.gen.go
+++ b/api/hosts/host.gen.go
@@ -58,8 +58,10 @@ func (n HostReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type HostCreateResult = HostReadResult
-type HostUpdateResult = HostReadResult
+type (
+	HostCreateResult = HostReadResult
+	HostUpdateResult = HostReadResult
+)
 
 type HostDeleteResult struct {
 	response *api.Response

--- a/api/hosts/host.gen.go
+++ b/api/hosts/host.gen.go
@@ -58,10 +58,8 @@ func (n HostReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	HostCreateResult = HostReadResult
-	HostUpdateResult = HostReadResult
-)
+type HostCreateResult = HostReadResult
+type HostUpdateResult = HostReadResult
 
 type HostDeleteResult struct {
 	response *api.Response
@@ -177,7 +175,7 @@ func (c *Client) Read(ctx context.Context, hostId string, opt ...Option) (*HostR
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}
@@ -209,7 +207,7 @@ func (c *Client) Update(ctx context.Context, hostId string, version uint32, opt 
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into Update request and automatic versioning not specified")
 		}
-		existingTarget, existingErr := c.Read(ctx, hostId, opt...)
+		existingTarget, existingErr := c.Read(ctx, hostId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)

--- a/api/hosts/option.gen.go
+++ b/api/hosts/option.gen.go
@@ -17,6 +17,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -32,6 +33,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -42,6 +46,14 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }
 

--- a/api/hostsets/host_set.gen.go
+++ b/api/hostsets/host_set.gen.go
@@ -58,8 +58,10 @@ func (n HostSetReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type HostSetCreateResult = HostSetReadResult
-type HostSetUpdateResult = HostSetReadResult
+type (
+	HostSetCreateResult = HostSetReadResult
+	HostSetUpdateResult = HostSetReadResult
+)
 
 type HostSetDeleteResult struct {
 	response *api.Response

--- a/api/hostsets/host_set.gen.go
+++ b/api/hostsets/host_set.gen.go
@@ -58,10 +58,8 @@ func (n HostSetReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	HostSetCreateResult = HostSetReadResult
-	HostSetUpdateResult = HostSetReadResult
-)
+type HostSetCreateResult = HostSetReadResult
+type HostSetUpdateResult = HostSetReadResult
 
 type HostSetDeleteResult struct {
 	response *api.Response
@@ -177,7 +175,7 @@ func (c *Client) Read(ctx context.Context, hostSetId string, opt ...Option) (*Ho
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}
@@ -209,7 +207,7 @@ func (c *Client) Update(ctx context.Context, hostSetId string, version uint32, o
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into Update request and automatic versioning not specified")
 		}
-		existingTarget, existingErr := c.Read(ctx, hostSetId, opt...)
+		existingTarget, existingErr := c.Read(ctx, hostSetId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -358,7 +356,7 @@ func (c *Client) AddHosts(ctx context.Context, hostSetId string, version uint32,
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into AddHosts request")
 		}
-		existingTarget, existingErr := c.Read(ctx, hostSetId, opt...)
+		existingTarget, existingErr := c.Read(ctx, hostSetId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -423,7 +421,7 @@ func (c *Client) SetHosts(ctx context.Context, hostSetId string, version uint32,
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into SetHosts request")
 		}
-		existingTarget, existingErr := c.Read(ctx, hostSetId, opt...)
+		existingTarget, existingErr := c.Read(ctx, hostSetId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -490,7 +488,7 @@ func (c *Client) RemoveHosts(ctx context.Context, hostSetId string, version uint
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into RemoveHosts request")
 		}
-		existingTarget, existingErr := c.Read(ctx, hostSetId, opt...)
+		existingTarget, existingErr := c.Read(ctx, hostSetId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)

--- a/api/hostsets/option.gen.go
+++ b/api/hostsets/option.gen.go
@@ -17,6 +17,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -32,6 +33,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -42,6 +46,14 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }
 

--- a/api/options.go
+++ b/api/options.go
@@ -12,8 +12,18 @@ func getOpts(opt ...Option) options {
 type Option func(*options)
 
 // options = how options are represented
-type options struct{}
+type options struct {
+	withSkipCurlOuptut bool
+}
 
 func getDefaultOptions() options {
 	return options{}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOuptut = true
+	}
 }

--- a/api/roles/option.gen.go
+++ b/api/roles/option.gen.go
@@ -17,6 +17,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -32,6 +33,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -42,6 +46,14 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }
 

--- a/api/roles/role.gen.go
+++ b/api/roles/role.gen.go
@@ -60,10 +60,8 @@ func (n RoleReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	RoleCreateResult = RoleReadResult
-	RoleUpdateResult = RoleReadResult
-)
+type RoleCreateResult = RoleReadResult
+type RoleUpdateResult = RoleReadResult
 
 type RoleDeleteResult struct {
 	response *api.Response
@@ -179,7 +177,7 @@ func (c *Client) Read(ctx context.Context, roleId string, opt ...Option) (*RoleR
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}
@@ -211,7 +209,7 @@ func (c *Client) Update(ctx context.Context, roleId string, version uint32, opt 
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into Update request and automatic versioning not specified")
 		}
-		existingTarget, existingErr := c.Read(ctx, roleId, opt...)
+		existingTarget, existingErr := c.Read(ctx, roleId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -360,7 +358,7 @@ func (c *Client) AddGrants(ctx context.Context, roleId string, version uint32, g
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into AddGrants request")
 		}
-		existingTarget, existingErr := c.Read(ctx, roleId, opt...)
+		existingTarget, existingErr := c.Read(ctx, roleId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -427,7 +425,7 @@ func (c *Client) AddPrincipals(ctx context.Context, roleId string, version uint3
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into AddPrincipals request")
 		}
-		existingTarget, existingErr := c.Read(ctx, roleId, opt...)
+		existingTarget, existingErr := c.Read(ctx, roleId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -492,7 +490,7 @@ func (c *Client) SetGrants(ctx context.Context, roleId string, version uint32, g
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into SetGrants request")
 		}
-		existingTarget, existingErr := c.Read(ctx, roleId, opt...)
+		existingTarget, existingErr := c.Read(ctx, roleId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -557,7 +555,7 @@ func (c *Client) SetPrincipals(ctx context.Context, roleId string, version uint3
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into SetPrincipals request")
 		}
-		existingTarget, existingErr := c.Read(ctx, roleId, opt...)
+		existingTarget, existingErr := c.Read(ctx, roleId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -624,7 +622,7 @@ func (c *Client) RemoveGrants(ctx context.Context, roleId string, version uint32
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into RemoveGrants request")
 		}
-		existingTarget, existingErr := c.Read(ctx, roleId, opt...)
+		existingTarget, existingErr := c.Read(ctx, roleId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -691,7 +689,7 @@ func (c *Client) RemovePrincipals(ctx context.Context, roleId string, version ui
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into RemovePrincipals request")
 		}
-		existingTarget, existingErr := c.Read(ctx, roleId, opt...)
+		existingTarget, existingErr := c.Read(ctx, roleId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)

--- a/api/roles/role.gen.go
+++ b/api/roles/role.gen.go
@@ -60,8 +60,10 @@ func (n RoleReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type RoleCreateResult = RoleReadResult
-type RoleUpdateResult = RoleReadResult
+type (
+	RoleCreateResult = RoleReadResult
+	RoleUpdateResult = RoleReadResult
+)
 
 type RoleDeleteResult struct {
 	response *api.Response

--- a/api/scopes/option.gen.go
+++ b/api/scopes/option.gen.go
@@ -19,6 +19,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -34,6 +35,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -44,6 +48,14 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }
 

--- a/api/scopes/scope.gen.go
+++ b/api/scopes/scope.gen.go
@@ -55,8 +55,10 @@ func (n ScopeReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type ScopeCreateResult = ScopeReadResult
-type ScopeUpdateResult = ScopeReadResult
+type (
+	ScopeCreateResult = ScopeReadResult
+	ScopeUpdateResult = ScopeReadResult
+)
 
 type ScopeDeleteResult struct {
 	response *api.Response

--- a/api/scopes/scope.gen.go
+++ b/api/scopes/scope.gen.go
@@ -55,10 +55,8 @@ func (n ScopeReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	ScopeCreateResult = ScopeReadResult
-	ScopeUpdateResult = ScopeReadResult
-)
+type ScopeCreateResult = ScopeReadResult
+type ScopeUpdateResult = ScopeReadResult
 
 type ScopeDeleteResult struct {
 	response *api.Response
@@ -174,7 +172,7 @@ func (c *Client) Read(ctx context.Context, scopeId string, opt ...Option) (*Scop
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}
@@ -206,7 +204,7 @@ func (c *Client) Update(ctx context.Context, scopeId string, version uint32, opt
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into Update request and automatic versioning not specified")
 		}
-		existingTarget, existingErr := c.Read(ctx, scopeId, opt...)
+		existingTarget, existingErr := c.Read(ctx, scopeId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)

--- a/api/sessions/option.gen.go
+++ b/api/sessions/option.gen.go
@@ -17,6 +17,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -32,6 +33,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -42,5 +46,13 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }

--- a/api/sessions/session.gen.go
+++ b/api/sessions/session.gen.go
@@ -65,8 +65,10 @@ func (n SessionReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type SessionCreateResult = SessionReadResult
-type SessionUpdateResult = SessionReadResult
+type (
+	SessionCreateResult = SessionReadResult
+	SessionUpdateResult = SessionReadResult
+)
 
 type SessionDeleteResult struct {
 	response *api.Response

--- a/api/sessions/session.gen.go
+++ b/api/sessions/session.gen.go
@@ -65,10 +65,8 @@ func (n SessionReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	SessionCreateResult = SessionReadResult
-	SessionUpdateResult = SessionReadResult
-)
+type SessionCreateResult = SessionReadResult
+type SessionUpdateResult = SessionReadResult
 
 type SessionDeleteResult struct {
 	response *api.Response
@@ -140,7 +138,7 @@ func (c *Client) Read(ctx context.Context, sessionId string, opt ...Option) (*Se
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}

--- a/api/targets/option.gen.go
+++ b/api/targets/option.gen.go
@@ -17,6 +17,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -32,6 +33,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -42,6 +46,14 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }
 

--- a/api/targets/target.gen.go
+++ b/api/targets/target.gen.go
@@ -61,10 +61,8 @@ func (n TargetReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	TargetCreateResult = TargetReadResult
-	TargetUpdateResult = TargetReadResult
-)
+type TargetCreateResult = TargetReadResult
+type TargetUpdateResult = TargetReadResult
 
 type TargetDeleteResult struct {
 	response *api.Response
@@ -185,7 +183,7 @@ func (c *Client) Read(ctx context.Context, targetId string, opt ...Option) (*Tar
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}
@@ -217,7 +215,7 @@ func (c *Client) Update(ctx context.Context, targetId string, version uint32, op
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into Update request and automatic versioning not specified")
 		}
-		existingTarget, existingErr := c.Read(ctx, targetId, opt...)
+		existingTarget, existingErr := c.Read(ctx, targetId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -366,7 +364,7 @@ func (c *Client) AddHostSets(ctx context.Context, targetId string, version uint3
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into AddHostSets request")
 		}
-		existingTarget, existingErr := c.Read(ctx, targetId, opt...)
+		existingTarget, existingErr := c.Read(ctx, targetId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -431,7 +429,7 @@ func (c *Client) SetHostSets(ctx context.Context, targetId string, version uint3
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into SetHostSets request")
 		}
-		existingTarget, existingErr := c.Read(ctx, targetId, opt...)
+		existingTarget, existingErr := c.Read(ctx, targetId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -498,7 +496,7 @@ func (c *Client) RemoveHostSets(ctx context.Context, targetId string, version ui
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into RemoveHostSets request")
 		}
-		existingTarget, existingErr := c.Read(ctx, targetId, opt...)
+		existingTarget, existingErr := c.Read(ctx, targetId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)

--- a/api/targets/target.gen.go
+++ b/api/targets/target.gen.go
@@ -61,8 +61,10 @@ func (n TargetReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type TargetCreateResult = TargetReadResult
-type TargetUpdateResult = TargetReadResult
+type (
+	TargetCreateResult = TargetReadResult
+	TargetUpdateResult = TargetReadResult
+)
 
 type TargetDeleteResult struct {
 	response *api.Response

--- a/api/users/option.gen.go
+++ b/api/users/option.gen.go
@@ -17,6 +17,7 @@ type options struct {
 	postMap                 map[string]interface{}
 	queryMap                map[string]string
 	withAutomaticVersioning bool
+	withSkipCurlOutput      bool
 }
 
 func getDefaultOptions() options {
@@ -32,6 +33,9 @@ func getOpts(opt ...Option) (options, []api.Option) {
 		o(&opts)
 	}
 	var apiOpts []api.Option
+	if opts.withSkipCurlOutput {
+		apiOpts = append(apiOpts, api.WithSkipCurlOutput(true))
+	}
 	return opts, apiOpts
 }
 
@@ -42,6 +46,14 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithAutomaticVersioning(enable bool) Option {
 	return func(o *options) {
 		o.withAutomaticVersioning = enable
+	}
+}
+
+// WithSkipCurlOutput tells the API to not use the current call for cURL output.
+// Useful for when we need to look up versions.
+func WithSkipCurlOutput(skip bool) Option {
+	return func(o *options) {
+		o.withSkipCurlOutput = true
 	}
 }
 

--- a/api/users/user.gen.go
+++ b/api/users/user.gen.go
@@ -57,10 +57,8 @@ func (n UserReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type (
-	UserCreateResult = UserReadResult
-	UserUpdateResult = UserReadResult
-)
+type UserCreateResult = UserReadResult
+type UserUpdateResult = UserReadResult
 
 type UserDeleteResult struct {
 	response *api.Response
@@ -176,7 +174,7 @@ func (c *Client) Read(ctx context.Context, userId string, opt ...Option) (*UserR
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req, apiOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error performing client request during Read call: %w", err)
 	}
@@ -208,7 +206,7 @@ func (c *Client) Update(ctx context.Context, userId string, version uint32, opt 
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into Update request and automatic versioning not specified")
 		}
-		existingTarget, existingErr := c.Read(ctx, userId, opt...)
+		existingTarget, existingErr := c.Read(ctx, userId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -357,7 +355,7 @@ func (c *Client) AddAccounts(ctx context.Context, userId string, version uint32,
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into AddAccounts request")
 		}
-		existingTarget, existingErr := c.Read(ctx, userId, opt...)
+		existingTarget, existingErr := c.Read(ctx, userId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -422,7 +420,7 @@ func (c *Client) SetAccounts(ctx context.Context, userId string, version uint32,
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into SetAccounts request")
 		}
-		existingTarget, existingErr := c.Read(ctx, userId, opt...)
+		existingTarget, existingErr := c.Read(ctx, userId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
@@ -489,7 +487,7 @@ func (c *Client) RemoveAccounts(ctx context.Context, userId string, version uint
 		if !opts.withAutomaticVersioning {
 			return nil, errors.New("zero version number passed into RemoveAccounts request")
 		}
-		existingTarget, existingErr := c.Read(ctx, userId, opt...)
+		existingTarget, existingErr := c.Read(ctx, userId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
 		if existingErr != nil {
 			if api.AsServerError(existingErr) != nil {
 				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)

--- a/api/users/user.gen.go
+++ b/api/users/user.gen.go
@@ -57,8 +57,10 @@ func (n UserReadResult) GetResponseMap() map[string]interface{} {
 	return n.response.Map
 }
 
-type UserCreateResult = UserReadResult
-type UserUpdateResult = UserReadResult
+type (
+	UserCreateResult = UserReadResult
+	UserUpdateResult = UserReadResult
+)
 
 type UserDeleteResult struct {
 	response *api.Response


### PR DESCRIPTION
This makes it so that the actual output is the update/delete.

Fixes #856