### PR TITLE
Revert "Refactor file formatting target (#1941)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,9 @@ build: build-ui-ifne
 install: export BOUNDARY_INSTALL_BINARY=1
 install: build
 
-# Format Go files, ignoring files marked as generated through the header defined at
-# https://pkg.go.dev/cmd/go#hdr-Generate_Go_files_by_processing_source
 .PHONY: fmt
 fmt:
-	grep -L -R "^\/\/ Code generated .* DO NOT EDIT\.$$" --exclude-dir=.git --include="*.go" | xargs gofumpt -w
+	gofumpt -w $$(find . -name '*.go' | grep -v pb.go | grep -v pb.gw.go)
 
 # Set env for all UI targets.
 UI_TARGETS := update-ui-version build-ui build-ui-ifne


### PR DESCRIPTION
This reverts commit 90297206648218192a9c386419b6798b8c7b1408. It
was causing unexpected errors on some platforms. More investigation
will be necessary.