### PR TITLE
feat(db): Suppress not found events during db lookups

### DIFF
--- a/internal/errors/option.go
+++ b/internal/errors/option.go
@@ -57,6 +57,8 @@ func WithCode(code Code) Option {
 	}
 }
 
+// WithoutEvent provides an option to suppress the event when wrapping or
+// creating a new error.
 func WithoutEvent() Option {
 	return func(o *Options) {
 		o.withoutEvent = true


### PR DESCRIPTION
Fixes #1925 

@jimlambrt I have been fixing a couple of related scheduler error spam and also thought that perhaps NotFound should be suppressed as well. This is going off your comment left in #1925 happy to discuss if you like