### PR TITLE
website: clarification on default TCP ports

### DIFF
--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -189,7 +189,7 @@ listener "tcp" {
 
 listener "tcp" {
   purpose = "cluster"
-  address = "10.0.0.5:9200"
+  address = "10.0.0.5:9201"
 }
 ```
 

--- a/website/content/docs/installing/high-availability.mdx
+++ b/website/content/docs/installing/high-availability.mdx
@@ -13,9 +13,9 @@ Installing Boundary as a high availability service requires certain infrastructu
 
 The following ports should be available:
 
-- Clients must have access to the Controller's port (default 9200)
+- Clients must have access to the Controller's `api` port (default 9200)
 - Clients must have access to the Worker's port (default 9202)
-- Workers must have access to the Controller's port (default 9201)
+- Workers must have access to the Controller's `cluster` port (default 9201)
 - Workers must have a route and port access to the hosts defined within the system in order to provide connectivity
 
 ## Architecture


### PR DESCRIPTION
Apologies in advance if they are not but I believe these changes are correct.

I was recently running through https://github.com/hashicorp/learn-boundary-target-aware-workers/pull/2 and thought these might be discrepancies or opportunity for further clarification.

These 2 changes are regarding https://www.boundaryproject.io/docs/configuration/listener/tcp#listening-on-multiple-interfaces and https://www.boundaryproject.io/docs/installing/high-availability#network-requirements.