### PR TITLE
docs(target): Mark additional fields as output only

### DIFF
--- a/internal/gen/controller.swagger.json
+++ b/internal/gen/controller.swagger.json
@@ -4981,7 +4981,8 @@
           "items": {
             "type": "string"
           },
-          "description": "The IDs of the Host Sets associated with this Target."
+          "description": "Output only. The IDs of the Host Sets associated with this Target.",
+          "readOnly": true
         },
         "host_sets": {
           "type": "array",
@@ -4996,7 +4997,8 @@
           "items": {
             "type": "string"
           },
-          "description": "The IDs of the Host Sources associated with this Target."
+          "description": "Output only. The IDs of the Host Sources associated with this Target.",
+          "readOnly": true
         },
         "host_sources": {
           "type": "array",
@@ -5025,7 +5027,8 @@
           "items": {
             "type": "string"
           },
-          "description": "The IDs of the application credential library ids associated with this Target. Deprecated: use application_credential_source_ids instead."
+          "description": "Output only. The IDs of the application credential library ids associated with this Target. Deprecated: use application_credential_source_ids instead.",
+          "readOnly": true
         },
         "application_credential_libraries": {
           "type": "array",
@@ -5040,7 +5043,8 @@
           "items": {
             "type": "string"
           },
-          "description": "The IDs of the application credential source ids associated with this Target."
+          "description": "Output only. The IDs of the application credential source ids associated with this Target.",
+          "readOnly": true
         },
         "application_credential_sources": {
           "type": "array",

--- a/internal/proto/local/controller/api/resources/targets/v1/target.proto
+++ b/internal/proto/local/controller/api/resources/targets/v1/target.proto
@@ -112,13 +112,13 @@ message Target {
 	// The type of the Target.
 	string type = 90;
 
-	// The IDs of the Host Sets associated with this Target.
+	// Output only. The IDs of the Host Sets associated with this Target.
 	repeated string host_set_ids = 100 [json_name="host_set_ids"];
 
 	// Output only. The Host Sets associated with this Target.
 	repeated HostSet host_sets = 110 [json_name="host_sets"];
 
-	// The IDs of the Host Sources associated with this Target.
+	// Output only. The IDs of the Host Sources associated with this Target.
 	repeated string host_source_ids = 420 [json_name="host_source_ids"];
 
 	// Output only. The Host Sources associated with this Target.
@@ -133,12 +133,12 @@ message Target {
 	// Optional boolean expression to filter the workers that are allowed to satisfy this request.
 	google.protobuf.StringValue worker_filter = 140 [json_name="worker_filter", (custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this: "worker_filter" that: "WorkerFilter"}];
 
-	// The IDs of the application credential library ids associated with this Target. Deprecated: use application_credential_source_ids instead.
+	// Output only. The IDs of the application credential library ids associated with this Target. Deprecated: use application_credential_source_ids instead.
 	repeated string application_credential_library_ids = 150 [json_name="application_credential_library_ids", deprecated = true];
 	// Output only. The application credential libraries associated with this Target. Deprecated: use application_credential_sources instead.
 	repeated CredentialLibrary application_credential_libraries = 180 [json_name="application_credential_libraries", deprecated = true];
 
-	// The IDs of the application credential source ids associated with this Target.
+	// Output only. The IDs of the application credential source ids associated with this Target.
 	repeated string application_credential_source_ids = 400 [json_name="application_credential_source_ids"];
 	// Output only. The application credential sources associated with this Target.
 	repeated CredentialSource application_credential_sources = 410 [json_name="application_credential_sources"];

--- a/sdk/pbs/controller/api/resources/targets/target.pb.go
+++ b/sdk/pbs/controller/api/resources/targets/target.pb.go
@@ -461,11 +461,11 @@ type Target struct {
 	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty"`
 	// The type of the Target.
 	Type string `protobuf:"bytes,90,opt,name=type,proto3" json:"type,omitempty"`
-	// The IDs of the Host Sets associated with this Target.
+	// Output only. The IDs of the Host Sets associated with this Target.
 	HostSetIds []string `protobuf:"bytes,100,rep,name=host_set_ids,proto3" json:"host_set_ids,omitempty"`
 	// Output only. The Host Sets associated with this Target.
 	HostSets []*HostSet `protobuf:"bytes,110,rep,name=host_sets,proto3" json:"host_sets,omitempty"`
-	// The IDs of the Host Sources associated with this Target.
+	// Output only. The IDs of the Host Sources associated with this Target.
 	HostSourceIds []string `protobuf:"bytes,420,rep,name=host_source_ids,proto3" json:"host_source_ids,omitempty"`
 	// Output only. The Host Sources associated with this Target.
 	HostSources []*HostSource `protobuf:"bytes,430,rep,name=host_sources,proto3" json:"host_sources,omitempty"`
@@ -475,7 +475,7 @@ type Target struct {
 	SessionConnectionLimit *wrapperspb.Int32Value `protobuf:"bytes,130,opt,name=session_connection_limit,proto3" json:"session_connection_limit,omitempty"`
 	// Optional boolean expression to filter the workers that are allowed to satisfy this request.
 	WorkerFilter *wrapperspb.StringValue `protobuf:"bytes,140,opt,name=worker_filter,proto3" json:"worker_filter,omitempty"`
-	// The IDs of the application credential library ids associated with this Target. Deprecated: use application_credential_source_ids instead.
+	// Output only. The IDs of the application credential library ids associated with this Target. Deprecated: use application_credential_source_ids instead.
 	//
 	// Deprecated: Do not use.
 	ApplicationCredentialLibraryIds []string `protobuf:"bytes,150,rep,name=application_credential_library_ids,proto3" json:"application_credential_library_ids,omitempty"`
@@ -483,7 +483,7 @@ type Target struct {
 	//
 	// Deprecated: Do not use.
 	ApplicationCredentialLibraries []*CredentialLibrary `protobuf:"bytes,180,rep,name=application_credential_libraries,proto3" json:"application_credential_libraries,omitempty"`
-	// The IDs of the application credential source ids associated with this Target.
+	// Output only. The IDs of the application credential source ids associated with this Target.
 	ApplicationCredentialSourceIds []string `protobuf:"bytes,400,rep,name=application_credential_source_ids,proto3" json:"application_credential_source_ids,omitempty"`
 	// Output only. The application credential sources associated with this Target.
 	ApplicationCredentialSources []*CredentialSource `protobuf:"bytes,410,rep,name=application_credential_sources,proto3" json:"application_credential_sources,omitempty"`


### PR DESCRIPTION
When creating or updating a target, the following fields should have
been marked as output only:

- host_set_ids
- host_source_ids
- application_credential_source_ids
- application_credential_library_ids

This updates the protobuf and generated files including the swagger file
used by the docs site to correctly mark these are output only.

Fixes #1588