### PR TITLE
chore(target): Remove unused option support from repo Create

### DIFF
--- a/internal/cmd/base/initial_resources.go
+++ b/internal/cmd/base/initial_resources.go
@@ -508,7 +508,6 @@ func (b *Server) CreateInitialTarget(ctx context.Context) (target.Target, error)
 		target.WithName("Generated target"),
 		target.WithDescription("Provides an initial target in Boundary"),
 		target.WithDefaultPort(uint32(b.DevTargetDefaultPort)),
-		target.WithHostSources([]string{b.DevHostSetId}),
 		target.WithSessionMaxSeconds(uint32(b.DevTargetSessionMaxSeconds)),
 		target.WithSessionConnectionLimit(int32(b.DevTargetSessionConnectionLimit)),
 		target.WithPublicId(b.DevTargetId),
@@ -518,6 +517,10 @@ func (b *Server) CreateInitialTarget(ctx context.Context) (target.Target, error)
 		return nil, fmt.Errorf("error creating in memory target: %w", err)
 	}
 	tt, _, _, err := targetRepo.CreateTarget(cancelCtx, t, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("error saving target to the db: %w", err)
+	}
+	tt, _, _, err = targetRepo.AddTargetHostSources(ctx, tt.GetPublicId(), tt.GetVersion(), []string{b.DevHostSetId})
 	if err != nil {
 		return nil, fmt.Errorf("error saving target to the db: %w", err)
 	}

--- a/internal/servers/controller/handlers/targets/target_service_test.go
+++ b/internal/servers/controller/handlers/targets/target_service_test.go
@@ -575,11 +575,13 @@ func TestUpdate(t *testing.T) {
 	tar, err := tcp.New(proj.GetPublicId(), target.WithName("default"), target.WithDescription("default"))
 	tar.DefaultPort = 2
 	require.NoError(t, err)
-	gtar, _, _, err := repo.CreateTarget(context.Background(), tar, target.WithHostSources([]string{hs[0].GetPublicId(), hs[1].GetPublicId()}))
+	gtar, _, _, err := repo.CreateTarget(context.Background(), tar)
+	require.NoError(t, err)
+	gtar, _, _, err = repo.AddTargetHostSources(context.Background(), gtar.GetPublicId(), gtar.GetVersion(), []string{hs[0].GetPublicId(), hs[1].GetPublicId()})
 	require.NoError(t, err)
 	tar = gtar.(*tcp.Target)
 
-	var version uint32 = 1
+	var version uint32 = gtar.GetVersion()
 
 	resetTarget := func() {
 		version++

--- a/internal/target/tcp/repository_tcp_target_test.go
+++ b/internal/target/tcp/repository_tcp_target_test.go
@@ -73,60 +73,6 @@ func TestRepository_CreateTarget(t *testing.T) {
 			wantHostSources: []string{},
 		},
 		{
-			name: "valid-org-with-host-sets",
-			args: args{
-				target: func() *tcp.Target {
-					target, err := tcp.New(proj.PublicId,
-						target.WithName("valid-org-with-host-sets"),
-						target.WithDescription("valid-org"),
-						target.WithDefaultPort(uint32(22)))
-					require.NoError(t, err)
-					return target
-				}(),
-				opt: []target.Option{target.WithHostSources(sets)},
-			},
-			wantErr:         false,
-			wantHostSources: sets,
-			wantCredLibs:    []string{},
-		},
-		{
-			name: "valid-org-with-cred-libs",
-			args: args{
-				target: func() *tcp.Target {
-					target, err := tcp.New(proj.PublicId,
-						target.WithName("valid-org-with-cred-libs"),
-						target.WithDescription("valid-org"),
-						target.WithDefaultPort(uint32(22)))
-					require.NoError(t, err)
-					return target
-				}(),
-				opt: []target.Option{target.WithCredentialSources(clIds)},
-			},
-			wantErr:         false,
-			wantCredLibs:    clIds,
-			wantHostSources: []string{},
-		},
-		{
-			name: "valid-org-with-cred-libs-and-host-sets",
-			args: args{
-				target: func() *tcp.Target {
-					target, err := tcp.New(proj.PublicId,
-						target.WithName("valid-org-with-cred-libs-and-host-sets"),
-						target.WithDescription("valid-org"),
-						target.WithDefaultPort(uint32(22)))
-					require.NoError(t, err)
-					return target
-				}(),
-				opt: []target.Option{
-					target.WithHostSources(sets),
-					target.WithCredentialSources(clIds),
-				},
-			},
-			wantErr:         false,
-			wantCredLibs:    clIds,
-			wantHostSources: sets,
-		},
-		{
 			name: "nil-target",
 			args: args{
 				target: nil,


### PR DESCRIPTION
For the target Repository's Create method, the options of
WithHostSources and WithCredentialSources where never used by the
targets.Service. As such the repository does not need to support these
options.

See: 51812ff77937a3e5e6873995b07ae5400965ac7c