### PR TITLE
Ensure the controller maintains the shared lock

### DIFF
--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -45,7 +45,7 @@ var DevOnlyControllerFlags = func(*Command, *FlagSet) {}
 
 type Command struct {
 	Context    context.Context
-	CancelFn	context.CancelFunc
+	CancelFn   context.CancelFunc
 	UI         cli.Ui
 	ShutdownCh chan struct{}
 
@@ -89,7 +89,7 @@ func NewCommand(ui cli.Ui) *Command {
 		UI:         ui,
 		ShutdownCh: MakeShutdownCh(),
 		Context:    ctx,
-		CancelFn: cancel,
+		CancelFn:   cancel,
 	}
 
 	go func() {

--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -45,6 +45,7 @@ var DevOnlyControllerFlags = func(*Command, *FlagSet) {}
 
 type Command struct {
 	Context    context.Context
+	CancelFn	context.CancelFunc
 	UI         cli.Ui
 	ShutdownCh chan struct{}
 
@@ -88,6 +89,7 @@ func NewCommand(ui cli.Ui) *Command {
 		UI:         ui,
 		ShutdownCh: MakeShutdownCh(),
 		Context:    ctx,
+		CancelFn: cancel,
 	}
 
 	go func() {

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -85,7 +85,8 @@ type Server struct {
 	DatabaseUrl            string
 	DevDatabaseCleanupFunc func() error
 
-	Database *gorm.DB
+	Database      *gorm.DB
+	SchemaManager *schema.Manager
 }
 
 func NewServer(cmd *Command) *Server {

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -36,9 +36,9 @@ var (
 type Command struct {
 	*base.Server
 
-	SighupCh      chan struct{}
-	ReloadedCh    chan struct{}
-	SigUSR2Ch     chan struct{}
+	SighupCh   chan struct{}
+	ReloadedCh chan struct{}
+	SigUSR2Ch  chan struct{}
 
 	Config     *config.Config
 	controller *controller.Controller
@@ -625,7 +625,7 @@ func (c *Command) connectSchemaManager(dialect string) error {
 		// 1 second is chosen so the shutdown is still responsive and this is a mostly
 		// non critical step since the lock should be released when the session with the
 		// database is closed.
-		ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 		if err := sm.SharedUnlock(ctx); err != nil {
 			return fmt.Errorf("Unable to release shared lock to the database: %w", err)

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -680,7 +680,7 @@ func (c *Command) ensureManagerConnection(i time.Duration) {
 		if err := c.SchemaManager.Ping(c.Context); err != nil && c.Context.Err() == nil {
 			c.SchemaManager, err = schema.NewManager(c.Context, "postgres", c.Database.DB())
 			if err != nil {
-				c.UI.Error("The Schema Manager lost connection with the DB and cannot ensure it's integrity.")
+				c.UI.Error("The Schema Manager lost connection with the DB and cannot ensure its integrity.")
 				c.CancelFn()
 				return
 			}
@@ -689,7 +689,7 @@ func (c *Command) ensureManagerConnection(i time.Duration) {
 				continue
 			}
 
-			c.UI.Error("The Schema Manager lost connection with the DB and cannot ensure it's integrity.")
+			c.UI.Error("The Schema Manager lost connection with the DB and cannot ensure its integrity.")
 			c.CancelFn()
 			return
 		}

--- a/internal/cmd/commands/server/server_test.go
+++ b/internal/cmd/commands/server/server_test.go
@@ -37,7 +37,6 @@ func TestEnsureManagerConnection_DBDisconnect(t *testing.T) {
 
 	require.NoError(t, c.connectSchemaManager(dialect))
 
-
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -75,7 +74,6 @@ func TestEnsureManagerConnection_Shutdown(t *testing.T) {
 	require.NoError(t, m.RollForward(ctx))
 
 	require.NoError(t, c.connectSchemaManager(dialect))
-
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/internal/cmd/commands/server/server_test.go
+++ b/internal/cmd/commands/server/server_test.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/boundary/internal/cmd/base"
 	"github.com/hashicorp/boundary/internal/db/schema"
@@ -12,6 +14,63 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestConnectSchemaManager(t *testing.T) {
+	dialect := "postgres"
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		prep func(*sql.DB)
+		err  bool
+	}{
+		{
+			name: "valid",
+			prep: func(d *sql.DB) {
+				m, err := schema.NewManager(ctx, dialect, d)
+				require.NoError(t, err)
+				require.NoError(t, m.RollForward(ctx))
+			},
+		},
+		{
+			name: "not initialized",
+			err:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			ch := make(chan struct{})
+			c := &Command{
+				Server:    base.NewServer(base.NewCommand(ui)),
+				SighupCh:  ch,
+				SigUSR2Ch: ch,
+			}
+			defer c.CancelFn()
+
+			end, u, _, err := docker.StartDbInDocker(dialect)
+			require.NoError(t, err)
+			defer end()
+
+			c.DatabaseUrl = u
+			require.NoError(t, c.ConnectToDatabase(dialect))
+
+			if tc.prep != nil {
+				tc.prep(c.Database.DB())
+			}
+
+			err = c.connectSchemaManager(dialect)
+			if tc.err {
+				assert.Error(t, err)
+				assert.Nil(t, c.SchemaManager)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, c.SchemaManager)
+			}
+		})
+	}
+}
 
 func TestEnsureManagerConnection_DBDisconnect(t *testing.T) {
 	ui := cli.NewMockUi()
@@ -41,7 +100,7 @@ func TestEnsureManagerConnection_DBDisconnect(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		c.ensureManagerConnection()
+		c.ensureManagerConnection(time.Millisecond)
 	}()
 
 	end()
@@ -79,7 +138,7 @@ func TestEnsureManagerConnection_Shutdown(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		c.ensureManagerConnection()
+		c.ensureManagerConnection(time.Millisecond)
 	}()
 
 	close(c.ShutdownCh)

--- a/internal/cmd/commands/server/server_test.go
+++ b/internal/cmd/commands/server/server_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/hashicorp/boundary/internal/db/schema"
+	"github.com/hashicorp/boundary/internal/docker"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureManagerConnection_DBDisconnect(t *testing.T) {
+	ui := cli.NewMockUi()
+	ch := make(chan struct{})
+	c := &Command{
+		Server:    base.NewServer(base.NewCommand(ui)),
+		SighupCh:  ch,
+		SigUSR2Ch: ch,
+	}
+
+	ctx := context.Background()
+	dialect := "postgres"
+	end, u, _, err := docker.StartDbInDocker(dialect)
+	require.NoError(t, err)
+	defer end()
+
+	c.DatabaseUrl = u
+	require.NoError(t, c.ConnectToDatabase(dialect))
+
+	m, err := schema.NewManager(ctx, dialect, c.Database.DB())
+	require.NoError(t, err)
+	require.NoError(t, m.RollForward(ctx))
+
+	require.NoError(t, c.connectSchemaManager(dialect))
+
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.ensureManagerConnection()
+	}()
+
+	end()
+	wg.Wait()
+
+	assert.Zero(t, ui.OutputWriter.String())
+	assert.Equal(t, "The Schema Manager lost connection with the DB and cannot ensure it's integrity.\n", ui.ErrorWriter.String())
+}
+
+func TestEnsureManagerConnection_Shutdown(t *testing.T) {
+	ui := cli.NewMockUi()
+	ch := make(chan struct{})
+	c := &Command{
+		Server:    base.NewServer(base.NewCommand(ui)),
+		SighupCh:  ch,
+		SigUSR2Ch: ch,
+	}
+
+	ctx := context.Background()
+	dialect := "postgres"
+	end, u, _, err := docker.StartDbInDocker(dialect)
+	require.NoError(t, err)
+	defer end()
+
+	c.DatabaseUrl = u
+	require.NoError(t, c.ConnectToDatabase(dialect))
+
+	m, err := schema.NewManager(ctx, dialect, c.Database.DB())
+	require.NoError(t, err)
+	require.NoError(t, m.RollForward(ctx))
+
+	require.NoError(t, c.connectSchemaManager(dialect))
+
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.ensureManagerConnection()
+	}()
+
+	close(c.ShutdownCh)
+	wg.Wait()
+
+	assert.Zero(t, ui.OutputWriter.String())
+	assert.Zero(t, ui.ErrorWriter.String())
+}

--- a/internal/db/schema/manager.go
+++ b/internal/db/schema/manager.go
@@ -19,6 +19,7 @@ type driver interface {
 	Lock(context.Context) error
 	Unlock(context.Context) error
 	UnlockShared(context.Context) error
+	Ping(context.Context) error
 	// Either starts a transactioon internal to the driver or sets a dirty
 	// bit so if the Run fails the CurrentState reflects it.
 	StartRun(context.Context) error
@@ -88,6 +89,15 @@ func (b *Manager) CurrentState(ctx context.Context) (*State, error) {
 	dbS.DatabaseSchemaVersion = v
 	dbS.Dirty = dirty
 	return &dbS, nil
+}
+
+// Ping verifies the connection to the database is still open.
+func (b *Manager) Ping(ctx context.Context) error {
+	const op = "schema.(Manager).Ping"
+	if err := b.driver.Ping(ctx); err != nil {
+		return errors.Wrap(err, op)
+	}
+	return nil
 }
 
 // SharedLock attempts to obtain a shared lock on the database.  This can fail

--- a/internal/db/schema/postgres/postgres.go
+++ b/internal/db/schema/postgres/postgres.go
@@ -56,7 +56,7 @@ var defaultMigrationsTable = "boundary_schema_version"
 type Postgres struct {
 	// Locking and unlocking need to use the same connection
 	conn *sql.Conn
-	tx *sql.Tx
+	tx   *sql.Tx
 }
 
 // New returns a postgres pointer with the provided db verified as

--- a/internal/db/schema/postgres/postgres_test.go
+++ b/internal/db/schema/postgres/postgres_test.go
@@ -386,11 +386,11 @@ func TestEnsureTable_Fresh(t *testing.T) {
 
 		tableCreated := false
 		query := "SELECT exists (SELECT 1 FROM information_schema.tables WHERE table_schema=(SELECT current_schema()) AND table_name = '" + defaultMigrationsTable + "')"
-		assert.NoError(t, p.db.QueryRowContext(ctx, query).Scan(&tableCreated))
+		assert.NoError(t, p.conn.QueryRowContext(ctx, query).Scan(&tableCreated))
 		assert.False(t, tableCreated)
 
 		assert.NoError(t, p.EnsureVersionTable(ctx))
-		assert.NoError(t, p.db.QueryRowContext(ctx, query).Scan(&tableCreated))
+		assert.NoError(t, p.conn.QueryRowContext(ctx, query).Scan(&tableCreated))
 		assert.True(t, tableCreated)
 	})
 }
@@ -414,7 +414,7 @@ func TestEnsureTable_ExistingTable(t *testing.T) {
 		assert.NoError(t, p.EnsureVersionTable(ctx))
 
 		oldTableCreate := `CREATE TABLE IF NOT EXISTS schema_migrations (version bigint primary key, dirty boolean not null)`
-		_, err = p.db.ExecContext(ctx, oldTableCreate)
+		_, err = p.conn.ExecContext(ctx, oldTableCreate)
 		assert.NoError(t, err)
 
 		assert.NoError(t, p.EnsureVersionTable(ctx))
@@ -439,23 +439,23 @@ func TestEnsureTable_OldTable(t *testing.T) {
 		})
 
 		oldTableCreate := `CREATE TABLE IF NOT EXISTS schema_migrations (version bigint primary key, dirty boolean not null)`
-		_, err = p.db.ExecContext(ctx, oldTableCreate)
+		_, err = p.conn.ExecContext(ctx, oldTableCreate)
 		assert.NoError(t, err)
 
 		tableExists := false
 		oldTableCheck := "SELECT exists (SELECT 1 FROM information_schema.tables WHERE table_schema=(SELECT current_schema()) AND table_name = 'schema_migrations')"
-		assert.NoError(t, p.db.QueryRowContext(ctx, oldTableCheck).Scan(&tableExists))
+		assert.NoError(t, p.conn.QueryRowContext(ctx, oldTableCheck).Scan(&tableExists))
 		assert.True(t, tableExists)
 
 		query := "SELECT exists (SELECT 1 FROM information_schema.tables WHERE table_schema=(SELECT current_schema()) AND table_name = '" + defaultMigrationsTable + "')"
-		assert.NoError(t, p.db.QueryRowContext(ctx, query).Scan(&tableExists))
+		assert.NoError(t, p.conn.QueryRowContext(ctx, query).Scan(&tableExists))
 		assert.False(t, tableExists)
 
 		assert.NoError(t, p.EnsureVersionTable(ctx))
 
-		assert.NoError(t, p.db.QueryRowContext(ctx, oldTableCheck).Scan(&tableExists))
+		assert.NoError(t, p.conn.QueryRowContext(ctx, oldTableCheck).Scan(&tableExists))
 		assert.False(t, tableExists)
-		assert.NoError(t, p.db.QueryRowContext(ctx, query).Scan(&tableExists))
+		assert.NoError(t, p.conn.QueryRowContext(ctx, query).Scan(&tableExists))
 		assert.True(t, tableExists)
 	})
 }

--- a/internal/db/schema/postgres/postgres_test.go
+++ b/internal/db/schema/postgres/postgres_test.go
@@ -329,6 +329,27 @@ func TestWithSchema(t *testing.T) {
 	})
 }
 
+func TestPostgres_Ping(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addr := pgConnectionString(ip, port)
+		p, err := open(t, ctx, addr)
+		if err != nil {
+			require.NoError(t, err)
+		}
+
+		assert.NoError(t, p.Ping(ctx))
+
+		require.NoError(t, p.close(t))
+		assert.Error(t, p.Ping(ctx))
+	})
+}
+
 func TestPostgres_Lock(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ctx := context.Background()

--- a/internal/db/schema/postgres/testing.go
+++ b/internal/db/schema/postgres/testing.go
@@ -135,6 +135,5 @@ func open(t *testing.T, ctx context.Context, u string) (*Postgres, error) {
 func (p *Postgres) close(t *testing.T) error {
 	t.Helper()
 	require.NoError(t, p.conn.Close())
-	require.NoError(t, p.db.Close())
 	return nil
 }

--- a/internal/docker/supported.go
+++ b/internal/docker/supported.go
@@ -40,7 +40,7 @@ func startDbInDockerSupported(dialect string) (cleanup func() error, retURL, con
 	}
 
 	cleanup = func() error {
-		return cleanupDockerResource(pool, resource)
+		return cleanupDockerResource(resource)
 	}
 
 	if err := pool.Retry(func() error {
@@ -62,10 +62,10 @@ func startDbInDockerSupported(dialect string) (cleanup func() error, retURL, con
 }
 
 // cleanupDockerResource will clean up the dockertest resources (postgres)
-func cleanupDockerResource(pool *dockertest.Pool, resource *dockertest.Resource) error {
+func cleanupDockerResource(resource *dockertest.Resource) error {
 	var err error
 	for i := 0; i < 10; i++ {
-		err = pool.Purge(resource)
+		err = resource.Close()
 		if err == nil {
 			return nil
 		}


### PR DESCRIPTION
This ensures that the DB connection remains open between the schema manager and the database.  Since this lock is used to ensure the migrate and init commands don't run at the same time as the controller we don't want the connection to silently fail.