### PR TITLE
fix (controller): Set controller CancelCtx

### DIFF
--- a/internal/servers/controller/listeners.go
+++ b/internal/servers/controller/listeners.go
@@ -26,6 +26,7 @@ func (c *Controller) startListeners() error {
 	configureForAPI := func(ln *base.ServerListener) error {
 		handler, err := c.handler(HandlerProperties{
 			ListenerConfig: ln.Config,
+			CancelCtx:      c.baseContext,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR sets the controllers CancelCtx to something besides nil, which I'm not sure it was ever set.  This ctx is passed to all grpc-gateway service registrations in handleGrpcGateway. 
