### PR TITLE
fix (kms): properly reconcile DEKs for existing scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 * worker: create new error to prevent `event.newError: missing error: invalid parameter` and handle session cancel 
   with no TOFU token ([Issue](https://github.com/hashicorp/boundary/issues/1902),
   [PR](https://github.com/hashicorp/boundary/pull/1929))
+* controller: Reconcile DEKs with existing scopes ([Issue](https://github.com/hashicorp/boundary/issues/1856),
+  [PR](https://github.com/hashicorp/boundary/pull/1976))
   
 ## 0.7.6 (2022/03/15)
 

--- a/internal/kms/const.go
+++ b/internal/kms/const.go
@@ -4,6 +4,11 @@ package kms
 // is used to select which DEK to return
 type KeyPurpose uint
 
+// ****************************************************************************
+// IMPORTANT: if you're adding a new KeyPurpose, you should consider whether or
+// not existing scopes need this new type of key.  If they do, then you may want
+// to add the new key into kms.ReconcileKeys(...)
+// ****************************************************************************
 const (
 	// KeyPurposeUnknown is the default, and indicates that a correct purpose
 	// wasn't specified

--- a/internal/kms/kms_ext_test.go
+++ b/internal/kms/kms_ext_test.go
@@ -210,7 +210,6 @@ func TestKms_ReconcileKeys(t *testing.T) {
 					_, err := k.GetWrapper(testCtx, id, kms.KeyPurposeAudit)
 					require.Error(t, err)
 				}
-
 			},
 			wantPurpose: []kms.KeyPurpose{kms.KeyPurposeOidc},
 		},

--- a/internal/kms/kms_ext_test.go
+++ b/internal/kms/kms_ext_test.go
@@ -138,7 +138,7 @@ func TestKms(t *testing.T) {
 }
 
 func TestKms_ReconcileKeys(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	testCtx := context.Background()
 	conn, _ := db.TestSetup(t, "postgres")
 	rw := db.New(conn)

--- a/internal/kms/options.go
+++ b/internal/kms/options.go
@@ -26,6 +26,7 @@ type options struct {
 	withRepository        *Repository
 	withOrderByVersion    db.OrderBy
 	withKeyId             string
+	withScopeIds          []string
 }
 
 func getDefaultOptions() options {
@@ -85,5 +86,12 @@ func WithOrderByVersion(orderBy db.OrderBy) Option {
 func WithKeyId(keyId string) Option {
 	return func(o *options) {
 		o.withKeyId = keyId
+	}
+}
+
+// WithScopeIds allows the specifying of optional scope ids.
+func WithScopeIds(scopeId ...string) Option {
+	return func(o *options) {
+		o.withScopeIds = scopeId
 	}
 }


### PR DESCRIPTION
When new DEKs are added to boundary we need to ensure that the keys
for existing scopes are reconciled.

This fix should address:
https://github.com/hashicorp/boundary/issues/1856