### PR TITLE
Optional: add versioned redirect

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -40,6 +40,12 @@ module.exports = [
       'https://learn.hashicorp.com/tutorials/boundary/getting-started-desktop-app',
     permanent: true,
   },
+  {
+    source: '/docs/:version/api-clients/desktop',
+    destination:
+      'https://learn.hashicorp.com/tutorials/boundary/getting-started-desktop-app',
+    permanent: true,
+  },
 
   /////////////////////////////////
   // DOMAIN MODEL CONCEPTS
@@ -132,13 +138,15 @@ module.exports = [
 
   {
     source: '/help/admin-ui/dynamic-host-catalogs-on-aws',
-    destination: 'https://learn.hashicorp.com/tutorials/boundary/aws-host-catalogs',
+    destination:
+      'https://learn.hashicorp.com/tutorials/boundary/aws-host-catalogs',
     permanent: false,
   },
 
   {
     source: '/help/admin-ui/dynamic-host-catalogs-on-azure',
-    destination: 'https://learn.hashicorp.com/tutorials/boundary/azure-host-catalogs',
+    destination:
+      'https://learn.hashicorp.com/tutorials/boundary/azure-host-catalogs',
     permanent: false,
   },
   ////////////////////////////////////////////


### PR DESCRIPTION
# Description

It looks like we have a redirect inplace
- from: https://www.boundaryproject.io/docs/api-clients/desktop
- to: https://learn.hashicorp.com/tutorials/boundary/getting-started-desktop-app

But not for a versioned-url
- https://www.boundaryproject.io/docs/v0.7.x/api-clients/desktop (which is still a valid page)

This adds a versioned redirect