### PR TITLE
Add redirect to managed groups domain model documentation

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -119,6 +119,11 @@ module.exports = [
     destination: '/docs/concepts/domain-model/credential-libraries',
     permanent: false,
   },
+  {
+    source: '/help/admin-ui/managed-groups',
+    destination: '/docs/concepts/domain-model/managed-groups',
+    permanent: false,
+  },
 
   ////////////////////////////////////////////
   // Adding sub-resources to existing resource


### PR DESCRIPTION
Add redirect to domain model documentation for managed groups. This is used when the user click the icon help in the managed group screen.

<img width="1503" alt="Screen Shot 2021-11-09 at 8 04 13 AM" src="https://user-images.githubusercontent.com/9775006/140960197-139bbcca-81ff-4395-83fc-01fa69b44217.png">
