### PR TITLE
fix 'make update-ui-version'

### DIFF
--- a/scripts/uiclone.sh
+++ b/scripts/uiclone.sh
@@ -27,3 +27,5 @@ cd "${UI_CLONE_DIR}"
 git reset --hard
 git fetch origin "${UI_COMMITISH}"
 git checkout "${UI_COMMITISH}"
+git pull --ff-only origin "${UI_COMMITISH}"
+git reset --hard "${UI_COMMITISH}"


### PR DESCRIPTION
- When using a branch name rather than a commit, the branch was not being
  updated to the latest version.