### PR TITLE
Error on missing capabilities

### DIFF
--- a/internal/credential/vault/jobs_test.go
+++ b/internal/credential/vault/jobs_test.go
@@ -283,7 +283,7 @@ func TestTokenRenewalJob_RunExpired(t *testing.T) {
 		DisplayName: t.Name(),
 		NoParent:    true,
 		Period:      "1s",
-		Policies:    []string{"default"},
+		Policies:    []string{"default", "boundary-controller"},
 	}
 	vc := v.client(t).cl
 	ct, err := vc.Auth().Token().Create(req)

--- a/internal/credential/vault/repository_credential_store_test.go
+++ b/internal/credential/vault/repository_credential_store_test.go
@@ -135,6 +135,11 @@ func TestRepository_CreateCredentialStoreNonResource(t *testing.T) {
 			tls:  TestClientTLS,
 		},
 		{
+			name:      "token-missing-capabilities",
+			tokenOpts: []TestOption{WithPolicies([]string{"default"})},
+			wantErr:   errors.VaultTokenMissingCapabilities,
+		},
+		{
 			name:      "no-tls-token-not-renewable",
 			tokenOpts: []TestOption{TestRenewableToken(false)},
 			wantErr:   errors.VaultTokenNotRenewable,
@@ -1056,6 +1061,11 @@ func TestRepository_UpdateCredentialStore_VaultToken(t *testing.T) {
 			name:               "valid",
 			wantOldTokenStatus: MaintainingToken,
 			wantCount:          1,
+		},
+		{
+			name:         "token-missing-capabilities",
+			newTokenOpts: []TestOption{WithPolicies([]string{"default"})},
+			wantErr:      errors.VaultTokenMissingCapabilities,
 		},
 		{
 			name:         "token-not-renewable",

--- a/internal/credential/vault/repository_credentials_test.go
+++ b/internal/credential/vault/repository_credentials_test.go
@@ -41,7 +41,7 @@ func TestRepository_IssueCredentials(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(repo)
 
-	_, token := v.CreateToken(t, vault.WithPolicies([]string{"default", "database", "pki"}))
+	_, token := v.CreateToken(t, vault.WithPolicies([]string{"default", "boundary-controller", "database", "pki"}))
 
 	var opts []vault.Option
 	opts = append(opts, vault.WithCACert(v.CaCert))

--- a/internal/credential/vault/vault_capabilities.go
+++ b/internal/credential/vault/vault_capabilities.go
@@ -242,6 +242,25 @@ func (pc pathCapabilities) vaultPolicy() string {
 	return b.String()
 }
 
+func (pc pathCapabilities) paths() []string {
+	var paths []string
+	for path := range pc {
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func (pc pathCapabilities) String() string {
+	var b strings.Builder
+	for k, v := range pc {
+		b.WriteString(k)
+		b.WriteString(": ")
+		b.WriteString(strings.Join(v.strings(), "|"))
+		b.WriteString(", ")
+	}
+	return strings.TrimSuffix(b.String(), ", ")
+}
+
 var requiredCapabilities = pathCapabilities{
 	"auth/token/lookup-self": readCapability,
 	"auth/token/renew-self":  updateCapability,

--- a/internal/credential/vault/vault_capabilities_test.go
+++ b/internal/credential/vault/vault_capabilities_test.go
@@ -525,6 +525,50 @@ func TestPathCapabilities_missing(t *testing.T) {
 	}
 }
 
+func TestPathCapabilities_String(t *testing.T) {
+	tests := []struct {
+		name string
+		pc   pathCapabilities
+		want string
+	}{
+		{
+			name: "empty-empty",
+		},
+		{
+			name: "one-path",
+			pc:   pathCapabilities{"one": createCapability},
+			want: "one: create",
+		},
+		{
+			name: "one-path-multiple-capabilities",
+			pc:   pathCapabilities{"one": createCapability | readCapability | updateCapability},
+			want: "one: create|read|update",
+		},
+		{
+			name: "multiple-paths",
+			pc:   pathCapabilities{"one": createCapability, "two": updateCapability},
+			want: "one: create, two: update",
+		},
+		{
+			name: "multiple-paths-multiple-capabilities",
+			pc: pathCapabilities{
+				"one":   createCapability,
+				"two":   createCapability | readCapability | updateCapability,
+				"three": readCapability | deleteCapability,
+			},
+			want: "one: create, two: create|read|update, three: read|delete",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got := tt.pc.String()
+			assert.Equalf(tt.want, got, "pathCapabilities.String(): want: {%s} got: {%s}", tt.want, got)
+		})
+	}
+}
+
 func TestCapabilities_missing(t *testing.T) {
 	tests := []struct {
 		have, require, want capabilities

--- a/internal/credential/vault/vault_capabilities_test.go
+++ b/internal/credential/vault/vault_capabilities_test.go
@@ -527,27 +527,27 @@ func TestPathCapabilities_missing(t *testing.T) {
 
 func TestPathCapabilities_String(t *testing.T) {
 	tests := []struct {
-		name string
-		pc   pathCapabilities
-		want string
+		name     string
+		pc       pathCapabilities
+		contains []string
 	}{
 		{
 			name: "empty-empty",
 		},
 		{
-			name: "one-path",
-			pc:   pathCapabilities{"one": createCapability},
-			want: "one: create",
+			name:     "one-path",
+			pc:       pathCapabilities{"one": createCapability},
+			contains: []string{"one: create"},
 		},
 		{
-			name: "one-path-multiple-capabilities",
-			pc:   pathCapabilities{"one": createCapability | readCapability | updateCapability},
-			want: "one: create|read|update",
+			name:     "one-path-multiple-capabilities",
+			pc:       pathCapabilities{"one": createCapability | readCapability | updateCapability},
+			contains: []string{"one: create|read|update"},
 		},
 		{
-			name: "multiple-paths",
-			pc:   pathCapabilities{"one": createCapability, "two": updateCapability},
-			want: "one: create, two: update",
+			name:     "multiple-paths",
+			pc:       pathCapabilities{"one": createCapability, "two": updateCapability},
+			contains: []string{"one: create", "two: update"},
 		},
 		{
 			name: "multiple-paths-multiple-capabilities",
@@ -556,7 +556,7 @@ func TestPathCapabilities_String(t *testing.T) {
 				"two":   createCapability | readCapability | updateCapability,
 				"three": readCapability | deleteCapability,
 			},
-			want: "one: create, two: create|read|update, three: read|delete",
+			contains: []string{"one: create", "two: create|read|update", "three: read|delete"},
 		},
 	}
 	for _, tt := range tests {
@@ -564,7 +564,9 @@ func TestPathCapabilities_String(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got := tt.pc.String()
-			assert.Equalf(tt.want, got, "pathCapabilities.String(): want: {%s} got: {%s}", tt.want, got)
+			for _, s := range tt.contains {
+				assert.Containsf(got, s, "expected %q to contain %s", got, s)
+			}
 		})
 	}
 }

--- a/internal/credential/vault/vault_test.go
+++ b/internal/credential/vault/vault_test.go
@@ -199,16 +199,11 @@ func TestClient_capabilities(t *testing.T) {
 			tt.name = fmt.Sprintf("%v", tt.polices)
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			var paths []string
-			for path := range tt.require {
-				paths = append(paths, path)
-			}
-
 			assert := assert.New(t)
 			_, token := v.CreateToken(t, WithPolicies(tt.polices))
 			client := v.clientUsingToken(t, token)
 
-			have, err := client.capabilities(paths)
+			have, err := client.capabilities(tt.require.paths())
 			assert.NoError(err)
 			got := have.missing(tt.require)
 			assert.Equalf(tt.wantMissing, got, "pathCapabilities: want: {%s} got: {%s}", tt.wantMissing, got)


### PR DESCRIPTION
### What does this PR do

Adds a stringer method and paths method to pathCapabilities
Adds check and returns error on missing capabilities when updating token in a cred store or creating cred store

Sample error if missing:
```
vault.(Repository).CreateCredentialStore: missing capabilites: sys/leases/revoke: update: vault token issue: error #3013
```
See unit test of `String` for more examples of how it would display