### PR TITLE
Ongoing OIDC: add support for migration logging to db and primary auth method migration

### DIFF
--- a/internal/cmd/commands/database/funcs.go
+++ b/internal/cmd/commands/database/funcs.go
@@ -67,6 +67,17 @@ func migrateDatabase(ctx context.Context, ui cli.Ui, dialect, u string, requireF
 	if base.Format(ui) == "table" {
 		ui.Info("Migrations successfully run.")
 	}
+	migrationLogs, err := schema.GetMigrationLog(ctx, dBase)
+	if err != nil {
+		ui.Error(fmt.Errorf("Error retrieving database migration logs: %w", err).Error())
+		return unlock, 2
+	}
+	if len(migrationLogs) > 0 && base.Format(ui) == "table" {
+		ui.Info("Migration Logs...")
+		for _, e := range migrationLogs {
+			ui.Info(e.Entry)
+		}
+	}
 	return unlock, 0
 }
 

--- a/internal/db/schema/manager.go
+++ b/internal/db/schema/manager.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/hashicorp/boundary/internal/db/schema/postgres"
 	"github.com/hashicorp/boundary/internal/errors"
@@ -38,16 +39,25 @@ type driver interface {
 // the underlying boundary database schema.
 // Manager is not thread safe.
 type Manager struct {
-	db      *sql.DB
-	driver  driver
-	dialect string
+	db              *sql.DB
+	driver          driver
+	dialect         string
+	migrationStates map[string]migrationState
 }
 
 // NewManager creates a new schema manager. An error is returned
 // if the provided dialect is unrecognized or if the passed in db is unreachable.
-func NewManager(ctx context.Context, dialect string, db *sql.DB) (*Manager, error) {
+func NewManager(ctx context.Context, dialect string, db *sql.DB, opt ...Option) (*Manager, error) {
 	const op = "schema.NewManager"
 	dbM := Manager{db: db, dialect: dialect}
+	opts := getOpts(opt...)
+	if opts.withMigrationStates != nil {
+		dbM.migrationStates = opts.withMigrationStates
+	} else {
+		// intentionally set it to the reference, so changes to the global var
+		// will be reflected in the manager instance
+		dbM.migrationStates = migrationStates
+	}
 	switch dialect {
 	case "postgres":
 		var err error
@@ -156,7 +166,7 @@ func (b *Manager) RollForward(ctx context.Context) error {
 		return errors.New(errors.NotSpecificIntegrity, op, fmt.Sprintf("schema is dirty with version %d", curVersion))
 	}
 
-	if err = b.runMigrations(ctx, newStatementProvider(b.dialect, curVersion)); err != nil {
+	if err = b.runMigrations(ctx, newStatementProvider(b.dialect, curVersion, WithMigrationStates(b.migrationStates))); err != nil {
 		return errors.Wrap(err, op)
 	}
 	return nil
@@ -199,4 +209,44 @@ func (b *Manager) runMigrations(ctx context.Context, qp *statementProvider) erro
 		return errors.Wrap(err, op)
 	}
 	return nil
+}
+
+// LogEntry represents a log entry generated during migrations.
+type LogEntry struct {
+	Id               int
+	MigrationVersion string
+	CreateTime       time.Time
+	Entry            string
+}
+
+// GetMigrationLog will retrieve the migration logs from the db for the last
+// migration. Once it's read the entries, it will delete them from the database.
+func GetMigrationLog(ctx context.Context, d *sql.DB) ([]LogEntry, error) {
+	const op = "schema.GetMigrationLog"
+	const sql = "select id, create_time, migration_version, entry from log_migration"
+	if d == nil {
+		return nil, errors.New(errors.InvalidParameter, op, "missing sql db")
+	}
+	rows, err := d.QueryContext(ctx, sql)
+	if err != nil {
+		return nil, errors.Wrap(err, op)
+	}
+	defer rows.Close()
+
+	var entries []LogEntry
+	for rows.Next() {
+		var e LogEntry
+		if err := rows.Scan(&e.Id, &e.CreateTime, &e.MigrationVersion, &e.Entry); err != nil {
+			return nil, errors.Wrap(err, op)
+		}
+		entries = append(entries, e)
+	}
+	if rows.Err() != nil {
+		return nil, errors.Wrap(err, op)
+	}
+	_, err = d.ExecContext(ctx, "delete from log_migration")
+	if err != nil {
+		return nil, errors.Wrap(err, op)
+	}
+	return entries, nil
 }

--- a/internal/db/schema/manager_test.go
+++ b/internal/db/schema/manager_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 	"database/sql"
+	"sort"
 	"strings"
 	"testing"
 
@@ -235,6 +236,69 @@ func TestManager_SharedLock(t *testing.T) {
 
 	assert.Error(t, m1.ExclusiveLock(ctx))
 	assert.Error(t, m2.ExclusiveLock(ctx))
+}
+
+func Test_GetMigrationLog(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c, u, _, err := docker.StartDbInDocker("postgres")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, c())
+	})
+	d, err := sql.Open("postgres", u)
+	require.NoError(t, err)
+	m, err := NewManager(ctx, "postgres", d)
+	require.NoError(t, err)
+	require.NoError(t, m.RollForward(ctx))
+
+	const insert = `insert into log_migration(entry) values ($1)`
+	createEntries := func(entries ...string) {
+		for _, e := range entries {
+			_, err := d.Exec(insert, e)
+			require.NoError(t, err)
+		}
+	}
+	tests := []struct {
+		name         string
+		d            *sql.DB
+		setup        func()
+		wantEntries  []string
+		wantErrMatch *errors.Template
+	}{
+		{
+			name:        "simple",
+			d:           d,
+			setup:       func() { createEntries("alice", "eve", "bob") },
+			wantEntries: []string{"alice", "eve", "bob"},
+		},
+		{
+			name:         "missing-sql-DB",
+			wantErrMatch: errors.T(errors.InvalidParameter),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			if tt.setup != nil {
+				tt.setup()
+			}
+			gotLog, err := GetMigrationLog(ctx, tt.d)
+			if tt.wantErrMatch != nil {
+				require.Error(err)
+				assert.Truef(errors.Match(tt.wantErrMatch, err), "expected error with code: %s and got err: %q", tt.wantErrMatch.Code, err)
+				return
+			}
+			require.NoError(err)
+			var got []string
+			for _, e := range gotLog {
+				got = append(got, e.Entry)
+			}
+			sort.Strings(got)
+			sort.Strings(tt.wantEntries)
+			assert.Equal(tt.wantEntries, got)
+		})
+	}
 }
 
 // Creates a new migrationState only with the versions <= the provided maxVer

--- a/internal/db/schema/migrations/postgres/2/80_log.up.sql
+++ b/internal/db/schema/migrations/postgres/2/80_log.up.sql
@@ -1,0 +1,48 @@
+begin;
+
+-- log_migration entries represent logs generated during migrations
+create table log_migration(
+  id bigint generated always as identity primary key,
+  migration_version bigint not null, -- cannot declare FK since the table is truncated during runtime
+  create_time wt_timestamp,
+  entry text not null
+);
+comment on table log_migration is 
+'log_migration entries are logging output from databaes migrations';
+
+-- log_migration triggers
+create trigger 
+  default_create_time_column
+before
+insert on log_migration
+  for each row execute procedure default_create_time();
+
+create trigger
+  immutable_columns
+before
+update on log_migration
+  for each row execute procedure immutable_columns('id', 'migration_version', 'create_time', 'entry');
+
+
+-- log_migration_version() defines a function to be used in a "before update"
+-- trigger for log_migrations entries.  Its intent: set the log_migration
+-- version column to the current migration version.  
+create or replace function
+  log_migration_version()
+  returns trigger
+as $$
+  declare current_version bigint;
+  begin
+    select max(version) from boundary_schema_version into current_version;
+    new.migration_version = current_version;
+    return new;
+  end;
+$$ language plpgsql;
+comment on function log_migration_version() is
+'log_migration_version will set the log_migration entries to the current migration version';    
+
+create trigger
+  migration_version_column
+before
+insert on log_migration
+  for each row execute procedure log_migration_version();

--- a/internal/db/schema/migrations/postgres/2/86_iam.up.sql
+++ b/internal/db/schema/migrations/postgres/2/86_iam.up.sql
@@ -18,16 +18,6 @@ add constraint auth_method
   foreign key (public_id, primary_auth_method_id) 
   references auth_method(scope_id, public_id); 
 
--- for backward compatibility, set any existing auth password method as the 
--- primary auth method, so they will continue to autovivify
-update 
-    iam_scope
-set 
-    primary_auth_method_id = p.scope_id
-from
-    (select scope_id from auth_password_method) as p 
-where p.scope_id = iam_scope.public_id;
-
 -- iam_user_acct_info provides account info for users by determining which
 -- auth_method is designated as for "account info" in the user's scope via the
 -- scope's primary_auth_method_id.  Every sub-type of auth_account must be

--- a/internal/db/schema/migrations/postgres/2/87_iam.up.sql
+++ b/internal/db/schema/migrations/postgres/2/87_iam.up.sql
@@ -1,0 +1,69 @@
+begin;
+
+
+-- the intent of this update statement: set the primary auth method for scopes
+-- that only have a single auth_password_method, since currently there are only
+-- auth_password_methods in boundary. Before this release all
+-- auth_password_methods were "basically" primary auth methods and would create
+-- an iam_user on first login.
+with single_authmethod (scope_id, public_id) as (
+  select 
+    am.scope_id, 
+    am.public_id  
+  from 
+    auth_password_method am,
+    (select 
+        scope_id, 
+        count(public_id) as cnt 
+     from 
+        auth_password_method 
+     group by scope_id) as singles
+    where 
+      am.scope_id = singles.scope_id and
+      singles.cnt = 1
+)
+update 
+  iam_scope
+set 
+  primary_auth_method_id = p.public_id
+from
+  single_authmethod p
+where p.scope_id = iam_scope.public_id;
+
+
+-- the intent of the insert with select statement: log the scopes that have more
+-- than 1 auth method and therefore cannot have their primary auth method
+-- automatically set for them.
+with many_authmethod (scope_id, authmethod_cnt) as (
+  select 
+    am.scope_id, 
+    many.cnt
+  from 
+    auth_password_method am,
+    (select 
+        scope_id, 
+        count(public_id) as cnt 
+     from 
+        auth_password_method 
+     group by scope_id) as many
+    where 
+      am.scope_id = many.scope_id and
+      many.cnt > 1
+)
+insert into log_migration(entry) 
+select 
+  distinct  concat(
+      'unable to set primary_auth_method for ', 
+      public_id,
+      ' there were ', 
+      m.authmethod_cnt, 
+      ' password auth methods for that scope.'
+  ) as entry
+from
+  iam_scope s,
+  many_authmethod m
+where 
+  s.primary_auth_method_id is null and 
+  s.public_id = m.scope_id;
+
+commit;

--- a/internal/db/schema/migrations/postgres/2/87_iam_test.go
+++ b/internal/db/schema/migrations/postgres/2/87_iam_test.go
@@ -1,0 +1,110 @@
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/auth/password"
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/db/schema"
+	"github.com/hashicorp/boundary/internal/docker"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_PrimaryAuthMethodChanges(t *testing.T) {
+	t.Parallel()
+	const priorMigration = 2086
+	const primaryAuthMethodMigration = 2087
+	t.Run("migrate-store", func(t *testing.T) {
+		// this is a sequential test which relies on:
+		// 1) initializing the db using a migration up to the "priorMigration"
+		//
+		// 2) seeding the database with some test scopes and auth methods
+		//
+		// 3) running the migrations that sets the primary auth methods for
+		// existing scopes which only have one auth method.
+		//
+		// 4) asserting some bits about the state of the db.
+		assert, require := assert.New(t), require.New(t)
+		dialect := "postgres"
+		ctx := context.Background()
+
+		c, u, _, err := docker.StartDbInDocker(dialect)
+		require.NoError(err)
+		t.Cleanup(func() {
+			require.NoError(c())
+		})
+		d, err := sql.Open(dialect, u)
+		require.NoError(err)
+
+		// migration to the prior migration (before the one we want to test)
+		oState := schema.TestCloneMigrationStates(t)
+		nState := schema.TestCreatePartialMigrationState(oState["postgres"], priorMigration)
+		oState["postgres"] = nState
+
+		m, err := schema.NewManager(ctx, dialect, d, schema.WithMigrationStates(oState))
+		require.NoError(err)
+
+		assert.NoError(m.RollForward(ctx))
+		state, err := m.CurrentState(ctx)
+		require.NoError(err)
+		assert.Equal(priorMigration, state.DatabaseSchemaVersion)
+		assert.False(state.Dirty)
+
+		// okay, now we can seed the database with test data
+		conn, err := gorm.Open(dialect, u)
+		require.NoError(err)
+		rootWrapper := db.TestWrapper(t)
+		iamRepo := iam.TestRepo(t, conn, rootWrapper)
+		org, _ := iam.TestScopes(t, iamRepo)
+		_ = password.TestAuthMethods(t, conn, org.PublicId, 3)
+		org2, _ := iam.TestScopes(t, iamRepo)
+		_ = password.TestAuthMethods(t, conn, org2.PublicId, 2)
+
+		org3, _ := iam.TestScopes(t, iamRepo)
+		org3AuthMethods := password.TestAuthMethods(t, conn, org3.PublicId, 1)
+		org4, _ := iam.TestScopes(t, iamRepo)
+		org4AuthMethods := password.TestAuthMethods(t, conn, org4.PublicId, 1)
+
+		// now we're ready for the migration we want to test.
+		oState = schema.TestCloneMigrationStates(t)
+		nState = schema.TestCreatePartialMigrationState(oState["postgres"], primaryAuthMethodMigration)
+		oState["postgres"] = nState
+
+		m, err = schema.NewManager(ctx, dialect, d, schema.WithMigrationStates(oState))
+		require.NoError(err)
+
+		assert.NoError(m.RollForward(ctx))
+		state, err = m.CurrentState(ctx)
+		require.NoError(err)
+		assert.Equal(primaryAuthMethodMigration, state.DatabaseSchemaVersion)
+		assert.False(state.Dirty)
+
+		t.Log("current migration version: ", state.DatabaseSchemaVersion)
+		entries, err := schema.GetMigrationLog(ctx, d)
+		require.NoError(err)
+		for _, e := range entries {
+			t.Logf("%+v", e)
+		}
+		assert.Equalf(2, len(entries), "expected 2 scopes without a primary auth method and got: %d", len(entries))
+
+		scope1, err := iamRepo.LookupScope(ctx, org.PublicId)
+		require.NoError(err)
+		assert.Empty(scope1.PrimaryAuthMethodId)
+		scope2, err := iamRepo.LookupScope(ctx, org2.PublicId)
+		require.NoError(err)
+		assert.Empty(scope2.PrimaryAuthMethodId)
+
+		scope3, err := iamRepo.LookupScope(ctx, org3.PublicId)
+		require.NoError(err)
+		assert.Equal(org3AuthMethods[0].PublicId, scope3.PrimaryAuthMethodId)
+
+		scope4, err := iamRepo.LookupScope(ctx, org4.PublicId)
+		require.NoError(err)
+		assert.Equal(org4AuthMethods[0].PublicId, scope4.PrimaryAuthMethodId)
+	})
+}

--- a/internal/db/schema/options.go
+++ b/internal/db/schema/options.go
@@ -1,0 +1,29 @@
+package schema
+
+// getOpts - iterate the inbound Options and return a struct.
+func getOpts(opt ...Option) options {
+	opts := getDefaultOptions()
+	for _, o := range opt {
+		o(&opts)
+	}
+	return opts
+}
+
+// Option - how Options are passed as arguments.
+type Option func(*options)
+
+// options = how options are represented
+type options struct {
+	withMigrationStates map[string]migrationState
+}
+
+func getDefaultOptions() options {
+	return options{}
+}
+
+// WithMigrationStates provides an optional migration states.
+func WithMigrationStates(states map[string]migrationState) Option {
+	return func(o *options) {
+		o.withMigrationStates = states
+	}
+}

--- a/internal/db/schema/options_test.go
+++ b/internal/db/schema/options_test.go
@@ -1,0 +1,22 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_GetOpts provides unit tests for GetOpts and all the options
+func Test_GetOpts(t *testing.T) {
+	t.Parallel()
+	t.Run("WithMigrationStates", func(t *testing.T) {
+		assert := assert.New(t)
+		oState := TestCloneMigrationStates(t)
+		nState := TestCreatePartialMigrationState(oState["postgres"], 8)
+		oState["postgres"] = nState
+		opts := getOpts(WithMigrationStates(oState))
+		testOpts := getDefaultOptions()
+		testOpts.withMigrationStates = oState
+		assert.Equal(opts, testOpts)
+	})
+}

--- a/internal/db/schema/postgres_migration.gen.go
+++ b/internal/db/schema/postgres_migration.gen.go
@@ -4,7 +4,7 @@ package schema
 
 func init() {
 	migrationStates["postgres"] = migrationState{
-		binarySchemaVersion: 2086,
+		binarySchemaVersion: 2087,
 		upMigrations: map[int][]byte{
 			1: []byte(`
 create domain wt_public_id as text
@@ -4987,6 +4987,54 @@ create trigger
 before insert on kms_oidc_key_version
 	for each row execute procedure kms_version_column('oidc_key_id');
 `),
+			2080: []byte(`
+-- log_migration entries represent logs generated during migrations
+create table log_migration(
+  id bigint generated always as identity primary key,
+  migration_version bigint not null, -- cannot declare FK since the table is truncated during runtime
+  create_time wt_timestamp,
+  entry text not null
+);
+comment on table log_migration is 
+'log_migration entries are logging output from databaes migrations';
+
+-- log_migration triggers
+create trigger 
+  default_create_time_column
+before
+insert on log_migration
+  for each row execute procedure default_create_time();
+
+create trigger
+  immutable_columns
+before
+update on log_migration
+  for each row execute procedure immutable_columns('id', 'migration_version', 'create_time', 'entry');
+
+
+-- log_migration_version() defines a function to be used in a "before update"
+-- trigger for log_migrations entries.  Its intent: set the log_migration
+-- version column to the current migration version.  
+create or replace function
+  log_migration_version()
+  returns trigger
+as $$
+  declare current_version bigint;
+  begin
+    select max(version) from boundary_schema_version into current_version;
+    new.migration_version = current_version;
+    return new;
+  end;
+$$ language plpgsql;
+comment on function log_migration_version() is
+'log_migration_version will set the log_migration entries to the current migration version';    
+
+create trigger
+  migration_version_column
+before
+insert on log_migration
+  for each row execute procedure log_migration_version();
+`),
 			2083: []byte(`
 -- auth_oidc_method_state_enum entries define the possible oidc auth method
 -- states. 
@@ -5611,16 +5659,6 @@ add constraint auth_method
   foreign key (public_id, primary_auth_method_id) 
   references auth_method(scope_id, public_id); 
 
--- for backward compatibility, set any existing auth password method as the 
--- primary auth method, so they will continue to autovivify
-update 
-    iam_scope
-set 
-    primary_auth_method_id = p.scope_id
-from
-    (select scope_id from auth_password_method) as p 
-where p.scope_id = iam_scope.public_id;
-
 -- iam_user_acct_info provides account info for users by determining which
 -- auth_method is designated as for "account info" in the user's scope via the
 -- scope's primary_auth_method_id.  Every sub-type of auth_account must be
@@ -5669,6 +5707,72 @@ select
 from 	
 	iam_user u
 left outer join iam_acct_info i on u.public_id = i.iam_user_id;
+`),
+			2087: []byte(`
+-- the intent of this update statement: set the primary auth method for scopes
+-- that only have a single auth_password_method, since currently there are only
+-- auth_password_methods in boundary. Before this release all
+-- auth_password_methods were "basically" primary auth methods and would create
+-- an iam_user on first login.
+with single_authmethod (scope_id, public_id) as (
+  select 
+    am.scope_id, 
+    am.public_id  
+  from 
+    auth_password_method am,
+    (select 
+        scope_id, 
+        count(public_id) as cnt 
+     from 
+        auth_password_method 
+     group by scope_id) as singles
+    where 
+      am.scope_id = singles.scope_id and
+      singles.cnt = 1
+)
+update 
+  iam_scope
+set 
+  primary_auth_method_id = p.public_id
+from
+  single_authmethod p
+where p.scope_id = iam_scope.public_id;
+
+
+-- the intent of the insert with select statement: log the scopes that have more
+-- than 1 auth method and therefore cannot have their primary auth method
+-- automatically set for them.
+with many_authmethod (scope_id, authmethod_cnt) as (
+  select 
+    am.scope_id, 
+    many.cnt
+  from 
+    auth_password_method am,
+    (select 
+        scope_id, 
+        count(public_id) as cnt 
+     from 
+        auth_password_method 
+     group by scope_id) as many
+    where 
+      am.scope_id = many.scope_id and
+      many.cnt > 1
+)
+insert into log_migration(entry) 
+select 
+  distinct  concat(
+      'unable to set primary_auth_method for ', 
+      public_id,
+      ' there were ', 
+      m.authmethod_cnt, 
+      ' password auth methods for that scope.'
+  ) as entry
+from
+  iam_scope s,
+  many_authmethod m
+where 
+  s.primary_auth_method_id is null and 
+  s.public_id = m.scope_id;
 `),
 		},
 	}

--- a/internal/db/schema/schema.go
+++ b/internal/db/schema/schema.go
@@ -9,8 +9,8 @@ import (
 
 // MigrateStore executes the migrations needed to initialize the store. It
 // returns true if migrations actually ran; false if the database is already current
-// or if there was an error.
-func MigrateStore(ctx context.Context, dialect string, url string) (bool, error) {
+// or if there was an error.  Supports the WithMigrationStates(...) option.
+func MigrateStore(ctx context.Context, dialect string, url string, opt ...Option) (bool, error) {
 	const op = "schema.MigrateStore"
 
 	d, err := sql.Open(dialect, url)
@@ -18,7 +18,7 @@ func MigrateStore(ctx context.Context, dialect string, url string) (bool, error)
 		return false, errors.Wrap(err, op)
 	}
 
-	sMan, err := NewManager(ctx, dialect, d)
+	sMan, err := NewManager(ctx, dialect, d, opt...)
 	if err != nil {
 		return false, errors.Wrap(err, op)
 	}

--- a/internal/db/schema/schema_test.go
+++ b/internal/db/schema/schema_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/hashicorp/boundary/internal/docker"
@@ -40,4 +41,34 @@ func TestMigrateStore(t *testing.T) {
 	ran, err = MigrateStore(ctx, dialect, u)
 	assert.NoError(t, err)
 	assert.False(t, ran)
+}
+
+func Test_MigrateStore_WithMigrationStates(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	dialect := "postgres"
+	ctx := context.Background()
+
+	c, u, _, err := docker.StartDbInDocker(dialect)
+	require.NoError(err)
+	t.Cleanup(func() {
+		require.NoError(c())
+	})
+	d, err := sql.Open(dialect, u)
+	require.NoError(err)
+
+	// migration to the prior migration (before the one we want to test)
+	oState := TestCloneMigrationStates(t)
+	nState := TestCreatePartialMigrationState(oState["postgres"], 8)
+	oState["postgres"] = nState
+
+	ran, err := MigrateStore(ctx, dialect, u, WithMigrationStates(oState))
+	assert.NoError(err)
+	assert.True(ran)
+
+	m, err := NewManager(ctx, dialect, d, WithMigrationStates(oState))
+	require.NoError(err)
+	state, err := m.CurrentState(ctx)
+	require.NoError(err)
+	assert.Equal(8, state.DatabaseSchemaVersion)
+	assert.False(state.Dirty)
 }

--- a/internal/db/schema/state.go
+++ b/internal/db/schema/state.go
@@ -15,8 +15,15 @@ type migrationState struct {
 // migrationStates is populated by the generated migration code with the key being the dialect.
 var migrationStates = make(map[string]migrationState)
 
-func getUpMigration(dialect string) map[int][]byte {
-	ms, ok := migrationStates[dialect]
+func getUpMigration(dialect string, opt ...Option) map[int][]byte {
+	opts := getOpts(opt...)
+	var ms migrationState
+	var ok bool
+	if opts.withMigrationStates != nil {
+		ms, ok = opts.withMigrationStates[dialect]
+	} else {
+		ms, ok = migrationStates[dialect]
+	}
 	if !ok {
 		return nil
 	}
@@ -31,4 +38,21 @@ func BinarySchemaVersion(dialect string) int {
 		return nilVersion
 	}
 	return ms.binarySchemaVersion
+}
+
+func cloneMigrationStates(states map[string]migrationState) map[string]migrationState {
+	nStates := map[string]migrationState{}
+	for k, s := range states {
+		newState := migrationState{
+			binarySchemaVersion: s.binarySchemaVersion,
+			upMigrations:        map[int][]byte{},
+		}
+		for v, up := range s.upMigrations {
+			cp := make([]byte, len(up))
+			copy(cp, up)
+			newState.upMigrations[v] = cp
+		}
+		nStates[k] = newState
+	}
+	return nStates
 }

--- a/internal/db/schema/statement.go
+++ b/internal/db/schema/statement.go
@@ -13,10 +13,10 @@ type statementProvider struct {
 	up       map[int][]byte
 }
 
-func newStatementProvider(dialect string, curVer int) *statementProvider {
+func newStatementProvider(dialect string, curVer int, opt ...Option) *statementProvider {
 	const op = "schema.newStatementProvider"
 	qp := statementProvider{pos: -1}
-	qp.up = getUpMigration(dialect)
+	qp.up = getUpMigration(dialect, opt...)
 	for k := range qp.up {
 		qp.versions = append(qp.versions, k)
 	}

--- a/internal/db/schema/testing.go
+++ b/internal/db/schema/testing.go
@@ -1,0 +1,27 @@
+package schema
+
+import (
+	"testing"
+)
+
+// Creates a new migrationState only with the versions <= the provided maxVer
+func TestCreatePartialMigrationState(om migrationState, maxVer int) migrationState {
+	nState := migrationState{
+		upMigrations: make(map[int][]byte),
+	}
+	for k := range om.upMigrations {
+		if k > maxVer {
+			// Don't store any versions past our test version.
+			continue
+		}
+		nState.upMigrations[k] = om.upMigrations[k]
+		if nState.binarySchemaVersion < k {
+			nState.binarySchemaVersion = k
+		}
+	}
+	return nState
+}
+
+func TestCloneMigrationStates(t *testing.T) map[string]migrationState {
+	return cloneMigrationStates(migrationStates)
+}


### PR DESCRIPTION
This PR adds:

- Logging to the db during migrations which requires a new table (with appropriate triggers) and changes to the `schema` package.
- The ability to override the global migrationStates (primarily in support of testing the migrations themselves) when running migrations.  this required adding support for options to a few of the types in the `schema` package.
-  Sets address primary_auth_method during migration for any scope with only one auth method and logs all scopes which have more than one auth method.

@mgaffney - I would appreciate your review of the schema changes for logging and the primary auth method update and reporting statements.

@jefferai, @talanknight - Currently, I'm outputting the migrations logs only for the `database migrate`, not the `init` subcommand.  I'd appreciate your review of the CLI changes.

@talanknight - I'm appreciate a complete review of this PR, especially the changes in the 