### PR TITLE
Turn security scanner osv off

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -7,7 +7,7 @@ container {
 binary {
 	secrets      = true
 	go_modules   = true
-	osv          = true
+	osv          = false
 	oss_index    = true
 	nvd          = true
 }


### PR DESCRIPTION
Related slack discussion: https://hashicorp.slack.com/archives/C010VJT0FRP/p1646414431447969

OSV scanning on the boundary binaries needs to be turned off, as it's currently blocking the pipeline. The security team plans to address the underlying issues soon. 

Link to successful run in a test commit: https://github.com/hashicorp/boundary/pull/1894/checks?check_run_id=5455113119