### PR TITLE
Update AWS host provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   ([PR](https://github.com/hashicorp/boundary/pull/1736))
 * controllers/workers: Add client IP to inbound request information which is included in
   Boundary events ([PR](https://github.com/hashicorp/boundary/pull/1678))
-* plugins/aws: AWS host sets will now return DNS hosts in addition to IP
-  addresses.
+* plugins/aws: AWS plugin based hosts now include DNS names in addition to the
+  IP addresses they already provide.
 
 ## 0.7.1 (2021/11/18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   ([PR](https://github.com/hashicorp/boundary/pull/1736))
 * controllers/workers: Add client IP to inbound request information which is included in
   Boundary events ([PR](https://github.com/hashicorp/boundary/pull/1678))
+* plugins/aws: AWS host sets will now return DNS hosts in addition to IP
+  addresses.
 
 ## 0.7.1 (2021/11/18)
 

--- a/plugins/host/mains/aws/go.mod
+++ b/plugins/host/mains/aws/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/boundary/plugins/host/mains/aws
 go 1.17
 
 require (
-	github.com/hashicorp/boundary-plugin-host-aws v0.0.0-20211113004817-756bc0960a0c
+	github.com/hashicorp/boundary-plugin-host-aws v0.0.0-20211206232153-e565bad02701
 	github.com/hashicorp/boundary/sdk v0.0.12-0.20211112235128-46a1edcb3b7b
 	github.com/hashicorp/go-hclog v1.0.0
 )

--- a/plugins/host/mains/aws/go.sum
+++ b/plugins/host/mains/aws/go.sum
@@ -257,8 +257,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/hashicorp/boundary-plugin-host-aws v0.0.0-20211113004817-756bc0960a0c h1:1Njxoz/qW+AiSDEp299IMdzlvrBZ8fCDCgt5Bbd4X3Q=
-github.com/hashicorp/boundary-plugin-host-aws v0.0.0-20211113004817-756bc0960a0c/go.mod h1:5sbsaBwfSDftXIXLpwU0LvPlhqkXWUFsZn4obxz5Hj8=
+github.com/hashicorp/boundary-plugin-host-aws v0.0.0-20211206232153-e565bad02701 h1:u7uhXKouEi2Do2645NBCOxzqWyUNXPGxebDAKeWaygM=
+github.com/hashicorp/boundary-plugin-host-aws v0.0.0-20211206232153-e565bad02701/go.mod h1:5sbsaBwfSDftXIXLpwU0LvPlhqkXWUFsZn4obxz5Hj8=
 github.com/hashicorp/boundary/sdk v0.0.12-0.20211112235128-46a1edcb3b7b h1:qURjJaF3/TUbDcPCUAg9PG9a95NCgPrrcrOsurBJ7Rc=
 github.com/hashicorp/boundary/sdk v0.0.12-0.20211112235128-46a1edcb3b7b/go.mod h1:Krt7KLGTnDPQTaVlgSygV5SeqWDrOfbYyVBmB0KILD4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
This updates the AWS host provider to include https://github.com/hashicorp/boundary-plugin-host-aws/pull/7.