### PR TITLE
chore: Add redirect for targets worker filtering

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -129,20 +129,24 @@ module.exports = [
     destination: '/docs/concepts/domain-model/managed-groups',
     permanent: false,
   },
-
   {
     source: '/help/admin-ui/dynamic-host-catalogs-on-aws',
     destination:
       'https://learn.hashicorp.com/tutorials/boundary/aws-host-catalogs',
     permanent: false,
   },
-
   {
     source: '/help/admin-ui/dynamic-host-catalogs-on-azure',
     destination:
       'https://learn.hashicorp.com/tutorials/boundary/azure-host-catalogs',
     permanent: false,
   },
+  {
+    source: '/help/admin-ui/targets/worker-filters',
+    destination: '/docs/concepts/filtering/worker-tags#target-worker-filtering',
+    permanent: false,
+  },
+
   ////////////////////////////////////////////
   // Adding sub-resources to existing resource
   ////////////////////////////////////////////


### PR DESCRIPTION
This creates a redirect from `/help/admin-ui/targets/worker-filters` to `/docs/concepts/filtering/worker-tags#target-worker-filtering`. This is related to [PR](https://github.com/hashicorp/boundary-ui/pull/1053) which will direct users to the docs for worker filters on targets.