### PR TITLE
Add a static README file to the host assets dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,7 @@ main
 /bin/
 update-ui-assets*
 /plugins/kms/assets/
-/plugins/host/assets/
+/plugins/host/assets/boundary-plugin*
 
 # Test config file
 test*.hcl

--- a/packages-oss.yml
+++ b/packages-oss.yml
@@ -105,7 +105,7 @@ build-command: VERSION_PKG_PATH=github.com/hashicorp/boundary/version;
       cd $ORIG_PATH;
     done;
     cd $ORIG_PATH/plugins/$PLUGIN_TYPE/assets;
-    for CURR_PLUGIN in $(ls); do
+    for CURR_PLUGIN in $(ls boundary-plugin*); do
       gzip -9 $CURR_PLUGIN;
     done;
     cd $ORIG_PATH;

--- a/plugins/host/assets/README.md
+++ b/plugins/host/assets/README.md
@@ -1,0 +1,3 @@
+This directory contains assets for host plugins. This file in particular exists
+so that the Go embed package does not throw errors when importing this module
+outside of the main tree.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,7 +53,7 @@ for PLUGIN_TYPE in host; do
         cd $ORIG_PATH;
     done;
     cd $ORIG_PATH/plugins/$PLUGIN_TYPE/assets;
-    for CURR_PLUGIN in $(ls); do
+    for CURR_PLUGIN in $(ls boundary-plugin*); do
         gzip -f -9 $CURR_PLUGIN;
     done;
     cd $ORIG_PATH;


### PR DESCRIPTION
This prevents errors when reaching into the main package to use testing code.

There are still some issues with respect to updating the test code to e.g. not expect to be able to create plugins not embedded into the test provider, which will be fixed in a more comprehensive set of changes to the test controller.