### PR TITLE
Pull up Server to top level of Init command

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -318,7 +318,7 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 		},
 		"database init": func() (cli.Command, error) {
 			return &database.InitCommand{
-				Command: base.NewCommand(ui),
+				Server: base.NewServer(base.NewCommand(ui)),
 			}, nil
 		},
 		"database migrate": func() (cli.Command, error) {

--- a/internal/cmd/commands/config/encryptdecrypt.go
+++ b/internal/cmd/commands/config/encryptdecrypt.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/cmd/base"
 	kms_plugin_assets "github.com/hashicorp/boundary/plugins/kms"
 	"github.com/hashicorp/boundary/sdk/wrapper"
@@ -151,7 +152,7 @@ func (c *EncryptDecryptCommand) Run(args []string) (ret int) {
 	wrapper, cleanupFunc, err := wrapper.GetWrapperFromPath(
 		c.Context,
 		kmsDefFile,
-		"config",
+		globals.KmsPurposeConfig,
 		configutil.WithPluginOptions(
 			pluginutil.WithPluginsMap(kms_plugin_assets.BuiltinKmsPlugins()),
 			pluginutil.WithPluginsFilesystem(kms_plugin_assets.KmsPluginPrefix, kms_plugin_assets.FileSystem()),

--- a/internal/cmd/commands/database/funcs_test.go
+++ b/internal/cmd/commands/database/funcs_test.go
@@ -220,11 +220,10 @@ func TestVerifyOplogIsEmpty(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, man.ApplyMigrations(ctx))
 
-	cmd := InitCommand{Command: base.NewCommand(cli.NewMockUi())}
-	cmd.srv = base.NewServer(&base.Command{UI: cmd.UI})
+	cmd := InitCommand{Server: base.NewServer(base.NewCommand(cli.NewMockUi()))}
 
-	cmd.srv.DatabaseUrl = u
-	require.NoError(t, cmd.srv.ConnectToDatabase(ctx, dialect))
+	cmd.DatabaseUrl = u
+	require.NoError(t, cmd.ConnectToDatabase(ctx, dialect))
 
 	assert.NoError(t, cmd.verifyOplogIsEmpty(ctx))
 }

--- a/internal/cmd/commands/database/migrate.go
+++ b/internal/cmd/commands/database/migrate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/cmd/base"
 	"github.com/hashicorp/boundary/internal/cmd/config"
 	"github.com/hashicorp/boundary/internal/errors"
@@ -291,7 +292,7 @@ func (c *MigrateCommand) ParseFlagsAndConfig(args []string) int {
 	wrapper, cleanupFunc, err := wrapper.GetWrapperFromPath(
 		c.Context,
 		wrapperPath,
-		"config",
+		globals.KmsPurposeConfig,
 		configutil.WithPluginOptions(
 			pluginutil.WithPluginsMap(kms_plugin_assets.BuiltinKmsPlugins()),
 			pluginutil.WithPluginsFilesystem(kms_plugin_assets.KmsPluginPrefix, kms_plugin_assets.FileSystem()),


### PR DESCRIPTION
Init was using a local server variable but not passing in the existing
command, resulting in the context being lost. This caused the command to
fail to run since the changes to add logging to KMS plugins were
introduced.

This also fixes a couple of places that were not using the global const
value for config KMS.