### PR TITLE
add doc link for dynamic host catalog hosts setup

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -130,6 +130,12 @@ module.exports = [
     permanent: false,
   },
 
+  {
+    source: '/help/admin-ui/host-catalog-set-up-cloud-hosts',
+    destination: 'https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts',
+    permanent: false,
+  },
+
   ////////////////////////////////////////////
   // Adding sub-resources to existing resource
   ////////////////////////////////////////////


### PR DESCRIPTION
This pr adds doc link for dynamic host catalogs to be shown in the helper text for ex: 
<img width="873" alt="Screen Shot 2022-02-15 at 6 26 53 PM" src="https://user-images.githubusercontent.com/15043878/154184703-5acf97a7-6a41-4183-9d17-387a357cd079.png">

