### PR TITLE
Switch request.WithContext to request.Clone

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -678,7 +678,7 @@ func (c *Client) NewRequest(ctx context.Context, method, requestPath string, bod
 	req.Header.Set("authorization", "Bearer "+token)
 	req.Header.Set("content-type", "application/json")
 	if ctx != nil {
-		req = req.WithContext(ctx)
+		req = req.Clone(ctx)
 	}
 
 	ret := &retryablehttp.Request{
@@ -735,7 +735,7 @@ func (c *Client) Do(r *retryablehttp.Request, opt ...Option) (*Response, error) 
 		// this as it will make reading the response body impossible
 		_ = cancel
 	}
-	r.Request = r.Request.WithContext(ctx)
+	r.Request = r.Request.Clone(ctx)
 
 	if backoff == nil {
 		backoff = retryablehttp.LinearJitterBackoff

--- a/internal/servers/common/handler.go
+++ b/internal/servers/common/handler.go
@@ -152,7 +152,7 @@ func WrapWithEventsHandler(h http.Handler, e *event.Eventer, kms *kms.Kms, liste
 		}
 
 		// Set the context back on the request
-		r = r.WithContext(ctx)
+		r = r.Clone(ctx)
 
 		{
 			method := r.Method

--- a/internal/servers/controller/handler.go
+++ b/internal/servers/controller/handler.go
@@ -352,7 +352,7 @@ func wrapHandlerWithCommonFuncs(h http.Handler, c *Controller, props HandlerProp
 		r.Header.Set("Grpc-Metadata-"+requestInfoMdKey, base58.FastBase58Encoding(marshalledRequestInfo))
 
 		// Set the context back on the request
-		r = r.WithContext(ctx)
+		r = r.Clone(ctx)
 		h.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
The Go docs now say to use request.Clone (introduced in Go
1.13) instead of request.WithContext (introduced in Go 1.7) as it deep
copies instead of shallow copies.