### PR TITLE
fix(subtypes): Do not transform unset oneof

### DIFF
--- a/internal/types/subtypes/interceptor_test.go
+++ b/internal/types/subtypes/interceptor_test.go
@@ -563,6 +563,21 @@ func TestTransformResponseAttributes(t *testing.T) {
 				},
 			},
 		},
+		{
+			"TestCreateResourceOneofUnset",
+			&attribute.TestCreateResourceResponse{
+				Item: &attribute.TestResource{
+					Id:   "trsr_one",
+					Type: "sub_resource",
+				},
+			},
+			&attribute.TestCreateResourceResponse{
+				Item: &attribute.TestResource{
+					Id:   "trsr_one",
+					Type: "sub_resource",
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
When the attrs oneof was unset, we would populate a zero
value attributes struct. Fixes the behavior and adds a test.