### PR TITLE
refactor(controller/worker): Listener code improvements

### DIFF
--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -611,7 +611,7 @@ func (c *Command) Run(args []string) int {
 
 		if err := c.controller.Start(); err != nil {
 			retErr := fmt.Errorf("Error starting controller: %w", err)
-			if err := c.controller.Shutdown(false); err != nil {
+			if err := c.controller.Shutdown(); err != nil {
 				c.UI.Error(retErr.Error())
 				retErr = fmt.Errorf("Error shutting down controller: %w", err)
 			}
@@ -640,7 +640,7 @@ func (c *Command) Run(args []string) int {
 				retErr = fmt.Errorf("Error shutting down worker: %w", err)
 			}
 			c.UI.Error(retErr.Error())
-			if err := c.controller.Shutdown(false); err != nil {
+			if err := c.controller.Shutdown(); err != nil {
 				c.UI.Error(fmt.Errorf("Error with controller shutdown: %w", err).Error())
 			}
 			return base.CommandCliError
@@ -677,7 +677,7 @@ func (c *Command) Run(args []string) int {
 				}
 			}
 
-			if err := c.controller.Shutdown(false); err != nil {
+			if err := c.controller.Shutdown(); err != nil {
 				c.UI.Error(fmt.Errorf("Error shutting down controller: %w", err).Error())
 			}
 

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -635,7 +635,7 @@ func (c *Command) Run(args []string) int {
 
 		if err := c.worker.Start(); err != nil {
 			retErr := fmt.Errorf("Error starting worker: %w", err)
-			if err := c.worker.Shutdown(false); err != nil {
+			if err := c.worker.Shutdown(); err != nil {
 				c.UI.Error(retErr.Error())
 				retErr = fmt.Errorf("Error shutting down worker: %w", err)
 			}
@@ -672,7 +672,7 @@ func (c *Command) Run(args []string) int {
 			}()
 
 			if !c.flagControllerOnly {
-				if err := c.worker.Shutdown(false); err != nil {
+				if err := c.worker.Shutdown(); err != nil {
 					c.UI.Error(fmt.Errorf("Error shutting down worker: %w", err).Error())
 				}
 			}

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -466,7 +466,7 @@ func (c *Command) Run(args []string) int {
 		if err := c.StartWorker(); err != nil {
 			c.UI.Error(err.Error())
 			if c.controller != nil {
-				if err := c.controller.Shutdown(false); err != nil {
+				if err := c.controller.Shutdown(); err != nil {
 					c.UI.Error(fmt.Errorf("Error with controller shutdown: %w", err).Error())
 				}
 			}
@@ -558,7 +558,7 @@ func (c *Command) StartController(ctx context.Context) error {
 
 	if err := c.controller.Start(); err != nil {
 		retErr := fmt.Errorf("Error starting controller: %w", err)
-		if err := c.controller.Shutdown(false); err != nil {
+		if err := c.controller.Shutdown(); err != nil {
 			c.UI.Error(retErr.Error())
 			retErr = fmt.Errorf("Error shutting down controller: %w", err)
 		}
@@ -626,7 +626,7 @@ func (c *Command) WaitForInterrupt() int {
 
 			// Do controller shutdown
 			if c.Config.Controller != nil {
-				if err := c.controller.Shutdown(c.Config.Worker != nil); err != nil {
+				if err := c.controller.Shutdown(); err != nil {
 					c.UI.Error(fmt.Errorf("Error shutting down controller: %w", err).Error())
 				}
 			}

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -582,7 +582,7 @@ func (c *Command) StartWorker() error {
 
 	if err := c.worker.Start(); err != nil {
 		retErr := fmt.Errorf("Error starting worker: %w", err)
-		if err := c.worker.Shutdown(false); err != nil {
+		if err := c.worker.Shutdown(); err != nil {
 			c.UI.Error(retErr.Error())
 			retErr = fmt.Errorf("Error shutting down worker: %w", err)
 		}
@@ -619,7 +619,7 @@ func (c *Command) WaitForInterrupt() int {
 
 			// Do worker shutdown
 			if c.Config.Worker != nil {
-				if err := c.worker.Shutdown(false); err != nil {
+				if err := c.worker.Shutdown(); err != nil {
 					c.UI.Error(fmt.Errorf("Error shutting down worker: %w", err).Error())
 				}
 			}

--- a/internal/servers/controller/controller.go
+++ b/internal/servers/controller/controller.go
@@ -337,15 +337,15 @@ func (c *Controller) registerSessionCleanupJob() error {
 	return nil
 }
 
-func (c *Controller) Shutdown(serversOnly bool) error {
+func (c *Controller) Shutdown() error {
 	const op = "controller.(Controller).Shutdown"
 	if !c.started.Load() {
 		event.WriteSysEvent(context.TODO(), op, "already shut down, skipping")
 	}
 	defer c.started.Store(false)
 	c.baseCancel()
-	if err := c.stopListeners(serversOnly); err != nil {
-		return fmt.Errorf("error stopping controller listeners: %w", err)
+	if err := c.stopServersAndListeners(); err != nil {
+		return fmt.Errorf("error stopping controller servers and listeners: %w", err)
 	}
 	c.schedulerWg.Wait()
 	c.tickerWg.Wait()

--- a/internal/servers/controller/controller.go
+++ b/internal/servers/controller/controller.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-
 	"github.com/hashicorp/boundary/internal/auth/oidc"
 	"github.com/hashicorp/boundary/internal/auth/password"
 	"github.com/hashicorp/boundary/internal/authtoken"
@@ -58,11 +56,9 @@ type Controller struct {
 	// Used for testing and tracking worker health
 	workerStatusUpdateTimes *sync.Map
 
-	// grpc gateway server
-	gatewayServer   *grpc.Server
-	gatewayTicket   string
-	gatewayListener gatewayListener
-	gatewayMux      *runtime.ServeMux
+	apiGrpcServer         *grpc.Server
+	apiGrpcServerListener grpcServerListener
+	apiGrpcGatewayTicket  string
 
 	// Repo factory methods
 	AuthTokenRepoFn       common.AuthTokenRepoFactory
@@ -279,7 +275,7 @@ func (c *Controller) Start() error {
 	if err := c.registerJobs(); err != nil {
 		return fmt.Errorf("error registering jobs: %w", err)
 	}
-	if err := c.startListeners(c.baseContext); err != nil {
+	if err := c.startListeners(); err != nil {
 		return fmt.Errorf("error starting controller listeners: %w", err)
 	}
 	if err := c.scheduler.Start(c.baseContext, c.schedulerWg); err != nil {

--- a/internal/servers/controller/controller_test.go
+++ b/internal/servers/controller/controller_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/boundary/internal/cmd/base"
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/go-secure-stdlib/listenerutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,4 +33,154 @@ func TestController_New(t *testing.T) {
 		_, err = New(testCtx, conf)
 		require.NoError(err)
 	})
+}
+
+func TestControllerNewListenerConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		listeners  []*base.ServerListener
+		assertions func(t *testing.T, c *Controller)
+		expErr     bool
+		expErrMsg  string
+	}{
+		{
+			name: "valid listener configuration",
+			listeners: []*base.ServerListener{
+				{
+					Config: &listenerutil.ListenerConfig{
+						Purpose: []string{"api"},
+					},
+				},
+				{
+					Config: &listenerutil.ListenerConfig{
+						Purpose: []string{"api"},
+					},
+				},
+				{
+					Config: &listenerutil.ListenerConfig{
+						Purpose: []string{"cluster"},
+					},
+				},
+			},
+			assertions: func(t *testing.T, c *Controller) {
+				require.Len(t, c.apiListeners, 2)
+				require.NotNil(t, c.clusterListener)
+			},
+		},
+		{
+			name:      "listeners are required",
+			listeners: []*base.ServerListener{},
+			expErr:    true,
+			expErrMsg: "no api listeners found",
+		},
+		{
+			name:      "listeners are required - not nil",
+			listeners: []*base.ServerListener{nil, nil},
+			expErr:    true,
+			expErrMsg: "no api listeners found",
+		},
+		{
+			name:      "listeners are required - with config",
+			listeners: []*base.ServerListener{{}, {}},
+			expErr:    true,
+			expErrMsg: "no api listeners found",
+		},
+		{
+			name: "listeners are required - with purposes",
+			listeners: []*base.ServerListener{
+				{
+					Config: &listenerutil.ListenerConfig{Purpose: nil},
+				},
+				{
+					Config: &listenerutil.ListenerConfig{Purpose: nil},
+				},
+			},
+			expErr:    true,
+			expErrMsg: "no api listeners found",
+		},
+		{
+			name: "both api and cluster listeners are required",
+			listeners: []*base.ServerListener{
+				{
+					Config: &listenerutil.ListenerConfig{
+						Purpose: []string{"api"},
+					},
+				},
+			},
+			expErr:    true,
+			expErrMsg: "exactly one cluster listener is required",
+		},
+		{
+			name: "both api and cluster listeners are required 2",
+			listeners: []*base.ServerListener{
+				{
+					Config: &listenerutil.ListenerConfig{
+						Purpose: []string{"cluster"},
+					},
+				},
+			},
+			expErr:    true,
+			expErrMsg: "no api listeners found",
+		},
+		{
+			name: "only one cluster listener is allowed",
+			listeners: []*base.ServerListener{
+				{
+					Config: &listenerutil.ListenerConfig{
+						Purpose: []string{"api"},
+					},
+				},
+				{
+					Config: &listenerutil.ListenerConfig{
+						Purpose: []string{"cluster"},
+					},
+				},
+				{
+					Config: &listenerutil.ListenerConfig{
+						Purpose: []string{"cluster"},
+					},
+				},
+			},
+			expErr:    true,
+			expErrMsg: "exactly one cluster listener is required",
+		},
+		{
+			name: "only one purpose is allowed per listener",
+			listeners: []*base.ServerListener{
+				{
+					Config: &listenerutil.ListenerConfig{
+						Purpose: []string{"api", "cluster"},
+					},
+				},
+			},
+			expErr:    true,
+			expErrMsg: `found listener with multiple purposes "api,cluster"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			tc := &TestController{
+				t:      t,
+				ctx:    ctx,
+				cancel: cancel,
+				opts:   nil,
+			}
+			conf := TestControllerConfig(t, ctx, tc, nil)
+			conf.Listeners = tt.listeners
+
+			c, err := New(ctx, conf)
+			if tt.expErr {
+				require.EqualError(t, err, tt.expErrMsg)
+				require.Nil(t, c)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, c)
+			tt.assertions(t, c)
+		})
+	}
 }

--- a/internal/servers/controller/cors_test.go
+++ b/internal/servers/controller/cors_test.go
@@ -20,50 +20,54 @@ const corsTestConfig = `
 disable_mlock = true
 
 telemetry {
-        prometheus_retention_time = "24h"
-        disable_hostname = true
+	prometheus_retention_time = "24h"
+	disable_hostname = true
 }
 
 kms "aead" {
-        purpose = "root"
-        aead_type = "aes-gcm"
-		key = "09iqFxRJNYsl/b8CQxjnGw=="
-		key_id = "global_root"
+	purpose = "root"
+	aead_type = "aes-gcm"
+	key = "09iqFxRJNYsl/b8CQxjnGw=="
+	key_id = "global_root"
 }
 
 kms "aead" {
-        purpose = "worker-auth"
-        aead_type = "aes-gcm"
-		key = "09iqFxRJNYsl/b8CQxjnGw=="
-		key_id = "global_worker-auth"
+	purpose = "worker-auth"
+	aead_type = "aes-gcm"
+	key = "09iqFxRJNYsl/b8CQxjnGw=="
+	key_id = "global_worker-auth"
 }
 
 listener "tcp" {
-        purpose = "api"
-        tls_disable = true
-        cors_enabled = false
+	purpose = "cluster"
 }
 
 listener "tcp" {
-        purpose = "api"
-        tls_disable = true
-        cors_enabled = true
-        cors_allowed_origins = []
+	purpose = "api"
+	tls_disable = true
+	cors_enabled = false
 }
 
 listener "tcp" {
-        purpose = "api"
-        tls_disable = true
-        cors_enabled = true
-        cors_allowed_origins = ["foobar.com", "barfoo.com"]
+	purpose = "api"
+	tls_disable = true
+	cors_enabled = true
+	cors_allowed_origins = []
 }
 
 listener "tcp" {
-        purpose = "api"
-        tls_disable = true
-        cors_enabled = true
-        cors_allowed_origins = ["*"]
-		cors_allowed_headers = ["x-foobar"]
+	purpose = "api"
+	tls_disable = true
+	cors_enabled = true
+	cors_allowed_origins = ["foobar.com", "barfoo.com"]
+}
+
+listener "tcp" {
+	purpose = "api"
+	tls_disable = true
+	cors_enabled = true
+	cors_allowed_origins = ["*"]
+	cors_allowed_headers = ["x-foobar"]
 }
 `
 

--- a/internal/servers/controller/listeners_test.go
+++ b/internal/servers/controller/listeners_test.go
@@ -1,0 +1,400 @@
+package controller
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/hashicorp/go-secure-stdlib/base62"
+	"github.com/hashicorp/go-secure-stdlib/configutil"
+	"github.com/hashicorp/go-secure-stdlib/listenerutil"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestStartListeners(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T)
+		listeners  []*listenerutil.ListenerConfig
+		assertions func(t *testing.T, c *Controller, apiAddrs []string, clusterAddr string)
+	}{
+		{
+			name: "one api, one cluster listener",
+			listeners: []*listenerutil.ListenerConfig{
+				{
+					Type:       "tcp",
+					Purpose:    []string{"api"},
+					Address:    "127.0.0.1:0",
+					TLSDisable: true,
+				},
+				{
+					Type:    "tcp",
+					Purpose: []string{"cluster"},
+					Address: "127.0.0.1:0",
+				},
+			},
+			assertions: func(t *testing.T, c *Controller, apiAddrs []string, clusterAddr string) {
+				rsp, err := http.Get("http://" + apiAddrs[0] + "/v1/auth-methods?scope_id=global")
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, rsp.StatusCode)
+
+				clusterGrpcDialNoError(t, c, "tcp", clusterAddr)
+			},
+		},
+		{
+			name: "multiple api, one cluster listeners",
+			listeners: []*listenerutil.ListenerConfig{
+				{
+					Type:       "tcp",
+					Purpose:    []string{"api"},
+					Address:    "127.0.0.1:0",
+					TLSDisable: true,
+				},
+				{
+					Type:       "tcp",
+					Purpose:    []string{"api"},
+					Address:    "127.0.0.1:0",
+					TLSDisable: true,
+				},
+				{
+					Type:    "tcp",
+					Purpose: []string{"cluster"},
+					Address: "127.0.0.1:0",
+				},
+			},
+			assertions: func(t *testing.T, c *Controller, apiAddrs []string, clusterAddr string) {
+				for _, apiAddr := range apiAddrs {
+					rsp, err := http.Get("http://" + apiAddr + "/v1/auth-methods?scope_id=global")
+					require.NoError(t, err)
+					require.Equal(t, http.StatusOK, rsp.StatusCode)
+				}
+
+				clusterGrpcDialNoError(t, c, "tcp", clusterAddr)
+			},
+		},
+		{
+			name:  "one api (tls), one cluster listener",
+			setup: testApiTlsSetup(t, "./boundary-startlistenerstest.cert", "./boundary-startlistenerstest.key"),
+			listeners: []*listenerutil.ListenerConfig{
+				{
+					Type:        "tcp",
+					Purpose:     []string{"api"},
+					Address:     "127.0.0.1:0",
+					TLSCertFile: "./boundary-startlistenerstest.cert",
+					TLSKeyFile:  "./boundary-startlistenerstest.key",
+				},
+				{
+					Type:    "tcp",
+					Purpose: []string{"cluster"},
+					Address: "127.0.0.1:0",
+				},
+			},
+			assertions: func(t *testing.T, c *Controller, apiAddrs []string, clusterAddr string) {
+				client := testTlsHttpClient(t, "./boundary-startlistenerstest.cert")
+				rsp, err := client.Get("https://" + apiAddrs[0] + "/v1/auth-methods?scope_id=global")
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, rsp.StatusCode)
+
+				clusterGrpcDialNoError(t, c, "tcp", clusterAddr)
+			},
+		},
+		{
+			name: "multiple api (tls), one cluster listener",
+			setup: func(t *testing.T) {
+				testApiTlsSetup(t, "./boundary-startlistenerstest0.cert", "./boundary-startlistenerstest0.key")(t)
+				testApiTlsSetup(t, "./boundary-startlistenerstest1.cert", "./boundary-startlistenerstest1.key")(t)
+			},
+			listeners: []*listenerutil.ListenerConfig{
+				{
+					Type:        "tcp",
+					Purpose:     []string{"api"},
+					Address:     "127.0.0.1:0",
+					TLSCertFile: "./boundary-startlistenerstest0.cert",
+					TLSKeyFile:  "./boundary-startlistenerstest0.key",
+				},
+				{
+					Type:        "tcp",
+					Purpose:     []string{"api"},
+					Address:     "127.0.0.1:0",
+					TLSCertFile: "./boundary-startlistenerstest1.cert",
+					TLSKeyFile:  "./boundary-startlistenerstest1.key",
+				},
+				{
+					Type:    "tcp",
+					Purpose: []string{"cluster"},
+					Address: "127.0.0.1:0",
+				},
+			},
+			assertions: func(t *testing.T, c *Controller, apiAddrs []string, clusterAddr string) {
+				for i, apiAddr := range apiAddrs {
+					client := testTlsHttpClient(t, "./boundary-startlistenerstest"+strconv.Itoa(i)+".cert")
+					rsp, err := client.Get("https://" + apiAddr + "/v1/auth-methods?scope_id=global")
+					require.NoError(t, err)
+					require.Equal(t, http.StatusOK, rsp.StatusCode)
+				}
+
+				clusterGrpcDialNoError(t, c, "tcp", clusterAddr)
+			},
+		},
+		{
+			name: "one api, one cluster listener on unix sockets",
+			listeners: []*listenerutil.ListenerConfig{
+				{
+					Type:       "unix",
+					Purpose:    []string{"api"},
+					Address:    "/tmp/boundary-listener-test-api.sock",
+					TLSDisable: true,
+				},
+				{
+					Type:    "unix",
+					Purpose: []string{"cluster"},
+					Address: "/tmp/boundary-listener-test-cluster.sock",
+				},
+			},
+			assertions: func(t *testing.T, c *Controller, apiAddrs []string, clusterAddr string) {
+				conn, err := net.Dial("unix", apiAddrs[0])
+				require.NoError(t, err)
+
+				cl := http.Client{
+					Transport: &http.Transport{
+						Dial: func(network, addr string) (net.Conn, error) { return conn, nil },
+					},
+				}
+				rsp, err := cl.Get("http://randomdomain.boundary/v1/auth-methods?scope_id=global")
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, rsp.StatusCode)
+				require.NoError(t, conn.Close())
+
+				clusterGrpcDialNoError(t, c, "unix", clusterAddr)
+			},
+		},
+		{
+			name: "multiple api, one cluster listener on unix sockets",
+			listeners: []*listenerutil.ListenerConfig{
+				{
+					Type:       "unix",
+					Purpose:    []string{"api"},
+					Address:    "/tmp/boundary-listener-test-api.sock",
+					TLSDisable: true,
+				},
+				{
+					Type:       "unix",
+					Purpose:    []string{"api"},
+					Address:    "/tmp/boundary-listener-test-api2.sock",
+					TLSDisable: true,
+				},
+				{
+					Type:    "unix",
+					Purpose: []string{"cluster"},
+					Address: "/tmp/boundary-listener-test-cluster.sock",
+				},
+			},
+			assertions: func(t *testing.T, c *Controller, apiAddrs []string, clusterAddr string) {
+				for _, apiAddr := range apiAddrs {
+					conn, err := net.Dial("unix", apiAddr)
+					require.NoError(t, err)
+
+					cl := http.Client{
+						Transport: &http.Transport{
+							Dial: func(network, addr string) (net.Conn, error) { return conn, nil },
+						},
+					}
+					rsp, err := cl.Get("http://randomdomain.boundary/v1/auth-methods?scope_id=global")
+					require.NoError(t, err)
+					require.Equal(t, http.StatusOK, rsp.StatusCode)
+					require.NoError(t, conn.Close())
+				}
+
+				clusterGrpcDialNoError(t, c, "unix", clusterAddr)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+
+			tc := &TestController{t: t, ctx: ctx, cancel: cancel, opts: &TestControllerOpts{}}
+			t.Cleanup(func() { tc.Shutdown() })
+
+			conf := TestControllerConfig(t, ctx, tc, nil)
+			conf.RawConfig.SharedConfig = &configutil.SharedConfig{Listeners: tt.listeners, DisableMlock: true}
+
+			err := conf.SetupListeners(nil, conf.RawConfig.SharedConfig, []string{"api", "cluster"})
+			require.NoError(t, err)
+
+			c, err := New(ctx, conf)
+			require.NoError(t, err)
+
+			c.baseContext = ctx
+			c.baseCancel = cancel
+
+			err = c.startListeners()
+			require.NoError(t, err)
+
+			apiAddrs := make([]string, 0)
+			for _, l := range c.apiListeners {
+				apiAddrs = append(apiAddrs, l.Mux.Addr().String())
+			}
+			tt.assertions(t, c, apiAddrs, c.clusterListener.Mux.Addr().String())
+		})
+	}
+}
+
+func clusterGrpcDialNoError(t *testing.T, c *Controller, network, addr string) {
+	grpcConn, err := grpc.Dial(addr,
+		grpc.WithInsecure(),
+		grpc.WithBlock(),
+		grpc.WithTimeout(5*time.Second),
+		grpc.WithContextDialer(clusterTestDialer(t, c, network)),
+	)
+	require.NoError(t, err)
+	require.NoError(t, grpcConn.Close())
+}
+
+func testApiTlsSetup(t *testing.T, certPath, keyPath string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Cleanup(func() {
+			require.NoError(t, os.Remove(certPath))
+			require.NoError(t, os.Remove(keyPath))
+		})
+
+		certBytes, _, priv := createTestCert(t)
+
+		certFile, err := os.Create(certPath)
+		require.NoError(t, err)
+		require.NoError(t, pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes}))
+		require.NoError(t, certFile.Close())
+
+		keyFile, err := os.Create(keyPath)
+		require.NoError(t, err)
+
+		marshaledKey, err := x509.MarshalPKCS8PrivateKey(priv)
+		require.NoError(t, err)
+
+		require.NoError(t, pem.Encode(keyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: marshaledKey}))
+		require.NoError(t, keyFile.Close())
+	}
+}
+
+func testTlsHttpClient(t *testing.T, filePath string) *http.Client {
+	f, err := os.Open(filePath)
+	require.NoError(t, err)
+
+	certBytes, err := ioutil.ReadAll(f)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(certBytes)
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: certPool},
+		},
+	}
+}
+
+func createTestCert(t *testing.T) ([]byte, ed25519.PublicKey, ed25519.PrivateKey) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement | x509.KeyUsageCertSign,
+		SerialNumber:          big.NewInt(0),
+		NotBefore:             time.Now().Add(-30 * time.Second),
+		NotAfter:              time.Now().Add(5 * time.Minute),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"/tmp/boundary-listener-test-cluster.sock"},
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, pub, priv)
+	require.NoError(t, err)
+
+	return certBytes, pub, priv
+}
+
+func clusterTestDialer(t *testing.T, c *Controller, network string) func(context.Context, string) (net.Conn, error) {
+	return func(ctx context.Context, addr string) (net.Conn, error) {
+		certBytes, _, priv := createTestCert(t)
+
+		marshaledKey, err := x509.MarshalPKCS8PrivateKey(priv)
+		require.NoError(t, err)
+
+		nonce, err := base62.Random(20)
+		require.NoError(t, err)
+
+		info := base.WorkerAuthInfo{
+			CertPEM:         pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes}),
+			KeyPEM:          pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: marshaledKey}),
+			ConnectionNonce: nonce,
+		}
+		infoBytes, err := json.Marshal(info)
+		require.NoError(t, err)
+
+		encInfo, err := c.conf.WorkerAuthKms.Encrypt(ctx, infoBytes, nil)
+		require.NoError(t, err)
+
+		protoEncInfo, err := proto.Marshal(encInfo)
+		require.NoError(t, err)
+
+		b64alpn := base64.RawStdEncoding.EncodeToString(protoEncInfo)
+
+		var nextProtos []string
+		var count int
+		for i := 0; i < len(b64alpn); i += 230 {
+			end := i + 230
+			if end > len(b64alpn) {
+				end = len(b64alpn)
+			}
+			nextProtos = append(nextProtos, fmt.Sprintf("v1workerauth-%02d-%s", count, b64alpn[i:end]))
+			count++
+		}
+
+		cert, err := x509.ParseCertificate(certBytes)
+		require.NoError(t, err)
+
+		rootCAs := x509.NewCertPool()
+		rootCAs.AddCert(cert)
+
+		tlsCert, err := tls.X509KeyPair(info.CertPEM, info.KeyPEM)
+		require.NoError(t, err)
+
+		conn, err := tls.Dial(network, addr, &tls.Config{
+			Certificates: []tls.Certificate{tlsCert},
+			RootCAs:      rootCAs,
+			NextProtos:   nextProtos,
+			MinVersion:   tls.VersionTLS13,
+		})
+		require.NoError(t, err)
+
+		_, err = conn.Write([]byte(nonce))
+		require.NoError(t, err)
+
+		return conn, nil
+	}
+}

--- a/internal/servers/controller/testing.go
+++ b/internal/servers/controller/testing.go
@@ -269,7 +269,7 @@ func (tc *TestController) Shutdown() {
 	tc.cancel()
 
 	if tc.c != nil {
-		if err := tc.c.Shutdown(false); err != nil {
+		if err := tc.c.Shutdown(); err != nil {
 			tc.t.Error(err)
 		}
 	}

--- a/internal/servers/worker/controller_connection.go
+++ b/internal/servers/worker/controller_connection.go
@@ -138,17 +138,13 @@ func (w *Worker) createClientConn(addr string) error {
 func (w *Worker) workerAuthTLSConfig() (*tls.Config, *base.WorkerAuthInfo, error) {
 	var err error
 	info := &base.WorkerAuthInfo{
-		Name:            w.conf.RawConfig.Worker.Name,
-		Description:     w.conf.RawConfig.Worker.Description,
-		ConnectionNonce: w.testReusedAuthNonce,
+		Name:        w.conf.RawConfig.Worker.Name,
+		Description: w.conf.RawConfig.Worker.Description,
 	}
-	if info.ConnectionNonce == "" {
-		if info.ConnectionNonce, err = base62.Random(20); err != nil {
-			return nil, nil, err
-		}
-		if w.testReuseAuthNonces {
-			w.testReusedAuthNonce = info.ConnectionNonce
-		}
+
+	info.ConnectionNonce, err = w.nonceFn(20)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	pubKey, privKey, err := ed25519.GenerateKey(w.conf.SecureRandomReader)

--- a/internal/servers/worker/listeners.go
+++ b/internal/servers/worker/listeners.go
@@ -5,12 +5,14 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"os"
 	"sync"
 	"time"
 
+	"github.com/hashicorp/boundary/internal/cmd/base"
 	"github.com/hashicorp/boundary/internal/libs/alpnmux"
 	"github.com/hashicorp/boundary/internal/observability/event"
 	"github.com/hashicorp/go-multierror"
@@ -18,7 +20,7 @@ import (
 
 func (w *Worker) startListeners() error {
 	const op = "worker.(Worker).startListeners"
-	servers := make([]func(), 0, len(w.conf.Listeners))
+
 	e := event.SysEventer()
 	if e == nil {
 		return fmt.Errorf("%s: sys eventer not initialized", op)
@@ -27,70 +29,15 @@ func (w *Worker) startListeners() error {
 	if err != nil {
 		return fmt.Errorf("%s: unable to initialize std logger: %w", op, err)
 	}
-	for _, ln := range w.conf.Listeners {
-		for _, purpose := range ln.Config.Purpose {
-			switch purpose {
-			case "api", "cluster":
-				// We may have this in dev mode; ignore
-				continue
 
-			case "proxy":
-				// Do nothing; handle below
-
-			default:
-				return fmt.Errorf("unknown listener purpose %q", purpose)
-			}
-
-			handler, err := w.handler(HandlerProperties{
-				ListenerConfig: ln.Config,
-			})
-			if err != nil {
-				return fmt.Errorf("%s: %w", op, err)
-			}
-
-			cancelCtx := w.baseContext
-
-			server := &http.Server{
-				Handler:           handler,
-				ReadHeaderTimeout: 10 * time.Second,
-				ReadTimeout:       30 * time.Second,
-				ErrorLog:          logger,
-				BaseContext: func(net.Listener) context.Context {
-					return cancelCtx
-				},
-			}
-			ln.HTTPServer = server
-
-			if ln.Config.HTTPReadHeaderTimeout > 0 {
-				server.ReadHeaderTimeout = ln.Config.HTTPReadHeaderTimeout
-			}
-			if ln.Config.HTTPReadTimeout > 0 {
-				server.ReadTimeout = ln.Config.HTTPReadTimeout
-			}
-			if ln.Config.HTTPWriteTimeout > 0 {
-				server.WriteTimeout = ln.Config.HTTPWriteTimeout
-			}
-			if ln.Config.HTTPIdleTimeout > 0 {
-				server.IdleTimeout = ln.Config.HTTPIdleTimeout
-			}
-
-			// Clear out in case this is a second start of the controller
-			ln.Mux.UnregisterProto(alpnmux.DefaultProto)
-			ln.Mux.UnregisterProto(alpnmux.NoProto)
-			l, err := ln.Mux.RegisterProto(alpnmux.DefaultProto, &tls.Config{
-				GetConfigForClient: w.getSessionTls,
-			})
-			if err != nil {
-				return fmt.Errorf("error getting tls listener: %w", err)
-			}
-			if l == nil {
-				return errors.New("could not get tls listener")
-			}
-
-			servers = append(servers, func() {
-				go server.Serve(l)
-			})
+	servers := make([]func(), 0, len(w.listeners))
+	for i := range w.listeners {
+		ln := w.listeners[i]
+		workerServer, err := w.configureForWorker(ln, logger)
+		if err != nil {
+			return fmt.Errorf("%s: failed to configure for worker: %w", op, err)
 		}
+		servers = append(servers, workerServer)
 	}
 
 	for _, s := range servers {
@@ -98,6 +45,53 @@ func (w *Worker) startListeners() error {
 	}
 
 	return nil
+}
+
+func (w *Worker) configureForWorker(ln *base.ServerListener, log *log.Logger) (func(), error) {
+	handler, err := w.handler(HandlerProperties{ListenerConfig: ln.Config})
+	if err != nil {
+		return nil, err
+	}
+
+	cancelCtx := w.baseContext
+	server := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		ErrorLog:          log,
+		BaseContext: func(net.Listener) context.Context {
+			return cancelCtx
+		},
+	}
+	ln.HTTPServer = server
+
+	if ln.Config.HTTPReadHeaderTimeout > 0 {
+		server.ReadHeaderTimeout = ln.Config.HTTPReadHeaderTimeout
+	}
+	if ln.Config.HTTPReadTimeout > 0 {
+		server.ReadTimeout = ln.Config.HTTPReadTimeout
+	}
+	if ln.Config.HTTPWriteTimeout > 0 {
+		server.WriteTimeout = ln.Config.HTTPWriteTimeout
+	}
+	if ln.Config.HTTPIdleTimeout > 0 {
+		server.IdleTimeout = ln.Config.HTTPIdleTimeout
+	}
+
+	// Clear out in case this is a second start of the controller
+	ln.Mux.UnregisterProto(alpnmux.DefaultProto)
+	ln.Mux.UnregisterProto(alpnmux.NoProto)
+	l, err := ln.Mux.RegisterProto(alpnmux.DefaultProto, &tls.Config{
+		GetConfigForClient: w.getSessionTls,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error getting tls listener: %w", err)
+	}
+	if l == nil {
+		return nil, errors.New("could not get tls listener")
+	}
+
+	return func() { go server.Serve(l) }, nil
 }
 
 func (w *Worker) stopListeners() error {

--- a/internal/servers/worker/listeners_test.go
+++ b/internal/servers/worker/listeners_test.go
@@ -1,0 +1,134 @@
+package worker
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"github.com/hashicorp/go-secure-stdlib/listenerutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartListeners(t *testing.T) {
+	tests := []struct {
+		name       string
+		listeners  []*listenerutil.ListenerConfig
+		expErr     bool
+		expErrMsg  string
+		assertions func(t *testing.T, w *Worker, addrs []string)
+	}{
+		{
+			name: "one tcp listener, one unix listener",
+			listeners: []*listenerutil.ListenerConfig{
+				{
+					Type:       "tcp",
+					Purpose:    []string{"proxy"},
+					Address:    "127.0.0.1:0",
+					TLSDisable: true,
+				},
+				{
+					Type:       "unix",
+					Purpose:    []string{"proxy"},
+					Address:    "/tmp/boundary-worker-test-start-listeners.sock",
+					TLSDisable: true,
+				},
+			},
+			expErr: false,
+			assertions: func(t *testing.T, w *Worker, addrs []string) {
+				require.Len(t, addrs, 2)
+
+				_, err := http.Get("http://" + addrs[0] + "/v1/proxy/")
+				require.ErrorIs(t, err, io.EOF) // empty response because of worker tls request validation
+
+				cl := http.Client{
+					Transport: &http.Transport{
+						Dial: func(network, addr string) (net.Conn, error) { return net.Dial("unix", addrs[1]) },
+					},
+				}
+				_, err = cl.Get("http://anything.domain/v1/proxy/")
+				require.ErrorIs(t, err, io.EOF) // empty response because of worker tls request validation
+			},
+		},
+		{
+			name: "multiple tcp listeners, multiple unix listeners",
+			listeners: []*listenerutil.ListenerConfig{
+				{
+					Type:       "tcp",
+					Purpose:    []string{"proxy"},
+					Address:    "127.0.0.1:0",
+					TLSDisable: true,
+				},
+				{
+					Type:       "tcp",
+					Purpose:    []string{"proxy"},
+					Address:    "127.0.0.1:0",
+					TLSDisable: true,
+				},
+				{
+					Type:       "unix",
+					Purpose:    []string{"proxy"},
+					Address:    "/tmp/boundary-worker-test-start-listeners0.sock",
+					TLSDisable: true,
+				},
+				{
+					Type:       "unix",
+					Purpose:    []string{"proxy"},
+					Address:    "/tmp/boundary-worker-test-start-listeners1.sock",
+					TLSDisable: true,
+				},
+			},
+			expErr: false,
+			assertions: func(t *testing.T, w *Worker, addrs []string) {
+				require.Len(t, addrs, 4)
+
+				_, err := http.Get("http://" + addrs[0] + "/v1/proxy/")
+				require.ErrorIs(t, err, io.EOF) // empty response because of worker tls request validation
+
+				_, err = http.Get("http://" + addrs[1] + "/v1/proxy/")
+				require.ErrorIs(t, err, io.EOF) // empty response because of worker tls request validation
+
+				for _, proxyAddr := range []string{addrs[2], addrs[3]} {
+					cl := http.Client{
+						Transport: &http.Transport{
+							Dial: func(network, addr string) (net.Conn, error) { return net.Dial("unix", proxyAddr) },
+						},
+					}
+					_, err = cl.Get("http://anything.domain/v1/proxy")
+					require.ErrorIs(t, err, io.EOF) // empty response because of worker tls request validation
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := NewTestWorker(t, &TestWorkerOpts{DisableAutoStart: true}).w.conf
+			conf.RawConfig.SharedConfig.Listeners = tt.listeners
+
+			err := conf.SetupListeners(nil, conf.RawConfig.SharedConfig, []string{"proxy"})
+			require.NoError(t, err)
+
+			w, err := New(conf)
+			require.NoError(t, err)
+			w.baseContext = context.Background()
+
+			err = w.startListeners()
+			if tt.expErr {
+				require.EqualError(t, err, tt.expErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+
+			addrs := make([]string, 0)
+			for _, l := range w.listeners {
+				addrs = append(addrs, l.Mux.Addr().String())
+			}
+			if tt.assertions != nil {
+				tt.assertions(t, w, addrs)
+			}
+		})
+	}
+}
+

--- a/internal/servers/worker/listeners_test.go
+++ b/internal/servers/worker/listeners_test.go
@@ -2,10 +2,17 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"strconv"
 	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/hashicorp/boundary/internal/libs/alpnmux"
 	"github.com/hashicorp/go-secure-stdlib/listenerutil"
 	"github.com/stretchr/testify/require"
 )
@@ -132,3 +139,251 @@ func TestStartListeners(t *testing.T) {
 	}
 }
 
+func TestStopHttpServersAndListeners(t *testing.T) {
+	tests := []struct {
+		name       string
+		workerFn   func(t *testing.T) *Worker
+		assertions func(t *testing.T, w *Worker)
+		expErr     bool
+		expErrStr  string
+	}{
+		{
+			name: "no listeners",
+			workerFn: func(t *testing.T) *Worker {
+				return &Worker{listeners: []*base.ServerListener{}}
+			},
+			expErr: false,
+		},
+		{
+			name: "nil listeners slice",
+			workerFn: func(t *testing.T) *Worker {
+				return &Worker{listeners: nil}
+			},
+			expErr: false,
+		},
+		{
+			name: "listeners with nil http server",
+			workerFn: func(t *testing.T) *Worker {
+				return &Worker{
+					listeners: []*base.ServerListener{
+						{HTTPServer: nil},
+						{HTTPServer: nil},
+						{HTTPServer: nil},
+					},
+				}
+			},
+			expErr: false,
+		},
+		{
+			name: "multiple listeners",
+			workerFn: func(t *testing.T) *Worker {
+				l1, err := net.Listen("tcp", "127.0.0.1:0")
+				require.NoError(t, err)
+				l2, err := net.Listen("unix", "/tmp/boundary-worker-TestStopHttpServersAndListeners-"+strconv.FormatInt(time.Now().UnixNano(), 10))
+				require.NoError(t, err)
+
+				s1 := &http.Server{}
+				s2 := &http.Server{}
+
+				go s1.Serve(l1)
+				go s2.Serve(l2)
+
+				// Make sure they're up
+				_, err = http.Get("http://" + l1.Addr().String())
+				require.NoError(t, err)
+
+				c := http.Client{Transport: &http.Transport{
+					Dial: func(network, addr string) (net.Conn, error) {
+						return net.Dial("unix", l2.Addr().String())
+					},
+				}}
+				_, err = c.Get("http://random.domain")
+				require.NoError(t, err)
+
+				return &Worker{
+					baseContext: context.Background(),
+					listeners: []*base.ServerListener{
+						{
+							ALPNListener: l1,
+							HTTPServer:   s1,
+							Mux:          alpnmux.New(l1),
+							Config:       &listenerutil.ListenerConfig{Type: "tcp"},
+						},
+						{
+							ALPNListener: l2,
+							HTTPServer:   s2,
+							Mux:          alpnmux.New(l2),
+							Config:       &listenerutil.ListenerConfig{Type: "tcp"},
+						},
+					},
+				}
+			},
+			assertions: func(t *testing.T, w *Worker) {
+				// Asserts the HTTP Servers are closed.
+				require.ErrorIs(t, w.listeners[0].HTTPServer.Serve(w.listeners[0].ALPNListener), http.ErrServerClosed)
+				require.ErrorIs(t, w.listeners[1].HTTPServer.Serve(w.listeners[1].ALPNListener), http.ErrServerClosed)
+
+				// Asserts the underlying listeners are closed.
+				require.ErrorIs(t, w.listeners[0].Mux.Close(), net.ErrClosed)
+				require.ErrorIs(t, w.listeners[1].Mux.Close(), net.ErrClosed)
+			},
+			expErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := tt.workerFn(t)
+			err := w.stopHttpServersAndListeners()
+			if tt.expErr {
+				require.EqualError(t, err, tt.expErrStr)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.assertions != nil {
+				tt.assertions(t, w)
+			}
+		})
+	}
+}
+
+func TestStopAnyListeners(t *testing.T) {
+	tests := []struct {
+		name       string
+		workerFn   func(t *testing.T) *Worker
+		assertions func(t *testing.T, w *Worker)
+		expErr     bool
+		expErrStr  string
+	}{
+		{
+			name: "nil listeners",
+			workerFn: func(t *testing.T) *Worker {
+				return &Worker{listeners: nil}
+			},
+			expErr: false,
+		},
+		{
+			name: "no listeners",
+			workerFn: func(t *testing.T) *Worker {
+				return &Worker{listeners: []*base.ServerListener{}}
+			},
+			expErr: false,
+		},
+		{
+			name: "listeners slice with nil server listeners",
+			workerFn: func(t *testing.T) *Worker {
+				return &Worker{listeners: []*base.ServerListener{nil, nil, nil}}
+			},
+			expErr: false,
+		},
+		{
+			name: "listeners with nil mux",
+			workerFn: func(t *testing.T) *Worker {
+				return &Worker{listeners: []*base.ServerListener{
+					{Mux: nil}, {Mux: nil}, {Mux: nil},
+				}}
+			},
+			expErr: false,
+		},
+		{
+			name: "multiple listeners, including a closed one",
+			workerFn: func(t *testing.T) *Worker {
+				l1, err := net.Listen("tcp", "127.0.0.1:0")
+				require.NoError(t, err)
+
+				l2, err := net.Listen("unix", "/tmp/boundary-worker-TestStopAnyListeners-"+strconv.FormatInt(time.Now().UnixNano(), 10))
+				require.NoError(t, err)
+
+				l3, err := net.Listen("tcp", "127.0.0.1:0")
+				require.NoError(t, err)
+				require.NoError(t, l3.Close())
+
+				return &Worker{listeners: []*base.ServerListener{
+					{
+						Config: &listenerutil.ListenerConfig{Type: "tcp"},
+						Mux:    alpnmux.New(l1),
+					},
+					{
+						Config: &listenerutil.ListenerConfig{Type: "tcp"},
+						Mux:    alpnmux.New(l2),
+					},
+					{
+						Config: &listenerutil.ListenerConfig{Type: "tcp"},
+						Mux:    alpnmux.New(l3),
+					},
+				}}
+			},
+			assertions: func(t *testing.T, w *Worker) {
+				for i := range w.listeners {
+					ln := w.listeners[i]
+					require.ErrorIs(t, ln.Mux.Close(), net.ErrClosed)
+				}
+			},
+			expErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := tt.workerFn(t)
+			err := c.stopAnyListeners()
+			if tt.expErr {
+				require.EqualError(t, err, tt.expErrStr)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.assertions != nil {
+				tt.assertions(t, c)
+			}
+		})
+	}
+}
+
+func TestListenerCloseErrorCheck(t *testing.T) {
+	tests := []struct {
+		name   string
+		lnType string
+		err    error
+		expErr error
+	}{
+		{
+			name:   "nil err",
+			lnType: "tcp",
+			err:    nil,
+			expErr: nil,
+		},
+		{
+			name:   "net.Closed",
+			lnType: "tcp",
+			err:    net.ErrClosed,
+			expErr: nil,
+		},
+		{
+			name:   "path err not unix type",
+			lnType: "tcp",
+			err:    &os.PathError{Op: "test"},
+			expErr: &os.PathError{Op: "test"},
+		},
+		{
+			name:   "path err unix type",
+			lnType: "unix",
+			err:    &os.PathError{Op: "test"},
+			expErr: nil,
+		},
+		{
+			name:   "literally anything else",
+			lnType: "tcp",
+			err:    fmt.Errorf("oops I errored"),
+			expErr: fmt.Errorf("oops I errored"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := listenerCloseErrorCheck(tt.lnType, tt.err)
+			require.Equal(t, tt.expErr, err)
+		})
+	}
+}

--- a/internal/servers/worker/testing.go
+++ b/internal/servers/worker/testing.go
@@ -148,7 +148,7 @@ func (tw *TestWorker) Shutdown() {
 	tw.cancel()
 
 	if tw.w != nil {
-		if err := tw.w.Shutdown(false); err != nil {
+		if err := tw.w.Shutdown(); err != nil {
 			tw.t.Error(err)
 		}
 	}

--- a/internal/servers/worker/testing.go
+++ b/internal/servers/worker/testing.go
@@ -183,8 +183,9 @@ type TestWorkerOpts struct {
 	// connection cannot be made back to the controller
 	StatusGracePeriodDuration time.Duration
 
-	// Whether to set the replay value
-	EnableAuthReplay bool
+	// Overrides worker's nonceFn, for cases where we want to have control
+	// over the nonce we send to the Controller
+	NonceFn randFn
 }
 
 func NewTestWorker(t *testing.T, opts *TestWorkerOpts) *TestWorker {
@@ -280,8 +281,8 @@ func NewTestWorker(t *testing.T, opts *TestWorkerOpts) *TestWorker {
 		t.Fatal(err)
 	}
 
-	if opts.EnableAuthReplay {
-		tw.w.testReuseAuthNonces = true
+	if opts.NonceFn != nil {
+		tw.w.nonceFn = opts.NonceFn
 	}
 
 	if !opts.DisableAutoStart {

--- a/internal/servers/worker/worker_test.go
+++ b/internal/servers/worker/worker_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWorkerNewListenerConfig(t *testing.T) {
+func TestWorkerNew(t *testing.T) {
 	tests := []struct {
 		name       string
 		in         *Config
@@ -74,6 +74,20 @@ func TestWorkerNewListenerConfig(t *testing.T) {
 			expErr: false,
 			assertions: func(t *testing.T, w *Worker) {
 				require.Len(t, w.listeners, 2)
+			},
+		},
+		{
+			name: "worker nonce func is set",
+			in: &Config{
+				Server: &base.Server{
+					Listeners: []*base.ServerListener{
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"proxy"}}},
+					},
+				},
+			},
+			expErr: false,
+			assertions: func(t *testing.T, w *Worker) {
+				require.NotNil(t, w.nonceFn)
 			},
 		},
 	}

--- a/internal/servers/worker/worker_test.go
+++ b/internal/servers/worker/worker_test.go
@@ -1,0 +1,100 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/hashicorp/boundary/internal/cmd/config"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/configutil"
+	"github.com/hashicorp/go-secure-stdlib/listenerutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkerNewListenerConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         *Config
+		expErr     bool
+		expErrMsg  string
+		assertions func(t *testing.T, w *Worker)
+	}{
+		{
+			name:      "nil listeners",
+			in:        &Config{Server: &base.Server{Listeners: nil}},
+			expErr:    true,
+			expErrMsg: "no proxy listeners found",
+		},
+		{
+			name:      "zero listeners",
+			in:        &Config{Server: &base.Server{Listeners: []*base.ServerListener{}}},
+			expErr:    true,
+			expErrMsg: "no proxy listeners found",
+		},
+		{
+			name: "populated with nil values",
+			in: &Config{
+				Server: &base.Server{
+					Listeners: []*base.ServerListener{
+						nil,
+						{Config: nil},
+						{Config: &listenerutil.ListenerConfig{Purpose: nil}},
+					},
+				},
+			},
+			expErr:    true,
+			expErrMsg: "no proxy listeners found",
+		},
+		{
+			name: "multiple purposes",
+			in: &Config{
+				Server: &base.Server{
+					Listeners: []*base.ServerListener{
+						nil,
+						{Config: nil},
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"api", "proxy"}}},
+					},
+				},
+			},
+			expErr:    true,
+			expErrMsg: `found listener with multiple purposes "api,proxy"`,
+		},
+		{
+			name: "valid listeners",
+			in: &Config{
+				Server: &base.Server{
+					Listeners: []*base.ServerListener{
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"api"}}},
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"proxy"}}},
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"proxy"}}},
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"cluster"}}},
+					},
+				},
+			},
+			expErr: false,
+			assertions: func(t *testing.T, w *Worker) {
+				require.Len(t, w.listeners, 2)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// New() panics if these aren't set
+			tt.in.Logger = hclog.Default()
+			tt.in.RawConfig = &config.Config{SharedConfig: &configutil.SharedConfig{DisableMlock: true}}
+
+			w, err := New(tt.in)
+			if tt.expErr {
+				require.EqualError(t, err, tt.expErrMsg)
+				require.Nil(t, w)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.assertions != nil {
+				tt.assertions(t, w)
+			}
+		})
+	}
+}

--- a/internal/tests/cluster/ipv6_listener_test.go
+++ b/internal/tests/cluster/ipv6_listener_test.go
@@ -77,16 +77,18 @@ func TestIPv6Listener(t *testing.T) {
 	time.Sleep(10 * time.Second)
 	expectWorkers(c1, w1)
 
+	c2 := c1.AddClusterControllerMember(t, &controller.TestControllerOpts{
+		Logger: c1.Config().Logger.ResetNamed("c2"),
+	})
+	defer c2.Shutdown()
+
+	time.Sleep(10 * time.Second)
+	expectWorkers(c2, w1)
+
 	require.NoError(w1.Worker().Shutdown(true))
 	time.Sleep(10 * time.Second)
 	expectWorkers(c1)
-
-	require.NoError(c1.Controller().Shutdown(true))
-	time.Sleep(10 * time.Second)
-
-	require.NoError(c1.Controller().Start())
-	time.Sleep(10 * time.Second)
-	expectWorkers(c1, w1)
+	expectWorkers(c2)
 
 	client, err := api.NewClient(nil)
 	require.NoError(err)

--- a/internal/tests/cluster/multi_controller_worker_test.go
+++ b/internal/tests/cluster/multi_controller_worker_test.go
@@ -64,7 +64,7 @@ func TestMultiControllerMultiWorkerConnections(t *testing.T) {
 	expectWorkers(t, c1, w1, w2)
 	expectWorkers(t, c2, w1, w2)
 
-	require.NoError(c1.Controller().Shutdown(true))
+	require.NoError(c2.Controller().Shutdown())
 	time.Sleep(10 * time.Second)
 	expectWorkers(t, c2, w1, w2)
 

--- a/internal/tests/cluster/unix_listener_test.go
+++ b/internal/tests/cluster/unix_listener_test.go
@@ -94,12 +94,16 @@ func TestUnixListener(t *testing.T) {
 	time.Sleep(10 * time.Second)
 	expectWorkers(c1)
 
-	require.NoError(c1.Controller().Shutdown(true))
-	time.Sleep(10 * time.Second)
+	require.NoError(c1.Controller().Shutdown())
+	c1 = controller.NewTestController(t, &controller.TestControllerOpts{
+		Config:                        conf,
+		Logger:                        logger.Named("c1"),
+		DisableOidcAuthMethodCreation: true,
+	})
+	defer c1.Shutdown()
 
-	require.NoError(c1.Controller().Start())
 	time.Sleep(10 * time.Second)
-	expectWorkers(c1, w1)
+	expectWorkers(c1)
 
 	client, err := api.NewClient(nil)
 	require.NoError(err)

--- a/internal/tests/cluster/unix_listener_test.go
+++ b/internal/tests/cluster/unix_listener_test.go
@@ -14,12 +14,11 @@ import (
 	"github.com/hashicorp/boundary/internal/servers/controller"
 	"github.com/hashicorp/boundary/internal/servers/worker"
 	"github.com/hashicorp/go-hclog"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUnixListener(t *testing.T) {
-	assert, require := assert.New(t), require.New(t)
+	require := require.New(t)
 	logger := hclog.New(&hclog.LoggerOptions{
 		Level: hclog.Trace,
 	})
@@ -53,28 +52,7 @@ func TestUnixListener(t *testing.T) {
 	})
 	defer c1.Shutdown()
 
-	expectWorkers := func(c *controller.TestController, workers ...*worker.TestWorker) {
-		updateTimes := c.Controller().WorkerStatusUpdateTimes()
-		workerMap := map[string]*worker.TestWorker{}
-		for _, w := range workers {
-			workerMap[w.Name()] = w
-		}
-		updateTimes.Range(func(k, v interface{}) bool {
-			require.NotNil(k)
-			require.NotNil(v)
-			if workerMap[k.(string)] == nil {
-				// We don't remove from updateTimes currently so if we're not
-				// expecting it we'll see an out-of-date entry
-				return true
-			}
-			assert.WithinDuration(time.Now(), v.(time.Time), 60*time.Second)
-			delete(workerMap, k.(string))
-			return true
-		})
-		assert.Empty(workerMap)
-	}
-
-	expectWorkers(c1)
+	expectWorkers(t, c1)
 
 	wconf, err := config.DevWorker()
 	require.NoError(err)
@@ -88,11 +66,11 @@ func TestUnixListener(t *testing.T) {
 	defer w1.Shutdown()
 
 	time.Sleep(10 * time.Second)
-	expectWorkers(c1, w1)
+	expectWorkers(t, c1, w1)
 
-	require.NoError(w1.Worker().Shutdown(true))
+	require.NoError(w1.Worker().Shutdown())
 	time.Sleep(10 * time.Second)
-	expectWorkers(c1)
+	expectWorkers(t, c1)
 
 	require.NoError(c1.Controller().Shutdown())
 	c1 = controller.NewTestController(t, &controller.TestControllerOpts{
@@ -103,7 +81,7 @@ func TestUnixListener(t *testing.T) {
 	defer c1.Shutdown()
 
 	time.Sleep(10 * time.Second)
-	expectWorkers(c1)
+	expectWorkers(t, c1)
 
 	client, err := api.NewClient(nil)
 	require.NoError(err)

--- a/internal/tests/cluster/worker_replay_test.go
+++ b/internal/tests/cluster/worker_replay_test.go
@@ -46,7 +46,7 @@ func TestWorkerReplay(t *testing.T) {
 
 	// Give time for it to connect
 	time.Sleep(10 * time.Second)
-	require.NoError(t, w1.Worker().Shutdown(true))
+	require.NoError(t, w1.Worker().Shutdown())
 
 	// Now, start up again
 	require.NoError(t, w1.Worker().Start())


### PR DESCRIPTION
Improving controller/worker listener code:

- (Controller) Only start a single gRPC Server for all API Listener
purposes.
- (Both) Improve logic around handling multiple listeners with the same
purpose.
- (Both) Improve naming around objects and functions.
- (Controller) Decouple gRPC Server and gRPC Gateway Service 
Registration.
- (Both) Improve shutdown process.
- (Both) Improve test cases and coverage.
- (Both) First pass at centralizing configuration and validation
on Controller/Worker objects.