### PR TITLE
[Website] Bump hashi-stack-menu

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2138,9 +2138,9 @@
       "integrity": "sha512-a2eWgjLwGAC2LjUHE7Xt6sRGGjyTWfrc4N+qVxsyZw4eE0EiNhMIKDYHWjmtb+tGh8r8j+ca3tSjsuOUePVPUw=="
     },
     "@hashicorp/react-hashi-stack-menu": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-2.0.3.tgz",
-      "integrity": "sha512-aDZTDxaoptY4F+iyn05Vfp7HvzIBuhCTxSIPREipd9OUfh4KhgN1aZfFyUHULJPznKnbcZgW9k8bbK4AIYf5Pg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-2.0.5.tgz",
+      "integrity": "sha512-Oxr+rBF6fyhc73IM2vqCwepab6t0OCWxIWECpxD5tTD1CtGgkNjDg5PVMSJ5sIeoNTGcKzlW/rcmT30owezVnQ==",
       "requires": {
         "@hashicorp/react-inline-svg": "^1.0.2",
         "slugify": "1.3.4"

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "@hashicorp/react-button": "5.0.0",
     "@hashicorp/react-content": "7.0.1",
     "@hashicorp/react-docs-page": "13.2.0",
-    "@hashicorp/react-hashi-stack-menu": "2.0.3",
+    "@hashicorp/react-hashi-stack-menu": "2.0.5",
     "@hashicorp/react-head": "3.1.0",
     "@hashicorp/react-hero": "7.2.1",
     "@hashicorp/react-image": "4.0.0",


### PR DESCRIPTION
[:mag: Preview link](https://boundary-5yt0rrijt-hashicorp.vercel.app/)

---

This PR bumps `<HashiStackMenu />` to `2.0.5`, removing the "About" link.