### PR TITLE
chore: bump ui commitish to latest from boundary-ui/main

### DIFF
--- a/internal/ui/VERSION
+++ b/internal/ui/VERSION
@@ -1,4 +1,4 @@
-b7937e77ad5a37fcf0bf0ed2b6d4e4b34d97b144 Merge pull request #383 from hashicorp/rename-core-to-admin
+882ba37c3ecfaa19e25231b0952328ce0731c1c5 Merge pull request #427 from hashicorp/controller-to-origin-rename
 # This file determines the version of the UI to embed in the boundary binary.
 # Update this file by running 'make update-ui-version' from the root of this repo.
 # Set UI_COMMITISH when running the above target to update to a specific version.

--- a/internal/ui/VERSION
+++ b/internal/ui/VERSION
@@ -1,4 +1,4 @@
-882ba37c3ecfaa19e25231b0952328ce0731c1c5 Merge pull request #427 from hashicorp/controller-to-origin-rename
+39932708b0d3306937e3fd8333db5934760bcd3b Merge pull request #432 from hashicorp/fix-scopes-nav
 # This file determines the version of the UI to embed in the boundary binary.
 # Update this file by running 'make update-ui-version' from the root of this repo.
 # Set UI_COMMITISH when running the above target to update to a specific version.


### PR DESCRIPTION
While there are no user-facing changes in admin, let's bump the commitish anyway to stay up-to-date.