### PR TITLE
Add a callback mechanism

### DIFF
--- a/internal/servers/controller/handler.go
+++ b/internal/servers/controller/handler.go
@@ -1,9 +1,11 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -55,14 +57,15 @@ func (c *Controller) handler(props HandlerProperties) (http.Handler, error) {
 
 	corsWrappedHandler := wrapHandlerWithCors(mux, props)
 	commonWrappedHandler := wrapHandlerWithCommonFuncs(corsWrappedHandler, c, props)
-	printablePathCheckHandler := cleanhttp.PrintablePathCheckHandler(commonWrappedHandler, nil)
+	callbackInterceptingHandler := wrapHandlerWithCallbackInterceptor(commonWrappedHandler, c)
+	printablePathCheckHandler := cleanhttp.PrintablePathCheckHandler(callbackInterceptingHandler, nil)
 
 	return printablePathCheckHandler, nil
 }
 
 func handleGrpcGateway(c *Controller, props HandlerProperties) (http.Handler, error) {
-	// Register*ServiceHandlerServer methods ignore the passed in ctx.  Using
-	// the a context now just in case this changes in the future
+	// Register*ServiceHandlerServer methods ignore the passed in ctx. Using it
+	// now however in case this changes in the future.
 	ctx := props.CancelCtx
 	mux := runtime.NewServeMux(
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.HTTPBodyMarshaler{
@@ -315,6 +318,85 @@ func wrapHandlerWithCors(h http.Handler, props HandlerProperties) http.Handler {
 			w.Header().Set("Access-Control-Max-Age", "300")
 			w.WriteHeader(http.StatusNoContent)
 			return
+		}
+
+		h.ServeHTTP(w, req)
+	})
+}
+
+type cmdAttrs struct {
+	Command    string      `json:"command,omitempty"`
+	Attributes interface{} `json:"attributes,omitempty"`
+}
+
+func wrapHandlerWithCallbackInterceptor(h http.Handler, c *Controller) http.Handler {
+	logCallbackErrors := os.Getenv("BOUNDARY_LOG_CALLBACK_ERRORS") != ""
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// If this doesn't have a callback suffix on a supported action, serve
+		// normally
+		if !strings.HasSuffix(req.URL.Path, ":authenticate:callback") {
+			h.ServeHTTP(w, req)
+			return
+		}
+
+		req.URL.Path = strings.TrimSuffix(req.URL.Path, ":callback")
+
+		// How we get the parameters changes based on the method. Right now only
+		// GET is supported with query args, but this can support POST with JSON
+		// or URL-encoded args. In those cases, the MIME type would have to be
+		// checked; for URL-encoded it'd use ParseForm like Get, and for JSON
+		// you'd use a json.RawMessage for Attributes consisting of the body. Or
+		// something very similar to that.
+		var useForm bool
+		switch req.Method {
+		case http.MethodGet:
+			if err := req.ParseForm(); err != nil {
+				if logCallbackErrors && c != nil {
+					c.logger.Trace("callback error", "method", req.Method, "url", req.URL.RequestURI(), "error", err)
+				}
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			useForm = true
+		}
+
+		attrs := &cmdAttrs{
+			Command: "callback",
+		}
+
+		switch {
+		case useForm:
+			if len(req.Form) > 0 {
+				values := make(map[string]interface{}, len(req.Form))
+				// This won't handle repeated values. That's fine, at least for now.
+				// We can address that if needed, which seems unlikely.
+				for k := range req.Form {
+					values[k] = req.Form.Get(k)
+				}
+				attrs.Attributes = values
+			}
+
+			attrBytes, err := json.Marshal(attrs)
+			if err != nil {
+				if logCallbackErrors && c != nil {
+					c.logger.Trace("callback error marshaling json", "method", req.Method, "url", req.URL.RequestURI(), "error", err)
+				}
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			// If there is any existing body, close it as we're going to replace
+			// it. It shouldn't be populated in this code path, but you never
+			// know.
+			if req.Body != nil {
+				if err := req.Body.Close(); err != nil {
+					if logCallbackErrors && c != nil {
+						c.logger.Trace("callback error closing original request body", "method", req.Method, "url", req.URL.RequestURI(), "error", err)
+					}
+				}
+			}
+			req.Body = ioutil.NopCloser(bytes.NewReader(attrBytes))
 		}
 
 		h.ServeHTTP(w, req)


### PR DESCRIPTION
This mechanism intercepts any request with the path ending in
`:callback`.

Currently this is limited to GET (but can support others), but in this
case will parse the form, and put the resulting variables in a
predictable format that is then sent along as JSON to grpc-gateway for
normal handling.