### PR TITLE
bug(host): Fix sync job failure blocking other set syncs

### DIFF
--- a/internal/host/plugin/query.go
+++ b/internal/host/plugin/query.go
@@ -43,4 +43,12 @@ sync_interval_seconds is null and last_sync_time <= wt_add_seconds_to_now(?)
   or
 sync_interval_seconds > 0 and wt_add_seconds(sync_interval_seconds, last_sync_time) <= current_timestamp
 `
+
+	updateSyncDataQuery = `
+update host_plugin_set
+set
+  last_sync_time = current_timestamp,
+  need_sync = false
+where public_id = ?
+`
 )

--- a/internal/host/plugin/repository_host_util.go
+++ b/internal/host/plugin/repository_host_util.go
@@ -200,7 +200,6 @@ func getSetChanges(
 	currentHostMap map[string]*Host,
 	newHostMap map[string]*hostInfo) (
 	setMembershipsToAdd, setMembershipsToRemove map[string][]string,
-	allSetIds map[string]struct{},
 ) {
 	// First, find sets that hosts should be added to: hosts that are new or
 	// have new set IDs returned.
@@ -224,11 +223,7 @@ func getSetChanges(
 			if setMembershipsToAdd == nil {
 				setMembershipsToAdd = make(map[string][]string)
 			}
-			if allSetIds == nil {
-				allSetIds = make(map[string]struct{})
-			}
 			setMembershipsToAdd[setToAdd] = append(setMembershipsToAdd[setToAdd], newHostId)
-			allSetIds[setToAdd] = struct{}{}
 		}
 	}
 
@@ -254,11 +249,7 @@ func getSetChanges(
 			if setMembershipsToRemove == nil {
 				setMembershipsToRemove = make(map[string][]string)
 			}
-			if allSetIds == nil {
-				allSetIds = make(map[string]struct{})
-			}
 			setMembershipsToRemove[setToRemove] = append(setMembershipsToRemove[setToRemove], currentHostId)
-			allSetIds[setToRemove] = struct{}{}
 		}
 	}
 

--- a/internal/host/plugin/repository_host_util_test.go
+++ b/internal/host/plugin/repository_host_util_test.go
@@ -303,7 +303,7 @@ func TestUtilFunctions(t *testing.T) {
 			// Run through the sets function
 			{
 				newHostMap[baseHostId].h.SetIds = tt.sets()
-				toAdd, toRemove, _ := getSetChanges(currentHostMap, newHostMap)
+				toAdd, toRemove := getSetChanges(currentHostMap, newHostMap)
 				assert.Equal(tt.setsToAdd, toAdd)
 				assert.Equal(tt.setsToRemove, toRemove)
 			}


### PR DESCRIPTION
During the plugin_host_set_sync job, a single set failing to sync
can cause all following syncs to fail.