### PR TITLE
Placeholder Plugin Providers for Repos and added testPlugin struct

### DIFF
--- a/internal/host/plugin/repository.go
+++ b/internal/host/plugin/repository.go
@@ -58,7 +58,7 @@ func NewRepository(r db.Reader, w db.Writer, kms *kms.Kms, plgm map[string]plgpb
 		reader:       r,
 		writer:       w,
 		kms:          kms,
-		plugins: 	  plgs,
+		plugins:      plgs,
 		defaultLimit: opts.withLimit,
 	}, nil
 }

--- a/internal/host/plugin/repository.go
+++ b/internal/host/plugin/repository.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/kms"
+	plgpb "github.com/hashicorp/boundary/sdk/pbs/plugin"
 )
 
 // A Repository stores and retrieves the persistent types in the plugin
@@ -15,6 +16,11 @@ type Repository struct {
 	reader db.Reader
 	writer db.Writer
 	kms    *kms.Kms
+
+	// plugins is a map from plugin resource id to host plugin client.
+	// TODO: When we are using go-plugin change from using a plgpb.HostPluginServiceServer
+	//    to the client.
+	plugins map[string]plgpb.HostPluginServiceServer
 	// defaultLimit provides a default for limiting the number of results
 	// returned from the repo
 	defaultLimit int
@@ -24,7 +30,7 @@ type Repository struct {
 // only be used for one transaction and it is not safe for concurrent go
 // routines to access it. WithLimit option is used as a repo wide default
 // limit applied to all ListX methods.
-func NewRepository(r db.Reader, w db.Writer, kms *kms.Kms, opt ...Option) (*Repository, error) {
+func NewRepository(r db.Reader, w db.Writer, kms *kms.Kms, plgm map[string]plgpb.HostPluginServiceServer, opt ...Option) (*Repository, error) {
 	const op = "plugin.NewRepository"
 	switch {
 	case r == nil:
@@ -33,6 +39,8 @@ func NewRepository(r db.Reader, w db.Writer, kms *kms.Kms, opt ...Option) (*Repo
 		return nil, errors.NewDeprecated(errors.InvalidParameter, op, "db.Writer")
 	case kms == nil:
 		return nil, errors.NewDeprecated(errors.InvalidParameter, op, "kms")
+	case plgm == nil:
+		return nil, errors.NewDeprecated(errors.InvalidParameter, op, "plgm")
 	}
 
 	opts := getOpts(opt...)
@@ -41,10 +49,16 @@ func NewRepository(r db.Reader, w db.Writer, kms *kms.Kms, opt ...Option) (*Repo
 		opts.withLimit = db.DefaultLimit
 	}
 
+	plgs := make(map[string]plgpb.HostPluginServiceServer, len(plgm))
+	for k, v := range plgm {
+		plgs[k] = v
+	}
+
 	return &Repository{
 		reader:       r,
 		writer:       w,
 		kms:          kms,
+		plugins: 	  plgs,
 		defaultLimit: opts.withLimit,
 	}, nil
 }

--- a/internal/host/plugin/repository_host_catalog_test.go
+++ b/internal/host/plugin/repository_host_catalog_test.go
@@ -156,16 +156,16 @@ func TestRepository_CreateCatalog(t *testing.T) {
 			name: "valid-with-attributes",
 			in: &HostCatalog{
 				HostCatalog: &store.HostCatalog{
-					ScopeId:     prj.GetPublicId(),
-					PluginId:    plg.GetPublicId(),
-					Attributes:  []byte(`{"k1":"foo"}`),
+					ScopeId:    prj.GetPublicId(),
+					PluginId:   plg.GetPublicId(),
+					Attributes: []byte(`{"k1":"foo"}`),
 				},
 			},
 			want: &HostCatalog{
 				HostCatalog: &store.HostCatalog{
-					ScopeId:     prj.GetPublicId(),
-					PluginId:    plg.GetPublicId(),
-					Attributes:  []byte(`{"k1":"foo"}`),
+					ScopeId:    prj.GetPublicId(),
+					PluginId:   plg.GetPublicId(),
+					Attributes: []byte(`{"k1":"foo"}`),
 				},
 			},
 		},

--- a/internal/host/plugin/repository_host_set_test.go
+++ b/internal/host/plugin/repository_host_set_test.go
@@ -71,8 +71,8 @@ func TestRepository_CreateSet(t *testing.T) {
 			name: "invalid-public-id-set",
 			in: &HostSet{
 				HostSet: &store.HostSet{
-					CatalogId: catalog.PublicId,
-					PublicId:  "abcd_OOOOOOOOOO",
+					CatalogId:  catalog.PublicId,
+					PublicId:   "abcd_OOOOOOOOOO",
 					Attributes: attrs,
 				},
 			},
@@ -91,13 +91,13 @@ func TestRepository_CreateSet(t *testing.T) {
 			name: "valid-no-options",
 			in: &HostSet{
 				HostSet: &store.HostSet{
-					CatalogId: catalog.PublicId,
+					CatalogId:  catalog.PublicId,
 					Attributes: attrs,
 				},
 			},
 			want: &HostSet{
 				HostSet: &store.HostSet{
-					CatalogId: catalog.PublicId,
+					CatalogId:  catalog.PublicId,
 					Attributes: attrs,
 				},
 			},
@@ -106,15 +106,15 @@ func TestRepository_CreateSet(t *testing.T) {
 			name: "valid-with-name",
 			in: &HostSet{
 				HostSet: &store.HostSet{
-					CatalogId: catalog.PublicId,
-					Name:      "test-name-repo",
+					CatalogId:  catalog.PublicId,
+					Name:       "test-name-repo",
 					Attributes: attrs,
 				},
 			},
 			want: &HostSet{
 				HostSet: &store.HostSet{
-					CatalogId: catalog.PublicId,
-					Name:      "test-name-repo",
+					CatalogId:  catalog.PublicId,
+					Name:       "test-name-repo",
 					Attributes: attrs,
 				},
 			},
@@ -125,14 +125,14 @@ func TestRepository_CreateSet(t *testing.T) {
 				HostSet: &store.HostSet{
 					CatalogId:   catalog.PublicId,
 					Description: ("test-description-repo"),
-					Attributes: attrs,
+					Attributes:  attrs,
 				},
 			},
 			want: &HostSet{
 				HostSet: &store.HostSet{
 					CatalogId:   catalog.PublicId,
 					Description: ("test-description-repo"),
-					Attributes: attrs,
+					Attributes:  attrs,
 				},
 			},
 		},
@@ -142,14 +142,14 @@ func TestRepository_CreateSet(t *testing.T) {
 				HostSet: &store.HostSet{
 					CatalogId:   catalog.PublicId,
 					Description: ("test-description-repo"),
-					Attributes: []byte(`{"k1":"foo"}`),
+					Attributes:  []byte(`{"k1":"foo"}`),
 				},
 			},
 			want: &HostSet{
 				HostSet: &store.HostSet{
 					CatalogId:   catalog.PublicId,
 					Description: ("test-description-repo"),
-					Attributes: []byte(`{"k1":"foo"}`),
+					Attributes:  []byte(`{"k1":"foo"}`),
 				},
 			},
 		},
@@ -195,8 +195,8 @@ func TestRepository_CreateSet(t *testing.T) {
 
 		in := &HostSet{
 			HostSet: &store.HostSet{
-				CatalogId: catalog.PublicId,
-				Name:      "test-name-repo",
+				CatalogId:  catalog.PublicId,
+				Name:       "test-name-repo",
 				Attributes: []byte("{}"),
 			},
 		}
@@ -227,7 +227,7 @@ func TestRepository_CreateSet(t *testing.T) {
 
 		in := &HostSet{
 			HostSet: &store.HostSet{
-				Name: "test-name-repo",
+				Name:       "test-name-repo",
 				Attributes: []byte("{}"),
 			},
 		}

--- a/internal/host/plugin/repository_test.go
+++ b/internal/host/plugin/repository_test.go
@@ -21,11 +21,11 @@ func TestRepository_New(t *testing.T) {
 	plgs := map[string]plgpb.HostPluginServiceServer{}
 
 	type args struct {
-		r    db.Reader
-		w    db.Writer
-		kms  *kms.Kms
+		r       db.Reader
+		w       db.Writer
+		kms     *kms.Kms
 		plugins map[string]plgpb.HostPluginServiceServer
-		opts []Option
+		opts    []Option
 	}
 
 	tests := []struct {
@@ -37,42 +37,42 @@ func TestRepository_New(t *testing.T) {
 		{
 			name: "valid",
 			args: args{
-				r:   rw,
-				w:   rw,
-				kms: kmsCache,
+				r:       rw,
+				w:       rw,
+				kms:     kmsCache,
 				plugins: plgs,
 			},
 			want: &Repository{
 				reader:       rw,
 				writer:       rw,
 				kms:          kmsCache,
-				plugins: plgs,
+				plugins:      plgs,
 				defaultLimit: db.DefaultLimit,
 			},
 		},
 		{
 			name: "valid-with-limit",
 			args: args{
-				r:    rw,
-				w:    rw,
-				kms:  kmsCache,
+				r:       rw,
+				w:       rw,
+				kms:     kmsCache,
 				plugins: plgs,
-				opts: []Option{WithLimit(5)},
+				opts:    []Option{WithLimit(5)},
 			},
 			want: &Repository{
 				reader:       rw,
 				writer:       rw,
 				kms:          kmsCache,
-				plugins: plgs,
+				plugins:      plgs,
 				defaultLimit: 5,
 			},
 		},
 		{
 			name: "nil-reader",
 			args: args{
-				r:   nil,
-				w:   rw,
-				kms: kmsCache,
+				r:       nil,
+				w:       rw,
+				kms:     kmsCache,
 				plugins: plgs,
 			},
 			want:      nil,
@@ -81,9 +81,9 @@ func TestRepository_New(t *testing.T) {
 		{
 			name: "nil-writer",
 			args: args{
-				r:   rw,
-				w:   nil,
-				kms: kmsCache,
+				r:       rw,
+				w:       nil,
+				kms:     kmsCache,
 				plugins: plgs,
 			},
 			want:      nil,
@@ -92,9 +92,9 @@ func TestRepository_New(t *testing.T) {
 		{
 			name: "nil-kms",
 			args: args{
-				r:   rw,
-				w:   rw,
-				kms: nil,
+				r:       rw,
+				w:       rw,
+				kms:     nil,
 				plugins: plgs,
 			},
 			want:      nil,
@@ -103,9 +103,9 @@ func TestRepository_New(t *testing.T) {
 		{
 			name: "nil-plugins",
 			args: args{
-				r:   rw,
-				w:   rw,
-				kms: kmsCache,
+				r:       rw,
+				w:       rw,
+				kms:     kmsCache,
 				plugins: nil,
 			},
 			want:      nil,
@@ -114,9 +114,9 @@ func TestRepository_New(t *testing.T) {
 		{
 			name: "all-nils",
 			args: args{
-				r:   nil,
-				w:   nil,
-				kms: nil,
+				r:       nil,
+				w:       nil,
+				kms:     nil,
 				plugins: nil,
 			},
 			want:      nil,

--- a/internal/host/plugin/testing.go
+++ b/internal/host/plugin/testing.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/plugin/host"
+	plgpb "github.com/hashicorp/boundary/sdk/pbs/plugin"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,4 +65,66 @@ func TestSet(t *testing.T, conn *gorm.DB, catalogId string, opt ...Option) *Host
 
 	require.NoError(t, w.Create(ctx, set))
 	return set
+}
+
+// testPlugin provides a host plugin service server where each method
+// can be overwritten.
+type testPlugin struct {
+	onCreateCatalog func(context.Context, *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error)
+	onUpdateCatalog func(context.Context, *plgpb.OnUpdateCatalogRequest) (*plgpb.OnUpdateCatalogResponse, error)
+	onDeleteCatalog func(context.Context, *plgpb.OnDeleteCatalogRequest) (*plgpb.OnDeleteCatalogResponse, error)
+	onCreateSet func(context.Context, *plgpb.OnCreateSetRequest) (*plgpb.OnCreateSetResponse, error)
+	onUpdateSet func(context.Context, *plgpb.OnUpdateSetRequest) (*plgpb.OnUpdateSetResponse, error)
+	onDeleteSet func(context.Context, *plgpb.OnDeleteSetRequest) (*plgpb.OnDeleteSetResponse, error)
+	listHosts func(context.Context, *plgpb.ListHostsRequest) (*plgpb.ListHostsResponse, error)
+	plgpb.UnimplementedHostPluginServiceServer
+}
+
+func (t testPlugin) OnCreateCatalog(ctx context.Context, req *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error) {
+	if t.onCreateCatalog != nil {
+		return t.UnimplementedHostPluginServiceServer.OnCreateCatalog(ctx, req)
+	}
+	return t.onCreateCatalog(ctx, req)
+}
+
+func (t testPlugin) OnUpdateCatalog(ctx context.Context, req *plgpb.OnUpdateCatalogRequest) (*plgpb.OnUpdateCatalogResponse, error) {
+	if t.onCreateCatalog != nil {
+		return t.UnimplementedHostPluginServiceServer.OnUpdateCatalog(ctx, req)
+	}
+	return t.onUpdateCatalog(ctx, req)
+}
+
+func (t testPlugin) OnDeleteCatalog(ctx context.Context, req *plgpb.OnDeleteCatalogRequest) (*plgpb.OnDeleteCatalogResponse, error) {
+	if t.onCreateCatalog != nil {
+		return t.UnimplementedHostPluginServiceServer.OnDeleteCatalog(ctx, req)
+	}
+	return t.onDeleteCatalog(ctx, req)
+}
+
+func (t testPlugin) OnCreateSet(ctx context.Context, req *plgpb.OnCreateSetRequest) (*plgpb.OnCreateSetResponse, error) {
+	if t.onCreateCatalog != nil {
+		return t.UnimplementedHostPluginServiceServer.OnCreateSet(ctx, req)
+	}
+	return t.onCreateSet(ctx, req)
+}
+
+func (t testPlugin) OnUpdateSet(ctx context.Context, req *plgpb.OnUpdateSetRequest) (*plgpb.OnUpdateSetResponse, error) {
+	if t.onCreateCatalog != nil {
+		return t.UnimplementedHostPluginServiceServer.OnUpdateSet(ctx, req)
+	}
+	return t.onUpdateSet(ctx, req)
+}
+
+func (t testPlugin) OnDeleteSet(ctx context.Context, req *plgpb.OnDeleteSetRequest) (*plgpb.OnDeleteSetResponse, error) {
+	if t.onCreateCatalog != nil {
+		return t.UnimplementedHostPluginServiceServer.OnDeleteSet(ctx, req)
+	}
+	return t.onDeleteSet(ctx, req)
+}
+
+func (t testPlugin) ListHosts(ctx context.Context, req *plgpb.ListHostsRequest) (*plgpb.ListHostsResponse, error) {
+	if t.onCreateCatalog != nil {
+		return t.UnimplementedHostPluginServiceServer.ListHosts(ctx, req)
+	}
+	return t.listHosts(ctx, req)
 }

--- a/internal/host/plugin/testing.go
+++ b/internal/host/plugin/testing.go
@@ -72,10 +72,10 @@ type testPlugin struct {
 	onCreateCatalog func(context.Context, *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error)
 	onUpdateCatalog func(context.Context, *plgpb.OnUpdateCatalogRequest) (*plgpb.OnUpdateCatalogResponse, error)
 	onDeleteCatalog func(context.Context, *plgpb.OnDeleteCatalogRequest) (*plgpb.OnDeleteCatalogResponse, error)
-	onCreateSet func(context.Context, *plgpb.OnCreateSetRequest) (*plgpb.OnCreateSetResponse, error)
-	onUpdateSet func(context.Context, *plgpb.OnUpdateSetRequest) (*plgpb.OnUpdateSetResponse, error)
-	onDeleteSet func(context.Context, *plgpb.OnDeleteSetRequest) (*plgpb.OnDeleteSetResponse, error)
-	listHosts func(context.Context, *plgpb.ListHostsRequest) (*plgpb.ListHostsResponse, error)
+	onCreateSet     func(context.Context, *plgpb.OnCreateSetRequest) (*plgpb.OnCreateSetResponse, error)
+	onUpdateSet     func(context.Context, *plgpb.OnUpdateSetRequest) (*plgpb.OnUpdateSetResponse, error)
+	onDeleteSet     func(context.Context, *plgpb.OnDeleteSetRequest) (*plgpb.OnDeleteSetResponse, error)
+	listHosts       func(context.Context, *plgpb.ListHostsRequest) (*plgpb.ListHostsResponse, error)
 	plgpb.UnimplementedHostPluginServiceServer
 }
 

--- a/internal/host/plugin/testing.go
+++ b/internal/host/plugin/testing.go
@@ -67,8 +67,7 @@ func TestSet(t *testing.T, conn *gorm.DB, catalogId string, opt ...Option) *Host
 	return set
 }
 
-// testPlugin provides a host plugin service server where each method
-// can be overwritten.
+// testPlugin provides a host plugin service server where each method can be overwritten for tests.
 type testPlugin struct {
 	onCreateCatalog func(context.Context, *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error)
 	onUpdateCatalog func(context.Context, *plgpb.OnUpdateCatalogRequest) (*plgpb.OnUpdateCatalogResponse, error)
@@ -81,49 +80,49 @@ type testPlugin struct {
 }
 
 func (t testPlugin) OnCreateCatalog(ctx context.Context, req *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error) {
-	if t.onCreateCatalog != nil {
+	if t.onCreateCatalog == nil {
 		return t.UnimplementedHostPluginServiceServer.OnCreateCatalog(ctx, req)
 	}
 	return t.onCreateCatalog(ctx, req)
 }
 
 func (t testPlugin) OnUpdateCatalog(ctx context.Context, req *plgpb.OnUpdateCatalogRequest) (*plgpb.OnUpdateCatalogResponse, error) {
-	if t.onCreateCatalog != nil {
+	if t.onUpdateCatalog == nil {
 		return t.UnimplementedHostPluginServiceServer.OnUpdateCatalog(ctx, req)
 	}
 	return t.onUpdateCatalog(ctx, req)
 }
 
 func (t testPlugin) OnDeleteCatalog(ctx context.Context, req *plgpb.OnDeleteCatalogRequest) (*plgpb.OnDeleteCatalogResponse, error) {
-	if t.onCreateCatalog != nil {
+	if t.onDeleteCatalog == nil {
 		return t.UnimplementedHostPluginServiceServer.OnDeleteCatalog(ctx, req)
 	}
 	return t.onDeleteCatalog(ctx, req)
 }
 
 func (t testPlugin) OnCreateSet(ctx context.Context, req *plgpb.OnCreateSetRequest) (*plgpb.OnCreateSetResponse, error) {
-	if t.onCreateCatalog != nil {
+	if t.onCreateSet == nil {
 		return t.UnimplementedHostPluginServiceServer.OnCreateSet(ctx, req)
 	}
 	return t.onCreateSet(ctx, req)
 }
 
 func (t testPlugin) OnUpdateSet(ctx context.Context, req *plgpb.OnUpdateSetRequest) (*plgpb.OnUpdateSetResponse, error) {
-	if t.onCreateCatalog != nil {
+	if t.onUpdateSet == nil {
 		return t.UnimplementedHostPluginServiceServer.OnUpdateSet(ctx, req)
 	}
 	return t.onUpdateSet(ctx, req)
 }
 
 func (t testPlugin) OnDeleteSet(ctx context.Context, req *plgpb.OnDeleteSetRequest) (*plgpb.OnDeleteSetResponse, error) {
-	if t.onCreateCatalog != nil {
+	if t.onDeleteSet == nil {
 		return t.UnimplementedHostPluginServiceServer.OnDeleteSet(ctx, req)
 	}
 	return t.onDeleteSet(ctx, req)
 }
 
 func (t testPlugin) ListHosts(ctx context.Context, req *plgpb.ListHostsRequest) (*plgpb.ListHostsResponse, error) {
-	if t.onCreateCatalog != nil {
+	if t.listHosts == nil {
 		return t.UnimplementedHostPluginServiceServer.ListHosts(ctx, req)
 	}
 	return t.listHosts(ctx, req)

--- a/internal/servers/controller/handlers/host_catalogs/host_catalog_service.go
+++ b/internal/servers/controller/handlers/host_catalogs/host_catalog_service.go
@@ -67,7 +67,7 @@ type Service struct {
 
 	staticRepoFn     common.StaticRepoFactory
 	pluginHostRepoFn common.PluginHostRepoFactory
-	pluginRepoFn common.HostPluginRepoFactory
+	pluginRepoFn     common.HostPluginRepoFactory
 	iamRepoFn        common.IamRepoFactory
 }
 

--- a/internal/servers/controller/handlers/host_catalogs/host_catalog_service_test.go
+++ b/internal/servers/controller/handlers/host_catalogs/host_catalog_service_test.go
@@ -272,7 +272,7 @@ func TestList(t *testing.T) {
 	var testPluginCatalogs []*pb.HostCatalog
 	name := "test"
 	plg := host.TestPlugin(t, conn, name, name)
-	for i := 0 ; i < 3; i++ {
+	for i := 0; i < 3; i++ {
 		hc := plugin.TestCatalog(t, conn, pWithCatalogs.GetPublicId(), plg.GetPublicId())
 		cat := &pb.HostCatalog{
 			Id:                          hc.GetPublicId(),
@@ -306,7 +306,7 @@ func TestList(t *testing.T) {
 
 	name = "different"
 	plg = host.TestPlugin(t, conn, name, name)
-	for i := 0 ; i < 3; i++ {
+	for i := 0; i < 3; i++ {
 		hc := plugin.TestCatalog(t, conn, pWithOtherCatalogs.GetPublicId(), plg.GetPublicId())
 		wantOtherCatalogs = append(wantOtherCatalogs, &pb.HostCatalog{
 			Id:                          hc.GetPublicId(),

--- a/internal/servers/controller/handlers/targets/target_service.go
+++ b/internal/servers/controller/handlers/targets/target_service.go
@@ -1731,7 +1731,7 @@ func validateSetSetsRequest(req *pbs.SetTargetHostSetsRequest) error {
 		badFields[globals.VersionField] = "Required field."
 	}
 	for _, id := range req.GetHostSetIds() {
-		if !handlers.ValidId(handlers.Id(id), static.HostSetPrefix)  &&
+		if !handlers.ValidId(handlers.Id(id), static.HostSetPrefix) &&
 			!strings.HasPrefix(id, fmt.Sprintf("%s_", plugin.HostSetPrefix)) {
 			badFields[globals.HostSetIdsField] = fmt.Sprintf("Incorrectly formatted host set identifier %q.", id)
 			break
@@ -1755,7 +1755,7 @@ func validateRemoveSetsRequest(req *pbs.RemoveTargetHostSetsRequest) error {
 		badFields[globals.HostSetIdsField] = "Must be non-empty."
 	}
 	for _, id := range req.GetHostSetIds() {
-		if !handlers.ValidId(handlers.Id(id), static.HostSetPrefix)  &&
+		if !handlers.ValidId(handlers.Id(id), static.HostSetPrefix) &&
 			!strings.HasPrefix(id, fmt.Sprintf("%s_", plugin.HostSetPrefix)) {
 			badFields[globals.HostSetIdsField] = fmt.Sprintf("Incorrectly formatted host set identifier %q.", id)
 			break
@@ -1779,7 +1779,7 @@ func validateAddHostSourcesRequest(req *pbs.AddTargetHostSourcesRequest) error {
 		badFields[globals.HostSourceIdsField] = "Must be non-empty."
 	}
 	for _, id := range req.GetHostSourceIds() {
-		if !handlers.ValidId(handlers.Id(id), static.HostSetPrefix)  &&
+		if !handlers.ValidId(handlers.Id(id), static.HostSetPrefix) &&
 			!strings.HasPrefix(id, fmt.Sprintf("%s_", plugin.HostSetPrefix)) {
 			badFields[globals.HostSourceIdsField] = fmt.Sprintf("Incorrectly formatted host source identifier %q.", id)
 			break
@@ -1800,7 +1800,7 @@ func validateSetHostSourcesRequest(req *pbs.SetTargetHostSourcesRequest) error {
 		badFields[globals.VersionField] = "Required field."
 	}
 	for _, id := range req.GetHostSourceIds() {
-		if !handlers.ValidId(handlers.Id(id), static.HostSetPrefix)  &&
+		if !handlers.ValidId(handlers.Id(id), static.HostSetPrefix) &&
 			!strings.HasPrefix(id, fmt.Sprintf("%s_", plugin.HostSetPrefix)) {
 			badFields[globals.HostSourceIdsField] = fmt.Sprintf("Incorrectly formatted host source identifier %q.", id)
 			break
@@ -1824,7 +1824,7 @@ func validateRemoveHostSourcesRequest(req *pbs.RemoveTargetHostSourcesRequest) e
 		badFields[globals.HostSourceIdsField] = "Must be non-empty."
 	}
 	for _, id := range req.GetHostSourceIds() {
-		if !handlers.ValidId(handlers.Id(id), static.HostSetPrefix)  &&
+		if !handlers.ValidId(handlers.Id(id), static.HostSetPrefix) &&
 			!strings.HasPrefix(id, fmt.Sprintf("%s_", plugin.HostSetPrefix)) {
 			badFields[globals.HostSourceIdsField] = fmt.Sprintf("Incorrectly formatted host source identifier %q.", id)
 			break

--- a/testing/dbtest/template.go
+++ b/testing/dbtest/template.go
@@ -13,10 +13,8 @@ import (
 
 var testDBPort = "5432"
 
-var (
-	// StartUsingTemplate creates a new test database from a postgres template database.
-	StartUsingTemplate func(dialect string, opt ...Option) (func() error, string, string, error) = startUsingTemplate
-)
+// StartUsingTemplate creates a new test database from a postgres template database.
+var StartUsingTemplate func(dialect string, opt ...Option) (func() error, string, string, error) = startUsingTemplate
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -39,12 +37,12 @@ const (
 )
 
 var supportedDialects = map[string]struct{}{
-	Postgres: struct{}{},
+	Postgres: {},
 }
 
 var supportedTemplates = map[string]struct{}{
-	BoundaryTemplate: struct{}{},
-	Template1:        struct{}{},
+	BoundaryTemplate: {},
+	Template1:        {},
 }
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyz"


### PR DESCRIPTION
This puts into place a way to provide plugins to the repositories.  A TODO is to move from providing the HostPluginServiceServer and change it to the client provided by go plugin once we are using go plugin.

Additionally I created a very light weight testPlugin which allows overwriting specific methods for test cases.  I use this in the CreateSet and CreateCatalog repo tests.