### PR TITLE
server: Add back controller shutdown on worker startup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,9 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   well as the error message)
   ([issue](https://github.com/hashicorp/boundary/issues/1305),
   [PR](https://github.com/hashicorp/boundary/pull/1384))
-
+* server: Fixed a regression in 0.4.0 that caused the controller to not shut
+  down on a multi-role server when there were issues starting the worker role.
+  ([PR](https://github.com/hashicorp/boundary/pull/1432))
 ### New and Improved
 
 * docker: Add support for muti-arch docker images (amd64/arm64) via Docker buildx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,9 +99,10 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   well as the error message)
   ([issue](https://github.com/hashicorp/boundary/issues/1305),
   [PR](https://github.com/hashicorp/boundary/pull/1384))
-* server: Fixed a regression in 0.4.0 that caused the controller to not shut
-  down on a multi-role server when there were issues starting the worker role.
+* server: Fixed a bug in 0.4.0 that caused a panic on worker startup failure
+  when the server was not configured with a controller role.
   ([PR](https://github.com/hashicorp/boundary/pull/1432))
+
 ### New and Improved
 
 * docker: Add support for muti-arch docker images (amd64/arm64) via Docker buildx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,9 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   well as the error message)
   ([issue](https://github.com/hashicorp/boundary/issues/1305),
   [PR](https://github.com/hashicorp/boundary/pull/1384))
+* server: Fix panic on worker startup failure when the server was not also
+  configured as a controller
+  ([PR](https://github.com/hashicorp/boundary/pull/1432))
 
 ### New and Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,9 +99,6 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   well as the error message)
   ([issue](https://github.com/hashicorp/boundary/issues/1305),
   [PR](https://github.com/hashicorp/boundary/pull/1384))
-* server: Fixed a bug in 0.4.0 that caused a panic on worker startup failure
-  when the server was not configured with a controller role.
-  ([PR](https://github.com/hashicorp/boundary/pull/1432))
 
 ### New and Improved
 

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -463,6 +463,11 @@ func (c *Command) Run(args []string) int {
 	if c.Config.Worker != nil {
 		if err := c.StartWorker(); err != nil {
 			c.UI.Error(err.Error())
+			if c.controller != nil {
+				if err := c.controller.Shutdown(false); err != nil {
+					c.UI.Error(fmt.Errorf("Error with controller shutdown: %w", err).Error())
+				}
+			}
 			return base.CommandCliError
 		}
 	}


### PR DESCRIPTION
This adds back the controller shutdown call on worker failure.

This was added in a15961e4 to address a panic discovered in testing, and
was mistakenly thought to be unnecessary. This, however, covers
multi-role scenarios where we have already started the controller, which
needs to be shut down gracefully if possible if we can't start the
worker.

A nil check has been added to ensure the panic does not resurface.