### PR TITLE
fix(docker): Add missing packages to dev docker image

### DIFF
--- a/docker/Dev.dockerfile
+++ b/docker/Dev.dockerfile
@@ -1,13 +1,15 @@
-FROM docker.mirror.hashicorp.services/alpine:3.10
+FROM docker.mirror.hashicorp.services/alpine:3.13.6
 
-RUN addgroup boundary && \
-    adduser -S -G boundary boundary
+RUN set -eux && \
+    addgroup boundary && \
+    adduser -s /bin/sh -S -G boundary boundary && \
+    apk add --no-cache wget ca-certificates dumb-init gnupg libcap openssl su-exec iputils libc6-compat iptables
 
 ADD bin/boundary /bin/boundary
 
 RUN mkdir /boundary/
 ADD ./config.hcl /boundary/config.hcl
-RUN chown -R boundary:boundary /boundary/ 
+RUN chown -R boundary:boundary /boundary/
 
 EXPOSE 9200 9201 9202
 VOLUME /boundary/


### PR DESCRIPTION
Trying to run the docker image built with `make docker-build-dev` would
result in an error at startup:

    standard_init_linux.go:228: exec user process caused: no such file or directory

This was due to the dev docker image lacking `dumb-init` which is used
by `docker-entrypoint.sh`.

This commit updates the dev dockerfile to add dumb-init. It also adds
additional packages so that the dev image aligns with the release image.