### PR TITLE
ci: Run sdk and api tests in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,28 @@ jobs:
         name: Save package cache
         paths:
         - .buildcache/packages/store
+  test-api:
+    machine:
+      image: ubuntu-2004:202107-02
+    resource_class: medium
+    working_directory: ~/boundary
+    steps:
+    - checkout
+    - run:
+        command: |
+          make install-go
+          source ~/.bashrc
+          echo 'export GOROOT=$GOROOT' >> "$BASH_ENV"
+          echo 'export GOPATH=$GOPATH' >> "$BASH_ENV"
+          echo 'export PATH=$PATH' >> "$BASH_ENV"
+          echo "$ go version"
+          go version
+        name: Install go
+    - run:
+        command: |
+          make test-api
+        name: Run API Tests
+        no_output_timeout: 15m
   darwin_arm64_package:
     docker:
     - image: docker.mirror.hashicorp.services/circleci/buildpack-deps
@@ -591,6 +613,28 @@ jobs:
         name: Save package cache
         paths:
         - .buildcache/packages/store
+  test-sdk:
+    machine:
+      image: ubuntu-2004:202107-02
+    resource_class: medium
+    working_directory: ~/boundary
+    steps:
+    - checkout
+    - run:
+        command: |
+          make install-go
+          source ~/.bashrc
+          echo 'export GOROOT=$GOROOT' >> "$BASH_ENV"
+          echo 'export GOPATH=$GOPATH' >> "$BASH_ENV"
+          echo 'export PATH=$PATH' >> "$BASH_ENV"
+          echo "$ go version"
+          go version
+        name: Install go
+    - run:
+        command: |
+          make test-sdk
+        name: Run SDK Tests
+        no_output_timeout: 15m
   algolia-index:
     docker:
     - image: docker.mirror.hashicorp.services/node:12
@@ -1052,6 +1096,16 @@ jobs:
     working_directory: ~/boundary
     steps:
     - checkout
+    - run:
+        command: |
+          make install-go
+          source ~/.bashrc
+          echo 'export GOROOT=$GOROOT' >> "$BASH_ENV"
+          echo 'export GOPATH=$GOPATH' >> "$BASH_ENV"
+          echo 'export PATH=$PATH' >> "$BASH_ENV"
+          echo "$ go version"
+          go version
+        name: Install go
     - run:
         command: |
           which pg_isready || sudo apt-get update && sudo apt-get install -y postgresql-client
@@ -1650,6 +1704,8 @@ workflows:
   ci:
     jobs:
     - build
+    - test-api
+    - test-sdk
     - test-sql-latest
     - test-sql-11-alpine
     - test-sql-12-alpine

--- a/.circleci/config/commands/install-go.yml
+++ b/.circleci/config/commands/install-go.yml
@@ -1,0 +1,14 @@
+---
+description: >
+  Ensure the right version of Go is installed and set PATH, GOPATH, GOROOT
+steps:
+  - run:
+      name: "Install go"
+      command: |
+        make install-go
+        source ~/.bashrc
+        echo 'export GOROOT=$GOROOT' >> "$BASH_ENV"
+        echo 'export GOPATH=$GOPATH' >> "$BASH_ENV"
+        echo 'export PATH=$PATH' >> "$BASH_ENV"
+        echo "$ go version"
+        go version

--- a/.circleci/config/jobs/build.yml
+++ b/.circleci/config/jobs/build.yml
@@ -1,6 +1,7 @@
 executor: go-machine
 steps:
 - checkout
+- install-go
 - run:
     name: "Initialize Test Database"
     command: |

--- a/.circleci/config/jobs/test-api.yml
+++ b/.circleci/config/jobs/test-api.yml
@@ -1,0 +1,9 @@
+executor: go-machine-medium
+steps:
+- checkout
+- install-go
+- run:
+    name: "Run API Tests"
+    no_output_timeout: 15m
+    command: |
+      make test-api

--- a/.circleci/config/jobs/test-sdk.yml
+++ b/.circleci/config/jobs/test-sdk.yml
@@ -1,0 +1,9 @@
+executor: go-machine-medium
+steps:
+- checkout
+- install-go
+- run:
+    name: "Run SDK Tests"
+    no_output_timeout: 15m
+    command: |
+      make test-sdk

--- a/.circleci/config/workflows/ci.yml
+++ b/.circleci/config/workflows/ci.yml
@@ -1,5 +1,7 @@
 jobs:
   - build
+  - test-api
+  - test-sdk
   - test-sql:
       matrix:
         parameters:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,4 +192,20 @@ Note that if `max_connections` is set too low, it may result in sporadic test
 failures if a connection cannot be established. In this case, reduce the number
 of concurrent tests via `GOMAXPROCS` or selectively run tests.
 
+### SDK and API tests
+
+Tests for the SDK and API modules can also be run. These do not require a test
+database:
+
+```
+$ make test-api
+$ make test-sdk
+```
+
+Or all of the test can be run with a single target:
+
+```
+$ make test-all
+```
+
 ## [Adding additional field to an existing API (or new API)](internal/adding-a-new-field-readme.md)

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,6 @@ test-database-down:
 	make -C testing/dbtest/docker clean
 
 .PHONY: test-ci
-test-ci: install-go
 test-ci: export CI_BUILD=1
 test-ci:
 	CGO_ENABLED=$(CGO_ENABLED) BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/build.sh'"
@@ -202,6 +201,17 @@ test-sql:
 .PHONY: test
 test:
 	go test ./... -timeout 30m
+
+.PHONY: test-sdk
+test-sdk:
+	$(MAKE) -C sdk/ test
+
+.PHONY: test-api
+test-api:
+	$(MAKE) -C api/ test
+
+.PHONY: test-all
+test-all: test-sdk test-api test
 
 .PHONY: install-go
 install-go:

--- a/Makefile
+++ b/Makefile
@@ -12,24 +12,30 @@ CGO_ENABLED?=0
 
 export GEN_BASEPATH := $(shell pwd)
 
+.PHONY: api
 api:
 	$(MAKE) --environment-overrides -C internal/api/genapi api
 
+.PHONY: cli
 cli:
 	$(MAKE) --environment-overrides -C internal/cmd/gencli cli
 
+.PHONY: tools
 tools:
 	go generate -tags tools tools/tools.go
 
+.PHONY: cleangen
 cleangen:
 	@rm -f ${GENERATED_CODE}
 
+.PHONY: dev
 dev: BUILD_TAGS+=dev
 dev: BUILD_TAGS+=ui
 dev: build-ui-ifne
 	@echo "==> Building Boundary with dev and UI features enabled"
 	@CGO_ENABLED=$(CGO_ENABLED) BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/build.sh'"
 
+.PHONY: fmt
 fmt:
 	gofumpt -w $$(find . -name '*.go' | grep -v pb.go | grep -v pb.gw.go)
 
@@ -43,6 +49,7 @@ $(UI_TARGETS): export UI_DEFAULT_BRANCH := main
 $(UI_TARGETS): export UI_CURRENT_COMMIT := $(shell head -n1 < "$(UI_VERSION_FILE)" | cut -d' ' -f1)
 $(UI_TARGETS): export UI_COMMITISH ?=
 
+.PHONY: update-ui-version
 update-ui-version:
 	@if [ -z "$(UI_COMMITISH)" ]; then \
 		echo "==> Setting UI version to latest commit on branch '$(UI_DEFAULT_BRANCH)'"; \
@@ -52,6 +59,7 @@ update-ui-version:
 	fi; \
 	./scripts/uiclone.sh && ./scripts/uiupdate.sh
 
+.PHONY: build-ui
 build-ui:
 	@if [ -z "$(UI_COMMITISH)" ]; then \
 		echo "==> Building default UI version from $(UI_VERSION_FILE): $(UI_CURRENT_COMMIT)"; \
@@ -61,6 +69,7 @@ build-ui:
 	fi; \
 	./scripts/uiclone.sh && ./scripts/uigen.sh
 
+.PHONY: build-ui-ifne
 build-ui-ifne:
 ifeq (,$(wildcard internal/ui/.tmp/boundary-ui))
 	@echo "==> No UI assets found, building..."
@@ -69,15 +78,19 @@ else
 	@echo "==> UI assets found, use build-ui target to update"
 endif
 
+.PHONY: perms-table
 perms-table:
 	@go run internal/website/permstable/permstable.go
 
+.PHONY: gen
 gen: cleangen proto api cli perms-table fmt
 
 ### oplog requires protoc-gen-go v1.20.0 or later
 # GO111MODULE=on go get -u github.com/golang/protobuf/protoc-gen-go@v1.40
+.PHONY: proto
 proto: protolint protobuild
 
+.PHONY: protobuild
 protobuild:
 	# To add a new directory containing a proto pass the  proto's root path in
 	# through the --proto_path flag.
@@ -150,37 +163,47 @@ protobuild:
 
 	@rm -R ${TMP_DIR}
 
+.PHONY: protolint
 protolint:
 	@buf check lint
 	@buf check breaking --against 'https://github.com/hashicorp/boundary.git#branch=stable-website'
 
+.PHONY: website
 # must have nodejs and npm installed
 website: website-install website-start
 
+.PHONY: website-install
 website-install:
 	@npm install --prefix website/
 
+.PHONY: website-start
 website-start:
 	@npm start --prefix website/
 
+.PHONY: test-database-up
 test-database-up:
 	make -C testing/dbtest/docker database-up
 
+.PHONY: test-database-down
 test-database-down:
 	make -C testing/dbtest/docker clean
 
+.PHONY: test-ci
 test-ci: install-go
 test-ci: export CI_BUILD=1
 test-ci:
 	CGO_ENABLED=$(CGO_ENABLED) BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/build.sh'"
 	~/.go/bin/go test ./... -v $(TESTARGS) -timeout 120m
 
+.PHONY: test-sql
 test-sql:
 	$(MAKE) -C internal/db/sqltest/ test
 
+.PHONY: test
 test:
 	go test ./... -timeout 30m
 
+.PHONY: install-go
 install-go:
 	./ci/goinstall.sh
 
@@ -192,8 +215,10 @@ IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
 IMAGE_TAG_DEV=$(REGISTRY_NAME)/$(IMAGE_NAME):latest-$(shell git rev-parse --short HEAD)
 DOCKER_DIR=./docker
 
+.PHONY: docker
 docker: docker-build docker-publish
 
+.PHONY: docker-build
 # builds from releases.hashicorp.com official binary
 docker-build:
 	docker build -t $(IMAGE_TAG) \
@@ -201,6 +226,7 @@ docker-build:
 	-f $(DOCKER_DIR)/Release.dockerfile docker/ 
 	docker tag $(IMAGE_TAG) hashicorp/boundary:latest
 
+.PHONY: docker-multiarch-build
 # builds multiarch from releases.hashicorp.com official binary
 docker-multiarch-build:
 	docker buildx build \
@@ -211,6 +237,7 @@ docker-multiarch-build:
 	--platform linux/amd64,linux/arm64 \
 	--file $(DOCKER_DIR)/Release.dockerfile docker/
 
+.PHONY: docker-build-dev
 # builds from locally generated binary in bin/
 docker-build-dev: export XC_OSARCH=linux/amd64
 docker-build-dev: dev
@@ -218,18 +245,19 @@ docker-build-dev: dev
 	docker build -t $(IMAGE_TAG_DEV) \
 	-f $(DOCKER_DIR)/Dev.dockerfile docker/
 
+.PHONY: docker-publish
 # requires appropriate permissions in dockerhub
 docker-publish:
 	docker push $(IMAGE_TAG)
 	docker push hashicorp/boundary:latest
 
-.PHONY: api cli tools gen proto website ci-config ci-verify set-ui-version docker docker-build docker-build-dev docker-publish test-database-up test-database-down
-
 .NOTPARALLEL:
 
+.PHONY: ci-config
 ci-config:
 	@$(MAKE) -C .circleci ci-config
 
+.PHONY: ci-verify
 ci-verify:
 	@$(MAKE) -C .circleci ci-verify
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,0 +1,6 @@
+.PHONY: all
+all: test
+
+.PHONY: test
+test:
+	go test -v ./...

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -1,0 +1,6 @@
+.PHONY: all
+all: test
+
+.PHONY: test
+test:
+	go test -v ./...


### PR DESCRIPTION
This adds new makefile targets and configuration to run the tests in the 
api and sdk modules. These do not run by default since `go test ./...` does
not cross module boundaries.