### PR TITLE
Use uint for internal types

### DIFF
--- a/internal/types/action/action.go
+++ b/internal/types/action/action.go
@@ -2,7 +2,7 @@ package action
 
 // Type defines a type for the Actions of Resources
 // actions are also stored as a lookup db table named iam_action
-type Type int
+type Type uint
 
 // not using iota intentionally, since the values are stored in the db as well.
 const (

--- a/internal/types/resource/resource.go
+++ b/internal/types/resource/resource.go
@@ -1,7 +1,7 @@
 package resource
 
 // Type defines the types of resources in the system
-type Type int
+type Type uint
 
 const (
 	Unknown     Type = 0

--- a/internal/types/scope/scope.go
+++ b/internal/types/scope/scope.go
@@ -1,7 +1,7 @@
 package scope
 
 // Type defines the possible types for Scopes
-type Type uint32
+type Type uint
 
 const (
 	Unknown Type = 0


### PR DESCRIPTION
The internal types `action.Type`, `resource.Type`, and `scope.Type` all start at zero, but aren't the same integer type. This is to align them all on `uint`.