### PR TITLE
Add read:self and delete:self to auth tokens and add logout command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## Next
 
+### Deprecations/Changes
+
+* Permissions in new scope default roles have been updated to include support
+  for `list`, `read:self`, and `delete:self` on `auth-token` resources. This
+  allows a user to list and manage their own authentication tokens. (As is the
+  case with other resources, `list` will still be limited to returning tokens on
+  which the user has authorization to perform actions, so granting this
+  capability does not automatically give user the ability to list other users'
+  authentication tokens.)
+
 ### New and Improved
 
 * cli/api/sdk: New User's attributes for: 
@@ -16,6 +26,14 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   from the user's primary auth method account.  These attributes will be empty
   when the user has no account in the primary auth method for their scope, or
   there is no designated primary auth method for their scope. 
+* cli: Support for reading and deleting the user's own token via the new
+  `read:self` and `delete:self` actions on auth tokens. If no token ID is
+  provided, the stored token's ID will be used (after prompting), or `"self"`
+  can be set to the ID to trigger this behavior without prompting.
+  ([PR](https://github.com/hashicorp/boundary/pull/1162))
+* cli: New `logout` command deletes the current token in Boundary and forgets it
+  from the local system credential store
+  ([PR](https://github.com/hashicorp/boundary/pull/1134))
 
 
 ### Bug Fixes

--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -3,8 +3,6 @@ package base
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -12,19 +10,15 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
 
 	"github.com/hashicorp/boundary/api"
-	"github.com/hashicorp/boundary/api/authtokens"
 	"github.com/hashicorp/boundary/sdk/wrapper"
-	nkeyring "github.com/jefferai/keyring"
 	"github.com/mitchellh/cli"
 	"github.com/pkg/errors"
 	"github.com/posener/complete"
-	zkeyring "github.com/zalando/go-keyring"
 )
 
 const (
@@ -240,143 +234,6 @@ func (c *Command) Client(opt ...Option) (*api.Client, error) {
 	}
 
 	return c.client, nil
-}
-
-func (c *Command) DiscoverKeyringTokenInfo() (string, string, error) {
-	tokenName := "default"
-
-	if c.FlagTokenName != "" {
-		tokenName = c.FlagTokenName
-	}
-
-	if tokenName == "none" {
-		c.UI.Warn(`"-token-name=none" is deprecated, please use "-keyring-type=none"`)
-		c.FlagKeyringType = "none"
-	}
-
-	if c.FlagKeyringType == "none" {
-		return "", "", nil
-	}
-
-	// Set so we can look it up later when printing out curl strings
-	os.Setenv(EnvTokenName, tokenName)
-
-	var foundKeyringType bool
-	keyringType := c.FlagKeyringType
-	switch runtime.GOOS {
-	case "windows":
-		switch keyringType {
-		case "auto", "wincred", "pass":
-			foundKeyringType = true
-			if keyringType == "auto" {
-				keyringType = "wincred"
-			}
-		}
-	case "darwin":
-		switch keyringType {
-		case "auto", "keychain", "pass":
-			foundKeyringType = true
-			if keyringType == "auto" {
-				keyringType = "keychain"
-			}
-		}
-	default:
-		switch keyringType {
-		case "auto", "secret-service", "pass":
-			foundKeyringType = true
-			if keyringType == "auto" {
-				keyringType = "pass"
-			}
-		}
-	}
-
-	if !foundKeyringType {
-		return "", "", fmt.Errorf("Given keyring type %q is not valid, or not valid for this platform", c.FlagKeyringType)
-	}
-
-	var available bool
-	switch keyringType {
-	case "wincred", "keychain":
-		available = true
-	case "pass", "secret-service":
-		avail := nkeyring.AvailableBackends()
-		for _, a := range avail {
-			if keyringType == string(a) {
-				available = true
-			}
-		}
-	}
-
-	if !available {
-		return "", "", fmt.Errorf("Keyring type %q is not available on this machine. For help with setting up keyrings, see https://www.boundaryproject.io/docs/api-clients/cli.", keyringType)
-	}
-
-	os.Setenv(EnvKeyringType, keyringType)
-
-	return keyringType, tokenName, nil
-}
-
-func (c *Command) ReadTokenFromKeyring(keyringType, tokenName string) *authtokens.AuthToken {
-	var token string
-	var err error
-
-	switch keyringType {
-	case "none":
-		return nil
-
-	case "wincred", "keychain":
-		token, err = zkeyring.Get(StoredTokenName, tokenName)
-		if err != nil {
-			if err == zkeyring.ErrNotFound {
-				c.UI.Error("No saved credential found, continuing without")
-			} else {
-				c.UI.Error(fmt.Sprintf("Error reading auth token from keyring: %s", err))
-				c.UI.Warn("Token must be provided via BOUNDARY_TOKEN env var or -token flag. Reading the token can also be disabled via -keyring-type=none.")
-			}
-			token = ""
-		}
-
-	default:
-		krConfig := nkeyring.Config{
-			LibSecretCollectionName: "login",
-			PassPrefix:              "HashiCorp_Boundary",
-			AllowedBackends:         []nkeyring.BackendType{nkeyring.BackendType(keyringType)},
-		}
-
-		kr, err := nkeyring.Open(krConfig)
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error opening keyring: %s", err))
-			c.UI.Warn("Token must be provided via BOUNDARY_TOKEN env var or -token flag. Reading the token can also be disabled via -keyring-type=none.")
-			break
-		}
-
-		item, err := kr.Get(tokenName)
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error fetching token from keyring: %s", err))
-			c.UI.Warn("Token must be provided via BOUNDARY_TOKEN env var or -token flag. Reading the token can also be disabled via -keyring-type=none.")
-			break
-		}
-
-		token = string(item.Data)
-	}
-
-	if token != "" {
-		tokenBytes, err := base64.RawStdEncoding.DecodeString(token)
-		switch {
-		case err != nil:
-			c.UI.Error(fmt.Errorf("Error base64-unmarshaling stored token from system credential store: %w", err).Error())
-		case len(tokenBytes) == 0:
-			c.UI.Error("Zero length token after decoding stored token from system credential store")
-		default:
-			var authToken authtokens.AuthToken
-			if err := json.Unmarshal(tokenBytes, &authToken); err != nil {
-				c.UI.Error(fmt.Sprintf("Error unmarshaling stored token information after reading from system credential store: %s", err))
-			} else {
-				return &authToken
-			}
-		}
-	}
-	return nil
 }
 
 type FlagSetBit uint

--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -126,7 +126,7 @@ func MakeShutdownCh() chan struct{} {
 // Client returns the HTTP API client. The client is cached on the command to
 // save performance on future calls.
 func (c *Command) Client(opt ...Option) (*api.Client, error) {
-	// Read the test client if present
+	// Read the cached client if present
 	if c.client != nil {
 		return c.client, nil
 	}

--- a/internal/cmd/base/initial_resources.go
+++ b/internal/cmd/base/initial_resources.go
@@ -62,6 +62,7 @@ func (b *Server) CreateInitialLoginRole(ctx context.Context) (*iam.Role, error) 
 		"id=*;type=scope;actions=list,read",
 		"id=*;type=auth-method;actions=authenticate,list",
 		"id={{account.id}};actions=read,change-password",
+		"id=*;type=auth-token;actions=list,read:self,delete:self",
 	}); err != nil {
 		return nil, fmt.Errorf("error creating grant for default generated grants: %w", err)
 	}

--- a/internal/cmd/base/initial_resources.go
+++ b/internal/cmd/base/initial_resources.go
@@ -517,7 +517,8 @@ func (b *Server) CreateInitialTarget(ctx context.Context) (target.Target, error)
 	b.Info["generated target id"] = b.DevTargetId
 
 	// If we have an unprivileged dev user, add user to the role that grants
-	// list/read:self/cancel:self, and an authorize-session role
+	// list/read:self/cancel:self on sessions, read:self/delete:self/list on
+	// tokens, and an authorize-session role
 	if b.DevUnprivilegedUserId != "" {
 		iamRepo, err := iam.NewRepository(rw, rw, kmsCache, iam.WithRandomReader(b.SecureRandomReader))
 		if err != nil {

--- a/internal/cmd/base/keyring.go
+++ b/internal/cmd/base/keyring.go
@@ -1,0 +1,173 @@
+package base
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/hashicorp/boundary/api/authtokens"
+	nkeyring "github.com/jefferai/keyring"
+	"github.com/pkg/errors"
+	zkeyring "github.com/zalando/go-keyring"
+)
+
+const (
+	NoneKeyring          = "none"
+	AutoKeyring          = "auto"
+	WincredKeyring       = "wincred"
+	PassKeyring          = "pass"
+	KeychainKeyring      = "keychain"
+	SecretServiceKeyring = "secret-service"
+
+	DefaultTokenName = "default"
+	LoginCollection  = "login"
+	PassPrefix       = "HashiCorp_Boundary"
+)
+
+func (c *Command) DiscoverKeyringTokenInfo() (string, string, error) {
+	tokenName := DefaultTokenName
+
+	if c.FlagTokenName != "" {
+		tokenName = c.FlagTokenName
+	}
+
+	if tokenName == NoneKeyring {
+		c.UI.Warn(`"-token-name=none" is deprecated, please use "-keyring-type=none"`)
+		c.FlagKeyringType = NoneKeyring
+	}
+
+	if c.FlagKeyringType == NoneKeyring {
+		return "", "", nil
+	}
+
+	// Set so we can look it up later when printing out curl strings
+	os.Setenv(EnvTokenName, tokenName)
+
+	var foundKeyringType bool
+	keyringType := c.FlagKeyringType
+	switch runtime.GOOS {
+	case "windows":
+		switch keyringType {
+		case AutoKeyring, WincredKeyring, PassKeyring:
+			foundKeyringType = true
+			if keyringType == AutoKeyring {
+				keyringType = WincredKeyring
+			}
+		}
+	case "darwin":
+		switch keyringType {
+		case AutoKeyring, KeychainKeyring, PassKeyring:
+			foundKeyringType = true
+			if keyringType == AutoKeyring {
+				keyringType = KeychainKeyring
+			}
+		}
+	default:
+		switch keyringType {
+		case AutoKeyring, SecretServiceKeyring, PassKeyring:
+			foundKeyringType = true
+			if keyringType == AutoKeyring {
+				keyringType = PassKeyring
+			}
+		}
+	}
+
+	if !foundKeyringType {
+		return "", "", fmt.Errorf("Given keyring type %q is not valid, or not valid for this platform", c.FlagKeyringType)
+	}
+
+	var available bool
+	switch keyringType {
+	case WincredKeyring, KeychainKeyring:
+		available = true
+	case PassKeyring, SecretServiceKeyring:
+		avail := nkeyring.AvailableBackends()
+		for _, a := range avail {
+			if keyringType == string(a) {
+				available = true
+			}
+		}
+	}
+
+	if !available {
+		return "", "", fmt.Errorf("Keyring type %q is not available on this machine. For help with setting up keyrings, see https://www.boundaryproject.io/docs/api-clients/cli.", keyringType)
+	}
+
+	os.Setenv(EnvKeyringType, keyringType)
+
+	return keyringType, tokenName, nil
+}
+
+func (c *Command) ReadTokenFromKeyring(keyringType, tokenName string) *authtokens.AuthToken {
+	var token string
+	var err error
+
+	switch keyringType {
+	case NoneKeyring:
+		return nil
+
+	case WincredKeyring, KeychainKeyring:
+		token, err = zkeyring.Get(StoredTokenName, tokenName)
+		if err != nil {
+			if err == zkeyring.ErrNotFound {
+				c.UI.Error("No saved credential found, continuing without")
+			} else {
+				c.UI.Error(fmt.Sprintf("Error reading auth token from keyring: %s", err))
+				c.UI.Warn("Token must be provided via BOUNDARY_TOKEN env var or -token flag. Reading the token can also be disabled via -keyring-type=none.")
+			}
+			token = ""
+		}
+
+	default:
+		krConfig := nkeyring.Config{
+			LibSecretCollectionName: LoginCollection,
+			PassPrefix:              PassPrefix,
+			AllowedBackends:         []nkeyring.BackendType{nkeyring.BackendType(keyringType)},
+		}
+
+		kr, err := nkeyring.Open(krConfig)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error opening keyring: %s", err))
+			c.UI.Warn("Token must be provided via BOUNDARY_TOKEN env var or -token flag. Reading the token can also be disabled via -keyring-type=none.")
+			break
+		}
+
+		item, err := kr.Get(tokenName)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error fetching token from keyring: %s", err))
+			c.UI.Warn("Token must be provided via BOUNDARY_TOKEN env var or -token flag. Reading the token can also be disabled via -keyring-type=none.")
+			break
+		}
+
+		token = string(item.Data)
+	}
+
+	if token != "" {
+		tokenBytes, err := base64.RawStdEncoding.DecodeString(token)
+		switch {
+		case err != nil:
+			c.UI.Error(fmt.Errorf("Error base64-unmarshaling stored token from system credential store: %w", err).Error())
+		case len(tokenBytes) == 0:
+			c.UI.Error("Zero length token after decoding stored token from system credential store")
+		default:
+			var authToken authtokens.AuthToken
+			if err := json.Unmarshal(tokenBytes, &authToken); err != nil {
+				c.UI.Error(fmt.Sprintf("Error unmarshaling stored token information after reading from system credential store: %s", err))
+			} else {
+				return &authToken
+			}
+		}
+	}
+	return nil
+}
+
+func TokenIdFromToken(token string) (string, error) {
+	split := strings.Split(token, "_")
+	if len(split) < 3 {
+		return "", errors.New("Unexpected stored token format")
+	}
+	return strings.Join(split[0:2], "_"), nil
+}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/boundary/internal/cmd/commands/hostcatalogscmd"
 	"github.com/hashicorp/boundary/internal/cmd/commands/hostscmd"
 	"github.com/hashicorp/boundary/internal/cmd/commands/hostsetscmd"
+	"github.com/hashicorp/boundary/internal/cmd/commands/logout"
 	"github.com/hashicorp/boundary/internal/cmd/commands/rolescmd"
 	"github.com/hashicorp/boundary/internal/cmd/commands/scopescmd"
 	"github.com/hashicorp/boundary/internal/cmd/commands/server"
@@ -536,6 +537,12 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 			return &hostscmd.StaticCommand{
 				Command: base.NewCommand(ui),
 				Func:    "update",
+			}, nil
+		},
+
+		"logout": func() (cli.Command, error) {
+			return &logout.LogoutCommand{
+				Command: base.NewCommand(ui),
 			}, nil
 		},
 

--- a/internal/cmd/commands/authtokenscmd/authtokens.gen.go
+++ b/internal/cmd/commands/authtokenscmd/authtokens.gen.go
@@ -130,11 +130,6 @@ func (c *Command) Run(args []string) int {
 		return base.CommandUserError
 	}
 
-	if strutil.StrListContains(flagsMap[c.Func], "id") && c.FlagId == "" {
-		c.PrintCliError(errors.New("ID is required but not passed in via -id"))
-		return base.CommandUserError
-	}
-
 	var opts []authtokens.Option
 
 	if strutil.StrListContains(flagsMap[c.Func], "scope-id") {

--- a/internal/cmd/commands/authtokenscmd/funcs.go
+++ b/internal/cmd/commands/authtokenscmd/funcs.go
@@ -3,13 +3,14 @@ package authtokenscmd
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/boundary/api/authtokens"
 	"github.com/hashicorp/boundary/internal/cmd/base"
 	"github.com/hashicorp/boundary/sdk/strutil"
 )
+
+const selfFlag = "self"
 
 func init() {
 	extraFlagsHandlingFunc = extraFlagsHandlingFuncImpl
@@ -25,31 +26,30 @@ func extraFlagsHandlingFuncImpl(c *Command, _ *base.FlagSets, _ *[]authtokens.Op
 	}
 
 	if c.FlagId == "" {
-		fmt.Printf("No ID provided; %s the stored token? (Pass an ID of %q to suppress this question.) y/n: ", c.Func, "self")
+		fmt.Printf("No ID provided; %s the stored token? (Pass an ID of %q to suppress this question.) y/n: ", c.Func, selfFlag)
 		var yesNo string
 		fmt.Scanf("%s", &yesNo)
 		switch yesNo {
 		case "y", "Y":
-			c.FlagId = "self"
+			c.FlagId = selfFlag
 		default:
 			c.PrintCliError(errors.New(`"Y" or "y" not provided, refusing to continue`))
 			return false
 		}
 	}
 
-	if c.FlagId == "self" {
+	if c.FlagId == selfFlag {
 		// We should have already read this and have it cached
 		client, err := c.Client()
 		if err != nil {
 			c.PrintCliError(fmt.Errorf("Error reading cached API client: %w", err))
 			return false
 		}
-		split := strings.Split(client.Token(), "_")
-		if len(split) < 3 {
-			c.PrintCliError(errors.New("Unexpected stored token format"))
+		c.FlagId, err = base.TokenIdFromToken(client.Token())
+		if err != nil {
+			c.PrintCliError(err)
 			return false
 		}
-		c.FlagId = strings.Join(split[0:2], "_")
 	}
 
 	return true

--- a/internal/cmd/commands/logout/logout.go
+++ b/internal/cmd/commands/logout/logout.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/authtokens"
@@ -93,13 +92,12 @@ func (c *LogoutCommand) Run(args []string) (ret int) {
 		return base.CommandUserError
 	}
 
-	split := strings.Split(client.Token(), "_")
-	if len(split) < 3 {
-		c.PrintCliError(errors.New("Unexpected stored token format."))
+	id, err := base.TokenIdFromToken(client.Token())
+	if err != nil {
+		c.PrintCliError(err)
 		return base.CommandUserError
 	}
 
-	id := strings.Join(split[0:2], "_")
 	authtokensClient := authtokens.NewClient(client)
 	_, err = authtokensClient.Delete(c.Context, id)
 	if apiErr := api.AsServerError(err); apiErr != nil && apiErr.Response().StatusCode() == http.StatusNotFound {

--- a/internal/cmd/commands/logout/logout.go
+++ b/internal/cmd/commands/logout/logout.go
@@ -1,0 +1,163 @@
+package logout
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/boundary/api"
+	"github.com/hashicorp/boundary/api/authtokens"
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	nkeyring "github.com/jefferai/keyring"
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	zkeyring "github.com/zalando/go-keyring"
+)
+
+var (
+	_ cli.Command             = (*LogoutCommand)(nil)
+	_ cli.CommandAutocomplete = (*LogoutCommand)(nil)
+)
+
+type LogoutCommand struct {
+	*base.Command
+
+	Func string
+}
+
+func (c *LogoutCommand) Synopsis() string {
+	return "Delete the current token within Boundary and forget it locally"
+}
+
+func (c *LogoutCommand) Help() string {
+	var args []string
+	args = append(args,
+		"Usage: boundary logout [options]",
+		"",
+		"  Delete the current token (as selected by -token-name) within Boundary and forget it from the local store. Example:",
+		"",
+		`    $ boundary logout`,
+		"",
+	)
+
+	return base.WrapForHelpText(args) + c.Flags().Help()
+}
+
+func (c *LogoutCommand) Flags() *base.FlagSets {
+	set := c.FlagSet(base.FlagSetNone)
+
+	f := set.NewFlagSet("Command Options")
+
+	f.StringVar(&base.StringVar{
+		Name:   "token-name",
+		Target: &c.FlagTokenName,
+		EnvVar: base.EnvTokenName,
+		Usage:  `If specified, the given value will be used as the name when loading the token from the system credential store. This must correspond to a name used when authenticating.`,
+	})
+
+	f.StringVar(&base.StringVar{
+		Name:    "keyring-type",
+		Target:  &c.FlagKeyringType,
+		Default: "auto",
+		EnvVar:  base.EnvKeyringType,
+		Usage:   `The type of keyring to use. Defaults to "auto" which will use the Windows credential manager, OSX keychain, or cross-platform password store depending on platform. Set to "none" to disable keyring functionality. Available types, depending on platform, are: "wincred", "keychain", "pass", and "secret-service".`,
+	})
+
+	return set
+}
+
+func (c *LogoutCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictAnything
+}
+
+func (c *LogoutCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *LogoutCommand) Run(args []string) (ret int) {
+	f := c.Flags()
+	if err := f.Parse(args); err != nil {
+		c.PrintCliError(err)
+		return base.CommandUserError
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.PrintCliError(fmt.Errorf("Error reading API client: %w", err))
+		return base.CommandCliError
+	}
+
+	if client.Token() == "" {
+		c.PrintCliError(errors.New("Empty or no token found in store. It might have already been deleted."))
+		return base.CommandUserError
+	}
+
+	split := strings.Split(client.Token(), "_")
+	if len(split) < 3 {
+		c.PrintCliError(errors.New("Unexpected stored token format."))
+		return base.CommandUserError
+	}
+
+	id := strings.Join(split[0:2], "_")
+	authtokensClient := authtokens.NewClient(client)
+	_, err = authtokensClient.Delete(c.Context, id)
+	if apiErr := api.AsServerError(err); apiErr != nil && apiErr.Response().StatusCode() == http.StatusNotFound {
+		c.UI.Output("The token was not found on the Boundary controller; proceeding to delete from the local store.")
+		goto DeleteLocal
+	}
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			c.PrintApiError(apiErr, "Error from controller when performing delete on token")
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to delete auth token: %w", err))
+		return base.CommandCliError
+	}
+
+	c.UI.Output("The token was successfully deleted within the Boundary controller.")
+
+DeleteLocal:
+	keyringType, tokenName, err := c.DiscoverKeyringTokenInfo()
+	if err != nil {
+		c.PrintCliError(fmt.Errorf("Error fetching keyring information to delete local stored token: %w", err))
+		return base.CommandCliError
+	}
+	if keyringType == "none" ||
+		tokenName == "none" ||
+		keyringType == "" ||
+		tokenName == "" {
+		c.UI.Output("Keyring type set to none or empty; not deleting local stored token.")
+		return base.CommandSuccess
+	}
+
+	switch keyringType {
+	case "wincred", "keychain":
+		if err := zkeyring.Delete(base.StoredTokenName, tokenName); err != nil {
+			c.PrintCliError(fmt.Errorf("Error deleting auth token from %q keyring: %w", keyringType, err))
+			return base.CommandCliError
+		}
+
+	default:
+		krConfig := nkeyring.Config{
+			LibSecretCollectionName: "login",
+			PassPrefix:              "HashiCorp_Boundary",
+			AllowedBackends:         []nkeyring.BackendType{nkeyring.BackendType(keyringType)},
+		}
+
+		kr, err := nkeyring.Open(krConfig)
+		if err != nil {
+			c.PrintCliError(fmt.Errorf("Error opening %q keyring: %w", keyringType, err))
+			return base.CommandCliError
+		}
+
+		if err := kr.Remove(tokenName); err != nil {
+			c.PrintCliError(fmt.Errorf("Error deleting token from %q keyring: %w", keyringType, err))
+			return base.CommandCliError
+		}
+	}
+
+	c.UI.Output("The token was successfully removed from the local credential store.")
+
+	return base.CommandSuccess
+}

--- a/internal/cmd/gencli/input.go
+++ b/internal/cmd/gencli/input.go
@@ -155,7 +155,6 @@ var inputStructs = map[string][]*cmdInfo{
 			Pkg:          "authtokens",
 			StdActions:   []string{"read", "delete", "list"},
 			Container:    "Scope",
-			HasId:        true,
 		},
 	},
 	"groups": {

--- a/internal/iam/repository_scope.go
+++ b/internal/iam/repository_scope.go
@@ -313,6 +313,12 @@ func (r *Repository) CreateScope(ctx context.Context, s *Scope, userId string, o
 							return errors.Wrap(err, op, errors.WithMsg("unable to create in memory role grant"))
 						}
 						grants = append(grants, roleGrant)
+
+						roleGrant, err = NewRoleGrant(defaultRolePublicId, "id=*;type=auth-token;actions=list,read:self,delete:self")
+						if err != nil {
+							return errors.Wrap(err, op, errors.WithMsg("unable to create in memory role grant"))
+						}
+						grants = append(grants, roleGrant)
 					}
 
 					roleGrantOplogMsgs := make([]*oplog.Message, 0, 3)

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -385,6 +385,7 @@ func (g Grant) validateType() error {
 		resource.Role,
 		resource.AuthMethod,
 		resource.Account,
+		resource.AuthToken,
 		resource.HostCatalog,
 		resource.HostSet,
 		resource.Host,

--- a/internal/servers/controller/handlers/authtokens/authtoken_service.go
+++ b/internal/servers/controller/handlers/authtokens/authtoken_service.go
@@ -23,7 +23,9 @@ var (
 	// individual resources
 	IdActions = action.ActionSet{
 		action.Read,
+		action.ReadSelf,
 		action.Delete,
+		action.DeleteSelf,
 	}
 
 	// CollectionActions contains the set of actions that can be performed on
@@ -98,10 +100,17 @@ func (s Service) ListAuthTokens(ctx context.Context, req *pbs.ListAuthTokensRequ
 	for _, item := range ul {
 		item.Scope = scopeInfoMap[item.GetScopeId()]
 		res.ScopeId = item.Scope.Id
-		item.AuthorizedActions = authResults.FetchActionSetForId(ctx, item.Id, IdActions, auth.WithResource(res)).Strings()
-		if len(item.AuthorizedActions) == 0 {
+		authorizedActions := authResults.FetchActionSetForId(ctx, item.Id, IdActions, auth.WithResource(res))
+		if len(authorizedActions) == 0 {
 			continue
 		}
+
+		if authorizedActions.OnlySelf() && item.GetUserId() != authResults.UserId {
+			continue
+		}
+
+		item.AuthorizedActions = authorizedActions.Strings()
+
 		if filter.Match(item) {
 			finalItems = append(finalItems, item)
 		}
@@ -114,7 +123,7 @@ func (s Service) GetAuthToken(ctx context.Context, req *pbs.GetAuthTokenRequest)
 	if err := validateGetRequest(req); err != nil {
 		return nil, err
 	}
-	authResults := s.authResult(ctx, req.GetId(), action.Read)
+	authResults := s.authResult(ctx, req.GetId(), action.ReadSelf)
 	if authResults.Error != nil {
 		return nil, authResults.Error
 	}
@@ -122,6 +131,15 @@ func (s Service) GetAuthToken(ctx context.Context, req *pbs.GetAuthTokenRequest)
 	if err != nil {
 		return nil, err
 	}
+
+	authzdActions := authResults.FetchActionSetForId(ctx, u.Id, IdActions)
+	// Check to see if we need to verify Read vs. just ReadSelf
+	if u.GetUserId() != authResults.UserId {
+		if !authzdActions.HasAction(action.Read) {
+			return nil, handlers.ForbiddenError()
+		}
+	}
+
 	u.Scope = authResults.Scope
 	u.AuthorizedActions = authResults.FetchActionSetForId(ctx, u.Id, IdActions).Strings()
 	return &pbs.GetAuthTokenResponse{Item: u}, nil
@@ -132,11 +150,24 @@ func (s Service) DeleteAuthToken(ctx context.Context, req *pbs.DeleteAuthTokenRe
 	if err := validateDeleteRequest(req); err != nil {
 		return nil, err
 	}
-	authResults := s.authResult(ctx, req.GetId(), action.Delete)
+	authResults := s.authResult(ctx, req.GetId(), action.DeleteSelf)
 	if authResults.Error != nil {
 		return nil, authResults.Error
 	}
-	_, err := s.deleteFromRepo(ctx, req.GetId())
+
+	at, err := s.getFromRepo(ctx, req.GetId())
+	if err != nil {
+		return nil, err
+	}
+	authzdActions := authResults.FetchActionSetForId(ctx, at.Id, IdActions)
+	// Check to see if we need to verify Delete vs. just DeleteSelf
+	if at.GetUserId() != authResults.UserId {
+		if !authzdActions.HasAction(action.Delete) {
+			return nil, handlers.ForbiddenError()
+		}
+	}
+
+	_, err = s.deleteFromRepo(ctx, req.GetId())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/servers/controller/handlers/authtokens/authtoken_service_test.go
+++ b/internal/servers/controller/handlers/authtokens/authtoken_service_test.go
@@ -37,10 +37,8 @@ func TestGetSelf(t *testing.T) {
 	logger := hclog.New(nil)
 	kms := kms.TestKms(t, conn, wrap)
 
-	iamRepo := iam.TestRepo(t, conn, wrap)
-
 	iamRepoFn := func() (*iam.Repository, error) {
-		return iamRepo, nil
+		return iam.TestRepo(t, conn, wrap), nil
 	}
 	tokenRepoFn := func() (*authtoken.Repository, error) {
 		return authtoken.NewRepository(rw, rw, kms)

--- a/internal/servers/controller/handlers/authtokens/authtoken_service_test.go
+++ b/internal/servers/controller/handlers/authtokens/authtoken_service_test.go
@@ -1,8 +1,10 @@
 package authtokens_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -14,15 +16,98 @@ import (
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/servers"
 	"github.com/hashicorp/boundary/internal/servers/controller/handlers"
 	"github.com/hashicorp/boundary/internal/servers/controller/handlers/authtokens"
 	"github.com/hashicorp/boundary/internal/types/scope"
+	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGetSelf(t *testing.T) {
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	logger := hclog.New(nil)
+	kms := kms.TestKms(t, conn, wrap)
+
+	iamRepo := iam.TestRepo(t, conn, wrap)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	tokenRepoFn := func() (*authtoken.Repository, error) {
+		return authtoken.NewRepository(rw, rw, kms)
+	}
+	serversRepoFn := func() (*servers.Repository, error) {
+		return servers.NewRepository(rw, rw, kms)
+	}
+
+	a, err := authtokens.NewService(tokenRepoFn, iamRepoFn)
+	require.NoError(t, err, "Couldn't create new auth token service.")
+
+	o, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrap))
+	at1 := authtoken.TestAuthToken(t, conn, kms, o.GetPublicId())
+	at2 := authtoken.TestAuthToken(t, conn, kms, o.GetPublicId())
+
+	cases := []struct {
+		name   string
+		token  *authtoken.AuthToken
+		readId string
+	}{
+		{
+			name:   "at1 read self",
+			token:  at1,
+			readId: at1.GetPublicId(),
+		},
+		{
+			name:   "at1 read at2",
+			token:  at1,
+			readId: at2.GetPublicId(),
+		},
+		{
+			name:   "at2 read self",
+			token:  at2,
+			readId: at2.GetPublicId(),
+		},
+		{
+			name:   "at2 read at1",
+			token:  at2,
+			readId: at1.GetPublicId(),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require, assert := require.New(t), assert.New(t)
+			// Setup the auth request information
+			req := httptest.NewRequest("GET", fmt.Sprintf("http://127.0.0.1/v1/auth-tokens/%s", tc.readId), nil)
+			requestInfo := auth.RequestInfo{
+				Path:        req.URL.Path,
+				Method:      req.Method,
+				TokenFormat: auth.AuthTokenTypeBearer,
+				PublicId:    tc.token.GetPublicId(),
+				Token:       tc.token.GetToken(),
+			}
+
+			ctx := auth.NewVerifierContext(context.Background(), logger, iamRepoFn, tokenRepoFn, serversRepoFn, kms, requestInfo)
+			got, err := a.GetAuthToken(ctx, &pbs.GetAuthTokenRequest{Id: tc.readId})
+			if tc.token.GetPublicId() != tc.readId {
+				require.Error(err)
+				require.Nil(got)
+				return
+			}
+			require.NoError(err)
+			require.NotNil(got)
+			assert.Equal(got.GetItem().GetId(), tc.token.GetPublicId())
+			// Ensure we didn't simply have e.g. read on all tokens
+			assert.Equal(got.Item.GetAuthorizedActions(), []string{"read:self", "delete:self"})
+		})
+	}
+}
 
 func TestGet(t *testing.T) {
 	conn, _ := db.TestSetup(t, "postgres")
@@ -53,7 +138,7 @@ func TestGet(t *testing.T) {
 		ApproximateLastUsedTime: at.GetApproximateLastAccessTime().GetTimestamp(),
 		ExpirationTime:          at.GetExpirationTime().GetTimestamp(),
 		Scope:                   &scopes.ScopeInfo{Id: org.GetPublicId(), Type: scope.Org.String(), ParentScopeId: scope.Global.String()},
-		AuthorizedActions:       []string{"read", "delete"},
+		AuthorizedActions:       []string{"read", "read:self", "delete", "delete:self"},
 	}
 
 	cases := []struct {
@@ -99,6 +184,75 @@ func TestGet(t *testing.T) {
 	}
 }
 
+func TestList_Self(t *testing.T) {
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	logger := hclog.New(nil)
+	kms := kms.TestKms(t, conn, wrap)
+
+	iamRepo := iam.TestRepo(t, conn, wrap)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	tokenRepoFn := func() (*authtoken.Repository, error) {
+		return authtoken.NewRepository(rw, rw, kms)
+	}
+	serversRepoFn := func() (*servers.Repository, error) {
+		return servers.NewRepository(rw, rw, kms)
+	}
+
+	// This will result in the scope having default permissions, which now
+	// includes list on auth tokens
+	o, _ := iam.TestScopes(t, iamRepo)
+
+	// Each of these should only end up being able to list themselves
+	at := authtoken.TestAuthToken(t, conn, kms, o.GetPublicId())
+	otherAt := authtoken.TestAuthToken(t, conn, kms, o.GetPublicId())
+
+	cases := []struct {
+		name      string
+		requester *authtoken.AuthToken
+		count     int
+	}{
+		{
+			name:      "First token sees only self",
+			requester: at,
+		},
+		{
+			name:      "Second token sees only self",
+			requester: otherAt,
+		},
+	}
+
+	a, err := authtokens.NewService(tokenRepoFn, iamRepoFn)
+	require.NoError(t, err)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require, assert := require.New(t), assert.New(t)
+			// Setup the auth request information
+			req := httptest.NewRequest("GET", fmt.Sprintf("http://127.0.0.1/v1/auth-tokens?scope_id=%s", o.GetPublicId()), nil)
+			requestInfo := auth.RequestInfo{
+				Path:        req.URL.Path,
+				Method:      req.Method,
+				TokenFormat: auth.AuthTokenTypeBearer,
+				PublicId:    tc.requester.GetPublicId(),
+				Token:       tc.requester.GetToken(),
+			}
+
+			ctx := auth.NewVerifierContext(context.Background(), logger, iamRepoFn, tokenRepoFn, serversRepoFn, kms, requestInfo)
+			got, err := a.ListAuthTokens(ctx, &pbs.ListAuthTokensRequest{ScopeId: o.GetPublicId()})
+			require.NoError(err)
+			require.Len(got.Items, 1)
+			assert.Equal(got.Items[0].GetId(), tc.requester.GetPublicId())
+			// Ensure we didn't simply have e.g. read on all tokens
+			assert.Equal(got.Items[0].GetAuthorizedActions(), []string{"read:self", "delete:self"})
+		})
+	}
+}
+
 func TestList(t *testing.T) {
 	conn, _ := db.TestSetup(t, "postgres")
 	rw := db.New(conn)
@@ -128,7 +282,7 @@ func TestList(t *testing.T) {
 			ApproximateLastUsedTime: at.GetApproximateLastAccessTime().GetTimestamp(),
 			ExpirationTime:          at.GetExpirationTime().GetTimestamp(),
 			Scope:                   &scopes.ScopeInfo{Id: scope.Global.String(), Type: scope.Global.String(), Name: scope.Global.String(), Description: "Global Scope"},
-			AuthorizedActions:       []string{"read", "delete"},
+			AuthorizedActions:       []string{"read", "read:self", "delete", "delete:self"},
 		})
 	}
 
@@ -147,7 +301,7 @@ func TestList(t *testing.T) {
 			ApproximateLastUsedTime: at.GetApproximateLastAccessTime().GetTimestamp(),
 			ExpirationTime:          at.GetExpirationTime().GetTimestamp(),
 			Scope:                   &scopes.ScopeInfo{Id: orgWithSomeTokens.GetPublicId(), Type: scope.Org.String(), ParentScopeId: scope.Global.String()},
-			AuthorizedActions:       []string{"read", "delete"},
+			AuthorizedActions:       []string{"read", "read:self", "delete", "delete:self"},
 		})
 	}
 
@@ -166,7 +320,7 @@ func TestList(t *testing.T) {
 			ApproximateLastUsedTime: at.GetApproximateLastAccessTime().GetTimestamp(),
 			ExpirationTime:          at.GetExpirationTime().GetTimestamp(),
 			Scope:                   &scopes.ScopeInfo{Id: orgWithOtherTokens.GetPublicId(), Type: scope.Org.String(), ParentScopeId: scope.Global.String()},
-			AuthorizedActions:       []string{"read", "delete"},
+			AuthorizedActions:       []string{"read", "read:self", "delete", "delete:self"},
 		})
 	}
 

--- a/internal/servers/controller/handlers/sessions/session_service.go
+++ b/internal/servers/controller/handlers/sessions/session_service.go
@@ -165,7 +165,7 @@ func (s Service) CancelSession(ctx context.Context, req *pbs.CancelSessionReques
 		return nil, err
 	}
 	authzdActions := authResults.FetchActionSetForId(ctx, ses.Id, IdActions)
-	// Check to see if we need to verify Read vs. just ReadSelf
+	// Check to see if we need to verify Cancel vs. just CancelSelf
 	if ses.GetUserId() != authResults.UserId {
 		if !authzdActions.HasAction(action.Cancel) {
 			return nil, handlers.ForbiddenError()

--- a/internal/servers/controller/handlers/sessions/session_service.go
+++ b/internal/servers/controller/handlers/sessions/session_service.go
@@ -76,14 +76,7 @@ func (s Service) GetSession(ctx context.Context, req *pbs.GetSessionRequest) (*p
 	authzdActions := authResults.FetchActionSetForId(ctx, ses.Id, IdActions)
 	// Check to see if we need to verify Read vs. just ReadSelf
 	if ses.GetUserId() != authResults.UserId {
-		var found bool
-		for _, v := range authzdActions {
-			if v == action.Read {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !authzdActions.HasAction(action.Read) {
 			return nil, handlers.ForbiddenError()
 		}
 	}
@@ -142,14 +135,8 @@ func (s Service) ListSessions(ctx context.Context, req *pbs.ListSessionsRequest)
 		if len(authorizedActions) == 0 {
 			continue
 		}
-		onlySelf := true
-		for _, v := range authorizedActions {
-			if v != action.ReadSelf && v != action.CancelSelf {
-				onlySelf = false
-				break
-			}
-		}
-		if onlySelf && item.GetUserId() != authResults.UserId {
+
+		if authorizedActions.OnlySelf() && item.GetUserId() != authResults.UserId {
 			continue
 		}
 
@@ -180,14 +167,7 @@ func (s Service) CancelSession(ctx context.Context, req *pbs.CancelSessionReques
 	authzdActions := authResults.FetchActionSetForId(ctx, ses.Id, IdActions)
 	// Check to see if we need to verify Read vs. just ReadSelf
 	if ses.GetUserId() != authResults.UserId {
-		var found bool
-		for _, v := range authzdActions {
-			if v == action.Cancel {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !authzdActions.HasAction(action.Cancel) {
 			return nil, handlers.ForbiddenError()
 		}
 	}

--- a/internal/tests/cli/boundary/_auth_tokens.bash
+++ b/internal/tests/cli/boundary/_auth_tokens.bash
@@ -20,3 +20,15 @@ function token_id() {
   local tid=$1
   strip $(read_token $tid | jq '.item.id') 
 }
+
+function logout_cmd() {
+  boundary logout
+}
+
+function get_token() {
+  boundary config get-token
+}
+
+function read_token_no_keyring() {
+  boundary auth-tokens read -keyring-type=none -id $1
+}

--- a/internal/tests/cli/boundary/_auth_tokens.bash
+++ b/internal/tests/cli/boundary/_auth_tokens.bash
@@ -1,0 +1,22 @@
+function read_token() {
+  if [[ "x$1" == "x" ]]
+  then
+    echo "y" | boundary auth-tokens read
+  else
+    boundary auth-tokens read -id $1
+  fi
+}
+
+function delete_token() {
+  if [[ "x$1" == "x" ]]
+  then
+    echo "y" | boundary auth-tokens delete
+  else
+    boundary auth-tokens delete -id $1
+  fi
+}
+
+function token_id() {
+  local tid=$1
+  strip $(read_token $tid | jq '.item.id') 
+}

--- a/internal/tests/cli/boundary/auth_token.bats
+++ b/internal/tests/cli/boundary/auth_token.bats
@@ -48,9 +48,25 @@ export NEW_USER='test'
 @test "boundary/token: can delete own token with id given" {
   run login $DEFAULT_UNPRIVILEGED_LOGIN
   [ "$status" -eq 0 ]
-  local tid=$(token_id "self")
-  run delete_token "$tid"
+  run token_id "self"
   [ "$status" -eq 0 ]
-  run read_token "$tid"
+  tid=$(echo "$output")
+  run delete_token $tid
+  [ "$status" -eq 0 ]
+  run read_token $tid
+  [ "$status" -eq 1 ]
+}
+
+@test "boundary/token/logout: can logout" {
+  run login $DEFAULT_UNPRIVILEGED_LOGIN
+  [ "$status" -eq 0 ]
+  run get_token
+  [ "$status" -eq 0 ]
+  local tid=$(token_id "self")
+  run logout_cmd
+  [ "$status" -eq 0 ]
+  run get_token
+  [ "$status" -eq 2 ]
+  run read_token_no_keyring $tid
   [ "$status" -eq 1 ]
 }

--- a/internal/tests/cli/boundary/auth_token.bats
+++ b/internal/tests/cli/boundary/auth_token.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+load _auth
+load _auth_tokens
+load _helpers
+
+export NEW_USER='test'
+
+@test "boundary/token: can login as unpriv user" {
+  run login $DEFAULT_UNPRIVILEGED_LOGIN
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/token: can read own token with no id given" {
+  run read_token ""
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/token: can read own token with self given" {
+  run read_token "self"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/token: can read own token id given" {
+  local tid=$(token_id "self")
+  run read_token "$tid"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/token: can delete own token with no id given" {
+  run login $DEFAULT_UNPRIVILEGED_LOGIN
+  [ "$status" -eq 0 ]
+  run delete_token ""
+  [ "$status" -eq 0 ]
+  run read_token ""
+  [ "$status" -eq 1 ]
+}
+
+@test "boundary/token: can delete own token with self given" {
+  run login $DEFAULT_UNPRIVILEGED_LOGIN
+  [ "$status" -eq 0 ]
+  run delete_token "self"
+  [ "$status" -eq 0 ]
+  run read_token ""
+  [ "$status" -eq 1 ]
+}
+
+@test "boundary/token: can delete own token with id given" {
+  run login $DEFAULT_UNPRIVILEGED_LOGIN
+  [ "$status" -eq 0 ]
+  local tid=$(token_id "self")
+  run delete_token "$tid"
+  [ "$status" -eq 0 ]
+  run read_token "$tid"
+  [ "$status" -eq 1 ]
+}

--- a/internal/tests/cli/boundary/roles.bats
+++ b/internal/tests/cli/boundary/roles.bats
@@ -49,8 +49,6 @@ export NEW_GRANT='id=*;type=*;actions=create,read,update,delete,list'
   [ "$status" -eq 0 ]
 }
 
-
-
 @test "boundary/role/add-principals: $NEW_ROLE role contains default principal" {	
   local rid=$(role_id $NEW_ROLE $DEFAULT_GLOBAL)
   run role_has_principal_id $rid $DEFAULT_USER

--- a/internal/types/action/action.go
+++ b/internal/types/action/action.go
@@ -1,5 +1,7 @@
 package action
 
+import "strings"
+
 // Type defines a type for the Actions of Resources
 // actions are also stored as a lookup db table named iam_action
 type Type uint
@@ -130,4 +132,29 @@ func (a ActionSet) Strings() []string {
 		ret[i] = act.String()
 	}
 	return ret
+}
+
+// HasAction returns whether the action set contains the given action.
+func (a ActionSet) HasAction(act Type) bool {
+	for _, v := range a {
+		if v == act {
+			return true
+		}
+	}
+	return false
+}
+
+// OnlySelf returns true if all actions in the action set are self types. An
+// empty set returns false. This may not be what you want so the caller should
+// validate length and act appropriately as well.
+func (a ActionSet) OnlySelf() bool {
+	if len(a) == 0 {
+		return false
+	}
+	for _, v := range a {
+		if !strings.HasSuffix(v.String(), ":self") {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/types/action/action.go
+++ b/internal/types/action/action.go
@@ -42,6 +42,7 @@ const (
 	ReadSelf         Type = 31
 	CancelSelf       Type = 32
 	ChangeState      Type = 33
+	DeleteSelf       Type = 34
 )
 
 var Map = map[string]Type{
@@ -78,6 +79,7 @@ var Map = map[string]Type{
 	ReadSelf.String():         ReadSelf,
 	CancelSelf.String():       CancelSelf,
 	ChangeState.String():      ChangeState,
+	DeleteSelf.String():       DeleteSelf,
 }
 
 func (a Type) String() string {
@@ -116,6 +118,7 @@ func (a Type) String() string {
 		"read:self",
 		"cancel:self",
 		"change-state",
+		"delete:self",
 	}[a]
 }
 

--- a/internal/types/action/action_test.go
+++ b/internal/types/action/action_test.go
@@ -124,3 +124,87 @@ func TestActionStrings(t *testing.T) {
 		})
 	}
 }
+
+func TestHasAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		actions ActionSet
+		action  Type
+		want    bool
+	}{
+		{
+			name:    "has 1",
+			actions: ActionSet{Read, AuthorizeSession},
+			action:  Read,
+			want:    true,
+		},
+		{
+			name:    "has 2",
+			actions: ActionSet{Read, AuthorizeSession},
+			action:  AuthorizeSession,
+			want:    true,
+		},
+		{
+			name:    "empty",
+			actions: ActionSet{},
+			action:  AuthorizeSession,
+			want:    false,
+		},
+		{
+			name:    "does not have 1",
+			actions: ActionSet{Read, AuthorizeSession},
+			action:  ReadSelf,
+			want:    false,
+		},
+		{
+			name:    "does not have 2",
+			actions: ActionSet{Read, AuthorizeSession},
+			action:  Delete,
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.actions.HasAction(tt.action))
+		})
+	}
+}
+
+func TestOnlySelf(t *testing.T) {
+	tests := []struct {
+		name    string
+		actions ActionSet
+		want    bool
+	}{
+		{
+			name:    "has only self 1",
+			actions: ActionSet{ReadSelf, CancelSelf},
+			want:    true,
+		},
+		{
+			name:    "has only self 2",
+			actions: ActionSet{ReadSelf},
+			want:    true,
+		},
+		{
+			name:    "empty is false",
+			actions: ActionSet{},
+			want:    false,
+		},
+		{
+			name:    "does not have only self 1",
+			actions: ActionSet{Read, AuthorizeSession},
+			want:    false,
+		},
+		{
+			name:    "does not have only self 2",
+			actions: ActionSet{ReadSelf, AuthorizeSession},
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.actions.OnlySelf())
+		})
+	}
+}

--- a/internal/types/action/action_test.go
+++ b/internal/types/action/action_test.go
@@ -87,6 +87,10 @@ func TestAction(t *testing.T) {
 			action: ChangeState,
 			want:   "change-state",
 		},
+		{
+			action: DeleteSelf,
+			want:   "delete:self",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {


### PR DESCRIPTION
I'm not convinced `boundary logout` is the right place to put this. It doesn't have symmetry with `authenticate` but it's shorter and easier to type than `deauthenticate`, and they're not really symmetric actions anyways. But I'm happy to be convinced otherwise.

Minor TODO: fix bats tests. The local variables don't seem to be capturing properly.