### PR TITLE
Fix nil TLSClientConfig

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -170,6 +170,10 @@ func (c *Config) ConfigureTLS() error {
 	if c.HttpClient == nil {
 		c.HttpClient = cleanhttp.DefaultPooledClient()
 	}
+
+	if c.HttpClient.Transport.(*http.Transport).TLSClientConfig == nil {
+		c.HttpClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{}
+	}
 	clientTLSConfig := c.HttpClient.Transport.(*http.Transport).TLSClientConfig
 
 	var clientCert tls.Certificate


### PR DESCRIPTION
The client from go-cleanhttp does not set TLSClientConfig. This can be a possible fix or go-cleanhttp can create the config at client creation.