### PR TITLE
docs:  add credential doc redirects and fix session redirect

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -109,7 +109,7 @@ module.exports = [
     permanent: false,
   },
   {
-    source: '/help/admin-ui/credential-sources',
+    source: '/help/admin-ui/credential-libraries',
     destination: '/docs/concepts/domain-model/credential-libraries',
     permanent: false,
   },

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -100,7 +100,17 @@ module.exports = [
   },
   {
     source: '/help/admin-ui/sessions',
-    destination: '/docs/common-workflows/manage-sessions',
+    destination: '/docs/concepts/domain-model/sessions',
+    permanent: false,
+  },
+  {
+    source: '/help/admin-ui/credential-stores',
+    destination: '/docs/concepts/domain-model/credential-stores',
+    permanent: false,
+  },
+  {
+    source: '/help/admin-ui/credential-sources',
+    destination: '/docs/concepts/domain-model/credential-libraries',
     permanent: false,
   },
 


### PR DESCRIPTION
This small PR introduces documentation redirects for credential stores and sources (libraries) intended for use by Boundary product UIs.  And it resolves an inconsistency with the redirect for sessions documentation.