### PR TITLE
fix(api): address base paths containing a v1 were being truncated

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -236,7 +236,7 @@ func (c *Config) setAddr(addr string) error {
 
 	// If there is a v1 segment, elide everything after it. Do this only for
 	// the last v1 segment in case it's part of the base path.
-	if lastIndex := strings.LastIndex(u.Path, "v1"); lastIndex != -1 {
+	if lastIndex := strings.LastIndex(u.Path, "v1/"); lastIndex != -1 {
 		u.Path = u.Path[:lastIndex]
 	}
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -57,6 +57,12 @@ func TestConfigSetAddress(t *testing.T) {
 			"http://127.0.0.1:9200/my-install",
 			"",
 		},
+		{
+			"valid project path containing v1",
+			"http://127.0.0.1:9200/randomPathHasv1InIt",
+			"http://127.0.0.1:9200/randomPathHasv1InIt",
+			"",
+		},
 	}
 
 	for _, v := range tests {


### PR DESCRIPTION
Base paths containing a v1 that was NOT part of the API path were being truncated.
Ex: My tempdir, var/folders/nz/fc5_5k1n4v105k3nlqcyw6nm0000gq, contains a v1. The base path created was /var/folders/nz/fc5_5k1n4, which did not exist.

Changed setAddr to truncate on v1/, not v1, and updated client test.