### PR TITLE
docs: update contributing guide with pronoun expectations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for contributing to Boundary! Here you can find common questions around reporting issues and opening
 pull requests to our project.
 
-When contributing in any way to the Boundary project (new issue, PR, etc), please be aware that our team identifies with many gender pronouns and to use non-binary pronouns when addressing our team. For more reading on our code of conduct, please see the [HashiCorp community guidelines](https://www.hashicorp.com/community-guidelines). 
+When contributing in any way to the Boundary project (new issue, PR, etc), please be aware that our team identifies with many gender pronouns. Please remember to use nonbinary pronouns (they/them) and gender neutral language ("Hello folks") when addressing our team. For more reading on our code of conduct, please see the [HashiCorp community guidelines](https://www.hashicorp.com/community-guidelines). 
 
 ## Issue Reporting
 ### Reporting Security Related Vulnerabilities
@@ -88,4 +88,3 @@ run:
 ```
 $ go test -run TestAuthTokenAuthenticator -v ./internal/auth
 ```
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,8 @@
 Thank you for contributing to Boundary! Here you can find common questions around reporting issues and opening
 pull requests to our project.
 
+When contributing in any way to the Boundary project (new issue, PR, etc), please be aware that our team identifies with many gender pronouns and to use non-binary pronouns when addressing our team. For more reading on our code of conduct, please see the [HashiCorp community guidelines](https://www.hashicorp.com/community-guidelines). 
+
 ## Issue Reporting
 ### Reporting Security Related Vulnerabilities
 


### PR DESCRIPTION
Update contributing guidelines with pronoun expectation and link to HashiCorp community guidelines. 