### PR TITLE
website: upgrade react-head

### DIFF
--- a/website/components/openapi-page/index.jsx
+++ b/website/components/openapi-page/index.jsx
@@ -1,7 +1,6 @@
 import { useState, useRef } from 'react'
 import Link from 'next/link'
 import OperationObject from './partials/operation-object'
-import Head from 'next/head'
 import HashiHead from '@hashicorp/react-head'
 import DocsSidenav from '@hashicorp/react-docs-sidenav'
 import Content from '@hashicorp/react-content'
@@ -32,7 +31,6 @@ function OpenApiPage({
   return (
     <div className={styles.root} data-theme={productSlug}>
       <HashiHead
-        is={Head}
         title={`${pageTitle} | ${productName} by HashiCorp`}
         description={info.description}
         siteName={`${productName} by HashiCorp`}

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2154,9 +2154,9 @@
       }
     },
     "@hashicorp/react-head": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-2.0.0.tgz",
-      "integrity": "sha512-3xmaf7cU1lCUS/hgnpqokUw731xAPR51q5rCLuazMtSVasjnGqqoFSQfkQRycllUiCGG/GiMYSaBCY+WlwQXTQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.1.0.tgz",
+      "integrity": "sha512-tXfxi9Aqhx83p6wt753WfiYUhOEMzrsWKON200zsNFdwN2WkHPwArWbR6+ludVXleEmsBufL8GRYq7iqnnKKlQ=="
     },
     "@hashicorp/react-hero": {
       "version": "7.2.1",

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,7 @@
     "@hashicorp/react-content": "7.0.1",
     "@hashicorp/react-docs-page": "13.2.0",
     "@hashicorp/react-hashi-stack-menu": "2.0.3",
-    "@hashicorp/react-head": "2.0.0",
+    "@hashicorp/react-head": "3.1.0",
     "@hashicorp/react-hero": "7.2.1",
     "@hashicorp/react-image": "4.0.0",
     "@hashicorp/react-product-downloader": "8.0.0",

--- a/website/pages/_app.js
+++ b/website/pages/_app.js
@@ -6,7 +6,6 @@ import useAnchorLinkAnalytics from '@hashicorp/nextjs-scripts/lib/anchor-link-an
 import HashiStackMenu from '@hashicorp/react-hashi-stack-menu'
 import Router from 'next/router'
 import HashiHead from '@hashicorp/react-head'
-import Head from 'next/head'
 import { ErrorBoundary } from '@hashicorp/nextjs-scripts/lib/bugsnag'
 import ProductSubnav from '../components/subnav'
 import Footer from 'components/footer'
@@ -29,7 +28,6 @@ export default function App({ Component, pageProps }) {
   return (
     <ErrorBoundary FallbackComponent={Error}>
       <HashiHead
-        is={Head}
         title={title}
         siteName={title}
         description={description}

--- a/website/pages/_document.js
+++ b/website/pages/_document.js
@@ -10,7 +10,9 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html>
-        <HashiHead is={Head} />
+        <Head>
+          <HashiHead />
+        </Head>
         <body>
           <Main />
           <NextScript />

--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -1,5 +1,4 @@
 import { VERSION, DESKTOP_VERSION } from 'data/version.js'
-import Head from 'next/head'
 import HashiHead from '@hashicorp/react-head'
 import { productName, productSlug } from 'data/metadata'
 import ProductDownloader from '@hashicorp/react-product-downloader'
@@ -11,7 +10,7 @@ const DESKTOP_BINARY_SLUG = 'boundary-desktop'
 export default function DownloadsPage({ binaryReleases, desktopReleases }) {
   return (
     <div className={styles.root}>
-      <HashiHead is={Head} title={`Downloads | ${productName} by HashiCorp`} />
+      <HashiHead title={`Downloads | ${productName} by HashiCorp`} />
       <ProductDownloader
         releases={binaryReleases}
         packageManagers={[


### PR DESCRIPTION
[Preview](https://boundary-po1gn88uf-hashicorp.vercel.app/)

Upgrading `react-head` and dependencies to set the new Safari theme-color feature.

[_Created by Sourcegraph campaign `kstraut/upgrade-react-head`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/upgrade-react-head)

**After**
<img width="1255" alt="Screen Shot 2021-06-25 at 9 07 58 AM" src="https://user-images.githubusercontent.com/36613477/123454023-f3f92680-d594-11eb-892d-36ab35f1900e.png">

**Before**
<img width="1256" alt="Screen Shot 2021-06-25 at 9 08 31 AM" src="https://user-images.githubusercontent.com/36613477/123454033-f5c2ea00-d594-11eb-9d1f-f85c0123bcde.png">
