### PR TITLE
Incorrect Grants when setting anonymous read permissions

### DIFF
--- a/website/content/docs/installing/no-gen-resources.mdx
+++ b/website/content/docs/installing/no-gen-resources.mdx
@@ -318,7 +318,7 @@ resource "boundary_role" "global_anon_listing" {
   scope_id = "global"
   grant_strings = [
     "id=*;type=auth-method;actions=list,authenticate",
-    "id=*;type=scope;actions=list,read",
+    "id=*;type=scope;actions=list,no-op",
     "id={{account.id}};actions=read,change-password"
   ]
   principal_ids = ["u_anon"]

--- a/website/content/docs/installing/no-gen-resources.mdx
+++ b/website/content/docs/installing/no-gen-resources.mdx
@@ -302,7 +302,7 @@ $ boundary roles create -name 'global_anon_listing' \
 $ boundary roles add-grants -id <global_anon_listing_id> \
   -recovery-config /tmp/recovery.hcl \
   -grant 'id=*;type=auth-method;actions=list,authenticate' \
-  -grant 'id=*;type=scope;actions=list,read' \
+  -grant 'id=*;type=scope;actions=list,no-op' \
   -grant 'id={{account.id}};actions=read,change-password'
 
 $ boundary roles add-principals -id <global_anon_listing_id> \

--- a/website/content/docs/installing/no-gen-resources.mdx
+++ b/website/content/docs/installing/no-gen-resources.mdx
@@ -302,7 +302,7 @@ $ boundary roles create -name 'global_anon_listing' \
 $ boundary roles add-grants -id <global_anon_listing_id> \
   -recovery-config /tmp/recovery.hcl \
   -grant 'id=*;type=auth-method;actions=list,authenticate' \
-  -grant 'type=scope;actions=list' \
+  -grant 'id=*;type=scope;actions=list,read' \
   -grant 'id={{account.id}};actions=read,change-password'
 
 $ boundary roles add-principals -id <global_anon_listing_id> \
@@ -318,7 +318,7 @@ resource "boundary_role" "global_anon_listing" {
   scope_id = "global"
   grant_strings = [
     "id=*;type=auth-method;actions=list,authenticate",
-    "type=scope;actions=list",
+    "id=*;type=scope;actions=list,read",
     "id={{account.id}};actions=read,change-password"
   ]
   principal_ids = ["u_anon"]


### PR DESCRIPTION
when setting the grants for the anonymous listing role it's only setting is 'type=scope;actions=list'. But I think it should be 'id=*;type=scope;actions=list,read'

With 'type=scope;actions=list', it's not possible to read the orgs in the global scope unauthenticated.

when initializing a server without skipping the default roles and in the dev server these permission are also set to 'id=*;type=scope;actions=list,read'