### PR TITLE
Validate current vault token on addr update

### DIFF
--- a/internal/credential/vault/supported.go
+++ b/internal/credential/vault/supported.go
@@ -113,7 +113,7 @@ func gotNewServer(t *testing.T, opt ...TestOption) *TestVaultServer {
 		dockerOptions.Mounts = append(dockerOptions.Mounts, fmt.Sprintf("%s:/vault/config/certificates", dataSrcDir))
 
 		if opts.vaultTLS == TestClientTLS {
-			clientCert := testClientCert(t, testCaCert(t))
+			clientCert := testClientCert(t, testCaCert(t), opt...)
 			server.clientCertBundle = clientCert
 			server.ClientCert = clientCert.Cert.Cert
 			server.ClientKey = clientCert.Cert.Key

--- a/internal/credential/vault/testing_test.go
+++ b/internal/credential/vault/testing_test.go
@@ -509,3 +509,34 @@ func TestTestVaultServer_VerifyTokenInvalid(t *testing.T) {
 	// Verify fake token is not valid
 	v.VerifyTokenInvalid(t, "fake-token")
 }
+
+func Test_testClientCert(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+
+	cert := testClientCert(t, testCaCert(t))
+	require.NotNil(cert)
+	assert.NotEmpty(cert.Cert.Cert)
+	assert.NotEmpty(cert.Cert.Key)
+
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(err)
+
+	cert1 := testClientCert(t, testCaCert(t), WithClientKey(key))
+	require.NotNil(cert1)
+	assert.NotEmpty(cert1.Cert.Cert)
+	assert.NotEmpty(cert1.Cert.Key)
+
+	// cert and cert1 should have different certs and keys
+	assert.NotEqual(cert1.Cert.Cert, cert.Cert.Cert)
+	assert.NotEqual(cert1.Cert.Key, cert.Cert.Key)
+
+	// Generate new cert with same key as cert1
+	cert2 := testClientCert(t, testCaCert(t), WithClientKey(key))
+	require.NotNil(cert2)
+	assert.NotEmpty(cert2.Cert.Cert)
+	assert.NotEmpty(cert2.Cert.Key)
+
+	// cert1 and cert2 should have different certs but the same key
+	assert.NotEqual(cert1.Cert.Cert, cert2.Cert.Cert)
+	assert.Equal(cert1.Cert.Key, cert2.Cert.Key)
+}


### PR DESCRIPTION
### What does this PR do

Validates current token when there is an address change
Validates client cert / key is valid on change
Adds WithClientKey TestOption, this option was needed to allow the test where we change a cert but not a key, since this is validated now it was failing.