### PR TITLE
bug(plugin): Fix incorrect use of WithIpAddrs in Repository.Endpoints

### DIFF
--- a/internal/host/plugin/repository_host_set.go
+++ b/internal/host/plugin/repository_host_set.go
@@ -816,7 +816,7 @@ func (r *Repository) Endpoints(ctx context.Context, setIds []string) ([]*host.En
 				opts = append(opts, endpoint.WithIpAddrs(h.GetIpAddresses()))
 			}
 			if len(h.GetDnsNames()) > 0 {
-				opts = append(opts, endpoint.WithIpAddrs(h.GetDnsNames()))
+				opts = append(opts, endpoint.WithDnsNames(h.GetDnsNames()))
 			}
 			addr, err := pref.Choose(ctx, opts...)
 			if err != nil {


### PR DESCRIPTION
When creating the options for the preferencer, this used WithIpAddrs for both the host addresses and also DNS names. This causes errors when a host contains DNS names that are not IP addresses (ie: whenever dns names are present).

This change will:
- Replace WithIpAddrs with WithDNSNames option for DNS Names when constructing options for the preferencer.
- Add a test which includes a DNS name to prevent regressions

Fixes #1848