### PR TITLE
Rename the UI passthrough dir flag/env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ developing the UI. To make UI development more convenient, the binary supports a
 _passthrough directory_. This is an arbitrary local directory from which UI
 assets are served. Note this option is only available in dev mode. For example:
 
-  ```BOUNDARY_DEV_PASSTHROUGH_DIRECTORY=/boundary-ui/ui/admin/dist ~/go/bin/boundary dev```
+  ```BOUNDARY_DEV_UI_PASSTHROUGH_DIR=/boundary-ui/ui/admin/dist ~/go/bin/boundary dev```
 
 ### Download and Run from Release Page
 

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -66,7 +66,7 @@ type Command struct {
 	flagWorkerAuthKey                string
 	flagWorkerProxyListenAddr        string
 	flagWorkerPublicAddr             string
-	flagPassthroughDirectory         string
+	flagUiPassthroughDir             string
 	flagRecoveryKey                  string
 	flagDatabaseUrl                  string
 	flagContainerImage               string
@@ -250,9 +250,9 @@ func (c *Command) Flags() *base.FlagSets {
 	})
 
 	f.StringVar(&base.StringVar{
-		Name:   "passthrough-directory",
-		Target: &c.flagPassthroughDirectory,
-		EnvVar: "BOUNDARY_DEV_PASSTHROUGH_DIRECTORY",
+		Name:   "ui-passthrough-dir",
+		Target: &c.flagUiPassthroughDir,
+		EnvVar: "BOUNDARY_DEV_UI_PASSTHROUGH_DIR",
 		Usage:  "Enables a passthrough directory in the webserver at /",
 	})
 
@@ -408,7 +408,7 @@ func (c *Command) Run(args []string) int {
 	c.DevTargetSessionConnectionLimit = c.flagTargetSessionConnectionLimit
 	c.DevHostAddress = host
 
-	c.Config.PassthroughDirectory = c.flagPassthroughDirectory
+	c.Config.DevUiPassthroughDir = c.flagUiPassthroughDir
 
 	for _, l := range c.Config.Listeners {
 		if len(l.Purpose) != 1 {

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -97,11 +97,11 @@ type Config struct {
 	Controller *Controller `hcl:"controller"`
 
 	// Dev-related options
-	DevController        bool   `hcl:"-"`
-	PassthroughDirectory string `hcl:"-"`
-	DevControllerKey     string `hcl:"-"`
-	DevWorkerAuthKey     string `hcl:"-"`
-	DevRecoveryKey       string `hcl:"-"`
+	DevController       bool   `hcl:"-"`
+	DevUiPassthroughDir string `hcl:"-"`
+	DevControllerKey    string `hcl:"-"`
+	DevWorkerAuthKey    string `hcl:"-"`
+	DevRecoveryKey      string `hcl:"-"`
 
 	// Eventing configuration for the controller
 	Eventing *event.EventerConfig `hcl:"events"`

--- a/internal/servers/controller/handler_noui.go
+++ b/internal/servers/controller/handler_noui.go
@@ -8,13 +8,13 @@ import (
 	"github.com/hashicorp/boundary/internal/observability/event"
 )
 
-func devPassthroughHandler(passthroughDir string) http.Handler {
+func devUiPassthroughHandler(uiPassthroughDir string) http.Handler {
 	const op = "controller.devPassthroughHandler"
 	ctx := context.TODO()
 	// Panic may not be ideal but this is never a production call and it'll
 	// panic on startup. We could also just change the function to return
 	// an error.
-	abs, err := filepath.Abs(passthroughDir)
+	abs, err := filepath.Abs(uiPassthroughDir)
 	if err != nil {
 		panic(err)
 	}
@@ -26,8 +26,8 @@ func devPassthroughHandler(passthroughDir string) http.Handler {
 }
 
 var handleUi = func(c *Controller) http.Handler {
-	if c.conf.RawConfig.PassthroughDirectory != "" {
-		return devPassthroughHandler(c.conf.RawConfig.PassthroughDirectory)
+	if c.conf.RawConfig.DevUiPassthroughDir != "" {
+		return devUiPassthroughHandler(c.conf.RawConfig.DevUiPassthroughDir)
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/servers/controller/handler_ui.go
+++ b/internal/servers/controller/handler_ui.go
@@ -16,8 +16,8 @@ func init() {
 
 func handleUiWithAssets(c *Controller) http.Handler {
 	var nextHandler http.Handler
-	if c.conf.RawConfig.PassthroughDirectory != "" {
-		nextHandler = devPassthroughHandler(c.conf.RawConfig.PassthroughDirectory)
+	if c.conf.RawConfig.DevUiPassthroughDir != "" {
+		nextHandler = devUiPassthroughHandler(c.conf.RawConfig.DevUiPassthroughDir)
 	} else {
 		nextHandler = ui.Handler()
 	}

--- a/internal/servers/controller/handler_ui_test.go
+++ b/internal/servers/controller/handler_ui_test.go
@@ -41,7 +41,7 @@ func TestUiRouting(t *testing.T) {
 
 	c := NewTestController(t, &TestControllerOpts{DisableAutoStart: true})
 
-	c.c.conf.RawConfig.PassthroughDirectory = tempDir
+	c.c.conf.RawConfig.DevUiPassthroughDir = tempDir
 	require.NoError(t, c.c.Start())
 	defer c.Shutdown()
 

--- a/website/content/docs/developing/ui.mdx
+++ b/website/content/docs/developing/ui.mdx
@@ -17,5 +17,5 @@ directory a passthrough directory, and you can enable it using an env var while 
 conjunction with running Boundary in dev mode:
 
 ```bash
-BOUNDARY_DEV_PASSTHROUGH_DIRECTORY=../boundary-ui/ui/admin/dist boundary dev
+BOUNDARY_DEV_UI_PASSTHROUGH_DIR=../boundary-ui/ui/admin/dist boundary dev
 ```


### PR DESCRIPTION
This puts it more in line with other upcoming options that use "dir"
instead of "directory" (plus it's easier to type), and makes it clear
that this directory and the passthrough behavior is related to the UI as
opposed to other upcoming items.