### PR TITLE
Fix migration for Postgres 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Canonical reference for changes, improvements, and bugfixes for Boundary.
 
+## 0.1.7 (2021/02/16)
+
+*Note* This release fixes an upgrade issue affecting users on Postgres 11
+upgrading to 0.1.5 or 0.1.6 and makes a modification to the `boundary dev`
+environment. It is otherwise identical to 0.1.6; see the entry for that version
+for more details.
+
+### Changes/Deprecations
+
+* `boundary dev` now uses Postgres 11 by default, rather than Postgres 12.
+
+### Bug Fixes
+
+* server: Fix an issue with migrations affecting Postgres 11
+  ([PR](https://github.com/hashicorp/boundary/pull/940))
+
 ## 0.1.6 (2021/02/12)
 
 ### Changes/Deprecations

--- a/internal/db/schema/migrations/postgres/1/01_server_tags_migrations.up.sql
+++ b/internal/db/schema/migrations/postgres/1/01_server_tags_migrations.up.sql
@@ -1,8 +1,12 @@
 begin;
 
 -- This series of expressions fixes the primary key on the server table
+-- PG 12+
 alter table session
-  drop constraint session_server_id_server_type_fkey;
+  drop constraint if exists session_server_id_server_type_fkey;
+-- PG 11
+alter table session
+  drop constraint if exists session_server_id_fkey;
 alter table server
   drop constraint server_pkey;
 alter table server

--- a/internal/db/schema/postgres_migration.gen.go
+++ b/internal/db/schema/postgres_migration.gen.go
@@ -4745,8 +4745,12 @@ create table wh_host_dimension (
 `),
 			1001: []byte(`
 -- This series of expressions fixes the primary key on the server table
+-- PG 12+
 alter table session
-  drop constraint session_server_id_server_type_fkey;
+  drop constraint if exists session_server_id_server_type_fkey;
+-- PG 11
+alter table session
+  drop constraint if exists session_server_id_fkey;
 alter table server
   drop constraint server_pkey;
 alter table server

--- a/internal/docker/supported.go
+++ b/internal/docker/supported.go
@@ -27,7 +27,7 @@ func startDbInDockerSupported(dialect string) (cleanup func() error, retURL, con
 	var url string
 	switch dialect {
 	case "postgres":
-		resource, err = pool.Run("postgres", "12", []string{"POSTGRES_PASSWORD=password", "POSTGRES_DB=boundary"})
+		resource, err = pool.Run("postgres", "11", []string{"POSTGRES_PASSWORD=password", "POSTGRES_DB=boundary"})
 		url = "postgres://postgres:password@localhost:%s?sslmode=disable"
 		if err == nil {
 			url = fmt.Sprintf("postgres://postgres:password@%s/boundary?sslmode=disable", resource.GetHostPort("5432/tcp"))


### PR DESCRIPTION
This fixes an issue with running migrations (likely in 0.1.5 and 0.1.6) against Postgres 11.

It also changes our dev environment to be using the PG 11 Docker image rather than PG 12.