### PR TITLE
Fix tests using multiple controllers

### DIFF
--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -25,12 +25,15 @@ type EnabledPlugin uint
 
 const (
 	EnabledPluginUnknown EnabledPlugin = iota
+	EnabledPluginHostLoopback
 	EnabledPluginHostAws
 	EnabledPluginHostAzure
 )
 
 func (e EnabledPlugin) String() string {
 	switch e {
+	case EnabledPluginHostLoopback:
+		return "Loopback"
 	case EnabledPluginHostAws:
 		return "AWS"
 	case EnabledPluginHostAzure:

--- a/internal/cmd/base/dev.go
+++ b/internal/cmd/base/dev.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/observability/event"
-	hostplugin "github.com/hashicorp/boundary/internal/plugin/host"
 	"github.com/hashicorp/boundary/internal/types/scope"
 	"github.com/hashicorp/boundary/testing/dbtest"
 	capoidc "github.com/hashicorp/cap/oidc"
@@ -141,18 +140,6 @@ func (b *Server) CreateDevDatabase(ctx context.Context, opt ...Option) error {
 
 	if _, _, err := b.CreateInitialScopes(ctx); err != nil {
 		return err
-	}
-
-	if opts.withHostPlugin != nil {
-		pluginId, plg := opts.withHostPlugin()
-		b.DevLoopbackHostPluginId = pluginId
-		opts := []hostplugin.Option{
-			hostplugin.WithDescription("Provides an initial loopback host plugin in Boundary"),
-			hostplugin.WithPublicId(b.DevLoopbackHostPluginId),
-		}
-		if _, err = b.RegisterHostPlugin(ctx, "loopback", plg, opts...); err != nil {
-			return err
-		}
 	}
 
 	if opts.withSkipHostResourcesCreation {

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/boundary/internal/auth/password"
 	"github.com/hashicorp/boundary/internal/cmd/base"
 	"github.com/hashicorp/boundary/internal/cmd/config"
-	"github.com/hashicorp/boundary/internal/host/plugin"
 	"github.com/hashicorp/boundary/internal/host/static"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/intglobals"
@@ -561,7 +560,8 @@ func (c *Command) Run(args []string) int {
 
 	var opts []base.Option
 	if c.flagCreateLoopbackHostPlugin {
-		opts = append(opts, base.WithHostPlugin("pl_1234567890", plugin.NewWrappingPluginClient(plugin.NewLoopbackPlugin())))
+		c.DevLoopbackHostPluginId = "pl_1234567890"
+		c.EnabledPlugins = append(c.EnabledPlugins, base.EnabledPluginHostLoopback)
 		c.Config.Controller.SchedulerRunJobInterval = 100 * time.Millisecond
 	}
 	switch c.flagDatabaseUrl {

--- a/internal/servers/controller/controller.go
+++ b/internal/servers/controller/controller.go
@@ -126,6 +126,15 @@ func New(ctx context.Context, conf *Config) (*Controller, error) {
 
 	for _, enabledPlugin := range c.enabledPlugins {
 		switch enabledPlugin {
+		case base.EnabledPluginHostLoopback:
+			plg := pluginhost.NewWrappingPluginClient(pluginhost.NewLoopbackPlugin())
+			opts := []hostplugin.Option{
+				hostplugin.WithDescription("Provides an initial loopback host plugin in Boundary"),
+				hostplugin.WithPublicId(conf.DevLoopbackHostPluginId),
+			}
+			if _, err = conf.RegisterHostPlugin(ctx, "loopback", plg, opts...); err != nil {
+				return nil, err
+			}
 		case base.EnabledPluginHostAzure, base.EnabledPluginHostAws:
 			pluginType := strings.ToLower(enabledPlugin.String())
 			client, cleanup, err := external_host_plugins.CreateHostPlugin(

--- a/internal/servers/controller/testing.go
+++ b/internal/servers/controller/testing.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/db/schema"
 	"github.com/hashicorp/boundary/internal/gen/testing/interceptor"
-	"github.com/hashicorp/boundary/internal/host/plugin"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/intglobals"
 	"github.com/hashicorp/boundary/internal/kms"
@@ -492,6 +491,9 @@ func TestControllerConfig(t *testing.T, ctx context.Context, tc *TestController,
 	tc.b.DevOidcAccountId = DefaultTestOidcAccountId
 	tc.b.DevUnprivilegedPasswordAccountId = DefaultTestUnprivilegedPasswordAccountId
 	tc.b.DevUnprivilegedOidcAccountId = DefaultTestUnprivilegedOidcAccountId
+	tc.b.DevLoopbackHostPluginId = DefaultTestPluginId
+
+	tc.b.EnabledPlugins = append(tc.b.EnabledPlugins, base.EnabledPluginHostLoopback)
 
 	// Start a logger
 	tc.b.Logger = opts.Logger
@@ -616,7 +618,6 @@ func TestControllerConfig(t *testing.T, ctx context.Context, tc *TestController,
 		}
 	} else if !opts.DisableDatabaseCreation {
 		var createOpts []base.Option
-		createOpts = append(createOpts, base.WithHostPlugin(DefaultTestPluginId, plugin.NewWrappingPluginClient(plugin.NewLoopbackPlugin())))
 		if opts.DisableAuthMethodCreation {
 			createOpts = append(createOpts, base.WithSkipAuthMethodCreation())
 		}


### PR DESCRIPTION
The previous PR only initialized plugins if they were required, which
meant that there may not actually be a plugin manager running because a
second node would not actually create the dev database, which is where
the plugin was being added. The assumption that a plugin manager is
running is still a fine one at the moment, but we just need to make sure
it's running in _all_ cases.