### PR TITLE
fix(controller): Clone messages before auditing

### DIFF
--- a/internal/servers/controller/interceptor.go
+++ b/internal/servers/controller/interceptor.go
@@ -240,7 +240,10 @@ func auditRequestInterceptor(
 		handler grpc.UnaryHandler) (interface{}, error,
 	) {
 		if msg, ok := req.(proto.Message); ok {
-			if err := event.WriteAudit(interceptorCtx, op, event.WithRequest(&event.Request{Details: msg})); err != nil {
+			// Clone the request before writing it to the audit log,
+			// in case downstream interceptors modify it.
+			clonedMsg := proto.Clone(msg)
+			if err := event.WriteAudit(interceptorCtx, op, event.WithRequest(&event.Request{Details: clonedMsg})); err != nil {
 				return req, status.Errorf(codes.Internal, "unable to write request msg audit: %s", err)
 			}
 		}
@@ -262,7 +265,10 @@ func auditResponseInterceptor(
 		resp, err := handler(interceptorCtx, req)
 
 		if msg, ok := resp.(proto.Message); ok {
-			if err := event.WriteAudit(interceptorCtx, op, event.WithResponse(&event.Response{Details: msg})); err != nil {
+			// Clone the response before writing it to the audit log,
+			// in case downstream interceptors modify it.
+			clonedMsg := proto.Clone(msg)
+			if err := event.WriteAudit(interceptorCtx, op, event.WithResponse(&event.Response{Details: clonedMsg})); err != nil {
 				return req, status.Errorf(codes.Internal, "unable to write response msg audit: %s", err)
 			}
 		}


### PR DESCRIPTION
It is not unreasonable for downstream users of the request and response
messages to mutate them, indeed we mutate the response
on the way out to get the desired external API. To avoid
inconsistent messages being audited, make a copy of the
entire message before returning from the interceptor.

This was discovered while testing the new subtype transformation
interceptor.