### PR TITLE
Remove Telemetry from config tests

### DIFF
--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -18,12 +18,11 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	berrors "github.com/hashicorp/boundary/internal/errors"
-
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/cmd/base/logging"
 	"github.com/hashicorp/boundary/internal/cmd/config"
 	"github.com/hashicorp/boundary/internal/db"
+	berrors "github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/observability/event"
 	"github.com/hashicorp/boundary/internal/servers"

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/observability/event"
@@ -64,12 +63,6 @@ func TestDevController(t *testing.T) {
 						"key_id":    "global_recovery",
 					},
 				},
-			},
-			Telemetry: &configutil.Telemetry{
-				DisableHostname:         true,
-				PrometheusRetentionTime: 24 * time.Hour,
-				UsageGaugePeriod:        10 * time.Minute,
-				MaximumGaugeCardinality: 500,
 			},
 		},
 		Controller: &Controller{
@@ -164,12 +157,6 @@ func TestDevWorker(t *testing.T) {
 					Type:    "tcp",
 					Purpose: []string{"proxy"},
 				},
-			},
-			Telemetry: &configutil.Telemetry{
-				DisableHostname:         true,
-				PrometheusRetentionTime: 24 * time.Hour,
-				UsageGaugePeriod:        10 * time.Minute,
-				MaximumGaugeCardinality: 500,
 			},
 		},
 		Worker: &Worker{


### PR DESCRIPTION
As @tmessi reported in slack CI builds on `main` are currently failing:

```
Tim Messier Today at 07:50
It looks like ed6c59a0539ecfba54835cd3c04b04f709303c60 is causing CI to fail on main (and any new branch since that commit). It updated the version of github.com/hashicorp/go-secure-stdlib/configutil which has this commit: 1b80d53b4662d4b15ea0c23754dd81e3ae21d58b that removes configutil.Telemetry but the tests in internal/cmd/config are using that struct so the tests fail to compile
```

Commit https://github.com/hashicorp/boundary/commit/9ba1948298b8d0d57919fe480b41c9aeb97fa03b removed telemetry as it was not being used but config_tests still used it, but it is only failing now that it has been removed from go-secure-stdlib

