### PR TITLE
Make PG resource usage nicer for dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -980,7 +980,7 @@ jobs:
     - run:
         command: |
           which pg_isready || sudo apt-get update && sudo apt-get install -y postgresql-client
-          make DOCKER_ARGS='-d' -C testing/dbtest/docker database-up
+          make DOCKER_ARGS='-d' PG_OPTS='-c shared_buffers=256MB -c max_connections=200000' -C testing/dbtest/docker database-up
           until pg_isready -h 127.0.0.1; do docker container inspect boundary-sql-tests &> /dev/null || exit -1; sleep 1; done
         name: Initialize Test Database
     - run:

--- a/.circleci/config/jobs/build.yml
+++ b/.circleci/config/jobs/build.yml
@@ -5,7 +5,7 @@ steps:
     name: "Initialize Test Database"
     command: |
       which pg_isready || sudo apt-get update && sudo apt-get install -y postgresql-client
-      make DOCKER_ARGS='-d' -C testing/dbtest/docker database-up
+      make DOCKER_ARGS='-d' PG_OPTS='-c shared_buffers=256MB -c max_connections=200000' -C testing/dbtest/docker database-up
       until pg_isready -h 127.0.0.1; do docker container inspect boundary-sql-tests &> /dev/null || exit -1; sleep 1; done
 - run:
     name: "Run Acceptance Tests"

--- a/testing/dbtest/docker/postgresql.conf
+++ b/testing/dbtest/docker/postgresql.conf
@@ -1,9 +1,10 @@
 listen_addresses           = '*'      # listen on all addresses so other containers can connect if need be.
-max_connections            = 200000   # set max connections to the limit to ensure tests can always get a connection.
-                                      # Note that this may need to be decreased if <4G are available for the container.
-shared_buffers             = 256MB    # A more reasonable default compared to the 32MB default config.
+max_connections            = 1000     # set max connections a higher limit than default; this will be set to the max limit for CI runs
+                                      # the limit to ensure tests can always get a connection.
+shared_buffers             = 64MB     # A more reasonable default compared to the 32MB default config.
                                       # This gives postgres more memory for storing results. But given that short lived nature of the
                                       # test databases and the relatively small data sets, there should not be a need to increase it much more then this.
+                                      # For CI runs this is increased to 256MB.
 dynamic_shared_memory_type = posix    # Use POSIX shared memory allocated using shm_open
 fsync                      = off      # Do not flush, can cause data corruption, but since it is for tests and the data is dropped anyway...
 synchronous_commit         = off      # Do not wait for WAL records to be written to disk before reporting success


### PR DESCRIPTION
This overrides settings specifically in CI scenarios to the current
values but reduces the resource requirements for local dev work.

Locally, these values solved my resource utilization issues while still allowing the tests to pass in 11.5 minutes.