### PR TITLE
Revert "internal/cmd/config: allow explicit origin list w/implicit CORS toggle"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,6 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## Next
 
-### Bug Fixes
-
-* You can now omit `cors_enabled` to use its implicit setting of `true` when
-  specifying `cors_allowed_origins`. Previously, omitting `cors_enabled` would
-  cause an explicit `cors_allowed_origins` to be ignored, resetting this value
-  to the desktop origin only.
-  [PR](https://github.com/hashicorp/boundary/pull/1247)
-
 ## 0.2.2 (2021/05/17)
 
 ### New and Improved

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -345,8 +345,8 @@ func Parse(d string) (*Config, error) {
 			if listener.CorsEnabled == nil {
 				listener.CorsEnabled = new(bool)
 				*listener.CorsEnabled = true
+				listener.CorsAllowedOrigins = []string{desktopCorsOrigin}
 			}
-
 			// If not the wildcard and they haven't disabled us auto-adding
 			// origin values, add the desktop client origin
 			if *listener.CorsEnabled &&

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -116,34 +116,6 @@ func TestDevController(t *testing.T) {
 		assert.Equal(t, []string{"*"}, l0.CorsAllowedOrigins)
 		assert.Nil(t, l0.CorsDisableDefaultAllowedOriginValues)
 
-		// Implicitly with explicit wildcard
-		conf = `
-		listener "tcp" {
-			purpose = "api"
-			cors_allowed_origins = ["*"]
-		}
-		`
-		actual, err = Parse(conf)
-		assert.NoError(t, err)
-		l0 = actual.Listeners[0]
-		assert.True(t, *l0.CorsEnabled)
-		assert.Equal(t, []string{"*"}, l0.CorsAllowedOrigins)
-		assert.Nil(t, l0.CorsDisableDefaultAllowedOriginValues)
-
-		// Implicitly with explicit non-wildcard
-		conf = `
-		listener "tcp" {
-			purpose = "api"
-			cors_allowed_origins = ["foobar"]
-		}
-		`
-		actual, err = Parse(conf)
-		assert.NoError(t, err)
-		l0 = actual.Listeners[0]
-		assert.True(t, *l0.CorsEnabled)
-		assert.Equal(t, []string{"foobar", desktopCorsOrigin}, l0.CorsAllowedOrigins)
-		assert.Nil(t, l0.CorsDisableDefaultAllowedOriginValues)
-
 		// Disabled, default behavior
 		conf = `
 		listener "tcp" {


### PR DESCRIPTION
Reverts hashicorp/boundary#1247

We're going to actually be changing this logic to `*` to fix some user issues so these extra additions aren't necessary.