### PR TITLE
Add redirect to domain model documentation for credential stores

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -103,6 +103,11 @@ module.exports = [
     destination: '/docs/common-workflows/manage-sessions',
     permanent: false,
   },
+  {
+    source: '/help/admin-ui/credential-stores',
+    destination: '/docs/concepts/domain-model/credential-stores',
+    permanent: false,
+  },
 
   ////////////////////////////////////////////
   // Adding sub-resources to existing resource


### PR DESCRIPTION
Add redirect to domain model documentation for credential stores. This is used when the user click the icon help in the credential-stores screen.

<img width="1501" alt="Screen Shot 2021-07-14 at 1 28 09 PM" src="https://user-images.githubusercontent.com/9775006/125688673-6097e1e4-08f6-4abd-997c-0bb108c27208.png">
