### PR TITLE
Actually enable loopback plugin in dev

### DIFF
--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -596,7 +596,7 @@ func (c *Command) Run(args []string) int {
 	c.ReleaseLogGate()
 
 	{
-		c.EnabledPlugins = []base.EnabledPlugin{base.EnabledPluginHostAws, base.EnabledPluginHostAzure}
+		c.EnabledPlugins = append(c.EnabledPlugins, base.EnabledPluginHostAws, base.EnabledPluginHostAzure)
 		conf := &controller.Config{
 			RawConfig: c.Config,
 			Server:    c.Server,

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -457,7 +457,7 @@ func (c *Command) Run(args []string) int {
 	c.ReleaseLogGate()
 
 	if c.Config.Controller != nil {
-		c.EnabledPlugins = []base.EnabledPlugin{base.EnabledPluginHostAws, base.EnabledPluginHostAzure}
+		c.EnabledPlugins = append(c.EnabledPlugins, base.EnabledPluginHostAws, base.EnabledPluginHostAzure)
 		if err := c.StartController(ctx); err != nil {
 			c.UI.Error(err.Error())
 			return base.CommandCliError


### PR DESCRIPTION
Although this was fixed for TestController earlier, in the dev flow the set of enabled plugins was being overridden after Loopback was added, if it was enabled via flags. This fixes it.