### PR TITLE
fix(genapi): Sort slice in removeDups template function

### DIFF
--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -816,5 +816,8 @@ func removeDups(in []string) []string {
 	for val := range vals {
 		ret = append(ret, val)
 	}
+
+	sort.Strings(ret)
+
 	return ret
 }


### PR DESCRIPTION
The removeDups template function converts a slice into a map and
back into a slice in order to leverage the map keys to remove
duplicates. However, since the iteration order over a map is not
specified it would be possible to get different orders for multiple runs
of `make api`. While this would not have an impact on any functionality,
it is causing sporadic failures for the new make-gen-deltas CI job.

See: https://go.dev/ref/spec#For_statements
Ref: d57603022a317c99ac4feb0bcb78727e08f9dcfb