### PR TITLE
fix(controller/targets): authorize-session should allow h_ ids

### DIFF
--- a/internal/servers/controller/handlers/targets/target_service.go
+++ b/internal/servers/controller/handlers/targets/target_service.go
@@ -2102,7 +2102,7 @@ func validateAuthorizeSessionRequest(req *pbs.AuthorizeSessionRequest) error {
 	}
 	if req.GetHostId() != "" {
 		switch host.SubtypeFromId(req.GetHostId()) {
-		case static.Subtype:
+		case static.Subtype, plugin.Subtype:
 		default:
 			badFields[globals.HostIdField] = "Incorrectly formatted identifier."
 		}

--- a/internal/servers/controller/handlers/targets/tcp/target_service_test.go
+++ b/internal/servers/controller/handlers/targets/tcp/target_service_test.go
@@ -2776,6 +2776,12 @@ func TestAuthorizeSession(t *testing.T) {
 			assert.NotEmpty(t, cmp.Diff(asRes1.GetItem().GetCredentials(), asRes2.GetItem().GetCredentials(), protocmp.Transform()),
 				"the credentials aren't unique per request authorized session")
 
+			_, err = s.AuthorizeSession(ctx, &pbs.AuthorizeSessionRequest{
+				Id:     tar.GetPublicId(),
+				HostId: asRes2.GetItem().GetHostId(),
+			})
+			require.NoError(t, err, "session must authorize with explicit host ID")
+
 			wantedHostId := tc.wantedHostId
 			if tc.wantedHostId == "?" {
 				wantedHostId = asRes2.GetItem().GetHostId()


### PR DESCRIPTION
The targets controller previously only allowed hosts from a static catalog
since it checked for the ID subtype from the static package.

This change validates host ids with the plugin.Subtype as well

Fixes: #1850