### PR TITLE
internal/host/plugin: Fix TestUpdateSet

### DIFF
--- a/internal/host/plugin/repository_host_set_test.go
+++ b/internal/host/plugin/repository_host_set_test.go
@@ -1220,7 +1220,8 @@ func TestRepository_UpdateSet(t *testing.T) {
 				check(t, gotUpdatedSet)
 			}
 
-			gotLookupSet, gotPlugin, err := repo.LookupSet(ctx, workingSet.GetPublicId())
+			gotLookupSet, _, err := repo.LookupSet(ctx, workingSet.GetPublicId())
+			assert.NoError(err)
 			assert.Empty(cmp.Diff(gotUpdatedSet, gotLookupSet, protocmp.Transform()))
 		})
 	}


### PR DESCRIPTION
Now asserts on error on the last lookup check and removes the plugin
lookup since we're not asserting on that.