### PR TITLE
Update broken link to common workflows

### DIFF
--- a/website/content/docs/getting-started/connect-to-target.mdx
+++ b/website/content/docs/getting-started/connect-to-target.mdx
@@ -198,5 +198,5 @@ details.
 
 ## Next Steps
 
-See our [common workflows](https://learn.hashicorp.com/collections/boundary/common-workflows) for in depth discussion on managing scopes, targets,
+See our [common workflows](https://www.boundaryproject.io/docs/common-workflows) for in depth discussion on managing scopes, targets,
 identities, and sessions.


### PR DESCRIPTION
The old link is a 404, updated with the right one.