### PR TITLE
[RDX-309] UI build timeout fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,7 @@ on:
     # Sequence of patterns matched against refs/heads
     branches:    
       # Push events on main branch
-      # - 'main'
-      - 'yarn-timeout-fix'
+      - 'main'
 
 env:
   PKG_NAME: "boundary"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,8 @@ on:
     # Sequence of patterns matched against refs/heads
     branches:    
       # Push events on main branch
-      - 'main'
+      # - 'main'
+      - 'yarn-timeout-fix'
 
 env:
   PKG_NAME: "boundary"
@@ -110,7 +111,7 @@ jobs:
           cd "$DIR"
           git fetch origin "$SHA"
           git checkout "$SHA"
-          yarn install
+          yarn install --network-concurrency 5
           yarn build:ui:admin
       - name: Go Build
         env:
@@ -173,7 +174,7 @@ jobs:
           cd "$DIR"
           git fetch origin "$SHA"
           git checkout "$SHA"
-          yarn install
+          yarn install --network-concurrency 5
           yarn build:ui:admin
       - name: Go Build
         env:
@@ -263,7 +264,7 @@ jobs:
           cd "$DIR"
           git fetch origin "$SHA"
           git checkout "$SHA"
-          yarn install
+          yarn install --network-concurrency 5
           yarn build:ui:admin
       - name: Go Build
         env:

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,13 +3,13 @@ schema = "1"
 project "boundary" {
   team = "#proj-boundary-release-engineering"
   slack {
-    notification_channel = "C01BWLSMJ03"
+    notification_channel = "C01A3A54G0L"
   }
   github {
     organization = "hashicorp"
     repository = "boundary"
     release_branches = [
-        "main"
+        "yarn-timeout-fix"
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,13 +3,13 @@ schema = "1"
 project "boundary" {
   team = "#proj-boundary-release-engineering"
   slack {
-    notification_channel = "C01A3A54G0L"
+    notification_channel = "C01BWLSMJ03"
   }
   github {
     organization = "hashicorp"
     repository = "boundary"
     release_branches = [
-        "yarn-timeout-fix"
+        "main"
     ]
   }
 }


### PR DESCRIPTION
There’s a pesky UI build issue where `yarn install` times out with a network issue causing folks to have to re-run the build manually in the Github UI. This is kind of build failure is easy to miss and this PR is a fix for that. 

I'd like to merge in this fix + have the Boundary team notify our team (release engineering) if they're still running into this issue. This error is sporadic and hard to reproduce unfortunately. 😕

The error looks like this: 

![image](https://user-images.githubusercontent.com/58451251/154526796-69d04538-0d8a-44a8-98b6-6ecc224891e3.png)
