### PR TITLE
fix (kms): Add kms.ReconcileKeys(...) to fix missing audit DEK scenario

### DIFF
--- a/internal/kms/kms_ext_test.go
+++ b/internal/kms/kms_ext_test.go
@@ -2,12 +2,15 @@ package kms_test
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/types/scope"
@@ -122,6 +125,72 @@ func TestKms(t *testing.T) {
 			})
 			// four purposes x 3 scopes
 			assert.Equal(t, 12, count)
+		})
+	}
+}
+
+func TestKms_ReconcileKeys(t *testing.T) {
+	t.Parallel()
+	testCtx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	tests := []struct {
+		name            string
+		kms             *kms.Kms
+		reader          io.Reader
+		setup           func()
+		wantErr         bool
+		wantErrMatch    *errors.Template
+		wantErrContains string
+	}{
+		{
+			name:            "missing-reader",
+			kms:             kms.TestKms(t, conn, wrapper),
+			wantErr:         true,
+			wantErrMatch:    errors.T(errors.InvalidParameter),
+			wantErrContains: "missing rand reader",
+		},
+		{
+			name:    "nothing-to-reconcile",
+			kms:     kms.TestKms(t, conn, wrapper),
+			reader:  rand.Reader,
+			wantErr: false,
+		},
+		{
+			name:   "reconcile-audit-key",
+			kms:    kms.TestKms(t, conn, wrapper),
+			reader: rand.Reader,
+			setup: func() {
+				require.NoError(t, conn.Where("1=1").Delete(kms.AllocAuditKey()).Error)
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			// start with no keys...
+			require.NoError(conn.Where("1=1").Delete(kms.AllocRootKey()).Error)
+			_, err := kms.CreateKeysTx(context.Background(), rw, rw, wrapper, rand.Reader, scope.Global.String())
+			require.NoError(err)
+
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			err = tt.kms.ReconcileKeys(testCtx, tt.reader)
+			if tt.wantErr {
+				assert.Error(err)
+				if tt.wantErrMatch != nil {
+					assert.Truef(errors.Match(tt.wantErrMatch, err), "expected %q and got err: %+v", tt.wantErrMatch.Code, err)
+				}
+				if tt.wantErrContains != "" {
+					assert.True(strings.Contains(err.Error(), tt.wantErrContains))
+				}
+				return
+			}
+			assert.NoError(err)
 		})
 	}
 }

--- a/internal/kms/kms_ext_test.go
+++ b/internal/kms/kms_ext_test.go
@@ -152,6 +152,14 @@ func TestKms_ReconcileKeys(t *testing.T) {
 			wantErrContains: "missing rand reader",
 		},
 		{
+			name:            "reader-interface-is-nil",
+			kms:             kms.TestKms(t, conn, wrapper),
+			reader:          func() io.Reader { var sr *strings.Reader; var r io.Reader = sr; return r }(),
+			wantErr:         true,
+			wantErrMatch:    errors.T(errors.InvalidParameter),
+			wantErrContains: "missing rand reader",
+		},
+		{
 			name:    "nothing-to-reconcile",
 			kms:     kms.TestKms(t, conn, wrapper),
 			reader:  rand.Reader,

--- a/internal/kms/repository.go
+++ b/internal/kms/repository.go
@@ -177,6 +177,10 @@ func CreateKeysTx(ctx context.Context, dbReader db.Reader, dbWriter db.Writer, r
 		KeyTypeOidcKeyVersion:     oidcKeyVersion,
 	}
 	if scopeId == scope.Global.String() {
+		k, err = generateKey(ctx, randomReader)
+		if err != nil {
+			return nil, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("error generating random bytes for oidc key in scope %s", scopeId)))
+		}
 		auditKey, auditKeyVersion, err := createAuditKeyTx(ctx, dbReader, dbWriter, rkvWrapper, k)
 		if err != nil {
 			return nil, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("unable to create audit key in scope %s", scopeId)))

--- a/internal/servers/controller/controller.go
+++ b/internal/servers/controller/controller.go
@@ -168,6 +168,10 @@ func New(ctx context.Context, conf *Config) (*Controller, error) {
 	); err != nil {
 		return nil, fmt.Errorf("error adding config keys to kms: %w", err)
 	}
+	if err := c.kms.ReconcileKeys(ctx, c.conf.SecureRandomReader); err != nil {
+		return nil, fmt.Errorf("error reconciling kms keys: %w", err)
+	}
+
 	// now that the kms is configured, we can get the audit wrapper and rotate
 	// the eventer audit wrapper, so the emitted events can include encrypt and
 	// hmac-sha256 data

--- a/internal/servers/controller/controller_test.go
+++ b/internal/servers/controller/controller_test.go
@@ -1,0 +1,34 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/require"
+)
+
+func TestController_New(t *testing.T) {
+	t.Run("ReconcileKeys", func(t *testing.T) {
+		require := require.New(t)
+		testCtx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
+		tc := &TestController{
+			t:      t,
+			ctx:    ctx,
+			cancel: cancel,
+			opts:   nil,
+		}
+		conf := TestControllerConfig(t, ctx, tc, nil)
+
+		// this tests a scenario where there is an audit DEK
+		c, err := New(testCtx, conf)
+		require.NoError(err)
+
+		// this tests a scenario where there is NOT an audit DEK
+		require.NoError(c.conf.Server.Database.Where("1=1").Delete(kms.AllocAuditKey()).Error)
+		_, err = New(testCtx, conf)
+		require.NoError(err)
+	})
+
+}


### PR DESCRIPTION
This fix address the situation where an existing boundary database
doesn't have the audit DEKs in the global scope.