### PR TITLE
fix order of parameters... refactor sort of makes this defect hard to detect

### DIFF
--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -274,7 +274,7 @@ func (c *Command) Run(args []string) int {
 			c.UI.Error("Invalid ID suffix, must be exactly 10 characters")
 			return base.CommandUserError
 		}
-		if !handlers.ValidId("abc", "abc_"+c.flagIdSuffix) {
+		if !handlers.ValidId("abc_"+c.flagIdSuffix, "abc") {
 			c.UI.Error("Invalid ID suffix, must be in the set A-Za-z0-9")
 			return base.CommandUserError
 		}


### PR DESCRIPTION
The recent refactor made it impossible to run `boundary dev`.  @talanknight you may want to recheck all references to `handlers.InValidId(...)`