### PR TITLE
Bumps components to remove internal md processing

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1896,9 +1896,9 @@
       "integrity": "sha512-5r2g9XNO6YHhl9/4GniiN1Reqs/mOu/7rUML+JQsN2qe7V3libr+cLa+iSYK7+pLmRlnc+Uwk7JwPPPJHVj5bA=="
     },
     "@hashicorp/react-hero": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-hero/-/react-hero-4.1.0.tgz",
-      "integrity": "sha512-HVVB6HBgE5TE3OVQ2f8QzDmkUz/nYRlDGZIrJxwpo5qvULrBtU1ugVefsjajt6XR8VBoigMqyBYWT2UAamz8vg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-hero/-/react-hero-5.0.0.tgz",
+      "integrity": "sha512-U1pnWtp4qhNpMwS/GmokdeenNe9sFCfeBmQjHYZUOQS5jYO064NnFHIqWYWCenqjf653u7QcUX8S+Cayr9ND6A==",
       "requires": {
         "@hashicorp/js-utils": "^1.0.8-alpha.0",
         "@hashicorp/localstorage-polyfill": "^1.0.14",
@@ -1907,7 +1907,6 @@
         "@hashicorp/react-image": "^2.0.3",
         "@hashicorp/react-text-input": "^3.0.1",
         "formik": "^1.5.8",
-        "marked": "^0.7.0",
         "promise-polyfill": "^8.1.0",
         "query-string": "^5.1.1"
       },
@@ -8425,9 +8424,9 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
+      "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -13898,9 +13897,9 @@
       "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
     },
     "ua-parser-js": {
-      "version": "0.7.23",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+      "integrity": "sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw=="
     },
     "unbzip2-stream": {
       "version": "1.4.3",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2219,13 +2219,12 @@
       }
     },
     "@hashicorp/react-vertical-text-block-list": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-vertical-text-block-list/-/react-vertical-text-block-list-3.0.1.tgz",
-      "integrity": "sha512-ci6GJjnnVtC+7IuGKo37aAyXFrhzlh1sb21XUA8xrGbq5QMlYjCSv2lmLJm8ZNW1Z2L+gcMYCJOP24xJoPDhhQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-vertical-text-block-list/-/react-vertical-text-block-list-4.0.0.tgz",
+      "integrity": "sha512-rUVCB5S33NGYtMJp+l45SZsx/WjZNb7RTeu6e6b1/vmcUCFa/S953dEix1AzJi+dbkyFx6Tt36JbSoevPRJ0AA==",
       "requires": {
         "@hashicorp/react-image": "^2.0.3",
-        "@hashicorp/react-link-wrap": "^0.0.3",
-        "marked": "^0.7.0"
+        "@hashicorp/react-link-wrap": "^0.0.3"
       },
       "dependencies": {
         "@hashicorp/react-image": {

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,7 @@
     "@hashicorp/react-docs-page": "10.3.1",
     "@hashicorp/react-hashi-stack-menu": "1.1.0",
     "@hashicorp/react-head": "1.1.6",
-    "@hashicorp/react-hero": "4.1.0",
+    "@hashicorp/react-hero": "5.0.0",
     "@hashicorp/react-image": "3.0.3",
     "@hashicorp/react-product-downloader": "7.0.0",
     "@hashicorp/react-product-features-list": "3.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,7 @@
     "@hashicorp/react-section-header": "3.0.1",
     "@hashicorp/react-subnav": "7.1.0",
     "@hashicorp/react-use-cases": "2.0.1",
-    "@hashicorp/react-vertical-text-block-list": "3.0.1",
+    "@hashicorp/react-vertical-text-block-list": "4.0.0",
     "change-case": "4.1.2",
     "classnames": "2.2.6",
     "next": "10.0.6",

--- a/website/pages/community/index.jsx
+++ b/website/pages/community/index.jsx
@@ -18,12 +18,12 @@ export default function CommunityPage() {
           {
             header: 'Community Forum',
             body:
-              '[Boundary Community Forum](https://discuss.hashicorp.com/c/boundary)',
+              '<a href="https://discuss.hashicorp.com/c/boundary">Boundary Community Forum</a>',
           },
           {
             header: 'Bug Tracker',
             body:
-              '[Issue tracker on GitHub](https://github.com/hashicorp/boundary/issues). Please only use this for reporting bugs. Do not ask for general help here; use the Community Form for that.',
+              '<a href="https://github.com/hashicorp/boundary/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here; use the Community Form for that.',
           },
         ]}
       />


### PR DESCRIPTION
This PR bumps `@hashicorp/react-vertical-text-block-list` and `@hashicorp/react-hero` to recently published versions which do not process markdown within the component.

### Affected pages

- [`/` (home page)](https://boundary-git-zsbump-components.hashicorp.vercel.app/), should be identical to [live site](https://www.boundaryproject.io/)
- [`/community`](https://boundary-git-zsbump-components.hashicorp.vercel.app/community), should be identical to [live site](https://www.boundaryproject.io/community)