### PR TITLE
refactor: replace `(*regexp.Regexp).Match` on `(*regexp.Regexp).MatchString`

### DIFF
--- a/internal/auth/password/repository_account.go
+++ b/internal/auth/password/repository_account.go
@@ -212,7 +212,7 @@ func validLoginName(u string) bool {
 	if u == "" {
 		return false
 	}
-	return !reInvalidLoginName.Match([]byte(u))
+	return !reInvalidLoginName.MatchString(u)
 }
 
 // UpdateAccount updates the repository entry for a.PublicId with the

--- a/internal/cmd/common/flags.go
+++ b/internal/cmd/common/flags.go
@@ -301,7 +301,7 @@ func HandleAttributeFlags(c *base.Command, suffix, fullField string, sepFields [
 			case strings.HasPrefix(field.Value, `"`): // explicitly quoted string
 				val = strings.Trim(field.Value, `"`)
 
-			case jsonNumberRegex.Match([]byte(strings.Trim(field.Value, `"`))): // number
+			case jsonNumberRegex.MatchString(strings.Trim(field.Value, `"`)): // number
 				// Same logic as above
 				if strings.Contains(field.Value, ".") {
 					val, err = strconv.ParseFloat(field.Value, 64)

--- a/internal/servers/controller/handlers/verifiers.go
+++ b/internal/servers/controller/handlers/verifiers.go
@@ -183,7 +183,7 @@ func ValidId(i Id, prefixes ...string) bool {
 			continue
 		}
 		id = strings.TrimPrefix(id, prefix)
-		if !reInvalidID.Match([]byte(id)) {
+		if !reInvalidID.MatchString(id) {
 			return true
 		}
 	}


### PR DESCRIPTION
This PR change one method of regexp.Regexp struct with a similar one,
as a result, code produces fewer allocations on the heap.