### PR TITLE
Update make targets:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ dev:
 	@echo "==> make build"
 	@echo "      to build the binary into the bin/ directory"
 	@echo "==> make install"
-	@echo "      to move the built binary into GOPATH/bin"
+	@echo "      to build the binary and install it into GOPATH/bin"
 
 .PHONY: build
 build: BUILD_TAGS+=ui

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,22 @@ cleangen:
 	@rm -f ${GENERATED_CODE}
 
 .PHONY: dev
-dev: BUILD_TAGS+=dev
-dev: BUILD_TAGS+=ui
-dev: build-ui-ifne
-	@echo "==> Building Boundary with dev and UI features enabled"
+dev:
+	@echo "This command has changed. Please use:"
+	@echo "==> make build"
+	@echo "      to build the binary into the bin/ directory"
+	@echo "==> make install"
+	@echo "      to move the built binary into GOPATH/bin"
+
+.PHONY: build
+build: BUILD_TAGS+=ui
+build: build-ui-ifne
+	@echo "==> Building Boundary with UI features enabled"
 	@CGO_ENABLED=$(CGO_ENABLED) BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/build.sh'"
+
+.PHONY: install
+install: export BOUNDARY_INSTALL_BINARY=1
+install: build
 
 .PHONY: fmt
 fmt:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -69,17 +69,18 @@ rm -f bin/*
 mkdir -p bin/
 
 # Build!
-echo "==> Building..."
+echo "==> Building into bin/..."
 BINARY_NAME="boundary${BINARY_SUFFIX}"
 go build -tags="${BUILD_TAGS}" \
     -ldflags "-X github.com/hashicorp/boundary/version.GitCommit=${GIT_COMMIT}${GIT_DIRTY}" \
     -o "bin/${BINARY_NAME}" \
     ./cmd/boundary
 
-
-# Copy binary into gopath
-echo "==> Copying binary into GOPATH"
-cp -f "bin/${BINARY_NAME}" "${GOPATH}/bin/"
+# Copy binary into gopath if desired
+if [ "${BOUNDARY_INSTALL_BINARY}x" != "x" ]; then
+    echo "==> Moving binary into GOPATH/bin..."
+    mv -f "bin/${BINARY_NAME}" "${GOPATH}/bin/"
+fi
 
 # Done!
 echo "==> Done!"


### PR DESCRIPTION
* `make dev` now shows a message indicating the new commands
* `make build` builds the binary into bin/
* `make install` will subsequently `mv` (not copy) the binary into
  GOPATH/bin

The reason for the `mv` is that M1 Macs seem to get pretty unhappy about
executing a copied binary if it's been modified, so an initial binary is
fine, then after changing and recompiling the command keeps getting
killed.