### PR TITLE
Ongoing OIDC work: resolve some ambiguity around errors during AuthMethod updates.

### DIFF
--- a/internal/auth/oidc/repository_auth_method_update.go
+++ b/internal/auth/oidc/repository_auth_method_update.go
@@ -109,7 +109,7 @@ func (r *Repository) UpdateAuthMethod(ctx context.Context, am *AuthMethod, versi
 	}
 
 	// prevent an "active" auth method from being updated in a manner that would create
-	// an incomplete and usable auth method.
+	// an incomplete and unusable auth method.
 	if origAm.OperationalState != string(InactiveState) {
 		if err := applyUpdate(am, origAm, fieldMaskPaths).isComplete(); err != nil {
 			return nil, db.NoRowsAffected, errors.Wrap(err, op, errors.WithMsg("update would result an an incomplete auth method"))

--- a/internal/auth/oidc/repository_auth_method_update.go
+++ b/internal/auth/oidc/repository_auth_method_update.go
@@ -17,9 +17,18 @@ import (
 )
 
 // UpdateAuthMethod will retrieve the auth method from the repository,
-// update it based on the field masks provided, and then validate it using
-// Repository.ValidateAuthMethod(...).  If the test succeeds, the auth method
-// is persisted in the repository and the written auth method is returned.
+// and update it based on the field masks provided.
+//
+// The auth method will not be persisted in the repository if the auth
+// method's OperationalStatus is currently ActivePublic or ActivePrivate
+// and the update would have resulted in an incomplete/non-operational
+// auth method.
+//
+// During update, the auth method will be tested/validated against its
+// provider's published OIDC discovery document. If this validation
+// succeeds, the auth method is persisted in the repository, and the
+// written auth method is returned.
+//
 // fieldMaskPaths provides field_mask.proto paths for fields that should
 // be updated.  Fields will be set to NULL if the field is a
 // zero value and included in fieldMask. Name, Description, DiscoveryUrl,
@@ -31,33 +40,20 @@ import (
 // Options supported:
 //
 // * WithDryRun: when this option is provided, the auth method is retrieved from
-// the repo, updated based on the fieldMask, tested via Repository.ValidateAuthMethod,
+// the repo, updated based on the fieldMask, tested via Repository.ValidateDiscoveryInfo,
 // the results of the update are returned, and and any errors reported.  The
 // updates are not peristed to the repository.
 //
-// * WithForce: when this option is provided, the auth method is persistented in
-// the repository without testing it fo validity with Repository.ValidateAuthMethod.
+// * WithForce: when this option is provided, the auth method is persisted in
+// the repository without testing it's validity against its provider's published
+// OIDC discovery document. Even if this option is provided, the auth method will
+//  not be persisted in the repository when the update would have resulted in
+// an incomplete/non-operational auth method and it's OperationalStatus is
+// currently ActivePublic or ActivePrivate.
 //
-// Successful updates must invalidate (delete) the Repository's cache of the
-// oidc.Provider for the AuthMethod.
+// Also, a successful update will invalidate (delete) the Repository's
+// cache of the oidc.Provider for the AuthMethod.
 func (r *Repository) UpdateAuthMethod(ctx context.Context, am *AuthMethod, version uint32, fieldMaskPaths []string, opt ...Option) (*AuthMethod, int, error) {
-
-	// ************************************************************************
-	// ************************************************************************
-	// TODO(jimlambrt) 3/2021: after some discussion, we've aligned on a need to
-	// disambiguate an error raised because the auth method is not "complete" vs
-	// "warnings" raised from Repository.ValidateAuthMethod(...). when an auth
-	// method and the discovery info published by the OIDC provider seem to
-	// indicate that there's a possible configuration issue.  A future PR, will
-	// distinguish between these two different auth method concerns (one an error
-	// and the other being a warning about a possible error/concern).  In that
-	// future PR, callers will not be allowed to "force" and update to an auth
-	// method which is active (private or public), if that updated would result
-	// in an incomplete auth method which would be unusable by users of the
-	// system.
-	// ************************************************************************
-	// ************************************************************************
-
 	const op = "oidc.(Repository).UpdateAuthMethod"
 	if am == nil {
 		return nil, db.NoRowsAffected, errors.New(errors.InvalidParameter, op, "missing auth method")
@@ -108,12 +104,20 @@ func (r *Repository) UpdateAuthMethod(ctx context.Context, am *AuthMethod, versi
 	opts := getOpts(opt...)
 	if opts.withDryRun {
 		updated := applyUpdate(am, origAm, fieldMaskPaths)
-		err := r.ValidateAuthMethod(ctx, WithAuthMethod(updated))
+		err := r.ValidateDiscoveryInfo(ctx, WithAuthMethod(updated))
 		return updated, db.NoRowsAffected, err
 	}
 
+	// prevent an "active" auth method from being updated in a manner that would create
+	// an incomplete and usable auth method.
+	if origAm.OperationalState != string(InactiveState) {
+		if err := applyUpdate(am, origAm, fieldMaskPaths).isComplete(); err != nil {
+			return nil, db.NoRowsAffected, errors.Wrap(err, op, errors.WithMsg("update would result an an incomplete auth method"))
+		}
+	}
+
 	if !opts.withForce {
-		if err := r.ValidateAuthMethod(ctx, WithAuthMethod(applyUpdate(am, origAm, fieldMaskPaths))); err != nil {
+		if err := r.ValidateDiscoveryInfo(ctx, WithAuthMethod(applyUpdate(am, origAm, fieldMaskPaths))); err != nil {
 			return nil, db.NoRowsAffected, errors.Wrap(err, op)
 		}
 	}
@@ -494,20 +498,21 @@ func applyUpdate(new, orig *AuthMethod, fieldMaskPaths []string) *AuthMethod {
 	return cp
 }
 
-// ValidateAuthMethod will test/validate the provided AuthMethod.
+// ValidateDiscoveryInfo will test/validate the provided AuthMethod against
+// the info from it's discovery URL.
 //
 // It will verify that all required fields for a working AuthMethod have values.
 //
-// If the AuthMethod contains a DiscoveryUrl for an OIDC provider, ValidateAuthMethod
-// retrieves the OpenID Configuration document. The values in the AuthMethod
+// If the AuthMethod is complete, ValidateDiscoveryInfo retrieves the auth
+// method's OpenID Configuration document. The values in the AuthMethod
 // (and associated data) are validated with the retrieved document. The issuer and
 // id token signing algorithm in the configuration are validated with the
-// retrieved document. ValidateAuthMethod also verifies the authorization, token,
+// retrieved document. ValidateDiscoveryInfo also verifies the authorization, token,
 // and user_info endpoints by connecting to each and uses any certificates in the
 // configuration as trust anchors to confirm connectivity.
 //
 // Options supported are: WithPublicId, WithAuthMethod
-func (r *Repository) ValidateAuthMethod(ctx context.Context, opt ...Option) error {
+func (r *Repository) ValidateDiscoveryInfo(ctx context.Context, opt ...Option) error {
 	const op = "oidc.(Repository).ValidateAuthMethod"
 	opts := getOpts(opt...)
 	var am *AuthMethod

--- a/internal/auth/oidc/repository_auth_method_update.go
+++ b/internal/auth/oidc/repository_auth_method_update.go
@@ -112,7 +112,7 @@ func (r *Repository) UpdateAuthMethod(ctx context.Context, am *AuthMethod, versi
 	// an incomplete and unusable auth method.
 	if origAm.OperationalState != string(InactiveState) {
 		if err := applyUpdate(am, origAm, fieldMaskPaths).isComplete(); err != nil {
-			return nil, db.NoRowsAffected, errors.Wrap(err, op, errors.WithMsg("update would result an an incomplete auth method"))
+			return nil, db.NoRowsAffected, errors.Wrap(err, op, errors.WithMsg("update would result in an incomplete auth method"))
 		}
 	}
 


### PR DESCRIPTION
This PR resolves a TODO for updates around errors for incomplete auth methods vs those that failed validation against their provider's discovery doc