### PR TITLE
website: add support for tip.boundaryproject.io

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -9,6 +9,7 @@ console.log(`NODE_ENV: ${process.env.NODE_ENV}`)
 module.exports = withHashicorp({
   defaultLayout: true,
   transpileModules: ['is-absolute-url', '@hashicorp/react-.*'],
+  tipBranch: 'main',
   mdx: { resolveIncludes: path.join(__dirname, 'pages/partials') },
 })({
   async redirects() {


### PR DESCRIPTION
adds proper configuration for tip.boundaryproject.io which will be a subdomain to showcase upcoming/unreleased documentation being prepared for the latest version. this documentation will be pulled from `origin/main`

this should be a simple review. i have not configured the actual domain DNS yet because i want this logic in place which to prevent indexing before the DNS change makes the actual subdomain propagate. In effect, you're just making sure this change doesn't break the site build and that i got the config option name correct