### PR TITLE
bug(worker): create error and handle session cancel with no tofu token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## Next
+### Bug Fixes
+* worker: create new error to prevent `event.newError: missing error: invalid parameter` and handle session cancel 
+with no TOFU token ([Issue](https://github.com/hashicorp/boundary/issues/1902),
+  [PR](https://github.com/hashicorp/boundary/pull/1929))
 ## 0.7.6 (2022/03/15)
 
 ### Bug Fixes


### PR DESCRIPTION
- Create new error if no tofu token found to prevent `event.newError: missing error: invalid parameter`
- Handle session cancellation before tofu token, to fix error where session was cancelled without making a connection (erred on no tofu token)

Fixes #1902