### PR TITLE
website(style): Update gray brand colors

### DIFF
--- a/website/components/branded-cta/branded-cta.module.css
+++ b/website/components/branded-cta/branded-cta.module.css
@@ -41,7 +41,7 @@
 .content {
   max-width: 647px;
   margin: 0;
-  color: var(--gray-3);
+  color: var(--gray-2);
 }
 
 .content-and-links {

--- a/website/components/homepage-hero/HomepageHero.module.css
+++ b/website/components/homepage-hero/HomepageHero.module.css
@@ -28,7 +28,7 @@
         margin-bottom: 32px;
 
         & :global(.progress-bar) {
-          background-color: var(--gray-6);
+          background-color: var(--gray-5);
 
           & > span {
             background: var(--boundary);

--- a/website/components/how-it-works/feature/logo-list/logo-list.module.css
+++ b/website/components/how-it-works/feature/logo-list/logo-list.module.css
@@ -12,5 +12,5 @@
 }
 
 .footerText {
-  color: var(--gray-5);
+  color: var(--gray-4);
 }

--- a/website/components/openapi-page/partials/operation-object/operation-object.module.css
+++ b/website/components/openapi-page/partials/operation-object/operation-object.module.css
@@ -1,5 +1,5 @@
 .root {
-  border-bottom: 1px solid var(--gray-6);
+  border-bottom: 1px solid var(--gray-5);
   margin: 0;
   margin-top: -1px;
   position: relative;
@@ -56,7 +56,7 @@
   composes: g-type-code from global;
 
   & .method {
-    color: var(--gray-4);
+    color: var(--gray-3);
 
     &[data-is-hovered='true'] {
       color: var(--brand);
@@ -64,7 +64,7 @@
   }
 
   & .path {
-    color: var(--gray-3);
+    color: var(--gray-2);
   }
 }
 
@@ -125,8 +125,8 @@
   & .columnSectionHeading {
     margin: 0 !important; /* Needed to override ".g-content p" margins */
     padding-bottom: 8px;
-    border-bottom: 1px solid var(--gray-6);
-    color: var(--gray-4);
+    border-bottom: 1px solid var(--gray-5);
+    color: var(--gray-3);
   }
 }
 

--- a/website/components/openapi-page/partials/property-object/property-object.module.css
+++ b/website/components/openapi-page/partials/property-object/property-object.module.css
@@ -1,6 +1,6 @@
 .root {
-  border-top: 1px solid var(--gray-6);
-  border-bottom: 1px solid var(--gray-6);
+  border-top: 1px solid var(--gray-5);
+  border-bottom: 1px solid var(--gray-5);
   padding: 16px 0;
   margin: -1px 0 0 0;
 
@@ -33,7 +33,7 @@
 
   & .title,
   & .description {
-    color: var(--gray-3);
+    color: var(--gray-2);
     margin: 8px 0 0 0;
   }
 
@@ -80,6 +80,6 @@
   & .propertiesContainer {
     margin: 8px 0 0 8px;
     padding-left: 16px;
-    border-left: 1px solid var(--gray-6);
+    border-left: 1px solid var(--gray-5);
   }
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1512,9 +1512,9 @@
       "integrity": "sha512-xyrD15VTKcmOQhMsZbWIoi1REVAHspBfYY3qxuI4Rxsx7S7mcsOjf7lxvlHfVzivkrBfpYfUP54f7Yji/FUv8Q=="
     },
     "@hashicorp/mktg-global-styles": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-global-styles/-/mktg-global-styles-2.1.0.tgz",
-      "integrity": "sha512-REr07tPJDKpyTh/u9tUS3sf29LnkDrWFVgY7FTvDJfbJ60IJ/R1TYNmcE7QKREGJ8j0p43QWEDabqVWOWvOXFA=="
+      "version": "2.1.1-canary.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-global-styles/-/mktg-global-styles-2.1.1-canary.0.tgz",
+      "integrity": "sha512-P/PtJNKU8SQPwiVM4FAXT28D3IQqQCtm1CuyP/5uJvZCljzHQ8bTWqQuoV0wVw5ceAPbYoQyACB9fait9eCm7Q=="
     },
     "@hashicorp/nextjs-scripts": {
       "version": "16.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "author": "HashiCorp",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "9.0.6",
-    "@hashicorp/mktg-global-styles": "2.1.0",
+    "@hashicorp/mktg-global-styles": "2.1.1-canary.0",
     "@hashicorp/nextjs-scripts": "16.0.1",
     "@hashicorp/react-alert-banner": "5.0.0",
     "@hashicorp/react-button": "4.0.0",

--- a/website/pages/home/style.css
+++ b/website/pages/home/style.css
@@ -1,8 +1,8 @@
 .p-home {
   & .break-section {
     background: linear-gradient(
-      var(--gray-7) 0%,
-      var(--gray-7) 50%,
+      var(--gray-6) 0%,
+      var(--gray-6) 50%,
       var(--white) 50%,
       var(--white) 100%
     );
@@ -24,7 +24,7 @@
   & .use-cases-section {
     padding-top: 128px;
     padding-bottom: 128px;
-    background-color: var(--gray-7);
+    background-color: var(--gray-6);
 
     @media (max-width: 800px) {
       padding-top: 88px;


### PR DESCRIPTION
Removes references to deprecated gray CSS properties and maps all gray colors to new brand values.

[_Created by Sourcegraph campaign `kstraut/product-sites-migrate-v3-gray-colors`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/product-sites-migrate-v3-gray-colors)