### PR TITLE
internal/servers/controller/handlers/users: fix dropped test error

### DIFF
--- a/internal/servers/controller/handlers/users/user_service_test.go
+++ b/internal/servers/controller/handlers/users/user_service_test.go
@@ -959,6 +959,8 @@ func TestRemoveAccount(t *testing.T) {
 	accts := password.TestAccounts(t, conn, amId, 3)
 
 	databaseWrapper, err := kmsCache.GetWrapper(context.Background(), o.PublicId, kms.KeyPurposeDatabase)
+	require.NoError(t, err)
+
 	oidcAm := oidc.TestAuthMethod(
 		t, conn, databaseWrapper, o.PublicId, oidc.ActivePrivateState,
 		"alice-rp", "fido",


### PR DESCRIPTION
This fixes a dropped test error in `internal/servers/controller/handlers/users`.