### PR TITLE
Update next steps in connect to target documentation

### DIFF
--- a/website/content/docs/getting-started/connect-to-target.mdx
+++ b/website/content/docs/getting-started/connect-to-target.mdx
@@ -198,5 +198,5 @@ details.
 
 ## Next Steps
 
-See our [common workflows](https://learn.hashicorp.com/collections/boundary/common-workflows) for in depth discussion on managing scopes, targets,
+See our [basic administration workflows](https://learn.hashicorp.com/collections/boundary/basic-administration) for in depth discussion on managing scopes, targets,
 identities, and sessions.


### PR DESCRIPTION
Currently, the documentation is linking to a page that errors with a 404. This fix brings people to the anticipated page.