### PR TITLE
Vault integration: database fixes

### DIFF
--- a/internal/db/schema/migrations/postgres/2/01_credential.up.sql
+++ b/internal/db/schema/migrations/postgres/2/01_credential.up.sql
@@ -4,7 +4,7 @@ begin;
   create table credential_store (
     public_id wt_public_id primary key,
     scope_id wt_scope_id not null
-      constraint iam_scope_fk
+      constraint iam_scope_fkey
         references iam_scope (public_id)
         on delete cascade
         on update cascade,
@@ -53,7 +53,7 @@ begin;
   create table credential_library (
     public_id wt_public_id primary key,
     store_id wt_public_id not null
-      constraint credential_store_fk
+      constraint credential_store_fkey
         references credential_store (public_id)
         on delete cascade
         on update cascade,
@@ -132,12 +132,12 @@ begin;
   -- credential_static
   create table credential_static (
     public_id wt_public_id primary key
-      constraint credential_fk
+      constraint credential_fkey
         references credential (public_id)
         on delete cascade
         on update cascade,
     store_id wt_public_id not null
-      constraint credential_store_fk
+      constraint credential_store_fkey
         references credential_store (public_id)
         on delete cascade
         on update cascade,
@@ -186,12 +186,12 @@ begin;
   -- credential_dynamic
   create table credential_dynamic (
     public_id wt_public_id primary key
-      constraint credential_fk
+      constraint credential_fkey
         references credential (public_id)
         on delete cascade
         on update cascade,
     library_id wt_public_id not null
-      constraint credential_library_fk
+      constraint credential_library_fkey
         references credential_library (public_id)
         on delete cascade
         on update cascade,

--- a/internal/db/schema/migrations/postgres/2/02_vault_credential.down.sql
+++ b/internal/db/schema/migrations/postgres/2/02_vault_credential.down.sql
@@ -9,6 +9,7 @@ begin;
   drop table credential_vault_library;
   drop table credential_vault_client_certificate;
   drop table credential_vault_token;
+  drop table credential_vault_token_status_enm;
   drop table credential_vault_store;
 
 commit;

--- a/internal/db/schema/migrations/postgres/2/02_vault_credential.up.sql
+++ b/internal/db/schema/migrations/postgres/2/02_vault_credential.up.sql
@@ -68,7 +68,7 @@ begin;
       )
   );
   comment on table credential_vault_token_status_enm is
-    'credential_vault_token_status_enm is an enumeration table for the status of vault tokens.'
+    'credential_vault_token_status_enm is an enumeration table for the status of vault tokens. '
     'It contains rows for representing the current, maintaining, revoked, and expired statuses.';
 
   insert into credential_vault_token_status_enm (name)

--- a/internal/db/schema/migrations/postgres/2/02_vault_credential.up.sql
+++ b/internal/db/schema/migrations/postgres/2/02_vault_credential.up.sql
@@ -3,7 +3,7 @@ begin;
   create table credential_vault_store (
     public_id wt_public_id primary key,
     scope_id wt_scope_id not null
-      constraint iam_scope_fk
+      constraint iam_scope_fkey
         references iam_scope (public_id)
         on delete cascade
         on update cascade,
@@ -25,7 +25,7 @@ begin;
       constraint tls_server_name_must_not_be_empty
         check(length(trim(tls_server_name)) > 0),
     tls_skip_verify boolean default false not null,
-    constraint credential_store_fk
+    constraint credential_store_fkey
       foreign key (scope_id, public_id)
       references credential_store (scope_id, public_id)
       on delete cascade
@@ -84,7 +84,7 @@ begin;
     store_id wt_public_id not null
       constraint credential_vault_token_store_id_uq
         unique
-      constraint credential_vault_store_fk
+      constraint credential_vault_store_fkey
         references credential_vault_store (public_id)
         on delete cascade
         on update cascade,
@@ -96,12 +96,12 @@ begin;
       constraint last_renewal_time_must_be_before_expiration_time
         check(last_renewal_time < expiration_time),
     key_id text not null
-      constraint kms_database_key_version_fk
+      constraint kms_database_key_version_fkey
         references kms_database_key_version (private_id)
         on delete restrict
         on update cascade,
     token_status text not null
-      constraint credential_vault_token_status_enm_fk
+      constraint credential_vault_token_status_enm_fkey
         references credential_vault_token_status_enm (name)
         on delete restrict
         on update cascade
@@ -123,7 +123,7 @@ begin;
 
   create table credential_vault_client_certificate (
     store_id wt_public_id primary key
-      constraint credential_vault_store_fk
+      constraint credential_vault_store_fkey
         references credential_vault_store (public_id)
         on delete cascade
         on update cascade,
@@ -132,7 +132,7 @@ begin;
         check(length(trim(certificate)) > 0),
     certificate_key bytea not null, -- encrypted PEM encoded private key for certificate
     key_id text not null
-      constraint kms_database_key_version_fk
+      constraint kms_database_key_version_fkey
         references kms_database_key_version (private_id)
         on delete restrict
         on update cascade
@@ -147,7 +147,7 @@ begin;
   create table credential_vault_library (
     public_id wt_public_id primary key,
     store_id wt_public_id not null
-      constraint credential_vault_store_fk
+      constraint credential_vault_store_fkey
         references credential_vault_store (public_id)
         on delete cascade
         on update cascade,
@@ -161,7 +161,7 @@ begin;
         check(length(trim(vault_path)) > 0),
     constraint credential_vault_library_store_id_name_uq
       unique(store_id, name),
-    constraint credential_library_fk
+    constraint credential_library_fkey
       foreign key (store_id, public_id)
       references credential_library (store_id, public_id)
       on delete cascade
@@ -194,17 +194,17 @@ begin;
   create table credential_vault_lease (
     public_id wt_public_id primary key,
     library_id wt_public_id not null
-      constraint credential_vault_library_fk
+      constraint credential_vault_library_fkey
         references credential_vault_library (public_id)
         on delete cascade
         on update cascade,
     session_id wt_public_id not null
-      constraint session_fk
+      constraint session_fkey
         references session (public_id)
         on delete cascade
         on update cascade,
     token_sha256 bytea not null
-      constraint credential_vault_token_fk
+      constraint credential_vault_token_fkey
         references credential_vault_token (token_sha256)
         on delete cascade
         on update cascade,
@@ -221,7 +221,7 @@ begin;
       constraint last_renewal_time_must_be_before_expiration_time
         check(last_renewal_time < expiration_time),
     is_renewable boolean not null,
-    constraint credential_dynamic_fk
+    constraint credential_dynamic_fkey
       foreign key (library_id, public_id)
       references credential_dynamic (library_id, public_id)
       on delete cascade

--- a/internal/db/schema/migrations/postgres/2/03_target.up.sql
+++ b/internal/db/schema/migrations/postgres/2/03_target.up.sql
@@ -23,17 +23,17 @@ begin;
 
   create table target_credential_library (
     target_id wt_public_id not null
-      constraint target_fk
+      constraint target_fkey
         references target (public_id)
         on delete cascade
         on update cascade,
     credential_library_id wt_public_id not null
-      constraint credential_library_fk
+      constraint credential_library_fkey
         references credential_library (public_id)
         on delete cascade
         on update cascade,
     target_credential_purpose text not null
-      constraint target_credential_purpose_fk
+      constraint target_credential_purpose_fkey
         references target_credential_purpose_enm (name)
         on delete restrict
         on update cascade,

--- a/internal/db/schema/migrations/postgres/2/04_session.up.sql
+++ b/internal/db/schema/migrations/postgres/2/04_session.up.sql
@@ -2,22 +2,22 @@ begin;
 
   create table session_credential_library (
     session_id wt_public_id not null
-      constraint session_fk
+      constraint session_fkey
         references session (public_id)
         on delete cascade
         on update cascade,
     credential_id wt_public_id not null
-      constraint credential_fk
+      constraint credential_fkey
         references credential (public_id)
         on delete cascade
         on update cascade,
     credential_library_id wt_public_id not null
-      constraint credential_library_fk
+      constraint credential_library_fkey
         references credential_library (public_id)
         on delete cascade
         on update cascade,
     target_credential_purpose text not null
-      constraint target_credential_purpose_fk
+      constraint target_credential_purpose_fkey
         references target_credential_purpose_enm (name)
         on delete restrict
         on update cascade,

--- a/internal/db/schema/postgres_migration.gen.go
+++ b/internal/db/schema/postgres_migration.gen.go
@@ -5294,7 +5294,7 @@ create table credential_vault_store (
       )
   );
   comment on table credential_vault_token_status_enm is
-    'credential_vault_token_status_enm is an enumeration table for the status of vault tokens.'
+    'credential_vault_token_status_enm is an enumeration table for the status of vault tokens. '
     'It contains rows for representing the current, maintaining, revoked, and expired statuses.';
 
   insert into credential_vault_token_status_enm (name)


### PR DESCRIPTION
* Rename foreign key constraint names to use `_fkey` suffix 
* Add `credential_vault_token_status_enm` table
* Add `token_sha256` to `credential_vault_lease` table as foreign key to `credential_vault_token` table
* Give `tls_skip_verify` a default value of `false` in the `credential_vault_store` table 
