### PR TITLE
internal/servers/worker: actually return when aborting closeConnections

### DIFF
--- a/internal/servers/worker/session.go
+++ b/internal/servers/worker/session.go
@@ -296,7 +296,8 @@ func (w *Worker) closeConnections(ctx context.Context, closeInfo map[string]stri
 
 	if err != nil {
 		w.logger.Error(err.Error())
-		w.logger.Error("serious error in processing return data from controller, aborting marking connections as closed")
+		w.logger.Error("serious error in processing return data from controller, aborting additional session/connection state modification")
+		return
 	}
 
 	// Mark connections as closed

--- a/internal/servers/worker/session_test.go
+++ b/internal/servers/worker/session_test.go
@@ -79,7 +79,7 @@ func TestMakeFakeSessionCloseInfo(t *testing.T) {
 	require.Equal(expected, actual)
 }
 
-func TestMakeFakeSessionCloseInfoPanicIfCloseInfoNil(t *testing.T) {
+func TestMakeFakeSessionCloseInfoErrorIfCloseInfoNil(t *testing.T) {
 	require := require.New(t)
 	actual, err := new(Worker).makeFakeSessionCloseInfo(nil)
 	require.Nil(actual)


### PR DESCRIPTION
This adds a return when aborting from closeConnections, which should
have happened as a part of #1369.

Note that it's currently inconsequential that it's not happening right
now, save some misleading log entries. setCloseTimeForResponse will
effectively no-op on empty or nil input maps.