### PR TITLE
fix(accounts): correct use of unkeyed literals

### DIFF
--- a/internal/servers/controller/handlers/accounts/account_service.go
+++ b/internal/servers/controller/handlers/accounts/account_service.go
@@ -866,7 +866,7 @@ func toProto(ctx context.Context, in auth.Account, opt ...handlers.Option) (*pb.
 			break
 		}
 		out.Attrs = &pb.Account_PasswordAccountAttributes{
-			&pb.PasswordAccountAttributes{
+			PasswordAccountAttributes: &pb.PasswordAccountAttributes{
 				LoginName: i.GetLoginName(),
 			},
 		}
@@ -878,7 +878,7 @@ func toProto(ctx context.Context, in auth.Account, opt ...handlers.Option) (*pb.
 			break
 		}
 		attrs := &pb.Account_OidcAccountAttributes{
-			&pb.OidcAccountAttributes{
+			OidcAccountAttributes: &pb.OidcAccountAttributes{
 				Issuer:   i.GetIssuer(),
 				Subject:  i.GetSubject(),
 				FullName: i.GetFullName(),

--- a/internal/servers/controller/handlers/accounts/validate_test.go
+++ b/internal/servers/controller/handlers/accounts/validate_test.go
@@ -63,7 +63,7 @@ func TestValidateCreateRequest(t *testing.T) {
 				Type:         oidc.Subtype.String(),
 				AuthMethodId: oidc.AuthMethodPrefix + "_1234567890",
 				Attrs: &pb.Account_OidcAccountAttributes{
-					&pb.OidcAccountAttributes{FullName: "something"},
+					OidcAccountAttributes: &pb.OidcAccountAttributes{FullName: "something"},
 				},
 			},
 			errContains: fieldError(nameClaimField, "This is a read only field."),
@@ -74,7 +74,7 @@ func TestValidateCreateRequest(t *testing.T) {
 				Type:         oidc.Subtype.String(),
 				AuthMethodId: oidc.AuthMethodPrefix + "_1234567890",
 				Attrs: &pb.Account_OidcAccountAttributes{
-					&pb.OidcAccountAttributes{Email: "something"},
+					OidcAccountAttributes: &pb.OidcAccountAttributes{Email: "something"},
 				},
 			},
 			errContains: fieldError(emailClaimField, "This is a read only field."),
@@ -93,7 +93,7 @@ func TestValidateCreateRequest(t *testing.T) {
 				Type:         password.Subtype.String(),
 				AuthMethodId: password.AuthMethodPrefix + "_1234567890",
 				Attrs: &pb.Account_PasswordAccountAttributes{
-					&pb.PasswordAccountAttributes{
+					PasswordAccountAttributes: &pb.PasswordAccountAttributes{
 						LoginName: "something",
 					},
 				},
@@ -105,7 +105,7 @@ func TestValidateCreateRequest(t *testing.T) {
 				Type:         oidc.Subtype.String(),
 				AuthMethodId: oidc.AuthMethodPrefix + "_1234567890",
 				Attrs: &pb.Account_OidcAccountAttributes{
-					&pb.OidcAccountAttributes{Subject: "no oidc errors"},
+					OidcAccountAttributes: &pb.OidcAccountAttributes{Subject: "no oidc errors"},
 				},
 			},
 		},


### PR DESCRIPTION
This is unusual and idiomatic, so lets use the keyed literal form