### PR TITLE
(alt 2) Add support for credential mapper overrides to the domain for update and lookup

### DIFF
--- a/internal/credential/vault/fields.go
+++ b/internal/credential/vault/fields.go
@@ -17,4 +17,7 @@ const (
 	tlsServerNameField  = "TlsServerName"
 	tlsSkipVerifyField  = "TlsSkipVerify"
 	tokenField          = "Token"
+
+	usernameAttributeField = "UsernameAttribute"
+	passwordAttributeField = "PasswordAttribute"
 )

--- a/internal/credential/vault/mapping_overriders.go
+++ b/internal/credential/vault/mapping_overriders.go
@@ -75,6 +75,24 @@ func (o *UserPasswordOverride) setLibraryId(i string) {
 	o.LibraryId = i
 }
 
+func (o *UserPasswordOverride) setUsernameAttribute(u string) {
+	o.UsernameAttribute = sanitize.String(u)
+}
+
+func (o *UserPasswordOverride) setPasswordAttribute(p string) {
+	o.PasswordAttribute = sanitize.String(p)
+}
+
+const noOverride = "\ufffeno override\uffff"
+
+func (o *UserPasswordOverride) deleteUsernameAttribute() {
+	o.UsernameAttribute = noOverride
+}
+
+func (o *UserPasswordOverride) deletePasswordAttribute() {
+	o.PasswordAttribute = noOverride
+}
+
 func (o *UserPasswordOverride) sanitize() {
 	if sentinel.Is(o.UsernameAttribute) {
 		o.UsernameAttribute = ""

--- a/internal/credential/vault/repository_credential_library.go
+++ b/internal/credential/vault/repository_credential_library.go
@@ -114,14 +114,15 @@ func (r *Repository) CreateCredentialLibrary(ctx context.Context, scopeId string
 // number of records updated. l is not changed.
 //
 // l must contain a valid PublicId. Only Name, Description, VaultPath,
-// HttpMethod, and HttpRequestBody can be updated. If l.Name is set to a
-// non-empty string, it must be unique within l.StoreId.
+// HttpMethod, HttpRequestBody, UsernameAttribute, and PasswordAttribute
+// can be updated. If l.Name is set to a non-empty string, it must be
+// unique within l.StoreId.
 //
 // An attribute of l will be set to NULL in the database if the attribute
 // in l is the zero value and it is included in fieldMaskPaths except for
-// HttpMethod.  If HttpMethod is in the fieldMaskPath but l.HttpMethod
-// is not set it will be set to the value "GET".  If storage has a value
-// for HttpRequestBody when l.HttpMethod is set to GET the update will fail.
+// HttpMethod. If HttpMethod is in the fieldMaskPath but l.HttpMethod is
+// not set it will be set to the value "GET". If storage has a value for
+// HttpRequestBody when l.HttpMethod is set to GET the update will fail.
 func (r *Repository) UpdateCredentialLibrary(ctx context.Context, scopeId string, l *CredentialLibrary, version uint32, fieldMaskPaths []string, _ ...Option) (*CredentialLibrary, int, error) {
 	const op = "vault.(Repository).UpdateCredentialLibrary"
 	if l == nil {
@@ -141,6 +142,7 @@ func (r *Repository) UpdateCredentialLibrary(ctx context.Context, scopeId string
 	}
 	l = l.clone()
 
+	var updateMappingOverride bool
 	for _, f := range fieldMaskPaths {
 		switch {
 		case strings.EqualFold(nameField, f):
@@ -148,22 +150,35 @@ func (r *Repository) UpdateCredentialLibrary(ctx context.Context, scopeId string
 		case strings.EqualFold(vaultPathField, f):
 		case strings.EqualFold(httpMethodField, f):
 		case strings.EqualFold(httpRequestBodyField, f):
+		case strings.EqualFold(usernameAttributeField, f), strings.EqualFold(passwordAttributeField, f):
+			updateMappingOverride = true
 		default:
 			return nil, db.NoRowsAffected, errors.New(ctx, errors.InvalidFieldMask, op, f)
 		}
 	}
-	var dbMask, nullFields []string
-	dbMask, nullFields = dbcommon.BuildUpdatePaths(
-		map[string]interface{}{
-			nameField:            l.Name,
-			descriptionField:     l.Description,
-			vaultPathField:       l.VaultPath,
-			httpMethodField:      l.HttpMethod,
-			httpRequestBodyField: l.HttpRequestBody,
-		},
-		fieldMaskPaths,
-		nil,
-	)
+
+	fieldValues := map[string]interface{}{
+		nameField:            l.Name,
+		descriptionField:     l.Description,
+		vaultPathField:       l.VaultPath,
+		httpMethodField:      l.HttpMethod,
+		httpRequestBodyField: l.HttpRequestBody,
+	}
+
+	if updateMappingOverride {
+		switch m := l.MappingOverride.(type) {
+		case nil:
+			fieldValues[usernameAttributeField] = ""
+			fieldValues[passwordAttributeField] = ""
+		case *UserPasswordOverride:
+			fieldValues[usernameAttributeField] = m.UsernameAttribute
+			fieldValues[passwordAttributeField] = m.PasswordAttribute
+		default:
+			return nil, db.NoRowsAffected, errors.New(ctx, errors.VaultInvalidMappingOverride, op, "Unknown mapping override")
+		}
+	}
+
+	dbMask, nullFields := dbcommon.BuildUpdatePaths(fieldValues, fieldMaskPaths, nil)
 
 	if strutil.StrListContains(nullFields, httpMethodField) {
 		// GET is the default value for the HttpMethod field in
@@ -181,6 +196,38 @@ func (r *Repository) UpdateCredentialLibrary(ctx context.Context, scopeId string
 		return nil, db.NoRowsAffected, errors.New(ctx, errors.EmptyFieldMask, op, "missing field mask")
 	}
 
+	origLib, err := r.LookupCredentialLibrary(ctx, l.PublicId)
+	switch {
+	case err != nil:
+		return nil, db.NoRowsAffected, errors.Wrap(ctx, err, op)
+	case origLib == nil:
+		return nil, db.NoRowsAffected, errors.New(ctx, errors.RecordNotFound, op, fmt.Sprintf("credential library %s", l.PublicId))
+	case origLib.Version != version:
+		return nil, db.NoRowsAffected, errors.New(ctx, errors.VersionMismatch, op, fmt.Sprintf("update version %d does not match db version %d", version, origLib.Version))
+	case updateMappingOverride && !validMappingOverride(l.MappingOverride, origLib.CredentialType()):
+		return nil, db.NoRowsAffected, errors.New(ctx, errors.VaultInvalidMappingOverride, op, "invalid mapping override for credential type")
+	}
+
+	var filteredDbMask, filteredNullFields []string
+	mappingOverrideDbMask := make(map[string]bool)
+	for _, f := range dbMask {
+		switch {
+		case strings.EqualFold(usernameAttributeField, f):
+			mappingOverrideDbMask[usernameAttributeField] = true
+		case strings.EqualFold(passwordAttributeField, f):
+			mappingOverrideDbMask[passwordAttributeField] = true
+		default:
+			filteredDbMask = append(filteredDbMask, f)
+		}
+	}
+	for _, f := range nullFields {
+		switch {
+		case strings.EqualFold(usernameAttributeField, f), strings.EqualFold(passwordAttributeField, f):
+		default:
+			filteredNullFields = append(filteredNullFields, f)
+		}
+	}
+
 	oplogWrapper, err := r.kms.GetWrapper(ctx, scopeId, kms.KeyPurposeOplog)
 	if err != nil {
 		return nil, db.NoRowsAffected, errors.Wrap(ctx, err, op, errors.WithCode(errors.Encrypt),
@@ -190,16 +237,75 @@ func (r *Repository) UpdateCredentialLibrary(ctx context.Context, scopeId string
 	var rowsUpdated int
 	var returnedCredentialLibrary *CredentialLibrary
 	_, err = r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{},
-		func(_ db.Reader, w db.Writer) error {
-			returnedCredentialLibrary = l.clone()
-			var err error
-			rowsUpdated, err = w.Update(ctx, returnedCredentialLibrary, dbMask, nullFields,
-				db.WithOplog(oplogWrapper, l.oplog(oplog.OpType_OP_TYPE_UPDATE)),
-				db.WithVersion(&version))
-			if err == nil && rowsUpdated > 1 {
-				return errors.New(ctx, errors.MultipleRecords, op, "more than 1 resource would have been updated")
+		func(rr db.Reader, w db.Writer) error {
+			var msgs []*oplog.Message
+			ticket, err := w.GetTicket(l)
+			if err != nil {
+				return errors.Wrap(ctx, err, op, errors.WithMsg("unable to get ticket"))
 			}
-			return err
+
+			l := l.clone()
+			var lOplogMsg oplog.Message
+
+			// Update the credential library table
+			switch {
+			case len(filteredDbMask) == 0 && len(filteredNullFields) == 0:
+				// the credential library's fields are not being updated,
+				// just one of its child objects, so we just need to
+				// update the library's version.
+				l.Version = version + 1
+				rowsUpdated, err = w.Update(ctx, l, []string{"Version"}, nil, db.NewOplogMsg(&lOplogMsg), db.WithVersion(&version))
+				if err != nil {
+					return errors.Wrap(ctx, err, op, errors.WithMsg("unable to update credential library version"))
+				}
+				switch rowsUpdated {
+				case 1:
+				case 0:
+					return nil
+				default:
+					return errors.New(ctx, errors.MultipleRecords, op, fmt.Sprintf("updated credential library version and %d rows updated", rowsUpdated))
+				}
+			default:
+				rowsUpdated, err = w.Update(ctx, l, filteredDbMask, filteredNullFields, db.NewOplogMsg(&lOplogMsg), db.WithVersion(&version))
+				if err != nil {
+					if errors.IsUniqueError(err) {
+						return errors.New(ctx, errors.NotUnique, op,
+							fmt.Sprintf("name %s already exists: %s", l.Name, l.PublicId))
+					}
+					return errors.Wrap(ctx, err, op, errors.WithMsg("unable to update credential library"))
+				}
+				switch rowsUpdated {
+				case 1:
+				case 0:
+					return nil
+				default:
+					return errors.New(ctx, errors.MultipleRecords, op, fmt.Sprintf("updated credential library and %d rows updated", rowsUpdated))
+				}
+			}
+			msgs = append(msgs, &lOplogMsg)
+			if updateMappingOverride {
+				chg, err := calcMappingOverrideChange(op, origLib, l, fieldMaskPaths)
+				if err != nil {
+					return errors.Wrap(ctx, err, op, errors.WithMsg("unable to calculate change to mapping override"))
+				}
+				msg, err := chg(ctx, w)
+				if err != nil {
+					return errors.Wrap(ctx, err, op, errors.WithMsg("unable to change mapping override"))
+				}
+				msgs = append(msgs, msg)
+			}
+			metadata := l.oplog(oplog.OpType_OP_TYPE_UPDATE)
+			if err := w.WriteOplogEntryWith(ctx, oplogWrapper, ticket, metadata, msgs); err != nil {
+				return errors.Wrap(ctx, err, op, errors.WithMsg("unable to write oplog"))
+			}
+
+			pl := allocPublicLibrary()
+			pl.PublicId = l.PublicId
+			if err := rr.LookupByPublicId(ctx, pl); err != nil {
+				return errors.Wrap(ctx, err, op, errors.WithMsg("unable to retrieve updated credential library"))
+			}
+			returnedCredentialLibrary = pl.toCredentialLibrary()
+			return nil
 		},
 	)
 
@@ -212,6 +318,152 @@ func (r *Repository) UpdateCredentialLibrary(ctx context.Context, scopeId string
 	}
 
 	return returnedCredentialLibrary, rowsUpdated, nil
+}
+
+type changeFunc func(ctx context.Context, w db.Writer) (*oplog.Message, error)
+
+func calcMappingOverrideChange(op errors.Op, ol, nl *CredentialLibrary, dbMask []string) (changeFunc, error) {
+	om, nm := ol.MappingOverride, nl.MappingOverride
+	if om == nil && nm == nil {
+		return noChange, nil
+	}
+
+	insertFn := func(mo MappingOverride) changeFunc {
+		mo.setLibraryId(ol.PublicId)
+		return func(ctx context.Context, w db.Writer) (*oplog.Message, error) {
+			var msg oplog.Message
+			if err := w.Create(ctx, mo, db.NewOplogMsg(&msg)); err != nil {
+				return nil, errors.Wrap(ctx, err, op)
+			}
+			return &msg, nil
+		}
+	}
+
+	deleteFn := func(mo MappingOverride) changeFunc {
+		mo.setLibraryId(ol.PublicId)
+		return func(ctx context.Context, w db.Writer) (*oplog.Message, error) {
+			var msg oplog.Message
+			rowsDeleted, err := w.Delete(ctx, mo, db.NewOplogMsg(&msg))
+			switch {
+			case err != nil:
+				return nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to delete mapping override"))
+			default:
+				switch rowsDeleted {
+				case 0, 1:
+				default:
+					return nil, errors.New(ctx, errors.MultipleRecords, op, fmt.Sprintf("delete mapping override and %d rows deleted", rowsDeleted))
+				}
+			}
+			return &msg, nil
+		}
+	}
+
+	updateFn := func(mo MappingOverride, dbMask []string) changeFunc {
+		mo.setLibraryId(ol.PublicId)
+		return func(ctx context.Context, w db.Writer) (*oplog.Message, error) {
+			var msg oplog.Message
+			rowsUpdated, err := w.Update(ctx, mo, dbMask, nil, db.NewOplogMsg(&msg))
+			switch {
+			case err != nil:
+				return nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to update mapping override"))
+			default:
+				switch rowsUpdated {
+				case 0, 1:
+				default:
+					return nil, errors.New(ctx, errors.MultipleRecords, op, fmt.Sprintf("update mapping override and %d rows updated", rowsUpdated))
+				}
+			}
+			return &msg, nil
+		}
+	}
+
+	mappingOverrideMask := make(map[string]bool)
+	for _, f := range dbMask {
+		switch {
+		case strings.EqualFold(usernameAttributeField, f):
+			mappingOverrideMask[usernameAttributeField] = true
+		case strings.EqualFold(passwordAttributeField, f):
+			mappingOverrideMask[passwordAttributeField] = true
+		}
+	}
+
+	switch {
+	case om == nil && nm != nil:
+		nmp, ok := nm.(*UserPasswordOverride)
+		if !ok {
+			return nil, fmt.Errorf("unexpected mapping override type %T: %v", nm, nm)
+		}
+		dmp := allocUserPasswordOverride()
+		if mappingOverrideMask[usernameAttributeField] {
+			dmp.setUsernameAttribute(nmp.UsernameAttribute)
+		}
+		if mappingOverrideMask[passwordAttributeField] {
+			dmp.setPasswordAttribute(nmp.PasswordAttribute)
+		}
+		if dmp.UsernameAttribute == "" && dmp.PasswordAttribute == "" {
+			return noChange, nil
+		}
+		return insertFn(dmp), nil
+	case om != nil && nm == nil:
+		// delete attributes in dbmask
+		dm := om.clone()
+		dmp, ok := dm.(*UserPasswordOverride)
+		if !ok {
+			return nil, fmt.Errorf("unexpected mapping override type %T: %v", dm, dm)
+		}
+		var mask []string
+		if mappingOverrideMask[usernameAttributeField] {
+			mask = append(mask, usernameAttributeField)
+			dmp.deleteUsernameAttribute()
+		}
+		if mappingOverrideMask[passwordAttributeField] {
+			mask = append(mask, passwordAttributeField)
+			dmp.deletePasswordAttribute()
+		}
+		if dmp.UsernameAttribute == noOverride && dmp.PasswordAttribute == noOverride {
+			return deleteFn(dmp), nil
+		}
+		return updateFn(dmp, mask), nil
+	case om != nil && nm != nil:
+		// delete or update
+		dm := om.clone()
+		dmp, ok := dm.(*UserPasswordOverride)
+		if !ok {
+			return nil, fmt.Errorf("unexpected mapping override type %T: %v", dm, dm)
+		}
+		nmp, ok := nm.(*UserPasswordOverride)
+		if !ok {
+			return nil, fmt.Errorf("unexpected mapping override type %T: %v", nm, nm)
+		}
+		var mask []string
+		if mappingOverrideMask[usernameAttributeField] {
+			mask = append(mask, usernameAttributeField)
+			switch nmp.UsernameAttribute {
+			case "":
+				dmp.deleteUsernameAttribute()
+			default:
+				dmp.setUsernameAttribute(nmp.UsernameAttribute)
+			}
+		}
+		if mappingOverrideMask[passwordAttributeField] {
+			mask = append(mask, passwordAttributeField)
+			switch nmp.PasswordAttribute {
+			case "":
+				dmp.deletePasswordAttribute()
+			default:
+				dmp.setPasswordAttribute(nmp.PasswordAttribute)
+			}
+		}
+		if dmp.UsernameAttribute == noOverride && dmp.PasswordAttribute == noOverride {
+			return deleteFn(dmp), nil
+		}
+		return updateFn(dmp, mask), nil
+	}
+	return noChange, nil
+}
+
+func noChange(_ context.Context, _ db.Writer) (*oplog.Message, error) {
+	return nil, nil
 }
 
 // LookupCredentialLibrary returns the CredentialLibrary for publicId.

--- a/internal/credential/vault/repository_credential_library.go
+++ b/internal/credential/vault/repository_credential_library.go
@@ -166,6 +166,12 @@ func (r *Repository) UpdateCredentialLibrary(ctx context.Context, scopeId string
 	)
 
 	if strutil.StrListContains(nullFields, httpMethodField) {
+		// GET is the default value for the HttpMethod field in
+		// CredentialLibrary. The http_method column in the database does
+		// not allow NULL values but it also does not define a default
+		// value. Therefore, if the httpMethodField is in nullFields:
+		// remove it from nullFields then add it to dbMask and set the
+		// value to GET.
 		dbMask = append(dbMask, httpMethodField)
 		nullFields = strutil.StrListDelete(nullFields, httpMethodField)
 		l.HttpMethod = string(MethodGet)

--- a/internal/db/schema/migrations/oss/postgres/10/04_vault_credential.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/10/04_vault_credential.up.sql
@@ -577,6 +577,7 @@ begin;
     'credential_vault_store_public is a view where each row contains a credential store. '
     'No encrypted data is returned. This view can be used to retrieve data which will be returned external to boundary.';
 
+-- Replaced in 21/05_vault_private_library.up.sql
      create view credential_vault_library_private as
      select library.public_id         as public_id,
             library.store_id          as store_id,

--- a/internal/db/schema/migrations/oss/postgres/22/05_vault_private_library.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/22/05_vault_private_library.up.sql
@@ -1,5 +1,6 @@
 begin;
 
+-- Replaces view from 10/04_vault_credential.up.sql
      drop view credential_vault_library_private;
 
      create view credential_vault_library_private as
@@ -44,5 +45,24 @@ begin;
   comment on view credential_vault_library_private is
     'credential_vault_library_private is a view where each row contains a credential library and the credential library''s data needed to connect to Vault. '
     'Each row may contain encrypted data. This view should not be used to retrieve data which will be returned external to boundary.';
+
+     create view credential_vault_library_public as
+     select public_id,
+            store_id,
+            name,
+            description,
+            create_time,
+            update_time,
+            version,
+            vault_path,
+            http_method,
+            http_request_body,
+            credential_type,
+            username_attribute,
+            password_attribute
+       from credential_vault_library_private;
+  comment on view credential_vault_library_public is
+    'credential_vault_library_public is a view where each row contains a credential library and any of library''s credential mapping overrides. '
+    'No encrypted data is returned. This view can be used to retrieve data which will be returned external to boundary.';
 
 commit;


### PR DESCRIPTION
An alternative implementation of #1760. This version allows individual fields of a credential mapping override to be updated. 