### PR TITLE
When running single-server mode, use public_cluster_addr if given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Canonical reference for changes, improvements, and bugfixes for Boundary.
 
+## Next
+
+### New and Improved
+
+* server: When running single-server mode and `controllers` is not specified in
+  the `worker` block, use `public_cluster_addr` if given
+  ([PR](https://github.com/hashicorp/boundary/pull/904))
+
 ## 0.1.5 (2021/01/29)
 
 *NOTE*: This version requires a database migration via the new `boundary

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -229,9 +229,16 @@ func (c *Command) Run(args []string) int {
 		if c.Config.Controller != nil {
 			switch len(c.Config.Worker.Controllers) {
 			case 0:
+				if c.Config.Controller.PublicClusterAddr != "" {
+					clusterAddr = c.Config.Controller.PublicClusterAddr
+				}
 				c.Config.Worker.Controllers = []string{clusterAddr}
 			case 1:
 				if c.Config.Worker.Controllers[0] == clusterAddr {
+					break
+				}
+				if c.Config.Controller.PublicClusterAddr != "" &&
+					c.Config.Worker.Controllers[0] == c.Config.Controller.PublicClusterAddr {
 					break
 				}
 				// Best effort see if it's a domain name and if not assume it must match


### PR DESCRIPTION
Right now you don't need to specify a controller address and we use the
cluster listener address; this allows overriding it to the
public_cluster_addr if one is given.

If `controllers` is specified we allow it to be either the cluster
listener or the public cluster address if one is specified before trying
to parse and use it.