### PR TITLE
Pass namespace to the Vault client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   a missing mandated cipher suite of the HTTP/2 (`h2`) specification that could
   result in no shared cipher suites between the Boundary API listener and those
   clients. ([PR](https://github.com/hashicorp/boundary/pull/1637))
+* vault: Fix credential store support when using Vault namespaces
+  ([Issue](https://github.com/hashicorp/boundary/issues/1597),
+  [PR](https://github.com/hashicorp/boundary/pull/1660))
 
 ## 0.6.2 (2021/09/27)
 

--- a/internal/credential/vault/vault.go
+++ b/internal/credential/vault/vault.go
@@ -79,6 +79,10 @@ func newClient(c *clientConfig) (*client, error) {
 	}
 	vClient.SetToken(string(c.Token))
 
+	if c.Namespace != "" {
+		vClient.SetNamespace(c.Namespace)
+	}
+
 	return &client{
 		cl:    vClient,
 		token: c.Token,


### PR DESCRIPTION
The namespace was plumbed all the way through the API but isn't actually
set on the client when it is created.

For various reasons this is hard to test right now except manually (although that will change in the future), but it works in my testing and works for @joatmon08 too.

Fixes #1597