### PR TITLE
Adding support to build multi-arch Boundary images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   ([issue](https://github.com/hashicorp/boundary/issues/1305),
   [PR](https://github.com/hashicorp/boundary/pull/1384))
 
+### New and Improved
+
+* docker: Add support for muti-arch docker images (amd64/arm64) via Docker buildx
+
 ## 0.4.0 (2021/06/29)
 
 ### New and Improved

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,16 @@ docker-build:
 	-f $(DOCKER_DIR)/Release.dockerfile docker/ 
 	docker tag $(IMAGE_TAG) hashicorp/boundary:latest
 
+# builds multiarch from releases.hashicorp.com official binary
+docker-multiarch-build:
+ 	docker buildx build \
+	--push \
+	--tag $(IMAGE_TAG) \
+	--tag hashicorp/boundary:latest \
+	--build-arg VERSION=$(VERSION) \
+	--platform linux/amd64,linux/arm64 \
+	--file $(DOCKER_DIR)/Release.dockerfile .
+	
 # builds from locally generated binary in bin/
 docker-build-dev: export XC_OSARCH=linux/amd64
 docker-build-dev: dev

--- a/docker/Release.dockerfile
+++ b/docker/Release.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM docker.mirror.hashicorp.services/alpine:3.13
 
 ARG VERSION=0.4.0
 

--- a/docker/Release.dockerfile
+++ b/docker/Release.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirror.hashicorp.services/alpine:3.10
+FROM alpine:3.13
 
 ARG VERSION=0.4.0
 
@@ -10,32 +10,31 @@ LABEL name="Boundary" \
       summary="Boundary provides simple and secure access to hosts and services" \
       description="The Boundary Docker image is designed to enable practitioners to run Boundary in server mode on a container scheduler"
 
-RUN addgroup boundary && \
-    adduser -s /bin/sh -S -G boundary boundary
-
-ADD https://releases.hashicorp.com/boundary/${VERSION}/boundary_${VERSION}_linux_amd64.zip /tmp/
-ADD https://releases.hashicorp.com/boundary/${VERSION}/boundary_${VERSION}_SHA256SUMS /tmp/
-ADD https://releases.hashicorp.com/boundary/${VERSION}/boundary_${VERSION}_SHA256SUMS.sig /tmp/ 
-
-RUN apk add --no-cache ca-certificates gnupg openssl libcap su-exec dumb-init tzdata 
-RUN cd /tmp/ && \
-    BUILD_GPGKEY=C874011F0AB405110D02105534365D9472D7468F; \
-    found=''; \
-    for server in \
-        hkp://p80.pool.sks-keyservers.net:80 \
-        hkp://keyserver.ubuntu.com:80 \
-        hkp://pgp.mit.edu:80 \
-    ; do \
-        echo "Fetching GPG key $BUILD_GPGKEY from $server"; \
-        gpg --keyserver "$server" --recv-keys "$BUILD_GPGKEY" && found=yes && break; \
-    done; \
-    test -z "$found" && echo >&2 "error: failed to fetch GPG key $BUILD_GPGKEY" && exit 1; \
+RUN set -eux && \
+    addgroup boundary && \
+    adduser -s /bin/sh -S -G boundary boundary && \
+    apk add --no-cache wget ca-certificates dumb-init gnupg libcap openssl su-exec iputils libc6-compat iptables && \
+    gpg --keyserver keyserver.ubuntu.com --recv-keys C874011F0AB405110D02105534365D9472D7468F && \
+    cd /tmp && \
+    apkArch="$(apk --print-arch)" && \
+    case "${apkArch}" in \
+        aarch64) boundaryArch='arm64' ;; \
+        armhf) boundaryArch='armhfv6' ;; \
+        x86) boundaryArch='386' ;; \
+        x86_64) boundaryArch='amd64' ;; \
+        *) echo >&2 "error: unsupported architecture: ${apkArch} (see https://releases.hashicorp.com/boundary/${VERSION}/ )" && exit 1 ;; \
+    esac && \
+    wget https://releases.hashicorp.com/boundary/${VERSION}/boundary_${VERSION}_linux_${boundaryArch}.zip && \
+    wget https://releases.hashicorp.com/boundary/${VERSION}/boundary_${VERSION}_SHA256SUMS && \
+    wget https://releases.hashicorp.com/boundary/${VERSION}/boundary_${VERSION}_SHA256SUMS.sig && \
     gpg --batch --verify boundary_${VERSION}_SHA256SUMS.sig boundary_${VERSION}_SHA256SUMS && \
-    grep boundary_${VERSION}_linux_amd64.zip boundary_${VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip -d /bin boundary_${VERSION}_linux_amd64.zip
+    grep boundary_${VERSION}_linux_${boundaryArch}.zip boundary_${VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip -d /bin boundary_${VERSION}_linux_${boundaryArch}.zip && \
+    rm boundary_${VERSION}_linux_${boundaryArch}.zip boundary_${VERSION}_SHA256SUMS boundary_${VERSION}_SHA256SUMS.sig && \
+    mkdir /boundary
 
-RUN mkdir /boundary/
-ADD config.hcl /boundary/config.hcl
+COPY config.hcl /boundary/config.hcl
+
 RUN chown -R boundary:boundary /boundary/ 
 
 EXPOSE 9200 9201 9202


### PR DESCRIPTION
- I've updated the release Dockerfile to support multiple architectures.

- I've also added a snippet in the Makefile called `docker-multiarch-build` that will build and push multiple architectures of the image to our Dockerhub. I've done it with Docker's `buildx` feature.