### PR TITLE
Display vault credential workflow in desktop video in homepage

### DIFF
--- a/website/components/homepage-hero/index.jsx
+++ b/website/components/homepage-hero/index.jsx
@@ -28,13 +28,13 @@ export default function HomepageHero({
           centered: false,
           videos: [
             {
-              name: 'UI',
-              playbackRate: uiVideo.playbackRate,
-              aspectRatio: uiVideo.aspectRatio,
+              name: 'Desktop',
+              playbackRate: desktopVideo.playbackRate,
+              aspectRatio: desktopVideo.aspectRatio,
               src: [
                 {
-                  srcType: uiVideo.srcType,
-                  url: uiVideo.url,
+                  srcType: desktopVideo.srcType,
+                  url: desktopVideo.url,
                 },
               ],
             },
@@ -50,13 +50,13 @@ export default function HomepageHero({
               ],
             },
             {
-              name: 'Desktop',
-              playbackRate: desktopVideo.playbackRate,
-              aspectRatio: desktopVideo.aspectRatio,
+              name: 'UI',
+              playbackRate: uiVideo.playbackRate,
+              aspectRatio: uiVideo.aspectRatio,
               src: [
                 {
-                  srcType: desktopVideo.srcType,
-                  url: desktopVideo.url,
+                  srcType: uiVideo.srcType,
+                  url: uiVideo.url,
                 },
               ],
             },

--- a/website/pages/home/index.jsx
+++ b/website/pages/home/index.jsx
@@ -39,10 +39,10 @@ export default function HomePage() {
         }}
         desktopVideo={{
           url:
-            'https://www.datocms-assets.com/2885/1614100044-hero-desktop.mp4',
+            'https://www.datocms-assets.com/2885/1646421743-hero-desktop-vault-credentials.mp4',
           srcType: 'mp4',
           aspectRatio: 0.59968354,
-          playbackRate: 1,
+          playbackRate: 2,
         }}
       />
 


### PR DESCRIPTION
This PR updates doc home page desktop video to show vault credential workflow. In addition, desktop video is made first video on the page.

Ref: [Updated desktop workflow video](https://www.datocms-assets.com/2885/1646421743-hero-desktop-vault-credentials.mp4)

Review changes in [vercel](https://boundary-ayij67iv9-hashicorp.vercel.app/).