### PR TITLE
Scope role grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ database migrate` command.
 * api/cli: Due to visibility changes on collection listing, a list
   will not include any resources if the user only has `list` as an authorized action.
   As a result `scope list`, which is used by the UI to populate the login scope dropdown, 
-  will be empty if the `u_anon` role grant does not include a `read` action 
+  will be empty if the role granting the `u_anon` user `list` privileges is not updated to also contain a `read` action
 
 ### New and Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 * server: When running single-server mode and `controllers` is not specified in
   the `worker` block, use `public_cluster_addr` if given
   ([PR](https://github.com/hashicorp/boundary/pull/904))
+* server: Add `read` action to default scope grant
+  ([PR](https://github.com/hashicorp/boundary/pull/913))
 
 ### Bug Fixes
 
@@ -32,6 +34,10 @@ database migrate` command.
 
 * controller/worker: Require names to be all lowercase. This removes ambiguity
   or accidental mismatching when using upcoming filtering features.
+* api/cli: Due to visibility changes on collection listing, a list
+  will not include any resources if the user only has `list` as an authorized action.
+  As a result `scope list`, which is used by the UI to populate the login scope dropdown, 
+  will be empty if the `u_anon` role grant does not include a `read` action 
 
 ### New and Improved
 

--- a/internal/cmd/base/initial_resources.go
+++ b/internal/cmd/base/initial_resources.go
@@ -54,7 +54,7 @@ func (b *Server) CreateInitialLoginRole(ctx context.Context) (*iam.Role, error) 
 		return nil, fmt.Errorf("error creating role for default generated grants: %w", err)
 	}
 	if _, err := iamRepo.AddRoleGrants(cancelCtx, role.PublicId, role.Version, []string{
-		"type=scope;actions=list",
+		"id=*;type=scope;actions=list,read",
 		"id=*;type=auth-method;actions=authenticate,list",
 		"id={{account.id}};actions=read,change-password",
 	}); err != nil {

--- a/internal/cmd/commands/scopes/funcs.go
+++ b/internal/cmd/commands/scopes/funcs.go
@@ -53,7 +53,7 @@ func generateScopeTableOutput(in *scopes.Scope) string {
 		ret = append(ret, "  Authorized Actions on Scope's Collections:")
 		for _, key := range keys {
 			ret = append(ret,
-				fmt.Sprintf("    %ss:", key),
+				fmt.Sprintf("    %s:", key),
 				base.WrapSlice(6, in.AuthorizedCollectionActions[key]),
 			)
 		}

--- a/internal/iam/repository_scope.go
+++ b/internal/iam/repository_scope.go
@@ -280,7 +280,7 @@ func (r *Repository) CreateScope(ctx context.Context, s *Scope, userId string, o
 				// Grants
 				{
 					grants := []interface{}{}
-					roleGrant, err := NewRoleGrant(defaultRolePublicId, "type=scope;actions=list")
+					roleGrant, err := NewRoleGrant(defaultRolePublicId, "id=*;type=scope;actions=list,read")
 					if err != nil {
 						return errors.Wrap(err, op, errors.WithMsg("unable to create in memory role grant"))
 					}


### PR DESCRIPTION
### What does this PR do

Adds `read` action to default scope role grants
Removes additional `s` from authorized actions in table view output (an `s` was being added in both the `populateCollectionAuthorizedActions` func and the print)

```
 boundary scopes read -id global

Scope information:
  Created Time:        Thu, 04 Feb 2021 14:07:08 PST
  ID:                  global
  Name:                global
  Updated Time:        Thu, 04 Feb 2021 14:07:53 PST
  Version:             2

  Scope (parent):
    ID:                global
    Name:              global
    Type:              global

  Authorized Actions:
    read

  Authorized Actions on Scope's Collections:
    auth-methodss:
      list
    scopess:
      list
```