### PR TITLE
Vault job credential and credential store cleanup

### DIFF
--- a/internal/credential/vault/jobs.go
+++ b/internal/credential/vault/jobs.go
@@ -370,7 +370,7 @@ func (r *TokenRevocationJob) Run(ctx context.Context) error {
 	}
 
 	// Fetch all tokens in the revoke state as well as all tokens in the maintaining state
-	// that have no credentials in an active state.
+	// that have no credentials in an active state.  Note SearchWhere requires query values
 	where := `
 token_status = ?
 or
@@ -851,7 +851,7 @@ func (r *CredentialStoreCleanupJob) Run(ctx context.Context) error {
 		return errors.Wrap(err, op)
 	}
 
-	// TODO(lcr) 06/2021: Oplog does not currently support bulk
+	// TODO (lcr 06/2021): Oplog does not currently support bulk
 	// operations. Push cleanup to the database once bulk
 	// operations are added.
 	var stores []*CredentialStore

--- a/internal/credential/vault/jobs.go
+++ b/internal/credential/vault/jobs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/oplog"
 	"github.com/hashicorp/boundary/internal/scheduler"
 	"github.com/hashicorp/go-hclog"
 	vault "github.com/hashicorp/vault/api"
@@ -15,10 +16,12 @@ import (
 )
 
 const (
-	tokenRenewalJobName         = "vault_token_renewal"
-	tokenRevocationJobName      = "vault_token_revocation"
-	credentialRenewalJobName    = "vault_credential_renewal"
-	credentialRevocationJobName = "vault_credential_revocation"
+	tokenRenewalJobName           = "vault_token_renewal"
+	tokenRevocationJobName        = "vault_token_revocation"
+	credentialRenewalJobName      = "vault_credential_renewal"
+	credentialRevocationJobName   = "vault_credential_revocation"
+	credentialStoreCleanupJobName = "vault_credential_store_cleanup"
+	credentialCleanupJobName      = "vault_credential_cleanup"
 
 	defaultNextRunIn = 5 * time.Minute
 	renewalWindow    = 10 * time.Minute
@@ -53,6 +56,20 @@ func RegisterJobs(ctx context.Context, scheduler *scheduler.Scheduler, r db.Read
 	}
 	if err = scheduler.RegisterJob(ctx, credRevoke); err != nil {
 		return errors.Wrap(err, op, errors.WithMsg("credential revocation job"))
+	}
+	credStoreCleanup, err := newCredentialStoreCleanupJob(r, w, kms, logger)
+	if err != nil {
+		return errors.Wrap(err, op)
+	}
+	if err = scheduler.RegisterJob(ctx, credStoreCleanup); err != nil {
+		return errors.Wrap(err, op, errors.WithMsg("credential store cleanup job"))
+	}
+	credCleanup, err := newCredentialCleanupJob(w)
+	if err != nil {
+		return errors.Wrap(err, op)
+	}
+	if err = scheduler.RegisterJob(ctx, credCleanup); err != nil {
+		return errors.Wrap(err, op, errors.WithMsg("credential cleanup job"))
 	}
 	return nil
 }
@@ -190,6 +207,13 @@ func (r *TokenRenewalJob) renewToken(ctx context.Context, s *privateStore) error
 		if s.TokenStatus == string(CurrentToken) {
 			r.logger.Info("Vault credential store current token has expired", "credential store id", s.StoreId)
 		}
+
+		// Set credentials associated with this token to expired as Vault will already cascade delete them
+		_, err = r.writer.Exec(ctx, updateCredentialStatusByTokenQuery, []interface{}{ExpiredCredential, token.TokenHmac})
+		if err != nil {
+			return errors.Wrap(err, op, errors.WithMsg("error updating credentials to revoked after revoking token"))
+		}
+
 		return nil
 	}
 	if err != nil {
@@ -345,15 +369,18 @@ func (r *TokenRevocationJob) Run(ctx context.Context) error {
 		return errors.Wrap(err, op)
 	}
 
-	// Fetch all tokens in the maintaining state that have no credentials in an active state
+	// Fetch all tokens in the revoke state as well as all tokens in the maintaining state
+	// that have no credentials in an active state.
 	where := `
 token_status = ?
+or
+(token_status = ?
   and token_hmac not in (
     select token_hmac from credential_vault_credential 
      where status = ?
-)
+))
 `
-	whereArgs := []interface{}{MaintainingToken, ActiveCredential}
+	whereArgs := []interface{}{RevokeToken, MaintainingToken, ActiveCredential}
 
 	var ps []*privateStore
 	err := r.reader.SearchWhere(ctx, &ps, where, whereArgs, db.WithLimit(r.limit))
@@ -419,7 +446,7 @@ func (r *TokenRevocationJob) revokeToken(ctx context.Context, s *privateStore) e
 	}
 
 	// Set credentials associated with this token to revoked as Vault will already cascade revoke them
-	_, err = r.writer.Exec(ctx, revokedCredentialQuery, []interface{}{token.TokenHmac})
+	_, err = r.writer.Exec(ctx, updateCredentialStatusByTokenQuery, []interface{}{RevokedCredential, token.TokenHmac})
 	if err != nil {
 		return errors.Wrap(err, op, errors.WithMsg("error updating credentials to revoked after revoking token"))
 	}
@@ -716,13 +743,18 @@ func (r *CredentialRevocationJob) revokeCred(ctx context.Context, c *privateCred
 		return errors.Wrap(err, op)
 	}
 
+	cred := c.toCredential()
+	var respErr *vault.ResponseError
 	err = vc.revokeLease(c.ExternalId)
+	if ok := errors.As(err, &respErr); ok && respErr.StatusCode == http.StatusBadRequest {
+		// Vault returned a 400 when attempting a revoke lease, the lease is already expired.
+		// Clobber error and set status to "revoked" below.
+		err = nil
+	}
 	if err != nil {
-		// TODO: handle perm issue
 		return errors.Wrap(err, op, errors.WithMsg("unable to revoke credential"))
 	}
 
-	cred := c.toCredential()
 	query, values := cred.updateStatusQuery(RevokedCredential)
 	numRows, err := r.writer.Exec(ctx, query, values)
 	if err != nil {
@@ -748,4 +780,197 @@ func (r *CredentialRevocationJob) Name() string {
 // Description is the human readable description of the job.
 func (r *CredentialRevocationJob) Description() string {
 	return "Periodically revokes dynamic credentials that are no longer in use and have been set for revocation (in the revoke state)."
+}
+
+// CredentialStoreCleanupJob is the recurring job that deletes Vault credential stores that
+// have been soft deleted and tokens have been revoked or expired.
+// The CredentialStoreCleanupJob is not thread safe, an attempt to Run the job concurrently
+// will result in an JobAlreadyRunning error.
+type CredentialStoreCleanupJob struct {
+	reader db.Reader
+	writer db.Writer
+	kms    *kms.Kms
+	logger hclog.Logger
+
+	limit        int
+	running      ua.Bool
+	numProcessed int
+	numStores    int
+}
+
+// newCredentialStoreCleanupJob creates a new in-memory CredentialStoreCleanupJob.
+//
+// No options are supported.
+func newCredentialStoreCleanupJob(r db.Reader, w db.Writer, kms *kms.Kms, logger hclog.Logger, opt ...Option) (*CredentialStoreCleanupJob, error) {
+	const op = "vault.newCredentialStoreCleanupJob"
+	switch {
+	case r == nil:
+		return nil, errors.New(errors.InvalidParameter, op, "missing db.Reader")
+	case w == nil:
+		return nil, errors.New(errors.InvalidParameter, op, "missing db.Writer")
+	case kms == nil:
+		return nil, errors.New(errors.InvalidParameter, op, "missing kms")
+	case logger == nil:
+		return nil, errors.New(errors.InvalidParameter, op, "missing logger")
+	}
+
+	opts := getOpts(opt...)
+	if opts.withLimit == 0 {
+		// zero signals the boundary defaults should be used.
+		opts.withLimit = db.DefaultLimit
+	}
+	return &CredentialStoreCleanupJob{
+		reader: r,
+		writer: w,
+		kms:    kms,
+		logger: logger,
+		limit:  opts.withLimit,
+	}, nil
+}
+
+// Status returns the current status of the credential store cleanup job.
+func (r *CredentialStoreCleanupJob) Status() scheduler.JobStatus {
+	return scheduler.JobStatus{
+		Completed: r.numProcessed,
+		Total:     r.numStores,
+	}
+}
+
+// Run deletes all vault credential stores in the repo that have been soft deleted.
+// Can not be run in parallel, if Run is invoked while already running an error with code
+// JobAlreadyRunning will be returned.
+func (r *CredentialStoreCleanupJob) Run(ctx context.Context) error {
+	const op = "vault.(CredentialStoreCleanupJob).Run"
+	if !r.running.CAS(r.running.Load(), true) {
+		return errors.New(errors.JobAlreadyRunning, op, "job already running")
+	}
+	defer r.running.Store(false)
+
+	// Verify context is not done before running
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, op)
+	}
+
+	// TODO(lcr) 06/2021: Oplog does not currently support bulk
+	// operations. Push cleanup to the database once bulk
+	// operations are added.
+	var stores []*CredentialStore
+	err := r.reader.SearchWhere(ctx, &stores, credStoreCleanupWhereClause, []interface{}{RevokeToken}, db.WithLimit(r.limit))
+	if err != nil {
+		return errors.Wrap(err, op)
+	}
+
+	// Set numProcessed and numStores for status report
+	r.numProcessed, r.numStores = 0, len(stores)
+	for _, store := range stores {
+		// Verify context is not done before renewing next token
+		if err := ctx.Err(); err != nil {
+			return errors.Wrap(err, op)
+		}
+
+		oplogWrapper, err := r.kms.GetWrapper(ctx, store.ScopeId, kms.KeyPurposeOplog)
+		if err != nil {
+			r.logger.Error("unable to get oplog wrapper for credential store cleanup job", "credential store id", store.PublicId)
+			r.numProcessed++
+			continue
+		}
+
+		_, err = r.writer.Delete(ctx, store, db.WithOplog(oplogWrapper, store.oplog(oplog.OpType_OP_TYPE_DELETE)))
+		if err != nil {
+			r.logger.Error("error deleting credential store", "error", err, "credential store id", store.PublicId)
+		}
+
+		r.numProcessed++
+	}
+
+	return nil
+}
+
+// NextRunIn determine when the next credential store cleanup job should run.
+func (r *CredentialStoreCleanupJob) NextRunIn() (time.Duration, error) {
+	return defaultNextRunIn, nil
+}
+
+// Name is the unique name of the job.
+func (r *CredentialStoreCleanupJob) Name() string {
+	return credentialStoreCleanupJobName
+}
+
+// Description is the human readable description of the job.
+func (r *CredentialStoreCleanupJob) Description() string {
+	return "Periodically deletes Vault credential stores that have been soft deleted and tokens have been revoked or expired."
+}
+
+// CredentialCleanupJob is the recurring job that deletes Vault credentials that are no longer
+// attached to a session (have a null session_id) and are not active.
+// The CredentialCleanupJob is not thread safe, an attempt to Run the job concurrently
+// will result in an JobAlreadyRunning error.
+type CredentialCleanupJob struct {
+	writer db.Writer
+
+	running  ua.Bool
+	numCreds int
+}
+
+// newCredentialCleanupJob creates a new in-memory CredentialCleanupJob.
+//
+// No options are supported.
+func newCredentialCleanupJob(w db.Writer) (*CredentialCleanupJob, error) {
+	const op = "vault.newCredentialCleanupJob"
+	if w == nil {
+		return nil, errors.New(errors.InvalidParameter, op, "missing db.Writer")
+	}
+
+	return &CredentialCleanupJob{
+		writer: w,
+	}, nil
+}
+
+// Status returns the current status of the credential cleanup job.
+func (r *CredentialCleanupJob) Status() scheduler.JobStatus {
+	// Cleanup runs a single exec command to the database, therefore completed and total
+	// are both set to numCreds.
+	return scheduler.JobStatus{
+		Completed: r.numCreds,
+		Total:     r.numCreds,
+	}
+}
+
+// Run deletes all Vault credential in the repo that have a null session_id and are not active.
+// Can not be run in parallel, if Run is invoked while already running an error with code
+// JobAlreadyRunning will be returned.
+func (r *CredentialCleanupJob) Run(ctx context.Context) error {
+	const op = "vault.(CredentialCleanupJob).Run"
+	if !r.running.CAS(r.running.Load(), true) {
+		return errors.New(errors.JobAlreadyRunning, op, "job already running")
+	}
+	defer r.running.Store(false)
+
+	// Verify context is not done before running
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, op)
+	}
+
+	numRows, err := r.writer.Exec(ctx, credCleanupQuery, nil)
+	if err != nil {
+		return errors.Wrap(err, op)
+	}
+	r.numCreds = numRows
+
+	return nil
+}
+
+// NextRunIn determine when the next credential cleanup job should run.
+func (r *CredentialCleanupJob) NextRunIn() (time.Duration, error) {
+	return defaultNextRunIn, nil
+}
+
+// Name is the unique name of the job.
+func (r *CredentialCleanupJob) Name() string {
+	return credentialCleanupJobName
+}
+
+// Description is the human readable description of the job.
+func (r *CredentialCleanupJob) Description() string {
+	return "Periodically deletes Vault credentials that are no longer attached to a session (have a null session_id) and are not active in Vault."
 }

--- a/internal/credential/vault/jobs_test.go
+++ b/internal/credential/vault/jobs_test.go
@@ -338,8 +338,22 @@ func TestTokenRenewalJob_Run(t *testing.T) {
 	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
 	v := NewTestVaultServer(t)
 
-	_, ct := v.CreateToken(t)
-	in, err := NewCredentialStore(prj.GetPublicId(), v.Addr, []byte(ct))
+	// Create 24 hour token
+	req := &vault.TokenCreateRequest{
+		DisplayName: t.Name(),
+		NoParent:    true,
+		Period:      "24h",
+		Policies:    []string{"default", "boundary-controller"},
+	}
+	vc := v.client(t).cl
+	secret, err := vc.Auth().Token().Create(req)
+	require.NoError(err)
+	require.NotNil(secret)
+	token, err := secret.TokenID()
+	require.NoError(err)
+	require.NotNil(token)
+
+	in, err := NewCredentialStore(prj.GetPublicId(), v.Addr, []byte(token))
 	require.NoError(err)
 	sche := scheduler.TestScheduler(t, conn, wrapper)
 	repo, err := NewRepository(rw, rw, kmsCache, sche)
@@ -821,14 +835,15 @@ func TestTokenRevocationJob_Run(t *testing.T) {
 	err = sche.RegisterJob(context.Background(), r)
 	require.NoError(err)
 
+	// No tokens should have been revoked since only the current token exists
 	err = r.Run(context.Background())
 	require.NoError(err)
-	// No tokens should have been revoked since only the current token exists
 	assert.Equal(0, r.numProcessed)
 
 	// Create maintaining tokens with and without credentials
 	noCredsToken := testVaultToken(t, conn, wrapper, v, cs, MaintainingToken, 5*time.Minute)
 	credsToken := testVaultToken(t, conn, wrapper, v, cs, MaintainingToken, 5*time.Minute)
+	revokeToken := testVaultToken(t, conn, wrapper, v, cs, RevokeToken, 5*time.Minute)
 
 	// inserting new tokens moves the current token to a maintaining state, move it back to current and set expiration time
 	count, err := rw.Exec(context.Background(), testUpdateTokenStatusExpirationQuery, []interface{}{CurrentToken, (5 * time.Minute).Seconds(), cs.outputToken.TokenHmac})
@@ -865,22 +880,40 @@ func TestTokenRevocationJob_Run(t *testing.T) {
 	// Create credential attached to credsToken
 	_, cred := testVaultCred(t, conn, v, cl, sess, credsToken, ActiveCredential, 5*time.Minute)
 
-	// Running should revoke noCredsToken
+	// Create fake credential attached to revokeToken
+	_, revokeCred := testVaultCred(t, conn, v, cl, sess, revokeToken, ActiveCredential, 5*time.Minute)
+
+	// Running should revoke noCredsToken and the revokeToken even though it has active
+	// credentials it has been marked for revocation
 	err = r.Run(context.Background())
 	require.NoError(err)
-	assert.Equal(1, r.numProcessed)
+	assert.Equal(2, r.numProcessed)
 
 	// Verify noCredsToken was revoked in vault
 	v.VerifyTokenInvalid(t, string(noCredsToken.GetToken()))
-
-	// Verify credsToken was not revoked in vault
-	lookupToken := v.LookupToken(t, string(credsToken.GetToken()))
-	assert.NotNil(lookupToken)
 
 	// Verify noCredsToken was set to revoked in repo
 	repoToken := allocToken()
 	require.NoError(rw.LookupWhere(context.Background(), &repoToken, "token_hmac = ?", []interface{}{noCredsToken.TokenHmac}))
 	assert.Equal(string(RevokedToken), repoToken.Status)
+
+	// Verify revokeToken was revoked in vault
+	v.VerifyTokenInvalid(t, string(revokeToken.GetToken()))
+
+	// Verify revokeToken was set to revoked in repo
+	repoToken = allocToken()
+	require.NoError(rw.LookupWhere(context.Background(), &repoToken, "token_hmac = ?", []interface{}{revokeToken.TokenHmac}))
+	assert.Equal(string(RevokedToken), repoToken.Status)
+
+	// Verify revokeCred attached to revokeToken were marked as revoked
+	lookupCred := allocCredential()
+	lookupCred.PublicId = revokeCred.PublicId
+	require.NoError(rw.LookupById(context.Background(), lookupCred))
+	assert.Equal(string(RevokedCredential), lookupCred.Status)
+
+	// Verify credsToken was not revoked in vault
+	lookupToken := v.LookupToken(t, string(credsToken.GetToken()))
+	assert.NotNil(lookupToken)
 
 	// Revoke credential in repo
 	query, queryValues := cred.updateStatusQuery(RevokedCredential)
@@ -1745,4 +1778,516 @@ func TestCredentialRevocationJob_Run(t *testing.T) {
 	assert.NoError(testDb.ValidateCredential(t, secret1))
 	assert.NoError(testDb.ValidateCredential(t, secret2))
 	assert.NoError(testDb.ValidateCredential(t, secret3))
+}
+
+func TestCredentialRevocationJob_RunDeleted(t *testing.T) {
+	t.Parallel()
+	assert, require := assert.New(t), require.New(t)
+
+	v := NewTestVaultServer(t, WithDockerNetwork(true))
+	testDb := v.MountDatabase(t)
+
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	org, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	sche := scheduler.TestScheduler(t, conn, wrapper)
+	repo, err := NewRepository(rw, rw, kmsCache, sche)
+	require.NoError(err)
+
+	_, token := v.CreateToken(t, WithPolicies([]string{"default", "boundary-controller", "database"}))
+	credStoreIn, err := NewCredentialStore(prj.GetPublicId(), v.Addr, []byte(token))
+	require.NoError(err)
+	cs, err := repo.CreateCredentialStore(context.Background(), credStoreIn)
+	require.NoError(err)
+
+	libPath := path.Join("database", "creds", "opened")
+	libIn, err := NewCredentialLibrary(cs.GetPublicId(), libPath)
+	require.NoError(err)
+	cl, err := repo.CreateCredentialLibrary(context.Background(), prj.GetPublicId(), libIn)
+	require.NoError(err)
+
+	at := authtoken.TestAuthToken(t, conn, kmsCache, org.GetPublicId())
+	uId := at.GetIamUserId()
+	hc := static.TestCatalogs(t, conn, prj.GetPublicId(), 1)[0]
+	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
+	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
+	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
+	tar := target.TestTcpTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSets([]string{hs.GetPublicId()}))
+	sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
+		UserId:      uId,
+		HostId:      h.GetPublicId(),
+		TargetId:    tar.GetPublicId(),
+		HostSetId:   hs.GetPublicId(),
+		AuthTokenId: at.GetPublicId(),
+		ScopeId:     prj.GetPublicId(),
+		Endpoint:    "tcp://127.0.0.1:22",
+	})
+
+	repoToken := allocToken()
+	require.NoError(rw.LookupWhere(context.Background(), &repoToken, "token_hmac = ?", []interface{}{cs.outputToken.TokenHmac}))
+
+	r, err := newCredentialRevocationJob(rw, rw, kmsCache, hclog.L())
+	require.NoError(err)
+
+	secret, cred := testVaultCred(t, conn, v, cl, sess, repoToken, ActiveCredential, 5*time.Hour)
+
+	err = r.Run(context.Background())
+	require.NoError(err)
+	// No credentials should have been revoked as expiration is 5 hours from now
+	assert.Equal(0, r.numCreds)
+
+	// Deleting the library should set the cred library_id to null, but not revoke the cred
+	count, err := rw.Delete(context.Background(), cl)
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	err = r.Run(context.Background())
+	require.NoError(err)
+	// No credentials should have been revoked
+	assert.Equal(0, r.numCreds)
+
+	// Verify the cred has a status of active with an empty libraryId
+	lookupCred := allocCredential()
+	lookupCred.PublicId = cred.PublicId
+	require.NoError(rw.LookupById(context.Background(), lookupCred))
+	assert.Equal(string(ActiveCredential), lookupCred.Status)
+	assert.Empty(lookupCred.LibraryId)
+
+	// secret should still be valid in test database
+	assert.NoError(testDb.ValidateCredential(t, secret))
+
+	// Deleting the session should set the cred session_id to null and schedule cred for revocation
+	count, err = rw.Delete(context.Background(), sess)
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	// cred should now have a status of revoke and empty sessionId
+	lookupCred = allocCredential()
+	lookupCred.PublicId = cred.PublicId
+	require.NoError(rw.LookupById(context.Background(), lookupCred))
+	assert.Empty(lookupCred.SessionId)
+	assert.Equal(string(RevokeCredential), lookupCred.Status)
+
+	err = r.Run(context.Background())
+	require.NoError(err)
+	// The revoke credential should have been revoked
+	assert.Equal(1, r.numCreds)
+
+	// cred should now have a status of revoked
+	lookupCred = allocCredential()
+	lookupCred.PublicId = cred.PublicId
+	require.NoError(rw.LookupById(context.Background(), lookupCred))
+	assert.Equal(string(RevokedCredential), lookupCred.Status)
+
+	// secret should no longer be valid in test database
+	assert.Error(testDb.ValidateCredential(t, secret))
+}
+
+func TestNewCredentialStoreCleanupJob(t *testing.T) {
+	t.Parallel()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+
+	type args struct {
+		r      db.Reader
+		w      db.Writer
+		kms    *kms.Kms
+		logger hclog.Logger
+	}
+	tests := []struct {
+		name        string
+		args        args
+		options     []Option
+		wantLimit   int
+		wantErr     bool
+		wantErrCode errors.Code
+	}{
+		{
+			name:        "nil reader",
+			wantErr:     true,
+			wantErrCode: errors.InvalidParameter,
+		},
+		{
+			name: "nil writer",
+			args: args{
+				r: rw,
+			},
+			wantErr:     true,
+			wantErrCode: errors.InvalidParameter,
+		},
+		{
+			name: "nil kms",
+			args: args{
+				r: rw,
+				w: rw,
+			},
+			wantErr:     true,
+			wantErrCode: errors.InvalidParameter,
+		},
+		{
+			name: "nil logger",
+			args: args{
+				r:   rw,
+				w:   rw,
+				kms: kmsCache,
+			},
+			wantErr:     true,
+			wantErrCode: errors.InvalidParameter,
+		},
+		{
+			name: "valid-no-options",
+			args: args{
+				r:      rw,
+				w:      rw,
+				kms:    kmsCache,
+				logger: hclog.L(),
+			},
+			wantLimit: db.DefaultLimit,
+		},
+		{
+			name: "valid-with-limit",
+			args: args{
+				r:      rw,
+				w:      rw,
+				kms:    kmsCache,
+				logger: hclog.L(),
+			},
+			options:   []Option{WithLimit(100)},
+			wantLimit: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+
+			got, err := newCredentialStoreCleanupJob(tt.args.r, tt.args.w, tt.args.kms, tt.args.logger, tt.options...)
+			if tt.wantErr {
+				require.Error(err)
+				assert.Nil(got)
+				assert.Truef(errors.Match(errors.T(tt.wantErrCode), err), "Unexpected error %s", err)
+				return
+			}
+			require.NoError(err)
+			require.NotNil(got)
+			assert.Equal(tt.args.r, got.reader)
+			assert.Equal(tt.args.w, got.writer)
+			assert.Equal(tt.args.kms, got.kms)
+			require.NotNil(got.logger)
+			assert.Equal(tt.wantLimit, got.limit)
+		})
+	}
+}
+
+func TestCredentialStoreCleanupJob_Run(t *testing.T) {
+	t.Parallel()
+	assert, require := assert.New(t), require.New(t)
+
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	v := NewTestVaultServer(t)
+
+	_, ct := v.CreateToken(t)
+	in, err := NewCredentialStore(prj.GetPublicId(), v.Addr, []byte(ct))
+	require.NoError(err)
+	sche := scheduler.TestScheduler(t, conn, wrapper)
+	repo, err := NewRepository(rw, rw, kmsCache, sche)
+	require.NoError(err)
+	cs1, err := repo.CreateCredentialStore(context.Background(), in)
+	require.NoError(err)
+
+	_, ct = v.CreateToken(t)
+	in, err = NewCredentialStore(prj.GetPublicId(), v.Addr, []byte(ct))
+	require.NoError(err)
+	cs2, err := repo.CreateCredentialStore(context.Background(), in)
+	require.NoError(err)
+
+	// Get token hmac for verifications below
+	repoToken := allocToken()
+	require.NoError(rw.LookupWhere(context.Background(), &repoToken, "store_id = ?", []interface{}{cs1.PublicId}))
+	cs1TokenHmac := repoToken.TokenHmac
+
+	repoToken = allocToken()
+	require.NoError(rw.LookupWhere(context.Background(), &repoToken, "store_id = ?", []interface{}{cs2.PublicId}))
+	cs2TokenHmac := repoToken.TokenHmac
+
+	// create second token on cs2
+	secondToken := testVaultToken(t, conn, wrapper, v, cs2, MaintainingToken, time.Hour)
+
+	r, err := newCredentialStoreCleanupJob(rw, rw, kmsCache, hclog.L())
+	require.NoError(err)
+
+	err = sche.RegisterJob(context.Background(), r)
+	require.NoError(err)
+
+	// No credential stores should have been cleaned up
+	err = r.Run(context.Background())
+	require.NoError(err)
+	assert.Equal(0, r.numStores)
+
+	// Soft delete both credential stores
+	count, err := repo.DeleteCredentialStore(context.Background(), cs1.PublicId)
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	count, err = repo.DeleteCredentialStore(context.Background(), cs2.PublicId)
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	// Verify tokens have been set to revoke
+	repoToken = allocToken()
+	require.NoError(rw.LookupWhere(context.Background(), &repoToken, "store_id = ?", []interface{}{cs1.PublicId}))
+	assert.Equal(string(RevokeToken), repoToken.Status)
+
+	repoToken = allocToken()
+	require.NoError(rw.LookupWhere(context.Background(), &repoToken, "store_id = ?", []interface{}{cs2.PublicId}))
+	assert.Equal(string(RevokeToken), repoToken.Status)
+
+	// Both soft deleted credential stores should not be cleaned up yet
+	err = r.Run(context.Background())
+	require.NoError(err)
+	assert.Equal(0, r.numStores)
+
+	// Update cs1 token to be marked as revoked
+	count, err = rw.Exec(context.Background(), updateTokenStatusQuery, []interface{}{RevokedToken, cs1TokenHmac})
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	// cs1 should be deleted
+	err = r.Run(context.Background())
+	require.NoError(err)
+	assert.Equal(1, r.numStores)
+
+	// Lookup of cs1 and its token should fail
+	agg := allocPublicStore()
+	agg.PublicId = cs1.PublicId
+	err = rw.LookupByPublicId(context.Background(), agg)
+	require.Error(err)
+	assert.True(errors.IsNotFoundError(err))
+	repoToken = allocToken()
+	err = rw.LookupWhere(context.Background(), &repoToken, "token_hmac = ?", []interface{}{cs1TokenHmac})
+	require.Error(err)
+	assert.True(errors.IsNotFoundError(err))
+
+	// Lookup of cs2 and its token should not error
+	_, err = repo.LookupCredentialStore(context.Background(), cs2.PublicId)
+	require.NoError(err)
+	repoToken = allocToken()
+	err = rw.LookupWhere(context.Background(), &repoToken, "token_hmac = ?", []interface{}{cs2TokenHmac})
+	require.NoError(err)
+
+	// Update cs2 token expiration time
+	count, err = rw.Exec(context.Background(), "update credential_vault_token set expiration_time = now() where token_hmac = ?;", []interface{}{cs2TokenHmac})
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	// cs2 still has a second token not yet revoked/expired
+	err = r.Run(context.Background())
+	require.NoError(err)
+	assert.Equal(0, r.numStores)
+
+	// Lookup of cs2 and its token should not error
+	_, err = repo.LookupCredentialStore(context.Background(), cs2.PublicId)
+	require.NoError(err)
+	repoToken = allocToken()
+	err = rw.LookupWhere(context.Background(), &repoToken, "token_hmac = ?", []interface{}{cs2TokenHmac})
+	require.NoError(err)
+
+	// set secondToken with an expired status
+	count, err = rw.Exec(context.Background(), updateTokenStatusQuery, []interface{}{ExpiredToken, secondToken.TokenHmac})
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	// With no un-expired or un-revoked tokens cs2 should now be deleted
+	err = r.Run(context.Background())
+	require.NoError(err)
+	assert.Equal(1, r.numStores)
+
+	// Lookup of cs2 and its token should fail
+	agg = allocPublicStore()
+	agg.PublicId = cs2.PublicId
+	err = rw.LookupByPublicId(context.Background(), agg)
+	require.Error(err)
+	assert.True(errors.IsNotFoundError(err))
+	repoToken = allocToken()
+	err = rw.LookupWhere(context.Background(), &repoToken, "token_hmac = ?", []interface{}{cs2TokenHmac})
+	require.Error(err)
+	assert.True(errors.IsNotFoundError(err))
+	err = rw.LookupWhere(context.Background(), &repoToken, "token_hmac = ?", []interface{}{secondToken.TokenHmac})
+	require.Error(err)
+	assert.True(errors.IsNotFoundError(err))
+}
+
+func TestNewCredentialCleanupJob(t *testing.T) {
+	t.Parallel()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+
+	type args struct {
+		w db.Writer
+	}
+	tests := []struct {
+		name        string
+		args        args
+		options     []Option
+		wantLimit   int
+		wantErr     bool
+		wantErrCode errors.Code
+	}{
+		{
+			name:        "nil writer",
+			wantErr:     true,
+			wantErrCode: errors.InvalidParameter,
+		},
+		{
+			name: "valid",
+			args: args{
+				w: rw,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+
+			got, err := newCredentialCleanupJob(tt.args.w)
+			if tt.wantErr {
+				require.Error(err)
+				assert.Nil(got)
+				assert.Truef(errors.Match(errors.T(tt.wantErrCode), err), "Unexpected error %s", err)
+				return
+			}
+			require.NoError(err)
+			require.NotNil(got)
+			assert.Equal(tt.args.w, got.writer)
+		})
+	}
+}
+
+func TestCredentialCleanupJob_Run(t *testing.T) {
+	t.Parallel()
+	assert, require := assert.New(t), require.New(t)
+
+	v := NewTestVaultServer(t, WithDockerNetwork(true))
+	v.MountDatabase(t)
+
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	org, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	sche := scheduler.TestScheduler(t, conn, wrapper)
+	repo, err := NewRepository(rw, rw, kmsCache, sche)
+	require.NoError(err)
+
+	_, token := v.CreateToken(t, WithPolicies([]string{"default", "boundary-controller", "database"}))
+	credStoreIn, err := NewCredentialStore(prj.GetPublicId(), v.Addr, []byte(token))
+	require.NoError(err)
+	cs, err := repo.CreateCredentialStore(context.Background(), credStoreIn)
+	require.NoError(err)
+
+	libPath := path.Join("database", "creds", "opened")
+	libIn, err := NewCredentialLibrary(cs.GetPublicId(), libPath)
+	require.NoError(err)
+	cl, err := repo.CreateCredentialLibrary(context.Background(), prj.GetPublicId(), libIn)
+	require.NoError(err)
+
+	at := authtoken.TestAuthToken(t, conn, kmsCache, org.GetPublicId())
+	uId := at.GetIamUserId()
+	hc := static.TestCatalogs(t, conn, prj.GetPublicId(), 1)[0]
+	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
+	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
+	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
+	tar := target.TestTcpTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSets([]string{hs.GetPublicId()}))
+	sess1 := session.TestSession(t, conn, wrapper, session.ComposedOf{
+		UserId:      uId,
+		HostId:      h.GetPublicId(),
+		TargetId:    tar.GetPublicId(),
+		HostSetId:   hs.GetPublicId(),
+		AuthTokenId: at.GetPublicId(),
+		ScopeId:     prj.GetPublicId(),
+		Endpoint:    "tcp://127.0.0.1:22",
+	})
+	sess2 := session.TestSession(t, conn, wrapper, session.ComposedOf{
+		UserId:      uId,
+		HostId:      h.GetPublicId(),
+		TargetId:    tar.GetPublicId(),
+		HostSetId:   hs.GetPublicId(),
+		AuthTokenId: at.GetPublicId(),
+		ScopeId:     prj.GetPublicId(),
+		Endpoint:    "tcp://127.0.0.1:22",
+	})
+
+	repoToken := allocToken()
+	require.NoError(rw.LookupWhere(context.Background(), &repoToken, "token_hmac = ?", []interface{}{cs.outputToken.TokenHmac}))
+
+	r, err := newCredentialCleanupJob(rw)
+	require.NoError(err)
+
+	_, sess1Cred1 := testVaultCred(t, conn, v, cl, sess1, repoToken, ActiveCredential, 5*time.Hour)
+	_, sess1Cred2 := testVaultCred(t, conn, v, cl, sess1, repoToken, ActiveCredential, 5*time.Hour)
+	_, sess1Cred3 := testVaultCred(t, conn, v, cl, sess1, repoToken, ActiveCredential, 5*time.Hour)
+	_, sess2Cred := testVaultCred(t, conn, v, cl, sess2, repoToken, ActiveCredential, 5*time.Hour)
+
+	// No credentials should be cleaned up
+	err = r.Run(context.Background())
+	require.NoError(err)
+	assert.Equal(0, r.numCreds)
+
+	// Delete sess1
+	count, err := rw.Delete(context.Background(), sess1)
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	// Credentials are still in the revoke state so none should be deleted yet
+	err = r.Run(context.Background())
+	require.NoError(err)
+	assert.Equal(0, r.numCreds)
+
+	query, queryArgs := sess1Cred1.updateStatusQuery(RevokedCredential)
+	count, err = rw.Exec(context.Background(), query, queryArgs)
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	query, queryArgs = sess1Cred2.updateStatusQuery(ExpiredCredential)
+	count, err = rw.Exec(context.Background(), query, queryArgs)
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	query, queryArgs = sess1Cred3.updateStatusQuery(UnknownCredentialStatus)
+	count, err = rw.Exec(context.Background(), query, queryArgs)
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	query, queryArgs = sess2Cred.updateStatusQuery(RevokedCredential)
+	count, err = rw.Exec(context.Background(), query, queryArgs)
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	// Only the three credentials associated with the deleted session should be deleted
+	err = r.Run(context.Background())
+	require.NoError(err)
+	assert.Equal(3, r.numCreds)
+
+	// Session 1 creds should no longer exist
+	lookupCred := allocCredential()
+	lookupCred.PublicId = sess1Cred1.PublicId
+	require.Error(rw.LookupById(context.Background(), lookupCred))
+	lookupCred.PublicId = sess1Cred2.PublicId
+	require.Error(rw.LookupById(context.Background(), lookupCred))
+	lookupCred.PublicId = sess1Cred3.PublicId
+	require.Error(rw.LookupById(context.Background(), lookupCred))
+
+	// Session 2 creds should still exist but be revoked
+	lookupCred.PublicId = sess2Cred.PublicId
+	require.NoError(rw.LookupById(context.Background(), lookupCred))
+	assert.Equal(string(RevokedCredential), lookupCred.Status)
 }

--- a/internal/credential/vault/jobs_test.go
+++ b/internal/credential/vault/jobs_test.go
@@ -339,19 +339,7 @@ func TestTokenRenewalJob_Run(t *testing.T) {
 	v := NewTestVaultServer(t)
 
 	// Create 24 hour token
-	req := &vault.TokenCreateRequest{
-		DisplayName: t.Name(),
-		NoParent:    true,
-		Period:      "24h",
-		Policies:    []string{"default", "boundary-controller"},
-	}
-	vc := v.client(t).cl
-	secret, err := vc.Auth().Token().Create(req)
-	require.NoError(err)
-	require.NotNil(secret)
-	token, err := secret.TokenID()
-	require.NoError(err)
-	require.NotNil(token)
+	_, token := v.CreateToken(t, WithTokenPeriod(24*time.Hour))
 
 	in, err := NewCredentialStore(prj.GetPublicId(), v.Addr, []byte(token))
 	require.NoError(err)
@@ -461,18 +449,9 @@ func TestTokenRenewalJob_RunExpired(t *testing.T) {
 	v := NewTestVaultServer(t)
 
 	// Create 1s token so it expires in vault before we can renew it
-	req := &vault.TokenCreateRequest{
-		DisplayName: t.Name(),
-		NoParent:    true,
-		Period:      "1s",
-		Policies:    []string{"default", "boundary-controller"},
-	}
-	vc := v.client(t).cl
-	ct, err := vc.Auth().Token().Create(req)
-	require.NoError(err)
-	require.NotNil(ct)
+	_, ct := v.CreateToken(t, WithTokenPeriod(time.Second))
 
-	in, err := NewCredentialStore(prj.GetPublicId(), v.Addr, []byte(ct.Auth.ClientToken))
+	in, err := NewCredentialStore(prj.GetPublicId(), v.Addr, []byte(ct))
 	assert.NoError(err)
 	require.NotNil(in)
 

--- a/internal/credential/vault/query.go
+++ b/internal/credential/vault/query.go
@@ -133,9 +133,9 @@ update credential_vault_credential
    and status = 'active';
 `
 
-	revokedCredentialQuery = `
+	updateCredentialStatusByTokenQuery = `
 update credential_vault_credential
-   set status = 'revoked'
+   set status = ?
  where token_hmac = ?;
 `
 
@@ -169,5 +169,21 @@ update credential_vault_store
  where public_id = $1
    and delete_time is null
 returning *;
+`
+
+	credStoreCleanupWhereClause = `
+delete_time is not null
+   and public_id not in 
+   (
+     select store_id from credential_vault_token
+      where status = ?
+        and expiration_time > now()
+   )
+`
+
+	credCleanupQuery = `
+delete from credential_vault_credential 
+ where session_id is null
+   and status not in ('active', 'revoke')
 `
 )

--- a/internal/credential/vault/store/vault.pb.go
+++ b/internal/credential/vault/store/vault.pb.go
@@ -616,12 +616,10 @@ type Credential struct {
 	PublicId string `protobuf:"bytes,1,opt,name=public_id,json=publicId,proto3" json:"public_id,omitempty" gorm:"primary_key"`
 	// library_id of the owning vault credential library.
 	// It must be set.
-	// @inject_tag: `gorm:"not_null"`
-	LibraryId string `protobuf:"bytes,2,opt,name=library_id,json=libraryId,proto3" json:"library_id,omitempty" gorm:"not_null"`
+	LibraryId string `protobuf:"bytes,2,opt,name=library_id,json=libraryId,proto3" json:"library_id,omitempty"`
 	// session_id of the session the credential was created for.
 	// It must be set.
-	// @inject_tag: `gorm:"not_null"`
-	SessionId string `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" gorm:"not_null"`
+	SessionId string `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	// token_hmac is the foreign key of the token used to acquire the secret.
 	// @inject_tag: `gorm:"not_null"`
 	TokenHmac []byte `protobuf:"bytes,4,opt,name=token_hmac,json=tokenHmac,proto3" json:"token_hmac,omitempty" gorm:"not_null"`

--- a/internal/db/domains_test.go
+++ b/internal/db/domains_test.go
@@ -1045,3 +1045,86 @@ select wt_to_sentinel($1);
 		})
 	}
 }
+
+func TestDomain_not_null_columns_func(t *testing.T) {
+	const (
+		createTable = `
+create table if not exists test_not_null_columns (
+  id bigint generated always as identity primary key,
+  one text,
+  two text,
+  three text
+);
+`
+		addTriggers = `
+create trigger
+  test_insert_not_null_columns
+before
+insert on test_not_null_columns
+  for each row execute procedure not_null_columns('one', 'two');
+`
+		dropTriggers = `drop trigger test_insert_not_null_columns on test_not_null_columns`
+	)
+
+	type rowData struct {
+		Id    int
+		Two   string
+		Three string
+	}
+
+	conn, _ := TestSetup(t, "postgres")
+	db := conn.DB()
+	_, err := db.Exec(createTable)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		stmt    string
+		wantErr bool
+	}{
+		{
+			name:    "null one",
+			stmt:    "insert into test_not_null_columns (one, two, three) values (null, 'two', 'three');",
+			wantErr: true,
+		},
+		{
+			name:    "null two",
+			stmt:    "insert into test_not_null_columns (one, two, three) values ('one', null, 'three');",
+			wantErr: true,
+		},
+		{
+			name:    "all null",
+			stmt:    "insert into test_not_null_columns (one, two, three) values (null, null, null);",
+			wantErr: true,
+		},
+		{
+			name:    "null three",
+			stmt:    "insert into test_not_null_columns (one, two, three) values ('one', 'two', null);",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			require, assert := require.New(t), assert.New(t)
+
+			_, err = db.Exec(addTriggers)
+			require.NoError(err)
+
+			_, err = db.Exec(tt.stmt)
+
+			if !tt.wantErr {
+				assert.NoError(err)
+				return
+			}
+			require.Error(err)
+
+			// Drop trigger and run insert again, it should now insert successfully
+			_, err = db.Exec(dropTriggers)
+			assert.NoError(err)
+
+			_, err = db.Exec(tt.stmt)
+			assert.NoError(err)
+		})
+	}
+}

--- a/internal/db/domains_test.go
+++ b/internal/db/domains_test.go
@@ -1066,12 +1066,6 @@ insert on test_not_null_columns
 		dropTriggers = `drop trigger test_insert_not_null_columns on test_not_null_columns`
 	)
 
-	type rowData struct {
-		Id    int
-		Two   string
-		Three string
-	}
-
 	conn, _ := TestSetup(t, "postgres")
 	db := conn.DB()
 	_, err := db.Exec(createTable)

--- a/internal/db/read_writer.go
+++ b/internal/db/read_writer.go
@@ -1014,9 +1014,12 @@ func (rw *Db) LookupWhere(_ context.Context, resource interface{}, where string,
 }
 
 // SearchWhere will search for all the resources it can find using a where
-// clause with parameters.  Supports the WithLimit option.  If
-// WithLimit < 0, then unlimited results are returned.  If WithLimit == 0, then
-// default limits are used for results.  Supports the WithOrder option.
+// clause with parameters.  Note parameters must be provided, if len(args) == 0
+// the where clause will not be applied.
+//
+//Supports the WithLimit option.  If WithLimit < 0, then unlimited results are returned.
+// If WithLimit == 0, then default limits are used for results.
+// Supports the WithOrder option.
 func (rw *Db) SearchWhere(_ context.Context, resources interface{}, where string, args []interface{}, opt ...Option) error {
 	const op = "db.SearchWhere"
 	opts := GetOpts(opt...)

--- a/internal/db/schema/migrations/postgres/12/03_vault_credential.down.sql
+++ b/internal/db/schema/migrations/postgres/12/03_vault_credential.down.sql
@@ -19,6 +19,7 @@ begin;
   drop table credential_vault_token_status_enm;
   drop table credential_vault_store;
 
+  drop function update_credential_status_column;
   drop function insert_credential_vault_token;
   drop function after_soft_delete_credential_vault_store;
   drop function before_soft_delete_credential_vault_store;

--- a/internal/db/schema/postgres_migration.gen.go
+++ b/internal/db/schema/postgres_migration.gen.go
@@ -5668,15 +5668,15 @@ create table credential_vault_store (
 
   create table credential_vault_credential (
     public_id wt_public_id primary key,
-    library_id wt_public_id not null
+    library_id wt_public_id
       constraint credential_vault_library_fkey
         references credential_vault_library (public_id)
-        on delete cascade
+        on delete set null
         on update cascade,
-    session_id wt_public_id not null
+    session_id wt_public_id
       constraint session_fkey
         references session (public_id)
-        on delete cascade
+        on delete set null
         on update cascade,
     token_hmac bytea not null
       constraint credential_vault_token_fkey
@@ -5714,11 +5714,30 @@ create table credential_vault_store (
   create trigger update_time_column before update on credential_vault_credential
     for each row execute procedure update_time_column();
 
+  -- update_credential_status_column() is a before update trigger function for
+  -- credential_vault_credential that changes the status of the credential to 'revoke' if
+  -- the session_id is updated to null
+  create function update_credential_status_column()
+      returns trigger
+  as $$
+  begin
+    if new.session_id is distinct from old.session_id then
+      if new.session_id is null and old.status = 'active' then
+        new.status = 'revoke';
+      end if;
+    end if;
+    return new;
+  end;
+  $$ language plpgsql;
+
+  create trigger update_credential_status_column before update on credential_vault_credential
+    for each row execute procedure update_credential_status_column();
+
   create trigger default_create_time_column before insert on credential_vault_credential
     for each row execute procedure default_create_time();
 
   create trigger immutable_columns before update on credential_vault_credential
-    for each row execute procedure immutable_columns('external_id', 'library_id','session_id', 'create_time');
+    for each row execute procedure immutable_columns('external_id', 'create_time');
 
   create trigger insert_credential_dynamic_subtype before insert on credential_vault_credential
     for each row execute procedure insert_credential_dynamic_subtype();

--- a/internal/db/schema/postgres_migration.gen.go
+++ b/internal/db/schema/postgres_migration.gen.go
@@ -5733,6 +5733,36 @@ create table credential_vault_store (
   create trigger update_credential_status_column before update on credential_vault_credential
     for each row execute procedure update_credential_status_column();
 
+  -- not_null_columns() will make the column names not null which are passed as
+  -- parameters when the trigger is created. It raises error code 23502 which is a
+  -- class 23 integrity constraint violation: not null column
+  create function not_null_columns()
+    returns trigger
+  as $$
+  declare
+      col_name  text;
+      new_value text;
+  begin
+      foreach col_name in array tg_argv loop
+              execute format('SELECT $1.%I', col_name) into new_value using new;
+              if new_value is null then
+                  raise exception 'not null column: %.%', tg_table_name, col_name using
+                      errcode = '23502',
+                      schema = tg_table_schema,
+                      table = tg_table_name,
+                      column = col_name;
+              end if;
+          end loop;
+      return new;
+  end;
+  $$ language plpgsql;
+
+  comment on function not_null_columns() is
+    'function used in before insert triggers to make columns not null on insert, but are allowed be updated to null';
+
+  create trigger not_null_columns before insert on credential_vault_credential
+      for each row execute procedure not_null_columns('library_id', 'session_id');
+
   create trigger default_create_time_column before insert on credential_vault_credential
     for each row execute procedure default_create_time();
 

--- a/internal/proto/local/controller/storage/credential/vault/store/v1/vault.proto
+++ b/internal/proto/local/controller/storage/credential/vault/store/v1/vault.proto
@@ -214,12 +214,10 @@ message Credential {
 
   // library_id of the owning vault credential library.
   // It must be set.
-  // @inject_tag: `gorm:"not_null"`
   string library_id = 2;
 
   // session_id of the session the credential was created for.
   // It must be set.
-  // @inject_tag: `gorm:"not_null"`
   string session_id = 3;
 
   // token_hmac is the foreign key of the token used to acquire the secret.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -197,7 +197,7 @@ func TestScheduler_RegisterJob(t *testing.T) {
 		{
 			name: "valid",
 			job: testJob{
-				name:        "name",
+				name:        "valid",
 				description: "description",
 			},
 		},
@@ -259,7 +259,7 @@ func TestScheduler_RegisterJob(t *testing.T) {
 	t.Run("multiple-schedulers-registering-same-job", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
 		tj := testJob{
-			name:        "name",
+			name:        "multiple-schedulers-registering-same-job",
 			description: "description",
 		}
 		err := sched.RegisterJob(context.Background(), tj)


### PR DESCRIPTION
### What does this PR do

- Allows library_id and session_id to be null on a credential
- On delete set null on both library_id and session_id instead of cascade
- Adds a trigger to set status to revoke when moving to null session_id
- Adds job to delete cred stores that are soft deleted and have no active tokens
- Adds job to delete credentials that have been soft deleted and are not active