### PR TITLE
Ensure job progress is always reported

### DIFF
--- a/internal/scheduler/additional_verification_test.go
+++ b/internal/scheduler/additional_verification_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"testing"
@@ -337,4 +338,103 @@ func TestSchedulerMonitorLoop(t *testing.T) {
 	run, err := repo.LookupRun(context.Background(), runId)
 	require.NoError(err)
 	assert.Equal(string(job.Interrupted), run.Status)
+}
+
+func TestSchedulerFinalStatusUpdate(t *testing.T) {
+	t.Parallel()
+	assert, require := assert.New(t), require.New(t)
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	rw := db.New(conn)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	iam.TestRepo(t, conn, wrapper)
+
+	sched := TestScheduler(t, conn, wrapper, WithRunJobsLimit(10), WithRunJobsInterval(time.Second))
+
+	jobReady := make(chan struct{})
+	jobErr := make(chan error)
+	fn := func(_ context.Context) error {
+		jobReady <- struct{}{}
+		return <-jobErr
+	}
+
+	jobStatus := make(chan JobStatus)
+	status := func() JobStatus {
+		return <-jobStatus
+	}
+	tj := testJob{name: "name", description: "desc", fn: fn, statusFn: status, nextRunIn: time.Hour}
+	err := sched.RegisterJob(context.Background(), tj)
+	require.NoError(err)
+
+	baseCtx, baseCnl := context.WithCancel(context.Background())
+	// call unexported start in order to bypass monitor loop
+	go sched.start(baseCtx)
+
+	// Wait for scheduler to run job
+	<-jobReady
+
+	require.Equal(mapLen(sched.runningJobs), 1)
+	runJob, ok := sched.runningJobs.Load(tj.name)
+	require.True(ok)
+	runId := runJob.(*runningJob).runId
+
+	// Complete job with error so FailRun is called
+	jobErr <- errors.New("scary error")
+
+	// Report status
+	jobStatus <- JobStatus{Total: 10, Completed: 10}
+
+	repo, err := job.NewRepository(rw, rw, kmsCache)
+	require.NoError(err)
+
+	run := waitForRunStatus(t, repo, runId, string(job.Failed))
+	assert.Equal(uint32(10), run.TotalCount)
+	assert.Equal(uint32(10), run.CompletedCount)
+
+	// Wait for scheduler to run job again
+	<-jobReady
+
+	require.Equal(mapLen(sched.runningJobs), 1)
+	runJob, ok = sched.runningJobs.Load(tj.name)
+	require.True(ok)
+	runId = runJob.(*runningJob).runId
+
+	// Complete job without error so CompleteRun is called
+	jobErr <- nil
+
+	// Report status
+	jobStatus <- JobStatus{Total: 20, Completed: 20}
+
+	repo, err = job.NewRepository(rw, rw, kmsCache)
+	require.NoError(err)
+
+	run = waitForRunStatus(t, repo, runId, string(job.Completed))
+	assert.Equal(uint32(20), run.TotalCount)
+	assert.Equal(uint32(20), run.CompletedCount)
+
+	baseCnl()
+}
+
+func waitForRunStatus(t *testing.T, repo *job.Repository, runId, status string) *job.Run {
+	t.Helper()
+	var run *job.Run
+
+	// Fail test if waiting for run status change takes longer than 5 seconds
+	timeout := time.NewTimer(5 * time.Second)
+	for {
+		select {
+		case <-timeout.C:
+			t.Fatal(fmt.Errorf("timed out waiting for job run %v to reach status: %v", runId, status))
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		var err error
+		run, err = repo.LookupRun(context.Background(), runId)
+		require.NoError(t, err)
+		if run.Status == status {
+			break
+		}
+	}
+
+	return run
 }

--- a/internal/scheduler/job/additional_verification_test.go
+++ b/internal/scheduler/job/additional_verification_test.go
@@ -49,7 +49,7 @@ func TestJobWorkflow(t *testing.T) {
 	require.NoError(err)
 	assert.Nil(newRuns)
 
-	run, err = repo.CompleteRun(context.Background(), run.PrivateId, time.Hour)
+	run, err = repo.CompleteRun(context.Background(), run.PrivateId, time.Hour, 0, 0)
 	require.NoError(err)
 	assert.Equal(Completed.string(), run.Status)
 
@@ -80,7 +80,7 @@ func TestJobWorkflow(t *testing.T) {
 	require.NoError(err)
 	assert.Nil(newRuns)
 
-	newRun, err = repo.FailRun(context.Background(), newRun.PrivateId)
+	newRun, err = repo.FailRun(context.Background(), newRun.PrivateId, 0, 0)
 	require.NoError(err)
 	assert.Equal(Failed.string(), newRun.Status)
 

--- a/internal/scheduler/job/query.go
+++ b/internal/scheduler/job/query.go
@@ -65,8 +65,10 @@ const completeRunQuery = `
 	update
 	  job_run
 	set
-	  status = 'completed',
-	  end_time = current_timestamp
+	  completed_count = ?,
+	  total_count     = ?,
+	  status          = 'completed',
+	  end_time        = current_timestamp
 	where
 	  private_id = ?
 	  and status = 'running'
@@ -77,8 +79,10 @@ const failRunQuery = `
 	update
 	  job_run
 	set
-	  status = 'failed',
-	  end_time = current_timestamp
+	  completed_count = ?,
+	  total_count     = ?,
+	  status          = 'failed',
+	  end_time        = current_timestamp
 	where
 	  private_id = ?
 	  and status = 'running'

--- a/internal/scheduler/job/repository_run.go
+++ b/internal/scheduler/job/repository_run.go
@@ -125,6 +125,10 @@ func (r *Repository) CompleteRun(ctx context.Context, runId string, nextRunIn ti
 	run.PrivateId = runId
 	_, err := r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{},
 		func(r db.Reader, w db.Writer) error {
+			// TODO (lcr 07/2021) this can potentially overwrite completed and total values
+			// persisted by the scheduler's monitor jobs loop.
+			// Add an on update sql trigger to protect the job_run table, once progress
+			// values are used in the critical path.
 			rows, err := r.Query(ctx, completeRunQuery, []interface{}{completed, total, runId})
 			if err != nil {
 				return errors.Wrap(err, op)
@@ -201,6 +205,10 @@ func (r *Repository) FailRun(ctx context.Context, runId string, completed, total
 	run.PrivateId = runId
 	_, err := r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{},
 		func(r db.Reader, w db.Writer) error {
+			// TODO (lcr 07/2021) this can potentially overwrite completed and total values
+			// persisted by the scheduler's monitor jobs loop.
+			// Add an on update sql trigger to protect the job_run table, once progress
+			// values are used in the critical path.
 			rows, err := r.Query(ctx, failRunQuery, []interface{}{completed, total, runId})
 			if err != nil {
 				return errors.Wrap(err, op)

--- a/internal/scheduler/job/repository_run_test.go
+++ b/internal/scheduler/job/repository_run_test.go
@@ -452,7 +452,6 @@ func TestRepository_CompleteRun(t *testing.T) {
 		name        string
 		orig        *Run
 		nextRunIn   time.Duration
-		opts        []Option
 		args        args
 		wantErr     bool
 		wantErrCode errors.Code
@@ -617,7 +616,6 @@ func TestRepository_FailRun(t *testing.T) {
 	tests := []struct {
 		name        string
 		orig        *Run
-		opts        []Option
 		args        args
 		wantErr     bool
 		wantErrCode errors.Code

--- a/internal/scheduler/job/repository_run_test.go
+++ b/internal/scheduler/job/repository_run_test.go
@@ -188,7 +188,7 @@ func TestRepository_RunJobsOrder(t *testing.T) {
 	assert.Equal(run.JobPluginId, firstJob.PluginId)
 
 	// End first job with time between last and middle
-	_, err = repo.CompleteRun(context.Background(), run.PrivateId, -6*time.Hour)
+	_, err = repo.CompleteRun(context.Background(), run.PrivateId, -6*time.Hour, 0, 0)
 	require.NoError(err)
 
 	runs, err = repo.RunJobs(context.Background(), server.PrivateId)
@@ -445,10 +445,15 @@ func TestRepository_CompleteRun(t *testing.T) {
 	server := testController(t, conn, wrapper)
 	job := testJob(t, conn, "name", "description", wrapper)
 
+	type args struct {
+		completed, total int
+	}
 	tests := []struct {
 		name        string
 		orig        *Run
 		nextRunIn   time.Duration
+		opts        []Option
+		args        args
 		wantErr     bool
 		wantErrCode errors.Code
 		wantErrMsg  string
@@ -513,6 +518,18 @@ func TestRepository_CompleteRun(t *testing.T) {
 			},
 			nextRunIn: time.Hour,
 		},
+		{
+			name: "valid-with-progress",
+			orig: &Run{
+				JobRun: &store.JobRun{
+					JobName:     job.Name,
+					JobPluginId: job.PluginId,
+					ServerId:    server.PrivateId,
+					Status:      Running.string(),
+				},
+			},
+			args: args{completed: 10, total: 20},
+		},
 	}
 
 	for _, tt := range tests {
@@ -531,7 +548,7 @@ func TestRepository_CompleteRun(t *testing.T) {
 				privateId = tt.orig.PrivateId
 			}
 
-			got, err := repo.CompleteRun(context.Background(), privateId, tt.nextRunIn)
+			got, err := repo.CompleteRun(context.Background(), privateId, tt.nextRunIn, tt.args.completed, tt.args.total)
 			if tt.wantErr {
 				require.Error(err)
 				assert.Truef(errors.Match(errors.T(tt.wantErrCode), err), "Unexpected error %s", err)
@@ -549,6 +566,8 @@ func TestRepository_CompleteRun(t *testing.T) {
 			require.NotNil(got)
 			assert.NotEmpty(got.EndTime)
 			assert.Equal(Completed.string(), got.Status)
+			assert.Equal(tt.args.completed, int(got.CompletedCount))
+			assert.Equal(tt.args.total, int(got.TotalCount))
 
 			updatedJob, err := repo.LookupJob(context.Background(), tt.orig.JobName)
 			assert.NoError(err)
@@ -573,7 +592,7 @@ func TestRepository_CompleteRun(t *testing.T) {
 		require.NoError(err)
 		require.NotNil(repo)
 
-		got, err := repo.CompleteRun(context.Background(), "fake-run-id", time.Hour)
+		got, err := repo.CompleteRun(context.Background(), "fake-run-id", time.Hour, 0, 0)
 		require.Error(err)
 		require.Nil(got)
 		assert.Truef(errors.Match(errors.T(errors.RecordNotFound), err), "Unexpected error %s", err)
@@ -592,9 +611,14 @@ func TestRepository_FailRun(t *testing.T) {
 	server := testController(t, conn, wrapper)
 	job := testJob(t, conn, "name", "description", wrapper)
 
+	type args struct {
+		completed, total int
+	}
 	tests := []struct {
 		name        string
 		orig        *Run
+		opts        []Option
+		args        args
 		wantErr     bool
 		wantErrCode errors.Code
 		wantErrMsg  string
@@ -658,6 +682,18 @@ func TestRepository_FailRun(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "valid-with-progress",
+			orig: &Run{
+				JobRun: &store.JobRun{
+					JobName:     job.Name,
+					JobPluginId: job.PluginId,
+					ServerId:    server.PrivateId,
+					Status:      Running.string(),
+				},
+			},
+			args: args{completed: 10, total: 20},
+		},
 	}
 
 	for _, tt := range tests {
@@ -676,7 +712,7 @@ func TestRepository_FailRun(t *testing.T) {
 				privateId = tt.orig.PrivateId
 			}
 
-			got, err := repo.FailRun(context.Background(), privateId)
+			got, err := repo.FailRun(context.Background(), privateId, tt.args.completed, tt.args.total)
 			if tt.wantErr {
 				require.Error(err)
 				assert.Truef(errors.Match(errors.T(tt.wantErrCode), err), "Unexpected error %s", err)
@@ -694,6 +730,8 @@ func TestRepository_FailRun(t *testing.T) {
 			require.NotNil(got)
 			assert.NotEmpty(got.EndTime)
 			assert.Equal(Failed.string(), got.Status)
+			assert.Equal(tt.args.completed, int(got.CompletedCount))
+			assert.Equal(tt.args.total, int(got.TotalCount))
 
 			// Delete job run so it does not clash with future runs
 			_, err = repo.deleteRun(context.Background(), privateId)
@@ -707,7 +745,7 @@ func TestRepository_FailRun(t *testing.T) {
 		require.NoError(err)
 		require.NotNil(repo)
 
-		got, err := repo.FailRun(context.Background(), "fake-run-id")
+		got, err := repo.FailRun(context.Background(), "fake-run-id", 0, 0)
 		require.Error(err)
 		require.Nil(got)
 		assert.Truef(errors.Match(errors.T(errors.RecordNotFound), err), "Unexpected error %s", err)


### PR DESCRIPTION
### What does this PR do

Adds a `WithProgress` option to the `CompleteRun` and `FailRun` calls so the final job status is always persisted.  Currently progress is only updated in the `MonitorJobs` loop, fast running jobs often start and finish before a single monitor job loop is triggered.  Even for long running jobs the final status should not be left to a race between `CompleteRun` and the `MonitorJobs` loop