### PR TITLE
Replace XC_OSARCH with GOOS and GOARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,8 @@ docker-multiarch-build:
 
 .PHONY: docker-build-dev
 # builds from locally generated binary in bin/
-docker-build-dev: export XC_OSARCH=linux/amd64
+docker-build-dev: export GOOS=linux
+docker-build-dev: export GOARCH=amd64
 docker-build-dev: dev
 	cp -r bin docker/
 	docker build -t $(IMAGE_TAG_DEV) \

--- a/website/content/docs/developing/building.mdx
+++ b/website/content/docs/developing/building.mdx
@@ -27,8 +27,8 @@ binary to somewhere in your `$PATH` such as `/usr/local/bin`.
 
 ## Cross Platform Build
 
-If you need to cross compile boundary for another OS or architecture, use the [XC_OSARCH](https://github.com/hashicorp/boundary/blob/master/scripts/build.sh#L26)
-environment variable to set this. Example: `$ XC_OSARCH=linux/amd64 make dev`
+If you need to cross compile boundary for another OS or architecture, use the [GOOS and GOARCH](https://github.com/hashicorp/boundary/blob/master/scripts/build.sh#L26)
+environment variable to set this. Example: `$ GOOS=linux GOARCH=amd64 make dev`
 
 For more details, please consult the [Boundary project on GitHub](https://github.com/hashicorp/boundary#build-and-start-boundary-in-dev-mode).
 


### PR DESCRIPTION
This replaces any remaining references to XC_OSARCH with GOOS and GOARCH
since the build script was updated to use the latter.