### PR TITLE
Add a Docker entrypoint script and modify Dockerfiles to mimic Vault, to enable mlock inside Docker containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## Next
 
+### New and Improved
+
+* mlock: Add a Docker entrypoint script and modify Dockerfiles to mimic Vault
+  ([PR](https://github.com/hashicorp/boundary/pull/1269))
+
 ## 0.2.3 (2021/05/21)
 
 ### Deprecations/Changes
@@ -26,9 +31,6 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 * sessions: Return a `200` and session information when canceling an
   already-canceled or terminated session
   ([PR](https://github.com/hashicorp/boundary/pull/1243))
-
-* mlock: Add a Docker entrypoint script and modify Dockerfiles to mimic Vault 
-  ([PR](https://github.com/hashicorp/boundary/pull/1269))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   already-canceled or terminated session
   ([PR](https://github.com/hashicorp/boundary/pull/1243))
 
+* mlock: Add a Docker entrypoint script and modify Dockerfiles to mimic Vault 
+  ([PR](https://github.com/hashicorp/boundary/pull/1269))
+
 ### Bug Fixes
 
 * cors: Change the default allowed origins when `cors_enabled` is not specified

--- a/docker/Dev.dockerfile
+++ b/docker/Dev.dockerfile
@@ -12,6 +12,6 @@ RUN chown -R boundary:boundary /boundary/
 EXPOSE 9200 9201 9202
 VOLUME /boundary/
 
-USER boundary
-ENTRYPOINT ["/bin/boundary"]
+COPY ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["server", "-config", "/boundary/config.hcl"]

--- a/docker/Release.dockerfile
+++ b/docker/Release.dockerfile
@@ -41,6 +41,6 @@ RUN chown -R boundary:boundary /boundary/
 EXPOSE 9200 9201 9202
 VOLUME /boundary/
 
-USER boundary
-ENTRYPOINT ["/bin/boundary"]
+COPY ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["server", "-config", "/boundary/config.hcl"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/dumb-init /bin/sh
+set -e
+
+# Note above that we run dumb-init as PID 1 in order to reap zombie processes
+# as well as forward signals to all processes in its session. Normally, sh
+# wouldn't do either of these functions so we'd leak zombies as well as do
+# unclean termination of all our sub-processes.
+
+# Prevent core dumps
+ulimit -c 0
+
+# If the user is trying to run Boundary directly with some arguments, then
+# pass them to Boundary.
+if [ "${1:0:1}" = '-' ]; then
+    set -- boundary "$@"
+fi
+
+if [ "$1" = 'server' ]; then
+    shift
+    set -- boundary server \
+        "$@"
+fi
+
+# If we are running Boundary, make sure it executes as the proper user.
+if [ "$1" = 'boundary' ]; then
+    if [ -z "$SKIP_CHOWN" ]; then
+        # If the config dir is bind mounted then chown it
+        if [ "$(stat -c %u /boundary)" != "$(id -u boundary)" ]; then
+            chown -R boundary:boundary /boundary || echo "Could not chown /boundary (may not have appropriate permissions)"
+        fi
+    fi
+
+    if [ -z "$SKIP_SETCAP" ]; then
+        # Allow mlock to avoid swapping Boundary memory to disk
+        setcap cap_ipc_lock=+ep $(readlink -f $(which boundary))
+
+        # In the case Boundary has been started in a container without IPC_LOCK privileges
+        if ! boundary -version 1>/dev/null 2>/dev/null; then
+            >&2 echo "Couldn't start Boundary with IPC_LOCK. Disabling IPC_LOCK, please use --privileged or --cap-add IPC_LOCK"
+            setcap cap_ipc_lock=-ep $(readlink -f $(which boundary))
+        fi
+    fi
+
+    if [ "$(id -u)" = '0' ]; then
+      set -- su-exec boundary "$@"
+    fi
+fi
+
+exec "$@"


### PR DESCRIPTION
* Add entrypoint script with logic borrowed from Vault's.  This script adds
IPC_LOCK capability at runtime and then executes Boundary under its own user.

* Modify Dockerfiles to use the entrypoint script.

* Remove USER directives from the Boundary Dockerfiles.  This is required to
allow the entrypoint to run setcap.

Because Boundary itself is no longer the entrypoint, the behavior of the
container with respect to passing or overriding arguments is different now.
The Vault script's logic around handling this was not copied entirely -- only
to the extent required to allow the `server` subcommand to run properly.