### PR TITLE
By default, add Boundary Desktop's origin to allowed CORS origins

### DIFF
--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -22,6 +22,8 @@ import (
 )
 
 const (
+	desktopCorsOrigin = "serve://boundary"
+
 	devConfig = `
 disable_mlock = true
 
@@ -327,13 +329,20 @@ func Parse(d string) (*Config, error) {
 	}
 	result.SharedConfig = sharedConfig
 
-	// If cors wasn't specified, enable default values
 	for _, listener := range result.SharedConfig.Listeners {
-		if strutil.StrListContains(listener.Purpose, "api") {
+		if strutil.StrListContains(listener.Purpose, "api") &&
+			(listener.CorsDisableDefaultAllowedOriginValues == nil || !*listener.CorsDisableDefaultAllowedOriginValues) {
+			// If CORS wasn't specified, enable default values
 			if listener.CorsEnabled == nil {
 				listener.CorsEnabled = new(bool)
 				*listener.CorsEnabled = true
-				listener.CorsAllowedOrigins = []string{"serve://boundary"}
+				listener.CorsAllowedOrigins = []string{desktopCorsOrigin}
+			}
+			// If not the wildcard and they haven't disabled us auto-adding
+			// origin values, add the desktop client origin
+			if *listener.CorsEnabled &&
+				!strutil.StrListContains(listener.CorsAllowedOrigins, "*") {
+				listener.CorsAllowedOrigins = strutil.AppendIfMissing(listener.CorsAllowedOrigins, desktopCorsOrigin)
 			}
 		}
 	}

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -61,14 +61,28 @@ allowed.
   `default_max_request_duration` for this listener.
 
 - `cors_enabled` `(boolean: true)` - Specifies if CORS should be enabled, which
-  allows Boundary to support external browser-based clients (not including
-  admin UI), such as Boundary Desktop.
+  allows Boundary to support external browser-based clients (not including admin
+  UI), such as Boundary Desktop. If not specified, CORS will be enabled with an
+  allowed origin that grants access to Boundary Desktop, unless overridden with
+  `cors_disable_default_allowed_origin_values`.
 
-- `cors_allowed_origins` `(array(string): ["serve://boundary"])` - an array of
+- `cors_disable_default_allowed_origin_values` `(boolean: false)` - Specifies
+  that Boundary should not append default allowed origin values to any specified
+  in `cors_allowed_origins`, such as Boundary Desktop's origin. This also
+  disables the behavior of enabling CORS if `cors_enabled` is not specified.
+
+- `cors_allowed_origins` `(array(string): ["serve://boundary"])` - An array of
   allowed CORS origins. Origins must include protocol, host, and port (if port
-  is different than the default for the specified protocol).
-  To allow all origins, set to `['*']`. By default, Boundary Desktop's origin
-  `serve://boundary` is allowed.
+  is different than the default for the specified protocol). To allow all
+  origins, set to `['*']`. By default, Boundary Desktop's origin
+  `serve://boundary` is appended to any values included here, unless
+  `cors_disable_default_allowed_origin_values` is specified.
+
+- `cors_allowed_headers` `(array(string): [])` – An array specifying headers
+  that are permitted to be on cross-origin requests. Headers set via this
+  parameter will be appended to the list of headers that Boundary allows by
+  default, such as `"Content-Type"`, `"X-Requested-With"`, and
+  `"Authorization"`.
 
 ### TLS
 

--- a/website/content/docs/configuration/listener/unix.mdx
+++ b/website/content/docs/configuration/listener/unix.mdx
@@ -62,14 +62,28 @@ allowed.
   `default_max_request_duration` for this listener.
 
 - `cors_enabled` `(boolean: true)` - Specifies if CORS should be enabled, which
-  allows Boundary to support external browser-based clients (not including
-  admin UI), such as Boundary Desktop.
+  allows Boundary to support external browser-based clients (not including admin
+  UI), such as Boundary Desktop. If not specified, CORS will be enabled with an
+  allowed origin that grants access to Boundary Desktop, unless overridden with
+  `cors_disable_default_allowed_origin_values`.
 
-- `cors_allowed_origins` `(array(string): ["serve://boundary"])` - an array of
+- `cors_disable_default_allowed_origin_values` `(boolean: false)` - Specifies
+  that Boundary should not append default allowed origin values to any specified
+  in `cors_allowed_origins`, such as Boundary Desktop's origin. This also
+  disables the behavior of enabling CORS if `cors_enabled` is not specified.
+
+- `cors_allowed_origins` `(array(string): ["serve://boundary"])` - An array of
   allowed CORS origins. Origins must include protocol, host, and port (if port
-  is different than the default for the specified protocol).
-  To allow all origins, set to `['*']`. By default, Boundary Desktop's origin
-  `serve://boundary` is allowed.
+  is different than the default for the specified protocol). To allow all
+  origins, set to `['*']`. By default, Boundary Desktop's origin
+  `serve://boundary` is appended to any values included here, unless
+  `cors_disable_default_allowed_origin_values` is specified.
+
+- `cors_allowed_headers` `(array(string): [])` – An array specifying headers
+  that are permitted to be on cross-origin requests. Headers set via this
+  parameter will be appended to the list of headers that Boundary allows by
+  default, such as `"Content-Type"`, `"X-Requested-With"`, and
+  `"Authorization"`.
 
 ### TLS
 


### PR DESCRIPTION
This also adds support for a flag to disable this behavior.

Fixes #1093