### PR TITLE
Swap host plugin server interface for client

### DIFF
--- a/internal/cmd/base/initial_resources.go
+++ b/internal/cmd/base/initial_resources.go
@@ -591,7 +591,7 @@ func (b *Server) CreateInitialTarget(ctx context.Context) (target.Target, error)
 // It also registers the plugin in the shared map of running plugins.  Since
 // all boundary provided host plugins must have a name, a name is required
 // when calling CreateHostPlugin and will be used even if WithName is provided.
-func (b *Server) CreateHostPlugin(ctx context.Context, name string, plg plgpb.HostPluginServiceServer, opt ...hostplugin.Option) (*hostplugin.Plugin, error) {
+func (b *Server) CreateHostPlugin(ctx context.Context, name string, plg plgpb.HostPluginServiceClient, opt ...hostplugin.Option) (*hostplugin.Plugin, error) {
 	if name == "" {
 		return nil, fmt.Errorf("no name provided when creating plugin.")
 	}
@@ -641,7 +641,7 @@ func (b *Server) CreateHostPlugin(ctx context.Context, name string, plg plgpb.Ho
 	}
 
 	if b.HostPlugins == nil {
-		b.HostPlugins = make(map[string]plgpb.HostPluginServiceServer)
+		b.HostPlugins = make(map[string]plgpb.HostPluginServiceClient)
 	}
 	b.HostPlugins[plugin.GetPublicId()] = plg
 

--- a/internal/cmd/base/option.go
+++ b/internal/cmd/base/option.go
@@ -36,7 +36,7 @@ type Options struct {
 	withEventFlags                 *EventFlags
 	withAttributeFieldPrefix       string
 	withStatusCode                 int
-	withHostPlugin                 func() (string, plugin.HostPluginServiceServer)
+	withHostPlugin                 func() (string, plugin.HostPluginServiceClient)
 }
 
 func getDefaultOptions() Options {
@@ -165,9 +165,9 @@ func WithDatabaseTemplate(template string) Option {
 
 // WithHostPlugin allows specifying a plugin ID and implementation to create at
 // startup
-func WithHostPlugin(pluginId string, plg plugin.HostPluginServiceServer) Option {
+func WithHostPlugin(pluginId string, plg plugin.HostPluginServiceClient) Option {
 	return func(o *Options) {
-		o.withHostPlugin = func() (string, plugin.HostPluginServiceServer) {
+		o.withHostPlugin = func() (string, plugin.HostPluginServiceClient) {
 			return pluginId, plg
 		}
 	}

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -114,7 +114,7 @@ type Server struct {
 	DevTargetSessionConnectionLimit  int
 	DevLoopbackHostPluginId          string
 
-	HostPlugins map[string]plgpb.HostPluginServiceServer
+	HostPlugins map[string]plgpb.HostPluginServiceClient
 
 	DevOidcSetup oidcSetup
 

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -551,7 +551,7 @@ func (c *Command) Run(args []string) int {
 
 	var opts []base.Option
 	if c.flagCreateLoopbackHostCatalogPlugin {
-		opts = append(opts, base.WithHostPlugin("pl_1234567890", plugin.NewLoopbackPlugin()))
+		opts = append(opts, base.WithHostPlugin("pl_1234567890", plugin.NewWrappingPluginClient(plugin.NewLoopbackPlugin())))
 	}
 	switch c.flagDatabaseUrl {
 	case "":

--- a/internal/host/plugin/client.go
+++ b/internal/host/plugin/client.go
@@ -1,0 +1,48 @@
+package plugin
+
+import (
+	"context"
+
+	plgpb "github.com/hashicorp/boundary/sdk/pbs/plugin"
+	"google.golang.org/grpc"
+)
+
+var _ plgpb.HostPluginServiceClient = (*WrappingPluginClient)(nil)
+
+// WrappingPluginClient provides a wrapper around a Server implementation that
+// can be used when loading a plugin in-memory
+type WrappingPluginClient struct {
+	Server plgpb.HostPluginServiceServer
+}
+
+func NewWrappingPluginClient(s plgpb.HostPluginServiceServer) *WrappingPluginClient {
+	return &WrappingPluginClient{Server: s}
+}
+
+func (tpc *WrappingPluginClient) OnCreateCatalog(ctx context.Context, req *plgpb.OnCreateCatalogRequest, opts ...grpc.CallOption) (*plgpb.OnCreateCatalogResponse, error) {
+	return tpc.Server.OnCreateCatalog(ctx, req)
+}
+
+func (tpc *WrappingPluginClient) OnUpdateCatalog(ctx context.Context, req *plgpb.OnUpdateCatalogRequest, opts ...grpc.CallOption) (*plgpb.OnUpdateCatalogResponse, error) {
+	return tpc.Server.OnUpdateCatalog(ctx, req)
+}
+
+func (tpc *WrappingPluginClient) OnDeleteCatalog(ctx context.Context, req *plgpb.OnDeleteCatalogRequest, opts ...grpc.CallOption) (*plgpb.OnDeleteCatalogResponse, error) {
+	return tpc.Server.OnDeleteCatalog(ctx, req)
+}
+
+func (tpc *WrappingPluginClient) OnCreateSet(ctx context.Context, req *plgpb.OnCreateSetRequest, opts ...grpc.CallOption) (*plgpb.OnCreateSetResponse, error) {
+	return tpc.Server.OnCreateSet(ctx, req)
+}
+
+func (tpc *WrappingPluginClient) OnUpdateSet(ctx context.Context, req *plgpb.OnUpdateSetRequest, opts ...grpc.CallOption) (*plgpb.OnUpdateSetResponse, error) {
+	return tpc.Server.OnUpdateSet(ctx, req)
+}
+
+func (tpc *WrappingPluginClient) OnDeleteSet(ctx context.Context, req *plgpb.OnDeleteSetRequest, opts ...grpc.CallOption) (*plgpb.OnDeleteSetResponse, error) {
+	return tpc.Server.OnDeleteSet(ctx, req)
+}
+
+func (tpc *WrappingPluginClient) ListHosts(ctx context.Context, req *plgpb.ListHostsRequest, opts ...grpc.CallOption) (*plgpb.ListHostsResponse, error) {
+	return tpc.Server.ListHosts(ctx, req)
+}

--- a/internal/host/plugin/immutable_fields_test.go
+++ b/internal/host/plugin/immutable_fields_test.go
@@ -102,8 +102,8 @@ func TestPluginSet_ImmutableFields(t *testing.T) {
 	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
 	plg := host.TestPlugin(t, conn, "test")
 	cat := TestCatalog(t, conn, prj.PublicId, plg.GetPublicId())
-	new := TestSet(t, conn, kmsCache, cat, map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &TestPluginServer{},
+	new := TestSet(t, conn, kmsCache, cat, map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): NewWrappingPluginClient(&TestPluginServer{}),
 	})
 
 	tests := []struct {

--- a/internal/host/plugin/repository.go
+++ b/internal/host/plugin/repository.go
@@ -22,7 +22,7 @@ type Repository struct {
 	//
 	// TODO: When we are using go-plugin change from using a
 	// plgpb.HostPluginServiceServer to the client.
-	plugins map[string]plgpb.HostPluginServiceServer
+	plugins map[string]plgpb.HostPluginServiceClient
 	// defaultLimit provides a default for limiting the number of results
 	// returned from the repo
 	defaultLimit int
@@ -32,7 +32,7 @@ type Repository struct {
 // only be used for one transaction and it is not safe for concurrent go
 // routines to access it. WithLimit option is used as a repo wide default
 // limit applied to all ListX methods.
-func NewRepository(r db.Reader, w db.Writer, kms *kms.Kms, plgm map[string]plgpb.HostPluginServiceServer, opt ...host.Option) (*Repository, error) {
+func NewRepository(r db.Reader, w db.Writer, kms *kms.Kms, plgm map[string]plgpb.HostPluginServiceClient, opt ...host.Option) (*Repository, error) {
 	const op = "plugin.NewRepository"
 	switch {
 	case r == nil:
@@ -54,7 +54,7 @@ func NewRepository(r db.Reader, w db.Writer, kms *kms.Kms, plgm map[string]plgpb
 		opts.WithLimit = db.DefaultLimit
 	}
 
-	plgs := make(map[string]plgpb.HostPluginServiceServer, len(plgm))
+	plgs := make(map[string]plgpb.HostPluginServiceClient, len(plgm))
 	for k, v := range plgm {
 		plgs[k] = v
 	}

--- a/internal/host/plugin/repository_host_catalog_test.go
+++ b/internal/host/plugin/repository_host_catalog_test.go
@@ -34,14 +34,16 @@ func TestRepository_CreateCatalog(t *testing.T) {
 	// gotPluginAttrs tracks which attributes a plugin has received through a closure and can be compared in the
 	// test against the expected values sent to the plugin.
 	var gotPluginAttrs *structpb.Struct
-	plgm := map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &TestPluginServer{
-			OnCreateCatalogFn: func(_ context.Context, req *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error) {
-				gotPluginAttrs = req.GetCatalog().GetAttributes()
-				return &plgpb.OnCreateCatalogResponse{Persisted: &plgpb.HostCatalogPersisted{Secrets: req.GetCatalog().GetSecrets()}}, nil
+	plgm := map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): &WrappingPluginClient{
+			Server: &TestPluginServer{
+				OnCreateCatalogFn: func(_ context.Context, req *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error) {
+					gotPluginAttrs = req.GetCatalog().GetAttributes()
+					return &plgpb.OnCreateCatalogResponse{Persisted: &plgpb.HostCatalogPersisted{Secrets: req.GetCatalog().GetSecrets()}}, nil
+				},
 			},
 		},
-		unimplementedPlugin.GetPublicId(): &plgpb.UnimplementedHostPluginServiceServer{},
+		unimplementedPlugin.GetPublicId(): &WrappingPluginClient{Server: &plgpb.UnimplementedHostPluginServiceServer{}},
 	}
 
 	tests := []struct {
@@ -378,8 +380,8 @@ func TestRepository_LookupCatalog(t *testing.T) {
 	wrapper := db.TestWrapper(t)
 	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
 	plg := hostplg.TestPlugin(t, conn, "test")
-	plgm := map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &TestPluginServer{},
+	plgm := map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): &WrappingPluginClient{Server: &TestPluginServer{}},
 	}
 	cat := TestCatalog(t, conn, prj.PublicId, plg.GetPublicId())
 	badId, err := newHostCatalogId(ctx)
@@ -444,8 +446,8 @@ func TestRepository_ListCatalogs_Multiple_Scopes(t *testing.T) {
 	rw := db.New(conn)
 	kms := kms.TestKms(t, conn, wrapper)
 	plg := hostplg.TestPlugin(t, conn, "test")
-	plgm := map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &TestPluginServer{},
+	plgm := map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): &WrappingPluginClient{Server: &TestPluginServer{}},
 	}
 	repo, err := NewRepository(rw, rw, kms, plgm)
 	assert.NoError(t, err)

--- a/internal/host/plugin/repository_host_set.go
+++ b/internal/host/plugin/repository_host_set.go
@@ -207,8 +207,8 @@ func (r *Repository) LookupSet(ctx context.Context, publicId string, opt ...host
 			return nil, nil, nil, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("no plugin found for plugin id %s", plg.GetPublicId()))
 		}
 		resp, err := plgClient.ListHosts(ctx, &plgpb.ListHostsRequest{
-			Catalog: plgCat,
-			Sets: []*hspb.HostSet{plgSet},
+			Catalog:   plgCat,
+			Sets:      []*hspb.HostSet{plgSet},
 			Persisted: persisted,
 		})
 		switch {
@@ -436,7 +436,7 @@ func (r *Repository) Endpoints(ctx context.Context, setIds []string) ([]*host.En
 
 	type catalogInfo struct {
 		publicId  string                        // ID of the catalog
-		plg       plgpb.HostPluginServiceServer // plugin client for the catalog
+		plg       plgpb.HostPluginServiceClient // plugin client for the catalog
 		setInfos  map[string]*setInfo           // map of set IDs to set information
 		plgCat    *hcpb.HostCatalog             // storage host catalog
 		persisted *plgpb.HostCatalogPersisted   // host catalog persisted (secret) data

--- a/internal/host/plugin/repository_test.go
+++ b/internal/host/plugin/repository_test.go
@@ -19,13 +19,13 @@ func TestRepository_New(t *testing.T) {
 	wrapper := db.TestWrapper(t)
 	kmsCache := kms.TestKms(t, conn, wrapper)
 
-	plgs := map[string]plgpb.HostPluginServiceServer{}
+	plgs := map[string]plgpb.HostPluginServiceClient{}
 
 	type args struct {
 		r       db.Reader
 		w       db.Writer
 		kms     *kms.Kms
-		plugins map[string]plgpb.HostPluginServiceServer
+		plugins map[string]plgpb.HostPluginServiceClient
 		opts    []host.Option
 	}
 

--- a/internal/host/plugin/testing.go
+++ b/internal/host/plugin/testing.go
@@ -40,7 +40,7 @@ func TestCatalog(t *testing.T, conn *db.DB, scopeId, pluginId string, opt ...Opt
 // TestSet creates a plugin host sets in the provided DB
 // with the provided catalog id. The catalog must have been created
 // previously. The test will fail if any errors are encountered.
-func TestSet(t *testing.T, conn *db.DB, kmsCache *kms.Kms, hc *HostCatalog, plgm map[string]plgpb.HostPluginServiceServer, opt ...Option) *HostSet {
+func TestSet(t *testing.T, conn *db.DB, kmsCache *kms.Kms, hc *HostCatalog, plgm map[string]plgpb.HostPluginServiceClient, opt ...Option) *HostSet {
 	t.Helper()
 	require := require.New(t)
 	ctx := context.Background()

--- a/internal/host/plugin/testing_test.go
+++ b/internal/host/plugin/testing_test.go
@@ -45,7 +45,7 @@ func Test_TestSet(t *testing.T) {
 	assert.NotEmpty(plg.GetPublicId())
 
 	c := TestCatalog(t, conn, prj.GetPublicId(), plg.GetPublicId())
-	set := TestSet(t, conn, kmsCache, c, map[string]plgpb.HostPluginServiceServer{plg.GetPublicId(): &TestPluginServer{}}, WithName("foo"), WithDescription("bar"))
+	set := TestSet(t, conn, kmsCache, c, map[string]plgpb.HostPluginServiceClient{plg.GetPublicId(): NewWrappingPluginClient(&TestPluginServer{})}, WithName("foo"), WithDescription("bar"))
 	assert.NotEmpty(set.GetPublicId())
 	db.AssertPublicId(t, HostSetPrefix, set.GetPublicId())
 	assert.Equal("foo", set.GetName())

--- a/internal/host/preferred_endpoint_test.go
+++ b/internal/host/preferred_endpoint_test.go
@@ -27,8 +27,8 @@ func TestPreferredEndpoint_Create(t *testing.T) {
 	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
 	plg := hostplg.TestPlugin(t, conn, "create")
 	catalog := plugin.TestCatalog(t, conn, prj.PublicId, plg.GetPublicId())
-	set := plugin.TestSet(t, conn, kmsCache, catalog, map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &plugin.TestPluginServer{},
+	set := plugin.TestSet(t, conn, kmsCache, catalog, map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): plugin.NewWrappingPluginClient(&plugin.TestPluginServer{}),
 	})
 
 	type args struct {
@@ -157,8 +157,8 @@ func TestPreferredEndpoint_Delete(t *testing.T) {
 	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
 	plg := hostplg.TestPlugin(t, conn, "create")
 	catalog := plugin.TestCatalog(t, conn, prj.PublicId, plg.GetPublicId())
-	set := plugin.TestSet(t, conn, kmsCache, catalog, map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &plgpb.UnimplementedHostPluginServiceServer{},
+	set := plugin.TestSet(t, conn, kmsCache, catalog, map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): plugin.NewWrappingPluginClient(&plgpb.UnimplementedHostPluginServiceServer{}),
 	})
 
 	peFunc := func(priority uint32, condition string) *host.PreferredEndpoint {

--- a/internal/servers/controller/controller.go
+++ b/internal/servers/controller/controller.go
@@ -107,14 +107,14 @@ func New(ctx context.Context, conf *Config) (*Controller, error) {
 		}
 	}
 
-	if _, err := conf.CreateHostPlugin(ctx, "azure", &azureplg.AzurePlugin{}, hostplugin.WithDescription("Boundary provided host plugin for Azure.")); err != nil {
+	if _, err := conf.CreateHostPlugin(ctx, "azure", pluginhost.NewWrappingPluginClient(&azureplg.AzurePlugin{}), hostplugin.WithDescription("Boundary provided host plugin for Azure.")); err != nil {
 		return nil, fmt.Errorf("error creating azure host plugin: %w", err)
 	}
-	if _, err := conf.CreateHostPlugin(ctx, "aws", &awsplg.AwsPlugin{}, hostplugin.WithDescription("Boundary provided host plugin for AWS.")); err != nil {
+	if _, err := conf.CreateHostPlugin(ctx, "aws", pluginhost.NewWrappingPluginClient(&awsplg.AwsPlugin{}), hostplugin.WithDescription("Boundary provided host plugin for AWS.")); err != nil {
 		return nil, fmt.Errorf("error creating aws host plugin: %w", err)
 	}
 	if conf.HostPlugins == nil {
-		conf.HostPlugins = make(map[string]plugin.HostPluginServiceServer)
+		conf.HostPlugins = make(map[string]plugin.HostPluginServiceClient)
 	}
 
 	// Set up repo stuff

--- a/internal/servers/controller/handlers/host_catalogs/host_catalog_service_test.go
+++ b/internal/servers/controller/handlers/host_catalogs/host_catalog_service_test.go
@@ -74,7 +74,7 @@ func TestGet_Static(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	pluginHostRepo := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	pluginRepo := func() (*host.Repository, error) {
 		return host.NewRepository(rw, rw, kms)
@@ -163,7 +163,7 @@ func TestGet_Plugin(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	pluginHostRepo := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	pluginRepo := func() (*host.Repository, error) {
 		return host.NewRepository(rw, rw, kms)
@@ -262,7 +262,7 @@ func TestList(t *testing.T) {
 		return iam.TestRepo(t, conn, wrapper), nil
 	}
 	pluginHostRepo := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	pluginRepo := func() (*host.Repository, error) {
 		return host.NewRepository(rw, rw, kms)
@@ -467,7 +467,7 @@ func TestDelete(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	pluginHostRepo := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	pluginRepo := func() (*host.Repository, error) {
 		return host.NewRepository(rw, rw, kms)
@@ -537,7 +537,7 @@ func TestDelete_twice(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	pluginHostRepo := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	pluginRepo := func() (*host.Repository, error) {
 		return host.NewRepository(rw, rw, kms)
@@ -572,7 +572,7 @@ func TestCreate_Static(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	pluginHostRepo := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	pluginRepo := func() (*host.Repository, error) {
 		return host.NewRepository(rw, rw, kms)
@@ -732,12 +732,12 @@ func TestCreate_Plugin(t *testing.T) {
 	name := "test"
 	plg := host.TestPlugin(t, conn, name)
 	pluginHostRepo := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{
-			plg.GetPublicId(): &plugin.TestPluginServer{
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{
+			plg.GetPublicId(): plugin.NewWrappingPluginClient(&plugin.TestPluginServer{
 				OnCreateCatalogFn: func(ctx context.Context, req *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error) {
 					return nil, nil
 				},
-			},
+			}),
 		})
 	}
 	defaultHc := plugin.TestCatalog(t, conn, proj.GetPublicId(), plg.GetPublicId())
@@ -899,7 +899,7 @@ func TestUpdate(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	pluginHostRepo := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	pluginRepo := func() (*host.Repository, error) {
 		return host.NewRepository(rw, rw, kms)

--- a/internal/servers/controller/handlers/host_sets/host_set_service_test.go
+++ b/internal/servers/controller/handlers/host_sets/host_set_service_test.go
@@ -57,7 +57,7 @@ func TestGet_Static(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	pluginRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	hc := static.TestCatalogs(t, conn, proj.GetPublicId(), 1)[0]
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
@@ -153,8 +153,8 @@ func TestGet_Plugin(t *testing.T) {
 	name := "test"
 	prefEndpoints := []string{"cidr:1.2.3.4", "cidr:2.3.4.5/24"}
 	plg := hostplugin.TestPlugin(t, conn, name)
-	plgm := map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &plugin.TestPluginServer{},
+	plgm := map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): plugin.NewWrappingPluginClient(&plugin.TestPluginServer{}),
 	}
 	pluginRepoFn := func() (*plugin.Repository, error) {
 		return plugin.NewRepository(rw, rw, kms, plgm)
@@ -253,7 +253,7 @@ func TestList_Static(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	pluginRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	hcs := static.TestCatalogs(t, conn, proj.GetPublicId(), 2)
 	hc, hcNoHosts := hcs[0], hcs[1]
@@ -352,8 +352,8 @@ func TestList_Plugin(t *testing.T) {
 	}
 	name := "test"
 	plg := hostplugin.TestPlugin(t, conn, name)
-	plgm := map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &plugin.TestPluginServer{},
+	plgm := map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): plugin.NewWrappingPluginClient(&plugin.TestPluginServer{}),
 	}
 	pluginRepoFn := func() (*plugin.Repository, error) {
 		return plugin.NewRepository(rw, rw, kms, plgm)
@@ -463,7 +463,7 @@ func TestDelete(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	pluginRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	hc := static.TestCatalogs(t, conn, proj.GetPublicId(), 1)[0]
 	h := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
@@ -542,7 +542,7 @@ func TestDelete_twice(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	plgRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	hc := static.TestCatalogs(t, conn, proj.GetPublicId(), 1)[0]
 	h := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
@@ -578,7 +578,7 @@ func TestCreate_Static(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	plgRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	hc := static.TestCatalogs(t, conn, proj.GetPublicId(), 1)[0]
 
@@ -723,12 +723,12 @@ func TestCreate_Plugin(t *testing.T) {
 	name := "test"
 	plg := hostplugin.TestPlugin(t, conn, name)
 	plgRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{
-			plg.GetPublicId(): &plugin.TestPluginServer{
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{
+			plg.GetPublicId(): plugin.NewWrappingPluginClient(&plugin.TestPluginServer{
 				OnCreateSetFn: func(ctx context.Context, req *plgpb.OnCreateSetRequest) (*plgpb.OnCreateSetResponse, error) {
 					return nil, nil
 				},
-			},
+			}),
 		})
 	}
 	hc := plugin.TestCatalog(t, conn, proj.GetPublicId(), plg.GetPublicId())
@@ -1002,7 +1002,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	plgRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	tested, err := host_sets.NewService(repoFn, plgRepoFn)
 	require.NoError(t, err, "Failed to create a new host set service.")
@@ -1352,7 +1352,7 @@ func TestAddHostSetHosts(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	plgRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	s, err := host_sets.NewService(repoFn, plgRepoFn)
 	require.NoError(t, err, "Error when getting new host set service.")
@@ -1472,7 +1472,7 @@ func TestSetHostSetHosts(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	plgRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	s, err := host_sets.NewService(repoFn, plgRepoFn)
 	require.NoError(t, err, "Error when getting new host set service.")
@@ -1588,7 +1588,7 @@ func TestRemoveHostSetHosts(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	plgRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	s, err := host_sets.NewService(repoFn, plgRepoFn)
 	require.NoError(t, err, "Error when getting new host set service.")

--- a/internal/servers/controller/handlers/targets/target_service_test.go
+++ b/internal/servers/controller/handlers/targets/target_service_test.go
@@ -88,7 +88,7 @@ func testService(t *testing.T, conn *db.DB, kms *kms.Kms, wrapper wrapping.Wrapp
 		return static.NewRepository(rw, rw, kms)
 	}
 	pluginHostRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	credentialRepoFn := func() (*vault.Repository, error) {
 		return vault.NewRepository(rw, rw, kms, sche)
@@ -986,8 +986,8 @@ func TestAddTargetHostSets(t *testing.T) {
 
 	plg := host.TestPlugin(t, conn, "test")
 	pluginHc := plugin.TestCatalog(t, conn, proj.GetPublicId(), plg.GetPublicId())
-	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &plugin.TestPluginServer{},
+	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): plugin.NewWrappingPluginClient(&plugin.TestPluginServer{}),
 	})
 
 	addCases := []struct {
@@ -1120,8 +1120,8 @@ func TestSetTargetHostSets(t *testing.T) {
 
 	plg := host.TestPlugin(t, conn, "test")
 	pluginHc := plugin.TestCatalog(t, conn, proj.GetPublicId(), plg.GetPublicId())
-	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &plugin.TestPluginServer{},
+	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): plugin.NewWrappingPluginClient(&plugin.TestPluginServer{}),
 	})
 
 	setCases := []struct {
@@ -1248,8 +1248,8 @@ func TestRemoveTargetHostSets(t *testing.T) {
 
 	plg := host.TestPlugin(t, conn, "test")
 	pluginHc := plugin.TestCatalog(t, conn, proj.GetPublicId(), plg.GetPublicId())
-	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &plugin.TestPluginServer{},
+	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): plugin.NewWrappingPluginClient(&plugin.TestPluginServer{}),
 	})
 
 	removeCases := []struct {
@@ -1388,8 +1388,8 @@ func TestAddTargetHostSources(t *testing.T) {
 
 	plg := host.TestPlugin(t, conn, "test")
 	pluginHc := plugin.TestCatalog(t, conn, proj.GetPublicId(), plg.GetPublicId())
-	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &plugin.TestPluginServer{},
+	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): plugin.NewWrappingPluginClient(&plugin.TestPluginServer{}),
 	})
 
 	addCases := []struct {
@@ -1522,8 +1522,8 @@ func TestSetTargetHostSources(t *testing.T) {
 
 	plg := host.TestPlugin(t, conn, "test")
 	pluginHc := plugin.TestCatalog(t, conn, proj.GetPublicId(), plg.GetPublicId())
-	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &plugin.TestPluginServer{},
+	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): plugin.NewWrappingPluginClient(&plugin.TestPluginServer{}),
 	})
 
 	setCases := []struct {
@@ -1644,8 +1644,8 @@ func TestRemoveTargetHostSources(t *testing.T) {
 
 	plg := host.TestPlugin(t, conn, "test")
 	pluginHc := plugin.TestCatalog(t, conn, proj.GetPublicId(), plg.GetPublicId())
-	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): &plugin.TestPluginServer{},
+	pluginHs := plugin.TestSet(t, conn, kms, pluginHc, map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): plugin.NewWrappingPluginClient(&plugin.TestPluginServer{}),
 	})
 
 	removeCases := []struct {
@@ -2589,8 +2589,8 @@ func TestAuthorizeSession(t *testing.T) {
 	}
 
 	plg := host.TestPlugin(t, conn, "test")
-	plgm := map[string]plgpb.HostPluginServiceServer{
-		plg.GetPublicId(): plugin.TestPluginServer{
+	plgm := map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): plugin.NewWrappingPluginClient(plugin.TestPluginServer{
 			ListHostsFn: func(_ context.Context, req *plgpb.ListHostsRequest) (*plgpb.ListHostsResponse, error) {
 				var setIds []string
 				for _, set := range req.GetSets() {
@@ -2609,7 +2609,7 @@ func TestAuthorizeSession(t *testing.T) {
 					},
 				}}, nil
 			},
-		},
+		}),
 	}
 	pluginHostRepoFn := func() (*plugin.Repository, error) {
 		return plugin.NewRepository(rw, rw, kms, plgm)
@@ -2814,7 +2814,7 @@ func TestAuthorizeSession_Errors(t *testing.T) {
 		return static.NewRepository(rw, rw, kms)
 	}
 	pluginHostRepoFn := func() (*plugin.Repository, error) {
-		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceServer{})
+		return plugin.NewRepository(rw, rw, kms, map[string]plgpb.HostPluginServiceClient{})
 	}
 	credentialRepoFn := func() (*vault.Repository, error) {
 		return vault.NewRepository(rw, rw, kms, sche)

--- a/internal/servers/controller/testing.go
+++ b/internal/servers/controller/testing.go
@@ -577,7 +577,7 @@ func NewTestController(t *testing.T, opts *TestControllerOpts) *TestController {
 		}
 	} else if !opts.DisableDatabaseCreation {
 		var createOpts []base.Option
-		createOpts = append(createOpts, base.WithHostPlugin("pl_1234567890", plugin.NewLoopbackPlugin()))
+		createOpts = append(createOpts, base.WithHostPlugin("pl_1234567890", plugin.NewWrappingPluginClient(plugin.NewLoopbackPlugin())))
 		if opts.DisableAuthMethodCreation {
 			createOpts = append(createOpts, base.WithSkipAuthMethodCreation())
 		}


### PR DESCRIPTION
We've been using the server interface for in-memory testing, but in actuality we need to use the client interface to be able to swap between in-memory and external.

This PR simply changes the interface references to the client side, and adds a wrapper that can be used when we are using in-memory plugins.