### PR TITLE
fix(session): Only check session status for reported sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 ## Next
 
 ### Bug Fixes
-
+* sessions: Sessions and session connections have been refactored 
+to better isolate transactions and prevent resource contention that caused deadlocks.
+([Issue](https://github.com/hashicorp/boundary/issues/1812),
+  [PR](https://github.com/hashicorp/boundary/pull/1919))
 * scheduler: Fix bug that causes erroneous logs when racing controllers
   attempted to run jobs
   ([Issue](https://github.com/hashicorp/boundary/issues/1903),

--- a/internal/servers/controller/controller.go
+++ b/internal/servers/controller/controller.go
@@ -303,7 +303,7 @@ func (c *Controller) registerJobs() error {
 // registerSessionConnectionCleanupJob is a helper method to abstract
 // registering the session connection cleanup job specifically.
 func (c *Controller) registerSessionConnectionCleanupJob() error {
-	sessionConnectionCleanupJob, err := newSessionConnectionCleanupJob(c.ConnectionRepoFn, int(c.conf.StatusGracePeriodDuration.Seconds()))
+	sessionConnectionCleanupJob, err := newSessionConnectionCleanupJob(c.ConnectionRepoFn, c.conf.StatusGracePeriodDuration)
 	if err != nil {
 		return fmt.Errorf("error creating session cleanup job: %w", err)
 	}

--- a/internal/servers/controller/handlers/workers/worker_service.go
+++ b/internal/servers/controller/handlers/workers/worker_service.go
@@ -79,45 +79,14 @@ func (ws *workerServiceServer) Status(ctx context.Context, req *pbs.StatusReques
 		Controllers: controllers,
 	}
 
-	var (
-		// For tracking the reported open connections.
-		reportedOpenConns []string
-		// For tracking the session IDs we've already requested
-		// cancellation for. We won't need to add connection cancel
-		// requests for these because canceling the session terminates the
-		// connections.
-		requestedSessionCancelIds []string
-	)
-
-	// This is a map of all sessions and their statuses. We keep track of
-	// this for easy lookup if we need to make change requests.
-	sessionStatuses := make(map[string]pbs.SESSIONSTATUS)
+	stateReport := make([]session.StateReport, 0, len(req.GetJobs()))
 
 	for _, jobStatus := range req.GetJobs() {
 		switch jobStatus.Job.GetType() {
-		// Check for session cancellation
 		case pbs.JOBTYPE_JOBTYPE_SESSION:
 			si := jobStatus.GetJob().GetSessionInfo()
 			if si == nil {
 				return nil, status.Error(codes.Internal, "Error getting session info at status time")
-			}
-
-			// Record status.
-			sessionStatuses[si.GetSessionId()] = si.Status
-
-			// Check connections before potentially bypassing the rest of the
-			// logic in the switch on si.Status.
-			sessConns := si.GetConnections()
-			for _, conn := range sessConns {
-				switch conn.Status {
-				case pbs.CONNECTIONSTATUS_CONNECTIONSTATUS_AUTHORIZED,
-					pbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CONNECTED:
-					// If it's active, report it as found. Otherwise don't
-					// report as found, so that we should attempt to close it.
-					// Note that unspecified is the default state for the enum
-					// but it's not ever explicitly set by us.
-					reportedOpenConns = append(reportedOpenConns, conn.GetConnectionId())
-				}
 			}
 
 			switch si.Status {
@@ -127,92 +96,46 @@ func (ws *workerServiceServer) Status(ctx context.Context, req *pbs.StatusReques
 				continue
 			}
 
-			sessionId := si.GetSessionId()
-			sessionInfo, _, err := sessRepo.LookupSession(ctx, sessionId)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "Error looking up session with id %s: %v", sessionId, err)
+			sr := session.StateReport{
+				SessionId:     si.GetSessionId(),
+				ConnectionIds: make([]string, 0, len(si.GetConnections())),
 			}
-			if sessionInfo == nil {
-				return nil, status.Errorf(codes.Internal, "Unknown session ID %s at status time.", sessionId)
-			}
-			if len(sessionInfo.States) == 0 {
-				return nil, status.Error(codes.Internal, "Empty session states during lookup at status time.")
-			}
-			// If the session from the DB is in canceling status, and we're
-			// here, it means the job is in pending or active; cancel it. If
-			// it's in terminated status something went wrong and we're
-			// mismatched, so ensure we cancel it also.
-			currState := sessionInfo.States[0].Status
-			if currState.ProtoVal() != si.Status {
-				switch currState {
-				case session.StatusCanceling,
-					session.StatusTerminated:
-					// If we're here the job is pending or active so we do want
-					// to actually send a change request
-					ret.JobsRequests = append(ret.JobsRequests, &pbs.JobChangeRequest{
-						Job: &pbs.Job{
-							Type: pbs.JOBTYPE_JOBTYPE_SESSION,
-							JobInfo: &pbs.Job_SessionInfo{
-								SessionInfo: &pbs.SessionJobInfo{
-									SessionId: sessionId,
-									Status:    currState.ProtoVal(),
-								},
-							},
-						},
-						RequestType: pbs.CHANGETYPE_CHANGETYPE_UPDATE_STATE,
-					})
-					// Log the session ID so we don't add a duplicate change
-					// request on connection normalization.
-					requestedSessionCancelIds = append(requestedSessionCancelIds, sessionId)
+			for _, conn := range si.GetConnections() {
+				switch conn.Status {
+				case pbs.CONNECTIONSTATUS_CONNECTIONSTATUS_AUTHORIZED,
+					pbs.CONNECTIONSTATUS_CONNECTIONSTATUS_CONNECTED:
+					sr.ConnectionIds = append(sr.ConnectionIds, conn.GetConnectionId())
 				}
 			}
+			stateReport = append(stateReport, sr)
 		}
 	}
 
-	// Normalize the current state of connections on the worker side
-	// with the data from the controller. In other words, if one of our
-	// found connections isn't supposed to be alive still, kill it.
-	//
-	// This is separate from the above session normalization and is
-	// additive to it, we don't add sessions that have already been
-	// added there as canceling sessions already closes the
-	// connections.
-	shouldCloseConnections, err := connectionRepo.ShouldCloseConnectionsOnWorker(ctx, reportedOpenConns, requestedSessionCancelIds)
+	notActive, err := session.WorkerStatusReport(ctx, sessRepo, connectionRepo, req.Worker.PrivateId, stateReport)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Error fetching connections that should be closed: %v", err)
+		return nil, status.Errorf(codes.Internal, "Error comparing state of sessions for worker: %s: %v", req.Worker.PrivateId, err)
 	}
-
-	for sessionId, connIds := range shouldCloseConnections {
+	for _, na := range notActive {
 		var connChanges []*pbs.Connection
-		for _, connId := range connIds {
+		for _, connId := range na.ConnectionIds {
 			connChanges = append(connChanges, &pbs.Connection{
 				ConnectionId: connId,
 				Status:       session.StatusClosed.ProtoVal(),
 			})
 		}
-
 		ret.JobsRequests = append(ret.JobsRequests, &pbs.JobChangeRequest{
 			Job: &pbs.Job{
 				Type: pbs.JOBTYPE_JOBTYPE_SESSION,
 				JobInfo: &pbs.Job_SessionInfo{
 					SessionInfo: &pbs.SessionJobInfo{
-						SessionId:   sessionId,
-						Status:      sessionStatuses[sessionId],
+						SessionId:   na.SessionId,
+						Status:      na.Status.ProtoVal(),
 						Connections: connChanges,
 					},
 				},
 			},
 			RequestType: pbs.CHANGETYPE_CHANGETYPE_UPDATE_STATE,
 		})
-	}
-
-	// Run our controller-side cleanup function.
-	closedConns, err := connectionRepo.CloseDeadConnectionsForWorker(ctx, req.Worker.PrivateId, reportedOpenConns)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Error closing dead conns for worker %s: %v", req.Worker.PrivateId, err)
-	}
-	if closedConns > 0 {
-		event.WriteSysEvent(ctx, op, "marked unclaimed connections as closed", "server_id", req.Worker.PrivateId, "count", closedConns)
 	}
 
 	return ret, nil

--- a/internal/servers/controller/multi_test.go
+++ b/internal/servers/controller/multi_test.go
@@ -3,7 +3,6 @@ package controller_test
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/boundary/api/authmethods"
 	"github.com/hashicorp/boundary/api/authtokens"
@@ -38,7 +37,6 @@ func TestAuthenticationMulti(t *testing.T) {
 	require.NoError(json.Unmarshal(token1Result.GetRawAttributes(), token1))
 	require.NotNil(token1)
 
-	time.Sleep(5 * time.Second)
 	auth = authmethods.NewClient(c2.Client())
 	token2Result, err := auth.Authenticate(c2.Context(), c2.Server().DevPasswordAuthMethodId, "login", map[string]interface{}{"login_name": c2.Server().DevLoginName, "password": c2.Server().DevPassword})
 	require.Nil(err)

--- a/internal/servers/controller/session_cleanup_job.go
+++ b/internal/servers/controller/session_cleanup_job.go
@@ -27,7 +27,7 @@ type sessionConnectionCleanupJob struct {
 
 	// The amount of time to give disconnected workers before marking
 	// their connections as closed.
-	gracePeriod int
+	gracePeriod time.Duration
 
 	// The total number of connections closed in the last run.
 	totalClosed int
@@ -36,7 +36,7 @@ type sessionConnectionCleanupJob struct {
 // newSessionConnectionCleanupJob instantiates the session cleanup job.
 func newSessionConnectionCleanupJob(
 	connectionRepoFn common.ConnectionRepoFactory,
-	gracePeriod int,
+	gracePeriod time.Duration,
 ) (*sessionConnectionCleanupJob, error) {
 	const op = "controller.newNewSessionConnectionCleanupJob"
 	switch {
@@ -44,7 +44,7 @@ func newSessionConnectionCleanupJob(
 		return nil, errors.NewDeprecated(errors.InvalidParameter, op, "missing connectionRepoFn")
 	case gracePeriod < session.DeadWorkerConnCloseMinGrace:
 		return nil, errors.NewDeprecated(
-			errors.InvalidParameter, op, fmt.Sprintf("invalid gracePeriod, must be greater than %d", session.DeadWorkerConnCloseMinGrace))
+			errors.InvalidParameter, op, fmt.Sprintf("invalid gracePeriod, must be greater than %s", session.DeadWorkerConnCloseMinGrace))
 	}
 
 	return &sessionConnectionCleanupJob{
@@ -102,7 +102,7 @@ func (j *sessionConnectionCleanupJob) Run(ctx context.Context) error {
 			event.WithInfo(
 				"private_id", result.ServerId,
 				"update_time", result.LastUpdateTime,
-				"grace_period_seconds", j.gracePeriod,
+				"grace_period_seconds", j.gracePeriod.Seconds(),
 				"number_connections_closed", result.NumberConnectionsClosed,
 			))
 

--- a/internal/session/options.go
+++ b/internal/session/options.go
@@ -21,22 +21,24 @@ type Option func(*options)
 
 // options = how options are represented
 type options struct {
-	withLimit             int
-	withOrderByCreateTime db.OrderBy
-	withScopeIds          []string
-	withUserId            string
-	withExpirationTime    *timestamp.Timestamp
-	withTestTofu          []byte
-	withListingConvert    bool
-	withSessionIds        []string
-	withServerId          string
-	withDbOpts            []db.Option
-	withWorkerStateDelay  time.Duration
+	withLimit                       int
+	withOrderByCreateTime           db.OrderBy
+	withScopeIds                    []string
+	withUserId                      string
+	withExpirationTime              *timestamp.Timestamp
+	withTestTofu                    []byte
+	withListingConvert              bool
+	withSessionIds                  []string
+	withServerId                    string
+	withDbOpts                      []db.Option
+	withWorkerStateDelay            time.Duration
+	withDeadWorkerConnCloseMinGrace time.Duration
 }
 
 func getDefaultOptions() options {
 	return options{
-		withWorkerStateDelay: 10 * time.Second,
+		withWorkerStateDelay:            10 * time.Second,
+		withDeadWorkerConnCloseMinGrace: DeadWorkerConnCloseMinGrace,
 	}
 }
 
@@ -114,10 +116,19 @@ func WithDbOpts(opts ...db.Option) Option {
 	}
 }
 
-// WithWorkerStateDelay is used byt queries to account for a delay in state
+// WithWorkerStateDelay is used by queries to account for a delay in state
 // propagation between worker and controller.
 func WithWorkerStateDelay(d time.Duration) Option {
 	return func(o *options) {
 		o.withWorkerStateDelay = d
+	}
+}
+
+// WithDeadWorkerConnCloseMinGrace is used to set the minimum allowable setting
+// for the CloseConnectionsForDeadWorkers method. This defaults to the default
+// server liveness setting.
+func WithDeadWorkerConnCloseMinGrace(d time.Duration) Option {
+	return func(o *options) {
+		o.withDeadWorkerConnCloseMinGrace = d
 	}
 }

--- a/internal/session/query.go
+++ b/internal/session/query.go
@@ -310,7 +310,7 @@ where
    dead_servers (server_id, last_update_time) as (
          select private_id, update_time
            from server
-          where update_time < wt_sub_seconds_from_now(?)
+          where update_time < wt_sub_seconds_from_now(@grace_period_seconds)
    ),
    closed_connections (connection_id, server_id) as (
          update session_connection

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -588,6 +588,56 @@ func (r *Repository) updateState(ctx context.Context, sessionId string, sessionV
 	return &updatedSession, returnedStates, nil
 }
 
+// checkIfNoLongerActive checks the given sessions to see if they are in a
+// non-active state, i.e. "canceling" or "terminated"
+// It returns a []StateReport for each session that is not active, with its current status.
+func (r *Repository) checkIfNoLongerActive(ctx context.Context, reportedSessions []string) ([]StateReport, error) {
+	const op = "session.(Repository).checkIfNotActive"
+
+	notActive := make([]StateReport, 0, len(reportedSessions))
+	args := make([]interface{}, 0, len(reportedSessions))
+	var inClause string
+	if len(reportedSessions) > 0 {
+		inClause = `and session_id in (%s)`
+		params := make([]string, len(reportedSessions))
+		for i, sessId := range reportedSessions {
+			params[i] = fmt.Sprintf("@%d", i)
+			args = append(args, sql.Named(fmt.Sprintf("%d", i), sessId))
+		}
+		inClause = fmt.Sprintf(inClause, strings.Join(params, ","))
+	}
+
+	_, err := r.writer.DoTx(
+		ctx,
+		db.StdRetryCnt,
+		db.ExpBackoff{},
+		func(reader db.Reader, w db.Writer) error {
+			rows, err := r.reader.Query(ctx, fmt.Sprintf(checkIfNotActive, inClause), args)
+			if err != nil {
+				return errors.Wrap(ctx, err, op)
+			}
+			defer rows.Close()
+
+			for rows.Next() {
+				var sessionId string
+				var status Status
+				if err := rows.Scan(&sessionId, &status); err != nil {
+					return errors.Wrap(ctx, err, op, errors.WithMsg("scan row failed"))
+				}
+				notActive = append(notActive, StateReport{
+					SessionId: sessionId,
+					Status:    status,
+				})
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op, errors.WithMsg("error checking if sessions are no longer active"))
+	}
+	return notActive, nil
+}
+
 func fetchStates(ctx context.Context, r db.Reader, sessionId string, opt ...db.Option) ([]*State, error) {
 	const op = "session.fetchStates"
 	var states []*State

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -597,15 +597,18 @@ func (r *Repository) checkIfNoLongerActive(ctx context.Context, reportedSessions
 	notActive := make([]StateReport, 0, len(reportedSessions))
 	args := make([]interface{}, 0, len(reportedSessions))
 	var inClause string
-	if len(reportedSessions) > 0 {
-		inClause = `and session_id in (%s)`
-		params := make([]string, len(reportedSessions))
-		for i, sessId := range reportedSessions {
-			params[i] = fmt.Sprintf("@%d", i)
-			args = append(args, sql.Named(fmt.Sprintf("%d", i), sessId))
-		}
-		inClause = fmt.Sprintf(inClause, strings.Join(params, ","))
+
+	if len(reportedSessions) <= 0 {
+		return notActive, nil
 	}
+
+	inClause = `and session_id in (%s)`
+	params := make([]string, len(reportedSessions))
+	for i, sessId := range reportedSessions {
+		params[i] = fmt.Sprintf("@%d", i)
+		args = append(args, sql.Named(fmt.Sprintf("%d", i), sessId))
+	}
+	inClause = fmt.Sprintf(inClause, strings.Join(params, ","))
 
 	_, err := r.writer.DoTx(
 		ctx,

--- a/internal/session/service_worker_status_report.go
+++ b/internal/session/service_worker_status_report.go
@@ -1,0 +1,48 @@
+package session
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/observability/event"
+)
+
+// StateReport is used to report on the state of a Session.
+type StateReport struct {
+	SessionId     string
+	Status        Status
+	ConnectionIds []string
+}
+
+// WorkerStatusReport is a domain service function that compares the state of
+// sessions and connections as reported by a Worker, to the known state in the
+// repositories. It returns a []StateReport for each session that is in the
+// canceling or terminated state. It also will check for any orphaned
+// connections, which is defined as a connection that is in an active state,
+// but was not reported by worker. Any orphaned connections will be marked as
+// closed.
+func WorkerStatusReport(ctx context.Context, repo *Repository, connRepo *ConnectionRepository, workerId string, report []StateReport) ([]StateReport, error) {
+	const op = "session.WorkerStatusReport"
+
+	reportedConnections := make([]string, 0)
+	reportedSessions := make([]string, 0, len(report))
+	for _, r := range report {
+		reportedSessions = append(reportedSessions, r.SessionId)
+		reportedConnections = append(reportedConnections, r.ConnectionIds...)
+	}
+
+	notActive, err := repo.checkIfNoLongerActive(ctx, reportedSessions)
+	if err != nil {
+		return nil, errors.New(ctx, errors.Internal, op, fmt.Sprintf("Error checking session state for worker %s: %v", workerId, err))
+	}
+
+	closed, err := connRepo.closeOrphanedConnections(ctx, workerId, reportedConnections)
+	if err != nil {
+		return notActive, errors.New(ctx, errors.Internal, op, fmt.Sprintf("Error closing orphaned connections for worker %s: %v", workerId, err))
+	}
+	if len(closed) > 0 {
+		event.WriteSysEvent(ctx, op, "marked unclaimed connections as closed", "server_id", workerId, "count", len(closed))
+	}
+	return notActive, err
+}

--- a/internal/session/service_worker_status_report_test.go
+++ b/internal/session/service_worker_status_report_test.go
@@ -1,0 +1,362 @@
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/authtoken"
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/host/static"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/servers"
+	"github.com/hashicorp/boundary/internal/session"
+	"github.com/hashicorp/boundary/internal/target"
+	"github.com/hashicorp/boundary/internal/target/tcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkerStatusReport(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	kms := kms.TestKms(t, conn, wrapper)
+	org, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+
+	serverRepo, _ := servers.NewRepository(rw, rw, kms)
+	serverRepo.UpsertServer(ctx, &servers.Server{
+		PrivateId: "test_controller1",
+		Type:      "controller",
+		Address:   "127.0.0.1",
+	})
+	serverRepo.UpsertServer(ctx, &servers.Server{
+		PrivateId: "test_worker1",
+		Type:      "worker",
+		Address:   "127.0.0.1",
+	})
+
+	repo, err := session.NewRepository(rw, rw, kms)
+	require.NoError(t, err)
+	connRepo, err := session.NewConnectionRepository(ctx, rw, rw, kms, session.WithWorkerStateDelay(0))
+	require.NoError(t, err)
+
+	at := authtoken.TestAuthToken(t, conn, kms, org.GetPublicId())
+	uId := at.GetIamUserId()
+	hc := static.TestCatalogs(t, conn, prj.GetPublicId(), 1)[0]
+	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
+	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
+	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
+	tar := tcp.TestTarget(
+		ctx,
+		t, conn, prj.GetPublicId(), "test",
+		target.WithHostSources([]string{hs.GetPublicId()}),
+		target.WithSessionConnectionLimit(-1),
+	)
+
+	type testCase struct {
+		worker              *servers.Server
+		req                 []session.StateReport
+		want                []session.StateReport
+		orphanedConnections []string
+	}
+	cases := []struct {
+		name   string
+		caseFn func(t *testing.T) testCase
+	}{
+		{
+			name: "No Sessions",
+			caseFn: func(t *testing.T) testCase {
+				worker := session.TestWorker(t, conn, wrapper)
+				return testCase{
+					worker: worker,
+					req:    []session.StateReport{},
+					want:   []session.StateReport{},
+				}
+			},
+		},
+		{
+			name: "Still Active",
+			caseFn: func(t *testing.T) testCase {
+				worker := session.TestWorker(t, conn, wrapper)
+				sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
+					UserId:          uId,
+					HostId:          h.GetPublicId(),
+					TargetId:        tar.GetPublicId(),
+					HostSetId:       hs.GetPublicId(),
+					AuthTokenId:     at.GetPublicId(),
+					ScopeId:         prj.GetPublicId(),
+					Endpoint:        "tcp://127.0.0.1:22",
+					ConnectionLimit: 10,
+				})
+				tofu := session.TestTofu(t)
+				sess, _, err = repo.ActivateSession(ctx, sess.PublicId, sess.Version, worker.PrivateId, worker.Type, tofu)
+				require.NoError(t, err)
+				require.NoError(t, err)
+
+				connection, _, err := connRepo.AuthorizeConnection(ctx, sess.PublicId, worker.PrivateId)
+				require.NoError(t, err)
+				return testCase{
+					worker: worker,
+					req: []session.StateReport{
+						{
+							SessionId:     sess.PublicId,
+							Status:        session.StatusActive,
+							ConnectionIds: []string{connection.PublicId},
+						},
+					},
+					want: []session.StateReport{},
+				}
+			},
+		},
+		{
+			name: "SessionClosed",
+			caseFn: func(t *testing.T) testCase {
+				worker := session.TestWorker(t, conn, wrapper)
+				sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
+					UserId:          uId,
+					HostId:          h.GetPublicId(),
+					TargetId:        tar.GetPublicId(),
+					HostSetId:       hs.GetPublicId(),
+					AuthTokenId:     at.GetPublicId(),
+					ScopeId:         prj.GetPublicId(),
+					Endpoint:        "tcp://127.0.0.1:22",
+					ConnectionLimit: 10,
+				})
+				tofu := session.TestTofu(t)
+				sess, _, err = repo.ActivateSession(ctx, sess.PublicId, sess.Version, worker.PrivateId, worker.Type, tofu)
+				require.NoError(t, err)
+				connection, _, err := connRepo.AuthorizeConnection(ctx, sess.PublicId, worker.PrivateId)
+				require.NoError(t, err)
+				_, err = repo.CancelSession(ctx, sess.PublicId, sess.Version)
+				require.NoError(t, err)
+
+				return testCase{
+					worker: worker,
+					req: []session.StateReport{
+						{
+							SessionId:     sess.PublicId,
+							Status:        session.StatusActive,
+							ConnectionIds: []string{connection.PublicId},
+						},
+					},
+					want: []session.StateReport{
+						{
+							SessionId: sess.PublicId,
+							Status:    session.StatusCanceling,
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "MultipleSessionsClosed",
+			caseFn: func(t *testing.T) testCase {
+				worker := session.TestWorker(t, conn, wrapper)
+				sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
+					UserId:          uId,
+					HostId:          h.GetPublicId(),
+					TargetId:        tar.GetPublicId(),
+					HostSetId:       hs.GetPublicId(),
+					AuthTokenId:     at.GetPublicId(),
+					ScopeId:         prj.GetPublicId(),
+					Endpoint:        "tcp://127.0.0.1:22",
+					ConnectionLimit: 10,
+				})
+				tofu := session.TestTofu(t)
+				sess, _, err = repo.ActivateSession(ctx, sess.PublicId, sess.Version, worker.PrivateId, worker.Type, tofu)
+				require.NoError(t, err)
+				connection, _, err := connRepo.AuthorizeConnection(ctx, sess.PublicId, worker.PrivateId)
+				require.NoError(t, err)
+				_, err = repo.CancelSession(ctx, sess.PublicId, sess.Version)
+				require.NoError(t, err)
+
+				sess2 := session.TestSession(t, conn, wrapper, session.ComposedOf{
+					UserId:          uId,
+					HostId:          h.GetPublicId(),
+					TargetId:        tar.GetPublicId(),
+					HostSetId:       hs.GetPublicId(),
+					AuthTokenId:     at.GetPublicId(),
+					ScopeId:         prj.GetPublicId(),
+					Endpoint:        "tcp://127.0.0.1:22",
+					ConnectionLimit: 10,
+				})
+				tofu2 := session.TestTofu(t)
+				sess2, _, err = repo.ActivateSession(ctx, sess2.PublicId, sess2.Version, worker.PrivateId, worker.Type, tofu2)
+				require.NoError(t, err)
+				connection2, _, err := connRepo.AuthorizeConnection(ctx, sess2.PublicId, worker.PrivateId)
+				require.NoError(t, err)
+				_, err = repo.CancelSession(ctx, sess2.PublicId, sess2.Version)
+				require.NoError(t, err)
+
+				return testCase{
+					worker: worker,
+					req: []session.StateReport{
+						{
+							SessionId:     sess.PublicId,
+							Status:        session.StatusActive,
+							ConnectionIds: []string{connection.PublicId},
+						},
+						{
+							SessionId:     sess2.PublicId,
+							Status:        session.StatusActive,
+							ConnectionIds: []string{connection2.PublicId},
+						},
+					},
+					want: []session.StateReport{
+						{
+							SessionId: sess.PublicId,
+							Status:    session.StatusCanceling,
+						},
+						{
+							SessionId: sess2.PublicId,
+							Status:    session.StatusCanceling,
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "OrphanedConnection",
+			caseFn: func(t *testing.T) testCase {
+				worker := session.TestWorker(t, conn, wrapper)
+				sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
+					UserId:          uId,
+					HostId:          h.GetPublicId(),
+					TargetId:        tar.GetPublicId(),
+					HostSetId:       hs.GetPublicId(),
+					AuthTokenId:     at.GetPublicId(),
+					ScopeId:         prj.GetPublicId(),
+					Endpoint:        "tcp://127.0.0.1:22",
+					ConnectionLimit: 10,
+				})
+				tofu := session.TestTofu(t)
+				sess, _, err = repo.ActivateSession(ctx, sess.PublicId, sess.Version, worker.PrivateId, worker.Type, tofu)
+				require.NoError(t, err)
+				connection, _, err := connRepo.AuthorizeConnection(ctx, sess.PublicId, worker.PrivateId)
+				require.NoError(t, err)
+
+				sess2 := session.TestSession(t, conn, wrapper, session.ComposedOf{
+					UserId:          uId,
+					HostId:          h.GetPublicId(),
+					TargetId:        tar.GetPublicId(),
+					HostSetId:       hs.GetPublicId(),
+					AuthTokenId:     at.GetPublicId(),
+					ScopeId:         prj.GetPublicId(),
+					Endpoint:        "tcp://127.0.0.1:22",
+					ConnectionLimit: 10,
+				})
+				tofu2 := session.TestTofu(t)
+				sess2, _, err = repo.ActivateSession(ctx, sess2.PublicId, sess2.Version, worker.PrivateId, worker.Type, tofu2)
+				require.NoError(t, err)
+				connection2, _, err := connRepo.AuthorizeConnection(ctx, sess2.PublicId, worker.PrivateId)
+				require.NoError(t, err)
+				require.NotEqual(t, connection.PublicId, connection2.PublicId)
+
+				return testCase{
+					worker: worker,
+					req: []session.StateReport{
+						{
+							SessionId:     sess2.PublicId,
+							Status:        session.StatusActive,
+							ConnectionIds: []string{connection2.PublicId},
+						},
+					},
+					want:                []session.StateReport{},
+					orphanedConnections: []string{connection.PublicId},
+				}
+			},
+		},
+		{
+			name: "MultipleSessionsAndOrphanedConnections",
+			caseFn: func(t *testing.T) testCase {
+				worker := session.TestWorker(t, conn, wrapper)
+				sess := session.TestSession(t, conn, wrapper, session.ComposedOf{
+					UserId:          uId,
+					HostId:          h.GetPublicId(),
+					TargetId:        tar.GetPublicId(),
+					HostSetId:       hs.GetPublicId(),
+					AuthTokenId:     at.GetPublicId(),
+					ScopeId:         prj.GetPublicId(),
+					Endpoint:        "tcp://127.0.0.1:22",
+					ConnectionLimit: 10,
+				})
+				tofu := session.TestTofu(t)
+				sess, _, err = repo.ActivateSession(ctx, sess.PublicId, sess.Version, worker.PrivateId, worker.Type, tofu)
+				require.NoError(t, err)
+				connection, _, err := connRepo.AuthorizeConnection(ctx, sess.PublicId, worker.PrivateId)
+				require.NoError(t, err)
+				_, err = repo.CancelSession(ctx, sess.PublicId, sess.Version)
+				require.NoError(t, err)
+
+				sess2 := session.TestSession(t, conn, wrapper, session.ComposedOf{
+					UserId:          uId,
+					HostId:          h.GetPublicId(),
+					TargetId:        tar.GetPublicId(),
+					HostSetId:       hs.GetPublicId(),
+					AuthTokenId:     at.GetPublicId(),
+					ScopeId:         prj.GetPublicId(),
+					Endpoint:        "tcp://127.0.0.1:22",
+					ConnectionLimit: 10,
+				})
+				tofu2 := session.TestTofu(t)
+				sess2, _, err = repo.ActivateSession(ctx, sess2.PublicId, sess2.Version, worker.PrivateId, worker.Type, tofu2)
+				require.NoError(t, err)
+				connection2, _, err := connRepo.AuthorizeConnection(ctx, sess2.PublicId, worker.PrivateId)
+				require.NoError(t, err)
+				connection3, _, err := connRepo.AuthorizeConnection(ctx, sess2.PublicId, worker.PrivateId)
+				require.NoError(t, err)
+				_, err = repo.CancelSession(ctx, sess2.PublicId, sess2.Version)
+				require.NoError(t, err)
+
+				return testCase{
+					worker: worker,
+					req: []session.StateReport{
+						{
+							SessionId:     sess.PublicId,
+							Status:        session.StatusActive,
+							ConnectionIds: []string{connection.PublicId},
+						},
+						{
+							SessionId:     sess2.PublicId,
+							Status:        session.StatusActive,
+							ConnectionIds: []string{connection2.PublicId},
+						},
+					},
+					want: []session.StateReport{
+						{
+							SessionId: sess.PublicId,
+							Status:    session.StatusCanceling,
+						},
+						{
+							SessionId: sess2.PublicId,
+							Status:    session.StatusCanceling,
+						},
+					},
+					orphanedConnections: []string{connection3.PublicId},
+				}
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+
+			tc := tt.caseFn(t)
+
+			got, err := session.WorkerStatusReport(ctx, repo, connRepo, tc.worker.PrivateId, tc.req)
+			require.NoError(err)
+			assert.ElementsMatch(tc.want, got)
+			for _, dc := range tc.orphanedConnections {
+				gotConn, states, err := connRepo.LookupConnection(ctx, dc)
+				require.NoError(err)
+				assert.Equal(session.ConnectionSystemError, session.ClosedReason(gotConn.ClosedReason))
+				assert.Equal(2, len(states))
+				assert.Nil(states[0].EndTime)
+				assert.Equal(session.StatusClosed, states[0].Status)
+			}
+		})
+	}
+}

--- a/internal/tests/cluster/session_cleanup_test.go
+++ b/internal/tests/cluster/session_cleanup_test.go
@@ -35,21 +35,14 @@ import (
 // worker is managing the lifecycle of a connection and will properly
 // unclaim it closed once the connection resumes, ensuring the
 // connection is marked as closed on the worker.
-//
-// * controller: Here, the controller is the one doing the work. The
-// connection will be open on the worker until status checks resume
-// from the worker. At this point, the controller will request the
-// status change on the worker, physically closing the connection
-// there.
 type timeoutBurdenType string
 
 const (
-	timeoutBurdenTypeDefault    timeoutBurdenType = "default"
-	timeoutBurdenTypeWorker     timeoutBurdenType = "worker"
-	timeoutBurdenTypeController timeoutBurdenType = "controller"
+	timeoutBurdenTypeDefault timeoutBurdenType = "default"
+	timeoutBurdenTypeWorker  timeoutBurdenType = "worker"
 )
 
-var timeoutBurdenCases = []timeoutBurdenType{timeoutBurdenTypeDefault, timeoutBurdenTypeWorker, timeoutBurdenTypeController}
+var timeoutBurdenCases = []timeoutBurdenType{timeoutBurdenTypeDefault, timeoutBurdenTypeWorker}
 
 func controllerGracePeriod(ty timeoutBurdenType) time.Duration {
 	if ty == timeoutBurdenTypeWorker {
@@ -60,10 +53,6 @@ func controllerGracePeriod(ty timeoutBurdenType) time.Duration {
 }
 
 func workerGracePeriod(ty timeoutBurdenType) time.Duration {
-	if ty == timeoutBurdenTypeController {
-		return helper.DefaultGracePeriod * 10
-	}
-
 	return helper.DefaultGracePeriod
 }
 
@@ -172,11 +161,6 @@ func testWorkerSessionCleanupSingle(burdenCase timeoutBurdenType) func(t *testin
 			sess.ExpectConnectionStateOnWorker(ctx, t, w1, session.StatusClosed)
 			sess.ExpectConnectionStateOnController(ctx, t, c1.Controller().ConnectionRepoFn, session.StatusConnected)
 
-		case timeoutBurdenTypeController:
-			// Wait on controller, then check worker
-			sess.ExpectConnectionStateOnController(ctx, t, c1.Controller().ConnectionRepoFn, session.StatusClosed)
-			sess.ExpectConnectionStateOnWorker(ctx, t, w1, session.StatusConnected)
-
 		default:
 			// Should be closed on both worker and controller. Wait on
 			// worker then check controller.
@@ -184,16 +168,7 @@ func testWorkerSessionCleanupSingle(burdenCase timeoutBurdenType) func(t *testin
 			sess.ExpectConnectionStateOnController(ctx, t, c1.Controller().ConnectionRepoFn, session.StatusClosed)
 		}
 
-		// Run send/receive test again to check expected connection-level
-		// behavior
-		if burdenCase == timeoutBurdenTypeController {
-			// Burden on controller, should be successful until connection
-			// resumes
-			sConn.TestSendRecvAll(t)
-		} else {
-			// Connection should die in other cases
-			sConn.TestSendRecvFail(t)
-		}
+		sConn.TestSendRecvFail(t)
 
 		// Resume the connection, and reconnect.
 		event.WriteSysEvent(ctx, op, "resuming controller/worker link")
@@ -212,12 +187,6 @@ func testWorkerSessionCleanupSingle(burdenCase timeoutBurdenType) func(t *testin
 			// connections are actually closed now that the worker is
 			// properly reporting in again.
 			sess.ExpectConnectionStateOnController(ctx, t, c1.Controller().ConnectionRepoFn, session.StatusClosed)
-
-		case timeoutBurdenTypeController:
-			// If we are expecting the controller to be the source of
-			// truth, the connection should now be forcibly closed after
-			// the worker gets a status change request back.
-			sConn.TestSendRecvFail(t)
 		}
 
 		// Proceed with new connection test
@@ -373,11 +342,6 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 			sess.ExpectConnectionStateOnWorker(ctx, t, w1, session.StatusClosed)
 			sess.ExpectConnectionStateOnController(ctx, t, c1.Controller().ConnectionRepoFn, session.StatusConnected)
 
-		case timeoutBurdenTypeController:
-			// Wait on controller, then check worker
-			sess.ExpectConnectionStateOnController(ctx, t, c1.Controller().ConnectionRepoFn, session.StatusClosed)
-			sess.ExpectConnectionStateOnWorker(ctx, t, w1, session.StatusConnected)
-
 		default:
 			// Should be closed on both worker and controller. Wait on
 			// worker then check controller.
@@ -387,14 +351,7 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 
 		// Run send/receive test again to check expected connection-level
 		// behavior
-		if burdenCase == timeoutBurdenTypeController {
-			// Burden on controller, should be successful until connection
-			// resumes
-			sConn.TestSendRecvAll(t)
-		} else {
-			// Connection should die in other cases
-			sConn.TestSendRecvFail(t)
-		}
+		sConn.TestSendRecvFail(t)
 
 		// Finally resume both, try again. Should behave as per normal.
 		event.WriteSysEvent(ctx, op, "resuming connections to both controllers")
@@ -414,12 +371,6 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 			// connections are actually closed now that the worker is
 			// properly reporting in again.
 			sess.ExpectConnectionStateOnController(ctx, t, c1.Controller().ConnectionRepoFn, session.StatusClosed)
-
-		case timeoutBurdenTypeController:
-			// If we are expecting the controller to be the source of
-			// truth, the connection should now be forcibly closed after
-			// the worker gets a status change request back.
-			sConn.TestSendRecvFail(t)
 		}
 
 		// Proceed with new connection test


### PR DESCRIPTION
When processing a worker status report, if the worker did not report any
sessions, the query would find all canceling or terminated sessions,
since the `in` clause would not be populated.
Now this will run the query if there are sessions reported and therefore
there is an `in` clause.