### PR TITLE
Do not register the build_info collectors multiple times.

### DIFF
--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -134,12 +134,10 @@ type Server struct {
 	StatusGracePeriodDuration time.Duration
 }
 
-// The only option used here is WithPrometheusRegisterer; all others are ignored.
+// NewServer creates a new Server.
+// The WithPrometheusRegisterer Option uses the passed in registry to initialize
+// the build info collectors.  All other Options are ignored.
 func NewServer(cmd *Command, opt ...Option) *Server {
-	// Create a new prometheus registry here to avoid "duplicate metrics collector
-	// registration" panics in tests where new servers are called consecutively.
-	// prometheus.DefaultRegisterer and prometheus.DefaultGatherer vars need to be
-	// assigned for promhttp package to work correctly.
 	opts := getOpts(opt...)
 	metric.InitializeBuildInfo(opts.withPrometheusRegisterer)
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -34,19 +34,19 @@ import (
 var Commands map[string]cli.CommandFactory
 
 func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
+	srv := base.NewServer(base.NewCommand(serverCmdUi),
+		base.WithPrometheusRegisterer(prometheus.DefaultRegisterer))
 	Commands = map[string]cli.CommandFactory{
 		"server": func() (cli.Command, error) {
 			return &server.Command{
-				Server: base.NewServer(base.NewCommand(serverCmdUi),
-					base.WithPrometheusRegisterer(prometheus.DefaultRegisterer)),
+				Server:    srv,
 				SighupCh:  base.MakeSighupCh(),
 				SigUSR2Ch: MakeSigUSR2Ch(),
 			}, nil
 		},
 		"dev": func() (cli.Command, error) {
 			return &dev.Command{
-				Server: base.NewServer(base.NewCommand(serverCmdUi),
-					base.WithPrometheusRegisterer(prometheus.DefaultRegisterer)),
+				Server:    srv,
 				SighupCh:  base.MakeSighupCh(),
 				SigUSR2Ch: MakeSigUSR2Ch(),
 			}, nil
@@ -321,7 +321,7 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 		},
 		"database init": func() (cli.Command, error) {
 			return &database.InitCommand{
-				Server: base.NewServer(base.NewCommand(ui), base.WithPrometheusRegisterer(prometheus.DefaultRegisterer)),
+				Server: base.NewServer(base.NewCommand(ui)),
 			}, nil
 		},
 		"database migrate": func() (cli.Command, error) {


### PR DESCRIPTION
Since we call base.NewServer multiple times when building the Commands map this was returning
an error "duplicate metrics collector registration attempted".  This PR only creates a single
server which is used for both the "server" command as well as "dev".