### PR TITLE
bug(connect): Fix Session has expired messaging

### DIFF
--- a/internal/cmd/commands/connect/connect.go
+++ b/internal/cmd/commands/connect/connect.go
@@ -626,13 +626,13 @@ func (c *Command) Run(args []string) (retCode int) {
 	case <-c.Context.Done():
 		termInfo.Reason = "Received shutdown signal"
 		sendSessionCancel = true
-	case <-timer.C:
-		termInfo.Reason = "Session has expired"
 	default:
 		if c.execCmdReturnValue != nil {
 			// Don't print out in this case, so ensure we clear it
 			termInfo.Reason = ""
 			sendSessionCancel = true
+		} else if !timer.Stop() {
+			termInfo.Reason = "Session has expired"
 		} else {
 			if c.connectionsLeft.Load() == 0 {
 				termInfo.Reason = "No connections left in session"


### PR DESCRIPTION
Sessions that time out were printing the message `"No connections left in session"` instead of `"Session has expired"`

termInfo.Reason was using a select on <-timer.C, which will never receive a value if the session has timed out; changing to use `!timer.Stop()` to detect if the timer has already finished.

Fixes #1817