### PR TITLE
Multi-arch Docker Build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ docker-multiarch-build:
 	docker buildx build \
 	--push \
 	--tag $(IMAGE_TAG) \
-	--tag hashicorp/boundary:latest \
+	--tag hashicorp/boundary:latest \	
 	--build-arg VERSION=$(VERSION) \
 	--platform linux/amd64,linux/arm64 \
 	--file $(DOCKER_DIR)/Release.dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -191,11 +191,11 @@ docker-multiarch-build:
 	docker buildx build \
 	--push \
 	--tag $(IMAGE_TAG) \
-	--tag hashicorp/boundary:latest \	
+	--tag hashicorp/boundary:latest \
 	--build-arg VERSION=$(VERSION) \
 	--platform linux/amd64,linux/arm64 \
 	--file $(DOCKER_DIR)/Release.dockerfile .
-	
+
 # builds from locally generated binary in bin/
 docker-build-dev: export XC_OSARCH=linux/amd64
 docker-build-dev: dev

--- a/docker/Release.dockerfile
+++ b/docker/Release.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirror.hashicorp.services/alpine:3.13
+FROM docker.mirror.hashicorp.services/alpine:3.11
 
 ARG VERSION=0.5.1
 

--- a/docker/Release.dockerfile
+++ b/docker/Release.dockerfile
@@ -1,6 +1,6 @@
 FROM docker.mirror.hashicorp.services/alpine:3.13
 
-ARG VERSION=0.5.0
+ARG VERSION=0.5.1
 
 LABEL name="Boundary" \
       maintainer="HashiCorp Boundary Team <boundary@hashicorp.com>" \
@@ -33,13 +33,13 @@ RUN set -eux && \
     rm boundary_${VERSION}_linux_${boundaryArch}.zip boundary_${VERSION}_SHA256SUMS boundary_${VERSION}_SHA256SUMS.sig && \
     mkdir /boundary
 
-COPY config.hcl /boundary/config.hcl
+COPY docker/config.hcl /boundary/config.hcl
 
 RUN chown -R boundary:boundary /boundary/ 
 
 EXPOSE 9200 9201 9202
 VOLUME /boundary/
 
-COPY ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["server", "-config", "/boundary/config.hcl"]


### PR DESCRIPTION
Fixed a few things with the multi-arch build:

- The makefile build would fail because it couldn't find the entrypoint and config file. Fixed that by passing in the docker directory
- Alpine 3.13 was failing the multi-arch builds so I've switched it Alpine 3.11 right now as this successfully builds
- Updated the version from Boundary 0.5.0 to 0.5.1

I've tested the Makefile build locally and had success building arm/amd images to a local registry.