### PR TITLE
updating db init without generated resources example

### DIFF
--- a/website/content/docs/installing/no-gen-resources.mdx
+++ b/website/content/docs/installing/no-gen-resources.mdx
@@ -118,7 +118,12 @@ From this command, you can see the flags available to skip the creation of auto-
 To initialize the Boundary database without generated resources:
 
 ```
-$ boundary database init -skip-initial-login-role-creation -config /etc/boundary.hcl
+$ boundary database init \
+   -skip-auth-method-creation \
+   -skip-host-resources-creation \
+   -skip-scopes-creation \
+   -skip-target-creation \
+   -config /etc/boundary.hcl
 ```
 
 When you start Boundary, you will effectively have a blank sheet to work against. The initial migrations in the database have been run (note that this includes creating special users like `u_anon` and the `global` scope) and the internal keyrings have been initialized. From here, it's required that


### PR DESCRIPTION
The existing documentation references this command to initialize the database without generated resources:

```shell
boundary database init -skip-initial-login-role-creation -config /etc/boundary.hcl
```

This is no longer supported and has been superceded with the following:

```shell
boundary database init \
   -skip-auth-method-creation \
   -skip-host-resources-creation \
   -skip-scopes-creation \
   -skip-target-creation \
   -config /etc/boundary.hcl
```

I was getting errors when following the existing example and had to look into the code to figure out its been changed so updating the docs to reflect this change.