### PR TITLE
Fix missing context

### DIFF
--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -528,7 +528,7 @@ func (b *Server) SetupKMSes(ctx context.Context, ui cli.Ui, config *config.Confi
 			}
 
 			if pluginLogger == nil {
-				pluginLogger, err = event.NewHclogLogger(b.Context, b.Eventer)
+				pluginLogger, err = event.NewHclogLogger(ctx, b.Eventer)
 				if err != nil {
 					return fmt.Errorf("Error creating KMS plugin logger: %w", err)
 				}

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -649,7 +649,7 @@ func (b *Server) CreateGlobalKmsKeys(ctx context.Context) error {
 		return fmt.Errorf("error creating kms cache: %w", err)
 	}
 	if err := kmsCache.AddExternalWrappers(
-		b.Context,
+		ctx,
 		kms.WithRootWrapper(b.RootKms),
 	); err != nil {
 		return fmt.Errorf("error adding config keys to kms: %w", err)


### PR DESCRIPTION
I ran into two errors when trying to use the commit (`58a448fc6`) of main.

![image](https://user-images.githubusercontent.com/8681572/161613537-f7aea267-40c4-433a-99bb-953a98fc4955.png)
![image](https://user-images.githubusercontent.com/8681572/161613586-b7398131-b8e5-4d0d-96de-77c4ce2d0751.png)

So I changed to use the passed in context instead of the command context. I'm unfamiliar of the difference but this got everything working.