### PR TITLE
circleci: don't force config regeneration

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -78,8 +78,6 @@ define GEN_CONFIG
 	@mv -f $@.tmp $@
 endef
 
-# Always re-generate the config, as we can't trust timestamps with git.
-.PHONY: $(OUT)
 $(OUT): $(CONFIG_SOURCE) 
 	$(GEN_CONFIG)
 	@echo "$@ updated"


### PR DESCRIPTION
This broke staging, which was relying on `make` not re-generating config when source timestamps indicated it was not necessary. We should remove this reliance on timestamps because it doesn't play well with Git in other contexts, but for now this gets staging working again.