### PR TITLE
Increment version of host during updates

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/20/06_plugin_host_views.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/20/06_plugin_host_views.up.sql
@@ -53,10 +53,7 @@ from
 comment on view host_plugin_catalog_with_secret is
   'host plugin catalog with its associated persisted data';
 
--- host_plugin_host_with_value_obj_and_set_memberships is useful for reading a
--- plugin host with its associated value objects (ip addresses, dns names) and
--- set membership as columns with delimited values. The delimiter depends on
--- the value objects (e.g. if they need ordering).
+-- REPLACED in 20/08_plugin_host_views.up.sql
 create view host_plugin_host_with_value_obj_and_set_memberships as
 select
   h.public_id,

--- a/internal/db/schema/migrations/oss/postgres/20/08_plugin_host_views.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/20/08_plugin_host_views.up.sql
@@ -1,0 +1,41 @@
+begin;
+
+alter table host_plugin_host
+  add column version wt_version;
+
+create trigger update_version_column after update on host_plugin_host
+  for each row execute procedure update_version_column();
+
+drop view host_plugin_host_with_value_obj_and_set_memberships;
+
+-- host_plugin_host_with_value_obj_and_set_memberships is useful for reading a
+-- plugin host with its associated value objects (ip addresses, dns names) and
+-- set membership as columns with delimited values. The delimiter depends on
+-- the value objects (e.g. if they need ordering).
+create view host_plugin_host_with_value_obj_and_set_memberships as
+select
+  h.public_id,
+  h.catalog_id,
+  h.external_id,
+  hc.scope_id,
+  hc.plugin_id,
+  h.name,
+  h.description,
+  h.create_time,
+  h.update_time,
+  h.version,
+  -- the string_agg(..) column will be null if there are no associated value objects
+  string_agg(distinct host(hip.address), '|') as ip_addresses,
+  string_agg(distinct hdns.name, '|') as dns_names,
+  string_agg(distinct hpsm.set_id, '|') as set_ids
+from
+  host_plugin_host h
+    join host_plugin_catalog hc                  on h.catalog_id = hc.public_id
+    left outer join host_ip_address hip          on h.public_id = hip.host_id
+    left outer join host_dns_name hdns           on h.public_id = hdns.host_id
+    left outer join host_plugin_set_member hpsm  on h.public_id = hpsm.host_id
+group by h.public_id, hc.plugin_id, hc.scope_id;
+comment on view host_plugin_host_with_value_obj_and_set_memberships is
+  'host plugin host with its associated value objects';
+
+commit;

--- a/internal/host/plugin/host.go
+++ b/internal/host/plugin/host.go
@@ -116,6 +116,7 @@ type hostAgg struct {
 	Description string
 	CreateTime  *timestamp.Timestamp
 	UpdateTime  *timestamp.Timestamp
+	Version     uint32
 	IpAddresses string
 	DnsNames    string
 	SetIds      string
@@ -132,6 +133,7 @@ func (agg *hostAgg) toHost() *Host {
 	h.Description = agg.Description
 	h.CreateTime = agg.CreateTime
 	h.UpdateTime = agg.UpdateTime
+	h.Version = agg.Version
 
 	if agg.IpAddresses != "" {
 		h.IpAddresses = strings.Split(agg.IpAddresses, aggregateDelimiter)

--- a/internal/host/plugin/repository_host_test.go
+++ b/internal/host/plugin/repository_host_test.go
@@ -175,6 +175,7 @@ func TestJob_UpsertHosts(t *testing.T) {
 
 				ph.SetIds = ph.SetIds[0 : len(ph.SetIds)-1]
 				e.SetIds = e.SetIds[0 : len(e.SetIds)-1]
+				e.Version++
 				return &input{
 					catalog: catalog,
 					sets:    setIds,

--- a/internal/host/plugin/repository_host_util.go
+++ b/internal/host/plugin/repository_host_util.go
@@ -75,6 +75,10 @@ func createNewHostMap(ctx context.Context,
 		// assume catalog ID and external ID don't change because if they do
 		// the public ID will be different as well.
 		currHost := currentHostMap[newHost.PublicId]
+		if currHost != nil {
+			hi.h.Version = currHost.Version
+		}
+
 		switch {
 		case currHost == nil,
 			currHost.Name != newHost.Name,

--- a/internal/host/plugin/store/host.pb.go
+++ b/internal/host/plugin/store/host.pb.go
@@ -447,8 +447,9 @@ type Host struct {
 	// plugin_host_catalog and must be set.
 	// @inject_tag: `gorm:"not_null"`
 	CatalogId string `protobuf:"bytes,7,opt,name=catalog_id,json=catalogId,proto3" json:"catalog_id,omitempty" gorm:"not_null"`
-	// @inject_tag: `gorm:"-"`
-	Version uint32 `protobuf:"varint,8,opt,name=version,proto3" json:"version,omitempty" gorm:"-"`
+	// version allows optimistic locking of the resource
+	// @inject_tag: `gorm:"default:null"`
+	Version uint32 `protobuf:"varint,8,opt,name=version,proto3" json:"version,omitempty" gorm:"default:null"`
 	// ip_addresses are the ip addresses associated with this host and will
 	// be persisted in the db through the HostAddress message.
 	// @inject_tag: `gorm:"-"`

--- a/internal/host/plugin/testing.go
+++ b/internal/host/plugin/testing.go
@@ -189,6 +189,7 @@ func TestExternalHosts(t *testing.T, catalog *HostCatalog, setIds []string, coun
 				ExternalId:  externalId,
 				IpAddresses: []string{ipStr},
 				DnsNames:    []string{dnsName},
+				Version:     1,
 			},
 		})
 	}

--- a/internal/proto/local/controller/storage/host/plugin/store/v1/host.proto
+++ b/internal/proto/local/controller/storage/host/plugin/store/v1/host.proto
@@ -160,7 +160,8 @@ message Host {
   // @inject_tag: `gorm:"not_null"`
   string catalog_id = 7;
 
-  // @inject_tag: `gorm:"-"`
+  // version allows optimistic locking of the resource
+  // @inject_tag: `gorm:"default:null"`
   uint32 version = 8;
 
   // ip_addresses are the ip addresses associated with this host and will

--- a/internal/servers/controller/handlers/hosts/host_service.go
+++ b/internal/servers/controller/handlers/hosts/host_service.go
@@ -598,10 +598,6 @@ func toProto(ctx context.Context, in host.Host, opt ...handlers.Option) (*pb.Hos
 		if outputFields.Has(globals.ExternalIdField) {
 			out.ExternalId = h.ExternalId
 		}
-		// FIXME? Seems we should be _using_ a version...
-		if outputFields.Has(globals.VersionField) {
-			out.Version = 1
-		}
 	}
 	return &out, nil
 }

--- a/internal/servers/controller/handlers/hosts/host_service_test.go
+++ b/internal/servers/controller/handlers/hosts/host_service_test.go
@@ -758,7 +758,7 @@ func TestCreate(t *testing.T) {
 	}
 }
 
-func TestUpdate(t *testing.T) {
+func TestUpdate_Static(t *testing.T) {
 	t.Parallel()
 	conn, _ := db.TestSetup(t, "postgres")
 	wrapper := db.TestWrapper(t)


### PR DESCRIPTION
Currently host does not use a version, which means it's not protected
against race conditions of either itself or its value objects. This adds
and plumbs through version to ensure that if a host or its value objects
change that they are not going to be affected by a race condition.