### PR TITLE
chore: build directly on the hose rather than Docker

### DIFF
--- a/scripts/uigen.sh
+++ b/scripts/uigen.sh
@@ -12,8 +12,8 @@ fi
 
 (
 	cd "$UI_CLONE_DIR"
-	if ! docker-compose -f docker-compose-embedding.yml run build; then
-		yarn install && yarn build
+	if ! yarn install && yarn build; then
+		echo "Please ensure Node v14+ and Yarn v1.22.10+ are installed."
 	fi
 )
 


### PR DESCRIPTION
The UI build is I/O heavy and thus runs much faster outside of a container.  Since the build script succeeds on WSL2, I think it's safe to end our reliance on Docker to build the UI.