### PR TITLE
Adopt new pgp key

### DIFF
--- a/docker/Release.dockerfile
+++ b/docker/Release.dockerfile
@@ -19,7 +19,7 @@ ADD https://releases.hashicorp.com/boundary/${VERSION}/boundary_${VERSION}_SHA25
 
 RUN apk add --no-cache ca-certificates gnupg openssl libcap su-exec dumb-init tzdata 
 RUN cd /tmp/ && \
-    BUILD_GPGKEY=91A6E7F85D05C65630BEF18951852D87348FFC4C; \
+    BUILD_GPGKEY=C874011F0AB405110D02105534365D9472D7468F; \
     found=''; \
     for server in \
         hkp://p80.pool.sks-keyservers.net:80 \


### PR DESCRIPTION
This adopts the new HashiCorp PGP key, as described at https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512/2 and https://hashicorp.com/security.

Please merge after reviewing 🙏 