### PR TITLE
Fix race with base context cancel and final run update in scheduler

### DIFF
--- a/internal/scheduler/additional_verification_test.go
+++ b/internal/scheduler/additional_verification_test.go
@@ -517,9 +517,8 @@ func TestSchedulerFinalStatusUpdate(t *testing.T) {
 	require.NoError(err)
 
 	baseCtx, baseCnl := context.WithCancel(context.Background())
-	var wg sync.WaitGroup
 	// call unexported start in order to bypass monitor loop
-	go sched.start(baseCtx, &wg)
+	go sched.start(baseCtx)
 
 	// Wait for scheduler to run job
 	<-jobReady

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -228,9 +228,8 @@ func (s *Scheduler) runJob(ctx context.Context, r *job.Run) error {
 	jobContext, rj.cancelCtx = context.WithCancel(ctx)
 
 	go func() {
+		defer rj.cancelCtx()
 		runErr := j.Run(jobContext)
-		// Job has ended, cancel job run specific context to clean up
-		rj.cancelCtx()
 
 		// Get final status report to update run progress with
 		status := j.Status()


### PR DESCRIPTION
### What does this PR do

Skips final job run update if the base context is no longer valid.  All repo actions are dependent on the base context, attempting to perform an update without a valid context will always fail.

### Testing

The following error was found intermittently in [circle-ci](https://circleci.com/api/v1.1/project/github/hashicorp/boundary/71541/output/102/0?file=true&allocation-id=61004daab3df255367f81b9d-0-build%2F5F75C3D6):
```
testing.go:54: 
        	Error Trace:	testing.go:54
        	            				testing.go:901
        	            				testing.go:1007
        	            				testing.go:1187
        	Error:      	Received unexpected error:
        	            	write tcp 127.0.0.1:36706->127.0.0.1:33410: use of closed network connection
        	Test:       	TestSchedulerJobProgress
        	Messages:   	Got error closing gorm db.
--- FAIL: TestSchedulerJobProgress (11.85s)
```

Running the test in a loop locally would hit this error occasionally, in three attempts it hit the error after 34, 59 and 24 attempts.  Debug logging revealed the error was always hit in the final update attempt of a job_run that was racing with the context being cancelled in the unit tests. 

While this error would likely not cause production issues it would add confusing logs to the controller shutdown.