### PR TITLE
test(worker): Remove test-only hooks from actual code

### DIFF
--- a/internal/servers/worker/controller_connection.go
+++ b/internal/servers/worker/controller_connection.go
@@ -138,17 +138,13 @@ func (w *Worker) createClientConn(addr string) error {
 func (w *Worker) workerAuthTLSConfig() (*tls.Config, *base.WorkerAuthInfo, error) {
 	var err error
 	info := &base.WorkerAuthInfo{
-		Name:            w.conf.RawConfig.Worker.Name,
-		Description:     w.conf.RawConfig.Worker.Description,
-		ConnectionNonce: w.testReusedAuthNonce,
+		Name:        w.conf.RawConfig.Worker.Name,
+		Description: w.conf.RawConfig.Worker.Description,
 	}
-	if info.ConnectionNonce == "" {
-		if info.ConnectionNonce, err = base62.Random(20); err != nil {
-			return nil, nil, err
-		}
-		if w.testReuseAuthNonces {
-			w.testReusedAuthNonce = info.ConnectionNonce
-		}
+
+	info.ConnectionNonce, err = w.nonceFn(20)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	pubKey, privKey, err := ed25519.GenerateKey(w.conf.SecureRandomReader)

--- a/internal/servers/worker/listeners.go
+++ b/internal/servers/worker/listeners.go
@@ -5,12 +5,14 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"os"
 	"sync"
 	"time"
 
+	"github.com/hashicorp/boundary/internal/cmd/base"
 	"github.com/hashicorp/boundary/internal/libs/alpnmux"
 	"github.com/hashicorp/boundary/internal/observability/event"
 	"github.com/hashicorp/go-multierror"
@@ -18,7 +20,7 @@ import (
 
 func (w *Worker) startListeners() error {
 	const op = "worker.(Worker).startListeners"
-	servers := make([]func(), 0, len(w.conf.Listeners))
+
 	e := event.SysEventer()
 	if e == nil {
 		return fmt.Errorf("%s: sys eventer not initialized", op)
@@ -27,70 +29,15 @@ func (w *Worker) startListeners() error {
 	if err != nil {
 		return fmt.Errorf("%s: unable to initialize std logger: %w", op, err)
 	}
-	for _, ln := range w.conf.Listeners {
-		for _, purpose := range ln.Config.Purpose {
-			switch purpose {
-			case "api", "cluster":
-				// We may have this in dev mode; ignore
-				continue
 
-			case "proxy":
-				// Do nothing; handle below
-
-			default:
-				return fmt.Errorf("unknown listener purpose %q", purpose)
-			}
-
-			handler, err := w.handler(HandlerProperties{
-				ListenerConfig: ln.Config,
-			})
-			if err != nil {
-				return fmt.Errorf("%s: %w", op, err)
-			}
-
-			cancelCtx := w.baseContext
-
-			server := &http.Server{
-				Handler:           handler,
-				ReadHeaderTimeout: 10 * time.Second,
-				ReadTimeout:       30 * time.Second,
-				ErrorLog:          logger,
-				BaseContext: func(net.Listener) context.Context {
-					return cancelCtx
-				},
-			}
-			ln.HTTPServer = server
-
-			if ln.Config.HTTPReadHeaderTimeout > 0 {
-				server.ReadHeaderTimeout = ln.Config.HTTPReadHeaderTimeout
-			}
-			if ln.Config.HTTPReadTimeout > 0 {
-				server.ReadTimeout = ln.Config.HTTPReadTimeout
-			}
-			if ln.Config.HTTPWriteTimeout > 0 {
-				server.WriteTimeout = ln.Config.HTTPWriteTimeout
-			}
-			if ln.Config.HTTPIdleTimeout > 0 {
-				server.IdleTimeout = ln.Config.HTTPIdleTimeout
-			}
-
-			// Clear out in case this is a second start of the controller
-			ln.Mux.UnregisterProto(alpnmux.DefaultProto)
-			ln.Mux.UnregisterProto(alpnmux.NoProto)
-			l, err := ln.Mux.RegisterProto(alpnmux.DefaultProto, &tls.Config{
-				GetConfigForClient: w.getSessionTls,
-			})
-			if err != nil {
-				return fmt.Errorf("error getting tls listener: %w", err)
-			}
-			if l == nil {
-				return errors.New("could not get tls listener")
-			}
-
-			servers = append(servers, func() {
-				go server.Serve(l)
-			})
+	servers := make([]func(), 0, len(w.listeners))
+	for i := range w.listeners {
+		ln := w.listeners[i]
+		workerServer, err := w.configureForWorker(ln, logger)
+		if err != nil {
+			return fmt.Errorf("%s: failed to configure for worker: %w", op, err)
 		}
+		servers = append(servers, workerServer)
 	}
 
 	for _, s := range servers {
@@ -98,6 +45,53 @@ func (w *Worker) startListeners() error {
 	}
 
 	return nil
+}
+
+func (w *Worker) configureForWorker(ln *base.ServerListener, log *log.Logger) (func(), error) {
+	handler, err := w.handler(HandlerProperties{ListenerConfig: ln.Config})
+	if err != nil {
+		return nil, err
+	}
+
+	cancelCtx := w.baseContext
+	server := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		ErrorLog:          log,
+		BaseContext: func(net.Listener) context.Context {
+			return cancelCtx
+		},
+	}
+	ln.HTTPServer = server
+
+	if ln.Config.HTTPReadHeaderTimeout > 0 {
+		server.ReadHeaderTimeout = ln.Config.HTTPReadHeaderTimeout
+	}
+	if ln.Config.HTTPReadTimeout > 0 {
+		server.ReadTimeout = ln.Config.HTTPReadTimeout
+	}
+	if ln.Config.HTTPWriteTimeout > 0 {
+		server.WriteTimeout = ln.Config.HTTPWriteTimeout
+	}
+	if ln.Config.HTTPIdleTimeout > 0 {
+		server.IdleTimeout = ln.Config.HTTPIdleTimeout
+	}
+
+	// Clear out in case this is a second start of the controller
+	ln.Mux.UnregisterProto(alpnmux.DefaultProto)
+	ln.Mux.UnregisterProto(alpnmux.NoProto)
+	l, err := ln.Mux.RegisterProto(alpnmux.DefaultProto, &tls.Config{
+		GetConfigForClient: w.getSessionTls,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error getting tls listener: %w", err)
+	}
+	if l == nil {
+		return nil, errors.New("could not get tls listener")
+	}
+
+	return func() { go server.Serve(l) }, nil
 }
 
 func (w *Worker) stopListeners() error {

--- a/internal/servers/worker/listeners_test.go
+++ b/internal/servers/worker/listeners_test.go
@@ -1,0 +1,134 @@
+package worker
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/go-secure-stdlib/listenerutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartListeners(t *testing.T) {
+	tests := []struct {
+		name       string
+		listeners  []*listenerutil.ListenerConfig
+		expErr     bool
+		expErrMsg  string
+		assertions func(t *testing.T, w *Worker, addrs []string)
+	}{
+		{
+			name: "one tcp listener, one unix listener",
+			listeners: []*listenerutil.ListenerConfig{
+				{
+					Type:       "tcp",
+					Purpose:    []string{"proxy"},
+					Address:    "127.0.0.1:0",
+					TLSDisable: true,
+				},
+				{
+					Type:       "unix",
+					Purpose:    []string{"proxy"},
+					Address:    "/tmp/boundary-worker-test-start-listeners.sock",
+					TLSDisable: true,
+				},
+			},
+			expErr: false,
+			assertions: func(t *testing.T, w *Worker, addrs []string) {
+				require.Len(t, addrs, 2)
+
+				_, err := http.Get("http://" + addrs[0] + "/v1/proxy/")
+				require.ErrorIs(t, err, io.EOF) // empty response because of worker tls request validation
+
+				cl := http.Client{
+					Transport: &http.Transport{
+						Dial: func(network, addr string) (net.Conn, error) { return net.Dial("unix", addrs[1]) },
+					},
+				}
+				_, err = cl.Get("http://anything.domain/v1/proxy/")
+				require.ErrorIs(t, err, io.EOF) // empty response because of worker tls request validation
+			},
+		},
+		{
+			name: "multiple tcp listeners, multiple unix listeners",
+			listeners: []*listenerutil.ListenerConfig{
+				{
+					Type:       "tcp",
+					Purpose:    []string{"proxy"},
+					Address:    "127.0.0.1:0",
+					TLSDisable: true,
+				},
+				{
+					Type:       "tcp",
+					Purpose:    []string{"proxy"},
+					Address:    "127.0.0.1:0",
+					TLSDisable: true,
+				},
+				{
+					Type:       "unix",
+					Purpose:    []string{"proxy"},
+					Address:    "/tmp/boundary-worker-test-start-listeners0.sock",
+					TLSDisable: true,
+				},
+				{
+					Type:       "unix",
+					Purpose:    []string{"proxy"},
+					Address:    "/tmp/boundary-worker-test-start-listeners1.sock",
+					TLSDisable: true,
+				},
+			},
+			expErr: false,
+			assertions: func(t *testing.T, w *Worker, addrs []string) {
+				require.Len(t, addrs, 4)
+
+				_, err := http.Get("http://" + addrs[0] + "/v1/proxy/")
+				require.ErrorIs(t, err, io.EOF) // empty response because of worker tls request validation
+
+				_, err = http.Get("http://" + addrs[1] + "/v1/proxy/")
+				require.ErrorIs(t, err, io.EOF) // empty response because of worker tls request validation
+
+				for _, proxyAddr := range []string{addrs[2], addrs[3]} {
+					cl := http.Client{
+						Transport: &http.Transport{
+							Dial: func(network, addr string) (net.Conn, error) { return net.Dial("unix", proxyAddr) },
+						},
+					}
+					_, err = cl.Get("http://anything.domain/v1/proxy")
+					require.ErrorIs(t, err, io.EOF) // empty response because of worker tls request validation
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := NewTestWorker(t, &TestWorkerOpts{DisableAutoStart: true}).w.conf
+			conf.RawConfig.SharedConfig.Listeners = tt.listeners
+
+			err := conf.SetupListeners(nil, conf.RawConfig.SharedConfig, []string{"proxy"})
+			require.NoError(t, err)
+
+			w, err := New(conf)
+			require.NoError(t, err)
+			w.baseContext = context.Background()
+
+			err = w.startListeners()
+			if tt.expErr {
+				require.EqualError(t, err, tt.expErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+
+			addrs := make([]string, 0)
+			for _, l := range w.listeners {
+				addrs = append(addrs, l.Mux.Addr().String())
+			}
+			if tt.assertions != nil {
+				tt.assertions(t, w, addrs)
+			}
+		})
+	}
+}

--- a/internal/servers/worker/testing.go
+++ b/internal/servers/worker/testing.go
@@ -183,8 +183,9 @@ type TestWorkerOpts struct {
 	// connection cannot be made back to the controller
 	StatusGracePeriodDuration time.Duration
 
-	// Whether to set the replay value
-	EnableAuthReplay bool
+	// Overrides worker's nonceFn, for cases where we want to have control
+	// over the nonce we send to the Controller
+	NonceFn randFn
 }
 
 func NewTestWorker(t *testing.T, opts *TestWorkerOpts) *TestWorker {
@@ -280,8 +281,8 @@ func NewTestWorker(t *testing.T, opts *TestWorkerOpts) *TestWorker {
 		t.Fatal(err)
 	}
 
-	if opts.EnableAuthReplay {
-		tw.w.testReuseAuthNonces = true
+	if opts.NonceFn != nil {
+		tw.w.nonceFn = opts.NonceFn
 	}
 
 	if !opts.DisableAutoStart {

--- a/internal/servers/worker/worker_test.go
+++ b/internal/servers/worker/worker_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWorkerNewListenerConfig(t *testing.T) {
+func TestWorkerNew(t *testing.T) {
 	tests := []struct {
 		name       string
 		in         *Config
@@ -74,6 +74,20 @@ func TestWorkerNewListenerConfig(t *testing.T) {
 			expErr: false,
 			assertions: func(t *testing.T, w *Worker) {
 				require.Len(t, w.listeners, 2)
+			},
+		},
+		{
+			name: "worker nonce func is set",
+			in: &Config{
+				Server: &base.Server{
+					Listeners: []*base.ServerListener{
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"proxy"}}},
+					},
+				},
+			},
+			expErr: false,
+			assertions: func(t *testing.T, w *Worker) {
+				require.NotNil(t, w.nonceFn)
 			},
 		},
 	}

--- a/internal/servers/worker/worker_test.go
+++ b/internal/servers/worker/worker_test.go
@@ -1,0 +1,100 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/hashicorp/boundary/internal/cmd/config"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/configutil"
+	"github.com/hashicorp/go-secure-stdlib/listenerutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkerNewListenerConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         *Config
+		expErr     bool
+		expErrMsg  string
+		assertions func(t *testing.T, w *Worker)
+	}{
+		{
+			name:      "nil listeners",
+			in:        &Config{Server: &base.Server{Listeners: nil}},
+			expErr:    true,
+			expErrMsg: "no proxy listeners found",
+		},
+		{
+			name:      "zero listeners",
+			in:        &Config{Server: &base.Server{Listeners: []*base.ServerListener{}}},
+			expErr:    true,
+			expErrMsg: "no proxy listeners found",
+		},
+		{
+			name: "populated with nil values",
+			in: &Config{
+				Server: &base.Server{
+					Listeners: []*base.ServerListener{
+						nil,
+						{Config: nil},
+						{Config: &listenerutil.ListenerConfig{Purpose: nil}},
+					},
+				},
+			},
+			expErr:    true,
+			expErrMsg: "no proxy listeners found",
+		},
+		{
+			name: "multiple purposes",
+			in: &Config{
+				Server: &base.Server{
+					Listeners: []*base.ServerListener{
+						nil,
+						{Config: nil},
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"api", "proxy"}}},
+					},
+				},
+			},
+			expErr:    true,
+			expErrMsg: `found listener with multiple purposes "api,proxy"`,
+		},
+		{
+			name: "valid listeners",
+			in: &Config{
+				Server: &base.Server{
+					Listeners: []*base.ServerListener{
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"api"}}},
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"proxy"}}},
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"proxy"}}},
+						{Config: &listenerutil.ListenerConfig{Purpose: []string{"cluster"}}},
+					},
+				},
+			},
+			expErr: false,
+			assertions: func(t *testing.T, w *Worker) {
+				require.Len(t, w.listeners, 2)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// New() panics if these aren't set
+			tt.in.Logger = hclog.Default()
+			tt.in.RawConfig = &config.Config{SharedConfig: &configutil.SharedConfig{DisableMlock: true}}
+
+			w, err := New(tt.in)
+			if tt.expErr {
+				require.EqualError(t, err, tt.expErrMsg)
+				require.Nil(t, w)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.assertions != nil {
+				tt.assertions(t, w)
+			}
+		})
+	}
+}

--- a/internal/tests/cluster/worker_replay_test.go
+++ b/internal/tests/cluster/worker_replay_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/boundary/internal/servers/controller"
 	"github.com/hashicorp/boundary/internal/servers/worker"
 	"github.com/hashicorp/go-hclog"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,24 +40,49 @@ func TestWorkerReplay(t *testing.T) {
 		Config:             conf,
 		WorkerAuthKms:      c1.Config().WorkerAuthKms,
 		InitialControllers: c1.ClusterAddrs(),
-		EnableAuthReplay:   true,
+		NonceFn: func(length int) (string, error) {
+			return "test_noncetest_nonce", nil
+		},
 	})
 
 	// Give time for it to connect
 	time.Sleep(10 * time.Second)
+
+	// Assert that the worker has connected
+	logBuf, err := os.ReadFile(ec.AllEvents.Name())
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(string(logBuf), "worker successfully authed"))
+
+	// Assert we have the expected nonce in the DB
+	nonces, err := c1.ServersRepo().ListNonces(c1.Context(), servers.NoncePurposeWorkerAuth)
+	require.NoError(t, err)
+	require.Len(t, nonces, 1)
+	require.Equal(t, &servers.Nonce{Nonce: "test_noncetest_nonce", Purpose: servers.NoncePurposeWorkerAuth}, nonces[0])
+
 	require.NoError(t, w1.Worker().Shutdown(true))
 
-	// Now, start up again
-	require.NoError(t, w1.Worker().Start())
+	// Now, start up again with the same nonce
+	w1 = worker.NewTestWorker(t, &worker.TestWorkerOpts{
+		Config:             conf,
+		WorkerAuthKms:      c1.Config().WorkerAuthKms,
+		InitialControllers: c1.ClusterAddrs(),
+		NonceFn: func(length int) (string, error) {
+			return "test_noncetest_nonce", nil
+		},
+	})
+
+	// Give time for it to connect
 	time.Sleep(10 * time.Second)
 
 	// We should find only one nonce, and one successful worker authentication,
 	// both in the output and in the database
 	ec.AllEvents.Close()
-	logBuf, err := os.ReadFile(ec.AllEvents.Name())
+	logBuf, err = os.ReadFile(ec.AllEvents.Name())
 	require.NoError(t, err)
-	assert.Equal(t, 1, strings.Count(string(logBuf), "worker successfully authed"))
-	nonces, err := c1.ServersRepo().ListNonces(c1.Context(), servers.NoncePurposeWorkerAuth)
+	require.Equal(t, 1, strings.Count(string(logBuf), "worker successfully authed"))
+
+	nonces, err = c1.ServersRepo().ListNonces(c1.Context(), servers.NoncePurposeWorkerAuth)
 	require.NoError(t, err)
-	assert.Len(t, nonces, 1)
+	require.Len(t, nonces, 1)
+	require.Equal(t, &servers.Nonce{Nonce: "test_noncetest_nonce", Purpose: servers.NoncePurposeWorkerAuth}, nonces[0])
 }


### PR DESCRIPTION
This change introduces a `nonceFn` field that can be changed
by a test but at runtime is transparent to the code that calls it.

The current nonce-generating logic defaults to a test-only field which
opens us up to this value inadvertently being set.
With this change, the default behavior becomes using `base62` to
generate a random nonce, and any tests have to explicitly change that.