### PR TITLE
worker: ensure connections are closed in local state on controller fail

### DIFF
--- a/internal/servers/worker/session.go
+++ b/internal/servers/worker/session.go
@@ -267,17 +267,35 @@ func (w *Worker) closeConnections(ctx context.Context, closeInfo map[string]stri
 	}
 
 	w.logger.Trace("marking connections as closed", "session_and_connection_ids", fmt.Sprintf("%#v", closeInfo))
-	response, err := w.closeConnection(ctx, w.makeCloseConnectionRequest(closeInfo))
+
+	// How we handle close info depends on whether or not we succeeded with
+	// marking them closed on the controller.
+	var sessionCloseInfo map[string][]*pbs.CloseConnectionResponseData
+
+	// TODO: This, along with the status call to the controller, probably needs a
+	// bit of formalization in terms of how we handle timeouts. For now, this
+	// just ensures consistency with the same status call in that it times out
+	// within an adequate period of time.
+	closeConnCtx, closeConnCancel := context.WithTimeout(ctx, statusTimeout)
+	defer closeConnCancel()
+	response, err := w.closeConnection(closeConnCtx, w.makeCloseConnectionRequest(closeInfo))
 	if err != nil {
 		w.logger.Error("error marking connections closed", "error", err)
 		w.logger.Warn(
 			"error contacting controller, connections will be closed only on worker",
 			"session_and_connection_ids", fmt.Sprintf("%#v", closeInfo),
 		)
+
+		// Since we could not reach the controller, we have to make a "fake" response set.
+		sessionCloseInfo = w.makeFakeSessionCloseInfo(closeInfo)
+	} else {
+		// Connection succeeded, so we can proceed with making the sessionCloseInfo
+		// off of the response data.
+		sessionCloseInfo = w.makeSessionCloseInfo(closeInfo, response)
 	}
 
 	// Mark connections as closed
-	closedIds, errs := w.setCloseTimeForResponse(w.makeSessionCloseInfo(closeInfo, response))
+	closedIds, errs := w.setCloseTimeForResponse(sessionCloseInfo)
 	if len(errs) > 0 {
 		for _, err := range errs {
 			w.logger.Error("error marking connection closed in state", "err", err)
@@ -326,6 +344,28 @@ func (w *Worker) makeSessionCloseInfo(
 	result := make(map[string][]*pbs.CloseConnectionResponseData)
 	for _, v := range response.GetCloseResponseData() {
 		result[closeInfo[v.GetConnectionId()]] = append(result[closeInfo[v.GetConnectionId()]], v)
+	}
+
+	return result
+}
+
+// makeFakeSessionCloseInfo makes a "fake" makeFakeSessionCloseInfo, intended
+// for use when we can't contact the controller.
+func (w *Worker) makeFakeSessionCloseInfo(
+	closeInfo map[string]string,
+) map[string][]*pbs.CloseConnectionResponseData {
+	if closeInfo == nil {
+		// Should never happen, panic if it does. Results will be
+		// undefined.
+		panic(errMakeSessionCloseInfoNilCloseInfo)
+	}
+
+	result := make(map[string][]*pbs.CloseConnectionResponseData)
+	for connectionId, sessionId := range closeInfo {
+		result[sessionId] = append(result[sessionId], &pbs.CloseConnectionResponseData{
+			ConnectionId: connectionId,
+			Status:       pbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CLOSED,
+		})
 	}
 
 	return result

--- a/internal/servers/worker/session_test.go
+++ b/internal/servers/worker/session_test.go
@@ -41,22 +41,25 @@ func TestMakeSessionCloseInfo(t *testing.T) {
 			{ConnectionId: "bar", Status: pbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CLOSED},
 		},
 	}
-	actual := new(Worker).makeSessionCloseInfo(closeInfo, response)
+	actual, err := new(Worker).makeSessionCloseInfo(closeInfo, response)
+	require.NoError(err)
 	require.Equal(expected, actual)
 }
 
-func TestMakeSessionCloseInfoPanicIfCloseInfoNil(t *testing.T) {
+func TestMakeSessionCloseInfoErrorIfCloseInfoNil(t *testing.T) {
 	require := require.New(t)
-	require.Panics(func() {
-		new(Worker).makeSessionCloseInfo(nil, nil)
-	})
+	actual, err := new(Worker).makeSessionCloseInfo(nil, nil)
+	require.Nil(actual)
+	require.ErrorIs(err, errMakeSessionCloseInfoNilCloseInfo)
 }
 
 func TestMakeSessionCloseInfoEmpty(t *testing.T) {
 	require := require.New(t)
+	actual, err := new(Worker).makeSessionCloseInfo(make(map[string]string), nil)
+	require.NoError(err)
 	require.Equal(
 		make(map[string][]*pbs.CloseConnectionResponseData),
-		new(Worker).makeSessionCloseInfo(make(map[string]string), nil),
+		actual,
 	)
 }
 
@@ -71,22 +74,25 @@ func TestMakeFakeSessionCloseInfo(t *testing.T) {
 			{ConnectionId: "bar", Status: pbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CLOSED},
 		},
 	}
-	actual := new(Worker).makeFakeSessionCloseInfo(closeInfo)
+	actual, err := new(Worker).makeFakeSessionCloseInfo(closeInfo)
+	require.NoError(err)
 	require.Equal(expected, actual)
 }
 
 func TestMakeFakeSessionCloseInfoPanicIfCloseInfoNil(t *testing.T) {
 	require := require.New(t)
-	require.Panics(func() {
-		new(Worker).makeFakeSessionCloseInfo(nil)
-	})
+	actual, err := new(Worker).makeFakeSessionCloseInfo(nil)
+	require.Nil(actual)
+	require.ErrorIs(err, errMakeSessionCloseInfoNilCloseInfo)
 }
 
 func TestMakeFakeSessionCloseInfoEmpty(t *testing.T) {
 	require := require.New(t)
+	actual, err := new(Worker).makeFakeSessionCloseInfo(make(map[string]string))
+	require.NoError(err)
 	require.Equal(
 		make(map[string][]*pbs.CloseConnectionResponseData),
-		new(Worker).makeFakeSessionCloseInfo(make(map[string]string)),
+		actual,
 	)
 }
 

--- a/internal/servers/worker/session_test.go
+++ b/internal/servers/worker/session_test.go
@@ -60,6 +60,36 @@ func TestMakeSessionCloseInfoEmpty(t *testing.T) {
 	)
 }
 
+func TestMakeFakeSessionCloseInfo(t *testing.T) {
+	require := require.New(t)
+	closeInfo := map[string]string{"foo": "one", "bar": "two"}
+	expected := map[string][]*pbs.CloseConnectionResponseData{
+		"one": {
+			{ConnectionId: "foo", Status: pbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CLOSED},
+		},
+		"two": {
+			{ConnectionId: "bar", Status: pbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CLOSED},
+		},
+	}
+	actual := new(Worker).makeFakeSessionCloseInfo(closeInfo)
+	require.Equal(expected, actual)
+}
+
+func TestMakeFakeSessionCloseInfoPanicIfCloseInfoNil(t *testing.T) {
+	require := require.New(t)
+	require.Panics(func() {
+		new(Worker).makeFakeSessionCloseInfo(nil)
+	})
+}
+
+func TestMakeFakeSessionCloseInfoEmpty(t *testing.T) {
+	require := require.New(t)
+	require.Equal(
+		make(map[string][]*pbs.CloseConnectionResponseData),
+		new(Worker).makeFakeSessionCloseInfo(make(map[string]string)),
+	)
+}
+
 func TestWorkerSetCloseTimeForResponse(t *testing.T) {
 	cases := []struct {
 		name             string

--- a/internal/servers/worker/status.go
+++ b/internal/servers/worker/status.go
@@ -16,7 +16,7 @@ import (
 // In the future we could make this configurable
 const (
 	statusInterval           = 2 * time.Second
-	statusTimeout            = 10 * time.Second
+	statusTimeout            = 3 * time.Second
 	defaultStatusGracePeriod = 30 * time.Second
 	statusGracePeriodEnvVar  = "BOUNDARY_STATUS_GRACE_PERIOD"
 )

--- a/internal/servers/worker/status.go
+++ b/internal/servers/worker/status.go
@@ -16,7 +16,7 @@ import (
 // In the future we could make this configurable
 const (
 	statusInterval           = 2 * time.Second
-	statusTimeout            = 3 * time.Second
+	statusTimeout            = 5 * time.Second
 	defaultStatusGracePeriod = 30 * time.Second
 	statusGracePeriodEnvVar  = "BOUNDARY_STATUS_GRACE_PERIOD"
 )

--- a/internal/servers/worker/testing_test.go
+++ b/internal/servers/worker/testing_test.go
@@ -1,0 +1,61 @@
+package worker
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	pbs "github.com/hashicorp/boundary/internal/gen/controller/servers/services"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestWorkerLookupSession(t *testing.T) {
+	require := require.New(t)
+	// This loads the golang reference time, see those docs for more details. We
+	// just use this as a stable non-zero time.
+	refTime, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05+07:00")
+	require.NoError(err)
+
+	tw := new(TestWorker)
+	tw.w = &Worker{
+		sessionInfoMap: new(sync.Map),
+	}
+	tw.w.sessionInfoMap.Store("foo", &sessionInfo{
+		id:     "foo",
+		status: pbs.SESSIONSTATUS_SESSIONSTATUS_ACTIVE,
+		connInfoMap: map[string]*connInfo{
+			"one": &connInfo{
+				id:        "one",
+				status:    pbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CLOSED,
+				closeTime: refTime,
+			},
+		},
+	})
+
+	expected := TestSessionInfo{
+		Id:     "foo",
+		Status: pbs.SESSIONSTATUS_SESSIONSTATUS_ACTIVE,
+		Connections: map[string]TestConnectionInfo{
+			"one": TestConnectionInfo{
+				Id:        "one",
+				Status:    pbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CLOSED,
+				CloseTime: refTime,
+			},
+		},
+	}
+
+	actual, ok := tw.LookupSession("foo")
+	require.True(ok)
+	require.Equal(expected, actual)
+}
+
+func TestTestWorkerLookupSessionMissing(t *testing.T) {
+	require := require.New(t)
+	tw := new(TestWorker)
+	tw.w = &Worker{
+		sessionInfoMap: new(sync.Map),
+	}
+	actual, ok := tw.LookupSession("missing")
+	require.False(ok)
+	require.Equal(TestSessionInfo{}, actual)
+}

--- a/internal/session/connection_state.go
+++ b/internal/session/connection_state.go
@@ -19,9 +19,10 @@ const (
 type ConnectionStatus string
 
 const (
-	StatusAuthorized ConnectionStatus = "authorized"
-	StatusConnected  ConnectionStatus = "connected"
-	StatusClosed     ConnectionStatus = "closed"
+	StatusAuthorized  ConnectionStatus = "authorized"
+	StatusConnected   ConnectionStatus = "connected"
+	StatusClosed      ConnectionStatus = "closed"
+	StatusUnspecified ConnectionStatus = "unspecified" // Utility state not valid in the DB
 )
 
 // String representation of the state's status
@@ -40,6 +41,20 @@ func (s ConnectionStatus) ProtoVal() workerpbs.CONNECTIONSTATUS {
 		return workerpbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CLOSED
 	}
 	return workerpbs.CONNECTIONSTATUS_CONNECTIONSTATUS_UNSPECIFIED
+}
+
+// ConnectionStatusFromProtoVal is the reverse of
+// ConnectionStatus.ProtoVal.
+func ConnectionStatusFromProtoVal(s workerpbs.CONNECTIONSTATUS) ConnectionStatus {
+	switch s {
+	case workerpbs.CONNECTIONSTATUS_CONNECTIONSTATUS_AUTHORIZED:
+		return StatusAuthorized
+	case workerpbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CONNECTED:
+		return StatusConnected
+	case workerpbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CLOSED:
+		return StatusClosed
+	}
+	return StatusUnspecified
 }
 
 // ConnectionState of the state of the connection


### PR DESCRIPTION
This backports some test work that is being added in #1340 to assert
that the worker is actually marking connections closed in its *local*
state on a failure to contact the controller. This was missed in #1357
during some late-stage refactoring.

Summary of the changes:

* If we can't actually contact the controller during connection closure
to mark the connections as closed, we actually construct a "fake"
response that just simply includes a closed state for all connections
requested. This is then used to update the local connection state.

* Added a 3 second timeout to the CloseConnection request to the
controller to ensure the call to close connections completed in a
timely manner and did not hang indefinitely.

Testing enhancements:

* Added a new helper in TestHelper called LookupSession that allows the
lookup of a session from the worker's internal session state.

* This is used in the new ExpectConnectionStateOnWorker check in the E2E
test, which is part of a larger amount of enhancements to the E2E test
that are coming in #1340.

* Added a ConnectionStatusFromProtoVal helper function to the session
package to allow the conversion of protobuf connection status values to
their higher-level counterparts; essentially it is a reverse of
ConnectionStatus.ProtoVal. This is used in some of our tests (with more
coming in #1340) to just help with keeping things more idiomatic.