### PR TITLE
Bump @types/node to latest release of v15

### DIFF
--- a/website/content/docs/concepts/security/permissions.mdx
+++ b/website/content/docs/concepts/security/permissions.mdx
@@ -461,7 +461,8 @@ documentation](https://www.boundaryproject.io/api-docs) for guidance.
             </li>
           </ul>
           <li>
-            <code>set-password</code>: Set a password on an account, without requiring the current password
+            <code>set-password</code>: Set a password on an account, without
+            requiring the current password
           </li>
           <ul>
             <li>
@@ -472,14 +473,17 @@ documentation](https://www.boundaryproject.io/api-docs) for guidance.
             </li>
           </ul>
           <li>
-            <code>change-password</code>: Change a password on an account given the current password
+            <code>change-password</code>: Change a password on an account given
+            the current password
           </li>
           <ul>
             <li>
               <code>id=&lt;id&gt;;actions=change-password</code>
             </li>
             <li>
-              <code>id=&lt;pin&gt;;type=&lt;type&gt;;actions=change-password</code>
+              <code>
+                id=&lt;pin&gt;;type=&lt;type&gt;;actions=change-password
+              </code>
             </li>
           </ul>
         </ul>
@@ -1312,7 +1316,8 @@ documentation](https://www.boundaryproject.io/api-docs) for guidance.
             </li>
           </ul>
           <li>
-            <code>set-principals</code>: Set the full set of principals on a role
+            <code>set-principals</code>: Set the full set of principals on a
+            role
           </li>
           <ul>
             <li>
@@ -1517,7 +1522,8 @@ documentation](https://www.boundaryproject.io/api-docs) for guidance.
             </li>
           </ul>
           <li>
-            <code>read:self</code>: Read a session, which must be associated with the calling user
+            <code>read:self</code>: Read a session, which must be associated
+            with the calling user
           </li>
           <ul>
             <li>
@@ -1525,7 +1531,8 @@ documentation](https://www.boundaryproject.io/api-docs) for guidance.
             </li>
           </ul>
           <li>
-            <code>cancel:self</code>: Cancel a session, which must be associated with the calling user
+            <code>cancel:self</code>: Cancel a session, which must be associated
+            with the calling user
           </li>
           <ul>
             <li>
@@ -1631,7 +1638,8 @@ documentation](https://www.boundaryproject.io/api-docs) for guidance.
             </li>
           </ul>
           <li>
-            <code>set-host-sets</code>: Set the full set of host sets on a target
+            <code>set-host-sets</code>: Set the full set of host sets on a
+            target
           </li>
           <ul>
             <li>

--- a/website/content/docs/getting-started/connect-to-target.mdx
+++ b/website/content/docs/getting-started/connect-to-target.mdx
@@ -112,11 +112,11 @@ command arguments, and these values are additionally injected as environment
 variables in the executed command:
 
 - `{{boundary.ip}}` (`BOUNDARY_PROXIED_IP`): The IP address of the listening
-socket that `boundary connect` has opened.
+  socket that `boundary connect` has opened.
 - `{{boundary.port}}` (`BOUNDARY_PROXIED_PORT`): The port of the listening
-socket that `boundary connect` has opened.
+  socket that `boundary connect` has opened.
 - `{{boundary.addr}}` (`BOUNDARY_PROXIED_ADDR`): The host:port format of the
-address. This is essentially equivalent to `{{boundary.ip}}:{{boundary.port}}`.
+  address. This is essentially equivalent to `{{boundary.ip}}:{{boundary.port}}`.
 
 For example, if you wanted to use Boundary to create an authenticated firewall
 around 'curl', you could update the default TCP target from a default port

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2830,9 +2830,9 @@
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg=="
     },
     "@types/node": {
-      "version": "14.17.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
-      "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
+      "version": "15.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
+      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2830,9 +2830,9 @@
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg=="
     },
     "@types/node": {
-      "version": "14.14.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
-      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+      "version": "14.17.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
+      "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/website/package.json
+++ b/website/package.json
@@ -32,7 +32,7 @@
     "react-player": "2.7.0"
   },
   "devDependencies": {
-    "@types/node": "^14.14.41",
+    "@types/node": "^14.17.3",
     "@types/react": "^17.0.3",
     "dart-linkcheck": "2.0.15",
     "glob": "7.1.6",

--- a/website/package.json
+++ b/website/package.json
@@ -32,7 +32,7 @@
     "react-player": "2.7.0"
   },
   "devDependencies": {
-    "@types/node": "^14.17.3",
+    "@types/node": "^15.12.2",
     "@types/react": "^17.0.3",
     "dart-linkcheck": "2.0.15",
     "glob": "7.1.6",


### PR DESCRIPTION
Bump `@types/node` to latest release of v14.

There is a [v15 available](https://www.npmjs.com/package/@types/node/v/15.12.2) and I am happy to bump to that, as initial PR I tough is safer to first bump to latest v14. Please let me know any thoughts on this.