### PR TITLE
Classification for role, session, users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,8 @@ protobuild:
 	@protoc-go-inject-tag -input=./internal/gen/controller/api/services/role_service.pb.go
 	@protoc-go-inject-tag -input=./sdk/pbs/controller/api/resources/sessions/session.pb.go
 	@protoc-go-inject-tag -input=./internal/gen/controller/api/services/session_service.pb.go
+	@protoc-go-inject-tag -input=./sdk/pbs/controller/api/resources/users/user.pb.go
+	@protoc-go-inject-tag -input=./internal/gen/controller/api/services/user_service.pb.go
 
 	# these protos, services and openapi artifacts are purely for testing purposes
 	@protoc-go-inject-tag -input=./internal/gen/testing/event/event.pb.go

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,8 @@ protobuild:
 	@protoc-go-inject-tag -input=./internal/gen/controller/api/services/credential_store_service.pb.go
 	@protoc-go-inject-tag -input=./sdk/pbs/controller/api/resources/credentiallibraries/credential_library.pb.go
 	@protoc-go-inject-tag -input=./internal/gen/controller/api/services/credential_library_service.pb.go
+	@protoc-go-inject-tag -input=./sdk/pbs/controller/api/resources/roles/role.pb.go
+	@protoc-go-inject-tag -input=./internal/gen/controller/api/services/role_service.pb.go
 
 	# these protos, services and openapi artifacts are purely for testing purposes
 	@protoc-go-inject-tag -input=./internal/gen/testing/event/event.pb.go

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,8 @@ protobuild:
 	@protoc-go-inject-tag -input=./internal/gen/controller/api/services/credential_library_service.pb.go
 	@protoc-go-inject-tag -input=./sdk/pbs/controller/api/resources/roles/role.pb.go
 	@protoc-go-inject-tag -input=./internal/gen/controller/api/services/role_service.pb.go
+	@protoc-go-inject-tag -input=./sdk/pbs/controller/api/resources/sessions/session.pb.go
+	@protoc-go-inject-tag -input=./internal/gen/controller/api/services/session_service.pb.go
 
 	# these protos, services and openapi artifacts are purely for testing purposes
 	@protoc-go-inject-tag -input=./internal/gen/testing/event/event.pb.go

--- a/internal/gen/controller/api/services/role_service.pb.go
+++ b/internal/gen/controller/api/services/role_service.pb.go
@@ -29,7 +29,7 @@ type GetRoleRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *GetRoleRequest) Reset() {
@@ -123,9 +123,9 @@ type ListRolesRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,proto3" json:"scope_id,omitempty"`
-	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty"`
-	Filter    string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty"`
+	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"`     // @gotags: `class:"public"`
+	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public"` // @gotags: `class:"public"`
+	Filter    string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty" class:"public"`        // @gotags: `class:"public"`
 }
 
 func (x *ListRolesRequest) Reset() {
@@ -335,7 +335,7 @@ type UpdateRoleRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	Item       *roles.Role            `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 	UpdateMask *fieldmaskpb.FieldMask `protobuf:"bytes,3,opt,name=update_mask,proto3" json:"update_mask,omitempty"`
 }
@@ -445,7 +445,7 @@ type DeleteRoleRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *DeleteRoleRequest) Reset() {
@@ -530,11 +530,11 @@ type AddRolePrincipalsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty"`
+	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`            // @gotags: `class:"public"`
+	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *AddRolePrincipalsRequest) Reset() {
@@ -642,11 +642,11 @@ type SetRolePrincipalsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty"`
+	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`            // @gotags: `class:"public"`
+	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *SetRolePrincipalsRequest) Reset() {
@@ -754,11 +754,11 @@ type RemoveRolePrincipalsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty"`
+	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`            // @gotags: `class:"public"`
+	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *RemoveRolePrincipalsRequest) Reset() {
@@ -866,11 +866,11 @@ type AddRoleGrantsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	GrantStrings []string `protobuf:"bytes,3,rep,name=grant_strings,proto3" json:"grant_strings,omitempty"`
+	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`            // @gotags: `class:"public"`
+	GrantStrings []string `protobuf:"bytes,3,rep,name=grant_strings,proto3" json:"grant_strings,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *AddRoleGrantsRequest) Reset() {
@@ -978,11 +978,11 @@ type SetRoleGrantsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	GrantStrings []string `protobuf:"bytes,3,rep,name=grant_strings,proto3" json:"grant_strings,omitempty"`
+	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`            // @gotags: `class:"public"`
+	GrantStrings []string `protobuf:"bytes,3,rep,name=grant_strings,proto3" json:"grant_strings,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *SetRoleGrantsRequest) Reset() {
@@ -1090,11 +1090,11 @@ type RemoveRoleGrantsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	GrantStrings []string `protobuf:"bytes,3,rep,name=grant_strings,proto3" json:"grant_strings,omitempty"`
+	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`            // @gotags: `class:"public"`
+	GrantStrings []string `protobuf:"bytes,3,rep,name=grant_strings,proto3" json:"grant_strings,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *RemoveRoleGrantsRequest) Reset() {

--- a/internal/gen/controller/api/services/session_service.pb.go
+++ b/internal/gen/controller/api/services/session_service.pb.go
@@ -28,7 +28,7 @@ type GetSessionRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *GetSessionRequest) Reset() {
@@ -122,9 +122,9 @@ type ListSessionsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty"`
-	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty"`
-	Filter    string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty"`
+	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public"`          // @gotags: `class:"public"`
+	Filter    string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty" class:"public"`                 // @gotags: `class:"public"`
 }
 
 func (x *ListSessionsRequest) Reset() {
@@ -232,8 +232,8 @@ type CancelSessionRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id      string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Version uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
+	Id      string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"`            // @gotags: `class:"public"`
+	Version uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *CancelSessionRequest) Reset() {

--- a/internal/gen/controller/api/services/user_service.pb.go
+++ b/internal/gen/controller/api/services/user_service.pb.go
@@ -29,7 +29,7 @@ type GetUserRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *GetUserRequest) Reset() {
@@ -123,9 +123,9 @@ type ListUsersRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty"`
-	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty"`
-	Filter    string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty"`
+	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public"`          // @gotags: `class:"public"`
+	Filter    string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty" class:"sensitive"`                 // @gotags: `class:"sensitive"`
 }
 
 func (x *ListUsersRequest) Reset() {
@@ -280,7 +280,7 @@ type CreateUserResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Uri  string      `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
+	Uri  string      `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public"` // @gotags: `class:"public"`
 	Item *users.User `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 }
 
@@ -335,7 +335,7 @@ type UpdateUserRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	Item       *users.User            `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 	UpdateMask *fieldmaskpb.FieldMask `protobuf:"bytes,3,opt,name=update_mask,proto3" json:"update_mask,omitempty"`
 }
@@ -445,7 +445,7 @@ type DeleteUserRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *DeleteUserRequest) Reset() {
@@ -530,10 +530,10 @@ type AddUserAccountsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The version ensures the User hasn't changed since it was last retrieved and if it has the request will fail.
-	Version    uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	AccountIds []string `protobuf:"bytes,3,rep,name=account_ids,proto3" json:"account_ids,omitempty"`
+	Version    uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`        // @gotags: `class:"public"`
+	AccountIds []string `protobuf:"bytes,3,rep,name=account_ids,proto3" json:"account_ids,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *AddUserAccountsRequest) Reset() {
@@ -641,10 +641,10 @@ type SetUserAccountsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The version ensures the User hasn't changed since it was last retrieved and if it has the request will fail.
-	Version    uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	AccountIds []string `protobuf:"bytes,3,rep,name=account_ids,proto3" json:"account_ids,omitempty"`
+	Version    uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`        // @gotags: `class:"public"`
+	AccountIds []string `protobuf:"bytes,3,rep,name=account_ids,proto3" json:"account_ids,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *SetUserAccountsRequest) Reset() {
@@ -752,10 +752,10 @@ type RemoveUserAccountsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The version ensures the User hasn't changed since it was last retrieved and if it has the request will fail.
-	Version    uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	AccountIds []string `protobuf:"bytes,3,rep,name=account_ids,proto3" json:"account_ids,omitempty"`
+	Version    uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`        // @gotags: `class:"public"`
+	AccountIds []string `protobuf:"bytes,3,rep,name=account_ids,proto3" json:"account_ids,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *RemoveUserAccountsRequest) Reset() {

--- a/internal/proto/controller/api/resources/roles/v1/role.proto
+++ b/internal/proto/controller/api/resources/roles/v1/role.proto
@@ -11,32 +11,32 @@ import "controller/custom_options/v1/options.proto";
 
 message Principal {
 	// Output only. The ID of the principal.
-	string id = 1;
+	string id = 1; // @gotags: `class:"public"`
 
 	// Output only. The type of the principal.
-	string type = 2;
+	string type = 2; // @gotags: `class:"public"`
 
 	// Output only. The Scope of the principal.
-	string scope_id = 3 [json_name="scope_id"];
+	string scope_id = 3 [json_name="scope_id"]; // @gotags: `class:"public"`
 }
 
 message GrantJson {
 	// Output only. The ID, if set.
-	string id = 1;
+	string id = 1; // @gotags: `class:"public"`
 
 	// Output only. The type, if set.
-	string type = 2;
+	string type = 2; // @gotags: `class:"public"`
 
 	// Output only. The actions.
-	repeated string actions = 3;
+	repeated string actions = 3; // @gotags: `class:"public"`
 }
 
 message Grant {
 	// Output only. The original user-supplied string.
-	string raw = 1;
+	string raw = 1; // @gotags: `class:"public"`
 
 	// Output only. The canonically-formatted string.
-	string canonical = 2;
+	string canonical = 2; // @gotags: `class:"public"`
 
 	// Output only. The JSON representation of the grant.
 	GrantJson json = 3;
@@ -45,45 +45,45 @@ message Grant {
 // Role contains all fields related to a Role resource
 message Role {
 	// Output only. The ID of the Role.
-	string id = 10;
+	string id = 10; // @gotags: `class:"public"`
 
 	// The ID of the Scope containing this Role.
-	string scope_id = 20 [json_name="scope_id"];
+	string scope_id = 20 [json_name="scope_id"]; // @gotags: `class:"public"`
 
 	// Output only. Scope information for this resource.
 	resources.scopes.v1.ScopeInfo scope = 30;
-	
+
 	// Optional name for identification purposes.
-	google.protobuf.StringValue name = 40 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this:"name" that: "name"}];
+	google.protobuf.StringValue name = 40 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this:"name" that: "name"}]; // @gotags: `class:"public"`
 
 	// Optional user-set description for identification purposes.
-	google.protobuf.StringValue description = 50 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this:"description" that: "description"}];
+	google.protobuf.StringValue description = 50 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this:"description" that: "description"}]; // @gotags: `class:"public"`
 
 	// Output only. The time this resource was created.
-	google.protobuf.Timestamp created_time = 60 [json_name="created_time"];
+	google.protobuf.Timestamp created_time = 60 [json_name="created_time"]; // @gotags: `class:"public"`
 
 	// Output only. The time this resource was last updated.
-	google.protobuf.Timestamp updated_time = 70 [json_name="updated_time"];
+	google.protobuf.Timestamp updated_time = 70 [json_name="updated_time"]; // @gotags: `class:"public"`
 
 	// Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	uint32 version = 80;
+	uint32 version = 80; // @gotags: `class:"public"`
 
 	// The Scope the grants will apply to. If the Role is at the global scope, this can be an org or project. If the Role is at an org scope, this can be a project within the org. It is invalid for this to be anything other than the Role's scope when the Role's scope is a project.
-	google.protobuf.StringValue grant_scope_id = 90 [json_name="grant_scope_id", (custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this:"grant_scope_id" that: "GrantScopeId"}];
+	google.protobuf.StringValue grant_scope_id = 90 [json_name="grant_scope_id", (custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = {this:"grant_scope_id" that: "GrantScopeId"}]; // @gotags: `class:"public"`
 
 	// Output only. The IDs (only) of principals that are assigned to this role.
-	repeated string principal_ids = 100 [json_name="principal_ids"];
+	repeated string principal_ids = 100 [json_name="principal_ids"]; // @gotags: `class:"public"`
 
 	// Output only. The principals that are assigned to this role.
 	repeated Principal principals = 110;
 
 	// Output only. The grants that this role provides for its principals.
-	repeated string grant_strings = 120 [json_name="grant_strings"];
+	repeated string grant_strings = 120 [json_name="grant_strings"]; // @gotags: `class:"public"`
 
 	// Output only. The parsed grant information.
 	repeated Grant grants = 130;
 
 	// Output only. The available actions on this resource for this user.
-	repeated string authorized_actions = 300 [json_name="authorized_actions"];
+	repeated string authorized_actions = 300 [json_name="authorized_actions"]; // @gotags: `class:"public"`
 }

--- a/internal/proto/controller/api/resources/sessions/v1/session.proto
+++ b/internal/proto/controller/api/resources/sessions/v1/session.proto
@@ -9,106 +9,106 @@ import "controller/api/resources/scopes/v1/scope.proto";
 
 message WorkerInfo {
   // The address of the worker.
-  string address = 10;
+  string address = 10; // @gotags: `class:"public"`
 }
 
 message SessionState {
   // The status of the Session, e.g. "pending", "active", "canceling", "terminated".
-  string status = 10;
+  string status = 10; // @gotags: `class:"public"`
 
   // Output only. The time the Session entered this state.
-  google.protobuf.Timestamp start_time = 20 [json_name = "start_time"];
+  google.protobuf.Timestamp start_time = 20 [json_name = "start_time"]; // @gotags: `class:"public"`
 
   // Output only. The time the Session stopped being in this state.
-  google.protobuf.Timestamp end_time = 30 [json_name = "end_time"];
+  google.protobuf.Timestamp end_time = 30 [json_name = "end_time"]; // @gotags: `class:"public"`
 }
 
 // Connection contains information about a specific connection in a session
 message Connection {
 
     // client_tcp_address of the connection
-    string client_tcp_address = 3;
+    string client_tcp_address = 3; // @gotags: `class:"public"`
 
     // client_tcp_port of the connection
-    uint32 client_tcp_port = 4;
+    uint32 client_tcp_port = 4; // @gotags: `class:"public"`
 
     // endpoint_tcp_address of the connection
-    string endpoint_tcp_address = 5;
+    string endpoint_tcp_address = 5; // @gotags: `class:"public"`
 
     // endpoint_tcp_port of the connection
-    uint32 endpoint_tcp_port = 6;
+    uint32 endpoint_tcp_port = 6; // @gotags: `class:"public"`
 
     // bytes_up of the connection
-    uint64 bytes_up = 7;
+    uint64 bytes_up = 7; // @gotags: `class:"public"`
 
     // bytes_down of the connection
-    uint64 bytes_down = 8;
+    uint64 bytes_down = 8; // @gotags: `class:"public"`
 
     // closed_reason of the conneciont
-    string closed_reason = 9;
+    string closed_reason = 9; // @gotags: `class:"public"`
 }
 
 // Session contains all fields related to a Session resource
 message Session {
   // Output only. The ID of the Session.
-  string id = 10;
+  string id = 10; // @gotags: `class:"public"`
 
   // Output only. The ID of the Target that created this Session.
-  string target_id = 20 [json_name = "target_id"];
+  string target_id = 20 [json_name = "target_id"]; // @gotags: `class:"public"`
 
   // Output only. Scope information for this resource.
   resources.scopes.v1.ScopeInfo scope = 30;
 
   // Output only. The time this resource was created.
-  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"];
+  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public"`
 
   // Output only. The time this resource was last updated.
-  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"];
+  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public"`
 
   // Version is used when canceling this Session to ensure that the operation is acting on a known session state.
-  uint32 version = 80;
+  uint32 version = 80; // @gotags: `class:"public"`
 
   // Output only. Type of the Session (e.g. tcp).
-  string type = 90;
+  string type = 90; // @gotags: `class:"public"`
 
   // Output only. After this time the connection will be expired, e.g. forcefully terminated.
-  google.protobuf.Timestamp expiration_time = 100 [json_name = "expiration_time"];
+  google.protobuf.Timestamp expiration_time = 100 [json_name = "expiration_time"]; // @gotags: `class:"public"`
 
   // Output only. The ID of the Auth Token used to authenticate.
-  string auth_token_id = 110 [json_name = "auth_token_id"];
+  string auth_token_id = 110 [json_name = "auth_token_id"]; // @gotags: `class:"public"`
 
   // Output only. The ID of the User that requested the Session.
-  string user_id = 120 [json_name = "user_id"];
+  string user_id = 120 [json_name = "user_id"]; // @gotags: `class:"public"`
 
   // Output only. The Host Set sourcing the Host for this Session.
-  string host_set_id = 130 [json_name = "host_set_id"];
+  string host_set_id = 130 [json_name = "host_set_id"]; // @gotags: `class:"public"`
 
   // Output only. The Host used by the Session.
-  string host_id = 140 [json_name = "host_id"];
+  string host_id = 140 [json_name = "host_id"]; // @gotags: `class:"public"`
 
   // Output only. The Scope of the Session.
-  string scope_id = 150 [json_name = "scope_id"];
+  string scope_id = 150 [json_name = "scope_id"]; // @gotags: `class:"public"`
 
   // Output only. The endpoint of the Session; that is, the address to which the worker is proxying data.
-  string endpoint = 160;
+  string endpoint = 160; // @gotags: `class:"public"`
 
   // Output only. The states of this Session in descending order from the current state to the first.
   repeated SessionState states = 170;
 
   // Output only. The current status of this Session.
-  string status = 180;
+  string status = 180; // @gotags: `class:"public"`
 
   // Output only. Worker information given to the client.
   repeated WorkerInfo worker_info = 190 [json_name = "worker_info"];
 
   // Output only. The certificate generated for the session. Raw DER bytes.
-  bytes certificate = 200;
+  bytes certificate = 200; // @gotags: `class:"public"`
 
   // Output only. If the session is terminated, this provides a short description as to why.
-  string termination_reason = 210 [json_name = "termination_reason"];
+  string termination_reason = 210 [json_name = "termination_reason"]; // @gotags: `class:"public"`
 
   // Output only. The available actions on this resource for this user.
-  repeated string authorized_actions = 300 [json_name="authorized_actions"];
+  repeated string authorized_actions = 300 [json_name="authorized_actions"]; // @gotags: `class:"public"`
 
   // Output only. The associated connections with this session.
   repeated Connection connections = 310;

--- a/internal/proto/controller/api/resources/users/v1/user.proto
+++ b/internal/proto/controller/api/resources/users/v1/user.proto
@@ -11,61 +11,61 @@ import "controller/custom_options/v1/options.proto";
 
 message Account {
   // Output only. The ID of the Account.
-  string id = 10;
+  string id = 10; // @gotags: `class:"public"`
 
   // Output only. The Scope containing the Account.
-  string scope_id = 20 [json_name = "scope_id"];
+  string scope_id = 20 [json_name = "scope_id"]; // @gotags: `class:"public"`
 }
 
 // User contains all fields related to a User resource
 message User {
   // Output only. The ID of the User.
-  string id = 10;
+  string id = 10; // @gotags: `class:"public"`
 
   // The ID of the Scope this resource is in.
-  string scope_id = 20 [json_name = "scope_id"];
+  string scope_id = 20 [json_name = "scope_id"]; // @gotags: `class:"public"`
 
   // Output only. Scope information for this resource.
   resources.scopes.v1.ScopeInfo scope = 30;
 
   // Optional name for identification purposes.
-  google.protobuf.StringValue name = 40 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = { this: "name" that: "name" }];
+  google.protobuf.StringValue name = 40 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = { this: "name" that: "name" }]; // @gotags: `class:"sensitive"`
 
   // Optional user-set description for identification purposes.
-  google.protobuf.StringValue description = 50 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = { this: "description" that: "description" }];
+  google.protobuf.StringValue description = 50 [(custom_options.v1.generate_sdk_option) = true, (custom_options.v1.mask_mapping) = { this: "description" that: "description" }]; // @gotags: `class:"sensitive"`
 
   // Output only. The time this resource was created.
-  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"];
+  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public"`
 
   // Output only. The time this resource was last updated.
-  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"];
+  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public"`
 
   // Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 80;
+  uint32 version = 80; // @gotags: `class:"public"`
 
   // Output only. Contains the list of Account IDs linked to this User.
-  repeated string account_ids = 90 [json_name = "account_ids"];
+  repeated string account_ids = 90 [json_name = "account_ids"]; // @gotags: `class:"public"`
 
   // Output only. The Accounts linked to this User.
   repeated Account accounts = 100;
 
   // Output only. The available actions on this resource for this user.
-  repeated string authorized_actions = 300 [json_name = "authorized_actions"];
+  repeated string authorized_actions = 300 [json_name = "authorized_actions"]; // @gotags: `class:"public"`
 
   // Output only. login_name is a string that maps to the user's account "login
   // name" from the scope's primary auth method
-  string login_name = 110 [json_name = "login_name"];
+  string login_name = 110 [json_name = "login_name"]; // @gotags: `class:"sensitive"`
 
   // Output only. full_name is a string that maps to the user's account name
   // from the scope's primary auth method
-  string full_name = 120 [json_name = "full_name"];
+  string full_name = 120 [json_name = "full_name"]; // @gotags: `class:"sensitive"`
 
   // Output only. email is a string that maps to the user's account email from
   // the scope's primary auth method
-  string email = 130 [json_name = "email"];
+  string email = 130 [json_name = "email"]; // @gotags: `class:"sensitive"`
 
   // Output only. primary_account_id is a string that maps to the user's account
   // public_id from the scope's primary auth method
-  string primary_account_id = 140 [json_name = "primary_account_id"];
+  string primary_account_id = 140 [json_name = "primary_account_id"]; // @gotags: `class:"public"`
 }

--- a/internal/proto/controller/api/services/v1/role_service.proto
+++ b/internal/proto/controller/api/services/v1/role_service.proto
@@ -180,7 +180,7 @@ service RoleService {
 }
 
 message GetRoleRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
 }
 
 message GetRoleResponse {
@@ -188,9 +188,9 @@ message GetRoleResponse {
 }
 
 message ListRolesRequest {
-  string scope_id = 1 [json_name="scope_id"];
-  bool recursive = 20 [json_name="recursive"];
-  string filter = 30 [json_name="filter"];
+  string scope_id = 1 [json_name="scope_id"]; // @gotags: `class:"public"`
+  bool recursive = 20 [json_name="recursive"]; // @gotags: `class:"public"`
+  string filter = 30 [json_name="filter"]; // @gotags: `class:"public"`
 }
 
 message ListRolesResponse {
@@ -207,7 +207,7 @@ message CreateRoleResponse {
 }
 
 message UpdateRoleRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
   resources.roles.v1.Role item = 2;
   google.protobuf.FieldMask update_mask = 3 [json_name="update_mask"];
 }
@@ -217,17 +217,17 @@ message UpdateRoleResponse {
 }
 
 message DeleteRoleRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
 }
 
 message DeleteRoleResponse {}
 
 message AddRolePrincipalsRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 2;
-  repeated string principal_ids = 3 [json_name="principal_ids"];
+  uint32 version = 2; // @gotags: `class:"public"`
+  repeated string principal_ids = 3 [json_name="principal_ids"]; // @gotags: `class:"public"`
 }
 
 message AddRolePrincipalsResponse {
@@ -235,11 +235,11 @@ message AddRolePrincipalsResponse {
 }
 
 message SetRolePrincipalsRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 2;
-  repeated string principal_ids = 3 [json_name="principal_ids"];
+  uint32 version = 2; // @gotags: `class:"public"`
+  repeated string principal_ids = 3 [json_name="principal_ids"]; // @gotags: `class:"public"`
 }
 
 message SetRolePrincipalsResponse {
@@ -247,11 +247,11 @@ message SetRolePrincipalsResponse {
 }
 
 message RemoveRolePrincipalsRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 2;
-  repeated string principal_ids = 3 [json_name="principal_ids"];
+  uint32 version = 2; // @gotags: `class:"public"`
+  repeated string principal_ids = 3 [json_name="principal_ids"]; // @gotags: `class:"public"`
 }
 
 message RemoveRolePrincipalsResponse {
@@ -259,11 +259,11 @@ message RemoveRolePrincipalsResponse {
 }
 
 message AddRoleGrantsRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 2;
-  repeated string grant_strings = 3 [json_name="grant_strings"];
+  uint32 version = 2; // @gotags: `class:"public"`
+  repeated string grant_strings = 3 [json_name="grant_strings"]; // @gotags: `class:"public"`
 }
 
 message AddRoleGrantsResponse {
@@ -271,11 +271,11 @@ message AddRoleGrantsResponse {
 }
 
 message SetRoleGrantsRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 2;
-  repeated string grant_strings = 3 [json_name="grant_strings"];
+  uint32 version = 2; // @gotags: `class:"public"`
+  repeated string grant_strings = 3 [json_name="grant_strings"]; // @gotags: `class:"public"`
 }
 
 message SetRoleGrantsResponse {
@@ -283,11 +283,11 @@ message SetRoleGrantsResponse {
 }
 
 message RemoveRoleGrantsRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 2;
-  repeated string grant_strings = 3 [json_name="grant_strings"];
+  uint32 version = 2; // @gotags: `class:"public"`
+  repeated string grant_strings = 3 [json_name="grant_strings"]; // @gotags: `class:"public"`
 }
 
 message RemoveRoleGrantsResponse {

--- a/internal/proto/controller/api/services/v1/session_service.proto
+++ b/internal/proto/controller/api/services/v1/session_service.proto
@@ -52,7 +52,7 @@ service SessionService {
 }
 
 message GetSessionRequest {
-	string id = 1;
+	string id = 1; // @gotags: `class:"public"`
 }
 
 message GetSessionResponse {
@@ -60,9 +60,9 @@ message GetSessionResponse {
 }
 
 message ListSessionsRequest {
-	string scope_id = 1;
-	bool recursive = 20 [json_name="recursive"];
-	string filter = 30 [json_name="filter"];
+	string scope_id = 1; // @gotags: `class:"public"`
+	bool recursive = 20 [json_name="recursive"]; // @gotags: `class:"public"`
+	string filter = 30 [json_name="filter"]; // @gotags: `class:"public"`
 }
 
 message ListSessionsResponse {
@@ -70,8 +70,8 @@ message ListSessionsResponse {
 }
 
 message CancelSessionRequest {
-	string id = 1;
-	uint32 version = 2;
+	string id = 1; // @gotags: `class:"public"`
+	uint32 version = 2; // @gotags: `class:"public"`
 }
 
 message CancelSessionResponse {

--- a/internal/proto/controller/api/services/v1/user_service.proto
+++ b/internal/proto/controller/api/services/v1/user_service.proto
@@ -136,7 +136,7 @@ service UserService {
 }
 
 message GetUserRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
 }
 
 message GetUserResponse {
@@ -144,9 +144,9 @@ message GetUserResponse {
 }
 
 message ListUsersRequest {
-  string scope_id = 1;
-  bool recursive = 20 [json_name="recursive"];
-  string filter = 30 [json_name="filter"];
+  string scope_id = 1; // @gotags: `class:"public"`
+  bool recursive = 20 [json_name="recursive"]; // @gotags: `class:"public"`
+  string filter = 30 [json_name="filter"]; // @gotags: `class:"sensitive"`
 }
 
 message ListUsersResponse {
@@ -158,12 +158,12 @@ message CreateUserRequest {
 }
 
 message CreateUserResponse {
-  string uri = 1;
+  string uri = 1; // @gotags: `class:"public"`
   resources.users.v1.User item = 2;
 }
 
 message UpdateUserRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
   resources.users.v1.User item = 2;
   google.protobuf.FieldMask update_mask = 3 [json_name="update_mask"];
 }
@@ -173,16 +173,16 @@ message UpdateUserResponse {
 }
 
 message DeleteUserRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
 }
 
 message DeleteUserResponse {}
 
 message AddUserAccountsRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
   // The version ensures the User hasn't changed since it was last retrieved and if it has the request will fail.
-  uint32 version = 2;
-  repeated string account_ids = 3 [json_name="account_ids"];
+  uint32 version = 2; // @gotags: `class:"public"`
+  repeated string account_ids = 3 [json_name="account_ids"]; // @gotags: `class:"public"`
 }
 
 message AddUserAccountsResponse {
@@ -190,10 +190,10 @@ message AddUserAccountsResponse {
 }
 
 message SetUserAccountsRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
   // The version ensures the User hasn't changed since it was last retrieved and if it has the request will fail.
-  uint32 version = 2;
-  repeated string account_ids = 3 [json_name="account_ids"];
+  uint32 version = 2; // @gotags: `class:"public"`
+  repeated string account_ids = 3 [json_name="account_ids"]; // @gotags: `class:"public"`
 }
 
 message SetUserAccountsResponse {
@@ -201,10 +201,10 @@ message SetUserAccountsResponse {
 }
 
 message RemoveUserAccountsRequest {
-  string id = 1;
+  string id = 1; // @gotags: `class:"public"`
   // The version ensures the User hasn't changed since it was last retrieved and if it has the request will fail.
-  uint32 version = 2;
-  repeated string account_ids = 3 [json_name="account_ids"];
+  uint32 version = 2; // @gotags: `class:"public"`
+  repeated string account_ids = 3 [json_name="account_ids"]; // @gotags: `class:"public"`
 }
 
 message RemoveUserAccountsResponse {

--- a/internal/servers/controller/handlers/authmethods/oidc_test.go
+++ b/internal/servers/controller/handlers/authmethods/oidc_test.go
@@ -1565,7 +1565,6 @@ func TestAuthenticate_OIDC_Start(t *testing.T) {
 			require.NotNil(got.GetOidcAuthMethodAuthenticateStartResponse())
 			require.NotEmpty(got.GetOidcAuthMethodAuthenticateStartResponse().GetAuthUrl())
 			require.NotEmpty(got.GetOidcAuthMethodAuthenticateStartResponse().GetTokenId())
-
 		})
 	}
 }

--- a/internal/tests/api/roles/classification_test.go
+++ b/internal/tests/api/roles/classification_test.go
@@ -1,0 +1,142 @@
+package roles_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/roles"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/scopes"
+	"github.com/hashicorp/boundary/sdk/wrapper"
+	"github.com/hashicorp/eventlogger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestRoles(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	pbNow := timestamppb.Now()
+	wrapper := wrapper.TestWrapper(t)
+	testEncryptingFilter := api.NewEncryptFilter(t, wrapper)
+
+	tests := []struct {
+		name string
+		in   *eventlogger.Event
+		want *eventlogger.Event
+	}{
+		{
+			name: "role",
+			in: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &pb.Role{
+					Id:      "id",
+					ScopeId: "scope-id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "scope-id",
+						Type:          "scope-type",
+						Name:          "scope-name",
+						Description:   "scope-description",
+						ParentScopeId: "scope-parent-scope-id",
+					},
+					Name:         &wrapperspb.StringValue{Value: "name"},
+					Description:  &wrapperspb.StringValue{Value: "description"},
+					CreatedTime:  pbNow,
+					UpdatedTime:  pbNow,
+					Version:      0,
+					GrantScopeId: &wrapperspb.StringValue{Value: "grant-scope-id"},
+					PrincipalIds: []string{
+						"principal-id",
+					},
+					Principals: []*pb.Principal{
+						{
+							Id:      "principal-id",
+							Type:    "principal-type",
+							ScopeId: "principal-scope-id",
+						},
+					},
+					GrantStrings: []string{
+						"grand-string",
+					},
+					Grants: []*pb.Grant{
+						{
+							Raw:       "raw",
+							Canonical: "canonical",
+							Json: &pb.GrantJson{
+								Id:      "grant-json-id",
+								Type:    "grant-json-type",
+								Actions: []string{"action"},
+							},
+						},
+					},
+					AuthorizedActions: []string{"action-1"},
+				},
+			},
+			want: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &pb.Role{
+					Id:      "id",
+					ScopeId: "scope-id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "scope-id",
+						Type:          "scope-type",
+						Name:          "scope-name",
+						Description:   "scope-description",
+						ParentScopeId: "scope-parent-scope-id",
+					},
+					Name:         &wrapperspb.StringValue{Value: "name"},
+					Description:  &wrapperspb.StringValue{Value: "description"},
+					CreatedTime:  pbNow,
+					UpdatedTime:  pbNow,
+					Version:      0,
+					GrantScopeId: &wrapperspb.StringValue{Value: "grant-scope-id"},
+					PrincipalIds: []string{
+						"principal-id",
+					},
+					Principals: []*pb.Principal{
+						{
+							Id:      "principal-id",
+							Type:    "principal-type",
+							ScopeId: "principal-scope-id",
+						},
+					},
+					GrantStrings: []string{
+						"grand-string",
+					},
+					Grants: []*pb.Grant{
+						{
+							Raw:       "raw",
+							Canonical: "canonical",
+							Json: &pb.GrantJson{
+								Id:      "grant-json-id",
+								Type:    "grant-json-type",
+								Actions: []string{"action"},
+							},
+						},
+					},
+					AuthorizedActions: []string{"action-1"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := testEncryptingFilter.Process(ctx, tt.in)
+			require.NoError(err)
+			require.NotNil(got)
+			gotJSON, err := json.Marshal(got)
+			require.NoError(err)
+
+			wantJSON, err := json.Marshal(tt.want)
+			require.NoError(err)
+			assert.JSONEq(string(wantJSON), string(gotJSON))
+		})
+	}
+}

--- a/internal/tests/api/sessions/classification_test.go
+++ b/internal/tests/api/sessions/classification_test.go
@@ -1,0 +1,160 @@
+package sessions_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/scopes"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/sessions"
+	"github.com/hashicorp/boundary/sdk/wrapper"
+	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/eventlogger/filters/encrypt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestSessions(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	pbNow := timestamppb.Now()
+	wrapper := wrapper.TestWrapper(t)
+	testEncryptingFilter := api.NewEncryptFilter(t, wrapper)
+	testEncryptingFilter.FilterOperationOverrides = map[encrypt.DataClassification]encrypt.FilterOperation{
+		// Use HMAC for sensitive fields for easy test comparisons
+		encrypt.SensitiveClassification: encrypt.HmacSha256Operation,
+	}
+
+	tests := []struct {
+		name string
+		in   *eventlogger.Event
+		want *eventlogger.Event
+	}{
+		{
+			name: "session",
+			in: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &pb.Session{
+					Id:       "id",
+					TargetId: "target_id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "scope-id",
+						Type:          "scope-type",
+						Name:          "scope-name",
+						Description:   "scope-description",
+						ParentScopeId: "scope-parent_scope_id",
+					},
+					CreatedTime:    pbNow,
+					UpdatedTime:    pbNow,
+					Version:        0,
+					Type:           "type",
+					ExpirationTime: pbNow,
+					AuthTokenId:    "auth_token_id",
+					UserId:         "user_id",
+					HostSetId:      "host_set_id",
+					HostId:         "host_id",
+					ScopeId:        "scope_id",
+					Endpoint:       "endpoint",
+					States: []*pb.SessionState{
+						{
+							Status:    "status",
+							StartTime: pbNow,
+							EndTime:   pbNow,
+						},
+					},
+					Status: "status",
+					WorkerInfo: []*pb.WorkerInfo{
+						{
+							Address: "worker-address",
+						},
+					},
+					Certificate:       []byte("certificate"),
+					TerminationReason: "termination_reason",
+					AuthorizedActions: []string{"action-1"},
+					Connections: []*pb.Connection{
+						{
+							ClientTcpAddress:   "client_tcp_address",
+							ClientTcpPort:      0,
+							EndpointTcpAddress: "endpoint_tcp_address",
+							EndpointTcpPort:    0,
+							BytesUp:            0,
+							BytesDown:          0,
+							ClosedReason:       "closed_reason",
+						},
+					},
+				},
+			},
+			want: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &pb.Session{
+					Id:       "id",
+					TargetId: "target_id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "scope-id",
+						Type:          "scope-type",
+						Name:          "scope-name",
+						Description:   "scope-description",
+						ParentScopeId: "scope-parent_scope_id",
+					},
+					CreatedTime:    pbNow,
+					UpdatedTime:    pbNow,
+					Version:        0,
+					Type:           "type",
+					ExpirationTime: pbNow,
+					AuthTokenId:    "auth_token_id",
+					UserId:         "user_id",
+					HostSetId:      "host_set_id",
+					HostId:         "host_id",
+					ScopeId:        "scope_id",
+					Endpoint:       "endpoint",
+					States: []*pb.SessionState{
+						{
+							Status:    "status",
+							StartTime: pbNow,
+							EndTime:   pbNow,
+						},
+					},
+					Status: "status",
+					WorkerInfo: []*pb.WorkerInfo{
+						{
+							Address: "worker-address",
+						},
+					},
+					Certificate:       []byte("certificate"),
+					TerminationReason: "termination_reason",
+					AuthorizedActions: []string{"action-1"},
+					Connections: []*pb.Connection{
+						{
+							ClientTcpAddress:   "client_tcp_address",
+							ClientTcpPort:      0,
+							EndpointTcpAddress: "endpoint_tcp_address",
+							EndpointTcpPort:    0,
+							BytesUp:            0,
+							BytesDown:          0,
+							ClosedReason:       "closed_reason",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := testEncryptingFilter.Process(ctx, tt.in)
+			require.NoError(err)
+			require.NotNil(got)
+			gotJSON, err := json.Marshal(got)
+			require.NoError(err)
+
+			wantJSON, err := json.Marshal(tt.want)
+			require.NoError(err)
+			assert.JSONEq(string(wantJSON), string(gotJSON))
+		})
+	}
+}

--- a/internal/tests/api/users/classification_test.go
+++ b/internal/tests/api/users/classification_test.go
@@ -1,0 +1,119 @@
+package users_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/scopes"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/users"
+	"github.com/hashicorp/boundary/sdk/wrapper"
+	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/eventlogger/filters/encrypt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestUsers(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	pbNow := timestamppb.Now()
+	wrapper := wrapper.TestWrapper(t)
+	testEncryptingFilter := api.NewEncryptFilter(t, wrapper)
+	testEncryptingFilter.FilterOperationOverrides = map[encrypt.DataClassification]encrypt.FilterOperation{
+		// Use HMAC for sensitive fields for easy test comparisons
+		encrypt.SensitiveClassification: encrypt.HmacSha256Operation,
+	}
+
+	tests := []struct {
+		name string
+		in   *eventlogger.Event
+		want *eventlogger.Event
+	}{
+		{
+			name: "role",
+			in: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &pb.User{
+					Id:      "id",
+					ScopeId: "scope-id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "scope-id",
+						Type:          "scope-type",
+						Name:          "scope-name",
+						Description:   "scope-description",
+						ParentScopeId: "scope-parent-scope-id",
+					},
+					Name:        &wrapperspb.StringValue{Value: "name"},
+					Description: &wrapperspb.StringValue{Value: "description"},
+					CreatedTime: pbNow,
+					UpdatedTime: pbNow,
+					Version:     0,
+					AccountIds:  []string{"account-id"},
+					Accounts: []*pb.Account{
+						{
+							Id:      "account-id",
+							ScopeId: "scope-id",
+						},
+					},
+					AuthorizedActions: []string{"action-1"},
+					LoginName:         "login-name",
+					FullName:          "full-name",
+					Email:             "email@test.test",
+					PrimaryAccountId:  "primary-account-id",
+				},
+			},
+			want: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload: &pb.User{
+					Id:      "id",
+					ScopeId: "scope-id",
+					Scope: &scopes.ScopeInfo{
+						Id:            "scope-id",
+						Type:          "scope-type",
+						Name:          "scope-name",
+						Description:   "scope-description",
+						ParentScopeId: "scope-parent-scope-id",
+					},
+					Name:        &wrapperspb.StringValue{Value: encrypt.TestHmacSha256(t, []byte("name"), wrapper, nil, nil)},
+					Description: &wrapperspb.StringValue{Value: encrypt.TestHmacSha256(t, []byte("description"), wrapper, nil, nil)},
+					CreatedTime: pbNow,
+					UpdatedTime: pbNow,
+					Version:     0,
+					AccountIds:  []string{"account-id"},
+					Accounts: []*pb.Account{
+						{
+							Id:      "account-id",
+							ScopeId: "scope-id",
+						},
+					},
+					AuthorizedActions: []string{"action-1"},
+					LoginName:         encrypt.TestHmacSha256(t, []byte("login-name"), wrapper, nil, nil),
+					FullName:          encrypt.TestHmacSha256(t, []byte("full-name"), wrapper, nil, nil),
+					Email:             encrypt.TestHmacSha256(t, []byte("email@test.test"), wrapper, nil, nil),
+					PrimaryAccountId:  "primary-account-id",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := testEncryptingFilter.Process(ctx, tt.in)
+			require.NoError(err)
+			require.NotNil(got)
+			gotJSON, err := json.Marshal(got)
+			require.NoError(err)
+
+			wantJSON, err := json.Marshal(tt.want)
+			require.NoError(err)
+			assert.JSONEq(string(wantJSON), string(gotJSON))
+		})
+	}
+}

--- a/sdk/pbs/controller/api/resources/roles/role.pb.go
+++ b/sdk/pbs/controller/api/resources/roles/role.pb.go
@@ -30,11 +30,11 @@ type Principal struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the principal.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The type of the principal.
-	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The Scope of the principal.
-	ScopeId string `protobuf:"bytes,3,opt,name=scope_id,proto3" json:"scope_id,omitempty"`
+	ScopeId string `protobuf:"bytes,3,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *Principal) Reset() {
@@ -96,11 +96,11 @@ type GrantJson struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID, if set.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The type, if set.
-	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The actions.
-	Actions []string `protobuf:"bytes,3,rep,name=actions,proto3" json:"actions,omitempty"`
+	Actions []string `protobuf:"bytes,3,rep,name=actions,proto3" json:"actions,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *GrantJson) Reset() {
@@ -162,9 +162,9 @@ type Grant struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The original user-supplied string.
-	Raw string `protobuf:"bytes,1,opt,name=raw,proto3" json:"raw,omitempty"`
+	Raw string `protobuf:"bytes,1,opt,name=raw,proto3" json:"raw,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The canonically-formatted string.
-	Canonical string `protobuf:"bytes,2,opt,name=canonical,proto3" json:"canonical,omitempty"`
+	Canonical string `protobuf:"bytes,2,opt,name=canonical,proto3" json:"canonical,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The JSON representation of the grant.
 	Json *GrantJson `protobuf:"bytes,3,opt,name=json,proto3" json:"json,omitempty"`
 }
@@ -229,34 +229,34 @@ type Role struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the Role.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The ID of the Scope containing this Role.
-	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty"`
+	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. Scope information for this resource.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,30,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Optional name for identification purposes.
-	Name *wrapperspb.StringValue `protobuf:"bytes,40,opt,name=name,proto3" json:"name,omitempty"`
+	Name *wrapperspb.StringValue `protobuf:"bytes,40,opt,name=name,proto3" json:"name,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Optional user-set description for identification purposes.
-	Description *wrapperspb.StringValue `protobuf:"bytes,50,opt,name=description,proto3" json:"description,omitempty"`
+	Description *wrapperspb.StringValue `protobuf:"bytes,50,opt,name=description,proto3" json:"description,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this resource was last updated.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty"`
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty"`
+	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The Scope the grants will apply to. If the Role is at the global scope, this can be an org or project. If the Role is at an org scope, this can be a project within the org. It is invalid for this to be anything other than the Role's scope when the Role's scope is a project.
-	GrantScopeId *wrapperspb.StringValue `protobuf:"bytes,90,opt,name=grant_scope_id,proto3" json:"grant_scope_id,omitempty"`
+	GrantScopeId *wrapperspb.StringValue `protobuf:"bytes,90,opt,name=grant_scope_id,proto3" json:"grant_scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The IDs (only) of principals that are assigned to this role.
-	PrincipalIds []string `protobuf:"bytes,100,rep,name=principal_ids,proto3" json:"principal_ids,omitempty"`
+	PrincipalIds []string `protobuf:"bytes,100,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The principals that are assigned to this role.
 	Principals []*Principal `protobuf:"bytes,110,rep,name=principals,proto3" json:"principals,omitempty"`
 	// Output only. The grants that this role provides for its principals.
-	GrantStrings []string `protobuf:"bytes,120,rep,name=grant_strings,proto3" json:"grant_strings,omitempty"`
+	GrantStrings []string `protobuf:"bytes,120,rep,name=grant_strings,proto3" json:"grant_strings,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The parsed grant information.
 	Grants []*Grant `protobuf:"bytes,130,rep,name=grants,proto3" json:"grants,omitempty"`
 	// Output only. The available actions on this resource for this user.
-	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty"`
+	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *Role) Reset() {

--- a/sdk/pbs/controller/api/resources/sessions/session.pb.go
+++ b/sdk/pbs/controller/api/resources/sessions/session.pb.go
@@ -28,7 +28,7 @@ type WorkerInfo struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The address of the worker.
-	Address string `protobuf:"bytes,10,opt,name=address,proto3" json:"address,omitempty"`
+	Address string `protobuf:"bytes,10,opt,name=address,proto3" json:"address,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *WorkerInfo) Reset() {
@@ -76,11 +76,11 @@ type SessionState struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The status of the Session, e.g. "pending", "active", "canceling", "terminated".
-	Status string `protobuf:"bytes,10,opt,name=status,proto3" json:"status,omitempty"`
+	Status string `protobuf:"bytes,10,opt,name=status,proto3" json:"status,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time the Session entered this state.
-	StartTime *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=start_time,proto3" json:"start_time,omitempty"`
+	StartTime *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=start_time,proto3" json:"start_time,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time the Session stopped being in this state.
-	EndTime *timestamppb.Timestamp `protobuf:"bytes,30,opt,name=end_time,proto3" json:"end_time,omitempty"`
+	EndTime *timestamppb.Timestamp `protobuf:"bytes,30,opt,name=end_time,proto3" json:"end_time,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *SessionState) Reset() {
@@ -143,19 +143,19 @@ type Connection struct {
 	unknownFields protoimpl.UnknownFields
 
 	// client_tcp_address of the connection
-	ClientTcpAddress string `protobuf:"bytes,3,opt,name=client_tcp_address,json=clientTcpAddress,proto3" json:"client_tcp_address,omitempty"`
+	ClientTcpAddress string `protobuf:"bytes,3,opt,name=client_tcp_address,json=clientTcpAddress,proto3" json:"client_tcp_address,omitempty" class:"public"` // @gotags: `class:"public"`
 	// client_tcp_port of the connection
-	ClientTcpPort uint32 `protobuf:"varint,4,opt,name=client_tcp_port,json=clientTcpPort,proto3" json:"client_tcp_port,omitempty"`
+	ClientTcpPort uint32 `protobuf:"varint,4,opt,name=client_tcp_port,json=clientTcpPort,proto3" json:"client_tcp_port,omitempty" class:"public"` // @gotags: `class:"public"`
 	// endpoint_tcp_address of the connection
-	EndpointTcpAddress string `protobuf:"bytes,5,opt,name=endpoint_tcp_address,json=endpointTcpAddress,proto3" json:"endpoint_tcp_address,omitempty"`
+	EndpointTcpAddress string `protobuf:"bytes,5,opt,name=endpoint_tcp_address,json=endpointTcpAddress,proto3" json:"endpoint_tcp_address,omitempty" class:"public"` // @gotags: `class:"public"`
 	// endpoint_tcp_port of the connection
-	EndpointTcpPort uint32 `protobuf:"varint,6,opt,name=endpoint_tcp_port,json=endpointTcpPort,proto3" json:"endpoint_tcp_port,omitempty"`
+	EndpointTcpPort uint32 `protobuf:"varint,6,opt,name=endpoint_tcp_port,json=endpointTcpPort,proto3" json:"endpoint_tcp_port,omitempty" class:"public"` // @gotags: `class:"public"`
 	// bytes_up of the connection
-	BytesUp uint64 `protobuf:"varint,7,opt,name=bytes_up,json=bytesUp,proto3" json:"bytes_up,omitempty"`
+	BytesUp uint64 `protobuf:"varint,7,opt,name=bytes_up,json=bytesUp,proto3" json:"bytes_up,omitempty" class:"public"` // @gotags: `class:"public"`
 	// bytes_down of the connection
-	BytesDown uint64 `protobuf:"varint,8,opt,name=bytes_down,json=bytesDown,proto3" json:"bytes_down,omitempty"`
+	BytesDown uint64 `protobuf:"varint,8,opt,name=bytes_down,json=bytesDown,proto3" json:"bytes_down,omitempty" class:"public"` // @gotags: `class:"public"`
 	// closed_reason of the conneciont
-	ClosedReason string `protobuf:"bytes,9,opt,name=closed_reason,json=closedReason,proto3" json:"closed_reason,omitempty"`
+	ClosedReason string `protobuf:"bytes,9,opt,name=closed_reason,json=closedReason,proto3" json:"closed_reason,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *Connection) Reset() {
@@ -246,45 +246,45 @@ type Session struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the Session.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The ID of the Target that created this Session.
-	TargetId string `protobuf:"bytes,20,opt,name=target_id,proto3" json:"target_id,omitempty"`
+	TargetId string `protobuf:"bytes,20,opt,name=target_id,proto3" json:"target_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. Scope information for this resource.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,30,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this resource was last updated.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty"`
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used when canceling this Session to ensure that the operation is acting on a known session state.
-	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty"`
+	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. Type of the Session (e.g. tcp).
-	Type string `protobuf:"bytes,90,opt,name=type,proto3" json:"type,omitempty"`
+	Type string `protobuf:"bytes,90,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. After this time the connection will be expired, e.g. forcefully terminated.
-	ExpirationTime *timestamppb.Timestamp `protobuf:"bytes,100,opt,name=expiration_time,proto3" json:"expiration_time,omitempty"`
+	ExpirationTime *timestamppb.Timestamp `protobuf:"bytes,100,opt,name=expiration_time,proto3" json:"expiration_time,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The ID of the Auth Token used to authenticate.
-	AuthTokenId string `protobuf:"bytes,110,opt,name=auth_token_id,proto3" json:"auth_token_id,omitempty"`
+	AuthTokenId string `protobuf:"bytes,110,opt,name=auth_token_id,proto3" json:"auth_token_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The ID of the User that requested the Session.
-	UserId string `protobuf:"bytes,120,opt,name=user_id,proto3" json:"user_id,omitempty"`
+	UserId string `protobuf:"bytes,120,opt,name=user_id,proto3" json:"user_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The Host Set sourcing the Host for this Session.
-	HostSetId string `protobuf:"bytes,130,opt,name=host_set_id,proto3" json:"host_set_id,omitempty"`
+	HostSetId string `protobuf:"bytes,130,opt,name=host_set_id,proto3" json:"host_set_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The Host used by the Session.
-	HostId string `protobuf:"bytes,140,opt,name=host_id,proto3" json:"host_id,omitempty"`
+	HostId string `protobuf:"bytes,140,opt,name=host_id,proto3" json:"host_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The Scope of the Session.
-	ScopeId string `protobuf:"bytes,150,opt,name=scope_id,proto3" json:"scope_id,omitempty"`
+	ScopeId string `protobuf:"bytes,150,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The endpoint of the Session; that is, the address to which the worker is proxying data.
-	Endpoint string `protobuf:"bytes,160,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
+	Endpoint string `protobuf:"bytes,160,opt,name=endpoint,proto3" json:"endpoint,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The states of this Session in descending order from the current state to the first.
 	States []*SessionState `protobuf:"bytes,170,rep,name=states,proto3" json:"states,omitempty"`
 	// Output only. The current status of this Session.
-	Status string `protobuf:"bytes,180,opt,name=status,proto3" json:"status,omitempty"`
+	Status string `protobuf:"bytes,180,opt,name=status,proto3" json:"status,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. Worker information given to the client.
 	WorkerInfo []*WorkerInfo `protobuf:"bytes,190,rep,name=worker_info,proto3" json:"worker_info,omitempty"`
 	// Output only. The certificate generated for the session. Raw DER bytes.
-	Certificate []byte `protobuf:"bytes,200,opt,name=certificate,proto3" json:"certificate,omitempty"`
+	Certificate []byte `protobuf:"bytes,200,opt,name=certificate,proto3" json:"certificate,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. If the session is terminated, this provides a short description as to why.
-	TerminationReason string `protobuf:"bytes,210,opt,name=termination_reason,proto3" json:"termination_reason,omitempty"`
+	TerminationReason string `protobuf:"bytes,210,opt,name=termination_reason,proto3" json:"termination_reason,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The available actions on this resource for this user.
-	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty"`
+	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The associated connections with this session.
 	Connections []*Connection `protobuf:"bytes,310,rep,name=connections,proto3" json:"connections,omitempty"`
 }

--- a/sdk/pbs/controller/api/resources/users/user.pb.go
+++ b/sdk/pbs/controller/api/resources/users/user.pb.go
@@ -30,9 +30,9 @@ type Account struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the Account.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The Scope containing the Account.
-	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty"`
+	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *Account) Reset() {
@@ -88,40 +88,40 @@ type User struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the User.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The ID of the Scope this resource is in.
-	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty"`
+	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. Scope information for this resource.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,30,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Optional name for identification purposes.
-	Name *wrapperspb.StringValue `protobuf:"bytes,40,opt,name=name,proto3" json:"name,omitempty"`
+	Name *wrapperspb.StringValue `protobuf:"bytes,40,opt,name=name,proto3" json:"name,omitempty" class:"sensitive"` // @gotags: `class:"sensitive"`
 	// Optional user-set description for identification purposes.
-	Description *wrapperspb.StringValue `protobuf:"bytes,50,opt,name=description,proto3" json:"description,omitempty"`
+	Description *wrapperspb.StringValue `protobuf:"bytes,50,opt,name=description,proto3" json:"description,omitempty" class:"sensitive"` // @gotags: `class:"sensitive"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this resource was last updated.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty"`
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty"`
+	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. Contains the list of Account IDs linked to this User.
-	AccountIds []string `protobuf:"bytes,90,rep,name=account_ids,proto3" json:"account_ids,omitempty"`
+	AccountIds []string `protobuf:"bytes,90,rep,name=account_ids,proto3" json:"account_ids,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The Accounts linked to this User.
 	Accounts []*Account `protobuf:"bytes,100,rep,name=accounts,proto3" json:"accounts,omitempty"`
 	// Output only. The available actions on this resource for this user.
-	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty"`
+	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. login_name is a string that maps to the user's account "login
 	// name" from the scope's primary auth method
-	LoginName string `protobuf:"bytes,110,opt,name=login_name,proto3" json:"login_name,omitempty"`
+	LoginName string `protobuf:"bytes,110,opt,name=login_name,proto3" json:"login_name,omitempty" class:"sensitive"` // @gotags: `class:"sensitive"`
 	// Output only. full_name is a string that maps to the user's account name
 	// from the scope's primary auth method
-	FullName string `protobuf:"bytes,120,opt,name=full_name,proto3" json:"full_name,omitempty"`
+	FullName string `protobuf:"bytes,120,opt,name=full_name,proto3" json:"full_name,omitempty" class:"sensitive"` // @gotags: `class:"sensitive"`
 	// Output only. email is a string that maps to the user's account email from
 	// the scope's primary auth method
-	Email string `protobuf:"bytes,130,opt,name=email,proto3" json:"email,omitempty"`
+	Email string `protobuf:"bytes,130,opt,name=email,proto3" json:"email,omitempty" class:"sensitive"` // @gotags: `class:"sensitive"`
 	// Output only. primary_account_id is a string that maps to the user's account
 	// public_id from the scope's primary auth method
-	PrimaryAccountId string `protobuf:"bytes,140,opt,name=primary_account_id,proto3" json:"primary_account_id,omitempty"`
+	PrimaryAccountId string `protobuf:"bytes,140,opt,name=primary_account_id,proto3" json:"primary_account_id,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 
 func (x *User) Reset() {


### PR DESCRIPTION
These did not require and refactors since they do not use subtypes, so
they could just be classified.

This also includes a lint fix that came from running `make gen` which
runs `gofumpt`.