### PR TITLE
doc: [ssh] Use `%n` for ProxyCommand

### DIFF
--- a/website/content/docs/common-workflows/workflow-ssh-proxycommand.mdx
+++ b/website/content/docs/common-workflows/workflow-ssh-proxycommand.mdx
@@ -19,7 +19,7 @@ Start by configuring a `Host` entry in `.ssh/ssh_config` for `localhost`:
 
 ```bash
 Host ttcp_*
-  ProxyCommand sh -c "boundary connect -target-id %h -exec nc -- {{boundary.ip}} {{boundary.port}}"
+  ProxyCommand sh -c "boundary connect -target-id %n -exec nc -- {{boundary.ip}} {{boundary.port}}"
 ```
 
 The `ProxyCommand` tells the SSH client to invoke `boundary connect`. We are passing the `-exec nc` flag to


### PR DESCRIPTION
Not sure if this is a general issue or a macOS issue, but when using the default SSH settings on macOS Monterey (12.0.1), `%h` causes the hostname to be lowercased before being substituted into `ProxyCommand`, which then fails for any target IDs that contain uppercase letters.

Instead, use `%n` because it preserves the case of the hostname.

Ref: https://man7.org/linux/man-pages/man5/ssh_config.5.html#TOKENS