### PR TITLE
Fix spelling of SubType

### DIFF
--- a/internal/api/genapi/input.go
+++ b/internal/api/genapi/input.go
@@ -55,7 +55,7 @@ type structInfo struct {
 
 	// mappings of names of resources and param names for sub slice types, e.g.
 	// role principals and group members
-	sliceSubTypes map[string]string
+	sliceSubtypes map[string]string
 
 	// outputOnly indicates that we shouldn't create options for setting members
 	// for mapping src field struct
@@ -169,7 +169,7 @@ var inputStructs = []*structInfo{
 			deleteTemplate,
 			listTemplate,
 		},
-		sliceSubTypes: map[string]string{
+		sliceSubtypes: map[string]string{
 			"Accounts": "accountIds",
 		},
 		pathArgs:            []string{"user"},
@@ -194,7 +194,7 @@ var inputStructs = []*structInfo{
 			deleteTemplate,
 			listTemplate,
 		},
-		sliceSubTypes: map[string]string{
+		sliceSubtypes: map[string]string{
 			"Members": "memberIds",
 		},
 		pathArgs:            []string{"group"},
@@ -229,7 +229,7 @@ var inputStructs = []*structInfo{
 			deleteTemplate,
 			listTemplate,
 		},
-		sliceSubTypes: map[string]string{
+		sliceSubtypes: map[string]string{
 			"Principals": "principalIds",
 			"Grants":     "grantStrings",
 		},
@@ -364,7 +364,7 @@ var inputStructs = []*structInfo{
 		},
 		pathArgs:       []string{"host-set"},
 		parentTypeName: "host-catalog",
-		sliceSubTypes: map[string]string{
+		sliceSubtypes: map[string]string{
 			"Hosts": "hostIds",
 		},
 		versionEnabled:      true,
@@ -401,7 +401,7 @@ var inputStructs = []*structInfo{
 			listTemplate,
 		},
 		pathArgs: []string{"target"},
-		sliceSubTypes: map[string]string{
+		sliceSubtypes: map[string]string{
 			"HostSets": "hostSetIds",
 		},
 		extraOptions: []fieldInfo{

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -43,7 +43,7 @@ type templateInput struct {
 	CollectionPath        string
 	ResourcePath          string
 	ParentTypeName        string
-	SliceSubTypes         map[string]string
+	SliceSubtypes         map[string]string
 	ExtraOptions          []fieldInfo
 	VersionEnabled        bool
 	TypeOnCreate          bool
@@ -79,9 +79,9 @@ func fillTemplates() {
 			os.Exit(1)
 		}
 
-		if len(in.sliceSubTypes) > 0 {
-			input.SliceSubTypes = in.sliceSubTypes
-			in.templates = append(in.templates, sliceSubTypeTemplate)
+		if len(in.sliceSubtypes) > 0 {
+			input.SliceSubtypes = in.sliceSubtypes
+			in.templates = append(in.templates, sliceSubtypeTemplate)
 		}
 
 		for _, t := range in.templates {
@@ -439,7 +439,7 @@ func (c *Client) Update(ctx context.Context, {{ .ResourceFunctionArg }} string, 
 }
 `))
 
-var sliceSubTypeTemplate = template.Must(template.New("").Funcs(
+var sliceSubtypeTemplate = template.Must(template.New("").Funcs(
 	template.FuncMap{
 		"makeSlice":         makeSlice,
 		"snakeCase":         snakeCase,
@@ -449,7 +449,7 @@ var sliceSubTypeTemplate = template.Must(template.New("").Funcs(
 ).Parse(`
 {{ $input := . }}
 {{ range $index, $op := makeSlice "Add" "Set" "Remove" }}
-{{ range $key, $value := $input.SliceSubTypes }}
+{{ range $key, $value := $input.SliceSubtypes }}
 {{ $fullName := print $op $key }}
 {{ $actionName := kebabCase $fullName }}
 {{ $resPath := getPathWithAction $input.PathArgs $input.ParentTypeName $actionName }}

--- a/internal/auth/subtype.go
+++ b/internal/auth/subtype.go
@@ -8,15 +8,15 @@ import (
 	"github.com/hashicorp/boundary/internal/db/timestamp"
 )
 
-type SubType int
+type Subtype int
 
 const (
-	UnknownSubtype SubType = iota
+	UnknownSubtype Subtype = iota
 	PasswordSubtype
 	OidcSubtype
 )
 
-func (t SubType) String() string {
+func (t Subtype) String() string {
 	switch t {
 	case PasswordSubtype:
 		return "password"
@@ -58,9 +58,9 @@ var (
 	_ Account = (*password.Account)(nil)
 )
 
-// SubtypeFromType converts a string to a SubType.
-// returns UnknownSubtype if no SubType with that name is found.
-func SubtypeFromType(t string) SubType {
+// SubtypeFromType converts a string to a Subtype.
+// returns UnknownSubtype if no Subtype with that name is found.
+func SubtypeFromType(t string) Subtype {
 	switch {
 	case strings.EqualFold(strings.TrimSpace(t), PasswordSubtype.String()):
 		return PasswordSubtype
@@ -72,8 +72,8 @@ func SubtypeFromType(t string) SubType {
 
 // SubtypeFromId takes any public id in the auth subsystem and uses the prefix to determine
 // what subtype the id is for.
-// Returns UnknownSubtype if no SubType with this id's prefix is found.
-func SubtypeFromId(id string) SubType {
+// Returns UnknownSubtype if no Subtype with this id's prefix is found.
+func SubtypeFromId(id string) Subtype {
 	switch {
 	case strings.HasPrefix(strings.TrimSpace(id), password.AuthMethodPrefix),
 		strings.HasPrefix(strings.TrimSpace(id), password.AccountPrefix):

--- a/internal/auth/subtype_test.go
+++ b/internal/auth/subtype_test.go
@@ -9,45 +9,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSubType(t *testing.T) {
+func TestSubtype(t *testing.T) {
 	tests := []struct {
-		subType     SubType
+		subtype     Subtype
 		id          string
 		wantString  string
-		wantSubtype SubType
+		wantSubtype Subtype
 	}{
 		{
-			subType:     UnknownSubtype,
+			subtype:     UnknownSubtype,
 			id:          "unknownPrefix" + "1234567890",
 			wantString:  "unknown",
 			wantSubtype: UnknownSubtype,
 		},
 		{
-			subType:     PasswordSubtype,
+			subtype:     PasswordSubtype,
 			id:          password.AuthMethodPrefix + "1234567890",
 			wantString:  "password",
 			wantSubtype: PasswordSubtype,
 		},
 		{
-			subType:     PasswordSubtype,
+			subtype:     PasswordSubtype,
 			id:          password.AccountPrefix + "1234567890",
 			wantString:  "password",
 			wantSubtype: PasswordSubtype,
 		},
 		{
-			subType:     OidcSubtype,
+			subtype:     OidcSubtype,
 			id:          oidc.AuthMethodPrefix + "1234567890",
 			wantString:  "oidc",
 			wantSubtype: OidcSubtype,
 		},
 		{
-			subType:     OidcSubtype,
+			subtype:     OidcSubtype,
 			id:          oidc.AccountPrefix + "1234567890",
 			wantString:  "oidc",
 			wantSubtype: OidcSubtype,
 		},
 		{
-			subType:     SubType(1000),
+			subtype:     Subtype(1000),
 			id:          "unknownPrefix" + "1234567890",
 			wantString:  "unknown",
 			wantSubtype: UnknownSubtype,
@@ -56,7 +56,7 @@ func TestSubType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.wantString, func(t *testing.T) {
 			assert, _ := assert.New(t), require.New(t)
-			s := tt.subType.String()
+			s := tt.subtype.String()
 			assert.Equal(tt.wantString, s)
 			assert.Equal(tt.wantSubtype, SubtypeFromType(s))
 

--- a/internal/cmd/common/help.go
+++ b/internal/cmd/common/help.go
@@ -41,7 +41,7 @@ func HelpMap(resType string) map[string]func() string {
 	}
 	return map[string]func() string{
 		"base": func() string {
-			return base.WrapForHelpText(subType([]string{
+			return base.WrapForHelpText(subtype([]string{
 				"Usage: boundary {{hyphentype}}s [sub command] [options] [args]",
 				"",
 				"  This command allows operations on Boundary {{type}} resources. Example:",
@@ -55,7 +55,7 @@ func HelpMap(resType string) map[string]func() string {
 		},
 
 		"create": func() string {
-			return base.WrapForHelpText(subType([]string{
+			return base.WrapForHelpText(subtype([]string{
 				"Usage: boundary {{hyphentype}}s create [options] [args]",
 				"",
 				"  Create {{articletype}}. Example:",
@@ -67,7 +67,7 @@ func HelpMap(resType string) map[string]func() string {
 		},
 
 		"update": func() string {
-			return base.WrapForHelpText(subType([]string{
+			return base.WrapForHelpText(subtype([]string{
 				"Usage: boundary {{hyphentype}}s update [options] [args]",
 				"",
 				"  Update {{articletype}} given its ID. Example:",
@@ -79,7 +79,7 @@ func HelpMap(resType string) map[string]func() string {
 		},
 
 		"read": func() string {
-			return base.WrapForHelpText(subType([]string{
+			return base.WrapForHelpText(subtype([]string{
 				"Usage: boundary {{hyphentype}}s read [options] [args]",
 				"",
 				"  Read {{articletype}} given its ID. Example:",
@@ -91,7 +91,7 @@ func HelpMap(resType string) map[string]func() string {
 		},
 
 		"delete": func() string {
-			return base.WrapForHelpText(subType([]string{
+			return base.WrapForHelpText(subtype([]string{
 				"Usage: boundary {{hyphentype}}s delete [options] [args]",
 				"",
 				"  Delete {{articletype}} given its ID. Example:",
@@ -103,7 +103,7 @@ func HelpMap(resType string) map[string]func() string {
 		},
 
 		"list": func() string {
-			return base.WrapForHelpText(subType([]string{
+			return base.WrapForHelpText(subtype([]string{
 				"Usage: boundary {{hyphentype}}s list [options] [args]",
 				"",
 				"  List {{type}}s within an enclosing scope or resource. Example:",
@@ -116,7 +116,7 @@ func HelpMap(resType string) map[string]func() string {
 	}
 }
 
-func subType(in []string, resType string, prefixMap map[string]string) []string {
+func subtype(in []string, resType string, prefixMap map[string]string) []string {
 	hyphenType := strings.ReplaceAll(resType, " ", "-")
 	articleType := resType
 	switch resType[0] {

--- a/internal/cmd/gencli/input.go
+++ b/internal/cmd/gencli/input.go
@@ -59,9 +59,9 @@ type cmdInfo struct {
 	// commands (e.g. "targets update tcp")
 	SubActionPrefix string
 
-	// NeedsSubTypeInCreate controls whether the sub-type must be passed in as
+	// NeedsSubtypeInCreate controls whether the sub-type must be passed in as
 	// an argument to a create call. Targets need this, accounts do not, etc.
-	NeedsSubTypeInCreate bool
+	NeedsSubtypeInCreate bool
 }
 
 var inputStructs = map[string][]*cmdInfo{
@@ -131,7 +131,7 @@ var inputStructs = map[string][]*cmdInfo{
 			HasDescription:       true,
 			Container:            "Scope",
 			VersionedActions:     []string{"update"},
-			NeedsSubTypeInCreate: true,
+			NeedsSubtypeInCreate: true,
 		},
 		{
 			ResourceType:         resource.AuthMethod.String(),
@@ -146,7 +146,7 @@ var inputStructs = map[string][]*cmdInfo{
 			HasDescription:       true,
 			Container:            "Scope",
 			VersionedActions:     []string{"update", "change-state"},
-			NeedsSubTypeInCreate: true,
+			NeedsSubtypeInCreate: true,
 		},
 	},
 	"authtokens": {
@@ -193,7 +193,7 @@ var inputStructs = map[string][]*cmdInfo{
 			HasDescription:       true,
 			Container:            "Scope",
 			VersionedActions:     []string{"update"},
-			NeedsSubTypeInCreate: true,
+			NeedsSubtypeInCreate: true,
 		},
 	},
 	"hostsets": {
@@ -316,7 +316,7 @@ var inputStructs = map[string][]*cmdInfo{
 			Container:            "Scope",
 			HasDescription:       true,
 			VersionedActions:     []string{"update"},
-			NeedsSubTypeInCreate: true,
+			NeedsSubtypeInCreate: true,
 		},
 	},
 	"users": {

--- a/internal/cmd/gencli/templates.go
+++ b/internal/cmd/gencli/templates.go
@@ -336,7 +336,7 @@ func (c *{{ camelCase .SubActionPrefix }}Command) Run(args []string) int {
 	{{ range $i, $action := $input.StdActions }}
 	{{ if eq $action "create" }}
 	case "create":
-		result, err = {{ $input.Pkg }}Client.Create(c.Context, {{ if (and $input.SubActionPrefix $input.NeedsSubTypeInCreate) }}"{{ $input.SubActionPrefix }}",{{ end }} c.Flag{{ $input.Container }}Id, opts...)
+		result, err = {{ $input.Pkg }}Client.Create(c.Context, {{ if (and $input.SubActionPrefix $input.NeedsSubtypeInCreate) }}"{{ $input.SubActionPrefix }}",{{ end }} c.Flag{{ $input.Container }}Id, opts...)
 	{{ end }}
 	{{ if eq $action "read" }}
 	case "read":

--- a/internal/host/subtype.go
+++ b/internal/host/subtype.go
@@ -6,14 +6,14 @@ import (
 	"github.com/hashicorp/boundary/internal/host/static"
 )
 
-type SubType int
+type Subtype int
 
 const (
-	UnknownSubtype SubType = iota
+	UnknownSubtype Subtype = iota
 	StaticSubtype
 )
 
-func (t SubType) String() string {
+func (t Subtype) String() string {
 	switch t {
 	case StaticSubtype:
 		return "static"
@@ -22,7 +22,7 @@ func (t SubType) String() string {
 }
 
 // Subtype uses the provided subtype
-func SubtypeFromType(t string) SubType {
+func SubtypeFromType(t string) Subtype {
 	switch {
 	case strings.EqualFold(strings.TrimSpace(t), StaticSubtype.String()):
 		return StaticSubtype
@@ -30,7 +30,7 @@ func SubtypeFromType(t string) SubType {
 	return UnknownSubtype
 }
 
-func SubtypeFromId(id string) SubType {
+func SubtypeFromId(id string) Subtype {
 	switch {
 	case strings.HasPrefix(strings.TrimSpace(id), static.HostPrefix),
 		strings.HasPrefix(strings.TrimSpace(id), static.HostSetPrefix),

--- a/internal/servers/controller/handlers/accounts/account_service.go
+++ b/internal/servers/controller/handlers/accounts/account_service.go
@@ -52,7 +52,7 @@ var (
 
 	// IdActions contains the set of actions that can be performed on
 	// individual resources
-	IdActions = map[auth.SubType]action.ActionSet{
+	IdActions = map[auth.Subtype]action.ActionSet{
 		auth.PasswordSubtype: {
 			action.NoOp,
 			action.Read,

--- a/internal/servers/controller/handlers/authmethods/authmethod_service.go
+++ b/internal/servers/controller/handlers/authmethods/authmethod_service.go
@@ -49,7 +49,7 @@ const (
 var (
 	// IdActions contains the set of actions that can be performed on
 	// individual resources
-	IdActions = make(map[auth.SubType]action.ActionSet)
+	IdActions = make(map[auth.Subtype]action.ActionSet)
 
 	// CollectionActions contains the set of actions that can be performed on
 	// this collection

--- a/internal/servers/controller/handlers/sessions/session_service_test.go
+++ b/internal/servers/controller/handlers/sessions/session_service_test.go
@@ -87,7 +87,7 @@ func TestGetSession(t *testing.T) {
 		Scope:             &scopes.ScopeInfo{Id: p.GetPublicId(), Type: scope.Project.String(), ParentScopeId: o.GetPublicId()},
 		States:            []*pb.SessionState{{Status: session.StatusPending.String(), StartTime: sess.CreateTime.GetTimestamp()}},
 		Certificate:       sess.Certificate,
-		Type:              target.TcpSubType.String(),
+		Type:              target.TcpSubtype.String(),
 		AuthorizedActions: testAuthorizedActions,
 	}
 
@@ -300,7 +300,7 @@ func TestList(t *testing.T) {
 			Status:            status,
 			States:            states,
 			Certificate:       sess.Certificate,
-			Type:              target.TcpSubType.String(),
+			Type:              target.TcpSubtype.String(),
 			AuthorizedActions: testAuthorizedActions,
 		})
 
@@ -335,7 +335,7 @@ func TestList(t *testing.T) {
 			Status:            status,
 			States:            states,
 			Certificate:       sess.Certificate,
-			Type:              target.TcpSubType.String(),
+			Type:              target.TcpSubtype.String(),
 			AuthorizedActions: testAuthorizedActions,
 		})
 	}
@@ -498,7 +498,7 @@ func TestCancel(t *testing.T) {
 		Scope:             &scopes.ScopeInfo{Id: p.GetPublicId(), Type: scope.Project.String(), ParentScopeId: o.GetPublicId()},
 		Status:            session.StatusCanceling.String(),
 		Certificate:       sess.Certificate,
-		Type:              target.TcpSubType.String(),
+		Type:              target.TcpSubtype.String(),
 		AuthorizedActions: testAuthorizedActions,
 	}
 

--- a/internal/servers/controller/handlers/targets/target_service.go
+++ b/internal/servers/controller/handlers/targets/target_service.go
@@ -1067,7 +1067,7 @@ func validateCreateRequest(req *pbs.CreateTargetRequest) error {
 			badFields["session_max_seconds"] = "This must be greater than zero."
 		}
 		switch target.SubtypeFromType(req.GetItem().GetType()) {
-		case target.TcpSubType:
+		case target.TcpSubtype:
 			tcpAttrs := &pb.TcpTargetAttributes{}
 			if err := handlers.StructToProto(req.GetItem().GetAttributes(), tcpAttrs); err != nil {
 				badFields["attributes"] = "Attribute fields do not match the expected format."
@@ -1111,8 +1111,8 @@ func validateUpdateRequest(req *pbs.UpdateTargetRequest) error {
 			badFields["session_max_seconds"] = "This must be greater than zero."
 		}
 		switch target.SubtypeFromId(req.GetItem().GetType()) {
-		case target.TcpSubType:
-			if req.GetItem().GetType() != "" && target.SubtypeFromType(req.GetItem().GetType()) != target.TcpSubType {
+		case target.TcpSubtype:
+			if req.GetItem().GetType() != "" && target.SubtypeFromType(req.GetItem().GetType()) != target.TcpSubtype {
 				badFields["type"] = "Cannot modify the resource type."
 			}
 			tcpAttrs := &pb.TcpTargetAttributes{}

--- a/internal/servers/controller/handlers/targets/target_service_test.go
+++ b/internal/servers/controller/handlers/targets/target_service_test.go
@@ -572,7 +572,7 @@ func TestUpdate(t *testing.T) {
 					Description:            wrapperspb.String("desc"),
 					SessionMaxSeconds:      wrapperspb.UInt32(3600),
 					SessionConnectionLimit: wrapperspb.Int32(5),
-					Type:                   target.TcpSubType.String(),
+					Type:                   target.TcpSubtype.String(),
 				},
 			},
 			res: &pbs.UpdateTargetResponse{
@@ -604,7 +604,7 @@ func TestUpdate(t *testing.T) {
 				Item: &pb.Target{
 					Name:        wrapperspb.String("name"),
 					Description: wrapperspb.String("desc"),
-					Type:        target.TcpSubType.String(),
+					Type:        target.TcpSubtype.String(),
 				},
 			},
 			res: &pbs.UpdateTargetResponse{

--- a/internal/target/repository.go
+++ b/internal/target/repository.go
@@ -126,11 +126,11 @@ func (r *Repository) LookupTarget(ctx context.Context, publicIdOrName string, op
 		}
 		return nil, nil, errors.Wrap(err, op)
 	}
-	subType, err := target.targetSubType()
+	subtype, err := target.targetSubtype()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, op)
 	}
-	return subType, hostSets, nil
+	return subtype, hostSets, nil
 }
 
 func fetchSets(ctx context.Context, r db.Reader, targetId string) ([]*TargetSet, error) {
@@ -171,11 +171,11 @@ func (r *Repository) ListTargets(ctx context.Context, opt ...Option) ([]Target, 
 	targets := make([]Target, 0, len(foundTargets))
 
 	for _, t := range foundTargets {
-		subType, err := t.targetSubType()
+		subtype, err := t.targetSubtype()
 		if err != nil {
 			return nil, errors.Wrap(err, op)
 		}
-		targets = append(targets, subType)
+		targets = append(targets, subtype)
 	}
 	return targets, nil
 }

--- a/internal/target/subtype.go
+++ b/internal/target/subtype.go
@@ -4,38 +4,38 @@ import (
 	"strings"
 )
 
-type SubType int
+type Subtype int
 
 const (
-	UnknownSubtype SubType = iota
-	TcpSubType
+	UnknownSubtype Subtype = iota
+	TcpSubtype
 )
 
-func (t SubType) String() string {
+func (t Subtype) String() string {
 	switch t {
-	case TcpSubType:
+	case TcpSubtype:
 		return "tcp"
 	}
 	return "unknown"
 }
 
-// SubtypeFromType converts a string to a SubType.
-// returns UnknownSubtype if no SubType with that name is found.
-func SubtypeFromType(t string) SubType {
+// SubtypeFromType converts a string to a Subtype.
+// returns UnknownSubtype if no Subtype with that name is found.
+func SubtypeFromType(t string) Subtype {
 	switch {
-	case strings.EqualFold(strings.TrimSpace(t), TcpSubType.String()):
-		return TcpSubType
+	case strings.EqualFold(strings.TrimSpace(t), TcpSubtype.String()):
+		return TcpSubtype
 	}
 	return UnknownSubtype
 }
 
 // SubtypeFromId takes any public id in the target subsystem and uses the prefix to determine
 // what subtype the id is for.
-// Returns UnknownSubtype if no SubType with this id's prefix is found.
-func SubtypeFromId(id string) SubType {
+// Returns UnknownSubtype if no Subtype with this id's prefix is found.
+func SubtypeFromId(id string) Subtype {
 	switch {
 	case strings.HasPrefix(strings.TrimSpace(id), TcpTargetPrefix):
-		return TcpSubType
+		return TcpSubtype
 	}
 	return UnknownSubtype
 }

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -79,9 +79,9 @@ func (t *targetView) SetTableName(n string) {
 	}
 }
 
-// targetSubType converts the target view to the concrete subtype
-func (t *targetView) targetSubType() (Target, error) {
-	const op = "target.targetView.targetSubType"
+// targetSubtype converts the target view to the concrete subtype
+func (t *targetView) targetSubtype() (Target, error) {
+	const op = "target.targetView.targetSubtype"
 	switch t.Type {
 	case TcpTargetType.String():
 		tcpTarget := allocTcpTarget()


### PR DESCRIPTION
The **t** in `Subtype` should not be capitalized unless `SubType` is referring to a type of submarine.