### PR TITLE
Restrict auth method listing for u_anon

### DIFF
--- a/internal/servers/controller/handlers/option_test.go
+++ b/internal/servers/controller/handlers/option_test.go
@@ -36,4 +36,14 @@ func Test_GetOpts(t *testing.T) {
 		opts = GetOpts(WithLogger(hclog.New(nil)))
 		assert.NotNil(opts.WithLogger)
 	})
+
+	t.Run("WithAnonymousListing", func(t *testing.T) {
+		assert := assert.New(t)
+
+		opts := GetOpts()
+		assert.False(opts.WithAnonymousListing)
+
+		opts = GetOpts(WithAnonymousListing(true))
+		assert.True(opts.WithAnonymousListing)
+	})
 }

--- a/internal/servers/controller/handlers/options.go
+++ b/internal/servers/controller/handlers/options.go
@@ -20,6 +20,7 @@ type Option func(*options)
 type options struct {
 	withDiscardUnknownFields bool
 	WithLogger               hclog.Logger
+	WithAnonymousListing     bool
 }
 
 func getDefaultOptions() options {
@@ -39,5 +40,13 @@ func WithDiscardUnknownFields(discard bool) Option {
 func WithLogger(logger hclog.Logger) Option {
 	return func(o *options) {
 		o.WithLogger = logger
+	}
+}
+
+// WithAnonymousListing provides an option when creating responses to only include those
+// desired for listing to anonymous users.
+func WithAnonymousListing(anonListing bool) Option {
+	return func(o *options) {
+		o.WithAnonymousListing = anonListing
 	}
 }


### PR DESCRIPTION
This keeps only essential information in list output for auth methods
when the user is u_anon. Boundary's default is to allow listing of
auth methods for anonymous users to allow discovery of authentication
points, but there's no need to return more information about internal
configuration than necessary.