### PR TITLE
Skip hidden directories when generating version numbers

### DIFF
--- a/internal/db/schema/migrations/generate/generate.go
+++ b/internal/db/schema/migrations/generate/generate.go
@@ -37,8 +37,11 @@ func generate(dialect string) {
 
 	var largestSchemaVersion int
 	for _, ver := range versions {
-		var verVal int
+		if strings.HasPrefix(ver, ".") {
+			continue
+		}
 
+		var verVal int
 		verVal, err := strconv.Atoi(ver)
 		if err != nil {
 			fmt.Printf("error reading major schema version directory %q.  Must be a number: %v\n", ver, err)


### PR DESCRIPTION
I was testing migrations and after opening the migrations directory in finder I started getting this error:

```
louisruch@Louis:~/boundary (main)$ make migrations
/Library/Developer/CommandLineTools/usr/bin/make --environment-overrides -C internal/db/schema/migrations/generate migrations
go run .
error reading major schema version directory ".DS_Store".  Must be a number: strconv.Atoi: parsing ".DS_Store": invalid syntax
exit status 1
make[1]: *** [migrations] Error 1
make: *** [migrations] Error 2
```

This forces me to rm the `.DS_Store`.  
However, since I can see this happening in the future I decided to added a check to skip all hidden directories (dirs prefixed with `.`)  in case there are other auto generated dirs that could be created by another OS or application.  

I can change this to just skip `.DS_Store` if preferred