### PR TITLE
Create the network address dimension

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/22/01_wh_network_address_dimensions.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/22/01_wh_network_address_dimensions.up.sql
@@ -1,0 +1,34 @@
+begin;
+
+  -- wh_network_address_dimension contains the addresses and calculated values
+  -- about those addresses.
+  create table wh_network_address_dimension (
+    address                   wh_dim_text primary key,
+    address_type              wh_dim_text, --(IP Address, DNS Name, Unknown)
+    ip_address_family         wh_dim_text, -- (IPv4, IPv6, Not Applicable)
+    private_ip_address_status wh_dim_text, -- (Public, Private, Not Applicable)
+    dns_name                  wh_dim_text,
+    ip4_address               wh_dim_text,
+    ip6_address               wh_dim_text
+  );
+
+  -- wh_network_address_group is referenced by the wh_host_dimension to id
+  -- the group of addresses on a host at the time a session is created.
+  create table wh_network_address_group (
+    key wh_dim_key primary key default wh_dim_key()
+  );
+
+  -- wh_network_address_group_membership groups the addresses
+  create table wh_network_address_group_membership (
+    network_address_group_key wh_dim_key
+      references wh_network_address_group (key)
+        on delete restrict
+        on update cascade,
+    network_address wh_dim_text
+      references wh_network_address_dimension (address)
+        on delete restrict
+        on update cascade,
+    primary key(network_address_group_key, network_address)
+  );
+
+commit;

--- a/internal/db/schema/migrations/oss/postgres/22/02_wh_network_address_dimensions.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/22/02_wh_network_address_dimensions.up.sql
@@ -37,6 +37,14 @@ begin;
     ('Unsupported', 'Unknown', 'Not Applicable', 'Not Applicable', 'None', 'None', 'None'),
     ('Unknown', 'Unknown', 'Not Applicable', 'Not Applicable', 'None', 'None', 'None');
 
+  -- prepare a group which can be referenced by the newly created
+  -- wh_host_dimension column.
+  insert into wh_network_address_group(key)
+  values('Unknown'), ('Unsupported');
+  insert into wh_network_address_group_membership(network_address_group_key, network_address)
+  values('Unknown', 'Unknown'), ('Unsupported', 'Unsupported');
+
+
   -- Migrate all the ip addresses and ignore any addresses which aren't ip.
   with
   ip_addresses(address, inet_address) as (
@@ -84,5 +92,38 @@ begin;
   from wh_host_dimension as whd
   where
     whd.host_address not in (select address from wh_network_address_dimension);
+
+  -- Allow the host dimension to reference a group of addresses as referenced
+  -- above.
+  alter table wh_host_dimension
+    add column network_address_group_key wh_dim_key not null
+      default 'Unknown'
+      references wh_network_address_group(key)
+        on delete restrict
+        on update cascade;
+
+-- -- remove this default when the wh_host_dimension_source populates this
+-- -- column or else there will be a not null constraint violation.
+--   alter table wh_host_dimension
+--     alter column network_address_group_key drop default;
+
+  insert into wh_network_address_group (key)
+  select distinct
+    host_address
+  from wh_host_dimension
+  -- There should only be a conflict when adding a key for 'Unknown' since
+  -- that was added in a previous step of this migration.
+  on conflict do nothing;
+
+  insert into wh_network_address_group_membership(network_address_group_key, network_address)
+  select distinct
+  host_address, host_address
+  from wh_host_dimension
+  -- There should only be a conflict when adding a key for 'Unknown' or
+  -- 'Unsupported' since that was added above.
+  on conflict do nothing;
+
+  update wh_host_dimension
+  set network_address_group_key = host_address;
 
 commit;

--- a/internal/db/schema/migrations/oss/postgres/22/02_wh_network_address_dimensions.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/22/02_wh_network_address_dimensions.up.sql
@@ -1,0 +1,84 @@
+begin;
+
+  -- try_cast_inet returns either the provided text cast into inet or a null.
+  create function try_cast_inet(text)
+    returns inet
+  as $$
+  begin
+    return cast($1 as inet);
+  exception when others then
+    return null::inet;
+  end;
+  $$ language plpgsql;
+
+  -- wh_private_address_status returns a warehouse appropriate string
+  -- representing if the address is private, public, or not applicable for the
+  -- provided address.  An address which cannot be cast to an inet results in
+  -- 'Not Applicable' being returned.
+  create function wh_private_address_status(inet) returns text
+  as $$
+  begin
+    case
+      when $1 << any ('{10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12, fc00::/7, fe80::/10}'::cidr[]) then
+        return 'Private';
+      else
+        return 'Public';
+      end case;
+  end;
+  $$ language plpgsql;
+
+  insert into wh_network_address_dimension(
+    address, address_type, ip_address_family, private_ip_address_status,
+    dns_name, ip4_address, ip6_address
+  )
+  values
+    ('Unsupported', 'Unknown', 'Not Applicable', 'Not Applicable', 'None', 'None', 'None'),
+    ('Unknown', 'Unknown', 'Not Applicable', 'Not Applicable', 'None', 'None', 'None');
+
+  with
+  ip_addresses(address, inet_address) as (
+    select hd.host_address as address, try_cast_inet(hd.host_address) as inet_address
+    from wh_host_dimension as hd
+    where try_cast_inet(hd.host_address) is not null
+  )
+  insert into wh_network_address_dimension(
+    address, address_type, ip_address_family, private_ip_address_status,
+    dns_name, ip4_address, ip6_address
+  )
+  select
+    address,
+    'IP Address',
+    case
+      when family(inet_address) = 4 then 'IPv4'
+      when family(inet_address) = 6 then 'IPv6'
+      else 'Not Applicable'
+    end,
+    wh_private_address_status(inet_address),
+    'None',
+    case
+      when family(inet_address) = 4 then address
+      else 'None'
+    end,
+    case
+      when family(inet_address) = 6 then address
+      else 'None'
+    end
+  from ip_addresses;
+
+  insert into wh_network_address_dimension(
+    address, address_type, ip_address_family, private_ip_address_status,
+    dns_name, ip4_address, ip6_address
+  )
+  select
+    whd.host_address,
+    'DNS Name',
+    'Not Applicable',
+    'Not Applicable',
+    whd.host_address,
+    'None',
+    'None'
+  from wh_host_dimension as whd
+  where
+    whd.host_address not in (select address from wh_network_address_dimension);
+
+commit;

--- a/internal/db/schema/migrations/oss/postgres_22_02_test.go
+++ b/internal/db/schema/migrations/oss/postgres_22_02_test.go
@@ -1,0 +1,223 @@
+package oss_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/db/common"
+	"github.com/hashicorp/boundary/internal/db/schema"
+	"github.com/hashicorp/boundary/testing/dbtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrations_WareHouse_HostAddresses(t *testing.T) {
+	const (
+		priorMigration   = 21001
+		currentMigration = 22002
+	)
+
+	t.Parallel()
+	ctx := context.Background()
+	dialect := dbtest.Postgres
+
+	c, u, _, err := dbtest.StartUsingTemplate(dialect, dbtest.WithTemplate(dbtest.Template1))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, c())
+	})
+	d, err := common.SqlOpen(dialect, u)
+	require.NoError(t, err)
+
+	// migration to the prior migration (before the one we want to test)
+	m, err := schema.NewManager(ctx, schema.Dialect(dialect), d, schema.WithEditions(
+		schema.TestCreatePartialEditions(schema.Dialect(dialect), schema.PartialEditions{"oss": priorMigration}),
+	))
+	require.NoError(t, err)
+
+	require.NoError(t, m.ApplyMigrations(ctx))
+	state, err := m.CurrentState(ctx)
+	require.NoError(t, err)
+	want := &schema.State{
+		Initialized: true,
+		Editions: []schema.EditionState{
+			{
+				Name:                  "oss",
+				BinarySchemaVersion:   priorMigration,
+				DatabaseSchemaVersion: priorMigration,
+				DatabaseSchemaState:   schema.Equal,
+			},
+		},
+	}
+	require.Equal(t, want, state)
+
+	// get a connection
+	dbType, err := db.StringToDbType(dialect)
+	require.NoError(t, err)
+	conn, err := db.Open(dbType, u)
+	require.NoError(t, err)
+	rw := db.New(conn)
+
+	type whAddress struct {
+		Address string
+		AddressType string
+		IpAddressFamily string
+		PrivateIpAddressStatus string
+		DnsName string
+		Ip4Address string
+		Ip6Address string
+	}
+	addresses := []whAddress {
+		{
+			Address: "10.0.0.1",
+			AddressType: "IP Address",
+			IpAddressFamily: "IPv4",
+			PrivateIpAddressStatus: "Private",
+			DnsName: "None",
+			Ip4Address: "10.0.0.1",
+			Ip6Address: "None",
+		},
+		{
+			Address: "12.3.4.5",
+			AddressType: "IP Address",
+			IpAddressFamily: "IPv4",
+			PrivateIpAddressStatus: "Public",
+			DnsName: "None",
+			Ip4Address: "12.3.4.5",
+			Ip6Address: "None",
+		},
+		{
+			Address: "fe80::1234:5678:1234:5678",
+			AddressType: "IP Address",
+			IpAddressFamily: "IPv6",
+			PrivateIpAddressStatus: "Private",
+			DnsName: "None",
+			Ip4Address: "None",
+			Ip6Address: "fe80::1234:5678:1234:5678",
+		},
+		{
+			Address: "2001:4860:4860::8888",
+			AddressType: "IP Address",
+			IpAddressFamily: "IPv6",
+			PrivateIpAddressStatus: "Public",
+			DnsName: "None",
+			Ip4Address: "None",
+			Ip6Address: "2001:4860:4860::8888",
+		},
+		{
+			Address: "foo",
+			AddressType: "DNS Name",
+			IpAddressFamily: "Not Applicable",
+			PrivateIpAddressStatus: "Not Applicable",
+			DnsName: "foo",
+			Ip4Address: "None",
+			Ip6Address: "None",
+		},
+		{
+			Address: "something.com",
+			AddressType: "DNS Name",
+			IpAddressFamily: "Not Applicable",
+			PrivateIpAddressStatus: "Not Applicable",
+			DnsName: "something.com",
+			Ip4Address: "None",
+			Ip6Address: "None",
+		},
+		{
+			Address: "10.0.foo.com",
+			AddressType: "DNS Name",
+			IpAddressFamily: "Not Applicable",
+			PrivateIpAddressStatus: "Not Applicable",
+			DnsName: "10.0.foo.com",
+			Ip4Address: "None",
+			Ip6Address: "None",
+		},
+		{
+			Address: "not valid anything",
+			AddressType: "DNS Name",
+			IpAddressFamily: "Not Applicable",
+			PrivateIpAddressStatus: "Not Applicable",
+			DnsName: "not valid anything",
+			Ip4Address: "None",
+			Ip6Address: "None",
+		},
+		{
+			Address: "Unsupported",
+			AddressType: "Unknown",
+			IpAddressFamily: "Not Applicable",
+			PrivateIpAddressStatus: "Not Applicable",
+			DnsName: "None",
+			Ip4Address: "None",
+			Ip6Address: "None",
+		},
+		{
+			Address: "Unknown",
+			AddressType: "Unknown",
+			IpAddressFamily: "Not Applicable",
+			PrivateIpAddressStatus: "Not Applicable",
+			DnsName: "None",
+			Ip4Address: "None",
+			Ip6Address: "None",
+		},
+	}
+	{
+		q := `
+insert into wh_host_dimension
+(host_id, host_type, host_name, host_description, host_address,
+host_set_id, host_set_type, host_set_name, host_set_description,
+host_catalog_id, host_catalog_type, host_catalog_name, host_catalog_description,
+target_id, target_type, target_name, target_description, target_default_port_number,
+target_session_max_seconds, target_session_connection_limit,
+project_id, project_name, project_description,
+organization_id, organization_name, organization_description,
+current_row_indicator, row_effective_time, row_expiration_time)
+values
+('h_1234567890', 'static', 'None', 'None', ?,
+'hs_1234567890', 'static', 'None', 'None',
+'hc_1234567890', 'static', 'None', 'None',
+'t_1234567890', 'tcp', 'None', 'None', 0,
+30, 1,
+'p_1234567890', 'None', 'None',
+'o_1234567890', 'None', 'None',
+'Expired', current_timestamp, current_timestamp)
+`
+		for _, a := range addresses {
+			_, err := rw.Exec(ctx, q, []interface{}{a.Address})
+			require.NoError(t, err)
+		}
+	}
+
+	// now we're ready for the migration we want to test.
+	m, err = schema.NewManager(ctx, schema.Dialect(dialect), d, schema.WithEditions(
+		schema.TestCreatePartialEditions(schema.Dialect(dialect), schema.PartialEditions{"oss": currentMigration}),
+	))
+	require.NoError(t, err)
+
+	require.NoError(t, m.ApplyMigrations(ctx))
+	state, err = m.CurrentState(ctx)
+	require.NoError(t, err)
+	want = &schema.State{
+		Initialized: true,
+		Editions: []schema.EditionState{
+			{
+				Name:                  "oss",
+				BinarySchemaVersion:   currentMigration,
+				DatabaseSchemaVersion: currentMigration,
+				DatabaseSchemaState:   schema.Equal,
+			},
+		},
+	}
+	require.Equal(t, want, state)
+	// Now read all the converted rows and see if we have transformed and
+	// calculated the values as expected.
+	{
+		rows,err := rw.Query(ctx, "select * from wh_network_address_dimension", nil)
+		require.NoError(t, err)
+		var results []whAddress
+		for rows.Next() {
+			var addr whAddress
+			require.NoError(t, rw.ScanRows(rows, &addr))
+			results = append(results, addr)
+		}
+		require.ElementsMatch(t, results, addresses)
+	}
+}

--- a/internal/db/schema/migrations/oss/postgres_22_02_test.go
+++ b/internal/db/schema/migrations/oss/postgres_22_02_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/boundary/internal/db/common"
 	"github.com/hashicorp/boundary/internal/db/schema"
 	"github.com/hashicorp/boundary/testing/dbtest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -218,6 +219,6 @@ values
 			require.NoError(t, rw.ScanRows(rows, &addr))
 			results = append(results, addr)
 		}
-		require.ElementsMatch(t, results, addresses)
+		assert.ElementsMatch(t, results, addresses)
 	}
 }

--- a/internal/db/sqltest/tests/wh/network_address_dimension/helper_functions.sql
+++ b/internal/db/sqltest/tests/wh/network_address_dimension/helper_functions.sql
@@ -1,0 +1,21 @@
+-- Tests that the helper methods for network address dimension work as expected.
+begin;
+select plan(11);
+
+-- test wh_try_cast_inet
+select is(wh_try_cast_inet('127.0.0.1'), '127.0.0.1'::inet);
+select is(wh_try_cast_inet('fe80::1234:1234:1234:1234'), 'fe80::1234:1234:1234:1234'::inet);
+select is(wh_try_cast_inet('not.an.ip.address'), null::inet);
+select is(wh_try_cast_inet('not even a dns name'), null::inet);
+
+-- test wh_private_address_status
+select is(wh_private_address_status('10.0.0.1'::inet), 'Private');
+select is(wh_private_address_status('192.168.0.1'::inet), 'Private');
+select is(wh_private_address_status('172.16.0.1'::inet), 'Private');
+select is(wh_private_address_status('73.2.3.4'::inet), 'Public');
+select is(wh_private_address_status('2001:4860:4860::8888'::inet), 'Public');
+select is(wh_private_address_status('fe80::1234:5678:1234:5678'::inet), 'Private');
+select is(wh_private_address_status(null::inet), 'Public');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
This also migrates existing addresses into the new dimension.

Left TODO:
- [ ] Populate the wh_network_address_group and wh_network_address_group_membership tables
- [ ] drop the `host_address` column and add a reference to the wh_network_address_group in the wh_host_dimension table
- [ ] Populate the newly created reference to the wh_network_address_group