### PR TITLE
Unify plugin building

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,27 +38,13 @@ case $(uname) in
 esac
 
 BINARY_SUFFIX=""
-if [ "${GOOS}x" == "windowsx" ]; then
+if [ "${GOOS}x" = "windowsx" ]; then
     BINARY_SUFFIX=".exe"
 fi
 
 # Build needed plugins first
 if [ "${SKIP_PLUGIN_BUILD}x" == "x" ]; then
-    ORIG_PATH=$(pwd);
-    for PLUGIN_TYPE in {"kms","host"}; do
-        echo "==> Building ${PLUGIN_TYPE} plugins..."
-        rm -f $ORIG_PATH/plugins/$PLUGIN_TYPE/assets/boundary-plugin-${PLUGIN_TYPE}*
-        for CURR_PLUGIN in $(ls $ORIG_PATH/plugins/$PLUGIN_TYPE/mains); do
-            cd $ORIG_PATH/plugins/$PLUGIN_TYPE/mains/$CURR_PLUGIN;
-            go build -v -o $ORIG_PATH/plugins/$PLUGIN_TYPE/assets/boundary-plugin-${PLUGIN_TYPE}-${CURR_PLUGIN}${BINARY_SUFFIX} .;
-            cd $ORIG_PATH;
-        done;
-        cd $ORIG_PATH/plugins/$PLUGIN_TYPE/assets;
-        for CURR_PLUGIN in $(ls boundary-plugin*); do
-            gzip -f -9 $CURR_PLUGIN;
-        done;
-        cd $ORIG_PATH;
-    done;
+    $DIR/scripts/plugins.sh
 fi
 
 if [ "${CI_BUILD}x" != "x" ]; then

--- a/scripts/plugins.sh
+++ b/scripts/plugins.sh
@@ -8,18 +8,22 @@ if [ "${GOOS}x" = "windowsx" ]; then
     BINARY_SUFFIX=".exe"
 fi
 
-ORIG_PATH=$(pwd);
-echo "==> Building Host Plugins..."
-for PLUGIN_TYPE in host; do
-    rm -f $ORIG_PATH/plugins/$PLUGIN_TYPE/assets/boundary-plugin-${PLUGIN_TYPE}*
-    for CURR_PLUGIN in $(ls $ORIG_PATH/plugins/$PLUGIN_TYPE/mains); do
-        cd $ORIG_PATH/plugins/$PLUGIN_TYPE/mains/$CURR_PLUGIN;
-        go build -v -o $ORIG_PATH/plugins/$PLUGIN_TYPE/assets/boundary-plugin-${PLUGIN_TYPE}-${CURR_PLUGIN}${BINARY_SUFFIX} .;
-        cd $ORIG_PATH;
+# Get the parent directory of where this script is.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+export DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+
+for PLUGIN_TYPE in {"kms","host"}; do
+    echo "==> Building ${PLUGIN_TYPE} plugins..."
+    rm -f $DIR/plugins/$PLUGIN_TYPE/assets/boundary-plugin-${PLUGIN_TYPE}*
+    for CURR_PLUGIN in $(ls $DIR/plugins/$PLUGIN_TYPE/mains); do
+        cd $DIR/plugins/$PLUGIN_TYPE/mains/$CURR_PLUGIN;
+        go build -v -o $DIR/plugins/$PLUGIN_TYPE/assets/boundary-plugin-${PLUGIN_TYPE}-${CURR_PLUGIN}${BINARY_SUFFIX} .;
+        cd $DIR;
     done;
-    cd $ORIG_PATH/plugins/$PLUGIN_TYPE/assets;
+    cd $DIR/plugins/$PLUGIN_TYPE/assets;
     for CURR_PLUGIN in $(ls boundary-plugin*); do
         gzip -f -9 $CURR_PLUGIN;
     done;
-    cd $ORIG_PATH;
+    cd $DIR;
 done;


### PR DESCRIPTION
This causes the build.sh script to chain to plugins.sh which makes
plugin building behave the same for both local and release builds.