### PR TITLE
fix: remove extra "s" from auth method authorized collections listing

### DIFF
--- a/internal/cmd/commands/authmethodscmd/funcs.go
+++ b/internal/cmd/commands/authmethodscmd/funcs.go
@@ -171,7 +171,7 @@ func printItemTable(in *authmethods.AuthMethod) string {
 		)
 		for _, key := range keys {
 			ret = append(ret,
-				fmt.Sprintf("    %ss:", key),
+				fmt.Sprintf("    %s:", key),
 				base.WrapSlice(6, in.AuthorizedCollectionActions[key]),
 			)
 		}


### PR DESCRIPTION
When reading an auth method's authorized collections we have an extra 's': 
```
Authorized Actions on Auth Method's Collections:
    accountss:
      create
      list
```

I think the plurality was intentional. If it is, we can supersede this with another larger PR that fixes this across our authorized actions listings. 