### PR TITLE
fix(schema): Prevent duplicate versions per edition

### DIFF
--- a/internal/db/schema/internal/edition/edition.go
+++ b/internal/db/schema/internal/edition/edition.go
@@ -121,6 +121,9 @@ func New(name string, dialect Dialect, m embed.FS, priority int) Edition {
 		}
 		contents = strings.TrimSpace(contents)
 
+		if _, exists := migrations[fullV]; exists {
+			panic(fmt.Sprintf("migration file for version %d already exists", fullV))
+		}
 		migrations[fullV] = []byte(contents)
 
 		return nil

--- a/internal/db/schema/internal/edition/edition_test.go
+++ b/internal/db/schema/internal/edition/edition_test.go
@@ -74,6 +74,8 @@ var (
 	noMinorVersion embed.FS
 	//go:embed testdata/invalid/no-major-version
 	noMajorVersion embed.FS
+	//go:embed testdata/invalid/duplicate-versions
+	duplicateVersions embed.FS
 )
 
 func TestNewPanics(t *testing.T) {
@@ -102,6 +104,10 @@ func TestNewPanics(t *testing.T) {
 		{
 			"noMajorVersion",
 			noMajorVersion,
+		},
+		{
+			"duplicateVersions",
+			duplicateVersions,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/db/schema/internal/edition/testdata/invalid/duplicate-versions/0/01_initial.up.sql
+++ b/internal/db/schema/internal/edition/testdata/invalid/duplicate-versions/0/01_initial.up.sql
@@ -1,0 +1,5 @@
+begin;
+  create table one (
+    id bigint primary key
+  );
+commit;

--- a/internal/db/schema/internal/edition/testdata/invalid/duplicate-versions/0/01_initial_also.up.sql
+++ b/internal/db/schema/internal/edition/testdata/invalid/duplicate-versions/0/01_initial_also.up.sql
@@ -1,0 +1,5 @@
+begin;
+  create table one_also (
+    id bigint primary key
+  );
+commit;


### PR DESCRIPTION
This should help prevent issues like the one fixed in
f2ad4de554d5e10365bd39c110f29f9a4c481fa5.

A version for a particular edition should only exist once, previously
which ever file was read last for a version would be included, which
would lead to some migrations not running.