### PR TITLE
Fix curl string building

### DIFF
--- a/api/output_string.go
+++ b/api/output_string.go
@@ -39,9 +39,9 @@ func (d *OutputStringError) parseRequest() {
 	}
 
 	// Build cURL string
-	d.parsedCurlString = "curl "
+	d.parsedCurlString = "curl"
 	if d.Request.Method != "GET" {
-		d.parsedCurlString = fmt.Sprintf("%s-X %s ", d.parsedCurlString, d.Request.Method)
+		d.parsedCurlString = fmt.Sprintf("%s -X %s", d.parsedCurlString, d.Request.Method)
 	}
 	for k, v := range d.Request.Header {
 		for _, h := range v {
@@ -57,7 +57,7 @@ func (d *OutputStringError) parseRequest() {
 					h = fmt.Sprintf("Bearer $(boundary config get-token -keyring-type %s -token-name %s)", keyringType, tokenName)
 				}
 			}
-			d.parsedCurlString = fmt.Sprintf("%s-H \"%s: %s\"", d.parsedCurlString, k, h)
+			d.parsedCurlString = fmt.Sprintf("%s -H \"%s: %s\"", d.parsedCurlString, k, h)
 		}
 	}
 
@@ -65,7 +65,7 @@ func (d *OutputStringError) parseRequest() {
 		// We need to escape single quotes since that's what we're using to
 		// quote the body
 		escapedBody := strings.Replace(string(body), "'", "'\"'\"'", -1)
-		d.parsedCurlString = fmt.Sprintf(" %s-d '%s'", d.parsedCurlString, escapedBody)
+		d.parsedCurlString = fmt.Sprintf("%s -d '%s'", d.parsedCurlString, escapedBody)
 	}
 
 	// Filters can have shell characters so we use single quotes to surround the URL

--- a/website/content/docs/concepts/filtering/resource-listing.mdx
+++ b/website/content/docs/concepts/filtering/resource-listing.mdx
@@ -75,7 +75,7 @@ flag with the Boundary CLI:
 
 ```
 $ boundary targets list -scope-id p_1234567890 -format json -filter '"authorize-session" in "/item/authorized_actions"' -output-curl-string
-curl -H "Authorization: Bearer $(boundary config get-token -keyring-type pass -token-name default)"-H "Content-Type: application/json" 'http://127.0.0.1:9200/v1/targets?filter=%22authorize-session%22+in+%22%2Fitem%2Fauthorized_actions%22&scope_id=p_1234567890'
+curl -H "Authorization: Bearer $(boundary config get-token -keyring-type pass -token-name default)" -H "Content-Type: application/json" 'http://127.0.0.1:9200/v1/targets?filter=%22authorize-session%22+in+%22%2Fitem%2Fauthorized_actions%22&scope_id=p_1234567890'
 ```
 
 Following are some examples.


### PR DESCRIPTION
I'm not sure why it was doing it the other way with assuming the string
being built would always have a space at the end, but, this way is
easier to understand and fixes a bug where there wasn't a space being
left between some fields.