### PR TITLE
chore:  bump desktop version to 1.1.0

### DIFF
--- a/website/data/version.js
+++ b/website/data/version.js
@@ -1,2 +1,2 @@
 export const VERSION = '0.3.0'
-export const DESKTOP_VERSION = '1.0.0'
+export const DESKTOP_VERSION = '1.1.0'


### PR DESCRIPTION
To be merged once desktop 1.1.0 appears on [releases](https://releases.hashicorp.com/boundary-desktop/).