### PR TITLE
internal/credential/vault: fix dropped error

### DIFF
--- a/internal/credential/vault/testing.go
+++ b/internal/credential/vault/testing.go
@@ -196,6 +196,7 @@ func createTestToken(t *testing.T, conn *gorm.DB, wrapper wrapping.Wrapper, scop
 	ctx := context.Background()
 	kkms := kms.TestKms(t, conn, wrapper)
 	databaseWrapper, err := kkms.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
+	require.NoError(t, err)
 
 	inToken, err := newToken(storeId, []byte(token), []byte(accessor), 5*time.Minute)
 	assert.NoError(t, err)


### PR DESCRIPTION
This fixes a dropped `err` variable in `internal/credential/vault`.