### PR TITLE
Move host ID lookup to shared function

### DIFF
--- a/internal/host/plugin/repository_host_catalog.go
+++ b/internal/host/plugin/repository_host_catalog.go
@@ -264,8 +264,9 @@ func toPluginCatalog(ctx context.Context, in *HostCatalog) (*pb.HostCatalog, err
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "nil storage plugin")
 	}
 	hc := &pb.HostCatalog{
-		Id:      in.GetPublicId(),
-		ScopeId: in.GetScopeId(),
+		Id:       in.GetPublicId(),
+		ScopeId:  in.GetScopeId(),
+		PluginId: in.GetPluginId(),
 	}
 	if in.GetAttributes() != nil {
 		attrs := &structpb.Struct{}


### PR DESCRIPTION
This allows us to perform a pre-flight host ID lookup when creating a
host set. This has two benefits:

* We don't create the host-set if a call with the given filter errors
  out
* We can return a set of matching host IDs in the response from a create
  call, instead of having to then issue a separate read response