### PR TITLE
feat(cmd): Include version metadata in output

### DIFF
--- a/internal/cmd/commands/version/version.go
+++ b/internal/cmd/commands/version/version.go
@@ -67,6 +67,9 @@ func (c *Command) Run(args []string) int {
 	if verInfo.Version != "" {
 		nonAttributeMap["Version Number"] = verInfo.VersionNumber()
 	}
+	if verInfo.VersionMetadata != "" {
+		nonAttributeMap["Metadata"] = verInfo.VersionMetadata
+	}
 
 	maxLength := base.MaxAttributesLength(nonAttributeMap, nil, nil)
 


### PR DESCRIPTION
If the VersionMetadata is set, include it in the output of the `boundary
version` subcommand.