### PR TITLE
fix(sql): Remove warning from create_time trigger

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/0/01_domain_types.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/0/01_domain_types.up.sql
@@ -63,6 +63,7 @@ comment on function
 is
   'function used in before update triggers to properly set update_time columns';
   
+-- Replaced in 21/01_default_time.up.sql
 create or replace function
   default_create_time()
   returns trigger

--- a/internal/db/schema/migrations/oss/postgres/21/01_default_time.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/21/01_default_time.up.sql
@@ -1,0 +1,14 @@
+begin;
+
+create or replace function default_create_time()
+  returns trigger
+as $$
+begin
+  if new.create_time is distinct from now() then
+    new.create_time = now();
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+commit;

--- a/internal/db/schema/migrations/oss/postgres/21/01_default_time.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/21/01_default_time.up.sql
@@ -1,5 +1,6 @@
 begin;
 
+-- Replaces function from 0/01_domain_types.up.sql
 create or replace function default_create_time()
   returns trigger
 as $$


### PR DESCRIPTION
Raising a warning in the default trigger used for setting the value in
create_time columns creates unnecessary noise in the PostgreSQL log
files.

Closes #1744