### PR TITLE
ci: Check that generated migration code is up to date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1321,6 +1321,150 @@ jobs:
         name: Save package cache
         paths:
         - .buildcache/packages/store
+  generated-check:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+    - checkout
+    - run:
+        command: |
+          make install-go
+          source ~/.bashrc
+          make tools
+        name: Setup
+    - run:
+        command: |
+          source ~/.bashrc
+          make check-migrations
+        name: Check Migrations
+    - run:
+        command: |
+          echo 'export SLACK_BUILD_STATUS="fail"' >> $BASH_ENV
+        name: Slack - Setting Failure Condition
+        when: on_fail
+    - run:
+        command: |
+          echo 'export SLACK_BUILD_STATUS="success"' >> $BASH_ENV
+        name: Slack - Setting Success Condition
+        when: on_success
+    - run:
+        command: |
+          if [ ! -x /bin/bash ]; then
+            echo Bash not installed.
+            exit 1
+          fi
+        name: Provide error if non-bash shell
+    - run:
+        command: |
+          current_branch_in_filter=false
+
+          IFS="," read -ra BRANCH_FILTERS <<< "master"
+
+          for i in "${BRANCH_FILTERS[@]}"; do
+            if [ "${i}" == "${CIRCLE_BRANCH}" ]; then
+              current_branch_in_filter=true
+            fi
+          done
+
+          if [ "x" == "xmaster" ] || [ "$current_branch_in_filter" = true ]; then
+            # Provide error if no webhook is set and error. Otherwise continue
+            if [ -z "webhook" ]; then
+              echo "NO SLACK WEBHOOK SET"
+              echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
+              exit 1
+            else
+              #Create Members string
+              if [ -n "" ]; then
+                IFS="," read -ra SLACK_MEMBERS <<< ""
+                for i in "${SLACK_MEMBERS[@]}"; do
+                  if [ $(echo ${i} | head -c 1) == "S" ]; then
+                    SLACK_MENTIONS="${SLACK_MENTIONS}<!subteam^${i}> "
+                  elif echo ${i} | grep -E "^(here|channel|everyone)$" > /dev/null; then
+                    SLACK_MENTIONS="${SLACK_MENTIONS}<!${i}> "
+                  else
+                    SLACK_MENTIONS="${SLACK_MENTIONS}<@${i}> "
+                  fi
+                done
+              fi
+              #If successful
+              if [ "$SLACK_BUILD_STATUS" = "success" ]; then
+                #Skip if fail_only
+                if [ true = true ]; then
+                  echo "The job completed successfully"
+                  echo '"fail_only" is set to "true". No Slack notification sent.'
+                else
+                  curl -X POST -H 'Content-type: application/json' \
+                    --data "{ \
+                              \"attachments\": [ \
+                                { \
+                                  \"fallback\": \":tada: A $CIRCLE_JOB job has succeeded!\", \
+                                  \"text\": \":tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS\", \
+                                  \"fields\": [ \
+                                    { \
+                                      \"title\": \"Project\", \
+                                      \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
+                                      \"short\": true \
+                                    }, \
+                                    { \
+                                      \"title\": \"Job Number\", \
+                                      \"value\": \"$CIRCLE_BUILD_NUM\", \
+                                      \"short\": true \
+                                    } \
+                                  ], \
+                                  \"actions\": [ \
+                                    { \
+                                      \"type\": \"button\", \
+                                      \"text\": \"Visit Job\", \
+                                      \"url\": \"$CIRCLE_BUILD_URL\" \
+                                    } \
+                                  ], \
+                                  \"color\": \"#1CBF43\" \
+                                } \
+                              ] \
+                            } " webhook
+                  echo "Job completed successfully. Alert sent."
+                fi
+              else
+                #If Failed
+                curl -X POST -H 'Content-type: application/json' \
+                  --data "{ \
+                    \"attachments\": [ \
+                      { \
+                        \"fallback\": \":red_circle: A $CIRCLE_JOB job has failed!\", \
+                        \"text\": \":red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS\", \
+                        \"fields\": [ \
+                          { \
+                            \"title\": \"Project\", \
+                            \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
+                            \"short\": true \
+                          }, \
+                          { \
+                            \"title\": \"Job Number\", \
+                            \"value\": \"$CIRCLE_BUILD_NUM\", \
+                            \"short\": true \
+                          } \
+                        ], \
+                        \"actions\": [ \
+                          { \
+                            \"type\": \"button\", \
+                            \"text\": \"Visit Job\", \
+                            \"url\": \"$CIRCLE_BUILD_URL\" \
+                          } \
+                        ], \
+                        \"color\": \"#ed5c5c\" \
+                      } \
+                    ] \
+                  } " webhook
+                echo "Job failed. Alert sent."
+              fi
+            fi
+          else
+            echo "Current branch is not included in only_for_branches filter; no status alert will be sent"
+          fi
+        name: Slack - Sending Status Alert
+        shell: /bin/bash
+        when: always
+    working_directory: ~/boundary
   freebsd_arm_package:
     docker:
     - image: docker.mirror.hashicorp.services/circleci/buildpack-deps
@@ -1544,6 +1688,7 @@ workflows:
   default:
     jobs:
     - build
+    - generated-check
     - test-sql-latest
     - test-sql-11-alpine
     - test-sql-12-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1328,7 +1328,7 @@ jobs:
         - .buildcache/packages/store
   generated-check:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202107-02
     steps:
     - checkout
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -974,6 +974,11 @@ jobs:
     - checkout
     - run:
         command: |
+          make install-go
+        name: Setup
+    - run:
+        command: |
+          source ~/.bashrc
           make test-ci
         name: Run Acceptance Tests
         no_output_timeout: 15m

--- a/.circleci/config/jobs/build.yml
+++ b/.circleci/config/jobs/build.yml
@@ -4,9 +4,14 @@ working_directory: ~/boundary
 steps:
 - checkout
 - run:
+    name: "Setup"
+    command: |
+      make install-go
+- run:
     name: "Run Acceptance Tests"
     no_output_timeout: 15m
     command: |
+      source ~/.bashrc
       make test-ci
 - slack/status:
     fail_only: true

--- a/.circleci/config/jobs/generated-check.yml
+++ b/.circleci/config/jobs/generated-check.yml
@@ -1,5 +1,5 @@
 machine:
-  image: 'ubuntu-1604:201903-01'
+  image: 'ubuntu-2004:202107-02'
 working_directory: ~/boundary
 steps:
 - checkout

--- a/.circleci/config/jobs/generated-check.yml
+++ b/.circleci/config/jobs/generated-check.yml
@@ -1,0 +1,20 @@
+machine:
+  image: 'ubuntu-1604:201903-01'
+working_directory: ~/boundary
+steps:
+- checkout
+- run:
+    name: "Setup"
+    command: |
+      make install-go
+      source ~/.bashrc
+      make tools
+- run:
+    name: "Check Migrations"
+    command: |
+      source ~/.bashrc
+      make check-migrations
+- slack/status:
+    fail_only: true
+    only_for_branches: master
+    webhook: webhook

--- a/.circleci/config/workflows/default.yml
+++ b/.circleci/config/workflows/default.yml
@@ -1,5 +1,6 @@
 jobs:
   - build
+  - generated-check
   - test-sql:
       matrix:
         parameters:

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ gen: cleangen proto api cli migrations perms-table fmt
 migrations:
 	$(MAKE) --environment-overrides -C internal/db/schema/migrations/generate migrations
 
+check-migrations:
+	$(MAKE) --environment-overrides -C internal/db/schema/migrations/generate check
+
 ### oplog requires protoc-gen-go v1.20.0 or later
 # GO111MODULE=on go get -u github.com/golang/protobuf/protoc-gen-go@v1.40
 proto: protolint protobuild

--- a/Makefile
+++ b/Makefile
@@ -156,16 +156,18 @@ website-start:
 	@npm start --prefix website/
 
 test-ci: install-go
-	~/.go/bin/go test ./... -v $(TESTARGS) -timeout 120m
+	go test ./... -v $(TESTARGS) -timeout 120m
 
 test-sql:
 	$(MAKE) -C internal/db/sqltest/ test
 
-test: 
-	~/.go/bin/go test ./... -timeout 30m
+test:
+	go test ./... -timeout 30m
 
-install-go:
+~/.go/bin/go:
 	./ci/goinstall.sh
+
+install-go: ~/.go/bin/go
 
 # Docker build and publish variables and targets
 REGISTRY_NAME?=docker.io/hashicorp

--- a/internal/db/schema/migrations/generate/Makefile
+++ b/internal/db/schema/migrations/generate/Makefile
@@ -6,4 +6,8 @@ migrations:
 	goimports -w ${GEN_BASEPATH}/internal/db/schema
 	gofumpt -w ${GEN_BASEPATH}/internal/db/schema
 
-.PHONY: migrations
+check: migrations
+	@git status --porcelain ${GEN_BASEPATH}/internal/db/schema
+	@git diff --exit-code ${GEN_BASEPATH}/internal/db/schema
+
+.PHONY: migrations check


### PR DESCRIPTION
This adds a new job to CircleCI to generate the go code from the sql
migration files and check if there are any changes. This will result in
CI failing if `make migrations` was not run after adding new sql
migration files.