### PR TITLE
Register the build info metrics using prometheus.DefaultRegistry in an init function

### DIFF
--- a/internal/cmd/base/option.go
+++ b/internal/cmd/base/option.go
@@ -4,7 +4,6 @@ import (
 	"github.com/hashicorp/boundary/internal/observability/event"
 	"github.com/hashicorp/boundary/sdk/pbs/plugin"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // getOpts - iterate the inbound Options and return a struct.
@@ -41,7 +40,6 @@ type Options struct {
 	withStatusCode                 int
 	withHostPlugin                 func() (string, plugin.HostPluginServiceClient)
 	withEventGating                bool
-	withPrometheusRegisterer       prometheus.Registerer
 }
 
 func getDefaultOptions() Options {
@@ -188,12 +186,5 @@ func WithHostPlugin(pluginId string, plg plugin.HostPluginServiceClient) Option 
 func WithEventGating(with bool) Option {
 	return func(o *Options) {
 		o.withEventGating = with
-	}
-}
-
-// WithPrometheusRegisterer uses the provided prometheus registerer
-func WithPrometheusRegisterer(with prometheus.Registerer) Option {
-	return func(o *Options) {
-		o.withPrometheusRegisterer = with
 	}
 }

--- a/internal/cmd/base/option_test.go
+++ b/internal/cmd/base/option_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/boundary/internal/observability/event"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -124,13 +123,5 @@ func Test_GetOpts(t *testing.T) {
 		assert.False(testOpts.withEventGating)
 		opts := getOpts(WithEventGating(true))
 		assert.True(opts.withEventGating)
-	})
-	t.Run("withPrometheusRegisterer", func(t *testing.T) {
-		assert := assert.New(t)
-		pmr := prometheus.NewRegistry()
-		opts := getOpts(WithPrometheusRegisterer(pmr))
-		testOpts := getDefaultOptions()
-		testOpts.withPrometheusRegisterer = pmr
-		assert.Equal(opts, testOpts)
 	})
 }

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -63,6 +63,10 @@ const (
 	statusGracePeriodEnvVar = "BOUNDARY_STATUS_GRACE_PERIOD"
 )
 
+func init() {
+	metric.InitializeBuildInfo(prometheus.DefaultRegisterer)
+}
+
 type Server struct {
 	*Command
 
@@ -135,12 +139,7 @@ type Server struct {
 }
 
 // NewServer creates a new Server.
-// The WithPrometheusRegisterer Option uses the passed in registry to initialize
-// the build info collectors.  All other Options are ignored.
-func NewServer(cmd *Command, opt ...Option) *Server {
-	opts := getOpts(opt...)
-	metric.InitializeBuildInfo(opts.withPrometheusRegisterer)
-
+func NewServer(cmd *Command) *Server {
 	return &Server{
 		Command:              cmd,
 		InfoKeys:             make([]string, 0, 20),
@@ -149,7 +148,7 @@ func NewServer(cmd *Command, opt ...Option) *Server {
 		ReloadFuncsLock:      new(sync.RWMutex),
 		ReloadFuncs:          make(map[string][]reloadutil.ReloadFunc),
 		StderrLock:           new(sync.Mutex),
-		PrometheusRegisterer: opts.withPrometheusRegisterer,
+		PrometheusRegisterer: prometheus.DefaultRegisterer,
 	}
 }
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -27,26 +27,23 @@ import (
 	"github.com/hashicorp/boundary/internal/cmd/commands/version"
 
 	"github.com/mitchellh/cli"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Commands is the mapping of all the available commands.
 var Commands map[string]cli.CommandFactory
 
 func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
-	srv := base.NewServer(base.NewCommand(serverCmdUi),
-		base.WithPrometheusRegisterer(prometheus.DefaultRegisterer))
 	Commands = map[string]cli.CommandFactory{
 		"server": func() (cli.Command, error) {
 			return &server.Command{
-				Server:    srv,
+				Server:    base.NewServer(base.NewCommand(serverCmdUi)),
 				SighupCh:  base.MakeSighupCh(),
 				SigUSR2Ch: MakeSigUSR2Ch(),
 			}, nil
 		},
 		"dev": func() (cli.Command, error) {
 			return &dev.Command{
-				Server:    srv,
+				Server:    base.NewServer(base.NewCommand(serverCmdUi)),
 				SighupCh:  base.MakeSighupCh(),
 				SigUSR2Ch: MakeSigUSR2Ch(),
 			}, nil


### PR DESCRIPTION
This fixes errors related to calling NewServer or NewCommand multiple times when using autocomplete.