### PR TITLE
Don't always assume plugins should be activated

### DIFF
--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -21,6 +21,25 @@ import (
 	"github.com/posener/complete"
 )
 
+type EnabledPlugin uint
+
+const (
+	EnabledPluginUnknown EnabledPlugin = iota
+	EnabledPluginHostAws
+	EnabledPluginHostAzure
+)
+
+func (e EnabledPlugin) String() string {
+	switch e {
+	case EnabledPluginHostAws:
+		return "AWS"
+	case EnabledPluginHostAzure:
+		return "Azure"
+	default:
+		return ""
+	}
+}
+
 const (
 	CommandSuccess int = iota
 	CommandApiError

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -59,14 +59,6 @@ const (
 	statusGracePeriodEnvVar = "BOUNDARY_STATUS_GRACE_PERIOD"
 )
 
-type EnabledPlugin uint
-
-const (
-	EnabledPluginUnknown EnabledPlugin = iota
-	EnabledPluginHostAws
-	EnabledPluginHostAzure
-)
-
 type Server struct {
 	*Command
 

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -59,6 +59,14 @@ const (
 	statusGracePeriodEnvVar = "BOUNDARY_STATUS_GRACE_PERIOD"
 )
 
+type EnabledPlugin uint
+
+const (
+	EnabledPluginUnknown EnabledPlugin = iota
+	EnabledPluginHostAws
+	EnabledPluginHostAzure
+)
+
 type Server struct {
 	*Command
 
@@ -114,7 +122,8 @@ type Server struct {
 	DevTargetSessionConnectionLimit  int
 	DevLoopbackHostPluginId          string
 
-	HostPlugins map[string]plgpb.HostPluginServiceClient
+	EnabledPlugins []EnabledPlugin
+	HostPlugins    map[string]plgpb.HostPluginServiceClient
 
 	DevOidcSetup oidcSetup
 

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -596,6 +596,7 @@ func (c *Command) Run(args []string) int {
 	c.ReleaseLogGate()
 
 	{
+		c.EnabledPlugins = []base.EnabledPlugin{base.EnabledPluginHostAws, base.EnabledPluginHostAzure}
 		conf := &controller.Config{
 			RawConfig: c.Config,
 			Server:    c.Server,

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -457,6 +457,7 @@ func (c *Command) Run(args []string) int {
 	c.ReleaseLogGate()
 
 	if c.Config.Controller != nil {
+		c.EnabledPlugins = []base.EnabledPlugin{base.EnabledPluginHostAws, base.EnabledPluginHostAzure}
 		if err := c.StartController(ctx); err != nil {
 			c.UI.Error(err.Error())
 			return base.CommandCliError

--- a/internal/servers/controller/testing.go
+++ b/internal/servers/controller/testing.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/boundary/internal/intglobals"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/observability/event"
-	hostplugin "github.com/hashicorp/boundary/internal/plugin/host"
 	"github.com/hashicorp/boundary/internal/servers"
 	"github.com/hashicorp/go-hclog"
 	wrapping "github.com/hashicorp/go-kms-wrapping"
@@ -416,17 +415,6 @@ func NewTestController(t *testing.T, opts *TestControllerOpts) *TestController {
 		t.Fatal(err)
 	}
 
-	tc.b.DevLoopbackHostPluginId = DefaultTestPluginId
-	plg := plugin.NewWrappingPluginClient(plugin.NewLoopbackPlugin())
-	plugOpts := []hostplugin.Option{
-		hostplugin.WithDescription("Provides an initial loopback host plugin in Boundary"),
-		hostplugin.WithPublicId(tc.b.DevLoopbackHostPluginId),
-	}
-	if _, err = tc.b.RegisterHostPlugin(ctx, "loopback", plg, plugOpts...); err != nil {
-		tc.Shutdown()
-		t.Fatal(err)
-	}
-
 	tc.buildClient()
 
 	if !opts.DisableAutoStart {
@@ -628,7 +616,7 @@ func TestControllerConfig(t *testing.T, ctx context.Context, tc *TestController,
 		}
 	} else if !opts.DisableDatabaseCreation {
 		var createOpts []base.Option
-		createOpts = append(createOpts, base.WithHostPlugin("pl_1234567890", plugin.NewWrappingPluginClient(plugin.NewLoopbackPlugin())))
+		createOpts = append(createOpts, base.WithHostPlugin(DefaultTestPluginId, plugin.NewWrappingPluginClient(plugin.NewLoopbackPlugin())))
 		if opts.DisableAuthMethodCreation {
 			createOpts = append(createOpts, base.WithSkipAuthMethodCreation())
 		}


### PR DESCRIPTION
When running test controllers from e.g. Terraform tests we don't have the external plugins built in, so don't always include them. Additionally, add the loopback plugin to the test controller.