### PR TITLE
If the database is already initialized, use 0 as the return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,6 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## Next
 
-### New and Improved
-
-* server: When performing recursive listing, `list` action is not longer
-  required to be granted to the calling user. Instead, the given scope acts as
-  the root point (so only results under that scope will be shown), and `list`
-  grant is evaluated per-scope.
-  [PR](https://github.com/hashicorp/boundary/pull/1016)
-
 ### Deprecations/Changes
 
 * authentication: The `auth-methods/<id>:authenticate:login` action is
@@ -26,6 +18,17 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   to better match other types of resources. `credentials` will still work for
   now but will be removed in a few releases. Finally, in the Go SDK, the
   `Authenticate` function now requires a `command` value to be passed in.
+
+### New and Improved
+
+* server: When performing recursive listing, `list` action is not longer
+  required to be granted to the calling user. Instead, the given scope acts as
+  the root point (so only results under that scope will be shown), and `list`
+  grant is evaluated per-scope.
+  [PR](https://github.com/hashicorp/boundary/pull/1016)
+* database init: If the database is already initialized, return 0 as the exit
+  code. This matches how the `database migrate` command works.
+  [PR](https://github.com/hashicorp/boundary/pull/1033)
 
 ### Bug Fixes
 

--- a/internal/cmd/commands/database/funcs.go
+++ b/internal/cmd/commands/database/funcs.go
@@ -53,8 +53,8 @@ func migrateDatabase(ctx context.Context, ui cli.Ui, dialect, u string, requireF
 		return unlock, 2
 	}
 	if requireFresh && st.InitializationStarted {
-		ui.Error(base.WrapAtLength("Database has already been initialized.  Please use 'boundary database migrate'."))
-		return unlock, 2
+		ui.Output(base.WrapAtLength("Database has already been initialized. Please use 'boundary database migrate' for any upgrade needs."))
+		return unlock, -1
 	}
 	if st.Dirty {
 		ui.Error(base.WrapAtLength("Database is in a bad state.  Please revert back to the last known good state."))

--- a/internal/cmd/commands/database/funcs_test.go
+++ b/internal/cmd/commands/database/funcs_test.go
@@ -116,8 +116,8 @@ func TestMigrateDatabase(t *testing.T) {
 				require.NoError(t, err)
 				return u
 			},
-			expectedCode:  2,
-			expectedError: "Database has already been initialized.  Please use 'boundary database\nmigrate'.\n",
+			expectedCode:   -1,
+			expectedOutput: "Database has already been initialized. Please use 'boundary database migrate'\nfor any upgrade needs.\n",
 		},
 		{
 			name:          "bad_url_require_fresh",

--- a/internal/cmd/commands/database/init.go
+++ b/internal/cmd/commands/database/init.go
@@ -241,7 +241,11 @@ func (c *InitCommand) Run(args []string) (retCode int) {
 
 	clean, errCode := migrateDatabase(c.Context, c.UI, dialect, migrationUrl, true)
 	defer clean()
-	if errCode != 0 {
+	switch errCode {
+	case 0:
+	case -1:
+		return 0
+	default:
 		return errCode
 	}
 


### PR DESCRIPTION
This matches the migrations code, which treats the operation as
idempotent.