### PR TITLE
Update references to "make dev"

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you have the following requirements met locally:
 
 You can get up and running with Boundary quickly. Simply run:
 
-  ```make dev```
+  ```make install```
 
 This will build Boundary. (The first time this is run it will fetch and compile
 UI assets; which will take a few extra minutes.) Once complete, run Boundary in
@@ -105,7 +105,7 @@ tools at the versions used by the Boundary team, run:
 
   ```make tools```
 
-Without doing so, you may encounter errors while running `make dev`. It is important
+Without doing so, you may encounter errors while running `make install`. It is important
 to also note that using `make tools` will install various tools used for Boundary
 development to the normal Go binary directory; this may overwrite or take precedence
 over tools that might already be installed on the system.

--- a/internal/adding-a-new-field-readme.md
+++ b/internal/adding-a-new-field-readme.md
@@ -57,9 +57,4 @@ At this point, the new field is available via Boundary's API.  All that's left i
 
 * Incorporate the new fields to the command's `funcs.go`.  Just a suggestion here: you may want to define a const for the new field name and reuse it everywhere it's required (which is several places)
 
-* Run `make cli` and `make dev`, before attempting to test cli changes
-
-
-
-
-
+* Run `make cli` and `make install`, before attempting to test cli changes

--- a/website/content/docs/developing/building.mdx
+++ b/website/content/docs/developing/building.mdx
@@ -16,9 +16,9 @@ Building Boundary from source requires:
 1. `$ git clone https://github.com/hashicorp/boundary` or if you're using SSH auth for
    github, `$ git clone git@github.com:hashicorp/boundary`
 2. `$ cd boundary`
-3. `$ make dev`
+3. `$ make install`
 
-The first time you run `make dev` it will build UI assets, which will take a
+The first time you run `make install` it will build UI assets, which will take a
 long time. After the initial build, you can update those assets to the
 currently-pinned version via `make build-ui`.
 
@@ -28,7 +28,7 @@ binary to somewhere in your `$PATH` such as `/usr/local/bin`.
 ## Cross Platform Build
 
 If you need to cross compile boundary for another OS or architecture, use the [GOOS and GOARCH](https://github.com/hashicorp/boundary/blob/master/scripts/build.sh#L26)
-environment variable to set this. Example: `$ GOOS=linux GOARCH=amd64 make dev`
+environment variable to set this. Example: `$ GOOS=linux GOARCH=amd64 make install`
 
 For more details, please consult the [Boundary project on GitHub](https://github.com/hashicorp/boundary#build-and-start-boundary-in-dev-mode).
 


### PR DESCRIPTION
"make dev" has been replaced with "make install" since b53e4d4c3ef151a65ac198fb45dc3ed5645aa0c6.