### PR TITLE
Update homepage desktop client CTA language

### DIFF
--- a/website/pages/home/index.jsx
+++ b/website/pages/home/index.jsx
@@ -19,7 +19,7 @@ export default function HomePage() {
             external: true,
           },
           {
-            title: 'Download macOS Client',
+            title: 'Boundary Desktop',
             url: '/downloads#desktop',
             linkType: 'inbound',
             theme: { variant: 'tertiary' },


### PR DESCRIPTION
Now that we offer both a Windows and macOS desktop client, the CTA button didn't make sense.