### PR TITLE
docs: Clarify note on VAULT_TOKEN env variable

### DIFF
--- a/website/content/docs/configuration/kms/transit.mdx
+++ b/website/content/docs/configuration/kms/transit.mdx
@@ -94,8 +94,9 @@ Authentication-related values must be provided, either as environment
 variables or as configuration parameters.
 
 ~> **Note:** Although the configuration file allows you to pass in
-`VAULT_TOKEN` as part of the KMS's parameters, it is _strongly_ recommended
-to set these values via environment variables.
+`token` as part of the KMS stanza's parameters, it is _strongly_ recommended
+to omit the `token` parameter from the configuration file and set the 
+token used to authenticate to Vault via the `VAULT_TOKEN` environment variable.
 
 The Vault token used to authenticate needs the following permissions on the
 transit key:


### PR DESCRIPTION
A slight update for clarity regarding the wording of the note regarding the recommendation of using the 'VAULT_TOKEN' environment variable as opposed to using the 'token' parameter in the configuration file.