### PR TITLE
Remove text in oidc command on json format

### DIFF
--- a/internal/cmd/commands/authenticate/oidc.go
+++ b/internal/cmd/commands/authenticate/oidc.go
@@ -101,7 +101,9 @@ func (c *OidcCommand) Run(args []string) int {
 		return base.CommandCliError
 	}
 
-	c.UI.Output("Opening returned authentication URL in your browser...")
+	if base.Format(c.UI) == "table" {
+		c.UI.Output("Opening returned authentication URL in your browser...")
+	}
 	if err := util.OpenURL(startResp.AuthUrl); err != nil {
 		c.UI.Error(fmt.Errorf("Unable to open authentication URL in browser: %w", err).Error())
 		c.UI.Warn("Please open the following URL manually in your web browser:")


### PR DESCRIPTION
Fixes #1193

Fixes that the openid connect authenticate command formatted as json returns
disturbing text. Therefore it can not be piped and parsed by another tool