### PR TITLE
feat: updated backport assistant

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,21 +1,49 @@
 ---
-  name: Backport Assistant Runner
-  
-  on:
-    pull_request_target:
-      types:
-        - closed
-  
-  jobs:
-    backport:
-      if: github.event.pull_request.merged
-      runs-on: ubuntu-latest
-      container: hashicorpdev/backport-assistant:0.2.1
-      steps:
-        - name: Run Backport Assistant
-          run: |
-            backport-assistant backport -automerge
-          env:
-            BACKPORT_LABEL_REGEXP: "(?P<target>website)/cherrypick"
-            BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
-            GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+name: Backport Assistant Runner
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    container: hashicorpdev/backport-assistant:0.2.3
+    steps:
+      - name: Backport changes to stable-website
+        run: |
+          backport-assistant backport -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
+          BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+      - name: Backport changes to latest release branch
+        run: |
+          resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/labels?per_page=100")
+          ret="$?"
+          if [[ "$ret" -ne 0 ]]; then
+              echo "The GitHub API returned $ret"
+              exit $ret
+          fi
+
+          # get the latest backport label excluding any website labels, ex: `backport/0.3.x` and not `backport/website`
+          latest_backport_label=$(echo "$resp" | jq -r '.[] | select(.name | (startswith("backport/") and (contains("website") | not))) | .name' | sort -rV | head -n1)
+          echo "Latest backport label: $latest_backport_label"
+
+          # set BACKPORT_TARGET_TEMPLATE for backport-assistant
+          # trims backport/ from the beginning with parameter substitution
+          export BACKPORT_TARGET_TEMPLATE="release/${latest_backport_label#backport/}"
+          backport-assistant backport -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+      - name: Backport changes to targeted release branch
+        run: |
+          backport-assistant backport -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.\\w+)"
+          BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

This introduces a workflow that leverages the already-implemented [backport-assistant](https://github.com/hashicorp/backport-assistant) to backport changes (primarily docs changes) to designated release/branches and/or stable-website

The incoming behavior is identical to [Waypoint](https://github.com/hashicorp/waypoint/blob/main/.github/workflows/backport.yml)


## Usage

Labels:
- <kbd>backport/website</kbd>
  - will backport changes to `stable-website` **AND** `release/{LATEST}`
  - `{LATEST}` is determined by the greatest semver out of all GitHub labels that begin with `"backport/"`
- <kbd>backport/0.6.x</kbd>
  - will backport changes to `release/0.6.x`
- <kbd>backport/{TARGET}</kbd>
  - will backport changes to `release/{TARGET}`

![image](https://user-images.githubusercontent.com/26389321/142074615-a4c1474d-0d61-4866-981a-4c8989bce42f.png)

## Dependencies

- [x] Requires a GitHub repo secret, `ELEVATED_GITHUB_TOKEN` to be created and added (should belong to a "hc-...-bot" GitHub bot account)

- [x] Requires GitHub labels to be created - ex:
  - <kbd>backport/website</kbd>
  - <kbd>backport/0.7.x</kbd>
  - <kbd>backport/0.6.x</kbd>

- [x] Requires release branches to be created - ex:
  - `release/0.7.x` (based on `v0.7.1`)
  - `release/0.6.x`(based on `v0.6.2`)
  - `release/0.5.x` (based on `v0.5.1`)

**note**, `release/...` branches will need to also be manually created following a net-new minor/major version release
