### PR TITLE
fix(cli): Remove duplication of target host sources

### DIFF
--- a/internal/cmd/commands/targetscmd/funcs.go
+++ b/internal/cmd/commands/targetscmd/funcs.go
@@ -676,41 +676,31 @@ func printItemTable(result api.GenericResult) string {
 	maxLength := base.MaxAttributesLength(nonAttributeMap, item.Attributes, keySubstMap)
 
 	var hostSourceMaps []map[string]interface{}
-	// used as a key to ensure there are no repeat printed values among HostSources and HostSets
-	type setInfo struct {
-		id            interface{}
-		hostCatalogID interface{}
-	}
-	hostSourceInfo := make(map[setInfo]map[string]interface{})
-	if len(item.HostSources) > 0 {
+	switch {
+	case len(item.HostSources) > 0:
 		for _, set := range item.HostSources {
 			m := map[string]interface{}{
 				"ID":              set.Id,
 				"Host Catalog ID": set.HostCatalogId,
 			}
-			k := setInfo{set.Id, set.HostCatalogId}
-			hostSourceInfo[k] = m
+			hostSourceMaps = append(hostSourceMaps, m)
 		}
 		if l := len("Host Catalog ID"); l > maxLength {
 			maxLength = l
 		}
-	}
-	if len(item.HostSets) > 0 {
+	case len(item.HostSets) > 0:
 		for _, set := range item.HostSets {
 			m := map[string]interface{}{
 				"ID":              set.Id,
 				"Host Catalog ID": set.HostCatalogId,
 			}
-			k := setInfo{set.Id, set.HostCatalogId}
-			hostSourceInfo[k] = m
+			hostSourceMaps = append(hostSourceMaps, m)			
 		}
 		if l := len("Host Catalog ID"); l > maxLength {
 			maxLength = l
 		}
 	}
-	for _, m := range hostSourceInfo {
-		hostSourceMaps = append(hostSourceMaps, m)
-	}
+
 
 	var credentialSourceMaps map[credential.Purpose][]map[string]interface{}
 	if len(item.ApplicationCredentialSources) > 0 {

--- a/internal/cmd/commands/targetscmd/funcs.go
+++ b/internal/cmd/commands/targetscmd/funcs.go
@@ -690,7 +690,6 @@ func printItemTable(result api.GenericResult) string {
 			}
 			k := setInfo{set.Id, set.HostCatalogId}
 			hostSourceInfo[k] = m
-			//hostSourceMaps = append(hostSourceMaps, m)
 		}
 		if l := len("Host Catalog ID"); l > maxLength {
 			maxLength = l
@@ -704,13 +703,11 @@ func printItemTable(result api.GenericResult) string {
 			}
 			k := setInfo{set.Id, set.HostCatalogId}
 			hostSourceInfo[k] = m
-			//hostSourceMaps = append(hostSourceMaps, m)
 		}
 		if l := len("Host Catalog ID"); l > maxLength {
 			maxLength = l
 		}
 	}
-	fmt.Println(hostSourceInfo)
 	for _, m := range hostSourceInfo {
 		hostSourceMaps = append(hostSourceMaps, m)
 	}

--- a/internal/cmd/commands/targetscmd/funcs.go
+++ b/internal/cmd/commands/targetscmd/funcs.go
@@ -694,13 +694,12 @@ func printItemTable(result api.GenericResult) string {
 				"ID":              set.Id,
 				"Host Catalog ID": set.HostCatalogId,
 			}
-			hostSourceMaps = append(hostSourceMaps, m)			
+			hostSourceMaps = append(hostSourceMaps, m)
 		}
 		if l := len("Host Catalog ID"); l > maxLength {
 			maxLength = l
 		}
 	}
-
 
 	var credentialSourceMaps map[credential.Purpose][]map[string]interface{}
 	if len(item.ApplicationCredentialSources) > 0 {

--- a/internal/cmd/commands/targetscmd/funcs.go
+++ b/internal/cmd/commands/targetscmd/funcs.go
@@ -676,13 +676,21 @@ func printItemTable(result api.GenericResult) string {
 	maxLength := base.MaxAttributesLength(nonAttributeMap, item.Attributes, keySubstMap)
 
 	var hostSourceMaps []map[string]interface{}
+	// used as a key to ensure there are no repeat printed values among HostSources and HostSets
+	type setInfo struct {
+		id            interface{}
+		hostCatalogID interface{}
+	}
+	hostSourceInfo := make(map[setInfo]map[string]interface{})
 	if len(item.HostSources) > 0 {
 		for _, set := range item.HostSources {
 			m := map[string]interface{}{
 				"ID":              set.Id,
 				"Host Catalog ID": set.HostCatalogId,
 			}
-			hostSourceMaps = append(hostSourceMaps, m)
+			k := setInfo{set.Id, set.HostCatalogId}
+			hostSourceInfo[k] = m
+			//hostSourceMaps = append(hostSourceMaps, m)
 		}
 		if l := len("Host Catalog ID"); l > maxLength {
 			maxLength = l
@@ -694,11 +702,17 @@ func printItemTable(result api.GenericResult) string {
 				"ID":              set.Id,
 				"Host Catalog ID": set.HostCatalogId,
 			}
-			hostSourceMaps = append(hostSourceMaps, m)
+			k := setInfo{set.Id, set.HostCatalogId}
+			hostSourceInfo[k] = m
+			//hostSourceMaps = append(hostSourceMaps, m)
 		}
 		if l := len("Host Catalog ID"); l > maxLength {
 			maxLength = l
 		}
+	}
+	fmt.Println(hostSourceInfo)
+	for _, m := range hostSourceInfo {
+		hostSourceMaps = append(hostSourceMaps, m)
 	}
 
 	var credentialSourceMaps map[credential.Purpose][]map[string]interface{}


### PR DESCRIPTION
Before this fix, calling `boundary targets read -id ttcp_1234567890` in the boundary dev environment would produce duplicate Host Catalog ID and ID values in the Host Sources section. Now, the same output should look like the sample below:

Target information:
  Created Time:               Fri, 17 Dec 2021 19:05:14 PST
  Description:                Provides an initial target in Boundary
  ID:                         ttcp_1234567890
  Name:                       Generated target
  Session Connection Limit:   -1
  Session Max Seconds:        28800
  Type:                       tcp
  Updated Time:               Fri, 17 Dec 2021 19:05:14 PST
  Version:                    2

  Scope:
    ID:                       p_1234567890
    Name:                     Generated project scope
    Parent Scope ID:          o_1234567890
    Type:                     project

  Authorized Actions:
    no-op
    read
    update
    delete
    add-host-sets
    set-host-sets
    remove-host-sets
    add-credential-libraries
    set-credential-libraries
    remove-credential-libraries
    add-credential-sources
    set-credential-sources
    remove-credential-sources
    authorize-session

  Host Sources:
    Host Catalog ID:          hcst_1234567890
    ID:                       hsst_1234567890

  Attributes:
    Default Port:             22