### PR TITLE
Use pointers for any Uber atomic values

### DIFF
--- a/internal/cmd/commands/connect/connect.go
+++ b/internal/cmd/commands/connect/connect.go
@@ -97,7 +97,7 @@ type Command struct {
 	listener           *net.TCPListener
 	listenerAddr       *net.TCPAddr
 	connsLeftCh        chan int32
-	connectionsLeft    atomic.Int32
+	connectionsLeft    *atomic.Int32
 	expiration         time.Time
 	execCmdReturnValue *atomic.Int32
 	proxyCtx           context.Context
@@ -314,6 +314,7 @@ func (c *Command) Run(args []string) (retCode int) {
 		return base.CommandCliError
 	}
 
+	c.connectionsLeft = atomic.NewInt32(0)
 	c.connsLeftCh = make(chan int32)
 
 	if c.flagListenAddr == "" {
@@ -572,7 +573,7 @@ func (c *Command) Run(args []string) (retCode int) {
 
 	if c.flagExec != "" {
 		c.connWg.Add(1)
-		c.execCmdReturnValue = new(atomic.Int32)
+		c.execCmdReturnValue = atomic.NewInt32(0)
 		go c.handleExec(passthroughArgs)
 	}
 

--- a/internal/servers/controller/controller.go
+++ b/internal/servers/controller/controller.go
@@ -30,7 +30,7 @@ type Controller struct {
 
 	baseContext context.Context
 	baseCancel  context.CancelFunc
-	started     ua.Bool
+	started     *ua.Bool
 
 	workerAuthCache *cache.Cache
 
@@ -53,6 +53,7 @@ func New(conf *Config) (*Controller, error) {
 	c := &Controller{
 		conf:                    conf,
 		logger:                  conf.Logger.Named("controller"),
+		started:                 ua.NewBool(false),
 		workerStatusUpdateTimes: new(sync.Map),
 	}
 

--- a/internal/servers/worker/worker.go
+++ b/internal/servers/worker/worker.go
@@ -25,7 +25,7 @@ type Worker struct {
 
 	baseContext context.Context
 	baseCancel  context.CancelFunc
-	started     ua.Bool
+	started     *ua.Bool
 
 	controllerStatusConn *atomic.Value
 	lastStatusSuccess    *atomic.Value
@@ -48,6 +48,7 @@ func New(conf *Config) (*Worker, error) {
 	w := &Worker{
 		conf:                  conf,
 		logger:                conf.Logger.Named("worker"),
+		started:               ua.NewBool(false),
 		controllerStatusConn:  new(atomic.Value),
 		lastStatusSuccess:     new(atomic.Value),
 		controllerResolver:    new(atomic.Value),


### PR DESCRIPTION
BK clued me into the fact that for some types, similar alignment
problems exist as with the normal atomic package (e.g. 64-bit types on
32-bit architectures) if they are not pointer values. So change the few
places they weren't pointers to pointers.

None of these are 64-bit, but it feels like best practice for using the
library and should just standardize on it.