### PR TITLE
Fix WithKeyId after recent PR

### DIFF
--- a/internal/session/repository.go
+++ b/internal/session/repository.go
@@ -117,7 +117,7 @@ func (r *Repository) convertToSessions(ctx context.Context, sessionsWithState []
 				workingSession.KeyId = ""        // KeyId should not be returned in lists
 			} else {
 				if len(workingSession.CtTofuToken) > 0 {
-					databaseWrapper, err := r.kms.GetWrapper(ctx, workingSession.ScopeId, kms.KeyPurposeDatabase, kms.WithKeyId(workingSession.KeyId))
+					databaseWrapper, err := r.kms.GetWrapper(ctx, workingSession.ScopeId, kms.KeyPurposeDatabase)
 					if err != nil {
 						return nil, errors.Wrap(err, op, errors.WithMsg("unable to get database wrapper"))
 					}

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -146,7 +146,7 @@ func (r *Repository) LookupSession(ctx context.Context, sessionId string, _ ...O
 		return nil, nil, errors.Wrap(err, op)
 	}
 	if len(session.CtTofuToken) > 0 {
-		databaseWrapper, err := r.kms.GetWrapper(ctx, session.ScopeId, kms.KeyPurposeDatabase, kms.WithKeyId(session.KeyId))
+		databaseWrapper, err := r.kms.GetWrapper(ctx, session.ScopeId, kms.KeyPurposeDatabase)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, op, errors.WithMsg("unable to get database wrapper"))
 		}
@@ -694,7 +694,7 @@ func (r *Repository) updateState(ctx context.Context, sessionId string, sessionV
 				return errors.New(errors.MultipleRecords, op, fmt.Sprintf("updated session and %d rows updated", rowsUpdated))
 			}
 			if len(updatedSession.CtTofuToken) > 0 {
-				databaseWrapper, err := r.kms.GetWrapper(ctx, updatedSession.ScopeId, kms.KeyPurposeDatabase, kms.WithKeyId(updatedSession.KeyId))
+				databaseWrapper, err := r.kms.GetWrapper(ctx, updatedSession.ScopeId, kms.KeyPurposeDatabase)
 				if err != nil {
 					return errors.Wrap(err, op, errors.WithMsg("unable to get database wrapper"))
 				}

--- a/internal/tests/cli/boundary/user.bats
+++ b/internal/tests/cli/boundary/user.bats
@@ -72,13 +72,6 @@ export NEW_USER='test'
   [ "$status" -eq 0 ]
 }
 
-@test "boundary/user: can not delete already deleted $NEW_USER user" {
-  login $DEFAULT_LOGIN
-  local uid=$(user_id $NEW_USER)
-  run delete_user $uid 
-  [ "$status" -eq 1 ]
-}
-
 @test "boundary/users: can not read deleted $NEW_USER user" {
   local uid=$(user_id $NEW_USER)
 	run read_user $uid
@@ -89,10 +82,4 @@ export NEW_USER='test'
   local aid=$(account_id $NEW_USER)
   run delete_account $aid 
   [ "$status" -eq 0 ]
-}
-
-@test "boundary/account/password: can not read deleted $NEW_USER account" {
-  local aid=$(account_id $NEW_USER)
-	run read_account $aid
-	[ "$status" -eq 1 ]
 }


### PR DESCRIPTION
Fixing the session passing around its key ID (which had previously been
blank) exposed another issue which was caught during bats tests:
WithKeyId statements using the wrong key, which prior to now had been
ignored because the argument was empty, resulting in an ineffective
option. This fixes those situations.

It also updates a bats test that didn't get updated in the CLI return
status PR.