### PR TITLE
bug(targets): fixes bug that caused a panic in authorize-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## Next
 
+### Bug Fixes
+
+* targets: Fix panic when using `boundary targets authorize-session`
+  ([issue](https://github.com/hashicorp/boundary/issues/1488),
+  [PR](https://github.com/hashicorp/boundary/pull/1496)).
+
 ## 0.5.1 (2021/08/16)
 
 ### New and Improved

--- a/internal/servers/controller/handlers/targets/target_service.go
+++ b/internal/servers/controller/handlers/targets/target_service.go
@@ -1098,6 +1098,13 @@ HostSourceIterationLoop:
 				CredentialStoreId: l.GetStoreId(),
 				Type:              credential.SubtypeFromId(l.GetPublicId()).String(),
 			},
+			CredentialSource: &pb.CredentialSource{
+				Id:                l.GetPublicId(),
+				Name:              l.GetName(),
+				Description:       l.GetDescription(),
+				CredentialStoreId: l.GetStoreId(),
+				Type:              credential.SubtypeFromId(l.GetPublicId()).String(),
+			},
 			Secret: &pb.SessionSecret{
 				Raw:     base64.StdEncoding.EncodeToString(jSecret),
 				Decoded: sSecret,

--- a/internal/servers/controller/handlers/targets/target_service_test.go
+++ b/internal/servers/controller/handlers/targets/target_service_test.go
@@ -2545,11 +2545,11 @@ func TestAuthorizeSession(t *testing.T) {
 	}})
 	require.NoError(t, err)
 
-	_, err = s.AddTargetCredentialLibraries(ctx,
-		&pbs.AddTargetCredentialLibrariesRequest{
-			Id:                              tar.GetPublicId(),
-			ApplicationCredentialLibraryIds: []string{clsResp.GetItem().GetId()},
-			Version:                         apiTar.GetItem().GetVersion(),
+	_, err = s.AddTargetCredentialSources(ctx,
+		&pbs.AddTargetCredentialSourcesRequest{
+			Id:                             tar.GetPublicId(),
+			ApplicationCredentialSourceIds: []string{clsResp.GetItem().GetId()},
+			Version:                        apiTar.GetItem().GetVersion(),
 		})
 	require.NoError(t, err)
 
@@ -2590,6 +2590,13 @@ func TestAuthorizeSession(t *testing.T) {
 		Endpoint:  fmt.Sprintf("tcp://%s", h.GetAddress()),
 		Credentials: []*pb.SessionCredential{{
 			CredentialLibrary: &pb.CredentialLibrary{
+				Id:                clsResp.GetItem().GetId(),
+				Name:              clsResp.GetItem().GetName().GetValue(),
+				Description:       clsResp.GetItem().GetDescription().GetValue(),
+				CredentialStoreId: store.GetPublicId(),
+				Type:              vault.Subtype.String(),
+			},
+			CredentialSource: &pb.CredentialSource{
 				Id:                clsResp.GetItem().GetId(),
 				Name:              clsResp.GetItem().GetName().GetValue(),
 				Description:       clsResp.GetItem().GetDescription().GetValue(),


### PR DESCRIPTION
Fixes #1488 

The panic is occurring here https://github.com/hashicorp/boundary/blob/main/internal/cmd/commands/targetscmd/funcs.go#L822 and the issue is at this point the target service has populated the `CredentialLibrary` struct and not the `CredentialSource` struct.  We could also update the targetscmd to support both in the interim...

Panic for reference:

```
boundary targets authorize-session -id ttcp_5PS2dktESb
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1f99a31]

goroutine 1 [running]:
github.com/hashicorp/boundary/internal/cmd/commands/targetscmd.printCustomActionOutputImpl(0xc00046c0a0)
	/Users/louisruch/boundary/internal/cmd/commands/targetscmd/funcs.go:822 +0x9d1
github.com/hashicorp/boundary/internal/cmd/commands/targetscmd.(*Command).Run(0xc00046c0a0, {0xc000134030, 0x2, 0x2})
	/Users/louisruch/boundary/internal/cmd/commands/targetscmd/targets.gen.go:324 +0x188b
github.com/mitchellh/cli.(*CLI).Run(0xc0001c6500)
	/Users/louisruch/go/pkg/mod/github.com/mitchellh/cli@v1.1.2/cli.go:262 +0x5f8
github.com/hashicorp/boundary/internal/cmd.RunCustom({0xc000134010, 0x60, 0x0}, 0x0)
	/Users/louisruch/boundary/internal/cmd/main.go:186 +0x9d6
github.com/hashicorp/boundary/internal/cmd.Run(...)
	/Users/louisruch/boundary/internal/cmd/main.go:92
main.main()
	/Users/louisruch/boundary/cmd/boundary/main.go:13 +0xc9
```