### PR TITLE
Already-canceled sessions return 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## Next
 
+### Deprecations/Changes
+
+* If a `cancel` operation is run on a session already in a canceling or
+  terminated state, a `200` and the session information will be returned instead
+  of an error.
+
+### New and Improved
+
+* sessions: Return a `200` and session information when canceling an
+  already-canceled or terminated session
+  ([PR](https://github.com/hashicorp/boundary/pull/1243))
+
 ## 0.2.2 (2021/05/17)
 
 ### New and Improved

--- a/internal/servers/controller/handlers/sessions/session_service.go
+++ b/internal/servers/controller/handlers/sessions/session_service.go
@@ -237,18 +237,19 @@ func (s Service) CancelSession(ctx context.Context, req *pbs.CancelSessionReques
 		}
 	}
 
+	var skipCancel bool
 	for _, state := range ses.States {
 		switch state.Status {
-		case session.StatusCanceling:
-			return nil, errors.New(errors.InvalidSessionState, op, "session already in canceling state")
-		case session.StatusTerminated:
-			return nil, errors.New(errors.InvalidSessionState, op, "session already terminated")
+		case session.StatusCanceling, session.StatusTerminated:
+			skipCancel = true
 		}
 	}
 
-	ses, err = s.cancelInRepo(ctx, req.GetId(), req.GetVersion())
-	if err != nil {
-		return nil, err
+	if !skipCancel {
+		ses, err = s.cancelInRepo(ctx, req.GetId(), req.GetVersion())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	outputOpts := make([]handlers.Option, 0, 3)

--- a/internal/servers/controller/handlers/sessions/session_service_test.go
+++ b/internal/servers/controller/handlers/sessions/session_service_test.go
@@ -521,8 +521,7 @@ func TestCancel(t *testing.T) {
 			name:    "Already canceled",
 			scopeId: sess.ScopeId,
 			req:     &pbs.CancelSessionRequest{Id: sess.GetPublicId()},
-			res:     nil,
-			err:     errors.New(errors.InvalidSessionState, "sessions.(Service).CancelSession", "session already in canceling state"),
+			res:     &pbs.CancelSessionResponse{Item: wireSess},
 		},
 		{
 			name: "Cancel a non existing Session",


### PR DESCRIPTION
If a session is already canceled or terminated, attempting to cancel it
will return the current session state and a 200, instead of an error.