### PR TITLE
website: upgrade consent-manager

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2093,13 +2093,12 @@
       }
     },
     "@hashicorp/react-consent-manager": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-5.3.2.tgz",
-      "integrity": "sha512-+diaaneosC7xMjODrPusvc5g1+0THX9gePHCfkMON7EsFC0fG5R7Cjn6sssBgOQbxYe0Bbx3amDmkhMcFjdDWQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-6.0.0.tgz",
+      "integrity": "sha512-ew15fmxR+Js9W1F160r324QNxhlKjj8txmueW2Ud/qlztzKpPoOOWALDEI4nUhEUqhdVC6/M6DHlXX+J9iv6wA==",
       "requires": {
         "@hashicorp/react-button": "^5.2.1",
         "@hashicorp/react-toggle": "^3.0.2",
-        "@segment/in-eu": "^0.2.1",
         "js-cookie": "^2.2.0"
       }
     },
@@ -3243,14 +3242,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
           "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         }
-      }
-    },
-    "@segment/in-eu": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@segment/in-eu/-/in-eu-0.2.1.tgz",
-      "integrity": "sha512-7JKBw/l3S9J0ldo/n6XPfd3sT89f300KOCvmZsd8sryVZOWlE4L2LMKT538I34bjRdaOd1aJ52TsOAZUOLqxiQ==",
-      "requires": {
-        "jstz": "^2.0.0"
       }
     },
     "@sindresorhus/is": {
@@ -9351,11 +9342,6 @@
           "dev": true
         }
       }
-    },
-    "jstz": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/jstz/-/jstz-2.1.1.tgz",
-      "integrity": "sha512-8hfl5RD6P7rEeIbzStBz3h4f+BQHfq/ABtoU6gXKQv5OcZhnmrIpG7e1pYaZ8hS9e0mp+bxUj08fnDUbKctYyA=="
     },
     "jsx-ast-utils": {
       "version": "3.2.0",

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "@hashicorp/platform-util": "^0.1.0",
     "@hashicorp/react-alert-banner": "^6.1.2",
     "@hashicorp/react-button": "^5.2.1",
-    "@hashicorp/react-consent-manager": "^5.3.2",
+    "@hashicorp/react-consent-manager": "^6.0.0",
     "@hashicorp/react-content": "^7.0.2",
     "@hashicorp/react-docs-page": "^13.5.1",
     "@hashicorp/react-enterprise-alert": "^5.0.1",


### PR DESCRIPTION
Upgrading `react-consent-manager` to enable global visitors to control tracking and privacy. For HashiCorp staff, see MKTG-036 for context.

[_Created by Sourcegraph campaign `mwickett/upgrade-consent-manager`._](https://sourcegraph.hashi-mktg.com/users/mwickett/campaigns/upgrade-consent-manager)