### PR TITLE
Add support for credential mapper overrides to the domain for update and lookup

### DIFF
--- a/internal/credential/vault/fields.go
+++ b/internal/credential/vault/fields.go
@@ -17,4 +17,6 @@ const (
 	tlsServerNameField  = "TlsServerName"
 	tlsSkipVerifyField  = "TlsSkipVerify"
 	tokenField          = "Token"
+
+	mappingOverrideField = "MappingOverride"
 )

--- a/internal/credential/vault/repository_credential_library.go
+++ b/internal/credential/vault/repository_credential_library.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/boundary/internal/db"
 	dbcommon "github.com/hashicorp/boundary/internal/db/common"
+	"github.com/hashicorp/boundary/internal/db/timestamp"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/oplog"
@@ -214,7 +215,7 @@ func (r *Repository) LookupCredentialLibrary(ctx context.Context, publicId strin
 	if publicId == "" {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "no public id")
 	}
-	l := allocCredentialLibrary()
+	l := allocPublicLibrary()
 	l.PublicId = publicId
 	if err := r.reader.LookupByPublicId(ctx, l); err != nil {
 		if errors.IsNotFoundError(err) {
@@ -222,8 +223,62 @@ func (r *Repository) LookupCredentialLibrary(ctx context.Context, publicId strin
 		}
 		return nil, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("failed for: %s", publicId)))
 	}
-	return l, nil
+	return l.toCredentialLibrary(), nil
 }
+
+// publicLibrary is a credential library and any of library's credential
+// mapping overrides. It does not include encrypted data and is safe to
+// return external to boundary.
+type publicLibrary struct {
+	PublicId          string `gorm:"primary_key"`
+	StoreId           string
+	Name              string
+	Description       string
+	CreateTime        *timestamp.Timestamp
+	UpdateTime        *timestamp.Timestamp
+	Version           uint32
+	VaultPath         string
+	HttpMethod        string
+	HttpRequestBody   []byte
+	CredentialType    string
+	UsernameAttribute string
+	PasswordAttribute string
+}
+
+func allocPublicLibrary() *publicLibrary {
+	return &publicLibrary{}
+}
+
+func (pl *publicLibrary) toCredentialLibrary() *CredentialLibrary {
+	cl := allocCredentialLibrary()
+	cl.PublicId = pl.PublicId
+	cl.StoreId = pl.StoreId
+	cl.Name = pl.Name
+	cl.Description = pl.Description
+	cl.CreateTime = pl.CreateTime
+	cl.UpdateTime = pl.UpdateTime
+	cl.Version = pl.Version
+	cl.VaultPath = pl.VaultPath
+	cl.HttpMethod = pl.HttpMethod
+	cl.HttpRequestBody = pl.HttpRequestBody
+	cl.CredentialLibrary.CredentialType = pl.CredentialType
+
+	if pl.UsernameAttribute != "" || pl.PasswordAttribute != "" {
+		up := allocUserPasswordOverride()
+		up.LibraryId = pl.PublicId
+		up.UsernameAttribute = pl.UsernameAttribute
+		up.PasswordAttribute = pl.PasswordAttribute
+		up.sanitize()
+		cl.MappingOverride = up
+	}
+	return cl
+}
+
+// TableName returns the table name for gorm.
+func (_ *publicLibrary) TableName() string { return "credential_vault_library_public" }
+
+// GetPublicId returns the public id.
+func (pl *publicLibrary) GetPublicId() string { return pl.PublicId }
 
 // DeleteCredentialLibrary deletes publicId from the repository and returns
 // the number of records deleted.

--- a/internal/credential/vault/repository_credential_library.go
+++ b/internal/credential/vault/repository_credential_library.go
@@ -166,6 +166,12 @@ func (r *Repository) UpdateCredentialLibrary(ctx context.Context, scopeId string
 	)
 
 	if strutil.StrListContains(nullFields, httpMethodField) {
+		// GET is the default value for the HttpMethod field in
+		// CredentialLibrary. The http_method column in the database does
+		// not allow NULL values but it also does not define a default
+		// value. Therefore, if the httpMethodField is in nullFields:
+		// remove it from nullFields then add it to dbMask and set the
+		// value to GET.
 		dbMask = append(dbMask, httpMethodField)
 		nullFields = strutil.StrListDelete(nullFields, httpMethodField)
 		l.HttpMethod = string(MethodGet)

--- a/internal/credential/vault/repository_credential_library_test.go
+++ b/internal/credential/vault/repository_credential_library_test.go
@@ -464,6 +464,20 @@ func TestRepository_UpdateCredentialLibrary(t *testing.T) {
 		}
 	}
 
+	changeCredentialType := func(t credential.Type) func(*CredentialLibrary) *CredentialLibrary {
+		return func(l *CredentialLibrary) *CredentialLibrary {
+			l.CredentialLibrary.CredentialType = string(t)
+			return l
+		}
+	}
+
+	changeMappingOverride := func(m MappingOverride) func(*CredentialLibrary) *CredentialLibrary {
+		return func(l *CredentialLibrary) *CredentialLibrary {
+			l.MappingOverride = m
+			return l
+		}
+	}
+
 	makeNil := func() func(*CredentialLibrary) *CredentialLibrary {
 		return func(l *CredentialLibrary) *CredentialLibrary {
 			return nil
@@ -508,6 +522,7 @@ func TestRepository_UpdateCredentialLibrary(t *testing.T) {
 		wantCount int
 		wantErr   errors.Code
 	}{
+
 		{
 			name: "nil-credential-library",
 			orig: &CredentialLibrary{
@@ -746,17 +761,21 @@ func TestRepository_UpdateCredentialLibrary(t *testing.T) {
 		{
 			name: "change-vault-path",
 			orig: &CredentialLibrary{
+				MappingOverride: NewUserPasswordOverride(WithOverrideUsernameAttribute("orig-username")),
 				CredentialLibrary: &store.CredentialLibrary{
-					HttpMethod: "GET",
-					VaultPath:  "/old/path",
+					HttpMethod:     "GET",
+					VaultPath:      "/old/path",
+					CredentialType: string(credential.UserPasswordType),
 				},
 			},
 			chgFn: changeVaultPath("/new/path"),
 			masks: []string{vaultPathField},
 			want: &CredentialLibrary{
+				MappingOverride: NewUserPasswordOverride(WithOverrideUsernameAttribute("orig-username")),
 				CredentialLibrary: &store.CredentialLibrary{
-					HttpMethod: "GET",
-					VaultPath:  "/new/path",
+					HttpMethod:     "GET",
+					VaultPath:      "/new/path",
+					CredentialType: string(credential.UserPasswordType),
 				},
 			},
 			wantCount: 1,
@@ -899,6 +918,196 @@ func TestRepository_UpdateCredentialLibrary(t *testing.T) {
 			},
 			wantCount: 1,
 		},
+		{
+			name: "read-only-credential-type-in-field-mask",
+			orig: &CredentialLibrary{
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod:     "GET",
+					VaultPath:      "/some/path",
+					Name:           "test-name-repo",
+					CredentialType: string(credential.UserPasswordType),
+				},
+			},
+			chgFn:   changeCredentialType(credential.UnspecifiedType),
+			masks:   []string{"PublicId", "CreateTime", "UpdateTime", "StoreId", "CredentialType"},
+			wantErr: errors.InvalidFieldMask,
+		},
+		{
+			name: "user-password-attributes-change-username-attribute",
+			orig: &CredentialLibrary{
+				MappingOverride: NewUserPasswordOverride(
+					WithOverrideUsernameAttribute("orig-username"),
+					WithOverridePasswordAttribute("orig-password"),
+				),
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod:     "GET",
+					VaultPath:      "/some/path",
+					Name:           "test-name-repo",
+					CredentialType: string(credential.UserPasswordType),
+				},
+			},
+			chgFn: changeMappingOverride(
+				NewUserPasswordOverride(
+					WithOverrideUsernameAttribute("changed-username"),
+				),
+			),
+			masks: []string{"MappingOverride"},
+			want: &CredentialLibrary{
+				MappingOverride: NewUserPasswordOverride(
+					WithOverrideUsernameAttribute("changed-username"),
+				),
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod:     "GET",
+					VaultPath:      "/some/path",
+					Name:           "test-name-repo",
+					CredentialType: string(credential.UserPasswordType),
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "user-password-attributes-change-password-attribute",
+			orig: &CredentialLibrary{
+				MappingOverride: NewUserPasswordOverride(
+					WithOverrideUsernameAttribute("orig-username"),
+					WithOverridePasswordAttribute("orig-password"),
+				),
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod:     "GET",
+					VaultPath:      "/some/path",
+					Name:           "test-name-repo",
+					CredentialType: string(credential.UserPasswordType),
+				},
+			},
+			chgFn: changeMappingOverride(
+				NewUserPasswordOverride(
+					WithOverridePasswordAttribute("changed-password"),
+				),
+			),
+			masks: []string{"MappingOverride"},
+			want: &CredentialLibrary{
+				MappingOverride: NewUserPasswordOverride(
+					WithOverridePasswordAttribute("changed-password"),
+				),
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod:     "GET",
+					VaultPath:      "/some/path",
+					Name:           "test-name-repo",
+					CredentialType: string(credential.UserPasswordType),
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "user-password-attributes-change-username-and-password-attributes",
+			orig: &CredentialLibrary{
+				MappingOverride: NewUserPasswordOverride(
+					WithOverrideUsernameAttribute("orig-username"),
+					WithOverridePasswordAttribute("orig-password"),
+				),
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod:     "GET",
+					VaultPath:      "/some/path",
+					Name:           "test-name-repo",
+					CredentialType: string(credential.UserPasswordType),
+				},
+			},
+			chgFn: changeMappingOverride(
+				NewUserPasswordOverride(
+					WithOverrideUsernameAttribute("changed-username"),
+					WithOverridePasswordAttribute("changed-password"),
+				),
+			),
+			masks: []string{"MappingOverride"},
+			want: &CredentialLibrary{
+				MappingOverride: NewUserPasswordOverride(
+					WithOverrideUsernameAttribute("changed-username"),
+					WithOverridePasswordAttribute("changed-password"),
+				),
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod:     "GET",
+					VaultPath:      "/some/path",
+					Name:           "test-name-repo",
+					CredentialType: string(credential.UserPasswordType),
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "no-mapping-override-change-username-and-password-attributes",
+			orig: &CredentialLibrary{
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod:     "GET",
+					VaultPath:      "/some/path",
+					Name:           "test-name-repo",
+					CredentialType: string(credential.UserPasswordType),
+				},
+			},
+			chgFn: changeMappingOverride(
+				NewUserPasswordOverride(
+					WithOverrideUsernameAttribute("changed-username"),
+					WithOverridePasswordAttribute("changed-password"),
+				),
+			),
+			masks: []string{"MappingOverride"},
+			want: &CredentialLibrary{
+				MappingOverride: NewUserPasswordOverride(
+					WithOverrideUsernameAttribute("changed-username"),
+					WithOverridePasswordAttribute("changed-password"),
+				),
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod:     "GET",
+					VaultPath:      "/some/path",
+					Name:           "test-name-repo",
+					CredentialType: string(credential.UserPasswordType),
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "user-password-attributes-delete-mapping-override",
+			orig: &CredentialLibrary{
+				MappingOverride: NewUserPasswordOverride(
+					WithOverrideUsernameAttribute("orig-username"),
+					WithOverridePasswordAttribute("orig-password"),
+				),
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod:     "GET",
+					VaultPath:      "/some/path",
+					Name:           "test-name-repo",
+					CredentialType: string(credential.UserPasswordType),
+				},
+			},
+			chgFn: changeMappingOverride(nil),
+			masks: []string{"MappingOverride"},
+			want: &CredentialLibrary{
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod:     "GET",
+					VaultPath:      "/some/path",
+					Name:           "test-name-repo",
+					CredentialType: string(credential.UserPasswordType),
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "set-mapping-override-on-unspecified-credential-type",
+			orig: &CredentialLibrary{
+				CredentialLibrary: &store.CredentialLibrary{
+					HttpMethod: "GET",
+					VaultPath:  "/some/path",
+					Name:       "test-name-repo",
+				},
+			},
+			chgFn: changeMappingOverride(
+				NewUserPasswordOverride(
+					WithOverrideUsernameAttribute("changed-username"),
+					WithOverridePasswordAttribute("changed-password"),
+				),
+			),
+			masks:   []string{"MappingOverride"},
+			wantErr: errors.VaultInvalidMappingOverride,
+		},
 	}
 
 	for _, tt := range tests {
@@ -940,18 +1149,35 @@ func TestRepository_UpdateCredentialLibrary(t *testing.T) {
 			underlyingDB, err := conn.SqlDB(ctx)
 			require.NoError(err)
 			dbassert := dbassert.New(t, underlyingDB)
-			if tt.want.Name == "" {
+
+			switch tt.want.Name {
+			case "":
 				dbassert.IsNull(got, "name")
-				return
+			default:
+				assert.Equal(tt.want.Name, got.Name)
 			}
-			assert.Equal(tt.want.Name, got.Name)
-			if tt.want.Description == "" {
+
+			switch tt.want.Description {
+			case "":
 				dbassert.IsNull(got, "description")
-				return
+			default:
+				assert.Equal(tt.want.Description, got.Description)
 			}
-			assert.Equal(tt.want.Description, got.Description)
+
 			if tt.wantCount > 0 {
 				assert.NoError(db.TestVerifyOplog(t, rw, got.GetPublicId(), db.WithOperation(oplog.OpType_OP_TYPE_UPDATE), db.WithCreateNotBefore(10*time.Second)))
+			}
+
+			switch w := tt.want.MappingOverride.(type) {
+			case nil:
+				assert.Nil(got.MappingOverride)
+			case *UserPasswordOverride:
+				g, ok := got.MappingOverride.(*UserPasswordOverride)
+				require.True(ok)
+				assert.Equal(w.UsernameAttribute, g.UsernameAttribute)
+				assert.Equal(w.PasswordAttribute, g.PasswordAttribute)
+			default:
+				assert.Fail("Unknown mapping override")
 			}
 		})
 	}

--- a/internal/db/schema/migrations/oss/postgres/10/04_vault_credential.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/10/04_vault_credential.up.sql
@@ -577,6 +577,7 @@ begin;
     'credential_vault_store_public is a view where each row contains a credential store. '
     'No encrypted data is returned. This view can be used to retrieve data which will be returned external to boundary.';
 
+-- Replaced in 21/05_vault_private_library.up.sql
      create view credential_vault_library_private as
      select library.public_id         as public_id,
             library.store_id          as store_id,

--- a/internal/db/schema/migrations/oss/postgres/22/05_vault_private_library.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/22/05_vault_private_library.up.sql
@@ -1,5 +1,6 @@
 begin;
 
+-- Replaces view from 10/04_vault_credential.up.sql
      drop view credential_vault_library_private;
 
      create view credential_vault_library_private as
@@ -44,5 +45,24 @@ begin;
   comment on view credential_vault_library_private is
     'credential_vault_library_private is a view where each row contains a credential library and the credential library''s data needed to connect to Vault. '
     'Each row may contain encrypted data. This view should not be used to retrieve data which will be returned external to boundary.';
+
+     create view credential_vault_library_public as
+     select public_id,
+            store_id,
+            name,
+            description,
+            create_time,
+            update_time,
+            version,
+            vault_path,
+            http_method,
+            http_request_body,
+            credential_type,
+            username_attribute,
+            password_attribute
+       from credential_vault_library_private;
+  comment on view credential_vault_library_public is
+    'credential_vault_library_public is a view where each row contains a credential library and any of library''s credential mapping overrides. '
+    'No encrypted data is returned. This view can be used to retrieve data which will be returned external to boundary.';
 
 commit;


### PR DESCRIPTION
An alternative implementation is in #1761. This version treats a credential mapping override as a value object which only allows the mapping override to be updated as a whole, not the individual fields of a credential mapping override. 