### PR TITLE
feat(proto): Add support for Audit Logs to Protobuf Account type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,8 @@ protobuild:
 	@protoc-go-inject-tag -input=./sdk/pbs/controller/api/resources/scopes/scope.pb.go
 	@protoc-go-inject-tag -input=./internal/gen/controller/servers/services/session_service.pb.go
 	@protoc-go-inject-tag -input=./sdk/pbs/controller/api/resources/targets/target.pb.go
+	@protoc-go-inject-tag -input=./sdk/pbs/controller/api/resources/accounts/account.pb.go
+	@protoc-go-inject-tag -input=./internal/gen/controller/api/services/account_service.pb.go
 
 	# these protos, services and openapi artifacts are purely for testing purposes
 	@protoc-go-inject-tag -input=./internal/gen/testing/event/event.pb.go

--- a/internal/gen/controller/api/services/account_service.pb.go
+++ b/internal/gen/controller/api/services/account_service.pb.go
@@ -29,7 +29,7 @@ type GetAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *GetAccountRequest) Reset() {
@@ -123,8 +123,8 @@ type ListAccountsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	AuthMethodId string `protobuf:"bytes,1,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty"`
-	Filter       string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty"`
+	AuthMethodId string `protobuf:"bytes,1,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Filter       string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty" class:"public"`                // @gotags: `class:"public"`
 }
 
 func (x *ListAccountsRequest) Reset() {
@@ -225,7 +225,7 @@ type CreateAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Item *accounts.Account `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
+	Item *accounts.Account `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"` // TODO(hugo) we're not setting `Type` here, and perhaps in other `Request` types, so it's all redacted. Should we be setting `Type`?
 }
 
 func (x *CreateAccountRequest) Reset() {
@@ -272,7 +272,7 @@ type CreateAccountResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Uri  string            `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
+	Uri  string            `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public"` // @gotags: `class:"public"`
 	Item *accounts.Account `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 }
 
@@ -327,7 +327,7 @@ type UpdateAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	Item       *accounts.Account      `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 	UpdateMask *fieldmaskpb.FieldMask `protobuf:"bytes,3,opt,name=update_mask,proto3" json:"update_mask,omitempty"`
 }
@@ -437,7 +437,7 @@ type DeleteAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *DeleteAccountRequest) Reset() {
@@ -522,11 +522,11 @@ type SetPasswordRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version  uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	Password string `protobuf:"bytes,3,opt,name=password,proto3" json:"password,omitempty"`
+	Version  uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`  // @gotags: `class:"public"`
+	Password string `protobuf:"bytes,3,opt,name=password,proto3" json:"password,omitempty" class:"secret"` // @gotags: `class:"secret"`
 }
 
 func (x *SetPasswordRequest) Reset() {
@@ -634,12 +634,12 @@ type ChangePasswordRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version         uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	CurrentPassword string `protobuf:"bytes,3,opt,name=current_password,proto3" json:"current_password,omitempty"`
-	NewPassword     string `protobuf:"bytes,4,opt,name=new_password,proto3" json:"new_password,omitempty"`
+	Version         uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`                  // @gotags: `class:"public"`
+	CurrentPassword string `protobuf:"bytes,3,opt,name=current_password,proto3" json:"current_password,omitempty" class:"secret"` // @gotags: `class:"secret"`
+	NewPassword     string `protobuf:"bytes,4,opt,name=new_password,proto3" json:"new_password,omitempty" class:"secret"`         // @gotags: `class:"secret"`
 }
 
 func (x *ChangePasswordRequest) Reset() {

--- a/internal/proto/local/controller/api/resources/accounts/v1/account.proto
+++ b/internal/proto/local/controller/api/resources/accounts/v1/account.proto
@@ -13,41 +13,41 @@ import "controller/custom_options/v1/options.proto";
 // Account contains all fields related to an Account resource
 message Account {
 	// Output only. The ID of the Account.
-	string id = 10;
+	string id = 10;  // @gotags: `class:"public"`
 
 	// Output only. Scope information for the Account.
-	resources.scopes.v1.ScopeInfo scope = 20;
+	resources.scopes.v1.ScopeInfo scope = 20; // @gotags: `class:"public"`
 
 	// Optional name for identification purposes.
-	google.protobuf.StringValue name = 30 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this:"name" that: "Name"}];
+	google.protobuf.StringValue name = 30 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this:"name" that: "Name"}];  // @gotags: `class:"public"`
 
 	// Optional user-set description for identification purposes.
-	google.protobuf.StringValue description = 40 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this:"description" that: "Description"}];
+	google.protobuf.StringValue description = 40 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this:"description" that: "Description"}];  // @gotags: `class:"public"`
 
 	// Output only. The time this resource was created.
-	google.protobuf.Timestamp created_time = 50 [json_name="created_time"];
+	google.protobuf.Timestamp created_time = 50 [json_name="created_time"];  // @gotags: `class:"public"`
 
 	// Output only. The time this resource was last updated.
-	google.protobuf.Timestamp updated_time = 60 [json_name="updated_time"];
+	google.protobuf.Timestamp updated_time = 60 [json_name="updated_time"];  // @gotags: `class:"public"`
 
 	// Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	uint32 version = 70;
+	uint32 version = 70;  // @gotags: `class:"public"`
 
 	// The type of this Account.
-	string type = 80;
+	string type = 80;  // @gotags: `class:"public"`
 
 	// The ID of the Auth Method that is associated with this Account.
-	string auth_method_id = 90 [json_name="auth_method_id"];
+	string auth_method_id = 90 [json_name="auth_method_id"];  // @gotags: `class:"public"`
 
 	// The attributes that are applicable for the specific Account type.
 	google.protobuf.Struct attributes = 100 [(custom_options.v1.generate_sdk_option) = true];
 
 	// Output only. managed_group_ids indicates IDs of the managed groups that currently contain this account
-	repeated string managed_group_ids = 110 [json_name="managed_group_ids"];
+	repeated string managed_group_ids = 110 [json_name="managed_group_ids"];  // @gotags: `class:"public"`
 
 	// Output only. The available actions on this resource for this user.
-	repeated string authorized_actions = 300 [json_name="authorized_actions"];
+	repeated string authorized_actions = 300 [json_name="authorized_actions"];  // @gotags: `class:"public"`
 }
 
 // Attributes associated only with Accounts with type "password".

--- a/internal/proto/local/controller/api/services/v1/account_service.proto
+++ b/internal/proto/local/controller/api/services/v1/account_service.proto
@@ -114,7 +114,7 @@ service AccountService {
 }
 
 message GetAccountRequest {
-  string id = 1;
+  string id = 1;  // @gotags: `class:"public"`
 }
 
 message GetAccountResponse {
@@ -122,8 +122,8 @@ message GetAccountResponse {
 }
 
 message ListAccountsRequest {
-  string auth_method_id = 1 [json_name="auth_method_id"];
-  string filter = 30 [json_name="filter"];
+  string auth_method_id = 1 [json_name="auth_method_id"];  // @gotags: `class:"public"`
+  string filter = 30 [json_name="filter"];  // @gotags: `class:"public"`
 }
 
 message ListAccountsResponse {
@@ -131,16 +131,16 @@ message ListAccountsResponse {
 }
 
 message CreateAccountRequest {
-  resources.accounts.v1.Account item = 2;
+  resources.accounts.v1.Account item = 2; // TODO(hugo) we're not setting `Type` here, and perhaps in other `Request` types, so it's all redacted. Should we be setting `Type`?
 }
 
 message CreateAccountResponse {
-  string uri = 1;
+  string uri = 1;  // @gotags: `class:"public"`
   resources.accounts.v1.Account item = 2;
 }
 
 message UpdateAccountRequest {
-  string id = 1;
+  string id = 1;  // @gotags: `class:"public"`
   resources.accounts.v1.Account item = 2;
   google.protobuf.FieldMask update_mask = 3 [json_name="update_mask"];
 }
@@ -150,17 +150,17 @@ message UpdateAccountResponse {
 }
 
 message DeleteAccountRequest {
-  string id = 1;
+  string id = 1;  // @gotags: `class:"public"`
 }
 
 message DeleteAccountResponse {}
 
 message SetPasswordRequest {
-  string id = 1;
+  string id = 1;  // @gotags: `class:"public"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 2;
-  string password = 3;
+  uint32 version = 2;  // @gotags: `class:"public"`
+  string password = 3; // @gotags: `class:"secret"`
 }
 
 message SetPasswordResponse {
@@ -168,12 +168,12 @@ message SetPasswordResponse {
 }
 
 message ChangePasswordRequest {
-  string id = 1;
+  string id = 1;  // @gotags: `class:"public"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 2;
-  string current_password = 3 [json_name="current_password"];
-  string new_password = 4 [json_name="new_password"];
+  uint32 version = 2;                                          // @gotags: `class:"public"`
+  string current_password = 3 [json_name="current_password"];  // @gotags: `class:"secret"`
+  string new_password = 4 [json_name="new_password"];          // @gotags: `class:"secret"`
 }
 
 message ChangePasswordResponse {

--- a/sdk/pbs/controller/api/resources/accounts/account.pb.go
+++ b/sdk/pbs/controller/api/resources/accounts/account.pb.go
@@ -32,30 +32,30 @@ type Account struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the Account.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. Scope information for the Account.
-	Scope *scopes.ScopeInfo `protobuf:"bytes,20,opt,name=scope,proto3" json:"scope,omitempty"`
+	Scope *scopes.ScopeInfo `protobuf:"bytes,20,opt,name=scope,proto3" json:"scope,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Optional name for identification purposes.
-	Name *wrapperspb.StringValue `protobuf:"bytes,30,opt,name=name,proto3" json:"name,omitempty"`
+	Name *wrapperspb.StringValue `protobuf:"bytes,30,opt,name=name,proto3" json:"name,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Optional user-set description for identification purposes.
-	Description *wrapperspb.StringValue `protobuf:"bytes,40,opt,name=description,proto3" json:"description,omitempty"`
+	Description *wrapperspb.StringValue `protobuf:"bytes,40,opt,name=description,proto3" json:"description,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,50,opt,name=created_time,proto3" json:"created_time,omitempty"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,50,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this resource was last updated.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=updated_time,proto3" json:"updated_time,omitempty"`
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version uint32 `protobuf:"varint,70,opt,name=version,proto3" json:"version,omitempty"`
+	Version uint32 `protobuf:"varint,70,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The type of this Account.
-	Type string `protobuf:"bytes,80,opt,name=type,proto3" json:"type,omitempty"`
+	Type string `protobuf:"bytes,80,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The ID of the Auth Method that is associated with this Account.
-	AuthMethodId string `protobuf:"bytes,90,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty"`
+	AuthMethodId string `protobuf:"bytes,90,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The attributes that are applicable for the specific Account type.
 	Attributes *structpb.Struct `protobuf:"bytes,100,opt,name=attributes,proto3" json:"attributes,omitempty"`
 	// Output only. managed_group_ids indicates IDs of the managed groups that currently contain this account
-	ManagedGroupIds []string `protobuf:"bytes,110,rep,name=managed_group_ids,proto3" json:"managed_group_ids,omitempty"`
+	ManagedGroupIds []string `protobuf:"bytes,110,rep,name=managed_group_ids,proto3" json:"managed_group_ids,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The available actions on this resource for this user.
-	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty"`
+	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *Account) Reset() {

--- a/sdk/pbs/controller/api/resources/accounts/account_taggable.go
+++ b/sdk/pbs/controller/api/resources/accounts/account_taggable.go
@@ -1,0 +1,280 @@
+package accounts
+
+import (
+	"github.com/hashicorp/eventlogger/filters/encrypt"
+)
+
+func (a *Account) Tags() ([]encrypt.PointerTag, error) {
+	if a.Attributes == nil {
+		return nil, nil
+	}
+
+	switch a.Type {
+	case "password":
+		return []encrypt.PointerTag{
+			{
+				Pointer:        "/Attributes/Fields/login_name",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/password",
+				Classification: encrypt.SecretClassification,
+			},
+		}, nil
+	case "oidc":
+		return []encrypt.PointerTag{
+			// `OidcAccountAttributes` Top-Level Fields
+			{
+				Pointer:        "/Attributes/Fields/issuer",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/subject",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/full_name",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/email",
+				Classification: encrypt.SensitiveClassification,
+			},
+
+			// Passthrough to the bottom fields because the library doesn't seem to understand the relationship
+			// between fields - If this is not here, it'll apply the transformation to the fields correctly as
+			// defined below, but then it'll redact all over them again because it picks on these top-level
+			// fields, thinks they're an entirely different thing.
+			//
+			// Note: This is not a "default" data classification. If there's more fields within these items that we
+			// haven't specified, they'll still get redacted. AFAIK, this tells the library to, when it sees this
+			// particular field, leave it undisturbed.
+			//
+			// Not sure if bug or feature...
+			{
+				Pointer:        "/Attributes/Fields/token_claims",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims",
+				Classification: encrypt.PublicClassification,
+			},
+
+			// OpenID Connect Token Claims
+			// UserInfo Claims can also appear here.
+			// TODO(hugo): This is a subset of all possible JWT Claims - Should we go with https://www.iana.org/assignments/jwt/jwt.xhtml?
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/iss",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/sub",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/aud",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/exp",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/iat",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/auth_time",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/nonce",
+				Classification: encrypt.SecretClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/auth_time",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/acr",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/amr",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/azp",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/at_hash",
+				Classification: encrypt.SecretClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/c_hash",
+				Classification: encrypt.SecretClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/name",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/given_name",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/family_name",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/middle_name",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/nickname",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/preferred_username",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/profile",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/picture",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/website",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/email",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/email_verified",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/gender",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/birthdate",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/zoneinfo",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/locale",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/phone_number",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/phone_number_verified",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/address",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/token_claims/Kind/StructValue/Fields/updated_at",
+				Classification: encrypt.PublicClassification,
+			},
+
+			// OpenID Connect UserInfo Claims
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/sub",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/name",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/given_name",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/family_name",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/middle_name",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/nickname",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/preferred_username",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/profile",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/picture",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/website",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/email",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/email_verified",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/gender",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/birthdate",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/zoneinfo",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/locale",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/phone_number",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/phone_number_verified",
+				Classification: encrypt.PublicClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/address",
+				Classification: encrypt.SensitiveClassification,
+			},
+			{
+				Pointer:        "/Attributes/Fields/userinfo_claims/Kind/StructValue/Fields/updated_at",
+				Classification: encrypt.PublicClassification,
+			},
+		}, nil
+	}
+
+	return nil, nil
+}

--- a/sdk/pbs/controller/api/resources/accounts/account_taggable_test.go
+++ b/sdk/pbs/controller/api/resources/accounts/account_taggable_test.go
@@ -1,0 +1,361 @@
+package accounts
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/scopes"
+	"github.com/hashicorp/boundary/sdk/wrapper"
+	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/eventlogger/filters/encrypt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestTags(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		testEvent *eventlogger.Event
+		wantEvent *eventlogger.Event
+	}{
+		{
+			name: "ensure unspecified fields get redacted",
+			testEvent: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &Account{
+					Id: "public-acc-id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "public-scope-id",
+						Type:          "public-scope-type",
+						Name:          "public-scope-name",
+						Description:   "public-scope-description",
+						ParentScopeId: "public-parent-scopeid",
+					},
+					Name:         wrapperspb.String("public-name"),
+					Description:  wrapperspb.String("public-description"),
+					CreatedTime:  timestamppb.New(now),
+					UpdatedTime:  timestamppb.New(now),
+					Version:      1,
+					Type:         "password",
+					AuthMethodId: "public-auth-method-id",
+					Attributes: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"hi": structpb.NewStringValue("some-random-value"),
+						},
+					},
+				},
+			},
+			wantEvent: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &Account{
+					Id: "public-acc-id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "public-scope-id",
+						Type:          "public-scope-type",
+						Name:          "public-scope-name",
+						Description:   "public-scope-description",
+						ParentScopeId: "public-parent-scopeid",
+					},
+					Name:         wrapperspb.String("public-name"),
+					Description:  wrapperspb.String("public-description"),
+					CreatedTime:  timestamppb.New(now),
+					UpdatedTime:  timestamppb.New(now),
+					Version:      1,
+					Type:         "password",
+					AuthMethodId: "public-auth-method-id",
+					Attributes: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"hi": structpb.NewStringValue(encrypt.RedactedData),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "password attributes",
+			testEvent: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &Account{
+					Id: "public-acc-id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "public-scope-id",
+						Type:          "public-scope-type",
+						Name:          "public-scope-name",
+						Description:   "public-scope-description",
+						ParentScopeId: "public-parent-scopeid",
+					},
+					Name:         wrapperspb.String("public-name"),
+					Description:  wrapperspb.String("public-description"),
+					CreatedTime:  timestamppb.New(now),
+					UpdatedTime:  timestamppb.New(now),
+					Version:      1,
+					Type:         "password",
+					AuthMethodId: "public-auth-method-id",
+					Attributes: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"login_name": structpb.NewStringValue("public-login-name"),
+							"password":   structpb.NewStringValue("secret-password"),
+						},
+					},
+				},
+			},
+			wantEvent: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &Account{
+					Id: "public-acc-id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "public-scope-id",
+						Type:          "public-scope-type",
+						Name:          "public-scope-name",
+						Description:   "public-scope-description",
+						ParentScopeId: "public-parent-scopeid",
+					},
+					Name:         wrapperspb.String("public-name"),
+					Description:  wrapperspb.String("public-description"),
+					CreatedTime:  timestamppb.New(now),
+					UpdatedTime:  timestamppb.New(now),
+					Version:      1,
+					Type:         "password",
+					AuthMethodId: "public-auth-method-id",
+					Attributes: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"login_name": structpb.NewStringValue("public-login-name"),
+							"password":   structpb.NewStringValue(encrypt.RedactedData),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "oidc attributes with token and user info claims",
+			testEvent: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &Account{
+					Id: "public-acc-id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "public-scope-id",
+						Type:          "public-scope-type",
+						Name:          "public-scope-name",
+						Description:   "public-scope-description",
+						ParentScopeId: "public-parent-scopeid",
+					},
+					Name:         wrapperspb.String("public-name"),
+					Description:  wrapperspb.String("public-description"),
+					CreatedTime:  timestamppb.New(now),
+					UpdatedTime:  timestamppb.New(now),
+					Version:      1,
+					Type:         "oidc",
+					AuthMethodId: "public-auth-method-id",
+					Attributes: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"issuer":    structpb.NewStringValue("public-issuer"),
+							"subject":   structpb.NewStringValue("sensitive-subject"),
+							"full_name": structpb.NewStringValue("sensitive-full-name"),
+							"email":     structpb.NewStringValue("sensitive-email"),
+							"token_claims": structpb.NewStructValue(&structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"iss":       structpb.NewStringValue("public-issuer"),
+									"sub":       structpb.NewStringValue("sensitive-subject"),
+									"aud":       structpb.NewStringValue("sensitive-audience"),
+									"exp":       structpb.NewNumberValue(float64(now.Unix())),
+									"iat":       structpb.NewNumberValue(float64(now.Unix())),
+									"auth_time": structpb.NewNumberValue(float64(now.Unix())),
+									"nonce":     structpb.NewStringValue("secret-nonce"),
+									"acr":       structpb.NewStringValue("public-acr"),
+									"amr": structpb.NewListValue(&structpb.ListValue{Values: []*structpb.Value{
+										structpb.NewStringValue("public-amr-1"),
+										structpb.NewStringValue("public-amr-2"),
+									}}),
+									"azp":                   structpb.NewStringValue("public-azp-1"),
+									"name":                  structpb.NewStringValue("sensitive-name"),
+									"given_name":            structpb.NewStringValue("sensitive-given-name"),
+									"family_name":           structpb.NewStringValue("sensitive-family-name"),
+									"middle_name":           structpb.NewStringValue("sensitive-middle-name"),
+									"nickname":              structpb.NewStringValue("sensitive-nickname"),
+									"preferred_username":    structpb.NewStringValue("sensitive-preferred-username"),
+									"profile":               structpb.NewStringValue("sensitive-profile"),
+									"picture":               structpb.NewStringValue("sensitive-picture"),
+									"website":               structpb.NewStringValue("sensitive-website"),
+									"email":                 structpb.NewStringValue("sensitive-email"),
+									"email_verified":        structpb.NewBoolValue(true),
+									"gender":                structpb.NewStringValue("sensitive-gender"),
+									"birthdate":             structpb.NewStringValue("sensitive-birthdate"),
+									"zoneinfo":              structpb.NewStringValue("public-zoneinfo"),
+									"locale":                structpb.NewStringValue("public-locale"),
+									"phone_number":          structpb.NewStringValue("sensitive-phone-number"),
+									"phone_number_verified": structpb.NewBoolValue(false),
+									"updated_at":            structpb.NewNumberValue(float64(now.Unix())),
+									"address": structpb.NewStructValue(&structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"formatted":      structpb.NewStringValue("sensitive-formatted"),
+											"street_address": structpb.NewStringValue("sensitive-street-address"),
+											"locality":       structpb.NewStringValue("sensitive-locality"),
+											"region":         structpb.NewStringValue("sensitive-region"),
+											"postal_code":    structpb.NewStringValue("sensitive-postal-code"),
+											"country":        structpb.NewStringValue("sensitive-country"),
+										},
+									}),
+								},
+							}),
+							"userinfo_claims": structpb.NewStructValue(&structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"name":                  structpb.NewStringValue("sensitive-name"),
+									"given_name":            structpb.NewStringValue("sensitive-given-name"),
+									"family_name":           structpb.NewStringValue("sensitive-family-name"),
+									"middle_name":           structpb.NewStringValue("sensitive-middle-name"),
+									"nickname":              structpb.NewStringValue("sensitive-nickname"),
+									"preferred_username":    structpb.NewStringValue("sensitive-preferred-username"),
+									"profile":               structpb.NewStringValue("sensitive-profile"),
+									"picture":               structpb.NewStringValue("sensitive-picture"),
+									"website":               structpb.NewStringValue("sensitive-website"),
+									"email":                 structpb.NewStringValue("sensitive-email"),
+									"email_verified":        structpb.NewBoolValue(true),
+									"gender":                structpb.NewStringValue("sensitive-gender"),
+									"birthdate":             structpb.NewStringValue("sensitive-birthdate"),
+									"zoneinfo":              structpb.NewStringValue("public-zoneinfo"),
+									"locale":                structpb.NewStringValue("public-locale"),
+									"phone_number":          structpb.NewStringValue("sensitive-phone-number"),
+									"phone_number_verified": structpb.NewBoolValue(false),
+									"updated_at":            structpb.NewNumberValue(float64(now.Unix())),
+									"address": structpb.NewStructValue(&structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"formatted":      structpb.NewStringValue("sensitive-formatted"),
+											"street_address": structpb.NewStringValue("sensitive-street-address"),
+											"locality":       structpb.NewStringValue("sensitive-locality"),
+											"region":         structpb.NewStringValue("sensitive-region"),
+											"postal_code":    structpb.NewStringValue("sensitive-postal-code"),
+											"country":        structpb.NewStringValue("sensitive-country"),
+										},
+									}),
+								},
+							}),
+						},
+					},
+					ManagedGroupIds:   []string{"public-managed-group-id-1", "public-managed-group-id-2"},
+					AuthorizedActions: []string{"public-authorized-actions-1", "public-authorized-actions-2"},
+				},
+			},
+			wantEvent: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &Account{
+					Id: "public-acc-id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "public-scope-id",
+						Type:          "public-scope-type",
+						Name:          "public-scope-name",
+						Description:   "public-scope-description",
+						ParentScopeId: "public-parent-scopeid",
+					},
+					Name:         wrapperspb.String("public-name"),
+					Description:  wrapperspb.String("public-description"),
+					CreatedTime:  timestamppb.New(now),
+					UpdatedTime:  timestamppb.New(now),
+					Version:      1,
+					Type:         "oidc",
+					AuthMethodId: "public-auth-method-id",
+					Attributes: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"issuer":    structpb.NewStringValue("public-issuer"),
+							"subject":   structpb.NewStringValue(encrypt.RedactedData),
+							"full_name": structpb.NewStringValue(encrypt.RedactedData),
+							"email":     structpb.NewStringValue(encrypt.RedactedData),
+							"token_claims": structpb.NewStructValue(&structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"iss":       structpb.NewStringValue("public-issuer"),
+									"sub":       structpb.NewStringValue(encrypt.RedactedData),
+									"aud":       structpb.NewStringValue(encrypt.RedactedData),
+									"exp":       structpb.NewNumberValue(float64(now.Unix())),
+									"iat":       structpb.NewNumberValue(float64(now.Unix())),
+									"auth_time": structpb.NewNumberValue(float64(now.Unix())),
+									"nonce":     structpb.NewStringValue(encrypt.RedactedData),
+									"acr":       structpb.NewStringValue("public-acr"),
+									"amr": structpb.NewListValue(&structpb.ListValue{Values: []*structpb.Value{
+										structpb.NewStringValue("public-amr-1"),
+										structpb.NewStringValue("public-amr-2"),
+									}}),
+									"azp":                   structpb.NewStringValue("public-azp-1"),
+									"name":                  structpb.NewStringValue(encrypt.RedactedData),
+									"given_name":            structpb.NewStringValue(encrypt.RedactedData),
+									"family_name":           structpb.NewStringValue(encrypt.RedactedData),
+									"middle_name":           structpb.NewStringValue(encrypt.RedactedData),
+									"nickname":              structpb.NewStringValue(encrypt.RedactedData),
+									"preferred_username":    structpb.NewStringValue(encrypt.RedactedData),
+									"profile":               structpb.NewStringValue(encrypt.RedactedData),
+									"picture":               structpb.NewStringValue(encrypt.RedactedData),
+									"website":               structpb.NewStringValue(encrypt.RedactedData),
+									"email":                 structpb.NewStringValue(encrypt.RedactedData),
+									"email_verified":        structpb.NewBoolValue(true),
+									"gender":                structpb.NewStringValue(encrypt.RedactedData),
+									"birthdate":             structpb.NewStringValue(encrypt.RedactedData),
+									"zoneinfo":              structpb.NewStringValue("public-zoneinfo"),
+									"locale":                structpb.NewStringValue("public-locale"),
+									"phone_number":          structpb.NewStringValue(encrypt.RedactedData),
+									"phone_number_verified": structpb.NewBoolValue(false),
+									"updated_at":            structpb.NewNumberValue(float64(now.Unix())),
+									"address":               structpb.NewStringValue(encrypt.RedactedData),
+								},
+							}),
+							"userinfo_claims": structpb.NewStructValue(&structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"name":                  structpb.NewStringValue(encrypt.RedactedData),
+									"given_name":            structpb.NewStringValue(encrypt.RedactedData),
+									"family_name":           structpb.NewStringValue(encrypt.RedactedData),
+									"middle_name":           structpb.NewStringValue(encrypt.RedactedData),
+									"nickname":              structpb.NewStringValue(encrypt.RedactedData),
+									"preferred_username":    structpb.NewStringValue(encrypt.RedactedData),
+									"profile":               structpb.NewStringValue(encrypt.RedactedData),
+									"picture":               structpb.NewStringValue(encrypt.RedactedData),
+									"website":               structpb.NewStringValue(encrypt.RedactedData),
+									"email":                 structpb.NewStringValue(encrypt.RedactedData),
+									"email_verified":        structpb.NewBoolValue(true),
+									"gender":                structpb.NewStringValue(encrypt.RedactedData),
+									"birthdate":             structpb.NewStringValue(encrypt.RedactedData),
+									"zoneinfo":              structpb.NewStringValue("public-zoneinfo"),
+									"locale":                structpb.NewStringValue("public-locale"),
+									"phone_number":          structpb.NewStringValue(encrypt.RedactedData),
+									"phone_number_verified": structpb.NewBoolValue(false),
+									"updated_at":            structpb.NewNumberValue(float64(now.Unix())),
+									"address":               structpb.NewStringValue(encrypt.RedactedData),
+								},
+							}),
+						},
+					},
+					ManagedGroupIds:   []string{"public-managed-group-id-1", "public-managed-group-id-2"},
+					AuthorizedActions: []string{"public-authorized-actions-1", "public-authorized-actions-2"},
+				},
+			},
+		},
+	}
+
+	testEncryptingFilter := api.NewEncryptFilter(t, wrapper.TestWrapper(t))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+
+			got, err := testEncryptingFilter.Process(context.Background(), tt.testEvent)
+			require.NoError(err)
+			require.NotNil(got)
+
+			actualJson, err := json.Marshal(got)
+			require.NoError(err)
+			t.Log(string(actualJson))
+
+			wantJson, err := json.Marshal(tt.wantEvent)
+			require.NoError(err)
+			assert.JSONEq(string(wantJson), string(actualJson))
+		})
+	}
+}

--- a/sdk/pbs/controller/api/testing.go
+++ b/sdk/pbs/controller/api/testing.go
@@ -19,5 +19,6 @@ func NewEncryptFilter(t *testing.T, w wrapping.Wrapper) *encrypt.Filter {
 		IgnoreTypes: []reflect.Type{
 			reflect.TypeOf(&fieldmaskpb.FieldMask{}),
 		},
+		FilterOperationOverrides: encrypt.DefaultFilterOperations(),
 	}
 }


### PR DESCRIPTION
Adds the necessary struct tags and taggable interface implementations to the proto Accounts package to facilitate audit logging.