### PR TITLE
fix(build): Include .exe suffix when building plugins for Windows

### DIFF
--- a/scripts/plugins.sh
+++ b/scripts/plugins.sh
@@ -3,13 +3,18 @@
 # This script builds the required plugins.
 set -e
 
+BINARY_SUFFIX=""
+if [ "${GOOS}x" == "windowsx" ]; then
+    BINARY_SUFFIX=".exe"
+fi
+
 ORIG_PATH=$(pwd);
 echo "==> Building Host Plugins..."
 for PLUGIN_TYPE in host; do
     rm -f $ORIG_PATH/plugins/$PLUGIN_TYPE/assets/boundary-plugin-${PLUGIN_TYPE}*
     for CURR_PLUGIN in $(ls $ORIG_PATH/plugins/$PLUGIN_TYPE/mains); do
         cd $ORIG_PATH/plugins/$PLUGIN_TYPE/mains/$CURR_PLUGIN;
-        go build -v -o $ORIG_PATH/plugins/$PLUGIN_TYPE/assets/boundary-plugin-${PLUGIN_TYPE}-${CURR_PLUGIN} .;
+        go build -v -o $ORIG_PATH/plugins/$PLUGIN_TYPE/assets/boundary-plugin-${PLUGIN_TYPE}-${CURR_PLUGIN}${BINARY_SUFFIX} .;
         cd $ORIG_PATH;
     done;
     cd $ORIG_PATH/plugins/$PLUGIN_TYPE/assets;


### PR DESCRIPTION
When moving to the new CRT build process, this was missed from the older
build scripts. When building the plugins for Windows, if the files do
not have the `.exe` suffix, boundary fails with errors like the
following:

    Error initializing controller: error creating aws host plugin: error fetching host plugin rpc client: exec:
    "C:\\Users\\alice\\AppData\\Local\\Temp\\441718622\\boundary-plugin-host-aws": file does not exist