### PR TITLE
fix(vault): Export mapping override field on credential library

### DIFF
--- a/internal/credential/vault/credential_library.go
+++ b/internal/credential/vault/credential_library.go
@@ -25,7 +25,7 @@ type CredentialLibrary struct {
 	*store.CredentialLibrary
 	tableName string `gorm:"-"`
 
-	mappingOverride MappingOverride `gorm:"-"`
+	MappingOverride MappingOverride `gorm:"-"`
 }
 
 // NewCredentialLibrary creates a new in memory CredentialLibrary
@@ -37,7 +37,7 @@ func NewCredentialLibrary(storeId string, vaultPath string, opt ...Option) (*Cre
 	opts := getOpts(opt...)
 
 	l := &CredentialLibrary{
-		mappingOverride: opts.withMappingOverride,
+		MappingOverride: opts.withMappingOverride,
 		CredentialLibrary: &store.CredentialLibrary{
 			StoreId:         storeId,
 			Name:            opts.withName,
@@ -54,7 +54,7 @@ func NewCredentialLibrary(storeId string, vaultPath string, opt ...Option) (*Cre
 
 func (l *CredentialLibrary) validate(ctx context.Context, caller errors.Op) error {
 	switch {
-	case !validMappingOverride(l.mappingOverride, l.CredentialType()):
+	case !validMappingOverride(l.MappingOverride, l.CredentialType()):
 		return errors.New(ctx, errors.VaultInvalidMappingOverride, caller, "invalid credential type for mapping override")
 	}
 	return nil
@@ -68,21 +68,21 @@ func allocCredentialLibrary() *CredentialLibrary {
 
 func (l *CredentialLibrary) clone() *CredentialLibrary {
 	var m MappingOverride
-	if l.mappingOverride != nil {
-		m = l.mappingOverride.clone()
+	if l.MappingOverride != nil {
+		m = l.MappingOverride.clone()
 	}
 
 	cp := proto.Clone(l.CredentialLibrary)
 	return &CredentialLibrary{
-		mappingOverride:   m,
+		MappingOverride:   m,
 		CredentialLibrary: cp.(*store.CredentialLibrary),
 	}
 }
 
 func (l *CredentialLibrary) setId(i string) {
 	l.PublicId = i
-	if l.mappingOverride != nil {
-		l.mappingOverride.setLibraryId(i)
+	if l.MappingOverride != nil {
+		l.MappingOverride.setLibraryId(i)
 	}
 }
 

--- a/internal/credential/vault/repository_credential_library.go
+++ b/internal/credential/vault/repository_credential_library.go
@@ -81,9 +81,9 @@ func (r *Repository) CreateCredentialLibrary(ctx context.Context, scopeId string
 			msgs = append(msgs, &lOplogMsg)
 
 			// insert mapper override (if exists)
-			if l.mappingOverride != nil {
+			if l.MappingOverride != nil {
 				var msg oplog.Message
-				if err := w.Create(ctx, newCredentialLibrary.mappingOverride, db.NewOplogMsg(&msg)); err != nil {
+				if err := w.Create(ctx, newCredentialLibrary.MappingOverride, db.NewOplogMsg(&msg)); err != nil {
 					return errors.Wrap(ctx, err, op)
 				}
 				msgs = append(msgs, &msg)

--- a/internal/credential/vault/repository_credential_library_test.go
+++ b/internal/credential/vault/repository_credential_library_test.go
@@ -189,7 +189,7 @@ func TestRepository_CreateCredentialLibrary(t *testing.T) {
 		{
 			name: "unknown-mapping-override-type",
 			in: &CredentialLibrary{
-				mappingOverride: unknownMapper(1),
+				MappingOverride: unknownMapper(1),
 				CredentialLibrary: &store.CredentialLibrary{
 					StoreId:        cs.GetPublicId(),
 					HttpMethod:     "GET",
@@ -202,7 +202,7 @@ func TestRepository_CreateCredentialLibrary(t *testing.T) {
 		{
 			name: "invalid-mapping-override-type",
 			in: &CredentialLibrary{
-				mappingOverride: NewUserPasswordOverride(WithOverrideUsernameAttribute("test")),
+				MappingOverride: NewUserPasswordOverride(WithOverrideUsernameAttribute("test")),
 				CredentialLibrary: &store.CredentialLibrary{
 					StoreId:    cs.GetPublicId(),
 					HttpMethod: "GET",
@@ -214,7 +214,7 @@ func TestRepository_CreateCredentialLibrary(t *testing.T) {
 		{
 			name: "valid-user-password-credential-type-with-override",
 			in: &CredentialLibrary{
-				mappingOverride: NewUserPasswordOverride(WithOverrideUsernameAttribute("test")),
+				MappingOverride: NewUserPasswordOverride(WithOverrideUsernameAttribute("test")),
 				CredentialLibrary: &store.CredentialLibrary{
 					StoreId:        cs.GetPublicId(),
 					HttpMethod:     "GET",
@@ -223,7 +223,7 @@ func TestRepository_CreateCredentialLibrary(t *testing.T) {
 				},
 			},
 			want: &CredentialLibrary{
-				mappingOverride: NewUserPasswordOverride(WithOverrideUsernameAttribute("test")),
+				MappingOverride: NewUserPasswordOverride(WithOverrideUsernameAttribute("test")),
 				CredentialLibrary: &store.CredentialLibrary{
 					StoreId:        cs.GetPublicId(),
 					HttpMethod:     "GET",
@@ -262,7 +262,7 @@ func TestRepository_CreateCredentialLibrary(t *testing.T) {
 
 			assert.NoError(db.TestVerifyOplog(t, rw, got.GetPublicId(), db.WithOperation(oplog.OpType_OP_TYPE_CREATE), db.WithCreateNotBefore(10*time.Second)))
 
-			if tt.in.mappingOverride != nil {
+			if tt.in.MappingOverride != nil {
 				override := allocUserPasswordOverride()
 				assert.NoError(rw.LookupWhere(ctx, &override, "library_id = ?", got.GetPublicId()))
 			}


### PR DESCRIPTION
The mapping override field in the vault credential library is not
special. There is no reason to not export it just like the other fields
in the struct.

This PR obviates some of the changes proposed in #1616. 