### PR TITLE
Fix `boundary database init` respecting format flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 * cli: It is now an error to run `boundary database migrate` on an uninitalized db.
   Use `boundary database init` instead.
   ([PR](https://github.com/hashicorp/boundary/pull/1184))
+* cli: Correctly honor the `-format` flag when running `boundary database init`
+  ([PR](https://github.com/hashicorp/boundary/pull/1204))
 
 ## 0.2.0 (2021/04/14)
 

--- a/internal/cmd/commands/database/init.go
+++ b/internal/cmd/commands/database/init.go
@@ -73,7 +73,7 @@ func (c *InitCommand) Help() string {
 }
 
 func (c *InitCommand) Flags() *base.FlagSets {
-	set := c.FlagSet(base.FlagSetHTTP)
+	set := c.FlagSet(base.FlagSetOutputFormat)
 
 	f := set.NewFlagSet("Command Options")
 
@@ -371,7 +371,7 @@ func (c *InitCommand) Run(args []string) (retCode int) {
 	case "table":
 		c.UI.Output(generateInitialScopeTableOutput(projScopeInfo))
 	case "json":
-		jsonMap["proj_scope"] = projScopeInfo
+		jsonMap["project_scope"] = projScopeInfo
 	}
 
 	if c.flagSkipHostResourcesCreation {


### PR DESCRIPTION
The output was ready for json format but the flag wasn't included.