### PR TITLE
[RelAPI Onboarding release/v0.7.x] Add release API metadata file

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,0 +1,6 @@
+url_docker_registry_dockerhub = "https://hub.docker.com/r/hashicorp/boundary"
+url_docker_registry_ecr = "https://gallery.ecr.aws/hashicorp/boundary"
+url_license = "https://github.com/hashicorp/boundary/blob/main/LICENSE"
+url_project_website = "https://www.boundaryproject.io"
+url_release_notes = "https://www.boundaryproject.io/docs/releases/release-notes"
+url_source_repository = "https://github.com/hashicorp/boundary"


### PR DESCRIPTION
Same as https://github.com/hashicorp/boundary/pull/1939 targetting the release/0.7.x branch, since auto-backporting failed in that PR.