### PR TITLE
feat(server): Add grpc_middleware recovery interceptor

### DIFF
--- a/internal/servers/controller/gateway.go
+++ b/internal/servers/controller/gateway.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/db"
@@ -77,6 +78,9 @@ func newGatewayServer(
 				errorInterceptor(ctx),         // convert domain and api errors into headers for the http proxy
 				statusCodeInterceptor(ctx),    // convert grpc codes into http status codes for the http proxy (can modify the resp)
 				auditResponseInterceptor(ctx), // as we finish, audit the response
+				grpc_recovery.UnaryServerInterceptor( // recover from panics with a grpc internal error
+					grpc_recovery.WithRecoveryHandlerContext(recoveryHandler()),
+				),
 			),
 		),
 	), ticket, nil

--- a/internal/servers/controller/interceptor.go
+++ b/internal/servers/controller/interceptor.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"runtime/debug"
 
+	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	"github.com/hashicorp/boundary/internal/errors"
 	pb "github.com/hashicorp/boundary/internal/gen/controller/api"
 	authpb "github.com/hashicorp/boundary/internal/gen/controller/auth"
@@ -17,9 +19,7 @@ import (
 	"github.com/hashicorp/boundary/internal/servers/controller/auth"
 	"github.com/hashicorp/boundary/internal/servers/controller/common"
 	"github.com/hashicorp/boundary/internal/servers/controller/handlers"
-
 	"github.com/mr-tron/base58"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -304,4 +304,18 @@ func workerRequestInfoInterceptor(ctx context.Context, eventer *event.Eventer) (
 		// call the handler...
 		return handler(interceptorCtx, req)
 	}, nil
+}
+
+func recoveryHandler() grpc_recovery.RecoveryHandlerFuncContext {
+	const op = "controller.recoveryHandler"
+	return func(ctx context.Context, p interface{}) (err error) {
+		event.WriteError(
+			ctx,
+			op,
+			fmt.Errorf("recovered from panic: %v", p),
+			event.WithInfo("stack", string(debug.Stack())),
+		)
+
+		return status.Errorf(codes.Internal, "%v", p)
+	}
 }


### PR DESCRIPTION
I added some panic causing code in target list:
```
func (s Service) ListTargets(ctx context.Context, req *pbs.ListTargetsRequest) (*pbs.ListTargetsResponse, error) {
	var myMap map[string]interface{}
	myMap["Louis"] = "hello"
        .....
```

Running list with the grpc_recovery:
```
boundary targets list -scope-id p_1234567890
Error from controller when performing list on targets

Error information:
  Kind:                Internal
  Message:             rpc error: code = Internal desc = assignment to entry in nil map
  Status:              500
  context:             Error from controller when performing list on targets
```

In server logs:
```
{
  "id": "KpfKq6ZnIw",
  "source": "https://hashicorp.com/boundary/dev-controller/boundary-dev",
  "specversion": "1.0",
  "type": "error",
  "data": {
    "error": "rpc error: code = Internal desc = assignment to entry in nil map",
    "error_fields": {},
    "id": "e_k9A0K1mzIJ",
    "version": "v0.1",
    "op": "handlers.ErrorHandler",
    "request_info": {
      "id": "gtraceid_V4iL5rqs7CYDPVJchN6s",
      "method": "GET",
      "path": "/v1/targets?scope_id=p_1234567890",
      "public_id": "at_grC7nXbpfV",
      "client_ip": "127.0.0.1"
    },
    "info": {
      "msg": "internal error returned"
    }
  },
  "datacontentype": "text/plain",
  "time": "2021-12-16T15:16:27.5506802-08:00"
}
```

Running list without the grpc_recovery:
```
boundary targets list -scope-id p_1234567890
Error trying to list targets: error performing client request during List call: Get "http://127.0.0.1:9200/v1/targets?scope_id=p_1234567890": EOF
```

And server panics:
```
panic: assignment to entry in nil map

goroutine 1689 [running]:
github.com/hashicorp/boundary/internal/servers/controller/handlers/targets.Service.ListTargets({{}, 0xc000d96b28, 0xc000d96a68, 0xc000d96af8, 0xc000d96b40, 0xc000d96a98, 0xc000d96a80, 0xc000d96ae0, 0xc0007fa780}, {0x3b93330, ...}, ...)
        /home/louis/boundary/internal/servers/controller/handlers/targets/target_service.go:142 +0x8b
github.com/hashicorp/boundary/internal/gen/controller/api/services._TargetService_ListTargets_Handler.func1({0x3b93330, 0xc000e5efc0}, {0x19c8d80, 0xc00061bae0})
        /home/louis/boundary/internal/gen/controller/api/services/target_service_grpc.pb.go:559 +0x78
github.com/hashicorp/boundary/internal/servers/controller.auditResponseInterceptor.func1({0x3b93330, 0xc000e5efc0}, {0x19c8d80, 0xc00061bae0}, 0xc000c8a7d0, 0x40a51d)
        /home/louis/boundary/internal/servers/controller/interceptor.go:262 +0x4e
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x3b93330, 0xc000e5efc0}, {0x19c8d80, 0xc00061bae0})
        /home/louis/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3a
github.com/hashicorp/boundary/internal/servers/controller.statusCodeInterceptor.func1({0x3b93330, 0xc000e5efc0}, {0x19c8d80, 0xc00061bae0}, 0x203000, 0x203000)
        /home/louis/boundary/internal/servers/controller/interceptor.go:207 +0x34
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x3b93330, 0xc000e5efc0}, {0x19c8d80, 0xc00061bae0})
        /home/louis/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3a
github.com/hashicorp/boundary/internal/servers/controller.errorInterceptor.func1({0x3b93330, 0xc000e5efc0}, {0x19c8d80, 0xc00061bae0}, 0x18e2b60, 0x0)
        /home/louis/boundary/internal/servers/controller/interceptor.go:156 +0x4e
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x3b93330, 0xc000e5efc0}, {0x19c8d80, 0xc00061bae0})
        /home/louis/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3a
github.com/hashicorp/boundary/internal/servers/controller.auditRequestInterceptor.func1({0x3b93330, 0xc000e5efc0}, {0x19c8d80, 0xc00061bae0}, 0x1a1c7a0, 0xc000e86e60)
        /home/louis/boundary/internal/servers/controller/interceptor.go:248 +0x198
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x3b93330, 0xc000e5efc0}, {0x19c8d80, 0xc00061bae0})
        /home/louis/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3a
github.com/hashicorp/boundary/internal/servers/controller.requestCtxInterceptor.func1({0x3b93330, 0xc000e5eed0}, {0x19c8d80, 0xc00061bae0}, 0x18, 0xc000e86e80)
        /home/louis/boundary/internal/servers/controller/interceptor.go:140 +0x5de
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x3b93330, 0xc000e5eed0}, {0x19c8d80, 0xc00061bae0})
        /home/louis/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3a
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1({0x3b93330, 0xc000e5eed0}, {0x19c8d80, 0xc00061bae0}, 0xc000c8abb8, 0x1867600)
        /home/louis/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:34 +0xbf
github.com/hashicorp/boundary/internal/gen/controller/api/services._TargetService_ListTargets_Handler({0x1ada460, 0xc000594bc0}, {0x3b93330, 0xc000e5eed0}, 0xc000e09080, 0xc000661020)
        /home/louis/boundary/internal/gen/controller/api/services/target_service_grpc.pb.go:561 +0x138
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000d1fc00, {0x3bb4cb8, 0xc000ed6180}, 0xc000d93680, 0xc000accea0, 0x499e258, 0x0)
        /home/louis/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:1297 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc000d1fc00, {0x3bb4cb8, 0xc000ed6180}, 0xc000d93680, 0x0)
        /home/louis/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:1626 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        /home/louis/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:941 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /home/louis/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:939 +0x294
```