### PR TITLE
fixed hcl config examples for sink

### DIFF
--- a/website/content/docs/configuration/events/file.mdx
+++ b/website/content/docs/configuration/events/file.mdx
@@ -10,7 +10,7 @@ description: |-
 The file sink configures Boundary to send events to a file.
 
 ```hcl
-sink = {
+sink {
     name = "obs-sink"
     description = "Observations sent to a file"
     event_types = ["observation"]
@@ -24,7 +24,6 @@ sink = {
 The `sink` stanza may be specified more than once to make Boundary send events
 to multiple sinks; however, each file sink must have a unique `path` +
 `file_name`.
-
 
 ## common parameters
 

--- a/website/content/docs/configuration/events/overview.mdx
+++ b/website/content/docs/configuration/events/overview.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # `events` Stanza
 
-The `events` stanza configures Boundary events-specific parameters.  
+The `events` stanza configures Boundary events-specific parameters.
 
 Example:
 
@@ -15,13 +15,13 @@ Example:
 events {
   observations_enabled = true
   sysevents_enabled = true
-  sink "stderr" = {
+  sink "stderr" {
     name = "all-events"
     description = "All events sent to stderr"
     event_types = ["*"]
     format = "hclog-text"
   }
-  sink = {
+  sink {
     name = "obs-sink"
     description = "Observations sent to a file"
     event_types = ["observation"]
@@ -34,25 +34,27 @@ events {
 ```
 
 - `audit_enabled` - Specifies if audit events should be emitted.  
-Note: audit events are a WIP and will only be emitted if they are both enabled and the env var `BOUNDARY_DEVELOPER_ENABLE_EVENTS` equals true. We anticipate many changes for audit events before they are generally available including what data is included and different options for redacting/encrypting that data.
+  Note: audit events are a WIP and will only be emitted if they are both enabled and the env var `BOUNDARY_DEVELOPER_ENABLE_EVENTS` equals true. We anticipate many changes for audit events before they are generally available including what data is included and different options for redacting/encrypting that data.
 
-- `observation_enabled` - Specifies if observation events should be emitted. 
+- `observation_enabled` - Specifies if observation events should be emitted.
 
-- `sysevents_enabled` - Specifies if system events should be emitted. 
+- `sysevents_enabled` - Specifies if system events should be emitted.
 
 - `sink` - Specifies the configuration of an event sink. Currently, two types of
   sink are supported: [file](/docs/configuration/events/file) and [stderr](/docs/configuration/events/stderr). If no sinks are configured then all
   events will be sent to a default [stderr](/docs/configuration/events/stderr) sink. Events may be sent to multiple
-  sinks.  
+  sinks.
 
-##  Default Events Stanza
+## Default Events Stanza
+
 If no event stanza is specified then the following default is used:
+
 ```hcl
 events {
   audit_enabled = false
   observations_enabled = true
   sysevents_enabled = true
-  sink "stderr" = {
+  sink "stderr" {
     name = "default"
     event_types = ["*"]
     format = "cloudevents-json"

--- a/website/content/docs/configuration/events/overview.mdx
+++ b/website/content/docs/configuration/events/overview.mdx
@@ -36,7 +36,7 @@ events {
 - `audit_enabled` - Specifies if audit events should be emitted.  
   Note: audit events are a WIP and will only be emitted if they are both enabled and the env var `BOUNDARY_DEVELOPER_ENABLE_EVENTS` equals true. We anticipate many changes for audit events before they are generally available including what data is included and different options for redacting/encrypting that data.
 
-- `observation_enabled` - Specifies if observation events should be emitted.
+- `observations_enabled` - Specifies if observation events should be emitted.
 
 - `sysevents_enabled` - Specifies if system events should be emitted.
 


### PR DESCRIPTION
This PR fixes typos in the events HCL stanza that is prevents a controller/worker from starting.

Current config:

```
sink = {
    name = "obs-sink"
    description = "Observations sent to a file"
    event_types = ["observation"]
    format = "cloudevents-json"
    file {
      file_name = "file-name"
    }
  }
```

The assignment operator `sink = {` on the first line causes an error `Error parsing config file: At 51:17: nested object expected: LBRACE got: ASSIGN`

This PR corrects the HCL to `sink {}` in :

- /docs/configuration/events/overview
- /docs/configuration/events/file