### PR TITLE
issuer and api url Field condition update

### DIFF
--- a/internal/auth/oidc/auth_method.go
+++ b/internal/auth/oidc/auth_method.go
@@ -69,7 +69,7 @@ func NewAuthMethod(scopeId string, clientId string, clientSecret ClientSecret, o
 	switch {
 	case opts.withIssuer != nil:
 		// trim off anything beyond scheme, host and port
-		u = strings.TrimSuffix(strings.TrimSuffix(opts.withIssuer.String(), "/"), "/.well-known/openid-configuration")
+		u = strings.SplitN(opts.withIssuer.String(), ".well-known/", 2)[0]
 	}
 
 	a := &AuthMethod{

--- a/internal/gen/controller/api/resources/authmethods/auth_method.pb.go
+++ b/internal/gen/controller/api/resources/authmethods/auth_method.pb.go
@@ -252,7 +252,7 @@ type OidcAuthMethodAttributes struct {
 	// "active-private", or "active-public".
 	State string `protobuf:"bytes,10,opt,name=state,proto3" json:"state,omitempty"`
 	// The issuer URL. Boundary expects only the schema, host, and port and will
-	// strip off "/.well-known/openid-configuration" if present. This will be
+	// strip off ".well-known/openid-configuration" if present. This will be
 	// used for configuration discovery as well as for validation of the "iss"
 	// claim.
 	Issuer *wrappers.StringValue `protobuf:"bytes,20,opt,name=issuer,proto3" json:"issuer,omitempty"`

--- a/internal/proto/local/controller/api/resources/authmethods/v1/auth_method.proto
+++ b/internal/proto/local/controller/api/resources/authmethods/v1/auth_method.proto
@@ -70,7 +70,7 @@ message OidcAuthMethodAttributes {
 	string state = 10 [json_name="state"];
 
 	// The issuer URL. Boundary expects only the schema, host, and port and will
-	// strip off "/.well-known/openid-configuration" if present. This will be
+	// strip off ".well-known/openid-configuration" if present. This will be
 	// used for configuration discovery as well as for validation of the "iss"
 	// claim.
 	google.protobuf.StringValue issuer = 20 [json_name="issuer", (custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this:"attributes.issuer" that:"Issuer"}];

--- a/internal/servers/controller/handlers/authmethods/authmethod_service.go
+++ b/internal/servers/controller/handlers/authmethods/authmethod_service.go
@@ -628,6 +628,9 @@ func toAuthMethodProto(in auth.AuthMethod) (*pb.AuthMethod, error) {
 			SigningAlgorithms: i.GetSigningAlgs(),
 			AllowedAudiences:  i.GetAudClaims(),
 		}
+		if i.DisableDiscoveredConfigValidation {
+			attrs.DisableDiscoveredConfigValidation = true
+		}
 		if i.GetIssuer() != "" {
 			attrs.Issuer = wrapperspb.String(i.Issuer)
 		}
@@ -705,12 +708,12 @@ func validateCreateRequest(req *pbs.CreateAuthMethodRequest) error {
 				badFields[attributesField] = "Attribute fields do not match the expected format."
 			} else {
 				if attrs.GetIssuer().GetValue() != "" {
-					du, err := url.Parse(attrs.GetIssuer().GetValue())
+					iss, err := url.Parse(attrs.GetIssuer().GetValue())
 					if err != nil {
 						badFields[issuerField] = fmt.Sprintf("Cannot be parsed as a url. %v", err)
 					}
-					if trimmed := strings.TrimSuffix(strings.TrimSuffix(du.RawPath, "/"), "/.well-known/openid-configuration"); trimmed != "" {
-						badFields[issuerField] = "The path should be empty or `/.well-known/openid-configuration`"
+					if !strutil.StrListContains([]string{"http", "https"}, iss.Scheme) {
+						badFields[issuerField] = fmt.Sprintf("Must have schema %q or %q specified", "http", "https")
 					}
 				}
 				if attrs.GetDisableDiscoveredConfigValidation() {
@@ -799,19 +802,29 @@ func validateUpdateRequest(req *pbs.UpdateAuthMethodRequest) error {
 			}
 			if handlers.MaskContains(req.GetUpdateMask().GetPaths(), issuerField) {
 				if attrs.GetIssuer().GetValue() != "" {
-					du, err := url.Parse(attrs.GetIssuer().GetValue())
+					iss, err := url.Parse(attrs.GetIssuer().GetValue())
 					if err != nil {
 						badFields[issuerField] = fmt.Sprintf("Cannot be parsed as a url. %v", err)
 					}
-					if trimmed := strings.TrimSuffix(strings.TrimSuffix(du.RawPath, "/"), "/.well-known/openid-configuration"); trimmed != "" {
-						badFields[issuerField] = "The path should be empty or `/.well-known/openid-configuration`"
+					if !strutil.StrListContains([]string{"http", "https"}, iss.Scheme) {
+						badFields[issuerField] = fmt.Sprintf("Must have schema %q or %q specified", "http", "https")
+					}
+				}
+			}
+			if handlers.MaskContains(req.GetUpdateMask().GetPaths(), apiUrlPrefixField) {
+				if attrs.GetApiUrlPrefix().GetValue() != "" {
+					cu, err := url.Parse(attrs.GetApiUrlPrefix().GetValue())
+					if err != nil || cu.Host == "" {
+						badFields[apiUrlPrefixField] = fmt.Sprintf("%q cannot be parsed as a url.", attrs.GetApiUrlPrefix().GetValue())
+					}
+					if !strutil.StrListContains([]string{"http", "https"}, cu.Scheme) {
+						badFields[apiUrlPrefixField] = fmt.Sprintf("Must have schema %q or %q specified", "http", "https")
 					}
 				}
 			}
 			if handlers.MaskContains(req.GetUpdateMask().GetPaths(), clientSecretField) && attrs.GetClientSecret().GetValue() == "" {
 				badFields[clientSecretField] = "Can change but cannot unset this field."
 			}
-
 			if handlers.MaskContains(req.GetUpdateMask().GetPaths(), clientIdField) && attrs.GetClientId().GetValue() == "" {
 				badFields[clientIdField] = "Can change but cannot unset this field."
 			}
@@ -826,21 +839,12 @@ func validateUpdateRequest(req *pbs.UpdateAuthMethodRequest) error {
 				badFields[callbackUrlField] = "Field is read only."
 			}
 
-			if attrs.GetMaxAge() != nil && attrs.GetMaxAge().GetValue() == 0 {
-				badFields[maxAgeField] = "Must not be `0`."
-			}
 			if len(attrs.GetSigningAlgorithms()) > 0 {
 				for _, sa := range attrs.GetSigningAlgorithms() {
 					if !oidc.SupportedAlgorithm(oidc.Alg(sa)) {
 						badFields[signingAlgorithmField] = fmt.Sprintf("Contains unsupported algorithm %q", sa)
 						break
 					}
-				}
-			}
-			if attrs.GetApiUrlPrefix() != nil {
-				if cu, err := url.Parse(attrs.GetApiUrlPrefix().GetValue()); err != nil || (cu.Scheme != "http" && cu.Scheme != "https") || cu.Host == "" {
-					badFields[apiUrlPrefixField] = fmt.Sprintf("%q cannot be parsed as a url.", attrs.GetApiUrlPrefix().GetValue())
-					break
 				}
 			}
 			if len(attrs.GetIdpCaCerts()) > 0 {

--- a/internal/servers/controller/handlers/authmethods/oidc_test.go
+++ b/internal/servers/controller/handlers/authmethods/oidc_test.go
@@ -285,6 +285,43 @@ func TestUpdate_OIDC(t *testing.T) {
 			},
 		},
 		{
+			name: "Update Issuer",
+			req: &pbs.UpdateAuthMethodRequest{
+				UpdateMask: &field_mask.FieldMask{
+					Paths: []string{"attributes.issuer"},
+				},
+				Item: &pb.AuthMethod{
+					Attributes: &structpb.Struct{
+						Fields: func() map[string]*structpb.Value {
+							f := defaultAttributeFields()
+							f["issuer"] = structpb.NewStringValue("http://localhost:72759/somepath/.well-known/openid-configuration")
+							f["disable_discovered_config_validation"] = structpb.NewBoolValue(true)
+							return f
+						}(),
+					},
+				},
+			},
+			res: &pbs.UpdateAuthMethodResponse{
+				Item: &pb.AuthMethod{
+					ScopeId:     o.GetPublicId(),
+					Name:        &wrapperspb.StringValue{Value: "default"},
+					Description: &wrapperspb.StringValue{Value: "default"},
+					Type:        auth.OidcSubtype.String(),
+					Attributes: &structpb.Struct{
+						Fields: func() map[string]*structpb.Value {
+							f := defaultReadAttributeFields()
+							f["issuer"] = structpb.NewStringValue("http://localhost:72759/somepath/")
+							f["disable_discovered_config_validation"] = structpb.NewBoolValue(true)
+							return f
+						}(),
+					},
+					Scope:                       defaultScopeInfo,
+					AuthorizedActions:           oidcAuthorizedActions,
+					AuthorizedCollectionActions: authorizedCollectionActions,
+				},
+			},
+		},
+		{
 			name: "No Update Mask",
 			req: &pbs.UpdateAuthMethodRequest{
 				Item: &pb.AuthMethod{
@@ -549,7 +586,24 @@ func TestUpdate_OIDC(t *testing.T) {
 					},
 				},
 			},
-			err: handlers.ApiErrorWithCode(codes.InvalidArgument),
+			res: &pbs.UpdateAuthMethodResponse{
+				Item: &pb.AuthMethod{
+					ScopeId:     o.GetPublicId(),
+					Name:        &wrapperspb.StringValue{Value: "default"},
+					Description: &wrapperspb.StringValue{Value: "default"},
+					Type:        auth.OidcSubtype.String(),
+					Attributes: &structpb.Struct{
+						Fields: func() map[string]*structpb.Value {
+							f := defaultReadAttributeFields()
+							f["max_age"] = structpb.NewNumberValue(0)
+							return f
+						}(),
+					},
+					Scope:                       defaultScopeInfo,
+					AuthorizedActions:           oidcAuthorizedActions,
+					AuthorizedCollectionActions: authorizedCollectionActions,
+				},
+			},
 		},
 		{
 			name: "Change Max Age",
@@ -769,6 +823,7 @@ func TestUpdate_OIDC(t *testing.T) {
 								lv, _ := structpb.NewList([]interface{}{string(oidc.EdDSA)})
 								return structpb.NewListValue(lv)
 							}()
+							f["disable_discovered_config_validation"] = structpb.NewBoolValue(true)
 							return f
 						}(),
 					},


### PR DESCRIPTION
Issuers and API Url both require a schema to be set (either http or https).
Modification on the issuer value now only strips off everything after and including ".well-known/".
Include the `disable_discovered_config_validation` on the auth method resource returned by the API.