### PR TITLE
Call OnCreate or OnUpdate on the plugin after db constraints are checked

### DIFF
--- a/internal/host/plugin/repository_host_catalog.go
+++ b/internal/host/plugin/repository_host_catalog.go
@@ -68,32 +68,16 @@ func (r *Repository) CreateCatalog(ctx context.Context, c *HostCatalog, _ ...Opt
 	if !ok || plgClient == nil {
 		return nil, nil, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("plugin %q not available", c.GetPluginId()))
 	}
-	plgResp, err := plgClient.OnCreateCatalog(ctx, &plgpb.OnCreateCatalogRequest{Catalog: plgHc})
-	if err != nil {
-		if status.Code(err) != codes.Unimplemented {
-			return nil, nil, errors.Wrap(ctx, err, op)
-		}
-	}
-
-	var hcSecret *HostCatalogSecret
-	if plgResp != nil && plgResp.GetPersisted().GetSecrets() != nil {
-		hcSecret, err = newHostCatalogSecret(ctx, id, plgResp.GetPersisted().GetSecrets())
-		if err != nil {
-			return nil, nil, errors.Wrap(ctx, err, op)
-		}
-		dbWrapper, err := r.kms.GetWrapper(ctx, c.ScopeId, kms.KeyPurposeDatabase)
-		if err != nil {
-			return nil, nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to get db wrapper"))
-		}
-		if err := hcSecret.encrypt(ctx, dbWrapper); err != nil {
-			return nil, nil, errors.Wrap(ctx, err, op)
-		}
-	}
 
 	oplogWrapper, err := r.kms.GetWrapper(ctx, c.ScopeId, kms.KeyPurposeOplog)
 	if err != nil {
 		return nil, nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to get oplog wrapper"))
 	}
+
+	// If the call to the plugin succeeded, we do not want to call it again if
+	// the transaction failed and is being retried.
+	var pluginCalledSuccessfully bool
+	var plgResp *plgpb.OnCreateCatalogResponse
 
 	var newHostCatalog *HostCatalog
 	_, err = r.writer.DoTx(
@@ -114,17 +98,40 @@ func (r *Repository) CreateCatalog(ctx context.Context, c *HostCatalog, _ ...Opt
 			}
 			msgs = append(msgs, &cOplogMsg)
 
-			if hcSecret != nil {
-				newSecret := hcSecret.clone()
-				q, v := newSecret.upsertQuery()
-				rows, err := w.Exec(ctx, q, v)
+			if !pluginCalledSuccessfully {
+				plgResp, err = plgClient.OnCreateCatalog(ctx, &plgpb.OnCreateCatalogRequest{Catalog: plgHc})
+				if err != nil {
+					if status.Code(err) != codes.Unimplemented {
+						return errors.Wrap(ctx, err, op)
+					}
+				}
+				pluginCalledSuccessfully = true
+			}
+
+			if plgResp != nil && plgResp.GetPersisted().GetSecrets() != nil {
+				hcSecret, err := newHostCatalogSecret(ctx, id, plgResp.GetPersisted().GetSecrets())
 				if err != nil {
 					return errors.Wrap(ctx, err, op)
 				}
-				if rows > 1 {
-					return errors.New(ctx, errors.MultipleRecords, op, "more than 1 catalog secret would have been created")
+				dbWrapper, err := r.kms.GetWrapper(ctx, c.ScopeId, kms.KeyPurposeDatabase)
+				if err != nil {
+					return errors.Wrap(ctx, err, op, errors.WithMsg("unable to get db wrapper"))
 				}
-				msgs = append(msgs, newSecret.oplogMessage(db.CreateOp))
+				if err := hcSecret.encrypt(ctx, dbWrapper); err != nil {
+					return errors.Wrap(ctx, err, op)
+				}
+				if hcSecret != nil {
+					newSecret := hcSecret.clone()
+					q, v := newSecret.upsertQuery()
+					rows, err := w.Exec(ctx, q, v)
+					if err != nil {
+						return errors.Wrap(ctx, err, op)
+					}
+					if rows > 1 {
+						return errors.New(ctx, errors.MultipleRecords, op, "more than 1 catalog secret would have been created")
+					}
+					msgs = append(msgs, newSecret.oplogMessage(db.CreateOp))
+				}
 			}
 
 			metadata := c.oplog(oplog.OpType_OP_TYPE_CREATE)
@@ -276,50 +283,18 @@ func (r *Repository) UpdateCatalog(ctx context.Context, c *HostCatalog, version 
 		return nil, nil, db.NoRowsAffected, errors.Wrap(ctx, err, op)
 	}
 
-	plgResp, err := plgClient.OnUpdateCatalog(ctx, &plgpb.OnUpdateCatalogRequest{
-		CurrentCatalog: currPlgHc,
-		NewCatalog:     newPlgHc,
-		Persisted:      currentCatalogPersisted,
-	})
+	dbWrapper, err := r.kms.GetWrapper(ctx, newCatalog.ScopeId, kms.KeyPurposeDatabase)
 	if err != nil {
-		if status.Code(err) != codes.Unimplemented {
-			return nil, nil, db.NoRowsAffected, errors.Wrap(ctx, err, op)
-		}
+		return nil, nil, db.NoRowsAffected, errors.Wrap(ctx, err, op, errors.WithMsg("unable to get db wrapper"))
 	}
-
-	// Success for OnUpdateCatalog. This means we can start updating.
-	// First, check for returned persisted data and encrypt it.
-	var hcSecret *HostCatalogSecret
-	var deleteSecrets bool
-	if plgResp != nil && plgResp.GetPersisted().GetSecrets() != nil {
-		if len(plgResp.GetPersisted().GetSecrets().GetFields()) == 0 {
-			// Flag the secret to be deleted.
-			hcSecret, err = newHostCatalogSecret(ctx, currentCatalog.GetPublicId(), plgResp.GetPersisted().GetSecrets())
-			if err != nil {
-				return nil, nil, db.NoRowsAffected, errors.Wrap(ctx, err, op)
-			}
-
-			deleteSecrets = true
-		} else {
-			hcSecret, err = newHostCatalogSecret(ctx, currentCatalog.GetPublicId(), plgResp.GetPersisted().GetSecrets())
-			if err != nil {
-				return nil, nil, db.NoRowsAffected, errors.Wrap(ctx, err, op)
-			}
-			dbWrapper, err := r.kms.GetWrapper(ctx, newCatalog.ScopeId, kms.KeyPurposeDatabase)
-			if err != nil {
-				return nil, nil, db.NoRowsAffected, errors.Wrap(ctx, err, op, errors.WithMsg("unable to get db wrapper"))
-			}
-			if err := hcSecret.encrypt(ctx, dbWrapper); err != nil {
-				return nil, nil, db.NoRowsAffected, errors.Wrap(ctx, err, op)
-			}
-		}
-	}
-
 	// Get the oplog.
 	oplogWrapper, err := r.kms.GetWrapper(ctx, newCatalog.ScopeId, kms.KeyPurposeOplog)
 	if err != nil {
 		return nil, nil, db.NoRowsAffected, errors.Wrap(ctx, err, op, errors.WithMsg("unable to get oplog wrapper"))
 	}
+
+	var pluginCalledSuccessfully bool
+	var plgResp *plgpb.OnUpdateCatalogResponse
 
 	var recordUpdated bool
 	var returnedCatalog *HostCatalog
@@ -360,13 +335,31 @@ func (r *Repository) UpdateCatalog(ctx context.Context, c *HostCatalog, version 
 				returnedCatalog = currentCatalog.clone()
 			}
 
-			if hcSecret != nil {
-				if deleteSecrets {
+			if !pluginCalledSuccessfully {
+				plgResp, err = plgClient.OnUpdateCatalog(ctx, &plgpb.OnUpdateCatalogRequest{
+					CurrentCatalog: currPlgHc,
+					NewCatalog:     newPlgHc,
+					Persisted:      currentCatalogPersisted,
+				})
+				if err != nil {
+					if status.Code(err) != codes.Unimplemented {
+						return errors.Wrap(ctx, err, op)
+					}
+				}
+				pluginCalledSuccessfully = true
+			}
+			var updatedPersisted bool
+			if plgResp != nil && plgResp.GetPersisted().GetSecrets() != nil {
+				if len(plgResp.GetPersisted().GetSecrets().GetFields()) == 0 {
+					// Flag the secret to be deleted.
+					hcSecret, err := newHostCatalogSecret(ctx, currentCatalog.GetPublicId(), plgResp.GetPersisted().GetSecrets())
+					if err != nil {
+						return errors.Wrap(ctx, err, op)
+					}
 					// We didn't set/encrypt the persisted data because there was
 					// none returned. Just delete the entry.
 					deletedSecret := hcSecret.clone()
 					q, v := deletedSecret.deleteQuery()
-					var err error
 					secretsUpdated, err := w.Exec(ctx, q, v)
 					if err != nil {
 						return errors.Wrap(ctx, err, op)
@@ -374,12 +367,20 @@ func (r *Repository) UpdateCatalog(ctx context.Context, c *HostCatalog, version 
 					if secretsUpdated != 1 {
 						return errors.New(ctx, errors.MultipleRecords, op, fmt.Sprintf("expected 1 catalog secret to be deleted, got %d", secretsUpdated))
 					}
+					updatedPersisted = true
 					msgs = append(msgs, deletedSecret.oplogMessage(db.DeleteOp))
 				} else {
+					hcSecret, err := newHostCatalogSecret(ctx, currentCatalog.GetPublicId(), plgResp.GetPersisted().GetSecrets())
+					if err != nil {
+						return errors.Wrap(ctx, err, op)
+					}
+					if err := hcSecret.encrypt(ctx, dbWrapper); err != nil {
+						return errors.Wrap(ctx, err, op)
+					}
+
 					// Update the secrets.
 					updatedSecret := hcSecret.clone()
 					q, v := updatedSecret.upsertQuery()
-					var err error
 					secretsUpdated, err := w.Exec(ctx, q, v)
 					if err != nil {
 						return errors.Wrap(ctx, err, op)
@@ -387,32 +388,33 @@ func (r *Repository) UpdateCatalog(ctx context.Context, c *HostCatalog, version 
 					if secretsUpdated != 1 {
 						return errors.New(ctx, errors.MultipleRecords, op, fmt.Sprintf("expected 1 catalog secret to be updated, got %d", secretsUpdated))
 					}
+					updatedPersisted = true
 					msgs = append(msgs, updatedSecret.oplogMessage(db.UpdateOp))
 				}
+			}
 
-				if !recordUpdated {
-					// we only updated secrets, so we need to increment the
-					// version of the host catalog manually.
-					returnedCatalog = newCatalog.clone()
-					returnedCatalog.Version = uint32(version) + 1
-					var cOplogMsg oplog.Message
-					catalogsUpdated, err := w.Update(
-						ctx,
-						returnedCatalog,
-						[]string{"version"},
-						[]string{},
-						db.NewOplogMsg(&cOplogMsg),
-						db.WithVersion(&version),
-					)
-					if err != nil {
-						return errors.Wrap(ctx, err, op)
-					}
-					if catalogsUpdated != 1 {
-						return errors.New(ctx, errors.MultipleRecords, op, fmt.Sprintf("expected 1 catalog to be updated, got %d", catalogsUpdated))
-					}
-					msgs = append(msgs, &cOplogMsg)
-					recordUpdated = true
+			if !recordUpdated && updatedPersisted {
+				// we only updated secrets, so we need to increment the
+				// version of the host catalog manually.
+				returnedCatalog = newCatalog.clone()
+				returnedCatalog.Version = uint32(version) + 1
+				var cOplogMsg oplog.Message
+				catalogsUpdated, err := w.Update(
+					ctx,
+					returnedCatalog,
+					[]string{"version"},
+					[]string{},
+					db.NewOplogMsg(&cOplogMsg),
+					db.WithVersion(&version),
+				)
+				if err != nil {
+					return errors.Wrap(ctx, err, op)
 				}
+				if catalogsUpdated != 1 {
+					return errors.New(ctx, errors.MultipleRecords, op, fmt.Sprintf("expected 1 catalog to be updated, got %d", catalogsUpdated))
+				}
+				msgs = append(msgs, &cOplogMsg)
+				recordUpdated = true
 			}
 
 			if len(msgs) != 0 {

--- a/internal/host/plugin/repository_host_catalog_test.go
+++ b/internal/host/plugin/repository_host_catalog_test.go
@@ -36,26 +36,12 @@ func TestRepository_CreateCatalog(t *testing.T) {
 	plg := hostplg.TestPlugin(t, conn, "test")
 	unimplementedPlugin := hostplg.TestPlugin(t, conn, "unimplemented")
 
-	// gotPluginAttrs tracks which attributes a plugin has received through a closure and can be compared in the
-	// test against the expected values sent to the plugin.
-	var gotPluginAttrs *structpb.Struct
-	plgm := map[string]plgpb.HostPluginServiceClient{
-		plg.GetPublicId(): &WrappingPluginClient{
-			Server: &TestPluginServer{
-				OnCreateCatalogFn: func(_ context.Context, req *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error) {
-					gotPluginAttrs = req.GetCatalog().GetAttributes()
-					return &plgpb.OnCreateCatalogResponse{Persisted: &plgpb.HostCatalogPersisted{Secrets: req.GetCatalog().GetSecrets()}}, nil
-				},
-			},
-		},
-		unimplementedPlugin.GetPublicId(): &WrappingPluginClient{Server: &plgpb.UnimplementedHostPluginServiceServer{}},
-	}
-
 	tests := []struct {
 		name       string
 		in         *HostCatalog
 		opts       []Option
 		want       *HostCatalog
+		wantPluginCalled bool
 		wantSecret *structpb.Struct
 		wantIsErr  errors.Code
 	}{
@@ -114,6 +100,7 @@ func TestRepository_CreateCatalog(t *testing.T) {
 					Attributes: []byte{},
 				},
 			},
+			wantPluginCalled: true,
 		},
 		{
 			name: "valid-unimplemented-plugin",
@@ -131,6 +118,7 @@ func TestRepository_CreateCatalog(t *testing.T) {
 					Attributes: []byte{},
 				},
 			},
+			wantPluginCalled: true,
 		},
 		{
 			name: "not-found-plugin",
@@ -161,6 +149,7 @@ func TestRepository_CreateCatalog(t *testing.T) {
 					Attributes: []byte{},
 				},
 			},
+			wantPluginCalled: true,
 		},
 		{
 			name: "valid-with-description",
@@ -180,6 +169,7 @@ func TestRepository_CreateCatalog(t *testing.T) {
 					Attributes:  []byte{},
 				},
 			},
+			wantPluginCalled: true,
 		},
 		{
 			name: "valid-with-attributes",
@@ -209,6 +199,7 @@ func TestRepository_CreateCatalog(t *testing.T) {
 					}(),
 				},
 			},
+			wantPluginCalled: true,
 		},
 		{
 			name: "valid-with-secret",
@@ -246,6 +237,7 @@ func TestRepository_CreateCatalog(t *testing.T) {
 				require.NoError(t, err)
 				return st
 			}(),
+			wantPluginCalled: true,
 		},
 	}
 
@@ -254,10 +246,34 @@ func TestRepository_CreateCatalog(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			kmsCache := kms.TestKms(t, conn, wrapper)
+
+			// gotPluginAttrs tracks which attributes a plugin has received through a closure and can be compared in the
+			// test against the expected values sent to the plugin.
+			var gotPluginAttrs *structpb.Struct
+			var pluginCalled bool
+			plgm := map[string]plgpb.HostPluginServiceClient{
+				plg.GetPublicId(): &WrappingPluginClient{
+					Server: &TestPluginServer{
+						OnCreateCatalogFn: func(_ context.Context, req *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error) {
+							pluginCalled = true
+							gotPluginAttrs = req.GetCatalog().GetAttributes()
+							return &plgpb.OnCreateCatalogResponse{Persisted: &plgpb.HostCatalogPersisted{Secrets: req.GetCatalog().GetSecrets()}}, nil
+						},
+					},
+				},
+				unimplementedPlugin.GetPublicId(): &WrappingPluginClient{Server: &TestPluginServer{
+					OnCreateCatalogFn: func(ctx context.Context, req *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error) {
+						pluginCalled = true
+						gotPluginAttrs = req.GetCatalog().GetAttributes()
+						return plgpb.UnimplementedHostPluginServiceServer{}.OnCreateCatalog(ctx, req)
+					},
+				}},
+			}
 			repo, err := NewRepository(rw, rw, kmsCache, sched, plgm)
 			assert.NoError(err)
 			assert.NotNil(repo)
 			got, _, err := repo.CreateCatalog(ctx, tt.in, tt.opts...)
+			assert.Equal(tt.wantPluginCalled, pluginCalled)
 			if tt.wantIsErr != 0 {
 				assert.Truef(errors.Match(errors.T(tt.wantIsErr), err), "want err: %q got: %q", tt.wantIsErr, err)
 				assert.Nil(got)
@@ -305,6 +321,17 @@ func TestRepository_CreateCatalog(t *testing.T) {
 	t.Run("invalid-duplicate-names", func(t *testing.T) {
 		assert := assert.New(t)
 		kms := kms.TestKms(t, conn, wrapper)
+		var pluginCalled bool
+		plgm := map[string]plgpb.HostPluginServiceClient{
+			plg.GetPublicId(): &WrappingPluginClient{
+				Server: &TestPluginServer{
+					OnCreateCatalogFn: func(_ context.Context, req *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error) {
+						pluginCalled = true
+						return &plgpb.OnCreateCatalogResponse{Persisted: &plgpb.HostCatalogPersisted{Secrets: req.GetCatalog().GetSecrets()}}, nil
+					},
+				},
+			},
+		}
 		repo, err := NewRepository(rw, rw, kms, sched, plgm)
 		assert.NoError(err)
 		assert.NotNil(repo)
@@ -321,13 +348,18 @@ func TestRepository_CreateCatalog(t *testing.T) {
 		got, _, err := repo.CreateCatalog(context.Background(), in)
 		assert.NoError(err)
 		assert.NotNil(got)
+		assert.True(pluginCalled)
 		assertPluginBasedPublicId(t, HostCatalogPrefix, got.PublicId)
 		assert.NotSame(in, got)
 		assert.Equal(in.Name, got.Name)
 		assert.Equal(in.Description, got.Description)
 		assert.Equal(got.CreateTime, got.UpdateTime)
 
+		// Reset pluginCalled so we can see that the plugin wasn't called w/
+		// the duplicate name.
+		pluginCalled = false
 		got2, _, err := repo.CreateCatalog(context.Background(), in)
+		assert.False(pluginCalled)
 		assert.Truef(errors.Match(errors.T(errors.NotUnique), err), "want err code: %v got err: %v", errors.NotUnique, err)
 		assert.Nil(got2)
 	})
@@ -335,6 +367,17 @@ func TestRepository_CreateCatalog(t *testing.T) {
 	t.Run("valid-duplicate-names-diff-scopes", func(t *testing.T) {
 		assert := assert.New(t)
 		kms := kms.TestKms(t, conn, wrapper)
+		var pluginCalled bool
+		plgm := map[string]plgpb.HostPluginServiceClient{
+			plg.GetPublicId(): &WrappingPluginClient{
+				Server: &TestPluginServer{
+					OnCreateCatalogFn: func(_ context.Context, req *plgpb.OnCreateCatalogRequest) (*plgpb.OnCreateCatalogResponse, error) {
+						pluginCalled = true
+						return &plgpb.OnCreateCatalogResponse{Persisted: &plgpb.HostCatalogPersisted{Secrets: req.GetCatalog().GetSecrets()}}, nil
+					},
+				},
+			},
+		}
 		repo, err := NewRepository(rw, rw, kms, sched, plgm)
 		assert.NoError(err)
 		assert.NotNil(repo)
@@ -352,6 +395,7 @@ func TestRepository_CreateCatalog(t *testing.T) {
 		got, _, err := repo.CreateCatalog(context.Background(), in)
 		assert.NoError(err)
 		assert.NotNil(got)
+		assert.True(pluginCalled)
 		assertPluginBasedPublicId(t, HostCatalogPrefix, got.PublicId)
 		assert.NotSame(in, got)
 		assert.Equal(in.Name, got.Name)
@@ -359,9 +403,11 @@ func TestRepository_CreateCatalog(t *testing.T) {
 		assert.Equal(got.CreateTime, got.UpdateTime)
 
 		in2.ScopeId = org.GetPublicId()
+		pluginCalled = false // reset pluginCalled for this next call to Create
 		got2, _, err := repo.CreateCatalog(context.Background(), in2)
 		assert.NoError(err)
 		assert.NotNil(got2)
+		assert.True(pluginCalled)
 		assertPluginBasedPublicId(t, HostCatalogPrefix, got2.PublicId)
 		assert.NotSame(in2, got2)
 		assert.Equal(in2.Name, got2.Name)


### PR DESCRIPTION
This move the calls which could potentially mutate data into the transaction so our db constraints can be checked prior.  The plugins are only called once if successful even if the transaction is retried later.  This doesn't solve all failure cases but arguably avoids calling the plugin when there is a clear error with the request.