### PR TITLE
[RelAPI Onboarding] Add release API metadata file

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,0 +1,6 @@
+url_docker_registry_dockerhub = "https://hub.docker.com/r/hashicorp/boundary"
+url_docker_registry_ecr = "https://gallery.ecr.aws/hashicorp/boundary"
+url_license = "https://github.com/hashicorp/boundary/blob/main/LICENSE"
+url_project_website = "https://www.boundaryproject.io"
+url_release_notes = "https://www.boundaryproject.io/docs/releases/release-notes"
+url_source_repository = "https://github.com/hashicorp/boundary"


### PR DESCRIPTION
👋  This PR adds a `.release/release-metadata.hcl` file to the repo. This contains static metadata that will be processed and sent as part of the payload in RelAPI POST requests, which will be sent when staging and production releases are triggered.  

This can be merged now, but will not have any effect until after the RelAPI launch. Similar additions are being added across all projects that publish to releases.hashicorp.com.