### PR TITLE
fix(logs): Remove erroneous scheduler run logs at first run.

### DIFF
--- a/internal/servers/controller/controller.go
+++ b/internal/servers/controller/controller.go
@@ -301,6 +301,11 @@ func (c *Controller) Start() error {
 	if err := c.startListeners(); err != nil {
 		return fmt.Errorf("error starting controller listeners: %w", err)
 	}
+
+	// Upsert server before starting tickers and scheduler to ensure the server exists
+	if err := c.upsertServer(c.baseContext); err != nil {
+		return fmt.Errorf("error upserting server: %w", err)
+	}
 	if err := c.scheduler.Start(c.baseContext, c.schedulerWg); err != nil {
 		return fmt.Errorf("error starting scheduler: %w", err)
 	}


### PR DESCRIPTION
The Scheduler is dependant on the server being inserted into the
database. Adding an upsert server call before starting scheduler
and tickers removes the race that caused log spam due to a missing
foreign key relationship.