### PR TITLE
Remove setup git CI step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
-      - name: Setup Git
-        run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
       - name: Set sha
         id: set-sha
         run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
@@ -153,8 +151,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Git
-        run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
       - name: Setup go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
This isn't needed for non-enterprise projects. Thanks to @claire-labry for pointing this out!! 