### PR TITLE
Refactor build ci worfklow to decouple UI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     branches:    
       # Push events on main branch
       - 'main'
+      - 'refactor-build-ci-worfklow-to-decouple-ui-build'
 
 env:
   PKG_NAME: "boundary"
@@ -96,25 +97,14 @@ jobs:
       - name: Set sha
         id: set-sha
         run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
-      - uses: actions/checkout@v2
+      - name: Download UI artifact
+        uses: dawidd6/action-download-artifact@v2
         with:
-          repository: "hashicorp/boundary-ui"
-          ref: ${{ steps.set-sha.outputs.sha }}
-          path: "internal/ui/.tmp/boundary-ui"
-      - name: Setup node and yarn
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: 'yarn'
-          cache-dependency-path: 'internal/ui/.tmp/boundary-ui/yarn.lock'
-      - name: Install Yarn
-        run: |
-          npm install -g yarn
-      - name: UI Build
-        working-directory: internal/ui/.tmp/boundary-ui
-        run: |
-          yarn install --network-timeout 300000
-          yarn build:ui:admin
+          workflow: build-admin-ui.yaml
+          commit: ${{ steps.set-sha.outputs.sha }}
+          repo: "hashicorp/boundary-ui"
+          name: admin-ui
+          path: internal/ui/.tmp/boundary-ui/ui/admin/dist
       - name: Go Build
         env:
           GOOS: ${{ matrix.goos }}
@@ -162,25 +152,14 @@ jobs:
       - name: Set sha
         id: set-sha
         run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
-      - uses: actions/checkout@v2
+      - name: Download UI artifact
+        uses: dawidd6/action-download-artifact@v2
         with:
-          repository: "hashicorp/boundary-ui"
-          ref: ${{ steps.set-sha.outputs.sha }}
-          path: "internal/ui/.tmp/boundary-ui"
-      - name: Setup node and yarn
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: 'yarn'
-          cache-dependency-path: 'internal/ui/.tmp/boundary-ui/yarn.lock'
-      - name: Install Yarn
-        run: |
-          npm install -g yarn
-      - name: UI Build
-        working-directory: internal/ui/.tmp/boundary-ui
-        run: |
-          yarn install --network-timeout 300000
-          yarn build:ui:admin
+          workflow: build-admin-ui.yaml
+          commit: ${{ steps.set-sha.outputs.sha }}
+          repo: "hashicorp/boundary-ui"
+          name: admin-ui
+          path: internal/ui/.tmp/boundary-ui/ui/admin/dist
       - name: Go Build
         env:
           GOOS: ${{ matrix.goos }}
@@ -255,25 +234,14 @@ jobs:
       - name: Set sha
         id: set-sha
         run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
-      - uses: actions/checkout@v2
+      - name: Download UI artifact
+        uses: dawidd6/action-download-artifact@v2
         with:
-          repository: "hashicorp/boundary-ui"
-          ref: ${{ steps.set-sha.outputs.sha }}
-          path: "internal/ui/.tmp/boundary-ui"
-      - name: Setup node and yarn
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: 'yarn'
-          cache-dependency-path: 'internal/ui/.tmp/boundary-ui/yarn.lock'
-      - name: Install Yarn
-        run: |
-          npm install -g yarn
-      - name: UI Build
-        working-directory: internal/ui/.tmp/boundary-ui
-        run: |
-          yarn install --network-timeout 300000
-          yarn build:ui:admin
+          workflow: build-admin-ui.yaml
+          commit: ${{ steps.set-sha.outputs.sha }}
+          repo: "hashicorp/boundary-ui"
+          name: admin-ui
+          path: internal/ui/.tmp/boundary-ui/ui/admin/dist
       - name: Go Build
         env:
           GOOS: ${{ matrix.goos }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
     branches:    
       # Push events on main branch
       - 'main'
-      - 'refactor-build-ci-worfklow-to-decouple-ui-build'
 
 env:
   PKG_NAME: "boundary"

--- a/internal/ui/VERSION
+++ b/internal/ui/VERSION
@@ -1,4 +1,4 @@
-8496c054888329073c568e9bd4944b209e966923 Merge pull request #980 from hashicorp/chore-radio-card-width
+8776b46277a239f82ba8ed8064366f449e63464b Chore update eslint (#1045)
 # This file determines the version of the UI to embed in the boundary binary.
 # Update this file by running 'make update-ui-version' from the root of this repo.
 # Set UI_COMMITISH when running the above target to update to a specific version.


### PR DESCRIPTION
Depends on: [chore: 🤖 Add build admin UI workflow](https://github.com/hashicorp/boundary-ui/pull/1043).

**This PR is missing:** Update the UI SHA [in version file](https://github.com/hashicorp/boundary/blob/main/internal/ui/VERSION). We need to unlock the dependency on the UI PR (mentioned above) first. I will update this from draft to PR when is ready.
- Refactors `build` workflow to decouple UI build from Boundary. Now consumes the artifacts generated by the UI.

UPDATE: the version of all GH actions will be updated in a separate PR [here](https://github.com/hashicorp/boundary/pull/2030)