### PR TITLE
Add testing section for individual/user testing 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,4 +66,24 @@ Any enhancements, new features, etc fall into this section.
 
 Any bug fixes fall into this section.
 
+## Testing
+
+To run the entire test suite run this command in the root of the project:
+
+```
+$ make test
+```
+
+Before running any test please ensure that Docker is started. Boundary uses a Docker container to initiate a database for testing.
+If a test is interrupted check to make certain that all Docker containers have been properly destroyed. 
+
+### Running individual tests
+
+If you don't want to run the entire test suite, you can just run a singe test
+with go. For example, if you wanted to run the tests TestAuthTokenAuthenticator, you would
+run:
+
+```
+$ go test -run TestAuthTokenAuthenticator -v ./internal/auth
+```
 

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,9 @@ website-start:
 test-ci: install-go
 	~/.go/bin/go test ./... -v $(TESTARGS) -timeout 120m
 
+test: 
+	~/.go/bin/go test ./... -timeout 120m
+
 install-go:
 	./ci/goinstall.sh
 

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ test-ci: install-go
 	~/.go/bin/go test ./... -v $(TESTARGS) -timeout 120m
 
 test: 
-	~/.go/bin/go test ./... -timeout 120m
+	~/.go/bin/go test ./... -timeout 30m
 
 install-go:
 	./ci/goinstall.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Boundary
-![](boundary.png)
+![](boundary.png) [![CircleCI](https://circleci.com/gh/hashicorp/boundary/tree/main.svg?style=svg)](https://circleci.com/gh/hashicorp/boundary/tree/main)
 ----
 
 **Please note**: We take Boundary's security and our users' trust very
@@ -204,3 +204,8 @@ could be taken in a production context:
 There are many, many more things that Boundary will do in the future in terms of
 integrations, features, and more. We have a long roadmap planned out, so stay
 tuned for information about new features and capabilities!
+
+## Contributing
+
+Thank you for your interest in contributing! Please refer to
+[CONTRIBUTING.md](https://github.com/hashicorp/boundary/blob/main/CONTRIBUTING.md) for guidance.


### PR DESCRIPTION
Howdy,
Some other Hashicorp products ([Waypoint](https://github.com/hashicorp/waypoint#running-the-unit-tests),[Consul](https://github.com/hashicorp/consul/blob/master/.github/CONTRIBUTING.md#testing),[Terraform](https://github.com/hashicorp/terraform/blob/master/.github/CONTRIBUTING.md#acceptance-tests-testing-interactions-with-external-services),[Nomad](https://github.com/hashicorp/nomad#testing),[Vault](https://github.com/hashicorp/vault#developing-vault), [Packer](https://github.com/hashicorp/packer/blob/master/.github/CONTRIBUTING.md#running-unit-tests),[Vagrant](https://github.com/hashicorp/vagrant/blob/main/.github/CONTRIBUTING.md#running-tests)) provide testing documentation in either their main readme or contributing documentation to help both operators and developers alike. We should do this too! 
I'm open to feedback on how to add a `make test` to the `Makefile` or something similar. 
