### PR TITLE
feat(wh): Add oidc related columns to wh_user_dimension

### DIFF
--- a/internal/db/schema/migrations/postgres/14/01_wh_user_dimension_oidc.up.sql
+++ b/internal/db/schema/migrations/postgres/14/01_wh_user_dimension_oidc.up.sql
@@ -1,0 +1,171 @@
+begin;
+
+  alter table wh_user_dimension
+    add column auth_method_external_id  wh_dim_text,
+    add column auth_account_external_id wh_dim_text,
+    add column auth_account_full_name   wh_dim_text,
+    add column auth_account_email       wh_dim_text
+  ;
+
+  drop view whx_user_dimension_source;
+  create view whx_user_dimension_source as
+       select -- id is the first column in the target view
+              u.public_id                       as user_id,
+              coalesce(u.name, 'None')          as user_name,
+              coalesce(u.description, 'None')   as user_description,
+              coalesce(aa.public_id, 'None')    as auth_account_id,
+              case
+                   when apa.public_id is not null then 'password auth account'
+                   when aoa.public_id is not null then 'oidc auth account'
+                   else 'None'
+                   end                          as auth_account_type,
+              case
+                   when apa.public_id is not null then coalesce(apa.name, 'None')
+                   when aoa.public_id is not null then coalesce(aoa.name, 'None')
+                   else 'None'
+                   end                          as auth_account_name,
+              case
+                   when apa.public_id is not null then coalesce(apa.description, 'None')
+                   when aoa.public_id is not null then coalesce(aoa.description, 'None')
+                   else 'None'
+                   end                          as auth_account_description,
+              case
+                  when apa.public_id is not null then 'Not Applicable'
+                  when aoa.public_id is null then 'None'
+                  else aoa.subject
+                  end                           as auth_account_external_id,
+              case
+                  when apa.public_id is not null then 'Not Applicable'
+                  when  aoa.public_id is not null
+                    and aoa.full_name is not null then aoa.full_name
+                  else 'None'
+                  end                           as auth_account_full_name,
+              case
+                  when apa.public_id is not null then 'Not Applicable'
+                  when  aoa.public_id is not null
+                    and aoa.email is not null then aoa.email
+                  else 'None'
+                  end                           as auth_account_email,
+              coalesce(am.public_id, 'None')    as auth_method_id,
+              case
+                   when apa.public_id is not null then 'password auth method'
+                   when aoa.public_id is not null then 'oidc auth method'
+                   else 'None'
+                   end                          as auth_method_type,
+              case
+                   when apm.public_id is not null then coalesce(apm.name, 'None')
+                   when aom.public_id is not null then coalesce(aom.name, 'None')
+                   else 'None'
+                   end                          as auth_method_name,
+              case
+                   when apm.public_id is not null then coalesce(apm.description, 'None')
+                   when aom.public_id is not null then coalesce(aom.description, 'None')
+                   else 'None'
+                   end                          as auth_method_description,
+              case
+                  when apa.public_id is not null then 'Not Applicable'
+                  when aom.public_id is null then 'None'
+                  else aom.issuer
+                  end                           as auth_method_external_id,
+              org.public_id                     as user_organization_id,
+              coalesce(org.name, 'None')        as user_organization_name,
+              coalesce(org.description, 'None') as user_organization_description
+         from iam_user as u
+    left join auth_account as aa on           u.public_id       = aa.iam_user_id
+    left join auth_method as am on            aa.auth_method_id = am.public_id
+    left join auth_password_account as apa on aa.public_id      = apa.public_id
+    left join auth_password_method as apm on  am.public_id      = apm.public_id
+    left join auth_oidc_account as aoa on     aa.public_id      = aoa.public_id
+    left join auth_oidc_method as aom on      am.public_id      = aom.public_id
+         join iam_scope as org on             u.scope_id        = org.public_id
+  ;
+
+  drop view whx_user_dimension_target;
+  create view whx_user_dimension_target as
+    select id,
+           user_id,
+           user_name,
+           user_description,
+           auth_account_id,
+           auth_account_type,
+           auth_account_name,
+           auth_account_description,
+           auth_account_external_id,
+           auth_account_full_name,
+           auth_account_email,
+           auth_method_id,
+           auth_method_type,
+           auth_method_name,
+           auth_method_description,
+           auth_method_external_id,
+           user_organization_id,
+           user_organization_name,
+           user_organization_description
+      from wh_user_dimension
+     where current_row_indicator = 'Current'
+  ;
+
+  drop function wh_upsert_user;
+  create function wh_upsert_user(p_user_id wt_user_id, p_auth_token_id wt_public_id)
+    returns wh_dim_id
+  as $$
+  declare
+    src     whx_user_dimension_target%rowtype;
+    target  whx_user_dimension_target%rowtype;
+    new_row wh_user_dimension%rowtype;
+    acct_id wt_public_id;
+  begin
+    select auth_account_id into strict acct_id
+      from auth_token
+     where public_id = p_auth_token_id;
+
+    select * into target
+      from whx_user_dimension_target as t
+     where t.user_id               = p_user_id
+       and t.auth_account_id       = acct_id;
+
+    select target.id, t.* into src
+      from whx_user_dimension_source as t
+     where t.user_id               = p_user_id
+       and t.auth_account_id       = acct_id;
+
+    if src is distinct from target then
+
+      -- expire the current row
+      update wh_user_dimension
+         set current_row_indicator = 'Expired',
+             row_expiration_time   = current_timestamp
+       where user_id               = p_user_id
+         and auth_account_id       = acct_id
+         and current_row_indicator = 'Current';
+
+      -- insert a new row
+      insert into wh_user_dimension (
+             user_id,                  user_name,              user_description,
+             auth_account_id,          auth_account_type,      auth_account_name,             auth_account_description,
+             auth_account_external_id, auth_account_full_name, auth_account_email,
+             auth_method_id,           auth_method_type,       auth_method_name,              auth_method_description,
+             auth_method_external_id,
+             user_organization_id,     user_organization_name, user_organization_description,
+             current_row_indicator,    row_effective_time,     row_expiration_time
+      )
+      select user_id,                  user_name,              user_description,
+             auth_account_id,          auth_account_type,      auth_account_name,             auth_account_description,
+             auth_account_external_id, auth_account_full_name, auth_account_email,
+             auth_method_id,           auth_method_type,       auth_method_name,              auth_method_description,
+             auth_method_external_id,
+             user_organization_id,     user_organization_name, user_organization_description,
+             'Current',                current_timestamp,      'infinity'::timestamptz
+        from whx_user_dimension_source
+       where user_id               = p_user_id
+         and auth_account_id       = acct_id
+      returning * into new_row;
+
+      return new_row.id;
+    end if;
+    return target.id;
+
+  end;
+  $$ language plpgsql;
+
+commit;

--- a/internal/db/schema/postgres_migration.gen.go
+++ b/internal/db/schema/postgres_migration.gen.go
@@ -4,7 +4,7 @@ package schema
 
 func init() {
 	migrationStates["postgres"] = migrationState{
-		binarySchemaVersion: 13001,
+		binarySchemaVersion: 14001,
 		upMigrations: map[int][]byte{
 			1: []byte(`
 create domain wt_public_id as text
@@ -6135,6 +6135,175 @@ alter table auth_oidc_account
   check(
     length(trim(userinfo_claims)) > 0
   );
+`),
+			14001: []byte(`
+alter table wh_user_dimension
+    add column auth_method_external_id  wh_dim_text,
+    add column auth_account_external_id wh_dim_text,
+    add column auth_account_full_name   wh_dim_text,
+    add column auth_account_email       wh_dim_text
+  ;
+
+  drop view whx_user_dimension_source;
+  create view whx_user_dimension_source as
+       select -- id is the first column in the target view
+              u.public_id                       as user_id,
+              coalesce(u.name, 'None')          as user_name,
+              coalesce(u.description, 'None')   as user_description,
+              coalesce(aa.public_id, 'None')    as auth_account_id,
+              case
+                   when apa.public_id is not null then 'password auth account'
+                   when aoa.public_id is not null then 'oidc auth account'
+                   else 'None'
+                   end                          as auth_account_type,
+              case
+                   when apa.public_id is not null then coalesce(apa.name, 'None')
+                   when aoa.public_id is not null then coalesce(aoa.name, 'None')
+                   else 'None'
+                   end                          as auth_account_name,
+              case
+                   when apa.public_id is not null then coalesce(apa.description, 'None')
+                   when aoa.public_id is not null then coalesce(aoa.description, 'None')
+                   else 'None'
+                   end                          as auth_account_description,
+              case
+                  when apa.public_id is not null then 'Not Applicable'
+                  when aoa.public_id is null then 'None'
+                  else aoa.subject
+                  end                           as auth_account_external_id,
+              case
+                  when apa.public_id is not null then 'Not Applicable'
+                  when  aoa.public_id is not null
+                    and aoa.full_name is not null then aoa.full_name
+                  else 'None'
+                  end                           as auth_account_full_name,
+              case
+                  when apa.public_id is not null then 'Not Applicable'
+                  when  aoa.public_id is not null
+                    and aoa.email is not null then aoa.email
+                  else 'None'
+                  end                           as auth_account_email,
+              coalesce(am.public_id, 'None')    as auth_method_id,
+              case
+                   when apa.public_id is not null then 'password auth method'
+                   when aoa.public_id is not null then 'oidc auth method'
+                   else 'None'
+                   end                          as auth_method_type,
+              case
+                   when apm.public_id is not null then coalesce(apm.name, 'None')
+                   when aom.public_id is not null then coalesce(aom.name, 'None')
+                   else 'None'
+                   end                          as auth_method_name,
+              case
+                   when apm.public_id is not null then coalesce(apm.description, 'None')
+                   when aom.public_id is not null then coalesce(aom.description, 'None')
+                   else 'None'
+                   end                          as auth_method_description,
+              case
+                  when apa.public_id is not null then 'Not Applicable'
+                  when aom.public_id is null then 'None'
+                  else aom.issuer
+                  end                           as auth_method_external_id,
+              org.public_id                     as user_organization_id,
+              coalesce(org.name, 'None')        as user_organization_name,
+              coalesce(org.description, 'None') as user_organization_description
+         from iam_user as u
+    left join auth_account as aa on           u.public_id       = aa.iam_user_id
+    left join auth_method as am on            aa.auth_method_id = am.public_id
+    left join auth_password_account as apa on aa.public_id      = apa.public_id
+    left join auth_password_method as apm on  am.public_id      = apm.public_id
+    left join auth_oidc_account as aoa on     aa.public_id      = aoa.public_id
+    left join auth_oidc_method as aom on      am.public_id      = aom.public_id
+         join iam_scope as org on             u.scope_id        = org.public_id
+  ;
+
+  drop view whx_user_dimension_target;
+  create view whx_user_dimension_target as
+    select id,
+           user_id,
+           user_name,
+           user_description,
+           auth_account_id,
+           auth_account_type,
+           auth_account_name,
+           auth_account_description,
+           auth_account_external_id,
+           auth_account_full_name,
+           auth_account_email,
+           auth_method_id,
+           auth_method_type,
+           auth_method_name,
+           auth_method_description,
+           auth_method_external_id,
+           user_organization_id,
+           user_organization_name,
+           user_organization_description
+      from wh_user_dimension
+     where current_row_indicator = 'Current'
+  ;
+
+  drop function wh_upsert_user;
+  create function wh_upsert_user(p_user_id wt_user_id, p_auth_token_id wt_public_id)
+    returns wh_dim_id
+  as $$
+  declare
+    src     whx_user_dimension_target%rowtype;
+    target  whx_user_dimension_target%rowtype;
+    new_row wh_user_dimension%rowtype;
+    acct_id wt_public_id;
+  begin
+    select auth_account_id into strict acct_id
+      from auth_token
+     where public_id = p_auth_token_id;
+
+    select * into target
+      from whx_user_dimension_target as t
+     where t.user_id               = p_user_id
+       and t.auth_account_id       = acct_id;
+
+    select target.id, t.* into src
+      from whx_user_dimension_source as t
+     where t.user_id               = p_user_id
+       and t.auth_account_id       = acct_id;
+
+    if src is distinct from target then
+
+      -- expire the current row
+      update wh_user_dimension
+         set current_row_indicator = 'Expired',
+             row_expiration_time   = current_timestamp
+       where user_id               = p_user_id
+         and auth_account_id       = acct_id
+         and current_row_indicator = 'Current';
+
+      -- insert a new row
+      insert into wh_user_dimension (
+             user_id,                  user_name,              user_description,
+             auth_account_id,          auth_account_type,      auth_account_name,             auth_account_description,
+             auth_account_external_id, auth_account_full_name, auth_account_email,
+             auth_method_id,           auth_method_type,       auth_method_name,              auth_method_description,
+             auth_method_external_id,
+             user_organization_id,     user_organization_name, user_organization_description,
+             current_row_indicator,    row_effective_time,     row_expiration_time
+      )
+      select user_id,                  user_name,              user_description,
+             auth_account_id,          auth_account_type,      auth_account_name,             auth_account_description,
+             auth_account_external_id, auth_account_full_name, auth_account_email,
+             auth_method_id,           auth_method_type,       auth_method_name,              auth_method_description,
+             auth_method_external_id,
+             user_organization_id,     user_organization_name, user_organization_description,
+             'Current',                current_timestamp,      'infinity'::timestamptz
+        from whx_user_dimension_source
+       where user_id               = p_user_id
+         and auth_account_id       = acct_id
+      returning * into new_row;
+
+      return new_row.id;
+    end if;
+    return target.id;
+
+  end;
+  $$ language plpgsql;
 `),
 			2001: []byte(`
 -- log_migration entries represent logs generated during migrations

--- a/internal/db/sqltest/initdb.d/03_widgets_persona.sql
+++ b/internal/db/sqltest/initdb.d/03_widgets_persona.sql
@@ -163,21 +163,24 @@ begin;
       ('key', 'apa___wilson', 'tok___wilson', 'tok___wilson'::bytea);
 
     insert into auth_oidc_method
-      (scope_id,       public_id,      client_id,      name,          state,            key_id)
+      (scope_id,       public_id,      client_id,      name,          state,            key_id,          issuer)
     values
-      ('o_____widget', 'aom___widget', 'aomc__widget', 'Widget OIDC', 'active-private', 'kdkv___widget');
+      ('o_____widget', 'aom___widget', 'aomc__widget', 'Widget OIDC', 'active-private', 'kdkv___widget', 'https://oidc.widget.test');
 
     insert into auth_oidc_account
-      (auth_method_id, public_id,      full_name, email,                issuer,                subject)
+      (auth_method_id, public_id,      name,             description,           full_name, email,                issuer,                subject)
     values
-      ('aom___widget', 'aoa___walter', 'Walter',  'walter@widget.test', 'https://widget.test', 'aoa___widget');
+      ('aom___widget', 'aoa___walter', 'walter account', 'Walter OIDC Account', 'Walter',  'walter@widget.test', 'https://widget.test', 'sub___walter'),
+      ('aom___widget', 'aoa___warren', 'warren account', 'Warren OIDC Account', null,      null,                 'https://widget.test', 'sub___warren');
 
     update auth_account set iam_user_id = 'u_____walter' where public_id = 'aoa___walter';
+    update auth_account set iam_user_id = 'u_____warren' where public_id = 'aoa___warren';
 
     insert into auth_token
       (key_id, auth_account_id, public_id, token)
     values
-      ('key', 'aoa___walter', 'oidc__walter', 'oidc__walter'::bytea);
+      ('key', 'aoa___walter', 'oidc__walter', 'oidc__walter'::bytea),
+      ('key', 'aoa___warren', 'oidc__warren', 'oidc__warren'::bytea);
 
   end;
   $$ language plpgsql;

--- a/internal/db/sqltest/tests/wh/upsert_user/upsert.sql
+++ b/internal/db/sqltest/tests/wh/upsert_user/upsert.sql
@@ -11,20 +11,24 @@ begin;
   insert into wh_user_dimension
     (
       id,
-      user_id,               user_name,                       user_description,
-      auth_account_id,       auth_account_type,               auth_account_name,             auth_account_description,
-      auth_method_id,        auth_method_type,                auth_method_name,              auth_method_description,
-      user_organization_id,  user_organization_name,          user_organization_description,
-      current_row_indicator, row_effective_time,              row_expiration_time
+      user_id,                  user_name,                       user_description,
+      auth_account_id,          auth_account_type,               auth_account_name,             auth_account_description,
+      auth_account_external_id, auth_account_full_name,          auth_account_email,
+      auth_method_id,           auth_method_type,                auth_method_name,              auth_method_description,
+      auth_method_external_id,
+      user_organization_id,     user_organization_name,          user_organization_description,
+      current_row_indicator,    row_effective_time,              row_expiration_time
     )
   values
     (
       'wud_____1',
-      'u_____walter',        'Walter',                        'This is Walter',
-      'apa___walter',        'password auth account',         'walter',                      'Account for Walter',
-      'apm___widget',        'password auth method',          'Widget Auth Password',        'None',
-      'o_____widget',        'Widget Inc',                    'None',
-      'Current',             '2021-07-21T12:01'::timestamptz, 'infinity'::timestamptz
+      'u_____walter',           'Walter',                        'This is Walter',
+      'apa___walter',           'password auth account',         'walter',                      'Account for Walter',
+      'None',                   'None',                          'None',
+      'apm___widget',           'password auth method',          'Widget Auth Password',        'None',
+      'None',
+      'o_____widget',           'Widget Inc',                    'None',
+      'Current',                '2021-07-21T12:01'::timestamptz, 'infinity'::timestamptz
     );
 
   select lives_ok($$select wh_upsert_user('u_____walter', 'tok___walter')$$);

--- a/internal/db/sqltest/tests/wh/user_dimension/oidc_auth_new_session.sql
+++ b/internal/db/sqltest/tests/wh/user_dimension/oidc_auth_new_session.sql
@@ -1,7 +1,7 @@
 -- oidc_auth_new_session tests the wh_user_dimesion when
 -- a new session is created using the oidc auth method.
 begin;
-  select plan(17);
+  select plan(40);
 
   select wtt_load('widgets', 'iam', 'kms', 'auth', 'hosts', 'targets');
 
@@ -14,26 +14,60 @@ begin;
   values
     ('p____bwidget' , 't_________wb' , 's___1wb-sths' , 'h_____wb__01' , 'u_____walter' , 'oidc__walter' , 'abc'::bytea , 'ep1'    , 's1____walter');
 
-  select is(count(*),                      1::bigint)               from wh_user_dimension;
-  select is(user_id,                       'u_____walter')          from wh_user_dimension;
-  select is(user_name,                     'Walter')                from wh_user_dimension;
-  select is(user_description,              'None')                  from wh_user_dimension;
+  select is(count(*),                      1::bigint)                  from wh_user_dimension;
+  select is(user_id,                       'u_____walter')             from wh_user_dimension;
+  select is(user_name,                     'Walter')                   from wh_user_dimension;
+  select is(user_description,              'None')                     from wh_user_dimension;
 
-  select is(auth_account_id,               'aoa___walter')          from wh_user_dimension;
-  select is(auth_account_type,             'password auth account') from wh_user_dimension;
-  select is(auth_account_name,             'None')                  from wh_user_dimension;
-  select is(auth_account_description,      'None')                  from wh_user_dimension;
+  select is(auth_account_id,               'aoa___walter')             from wh_user_dimension;
+  select is(auth_account_type,             'oidc auth account')        from wh_user_dimension;
+  select is(auth_account_name,             'walter account')           from wh_user_dimension;
+  select is(auth_account_description,      'Walter OIDC Account')      from wh_user_dimension;
+  select is(auth_account_external_id,      'sub___walter')             from wh_user_dimension;
+  select is(auth_account_full_name,        'Walter')                   from wh_user_dimension;
+  select is(auth_account_email,            'walter@widget.test')       from wh_user_dimension;
 
-  select is(auth_method_id,                'aom___widget')          from wh_user_dimension;
-  select is(auth_method_type,              'password auth method')  from wh_user_dimension;
-  select is(auth_method_name,              'None')                  from wh_user_dimension;
-  select is(auth_method_description,       'None')                  from wh_user_dimension;
+  select is(auth_method_id,                'aom___widget')             from wh_user_dimension;
+  select is(auth_method_type,              'oidc auth method')         from wh_user_dimension;
+  select is(auth_method_name,              'Widget OIDC')              from wh_user_dimension;
+  select is(auth_method_description,       'None')                     from wh_user_dimension;
+  select is(auth_method_external_id,       'https://oidc.widget.test') from wh_user_dimension;
 
-  select is(user_organization_id,          'o_____widget')          from wh_user_dimension;
-  select is(user_organization_name,        'Widget Inc')            from wh_user_dimension;
-  select is(user_organization_description, 'None')                  from wh_user_dimension;
+  select is(user_organization_id,          'o_____widget')             from wh_user_dimension;
+  select is(user_organization_name,        'Widget Inc')               from wh_user_dimension;
+  select is(user_organization_description, 'None')                     from wh_user_dimension;
 
-  select is(current_row_indicator,         'Current')               from wh_user_dimension;
+  select is(current_row_indicator,         'Current')                  from wh_user_dimension;
+
+  -- insert session without full name or email
+  insert into session
+    ( scope_id      , target_id      , host_set_id    , host_id        , user_id        , auth_token_id  , certificate  , endpoint , public_id)
+  values
+    ('p____bwidget' , 't_________wb' , 's___1wb-sths' , 'h_____wb__01' , 'u_____warren' , 'oidc__warren' , 'abc'::bytea , 'ep1'    , 's1____warren');
+
+  select is(count(*),                      1::bigint)                  from wh_user_dimension where user_id = 'u_____warren';
+  select is(user_name,                     'Warren')                   from wh_user_dimension where user_id = 'u_____warren';
+  select is(user_description,              'None')                     from wh_user_dimension where user_id = 'u_____warren';
+
+  select is(auth_account_id,               'aoa___warren')             from wh_user_dimension where user_id = 'u_____warren';
+  select is(auth_account_type,             'oidc auth account')        from wh_user_dimension where user_id = 'u_____warren';
+  select is(auth_account_name,             'warren account')           from wh_user_dimension where user_id = 'u_____warren';
+  select is(auth_account_description,      'Warren OIDC Account')      from wh_user_dimension where user_id = 'u_____warren';
+  select is(auth_account_external_id,      'sub___warren')             from wh_user_dimension where user_id = 'u_____warren';
+  select is(auth_account_full_name,        'None')                     from wh_user_dimension where user_id = 'u_____warren';
+  select is(auth_account_email,            'None')                     from wh_user_dimension where user_id = 'u_____warren';
+
+  select is(auth_method_id,                'aom___widget')             from wh_user_dimension where user_id = 'u_____warren';
+  select is(auth_method_type,              'oidc auth method')         from wh_user_dimension where user_id = 'u_____warren';
+  select is(auth_method_name,              'Widget OIDC')              from wh_user_dimension where user_id = 'u_____warren';
+  select is(auth_method_description,       'None')                     from wh_user_dimension where user_id = 'u_____warren';
+  select is(auth_method_external_id,       'https://oidc.widget.test') from wh_user_dimension where user_id = 'u_____warren';
+
+  select is(user_organization_id,          'o_____widget')             from wh_user_dimension where user_id = 'u_____warren';
+  select is(user_organization_name,        'Widget Inc')               from wh_user_dimension where user_id = 'u_____warren';
+  select is(user_organization_description, 'None')                     from wh_user_dimension where user_id = 'u_____warren';
+
+  select is(current_row_indicator,         'Current')                  from wh_user_dimension where user_id = 'u_____warren';
 
   select * from finish();
 rollback;

--- a/internal/db/sqltest/tests/wh/user_dimension/password_auth_description_change.sql
+++ b/internal/db/sqltest/tests/wh/user_dimension/password_auth_description_change.sql
@@ -2,7 +2,7 @@
 -- sessions are created using the password auth method
 -- after the auth_password_account has its description change.
 begin;
-  select plan(32);
+  select plan(40);
 
   select wtt_load('widgets', 'iam', 'kms', 'auth', 'hosts', 'targets');
 
@@ -24,11 +24,15 @@ begin;
   select is(auth_account_type,             'password auth account') from wh_user_dimension;
   select is(auth_account_name,             'None')                  from wh_user_dimension;
   select is(auth_account_description,      'None')                  from wh_user_dimension;
+  select is(auth_account_external_id,      'Not Applicable')        from wh_user_dimension;
+  select is(auth_account_full_name,        'Not Applicable')        from wh_user_dimension;
+  select is(auth_account_email,            'Not Applicable')        from wh_user_dimension;
 
   select is(auth_method_id,                'apm___widget')          from wh_user_dimension;
   select is(auth_method_type,              'password auth method')  from wh_user_dimension;
   select is(auth_method_name,              'Widget Auth Password')  from wh_user_dimension;
   select is(auth_method_description,       'None')                  from wh_user_dimension;
+  select is(auth_method_external_id,       'Not Applicable')        from wh_user_dimension;
 
   select is(user_organization_id,          'o_____widget')          from wh_user_dimension;
   select is(user_organization_name,        'Widget Inc')            from wh_user_dimension;
@@ -62,11 +66,15 @@ begin;
   select is(auth_account_type,             'password auth account')   from wh_user_dimension where current_row_indicator = 'Current';
   select is(auth_account_name,             'None')                    from wh_user_dimension where current_row_indicator = 'Current';
   select is(auth_account_description,      'Walter Password Account') from wh_user_dimension where current_row_indicator = 'Current';
+  select is(auth_account_external_id,      'Not Applicable')          from wh_user_dimension where current_row_indicator = 'Current';
+  select is(auth_account_full_name,        'Not Applicable')          from wh_user_dimension where current_row_indicator = 'Current';
+  select is(auth_account_email,            'Not Applicable')          from wh_user_dimension where current_row_indicator = 'Current';
 
   select is(auth_method_id,                'apm___widget')            from wh_user_dimension where current_row_indicator = 'Current';
   select is(auth_method_type,              'password auth method')    from wh_user_dimension where current_row_indicator = 'Current';
   select is(auth_method_name,              'Widget Auth Password')    from wh_user_dimension where current_row_indicator = 'Current';
   select is(auth_method_description,       'None')                    from wh_user_dimension where current_row_indicator = 'Current';
+  select is(auth_method_external_id,       'Not Applicable')          from wh_user_dimension where current_row_indicator = 'Current';
 
   select is(user_organization_id,          'o_____widget')            from wh_user_dimension where current_row_indicator = 'Current';
   select is(user_organization_name,        'Widget Inc')              from wh_user_dimension where current_row_indicator = 'Current';

--- a/internal/db/sqltest/tests/wh/user_dimension/password_auth_new_session.sql
+++ b/internal/db/sqltest/tests/wh/user_dimension/password_auth_new_session.sql
@@ -1,7 +1,7 @@
 -- password_auth_new_session tests the wh_user_dimesion when
 -- a new session is created using the password auth method.
 begin;
-  select plan(17);
+  select plan(21);
 
   select wtt_load('widgets', 'iam', 'kms', 'auth', 'hosts', 'targets');
 
@@ -23,11 +23,15 @@ begin;
   select is(auth_account_type,             'password auth account') from wh_user_dimension;
   select is(auth_account_name,             'None')                  from wh_user_dimension;
   select is(auth_account_description,      'None')                  from wh_user_dimension;
+  select is(auth_account_external_id,      'Not Applicable')        from wh_user_dimension;
+  select is(auth_account_full_name,        'Not Applicable')        from wh_user_dimension;
+  select is(auth_account_email,            'Not Applicable')        from wh_user_dimension;
 
   select is(auth_method_id,                'apm___widget')          from wh_user_dimension;
   select is(auth_method_type,              'password auth method')  from wh_user_dimension;
   select is(auth_method_name,              'Widget Auth Password')  from wh_user_dimension;
   select is(auth_method_description,       'None')                  from wh_user_dimension;
+  select is(auth_method_external_id,       'Not Applicable')        from wh_user_dimension;
 
   select is(user_organization_id,          'o_____widget')          from wh_user_dimension;
   select is(user_organization_name,        'Widget Inc')            from wh_user_dimension;

--- a/internal/db/sqltest/tests/wh/user_dimension_views/source.sql
+++ b/internal/db/sqltest/tests/wh/user_dimension_views/source.sql
@@ -1,34 +1,40 @@
 -- source tests teh whx_user_dimension_source view.
 begin;
-  select plan(4);
+  select plan(5);
   select wtt_load('widgets', 'iam', 'kms', 'auth', 'hosts', 'targets');
 
   -- auth_password_account
   select is(s.*, row(
-    'u_____walter', 'Walter',                'None',
-    'apa___walter', 'password auth account', 'None',                 'None',
-    'apm___widget', 'password auth method',  'Widget Auth Password', 'None',
-    'o_____widget', 'Widget Inc',            'None'
+    'u_____walter',   'Walter',                'None',
+    'apa___walter',   'password auth account', 'None',                 'None',
+    'Not Applicable', 'Not Applicable',        'Not Applicable',
+    'apm___widget',   'password auth method',  'Widget Auth Password', 'None',
+    'Not Applicable',
+    'o_____widget',   'Widget Inc',            'None'
   )::whx_user_dimension_source)
     from whx_user_dimension_source as s
    where s.user_id         = 'u_____walter'
      and s.auth_account_id = 'apa___walter';
 
   select is(s.*, row(
-    'u_____walter', 'Walter',                'None',
-    'apa1__walter', 'password auth account', 'None',                   'None',
-    'apm1__widget', 'password auth method',  'Widget Auth Password 1', 'None',
-    'o_____widget', 'Widget Inc',            'None'
+    'u_____walter',   'Walter',                'None',
+    'apa1__walter',   'password auth account', 'None',                   'None',
+    'Not Applicable', 'Not Applicable',        'Not Applicable',
+    'apm1__widget',   'password auth method',  'Widget Auth Password 1', 'None',
+    'Not Applicable',
+    'o_____widget',   'Widget Inc',            'None'
   )::whx_user_dimension_source)
     from whx_user_dimension_source as s
    where s.user_id         = 'u_____walter'
      and s.auth_account_id = 'apa1__walter';
 
   select is(s.*, row(
-    'u_____warren', 'Warren',                'None',
-    'apa___warren', 'password auth account', 'None',                 'None',
-    'apm___widget', 'password auth method',  'Widget Auth Password', 'None',
-    'o_____widget', 'Widget Inc',            'None'
+    'u_____warren',   'Warren',                'None',
+    'apa___warren',   'password auth account', 'None',                 'None',
+    'Not Applicable', 'Not Applicable',        'Not Applicable',
+    'apm___widget',   'password auth method',  'Widget Auth Password', 'None',
+    'Not Applicable',
+    'o_____widget',   'Widget Inc',            'None'
   )::whx_user_dimension_source)
     from whx_user_dimension_source as s
    where s.user_id         = 'u_____warren'
@@ -36,14 +42,28 @@ begin;
 
   -- auth_oidc_account
   select is(s.*, row(
-    'u_____walter', 'Walter',                'None',
-    'aoa___walter', 'password auth account', 'None', 'None',
-    'aom___widget', 'password auth method',  'None', 'None',
-    'o_____widget', 'Widget Inc',            'None'
+    'u_____walter',             'Walter',            'None',
+    'aoa___walter',             'oidc auth account', 'walter account',     'Walter OIDC Account',
+    'sub___walter',             'Walter',            'walter@widget.test',
+    'aom___widget',             'oidc auth method',  'Widget OIDC',        'None',
+    'https://oidc.widget.test',
+    'o_____widget',             'Widget Inc',        'None'
   )::whx_user_dimension_source)
     from whx_user_dimension_source as s
    where s.user_id         = 'u_____walter'
      and s.auth_account_id = 'aoa___walter';
+
+  select is(s.*, row(
+    'u_____warren',             'Warren',            'None',
+    'aoa___warren',             'oidc auth account', 'warren account', 'Warren OIDC Account',
+    'sub___warren',             'None',              'None',
+    'aom___widget',             'oidc auth method',  'Widget OIDC',    'None',
+    'https://oidc.widget.test',
+    'o_____widget',             'Widget Inc',        'None'
+  )::whx_user_dimension_source)
+    from whx_user_dimension_source as s
+   where s.user_id         = 'u_____warren'
+     and s.auth_account_id = 'aoa___warren';
 
   select * from finish();
 rollback;

--- a/internal/db/sqltest/tests/wh/user_dimension_views/target.sql
+++ b/internal/db/sqltest/tests/wh/user_dimension_views/target.sql
@@ -7,36 +7,44 @@ begin;
   insert into wh_user_dimension
     (
       id,
-      user_id,               user_name,                       user_description,
-      auth_account_id,       auth_account_type,               auth_account_name,             auth_account_description,
-      auth_method_id,        auth_method_type,                auth_method_name,              auth_method_description,
-      user_organization_id,  user_organization_name,          user_organization_description,
-      current_row_indicator, row_effective_time,              row_expiration_time
+      user_id,                  user_name,                       user_description,
+      auth_account_id,          auth_account_type,               auth_account_name,             auth_account_description,
+      auth_account_external_id, auth_account_full_name,          auth_account_email,
+      auth_method_id,           auth_method_type,                auth_method_name,              auth_method_description,
+      auth_method_external_id,
+      user_organization_id,     user_organization_name,          user_organization_description,
+      current_row_indicator,    row_effective_time,              row_expiration_time
     )
   values
     (
       'wud_____1',
-      'u_____walter',        'Walter',                        'None',
-      'apa___walter',        'password auth account',         'None',                        'None',
-      'apm___widget',        'password auth method',          'Widget Auth Password',        'None',
-      'o_____widget',        'Widget Inc',                    'None',
-      'Expired',             '2021-07-21T11:01'::timestamptz, '2021-07-21T12:01'::timestamptz
+      'u_____walter',           'Walter',                        'None',
+      'apa___walter',           'password auth account',         'None',                        'None',
+      'Not Applicable',         'Not Applicable',                'Not Applicable',
+      'apm___widget',           'password auth method',          'Widget Auth Password',        'None',
+      'Not Applicable',
+      'o_____widget',           'Widget Inc',                    'None',
+      'Expired',                '2021-07-21T11:01'::timestamptz, '2021-07-21T12:01'::timestamptz
     ),
     (
       'wud_____2',
-      'u_____walter',        'Walter',                        'This is Walter',
-      'apa___walter',        'password auth account',         'walter',                      'Account for Walter',
-      'apm___widget',        'password auth method',          'Widget Auth Password',        'None',
-      'o_____widget',        'Widget Inc',                    'None',
-      'Current',             '2021-07-21T12:01'::timestamptz, 'infinity'::timestamptz
+      'u_____walter',           'Walter',                        'This is Walter',
+      'apa___walter',           'password auth account',         'walter',                      'Account for Walter',
+      'Not Applicable',         'Not Applicable',                'Not Applicable',
+      'apm___widget',           'password auth method',          'Widget Auth Password',        'None',
+      'Not Applicable',
+      'o_____widget',           'Widget Inc',                    'None',
+      'Current',                '2021-07-21T12:01'::timestamptz, 'infinity'::timestamptz
     );
 
   select is(t.*, row(
     'wud_____2',
-    'u_____walter', 'Walter',                'This is Walter',
-    'apa___walter', 'password auth account', 'walter',               'Account for Walter',
-    'apm___widget', 'password auth method',  'Widget Auth Password', 'None',
-    'o_____widget', 'Widget Inc',            'None'
+    'u_____walter',   'Walter',                'This is Walter',
+    'apa___walter',   'password auth account', 'walter',               'Account for Walter',
+    'Not Applicable', 'Not Applicable',        'Not Applicable',
+    'apm___widget',   'password auth method',  'Widget Auth Password', 'None',
+    'Not Applicable',
+    'o_____widget',   'Widget Inc',            'None'
   )::whx_user_dimension_target)
     from whx_user_dimension_target as t
    where t.user_id         = 'u_____walter'


### PR DESCRIPTION
This adds new columns to the wh_user_dimension to provide additional
data from OIDC that does not apply to Password Auth.

Note: Given the specifics of the data, it is possible these columns may
be used by other auth methods in the future, hence the lack of `oidc` in
the column names.

The specific columns are:

- auth_method_external_id
    For OIDC this is the Issuer
- auth_account_external_id
    For OIDC this is the Subject
- auth_account_full_name
    For OIDC this is the account's Full Name, and can be `None`.
- auth_account_email
    For OIDC this is the account's Email, and can be `None`.

For all of these new columns, they will be `Not Applicable` if the auth
method is Password.