### PR TITLE
recommend layer 4 network load balancers for HA

### DIFF
--- a/website/content/docs/installing/high-availability.mdx
+++ b/website/content/docs/installing/high-availability.mdx
@@ -25,7 +25,7 @@ The general architecture for the server infrastructure requires 3 controllers an
 ![](/img/production.png)
 
 As shown above, Boundary is broken up into its controller and worker server components across 3 [EC2 instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance), in
-3 separate [subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet), in three separate availability zones, with the controller API and UI being publically exposed by an [application load balancer (ALB)](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb). The worker and controller VM's are in independent [auto-scaling groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group), allowing them to maintain their exact capacity.
+3 separate [subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet), in three separate availability zones, with the controller API and UI being publically exposed by a [load balancer (LB)](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb). The worker and controller VM's are in independent [auto-scaling groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group), allowing them to maintain their exact capacity.
 
 The workers must be able to establish a connection to the hosts with which they interact. In the architecture above, we place them in the public subnet so our remote client can establish a session between them and the target VM.
 
@@ -35,7 +35,7 @@ Boundary requires an external [Postgres](https://www.postgresql.org/) and [KMS](
 
 ### API and Console Load Balancer
 
-Load balancing the controller allows operators to secure the ingress to the Boundary system. We recommend placing all Boundary servers in private networks and using load balancing techniques to expose services such as the API and administrative console to public networks. In the high availability architecture, we recommend load balancing using a layer 7 load balancer and further constraining ingress to that load balancer with layer 4 constraints such as [security groups](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) or [IP tables](https://wiki.archlinux.org/index.php/Iptables).
+Load balancing the controller allows operators to secure the ingress to the Boundary system. We recommend placing all Boundary servers in private networks and using load balancing techniques to expose services such as the API and administrative console to public networks. In the high availability architecture, we recommend load balancing using a layer 4 load balancer and further constraining ingress to that load balancer with layer 4 constraints such as [security groups](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) or [IP tables](https://wiki.archlinux.org/index.php/Iptables).
 
 For general configuration, we recommend the following:
 


### PR DESCRIPTION
current reference architecture for an aws deployment uses a network (layer 4) load balancer. 

https://github.com/hashicorp/boundary-reference-architecture/blob/main/deployment/aws/aws/lb.tf#L3

I have tried and tried to get an application load balancer to work to no avail. im not an expert in these things... 

my understanding is i would setup the tls termination on the controller itself, so from an aws perspective the lb is handling tcp  (L4) not https or http (L7). 

if i am correct, there are further clarifications to this doc i can make, namely the "HTTPS listener" part below this.

if i am incorrect, i would appreciate some advice in getting an alb working. i can submit a pull to  the ref architecture repo if i get it working. (not really sure how to implement health checks using a network lb, so any advice there would also help me update the ref repo.)