### PR TITLE
Add support for update/lookup to credential library API/SDK/CLI

### DIFF
--- a/internal/cmd/commands/credentiallibrariescmd/vault_funcs.go
+++ b/internal/cmd/commands/credentiallibrariescmd/vault_funcs.go
@@ -37,8 +37,13 @@ func extraVaultActionsFlagsMapFuncImpl() map[string][]string {
 			credentialTypeFlagName,
 			credentialMappingFlagName,
 		},
+		"update": {
+			pathFlagName,
+			httpMethodFlagName,
+			httpRequestBodyFlagName,
+			credentialMappingFlagName,
+		},
 	}
-	flags["update"] = flags["create"]
 	return flags
 }
 
@@ -122,7 +127,7 @@ func extraVaultFlagHandlingFuncImpl(c *VaultCommand, _ *base.FlagSets, opts *[]c
 		mappings := make(map[string]interface{}, len(c.flagCredentialMapping))
 		for _, mapping := range c.flagCredentialMapping {
 			switch {
-			case len(mapping.Keys) != 1 || mapping.Keys[0] == "":
+			case len(mapping.Keys) != 1 || mapping.Keys[0] == "" || mapping.Value == "":
 				// mapping override does not support key segments (e.g. 'x.y=z')
 				c.UI.Error("Credential mapping override must be in the format 'key=value', 'key=null' to clear field or 'null' to clear all.")
 				return false

--- a/internal/credential/vault/fields.go
+++ b/internal/credential/vault/fields.go
@@ -18,5 +18,7 @@ const (
 	tlsSkipVerifyField  = "TlsSkipVerify"
 	tokenField          = "Token"
 
-	mappingOverrideField = "MappingOverride"
+	// MappingOverrideField represents the field mask indicating a mapping override
+	// update has been requested.
+	MappingOverrideField = "MappingOverride"
 )

--- a/internal/credential/vault/repository_credential_library.go
+++ b/internal/credential/vault/repository_credential_library.go
@@ -149,7 +149,7 @@ func (r *Repository) UpdateCredentialLibrary(ctx context.Context, scopeId string
 		case strings.EqualFold(vaultPathField, f):
 		case strings.EqualFold(httpMethodField, f):
 		case strings.EqualFold(httpRequestBodyField, f):
-		case strings.EqualFold(mappingOverrideField, f):
+		case strings.EqualFold(MappingOverrideField, f):
 			updateMappingOverride = true
 		default:
 			return nil, db.NoRowsAffected, errors.New(ctx, errors.InvalidFieldMask, op, f)
@@ -163,7 +163,7 @@ func (r *Repository) UpdateCredentialLibrary(ctx context.Context, scopeId string
 			vaultPathField:       l.VaultPath,
 			httpMethodField:      l.HttpMethod,
 			httpRequestBodyField: l.HttpRequestBody,
-			mappingOverrideField: l.MappingOverride,
+			MappingOverrideField: l.MappingOverride,
 		},
 		fieldMaskPaths,
 		nil,
@@ -198,14 +198,14 @@ func (r *Repository) UpdateCredentialLibrary(ctx context.Context, scopeId string
 	var filteredDbMask, filteredNullFields []string
 	for _, f := range dbMask {
 		switch {
-		case strings.EqualFold(mappingOverrideField, f):
+		case strings.EqualFold(MappingOverrideField, f):
 		default:
 			filteredDbMask = append(filteredDbMask, f)
 		}
 	}
 	for _, f := range nullFields {
 		switch {
-		case strings.EqualFold(mappingOverrideField, f):
+		case strings.EqualFold(MappingOverrideField, f):
 		default:
 			filteredNullFields = append(filteredNullFields, f)
 		}

--- a/internal/credential/vault/setup_manual_test.go
+++ b/internal/credential/vault/setup_manual_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/hashicorp/boundary/internal/servers/worker"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
+
+	_ "github.com/hashicorp/boundary/internal/servers/controller/handlers/targets/tcp"
 )
 
 func TestSetupSleepyDevEnvironment(t *testing.T) {


### PR DESCRIPTION
Some results from manual testing:

Updating from nothing to a user and password mapping:
```
boundary credential-libraries update vault -addr  "http://127.0.0.1:40783" -id clvlt_sy0SWemkbS -credential-mapping-override username_attribute=user -credential-mapping-override password_attribute=pass

Credential Library information:
  Created Time:          Wed, 08 Dec 2021 18:00:04 PST
  Credential Store ID:   csvlt_jnEvaiatyw
  ID:                    clvlt_sy0SWemkbS
  Type:                  vault
  Updated Time:          Wed, 08 Dec 2021 18:00:43 PST
  Version:               2

  Scope:
    ID:                  p_1234567890
    Name:                Generated project scope
    Parent Scope ID:     o_1234567890
    Type:                project

  Authorized Actions:
    no-op
    read
    update
    delete

  Attributes:
    HTTP Method:         GET
    Path:                no

  Credential Type:
    user_password
  Credential Mapping Overrides:
    password_attribute:  pass
    username_attribute:  user
```

Clearing the password mapping and changing the user mapping:
```
boundary credential-libraries update vault -addr  "http://127.0.0.1:40783" -id clvlt_sy0SWemkbS -credential-mapping-override username_attribute=user-new -credential-mapping-override password_attribute=null

Credential Library information:
  Created Time:          Wed, 08 Dec 2021 18:00:04 PST
  Credential Store ID:   csvlt_jnEvaiatyw
  ID:                    clvlt_sy0SWemkbS
  Type:                  vault
  Updated Time:          Wed, 08 Dec 2021 18:00:53 PST
  Version:               3

  Scope:
    ID:                  p_1234567890
    Name:                Generated project scope
    Parent Scope ID:     o_1234567890
    Type:                project

  Authorized Actions:
    no-op
    read
    update
    delete

  Attributes:
    HTTP Method:         GET
    Path:                no

  Credential Type:
    user_password
  Credential Mapping Overrides:
    username_attribute:  user-new
```

Just updating the password mapping:
```
boundary credential-libraries update vault -addr  "http://127.0.0.1:40783" -id clvlt_sy0SWemkbS -credential-mapping-override password_attribute=pass-new

Credential Library information:
  Created Time:          Wed, 08 Dec 2021 18:00:04 PST
  Credential Store ID:   csvlt_jnEvaiatyw
  ID:                    clvlt_sy0SWemkbS
  Type:                  vault
  Updated Time:          Wed, 08 Dec 2021 18:01:06 PST
  Version:               4

  Scope:
    ID:                  p_1234567890
    Name:                Generated project scope
    Parent Scope ID:     o_1234567890
    Type:                project

  Authorized Actions:
    no-op
    read
    update
    delete

  Attributes:
    HTTP Method:         GET
    Path:                no

  Credential Type:
    user_password
  Credential Mapping Overrides:
    password_attribute:  pass-new
    username_attribute:  user-new
```

Clearing all mappings:
```
boundary credential-libraries update vault -addr  "http://127.0.0.1:40783" -id clvlt_sy0SWemkbS -credential-mapping-override null

Credential Library information:
  Created Time:          Wed, 08 Dec 2021 18:00:04 PST
  Credential Store ID:   csvlt_jnEvaiatyw
  ID:                    clvlt_sy0SWemkbS
  Type:                  vault
  Updated Time:          Wed, 08 Dec 2021 18:01:21 PST
  Version:               5

  Scope:
    ID:                  p_1234567890
    Name:                Generated project scope
    Parent Scope ID:     o_1234567890
    Type:                project

  Authorized Actions:
    no-op
    read
    update
    delete

  Attributes:
    HTTP Method:         GET
    Path:                no

  Credential Type:
    user_password

```