### PR TITLE
Docs: redirect Desktop install links to Learn

### DIFF
--- a/website/content/docs/getting-started/index.mdx
+++ b/website/content/docs/getting-started/index.mdx
@@ -15,8 +15,7 @@ The examples in Getting Started all revolve around running in `dev mode`. There 
 1. [Docker](https://docs.docker.com/get-docker/) is installed
 1. A route to download the [Postgres Docker image](https://hub.docker.com/_/postgres) is available or a local image cache is available
 1. A [Boundary binary](https://www.boundaryproject.io/downloads) in your `$PATH`
-1. Optionally, an [installation of Boundary Desktop](/docs/api-clients/desktop#install-boundary-desktop) if you want to use the
-   desktop examples
+1. Optionally, an [installation of Boundary Desktop](https://learn.hashicorp.com/tutorials/boundary/getting-started-desktop-app) if you want to use the desktop examples
 
 ## What is Dev Mode?
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -76,7 +76,12 @@
       },
       {
         "title": "Desktop",
+        "hidden": true,
         "path": "api-clients/desktop"
+      },
+      {
+        "title": "Desktop",
+        "href": "https://learn.hashicorp.com/tutorials/boundary/getting-started-desktop-app"
       }
     ]
   },

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -29,6 +29,12 @@ module.exports = [
     destination: '/docs/api-clients/desktop#connect',
     permanent: false,
   },
+  {
+    source: '/docs/api-clients/desktop',
+    destination:
+      'https://learn.hashicorp.com/tutorials/boundary/getting-started-desktop-app',
+    permanent: true,
+  },
 
   /////////////////////////////////
   // DOMAIN MODEL CONCEPTS


### PR DESCRIPTION
:tickets: [Asana ticket](https://app.asana.com/0/563192436488770/1200984485270757/f)
:mag: [Docs deploy preview](https://boundary-46vj9ua5h-hashicorp.vercel.app/docs)

This PR:

- updates the docs sidebar to redirect API-Clients/Desktop to the Install Boundary Desktop Learn tutorial
- fixes an internal link to API-Clients/Desktop in `index.mdx`
- adds a permanent redirect to the learn tutorial in `redirects.js`

Requested review scope:

- [x] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

Review urgency:

- [ ] ASAP (bug fixes, broken content, imminent releases)
- [ ] 3 days (small changes, easy reviews)
- [x] 1 week (default)
- [ ] Best effort (very non-urgent)

I have:

- [x] Verified that all status checks have passed
- [x] Verified that preview environment has successfully deployed (navigate to `/_logs` to inspect a failed deploy!)
- [x] Assigned an appropriate `label` (either `Platform` or a product name)
- [x] Requested at least one review