### PR TITLE
refact(controller/targets): Move tcp functionality into subpackage

### DIFF
--- a/internal/cmd/base/initial_resources.go
+++ b/internal/cmd/base/initial_resources.go
@@ -514,7 +514,7 @@ func (b *Server) CreateInitialTarget(ctx context.Context) (target.Target, error)
 		target.WithSessionConnectionLimit(int32(b.DevTargetSessionConnectionLimit)),
 		target.WithPublicId(b.DevTargetId),
 	}
-	t, err := tcp.New(b.DevProjectId, opts...)
+	t, err := target.New(ctx, tcp.Subtype, b.DevProjectId, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating in memory target: %w", err)
 	}

--- a/internal/cmd/commands/server/worker_shutdown_reload_test.go
+++ b/internal/cmd/commands/server/worker_shutdown_reload_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+
+	_ "github.com/hashicorp/boundary/internal/servers/controller/handlers/targets/tcp"
 )
 
 const shutdownReloadApiAddr = "http://127.0.0.1:9203"

--- a/internal/credential/vault/jobs_test.go
+++ b/internal/credential/vault/jobs_test.go
@@ -829,7 +829,7 @@ func TestTokenRevocationJob_Run(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	target.TestCredentialLibrary(t, conn, tar.GetPublicId(), cl.GetPublicId())
 	sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
 		UserId:      uId,
@@ -1028,7 +1028,7 @@ func TestCredentialRenewalJob_RunLimits(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	target.TestCredentialLibrary(t, conn, tar.GetPublicId(), cl.GetPublicId())
 	sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
 		UserId:      uId,
@@ -1141,7 +1141,7 @@ func TestCredentialRenewalJob_Run(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
 		UserId:      uId,
 		HostId:      h.GetPublicId(),
@@ -1251,7 +1251,7 @@ func TestCredentialRenewalJob_RunExpired(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
 		UserId:      uId,
 		HostId:      h.GetPublicId(),
@@ -1328,7 +1328,7 @@ func TestCredentialRenewalJob_NextRunIn(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	target.TestCredentialLibrary(t, conn, tar.GetPublicId(), cl.GetPublicId())
 	sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
 		UserId:      uId,
@@ -1571,7 +1571,7 @@ func TestCredentialRevocationJob_RunLimits(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	target.TestCredentialLibrary(t, conn, tar.GetPublicId(), cl.GetPublicId())
 	sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
 		UserId:      uId,
@@ -1686,7 +1686,7 @@ func TestCredentialRevocationJob_Run(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
 		UserId:      uId,
 		HostId:      h.GetPublicId(),
@@ -1780,7 +1780,7 @@ func TestCredentialRevocationJob_RunDeleted(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
 		UserId:      uId,
 		HostId:      h.GetPublicId(),
@@ -2172,7 +2172,7 @@ func TestCredentialCleanupJob_Run(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	sess1 := session.TestSession(t, conn, wrapper, session.ComposedOf{
 		UserId:      uId,
 		HostId:      h.GetPublicId(),

--- a/internal/credential/vault/repository_credentials_test.go
+++ b/internal/credential/vault/repository_credentials_test.go
@@ -106,7 +106,7 @@ func TestRepository_IssueCredentials(t *testing.T) {
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
 
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 
 	rc2dc := func(rcs []credential.Request) []*session.DynamicCredential {
 		var dcs []*session.DynamicCredential
@@ -224,7 +224,7 @@ func TestRepository_Revoke(t *testing.T) {
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
 
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	target.TestCredentialLibrary(t, conn, tar.GetPublicId(), cl.GetPublicId())
 
 	const (
@@ -342,7 +342,7 @@ func Test_TerminateSession(t *testing.T) {
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
 
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	target.TestCredentialLibrary(t, conn, tar.GetPublicId(), cl.GetPublicId())
 
 	const (

--- a/internal/credential/vault/testing_external_test.go
+++ b/internal/credential/vault/testing_external_test.go
@@ -1,6 +1,7 @@
 package vault_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/boundary/internal/authtoken"
@@ -35,7 +36,7 @@ func Test_TestCredentials(t *testing.T) {
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
 
-	tar := tcp.TestTarget(t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 	target.TestCredentialLibrary(t, conn, tar.GetPublicId(), cl.GetPublicId())
 
 	at := authtoken.TestAuthToken(t, conn, kms, org.GetPublicId())

--- a/internal/servers/controller/handlers/sessions/session_service_test.go
+++ b/internal/servers/controller/handlers/sessions/session_service_test.go
@@ -59,7 +59,7 @@ func TestGetSession(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, p.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, p.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 
 	sess := session.TestSession(t, conn, wrap, session.ComposedOf{
 		UserId:      uId,
@@ -176,7 +176,7 @@ func TestList_Self(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, pWithSessions.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, pWithSessions.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 
 	// By default a user can read/cancel their own sessions.
 	session.TestSession(t, conn, wrap, session.ComposedOf{
@@ -260,13 +260,13 @@ func TestList(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, pWithSessions.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, pWithSessions.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 
 	hcOther := static.TestCatalogs(t, conn, pWithOtherSessions.GetPublicId(), 1)[0]
 	hsOther := static.TestSets(t, conn, hcOther.GetPublicId(), 1)[0]
 	hOther := static.TestHosts(t, conn, hcOther.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hsOther.GetPublicId(), []*static.Host{hOther})
-	tarOther := tcp.TestTarget(t, conn, pWithOtherSessions.GetPublicId(), "test", target.WithHostSources([]string{hsOther.GetPublicId()}))
+	tarOther := tcp.TestTarget(context.Background(), t, conn, pWithOtherSessions.GetPublicId(), "test", target.WithHostSources([]string{hsOther.GetPublicId()}))
 
 	var wantSession []*pb.Session
 	var totalSession []*pb.Session
@@ -502,7 +502,7 @@ func TestCancel(t *testing.T) {
 	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
-	tar := tcp.TestTarget(t, conn, p.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	tar := tcp.TestTarget(context.Background(), t, conn, p.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
 
 	sess := session.TestSession(t, conn, wrap, session.ComposedOf{
 		UserId:      uId,

--- a/internal/servers/controller/handlers/targets/options.go
+++ b/internal/servers/controller/handlers/targets/options.go
@@ -1,0 +1,44 @@
+package targets
+
+import (
+	"github.com/hashicorp/boundary/internal/target"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func getOpts(opt ...option) options {
+	opts := getDefaultOptions()
+	for _, o := range opt {
+		o(&opts)
+	}
+	return opts
+}
+
+// Option - how Options are passed as arguments
+type option func(*options)
+
+// options = how options are represented
+type options struct {
+	withTarget target.Target
+	withStruct *structpb.Struct
+}
+
+func getDefaultOptions() options {
+	return options{
+		withTarget: nil,
+		withStruct: nil,
+	}
+}
+
+// withTarget provides an option to provide a target.Target.
+func withTarget(t target.Target) option {
+	return func(o *options) {
+		o.withTarget = t
+	}
+}
+
+// withStruct provides an option to provide a structpb.Struct.
+func withStruct(s *structpb.Struct) option {
+	return func(o *options) {
+		o.withStruct = s
+	}
+}

--- a/internal/servers/controller/handlers/targets/registry.go
+++ b/internal/servers/controller/handlers/targets/registry.go
@@ -1,0 +1,101 @@
+package targets
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/boundary/internal/servers/controller/handlers"
+	"github.com/hashicorp/boundary/internal/target"
+	"github.com/hashicorp/boundary/internal/types/subtypes"
+	"google.golang.org/protobuf/proto"
+)
+
+// Attributes represent the subtype specific request/response attributes.
+type Attributes interface {
+	proto.Message
+
+	// Options create target.Options to be used to create a target.Target.
+	Options() []target.Option
+	// Vet validates the Attributes and returns a map of fields to error messages
+	// if any fields are invalid.
+	Vet() map[string]string
+}
+
+type attributeFunc func(target.Target) Attributes
+
+type registryEntry struct {
+	maskManager handlers.MaskManager
+	attrFunc    attributeFunc
+}
+
+type registry struct {
+	sync.Map
+}
+
+func (r registry) get(s subtypes.Subtype) (*registryEntry, error) {
+	v, ok := r.Load(s)
+	if !ok {
+		return nil, fmt.Errorf("subtype %q not registered", s)
+	}
+
+	re, ok := v.(*registryEntry)
+	if !ok {
+		return nil, fmt.Errorf("malformed registry subtypye %q registered as incorrect type %T", s, v)
+	}
+	return re, nil
+}
+
+func (r registry) maskManager(s subtypes.Subtype) (handlers.MaskManager, error) {
+	re, err := r.get(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return re.maskManager, nil
+}
+
+// newAttribute creates an Attribute for the given subtype. It delegates the
+// allocation of the Attribute to the registered attrFunc for the given
+// subtype. An error is returned if the provided subtype is not registered. It
+// supports the options of:
+//
+// - withTarget: The Attribute will be initialized based on the given
+// target.Target. This initialization is delegated to the attrFunc.
+//
+// - withStruct: The Attribute will be initialized based on the given
+// structpb.Struct. This is *not* delegated.
+//
+// These two options are mutually exclusive. If both are provided, and error is returned.
+// If no options are provided an empty Attribute will be returned.
+func (r registry) newAttribute(s subtypes.Subtype, opt ...option) (Attributes, error) {
+	re, err := r.get(s)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := getOpts(opt...)
+	if opts.withTarget != nil && opts.withStruct != nil {
+		return nil, fmt.Errorf("cannot use both withTarget and withStruct")
+	}
+
+	attr := re.attrFunc(opts.withTarget)
+	if opts.withStruct != nil {
+		if err := handlers.StructToProto(opts.withStruct, attr); err != nil {
+			return nil, fmt.Errorf("Provided attributes don't match expected format.")
+		}
+	}
+
+	return attr, nil
+}
+
+var subtypeRegistry = registry{}
+
+// Register registers a subtype for used by the service handler.
+func Register(s subtypes.Subtype, maskManager handlers.MaskManager, af attributeFunc) {
+	if _, existed := subtypeRegistry.LoadOrStore(s, &registryEntry{
+		maskManager: maskManager,
+		attrFunc:    af,
+	}); existed {
+		panic(fmt.Sprintf("subtype %s already registered", s))
+	}
+}

--- a/internal/servers/controller/handlers/targets/target_service.go
+++ b/internal/servers/controller/handlers/targets/target_service.go
@@ -1351,7 +1351,7 @@ func (s Service) addCredentialSourcesInRepo(ctx context.Context, targetId string
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	credLibs, err := createCredLibs(targetId, applicationIds, egressIds, nil)
+	credLibs, err := createCredLibs(targetId, applicationIds, nil, egressIds)
 	if err != nil {
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to set credential sources in target: %v.", err)
 	}
@@ -1374,7 +1374,7 @@ func (s Service) setCredentialSourcesInRepo(ctx context.Context, targetId string
 		return nil, nil, nil, err
 	}
 
-	credLibs, err := createCredLibs(targetId, applicationIds, egressIds, nil)
+	credLibs, err := createCredLibs(targetId, applicationIds, nil, egressIds)
 	if err != nil {
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to set credential sources in target: %v.", err)
 	}
@@ -1402,7 +1402,7 @@ func (s Service) removeCredentialSourcesInRepo(ctx context.Context, targetId str
 		return nil, nil, nil, err
 	}
 
-	credLibs, err := createCredLibs(targetId, applicationIds, egressIds, nil)
+	credLibs, err := createCredLibs(targetId, applicationIds, nil, egressIds)
 	if err != nil {
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to set credential sources in target: %v.", err)
 	}

--- a/internal/servers/controller/handlers/targets/tcp/tcp.go
+++ b/internal/servers/controller/handlers/targets/tcp/tcp.go
@@ -1,0 +1,57 @@
+package tcp
+
+import (
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/hashicorp/boundary/internal/servers/controller/handlers"
+	"github.com/hashicorp/boundary/internal/servers/controller/handlers/targets"
+	"github.com/hashicorp/boundary/internal/target"
+	"github.com/hashicorp/boundary/internal/target/tcp"
+	"github.com/hashicorp/boundary/internal/target/tcp/store"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/targets"
+)
+
+type attribute struct {
+	*pb.TcpTargetAttributes
+}
+
+func (a *attribute) Options() []target.Option {
+	var opts []target.Option
+	if a.GetDefaultPort().GetValue() != 0 {
+		opts = append(opts, target.WithDefaultPort(a.GetDefaultPort().GetValue()))
+	}
+	return opts
+}
+
+func (a *attribute) Vet() map[string]string {
+	badFields := map[string]string{}
+	if a.GetDefaultPort() != nil && a.GetDefaultPort().GetValue() == 0 {
+		badFields["attributes.default_port"] = "This optional field cannot be set to 0."
+	}
+	return badFields
+}
+
+func newAttribute(t target.Target) targets.Attributes {
+	a := &attribute{
+		&pb.TcpTargetAttributes{},
+	}
+	if t != nil {
+		if t.GetDefaultPort() > 0 {
+			a.DefaultPort = &wrappers.UInt32Value{Value: t.GetDefaultPort()}
+		}
+	}
+	return a
+}
+
+func init() {
+	var maskManager handlers.MaskManager
+	var err error
+
+	if maskManager, err = handlers.NewMaskManager(
+		handlers.MaskDestination{&store.Target{}},
+		handlers.MaskSource{&pb.Target{}, &pb.TcpTargetAttributes{}},
+	); err != nil {
+		panic(err)
+	}
+
+	targets.Register(tcp.Subtype, maskManager, newAttribute)
+}

--- a/internal/session/testing.go
+++ b/internal/session/testing.go
@@ -133,7 +133,7 @@ func TestSessionParams(t *testing.T, conn *db.DB, wrapper wrapping.Wrapper, iamR
 	sets := static.TestSets(t, conn, cats[0].PublicId, 1)
 	_ = static.TestSetMembers(t, conn, sets[0].PublicId, hosts)
 
-	tcpTarget := tcp.TestTarget(t, conn, proj.PublicId, "test target")
+	tcpTarget := tcp.TestTarget(ctx, t, conn, proj.PublicId, "test target")
 
 	kms := kms.TestKms(t, conn, wrapper)
 	targetRepo, err := target.NewRepository(rw, rw, kms)
@@ -155,10 +155,10 @@ func TestSessionParams(t *testing.T, conn *db.DB, wrapper wrapping.Wrapper, iamR
 	return ComposedOf{
 		UserId:          user.PublicId,
 		HostId:          hosts[0].PublicId,
-		TargetId:        tcpTarget.PublicId,
+		TargetId:        tcpTarget.GetPublicId(),
 		HostSetId:       sets[0].PublicId,
 		AuthTokenId:     at.PublicId,
-		ScopeId:         tcpTarget.ScopeId,
+		ScopeId:         tcpTarget.GetScopeId(),
 		Endpoint:        "tcp://127.0.0.1:22",
 		ExpirationTime:  &timestamp.Timestamp{Timestamp: expTime},
 		ConnectionLimit: tcpTarget.GetSessionConnectionLimit(),

--- a/internal/target/tcp/exports_test.go
+++ b/internal/target/tcp/exports_test.go
@@ -12,8 +12,8 @@ var (
 // NewTestTarget is a test helper that bypasses the scopeId checks
 // performed by NewTarget, allowing tests to create Targets with
 // nil scopeIds for more robust testing.
-func NewTestTarget(scopeId string, opt ...target.Option) *Target {
-	t, _ := New("testScope", opt...)
-	t.ScopeId = scopeId
+func NewTestTarget(scopeId string, opt ...target.Option) target.Target {
+	t, _ := newTarget("testScope", opt...)
+	t.SetScopeId(scopeId)
 	return t
 }

--- a/internal/target/tcp/immutable_fields_test.go
+++ b/internal/target/tcp/immutable_fields_test.go
@@ -26,7 +26,8 @@ func TestTarget_ImmutableFields(t *testing.T) {
 	ts := timestamp.Timestamp{Timestamp: &timestamppb.Timestamp{Seconds: 0, Nanos: 0}}
 
 	_, proj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
-	new := tcp.TestTarget(t, conn, proj.PublicId, tcp.TestId(t))
+	ctx := context.Background()
+	new := tcp.TestTarget(ctx, t, conn, proj.PublicId, tcp.TestId(t))
 
 	tests := []struct {
 		name      string
@@ -95,7 +96,8 @@ func TestTcpTarget_ImmutableFields(t *testing.T) {
 	ts := timestamp.Timestamp{Timestamp: &timestamppb.Timestamp{Seconds: 0, Nanos: 0}}
 
 	_, proj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
-	new := tcp.TestTarget(t, conn, proj.PublicId, tcp.TestId(t))
+	ctx := context.Background()
+	new := tcp.TestTarget(ctx, t, conn, proj.PublicId, tcp.TestId(t))
 
 	tests := []struct {
 		name      string
@@ -163,18 +165,19 @@ func TestTargetHostSet_ImmutableFields(t *testing.T) {
 	ts := timestamp.Timestamp{Timestamp: &timestamppb.Timestamp{Seconds: 0, Nanos: 0}}
 
 	_, proj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
-	projTarget := tcp.TestTarget(t, conn, proj.PublicId, tcp.TestId(t))
+	ctx := context.Background()
+	projTarget := tcp.TestTarget(ctx, t, conn, proj.PublicId, tcp.TestId(t))
 	testCats := static.TestCatalogs(t, conn, proj.PublicId, 1)
 	hsets := static.TestSets(t, conn, testCats[0].GetPublicId(), 2)
 	require.Equal(t, 2, len(hsets))
 
-	updateTarget := tcp.TestTarget(t, conn, proj.PublicId, tcp.TestId(t))
+	updateTarget := tcp.TestTarget(ctx, t, conn, proj.PublicId, tcp.TestId(t))
 	updateHset := hsets[1]
 
-	_, gotHostSources, _, err := repo.AddTargetHostSources(context.Background(), projTarget.PublicId, 1, []string{hsets[0].PublicId})
+	_, gotHostSources, _, err := repo.AddTargetHostSources(ctx, projTarget.GetPublicId(), 1, []string{hsets[0].PublicId})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(gotHostSources))
-	new, err := target.NewTargetHostSet(projTarget.PublicId, gotHostSources[0].Id())
+	new, err := target.NewTargetHostSet(projTarget.GetPublicId(), gotHostSources[0].Id())
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -186,7 +189,7 @@ func TestTargetHostSet_ImmutableFields(t *testing.T) {
 			name: "target_id",
 			update: func() *target.TargetHostSet {
 				target := new.Clone().(*target.TargetHostSet)
-				target.TargetId = updateTarget.PublicId
+				target.TargetId = updateTarget.GetPublicId()
 				return target
 			}(),
 			fieldMask: []string{"TargetId"},

--- a/internal/target/tcp/register.go
+++ b/internal/target/tcp/register.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	target.Register(Subtype, allocTarget, vet, vetCredentialLibraries, TargetPrefix)
+	target.Register(Subtype, newTarget, allocTarget, vet, vetCredentialLibraries, TargetPrefix)
 }
 
 const (

--- a/internal/target/tcp/target.go
+++ b/internal/target/tcp/target.go
@@ -37,9 +37,9 @@ var (
 	_ oplog.ReplayableMessage = (*Target)(nil)
 )
 
-// New creates a new in memory tcp target.  WithName, WithDescription and
+// newTarget creates a new in memory tcp target.  WithName, WithDescription and
 // WithDefaultPort options are supported
-func New(scopeId string, opt ...target.Option) (*Target, error) {
+func newTarget(scopeId string, opt ...target.Option) (target.Target, error) {
 	const op = "tcp.NewTarget"
 	opts := target.GetOpts(opt...)
 	if scopeId == "" {

--- a/internal/target/tcp/testing_test.go
+++ b/internal/target/tcp/testing_test.go
@@ -25,6 +25,7 @@ func Test_TestTcpTarget(t *testing.T) {
 	_, proj := iam.TestScopes(t, iamRepo)
 	repo, err := target.NewRepository(rw, rw, testKms)
 	require.NoError(err)
+	ctx := context.Background()
 
 	cats := static.TestCatalogs(t, conn, proj.PublicId, 1)
 	hsets := static.TestSets(t, conn, cats[0].GetPublicId(), 2)
@@ -33,12 +34,12 @@ func Test_TestTcpTarget(t *testing.T) {
 		sets = append(sets, s.PublicId)
 	}
 	name := tcp.TestTargetName(t, proj.PublicId)
-	tar := tcp.TestTarget(t, conn, proj.PublicId, name, target.WithHostSources(sets))
+	tar := tcp.TestTarget(ctx, t, conn, proj.PublicId, name, target.WithHostSources(sets))
 	require.NotNil(t)
-	require.NotEmpty(tar.PublicId)
-	require.Equal(name, tar.Name)
+	require.NotEmpty(tar.GetPublicId())
+	require.Equal(name, tar.GetName())
 
-	_, foundSources, _, err := repo.LookupTarget(context.Background(), tar.PublicId)
+	_, foundSources, _, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
 	require.NoError(err)
 	foundIds := make([]string, 0, len(foundSources))
 	for _, s := range foundSources {
@@ -57,8 +58,9 @@ func Test_TestCredentialLibrary(t *testing.T) {
 	_, proj := iam.TestScopes(t, iamRepo)
 	repo, err := target.NewRepository(rw, rw, testKms)
 	require.NoError(err)
+	ctx := context.Background()
 
-	tar := tcp.TestTarget(t, conn, proj.PublicId, t.Name())
+	tar := tcp.TestTarget(ctx, t, conn, proj.PublicId, t.Name())
 	store := vault.TestCredentialStores(t, conn, wrapper, proj.GetPublicId(), 1)[0]
 	vlibs := vault.TestCredentialLibraries(t, conn, wrapper, store.GetPublicId(), 2)
 	var libIds []string
@@ -72,7 +74,7 @@ func Test_TestCredentialLibrary(t *testing.T) {
 
 	assert.Len(libs, 2)
 
-	_, _, foundSources, err := repo.LookupTarget(context.Background(), tar.PublicId)
+	_, _, foundSources, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
 	require.NoError(err)
 	foundIds := make([]string, 0, len(foundSources))
 	for _, s := range foundSources {

--- a/internal/tests/api/targets/target_test.go
+++ b/internal/tests/api/targets/target_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/boundary/internal/target/tcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	_ "github.com/hashicorp/boundary/internal/servers/controller/handlers/targets/tcp"
 )
 
 func TestHostSetASD(t *testing.T) {

--- a/internal/tests/cluster/package_registry_test.go
+++ b/internal/tests/cluster/package_registry_test.go
@@ -1,4 +1,4 @@
-package main
+package cluster
 
 import (
 	// Enable tcp target support.

--- a/internal/types/subtypes/registry.go
+++ b/internal/types/subtypes/registry.go
@@ -70,6 +70,18 @@ func (r *Registry) SubtypeFromId(id string) Subtype {
 	return subtype
 }
 
+// Prefixes returns the list of all known Prefixes.
+func (r *Registry) Prefixes() []string {
+	r.RLock()
+	defer r.RUnlock()
+
+	ret := make([]string, 0, len(r.subtypesPrefixes))
+	for p := range r.subtypesPrefixes {
+		ret = append(ret, p)
+	}
+	return ret
+}
+
 // Register registers all the prefixes for a provided Subtype. Register returns
 // an error if the subtype has already been registered or if any of the
 // prefixes are associated with another subtype.


### PR DESCRIPTION
This follows a similar pattern as the target domain package, providing a 
subpackage for the tcp target functionality, allowing this to be pluggable.