### PR TITLE
chore: updates to azure and AWS doc links

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -131,11 +131,16 @@ module.exports = [
   },
 
   {
-    source: '/help/admin-ui/host-catalog-set-up-cloud-hosts',
-    destination: 'https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts',
+    source: '/help/admin-ui/dynamic-host-catalogs-on-aws',
+    destination: 'https://learn.hashicorp.com/tutorials/boundary/aws-host-catalogs',
     permanent: false,
   },
 
+  {
+    source: '/help/admin-ui/dynamic-host-catalogs-on-azure',
+    destination: 'https://learn.hashicorp.com/tutorials/boundary/azure-host-catalogs',
+    permanent: false,
+  },
   ////////////////////////////////////////////
   // Adding sub-resources to existing resource
   ////////////////////////////////////////////


### PR DESCRIPTION
This pr updates the existing dynamic host catalog doc link for azure and adds a new doc link for aws. 