### PR TITLE
fix(connect): do not panic on multiple `--` args

### DIFF
--- a/internal/cmd/commands/connect/connect.go
+++ b/internal/cmd/commands/connect/connect.go
@@ -264,6 +264,7 @@ func (c *Command) Run(args []string) (retCode int) {
 		if v == "--" {
 			passthroughArgs = args[i+1:]
 			args = args[:i]
+			break // only consider the first instance of '--' in the args list
 		}
 	}
 


### PR DESCRIPTION
Passthrough args looks for the an instance of -- and re-slices the arg
list to pass through those args to the underlying connect exec command.
However such commands may also need to parse their own '--', such as
kubectl exec.

This change updates the logic so that boundary arg parser only considers
the first instance of '--' when deciding which args to pass to the
-exec= commands.

Fixes: #1857