### PR TITLE
Migrate the server upsert query to use database time

### DIFF
--- a/internal/servers/query.go
+++ b/internal/servers/query.go
@@ -5,7 +5,7 @@ const (
 		insert into server
 			(private_id, type, description, address, update_time)
 		values
-			($1, $2, $3, $4)
+			($1, $2, $3, $4, now())
 		on conflict on constraint server_pkey
 		do update set
 			type = $2,

--- a/internal/servers/query.go
+++ b/internal/servers/query.go
@@ -5,13 +5,13 @@ const (
 		insert into server
 			(private_id, type, description, address, update_time)
 		values
-			($1, $2, $3, $4, $5)
+			($1, $2, $3, $4)
 		on conflict on constraint server_pkey
 		do update set
 			type = $2,
 			description = $3,
 			address = $4,
-			update_time = $5;
+			update_time = now();
 	`
 	deleteWhereCreateTimeSql = `create_time < $1`
 	deleteTagsSql            = `server_id = $1`

--- a/internal/servers/repository.go
+++ b/internal/servers/repository.go
@@ -136,7 +136,6 @@ func (r *Repository) UpsertServer(ctx context.Context, server *Server, opt ...Op
 					server.Type,
 					server.Description,
 					server.Address,
-					time.Now().Format(time.RFC3339),
 				})
 			if err != nil {
 				return errors.Wrap(err, op+":Upsert")


### PR DESCRIPTION
This ensures that we are using consistent ideas of time regardless of
the local time on each worker (for this query).