### PR TITLE
feat(config): Env/file support for Worker description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### New and Improved
 
+* config: The `description` field for workers now supports being set
+  from environment variables or a file on disk
+  ([PR](https://github.com/hashicorp/boundary/pull/1783))
 * config: The `max_open_connections` field for the database field in controllers now supports being set
   from environment variables or a file on disk
   ([PR](https://github.com/hashicorp/boundary/pull/1776))

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -376,6 +376,14 @@ func Parse(d string) (*Config, error) {
 			return nil, errors.New("Worker name contains non-printable characters")
 		}
 
+		result.Worker.Description, err = parseutil.ParsePath(result.Worker.Description)
+		if err != nil && !errors.Is(err, parseutil.ErrNotAUrl) {
+			return nil, fmt.Errorf("Error parsing worker description: %w", err)
+		}
+		if !strutil.Printable(result.Worker.Description) {
+			return nil, errors.New("Worker description contains non-printable characters")
+		}
+
 		if result.Worker.TagsRaw != nil {
 			switch t := result.Worker.TagsRaw.(type) {
 			// We allow `tags` to be a simple string containing a URL with schema.

--- a/website/content/docs/configuration/worker.mdx
+++ b/website/content/docs/configuration/worker.mdx
@@ -23,6 +23,9 @@ worker {
   the name will be read.
 
 - `description` - Specifies a friendly description of this worker.
+  This value can be a direct description string, can refer to a file on disk
+  (file://) from which a description will be read; or an env var (env://) from
+  which the description will be read.
 
 - `public_addr` - Specifies the public host or IP address (and optionally port)
   at which the worker can be reached _by clients for proxying_. This defaults to


### PR DESCRIPTION
Mostly for completeness and consistency, since the Controller description already supports it.