### PR TITLE
feat(host): Add host set information to static host

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/25/01_static_host_view.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/25/01_static_host_view.up.sql
@@ -1,0 +1,24 @@
+begin;
+
+-- static_host_with_set_memberships is used for associating a static host instance with all its related host sets
+-- in the set_ids column. Currently there are no size limits.
+create view static_host_with_set_memberships as
+select
+  h.public_id,
+  h.create_time,
+  h.update_time,
+  h.name,
+  h.description,
+  h.catalog_id,
+  h.address,
+  h.version,
+  -- the string_agg(..) column will be null if there are no associated value objects
+  string_agg(distinct hsm.set_id, '|') as set_ids
+from
+  static_host h
+    left outer join static_host_set_member hsm on h.public_id = hsm.host_id
+group by h.public_id;
+comment on view static_host_with_set_memberships is
+  'static host with its associated host sets';
+
+commit;

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -22,4 +22,5 @@ type Host interface {
 	GetAddress() string
 	GetIpAddresses() []string
 	GetDnsNames() []string
+	GetSetIds() []string
 }

--- a/internal/host/plugin/host.go
+++ b/internal/host/plugin/host.go
@@ -104,6 +104,11 @@ func (h *Host) oplog(op oplog.OpType) oplog.Metadata {
 	return metadata
 }
 
+// GetSetIds returns host set ids
+func (h *Host) GetSetIds() []string {
+	return h.SetIds
+}
+
 // hostAgg is a view that aggregates the host's value objects in to
 // string fields delimited with the aggregateDelimiter of "|"
 type hostAgg struct {
@@ -158,6 +163,7 @@ func (agg *hostAgg) TableName() string {
 	return "host_plugin_host_with_value_obj_and_set_memberships"
 }
 
+// GetPublicId returns the host public id as a string
 func (agg *hostAgg) GetPublicId() string {
 	return agg.PublicId
 }

--- a/internal/host/static/host.go
+++ b/internal/host/static/host.go
@@ -1,6 +1,10 @@
 package static
 
 import (
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/boundary/internal/db/timestamp"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/host/static/store"
 	"github.com/hashicorp/boundary/internal/oplog"
@@ -15,7 +19,8 @@ const (
 // A Host contains a static address.
 type Host struct {
 	*store.Host
-	tableName string `gorm:"-"`
+	SetIds    []string `gorm:"-"`
+	tableName string   `gorm:"-"`
 }
 
 // NewHost creates a new in memory Host for address assigned to catalogId.
@@ -70,9 +75,18 @@ func allocHost() *Host {
 
 func (h *Host) clone() *Host {
 	cp := proto.Clone(h.Host)
-	return &Host{
+	nh := &Host{
 		Host: cp.(*store.Host),
 	}
+	switch {
+	case h.SetIds == nil:
+	case len(h.SetIds) == 0:
+		nh.SetIds = make([]string, 0)
+	default:
+		nh.SetIds = make([]string, len(h.SetIds))
+		copy(nh.SetIds, h.SetIds)
+	}
+	return nh
 }
 
 func (h *Host) oplog(op oplog.OpType) oplog.Metadata {
@@ -85,4 +99,56 @@ func (h *Host) oplog(op oplog.OpType) oplog.Metadata {
 		metadata["catalog-id"] = []string{h.CatalogId}
 	}
 	return metadata
+}
+
+// GetSetIds returns host set ids
+func (h *Host) GetSetIds() []string {
+	return h.SetIds
+}
+
+type hostAgg struct {
+	PublicId    string `gorm:"primary_key"`
+	CatalogId   string
+	Name        string
+	Description string
+	CreateTime  *timestamp.Timestamp
+	UpdateTime  *timestamp.Timestamp
+	Version     uint32
+	Address     string
+	SetIds      string
+}
+
+func (agg *hostAgg) toHost() *Host {
+	h := allocHost()
+	h.PublicId = agg.PublicId
+	h.CatalogId = agg.CatalogId
+	h.Name = agg.Name
+	h.Description = agg.Description
+	h.CreateTime = agg.CreateTime
+	h.UpdateTime = agg.UpdateTime
+	h.Version = agg.Version
+	h.Address = agg.Address
+	h.SetIds = agg.getSetIds()
+	return h
+}
+
+// TableName returns the table name for gorm
+func (agg *hostAgg) TableName() string {
+	return "static_host_with_set_memberships"
+}
+
+// GetPublicId returns the host public id as a string
+func (agg *hostAgg) GetPublicId() string {
+	return agg.PublicId
+}
+
+// GetSetIds returns a list of all associated host sets to the host
+func (agg *hostAgg) getSetIds() []string {
+	const aggregateDelimiter = "|"
+	var ids []string
+	if agg.SetIds != "" {
+		ids = strings.Split(agg.SetIds, aggregateDelimiter)
+		sort.Strings(ids)
+	}
+	return ids
 }

--- a/internal/host/static/repository_host.go
+++ b/internal/host/static/repository_host.go
@@ -171,6 +171,9 @@ func (r *Repository) UpdateHost(ctx context.Context, scopeId string, h *Host, ve
 			if err != nil {
 				return errors.Wrap(ctx, err, op)
 			}
+			if rowsUpdated > 1 {
+				return errors.New(ctx, errors.MultipleRecords, op, "more than 1 resource would have been updated")
+			}
 			ha := &hostAgg{
 				PublicId: h.PublicId,
 			}
@@ -178,9 +181,6 @@ func (r *Repository) UpdateHost(ctx context.Context, scopeId string, h *Host, ve
 				return errors.Wrap(ctx, err, op, errors.WithMsg("failed to lookup host after update"))
 			}
 			returnedHost.SetIds = ha.getSetIds()
-			if rowsUpdated > 1 {
-				return errors.New(ctx, errors.MultipleRecords, op, "more than 1 resource would have been updated")
-			}
 			return nil
 		},
 	)

--- a/internal/host/static/repository_host.go
+++ b/internal/host/static/repository_host.go
@@ -171,6 +171,13 @@ func (r *Repository) UpdateHost(ctx context.Context, scopeId string, h *Host, ve
 			if err != nil {
 				return errors.Wrap(ctx, err, op)
 			}
+			ha := &hostAgg{
+				PublicId: h.PublicId,
+			}
+			if err := r.reader.LookupByPublicId(ctx, ha); err != nil {
+				return errors.Wrap(ctx, err, op, errors.WithMsg("failed to lookup host after update"))
+			}
+			returnedHost.SetIds = ha.getSetIds()
 			if rowsUpdated > 1 {
 				return errors.New(ctx, errors.MultipleRecords, op, "more than 1 resource would have been updated")
 			}
@@ -203,15 +210,16 @@ func (r *Repository) LookupHost(ctx context.Context, publicId string, opt ...Opt
 	if publicId == "" {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "no public id")
 	}
-	h := allocHost()
-	h.PublicId = publicId
-	if err := r.reader.LookupByPublicId(ctx, h); err != nil {
+	ha := &hostAgg{
+		PublicId: publicId,
+	}
+	if err := r.reader.LookupByPublicId(ctx, ha); err != nil {
 		if errors.IsNotFoundError(err) {
 			return nil, nil
 		}
 		return nil, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("failed for %s", publicId)))
 	}
-	return h, nil
+	return ha.toHost(), nil
 }
 
 // ListHosts returns a slice of Hosts for the catalogId.
@@ -227,11 +235,16 @@ func (r *Repository) ListHosts(ctx context.Context, catalogId string, opt ...Opt
 		// non-zero signals an override of the default limit for the repo.
 		limit = opts.withLimit
 	}
-	var hosts []*Host
-	err := r.reader.SearchWhere(ctx, &hosts, "catalog_id = ?", []interface{}{catalogId}, db.WithLimit(limit))
+	var aggs []*hostAgg
+	err := r.reader.SearchWhere(ctx, &aggs, "catalog_id = ?", []interface{}{catalogId}, db.WithLimit(limit))
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
+	hosts := make([]*Host, 0, len(aggs))
+	for _, ha := range aggs {
+		hosts = append(hosts, ha.toHost())
+	}
+
 	return hosts, nil
 }
 

--- a/internal/host/static/repository_host_test.go
+++ b/internal/host/static/repository_host_test.go
@@ -606,6 +606,12 @@ func TestRepository_UpdateHost(t *testing.T) {
 			assert.NoError(err)
 			require.NotNil(orig)
 
+			if tt.wantIsErr == 0 {
+				set := TestSets(t, conn, catalog.GetPublicId(), 1)[0]
+				TestSetMembers(t, conn, set.PublicId, []*Host{orig})
+				tt.want.SetIds = []string{set.PublicId}
+			}
+
 			if tt.chgFn != nil {
 				orig = tt.chgFn(orig)
 			}
@@ -629,6 +635,9 @@ func TestRepository_UpdateHost(t *testing.T) {
 			if tt.want.Name == "" {
 				dbassert.IsNull(got, "name")
 				return
+			}
+			if tt.wantIsErr == 0 {
+				assert.Equal(tt.want.SetIds, got.SetIds)
 			}
 			assert.Equal(tt.want.Name, got.Name)
 			if tt.want.Description == "" {

--- a/internal/host/static/repository_host_test.go
+++ b/internal/host/static/repository_host_test.go
@@ -606,11 +606,9 @@ func TestRepository_UpdateHost(t *testing.T) {
 			assert.NoError(err)
 			require.NotNil(orig)
 
-			if tt.wantIsErr == 0 {
-				set := TestSets(t, conn, catalog.GetPublicId(), 1)[0]
-				TestSetMembers(t, conn, set.PublicId, []*Host{orig})
-				tt.want.SetIds = []string{set.PublicId}
-			}
+			set := TestSets(t, conn, catalog.GetPublicId(), 1)[0]
+			TestSetMembers(t, conn, set.PublicId, []*Host{orig})
+			want_SetIds := []string{set.PublicId}
 
 			if tt.chgFn != nil {
 				orig = tt.chgFn(orig)
@@ -636,9 +634,7 @@ func TestRepository_UpdateHost(t *testing.T) {
 				dbassert.IsNull(got, "name")
 				return
 			}
-			if tt.wantIsErr == 0 {
-				assert.Equal(tt.want.SetIds, got.SetIds)
-			}
+			assert.Equal(want_SetIds, got.SetIds)
 			assert.Equal(tt.want.Name, got.Name)
 			if tt.want.Description == "" {
 				dbassert.IsNull(got, "description")
@@ -964,10 +960,9 @@ func TestRepository_ListHosts_HostSets(t *testing.T) {
 	hostsC = append(hostsC, hostsC0...)
 
 	tests := []struct {
-		name      string
-		in        string
-		want      []*Host
-		wantIsErr errors.Code
+		name string
+		in   string
+		want []*Host
 	}{
 		{
 			name: "with-hostsets",
@@ -994,7 +989,6 @@ func TestRepository_ListHosts_HostSets(t *testing.T) {
 			require.NotNil(repo)
 			got, err := repo.ListHosts(context.Background(), tt.in)
 			require.NoError(err)
-			// Make sure outputs match. Ignore timestamps.
 			assert.Empty(
 				cmp.Diff(
 					tt.want,

--- a/internal/host/static/repository_host_test.go
+++ b/internal/host/static/repository_host_test.go
@@ -608,7 +608,7 @@ func TestRepository_UpdateHost(t *testing.T) {
 
 			set := TestSets(t, conn, catalog.GetPublicId(), 1)[0]
 			TestSetMembers(t, conn, set.PublicId, []*Host{orig})
-			want_SetIds := []string{set.PublicId}
+			wantSetIds := []string{set.PublicId}
 
 			if tt.chgFn != nil {
 				orig = tt.chgFn(orig)
@@ -634,7 +634,7 @@ func TestRepository_UpdateHost(t *testing.T) {
 				dbassert.IsNull(got, "name")
 				return
 			}
-			assert.Equal(want_SetIds, got.SetIds)
+			assert.Equal(wantSetIds, got.SetIds)
 			assert.Equal(tt.want.Name, got.Name)
 			if tt.want.Description == "" {
 				dbassert.IsNull(got, "description")

--- a/internal/servers/controller/handlers/hosts/host_service.go
+++ b/internal/servers/controller/handlers/hosts/host_service.go
@@ -257,9 +257,7 @@ func (s Service) UpdateHost(ctx context.Context, req *pbs.UpdateHostRequest) (*p
 		idActions := idActionsTypeMap[host.SubtypeFromId(req.GetId())]
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, h.GetPublicId(), idActions).Strings()))
 	}
-	if outputFields.Has(globals.HostSetIdField) {
-		outputOpts = append(outputOpts, handlers.WithHostSetIds(h.GetSetIds()))
-	}
+	outputOpts = append(outputOpts, handlers.WithHostSetIds(h.GetSetIds()))
 
 	item, err := toProto(ctx, h, outputOpts...)
 	if err != nil {

--- a/internal/servers/controller/handlers/hosts/host_service.go
+++ b/internal/servers/controller/handlers/hosts/host_service.go
@@ -130,11 +130,7 @@ func (s Service) ListHosts(ctx context.Context, req *pbs.ListHostsRequest) (*pbs
 		if outputFields.Has(globals.AuthorizedActionsField) {
 			outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authorizedActions))
 		}
-
-		switch h := item.(type) {
-		case *plugin.Host:
-			outputOpts = append(outputOpts, handlers.WithHostSetIds(h.SetIds))
-		}
+		outputOpts = append(outputOpts, handlers.WithHostSetIds(item.GetSetIds()))
 		item, err := toProto(ctx, item, outputOpts...)
 		if err != nil {
 			return nil, err
@@ -180,11 +176,7 @@ func (s Service) GetHost(ctx context.Context, req *pbs.GetHostRequest) (*pbs.Get
 		idActions := idActionsTypeMap[host.SubtypeFromId(req.GetId())]
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, h.GetPublicId(), idActions).Strings()))
 	}
-
-	switch h := h.(type) {
-	case *plugin.Host:
-		outputOpts = append(outputOpts, handlers.WithHostSetIds(h.SetIds))
-	}
+	outputOpts = append(outputOpts, handlers.WithHostSetIds(h.GetSetIds()))
 	item, err := toProto(ctx, h, outputOpts...)
 	if err != nil {
 		return nil, err

--- a/internal/servers/controller/handlers/hosts/host_service.go
+++ b/internal/servers/controller/handlers/hosts/host_service.go
@@ -257,6 +257,9 @@ func (s Service) UpdateHost(ctx context.Context, req *pbs.UpdateHostRequest) (*p
 		idActions := idActionsTypeMap[host.SubtypeFromId(req.GetId())]
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, h.GetPublicId(), idActions).Strings()))
 	}
+	if outputFields.Has(globals.HostSetIdField) {
+		outputOpts = append(outputOpts, handlers.WithHostSetIds(h.GetSetIds()))
+	}
 
 	item, err := toProto(ctx, h, outputOpts...)
 	if err != nil {

--- a/internal/servers/controller/handlers/hosts/host_service_test.go
+++ b/internal/servers/controller/handlers/hosts/host_service_test.go
@@ -803,11 +803,13 @@ func TestUpdate_Static(t *testing.T) {
 	require.NoError(t, err, "Couldn't create new static repo.")
 
 	hc := static.TestCatalogs(t, conn, proj.GetPublicId(), 1)[0]
+	s := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
 
 	h, err := static.NewHost(hc.GetPublicId(), static.WithName("default"), static.WithDescription("default"), static.WithAddress("defaultaddress"))
 	require.NoError(t, err)
 	h, err = repo.CreateHost(context.Background(), proj.GetPublicId(), h)
 	require.NoError(t, err)
+	static.TestSetMembers(t, conn, s.GetPublicId(), []*static.Host{h})
 
 	var version uint32 = 1
 
@@ -857,6 +859,7 @@ func TestUpdate_Static(t *testing.T) {
 						"address": structpb.NewStringValue("defaultaddress"),
 					}},
 					AuthorizedActions: testAuthorizedActions[static.Subtype],
+					HostSetIds:        []string{s.GetPublicId()},
 				},
 			},
 		},
@@ -885,6 +888,7 @@ func TestUpdate_Static(t *testing.T) {
 						"address": structpb.NewStringValue("defaultaddress"),
 					}},
 					AuthorizedActions: testAuthorizedActions[static.Subtype],
+					HostSetIds:        []string{s.GetPublicId()},
 				},
 			},
 		},
@@ -955,6 +959,7 @@ func TestUpdate_Static(t *testing.T) {
 						"address": structpb.NewStringValue("defaultaddress"),
 					}},
 					AuthorizedActions: testAuthorizedActions[static.Subtype],
+					HostSetIds:        []string{s.GetPublicId()},
 				},
 			},
 		},
@@ -980,6 +985,7 @@ func TestUpdate_Static(t *testing.T) {
 						"address": structpb.NewStringValue("defaultaddress"),
 					}},
 					AuthorizedActions: testAuthorizedActions[static.Subtype],
+					HostSetIds:        []string{s.GetPublicId()},
 				},
 			},
 		},
@@ -1007,6 +1013,7 @@ func TestUpdate_Static(t *testing.T) {
 						"address": structpb.NewStringValue("defaultaddress"),
 					}},
 					AuthorizedActions: testAuthorizedActions[static.Subtype],
+					HostSetIds:        []string{s.GetPublicId()},
 				},
 			},
 		},
@@ -1034,6 +1041,7 @@ func TestUpdate_Static(t *testing.T) {
 						"address": structpb.NewStringValue("defaultaddress"),
 					}},
 					AuthorizedActions: testAuthorizedActions[static.Subtype],
+					HostSetIds:        []string{s.GetPublicId()},
 				},
 			},
 		},


### PR DESCRIPTION
Updates LookupHost and ListHost API to include sets a static host is part of, as like with plugin hosts.