### PR TITLE
bug(credential): Fix panic in credential Issue

### DIFF
--- a/internal/credential/vault/private_library.go
+++ b/internal/credential/vault/private_library.go
@@ -262,6 +262,9 @@ func (pl *privateLibrary) retrieveCredential(ctx context.Context, op errors.Op, 
 		// expired or invalid token
 		return nil, errors.Wrap(ctx, err, op)
 	}
+	if secret == nil {
+		return nil, errors.E(ctx, errors.WithCode(errors.VaultEmptySecret), errors.WithOp(op))
+	}
 
 	leaseDuration := time.Duration(secret.LeaseDuration) * time.Second
 	cred, err := newCredential(pl.GetPublicId(), sessionId, secret.LeaseID, pl.TokenHmac, leaseDuration)

--- a/internal/errors/code.go
+++ b/internal/errors/code.go
@@ -109,6 +109,7 @@ const (
 	VaultCredentialRequest        Code = 3014 // VaultCredentialRequest represents an error returned from Vault when retrieving a credential
 	VaultInvalidMappingOverride   Code = 3015 // VaultInvalidMappingOverride represents an error returned when a credential mapping is unknown or does not match a credential type
 	VaultInvalidCredentialMapping Code = 3016 // VaultInvalidCredentialMapping represents an error returned when a Vault secret failed to be mapped to a specific credential type
+	VaultEmptySecret              Code = 3017 // VaultEmptySecret represents a empty secret was returned from Vault without error
 
 	// OIDC authentication provided errors
 	OidcProviderCallbackError Code = 4000 // OidcProviderCallbackError represents an error that is passed by the OIDC provider to the callback endpoint

--- a/internal/errors/code_test.go
+++ b/internal/errors/code_test.go
@@ -293,6 +293,11 @@ func TestCode_Both_String_Info(t *testing.T) {
 			want: VaultInvalidCredentialMapping,
 		},
 		{
+			name: "VaultEmptySecret",
+			c:    VaultEmptySecret,
+			want: VaultEmptySecret,
+		},
+		{
 			name: "OidcProviderCallbackError",
 			c:    OidcProviderCallbackError,
 			want: OidcProviderCallbackError,

--- a/internal/errors/info.go
+++ b/internal/errors/info.go
@@ -236,6 +236,10 @@ var errorCodeInfo = map[Code]Info{
 		Message: "mapping vault secret to a credential type failed",
 		Kind:    Integrity,
 	},
+	VaultEmptySecret: {
+		Message: "vault secret is empty",
+		Kind:    Integrity,
+	},
 	OidcProviderCallbackError: {
 		Message: "oidc provider callback error",
 		Kind:    External,


### PR DESCRIPTION
Vault KV backend returns a nil secret and no error if the secret does not
exist. This caused a panic in during Issue:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xf68eae]

panic({0x1823340, 0x4028a00})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/hashicorp/boundary/internal/credential/vault.(*privateLibrary).retrieveCredential(0xc0009a0960, {0x3276ea0, 0xc0001b8000}, {0x1adb341, 0x18}, {0xc000560110, 0xc})
	/home/louis/boundary/internal/credential/vault/private_library.go:266 +0x12e
github.com/hashicorp/boundary/internal/credential/vault.(*Repository).Issue(0xc000713440, {0x3276ea0, 0xc0001b8000}, {0xc000560110, 0xc}, {0xc000de8ba0, 0xc00069aed0, 0xf})
	/home/louis/boundary/internal/credential/vault/repository_credentials.go:37 +0x245