### PR TITLE
internal/servers/worker: fix TestWorkerWaitForNextSuccessfulStatusUpdate

### DIFF
--- a/internal/servers/worker/status_test.go
+++ b/internal/servers/worker/status_test.go
@@ -14,9 +14,10 @@ import (
 
 func TestWorkerWaitForNextSuccessfulStatusUpdate(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 	for _, name := range []string{"ok", "timeout"} {
 		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
 			// As-needed initialization of a mock worker
 			w := &Worker{
 				logger:            hclog.New(nil),
@@ -24,7 +25,7 @@ func TestWorkerWaitForNextSuccessfulStatusUpdate(t *testing.T) {
 				baseContext:       context.Background(),
 				conf: &Config{
 					Server: &base.Server{
-						StatusGracePeriodDuration: time.Second * 1,
+						StatusGracePeriodDuration: time.Second * 2,
 					},
 				},
 			}


### PR DESCRIPTION
This fixes this test which was failing intermittently.

* Ups the grace period timeout to 2s.
* Re-positions the testify require.New() so that incorrect code path
  warnings are not given.