### PR TITLE
ci(proto): Detect unchecked API and proto changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,47 @@ jobs:
         command: |
           make test-sql POSTGRES_DOCKER_IMAGE_BASE=docker.mirror.hashicorp.services/postgres PG_DOCKER_TAG=11-alpine
         name: Run SQL PgTap Tests
+  make-gen-deltas:
+    machine:
+      image: ubuntu-2004:202111-01
+    resource_class: medium
+    working_directory: ~/boundary
+    steps:
+    - checkout
+    - run:
+        command: |
+          make install-go
+          source ~/.bashrc
+          echo 'export GOROOT=$GOROOT' >> "$BASH_ENV"
+          echo 'export GOPATH=$GOPATH' >> "$BASH_ENV"
+          echo 'export PATH=$PATH' >> "$BASH_ENV"
+          echo "$ go version"
+          go version
+        name: Install go
+    - run:
+        command: |-
+          make tools
+
+          VERSION="3.17.3"
+          PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+          ARCH="$(uname -m)"
+          PACKAGE_NAME=protoc-$VERSION-linux-$ARCH.zip
+          curl -LO $PB_REL/download/v$VERSION/$PACKAGE_NAME
+          unzip $PACKAGE_NAME -d $HOME/.local
+          rm $PACKAGE_NAME
+
+          echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
+          echo "$ protoc --version"
+          protoc --version
+        name: Install protobuf
+    - run:
+        command: |-
+          make gen
+          echo "Testing git diffs..."
+          git diff --exit-code
+          git status --porcelain
+          test -z "$(git status --porcelain)"
+        name: Check make gen deltas
   test-sdk:
     machine:
       image: ubuntu-2004:202111-01
@@ -290,6 +331,7 @@ workflows:
           branches:
             only:
             - stable-website
+    - make-gen-deltas
   trigger-merge-to-ent:
     jobs:
     - trigger-merge-to-ent:
@@ -315,6 +357,26 @@ workflows:
 #                     echo \"$ go version\"
 #                     go version
 #                 name: Install go
+#     install-protobuf:
+#         description: |
+#             Ensure protobuf is installed
+#         steps:
+#             - run:
+#                 command: |-
+#                     make tools
+# 
+#                     VERSION=\"3.17.3\"
+#                     PB_REL=\"https://github.com/protocolbuffers/protobuf/releases\"
+#                     ARCH=\"$(uname -m)\"
+#                     PACKAGE_NAME=protoc-$VERSION-linux-$ARCH.zip
+#                     curl -LO $PB_REL/download/v$VERSION/$PACKAGE_NAME
+#                     unzip $PACKAGE_NAME -d $HOME/.local
+#                     rm $PACKAGE_NAME
+# 
+#                     echo 'export PATH=$HOME/.local/bin:$PATH' >> \"$BASH_ENV\"
+#                     echo \"$ protoc --version\"
+#                     protoc --version
+#                 name: Install protobuf
 # executors:
 #     go-machine:
 #         machine:
@@ -363,6 +425,20 @@ workflows:
 #                 fail_only: true
 #                 only_for_branches: master
 #                 webhook: webhook
+#     make-gen-deltas:
+#         executor: go-machine-medium
+#         steps:
+#             - checkout
+#             - install-go
+#             - install-protobuf
+#             - run:
+#                 command: |-
+#                     make gen
+#                     echo \"Testing git diffs...\"
+#                     git diff --exit-code
+#                     git status --porcelain
+#                     test -z \"$(git status --porcelain)\"
+#                 name: Check make gen deltas
 #     test-api:
 #         executor: go-machine-medium
 #         steps:
@@ -424,6 +500,7 @@ workflows:
 #                     branches:
 #                         only:
 #                             - stable-website
+#             - make-gen-deltas
 #     trigger-merge-to-ent:
 #         jobs:
 #             - trigger-merge-to-ent:

--- a/.circleci/config/commands/install-protobuf.yml
+++ b/.circleci/config/commands/install-protobuf.yml
@@ -1,0 +1,20 @@
+---
+description: >
+  Ensure protobuf is installed
+steps:
+  - run:
+      name: "Install protobuf"
+      command: |
+        make tools
+
+        VERSION="3.17.3"
+        PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+        ARCH="$(uname -m)"
+        PACKAGE_NAME=protoc-$VERSION-linux-$ARCH.zip
+        curl -LO $PB_REL/download/v$VERSION/$PACKAGE_NAME
+        unzip $PACKAGE_NAME -d $HOME/.local
+        rm $PACKAGE_NAME
+
+        echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
+        echo "$ protoc --version"
+        protoc --version

--- a/.circleci/config/jobs/make-gen-deltas.yml
+++ b/.circleci/config/jobs/make-gen-deltas.yml
@@ -1,0 +1,13 @@
+executor: go-machine-medium
+steps:
+- checkout
+- install-go
+- install-protobuf
+- run:
+    name: "Check make gen deltas"
+    command: |
+      make gen
+      echo "Testing git diffs..."
+      git diff --exit-code
+      git status --porcelain
+      test -z "$(git status --porcelain)"

--- a/.circleci/config/workflows/ci.yml
+++ b/.circleci/config/workflows/ci.yml
@@ -11,3 +11,4 @@ jobs:
           branches:
             only:
               - stable-website
+  - make-gen-deltas


### PR DESCRIPTION
Addition of workflow job, `make-gen-deltas`, to run `make gen` and detect diffs, in case proto changes are made but generated files are not checked in.