### PR TITLE
Warehouse contains "Unsupported" host_address for plugin based hosts

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/19/03_hostplugin.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/19/03_hostplugin.up.sql
@@ -6,6 +6,7 @@ begin;
   ├──────────────────┤
   │public_id (pk)    │
   │scope_id (fk)     │
+  │name              │
   └──────────────────┘
             ┼
             ┼
@@ -20,8 +21,6 @@ begin;
   │name              │
   │description       │
   │version           │
-  │plugin_name       │
-  │id_prefix         │
   └──────────────────┘
 */
   create table plugin_host (

--- a/internal/db/schema/migrations/oss/postgres/19/07_wh_session_dimensions.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/19/07_wh_session_dimensions.up.sql
@@ -6,8 +6,9 @@ begin;
 -- resources.  While this will return rows where there are host_sets where hosts
 -- are not in the host sets, this view is only used when looking up a row by
 -- host, set, and target so the records where hosts and host sets aren't
--- related beyond the shared catalog will be ignored.
--- TODO: Support a host having multiple addresses.
+-- related beyond the shared catalog will be ignored.  Retrieving the ip address
+-- or dns name of plugin based hosts is not supported in this version of the
+-- warehouse.
 drop view whx_host_dimension_source;
 create view whx_host_dimension_source as
 select -- id is the first column in the target view
@@ -22,8 +23,7 @@ select -- id is the first column in the target view
             when ph.public_id is not null then coalesce(ph.description, 'None')
             else 'Unknown' end          as host_description,
 
-       -- TODO: update this to be endpoint address...
-       coalesce(sh.address, 'Unknown')  as host_address,
+       coalesce(sh.address, 'Unsupported')  as host_address,
 
        hs.public_id                     as host_set_id,
        case when shs.public_id is not null then 'static host set'

--- a/internal/db/sqltest/initdb.d/03_widgets_persona.sql
+++ b/internal/db/sqltest/initdb.d/03_widgets_persona.sql
@@ -236,6 +236,44 @@ begin;
            static_host_set as s
      where h.catalog_id = s.catalog_id
        and h.address like '%.widget';
+
+    insert into plugin_host
+      (scope_id, public_id, name)
+    values
+      ('global', 'plg___wb-hplg', 'Short Host Plugin');
+
+    insert into host_plugin_catalog
+      (scope_id, public_id, plugin_id, name, attributes)
+    values
+      ('p____bwidget', 'c___wb-plghcl', 'plg___wb-hplg', 'Big Widget Plugin Catalog', ''),
+      ('p____swidget', 'c___ws-plghcl', 'plg___wb-hplg',  'Small Widget Plugin Catalog', '');
+
+    insert into host_plugin_host
+      (catalog_id, public_id, external_id)
+    values
+      ('c___wb-plghcl', 'h_____wb__01-plgh', '1 big widget'),
+      ('c___wb-plghcl', 'h_____wb__02-plgh', '2 big widget'),
+      ('c___wb-plghcl', 'h_____wb__03-plgh', '3 big widget'),
+
+      ('c___ws-plghcl', 'h_____ws__01-plgh', '1 small widget'),
+      ('c___ws-plghcl', 'h_____ws__02-plgh', '2 small widget'),
+      ('c___ws-plghcl', 'h_____ws__03-plgh', '3 small widget');
+
+    insert into host_plugin_set
+      (catalog_id, public_id, name, attributes, need_sync)
+    values
+      ('c___wb-plghcl', 's___1wb-plghs', 'Big Widget Plugin Set 1', '', false),
+      ('c___wb-plghcl', 's___2wb-plghs', 'Big Widget Plugin Set 2', '', false),
+      ('c___ws-plghcl', 's___1ws-plghs', 'Small Widget Plugin Set 1', '', false),
+      ('c___ws-plghcl', 's___2ws-plghs', 'Small Widget Plugin Set 2', '', false);
+
+    insert
+      into host_plugin_set_member
+           ( host_id,     set_id,      catalog_id)
+    select h.public_id, s.public_id, s.catalog_id
+      from host_plugin_host as h,
+           host_plugin_set as s
+     where h.catalog_id = s.catalog_id;
   end;
   $$ language plpgsql;
 
@@ -257,7 +295,11 @@ begin;
       ('t_________wb', 's___1wb-sths'),
       ('t_________wb', 's___2wb-sths'),
       ('t_________ws', 's___1ws-sths'),
-      ('t_________ws', 's___2ws-sths');
+      ('t_________ws', 's___2ws-sths'),
+      ('t_________wb', 's___1wb-plghs'),
+      ('t_________wb', 's___2wb-plghs'),
+      ('t_________ws', 's___1ws-plghs'),
+      ('t_________ws', 's___2ws-plghs');
 
   end;
   $$ language plpgsql;

--- a/internal/db/sqltest/tests/wh/host_dimension_views/source.sql
+++ b/internal/db/sqltest/tests/wh/host_dimension_views/source.sql
@@ -1,9 +1,9 @@
 -- source tests the whx_host_dimension_source view.
 begin;
-  select plan(1);
+  select plan(2);
   select wtt_load('widgets', 'iam', 'kms', 'auth', 'hosts', 'targets');
 
-  -- auth_password_account
+  -- Static hosts
   select is(s.*, row(
     'h_____wb__01', 'static host',         'None',                      'None', '1.big.widget',
     's___2wb-sths', 'static host set',     'Big Widget Static Set 2',   'None',
@@ -16,6 +16,20 @@ begin;
    where s.host_id     = 'h_____wb__01'
      and s.host_set_id = 's___2wb-sths'
      and s.target_id   = 't_________wb';
+
+  -- Plugin based hosts
+  select is(s.*, row(
+    'h_____wb__01-plgh',  'plugin host',         'None',                      'None', 'Unsupported',
+    's___2wb-plghs',      'plugin host set',     'Big Widget Plugin Set 2',   'None',
+    'c___wb-plghcl',      'plugin host catalog', 'Big Widget Plugin Catalog', 'None',
+    't_________wb',       'tcp target',          'Big Widget Target',         'None', 0,              28800, 1,
+    'p____bwidget',       'Big Widget Factory',  'None',
+    'o_____widget',       'Widget Inc',          'None'
+    )::whx_host_dimension_source)
+  from whx_host_dimension_source as s
+  where s.host_id     = 'h_____wb__01-plgh'
+    and s.host_set_id = 's___2wb-plghs'
+    and s.target_id   = 't_________wb';
 
   select * from finish();
 rollback;


### PR DESCRIPTION
Updates the comments for the migration script which updates the whx_host_dimension_source view as well as changes the value for host_address to "Unsupported". 

Since this view is now likely to be used with the release of plugins please consider redoing the review of the whole view as part of this PR.