### PR TITLE
fix(config): Prevent panic when setting audit config filter orverrides

### DIFF
--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -657,6 +657,14 @@ func parseEventing(eventObj *ast.ObjectItem) (*event.EventerConfig, error) {
 			}
 		}
 
+		// parse map into event types
+		if s.AuditConfig != nil && s.AuditConfig.FilterOverridesHCL != nil {
+			s.AuditConfig.FilterOverrides = make(map[event.DataClassification]event.FilterOperation, len(s.AuditConfig.FilterOverridesHCL))
+			for k, v := range s.AuditConfig.FilterOverridesHCL {
+				s.AuditConfig.FilterOverrides[event.DataClassification(k)] = event.FilterOperation(v)
+			}
+		}
+
 		if err := s.Validate(); err != nil {
 			return nil, err
 		}

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -799,6 +799,52 @@ func TestController_EventingConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "audit_config",
+			config: []string{
+				`events {
+					audit_enabled = true
+					sink {
+						name = "audit-sink"
+						format = "cloudevents-json"
+						event_types = ["audit"]
+						file {
+							file_name = "audit.log"
+						}
+						audit_config {
+							audit_filter_overrides {
+								sensitive = ""
+								secret    = "hmac-sha256"
+							}
+						}
+					}
+				}`,
+			},
+			wantEventerConfig: &event.EventerConfig{
+				AuditEnabled: true,
+				Sinks: []*event.SinkConfig{
+					{
+						Type:       "file",
+						Name:       "audit-sink",
+						Format:     "cloudevents-json",
+						EventTypes: []event.Type{"audit"},
+						FileConfig: &event.FileSinkTypeConfig{
+							FileName: "audit.log",
+						},
+						AuditConfig: &event.AuditConfig{
+							FilterOverridesHCL: map[string]string{
+								"sensitive": "",
+								"secret":    "hmac-sha256",
+							},
+							FilterOverrides: event.AuditFilterOperations{
+								event.SensitiveClassification: event.NoOperation,
+								event.SecretClassification:    event.HmacSha256Operation,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/observability/event/audit_config.go
+++ b/internal/observability/event/audit_config.go
@@ -10,7 +10,8 @@ import (
 type AuditConfig struct {
 	// FilterOverrides provide an optional a set of overrides for the
 	// FilterOperations to be applied to DataClassifications.
-	FilterOverrides AuditFilterOperations `hcl:"audit_filter_overrides"`
+	FilterOverrides    AuditFilterOperations `hcl:"-"`
+	FilterOverridesHCL map[string]string     `hcl:"audit_filter_overrides"`
 
 	// wrapper to use for audit event crypto operations.
 	wrapper wrapping.Wrapper


### PR DESCRIPTION
This updates the config parsing for this stanza so prevent panics like
the following:

    panic: reflect.Value.MapIndex: value of type string is not assignable to type event.DataClassification

    goroutine 1 [running]:
    reflect.Value.assignTo({0x13fbb20, 0xc000a28700, 0x461367}, {0x1693f9d, 0x16}, 0x14375c0, 0x0)
            /usr/lib/go/src/reflect/value.go:2810 +0x2ad
    reflect.Value.MapIndex({0x145b1c0, 0xc000a16570, 0xc00072ff20}, {0x13fbb20, 0xc000a28700, 0x98})
            /usr/lib/go/src/reflect/value.go:1535 +0x7e
    github.com/hashicorp/hcl.(*decoder).decodeMap(0x8, {0xc00012b0b0, 0x28}, {0x67b40a8, 0xc0005fdc80}, {0x14bac80, 0xc0005fdc20, 0x1})
            /go/pkg/mod/github.com/hashicorp/hcl@v1.0.0/decoder.go:380 +0xa95
    github.com/hashicorp/hcl.(*decoder).decode(0xc000731360, {0xc00012b0b0, 0x28}, {0x67b40a8, 0xc0005fdc80}, {0x14bac80, 0xc0005fdc20, 0x0})
            /go/pkg/mod/github.com/hashicorp/hcl@v1.0.0/decoder.go:100 +0x395
    github.com/hashicorp/hcl.(*decoder).decodeStruct(0x203000, {0xc0005bf500, 0x11}, {0x67b40a8, 0xc0005fdc08}, {0x14fada0, 0xc0005fdc20, 0x7296ce0})
            /go/pkg/mod/github.com/hashicorp/hcl@v1.0.0/decoder.go:702 +0x1349
    github.com/hashicorp/hcl.(*decoder).decode(0xc000731360, {0xc0005bf500, 0x11}, {0x67b40a8, 0xc0005fdc08}, {0x14fada0, 0xc0005fdc20, 0x0})
            /go/pkg/mod/github.com/hashicorp/hcl@v1.0.0/decoder.go:108 +0x62f
    github.com/hashicorp/hcl.(*decoder).decodePtr(0x8, {0xc0005bf500, 0x11}, {0x67b40a8, 0xc0005fdc08}, {0x1442220, 0xc0005ca2f0, 0x1})
            /go/pkg/mod/github.com/hashicorp/hcl@v1.0.0/decoder.go:405 +0xd3
    github.com/hashicorp/hcl.(*decoder).decode(0xc000731360, {0xc0005bf500, 0x11}, {0x67b40a8, 0xc0005fdc08}, {0x1442220, 0xc0005ca2f0, 0x12})
            /go/pkg/mod/github.com/hashicorp/hcl@v1.0.0/decoder.go:102 +0x3e8
    github.com/hashicorp/hcl.(*decoder).decodeStruct(0x7f8c99b698f0, {0x1676310, 0x4}, {0x67b40d0, 0xc0005c82a0}, {0x1621c80, 0xc0005ca240, 0x0})
            /go/pkg/mod/github.com/hashicorp/hcl@v1.0.0/decoder.go:702 +0x1349
    github.com/hashicorp/hcl.(*decoder).decode(0xc000731360, {0x1676310, 0x4}, {0x67b40d0, 0xc0005c82a0}, {0x1621c80, 0xc0005ca240, 0xc0005ca240})
            /go/pkg/mod/github.com/hashicorp/hcl@v1.0.0/decoder.go:108 +0x62f
    github.com/hashicorp/hcl.DecodeObject({0x1442400, 0xc0005ca240}, {0x67b40d0, 0xc0005c82a0})
            /go/pkg/mod/github.com/hashicorp/hcl@v1.0.0/decoder.go:60 +0x126
    github.com/hashicorp/boundary/internal/cmd/config.parseEventing(0xc0005fa2a0)
            /go/src/github.com/hashicorp/boundary/internal/cmd/config/config.go:622 +0x1ec
    github.com/hashicorp/boundary/internal/cmd/config.Parse({0xc000683100, 0x66c})
            /go/src/github.com/hashicorp/boundary/internal/cmd/config/config.go:553 +0x149b
    github.com/hashicorp/boundary/internal/cmd/config.LoadFile({0x7fff4c8fdeef, 0xc0008e2d40}, {0x0, 0x0})
            /go/src/github.com/hashicorp/boundary/internal/cmd/config/config.go:306 +0x6f
    github.com/hashicorp/boundary/internal/cmd/commands/database.(*InitCommand).ParseFlagsAndConfig(0xc0005ae000, {0xc000132030, 0x2, 0x2})
            /go/src/github.com/hashicorp/boundary/internal/cmd/commands/database/init.go:516 +0x605
    github.com/hashicorp/boundary/internal/cmd/commands/database.(*InitCommand).Run(0xc0005ae000, {0xc000132030, 0xc0002857a0, 0xc000285788})
            /go/src/github.com/hashicorp/boundary/internal/cmd/commands/database/init.go:175 +0x4a
    github.com/mitchellh/cli.(*CLI).Run(0xc0002b2c80)
            /go/pkg/mod/github.com/mitchellh/cli@v1.1.2/cli.go:262 +0x5f8
    github.com/hashicorp/boundary/internal/cmd.RunCustom({0xc000132010, 0x60, 0x0}, 0x0)
            /go/src/github.com/hashicorp/boundary/internal/cmd/main.go:186 +0x9d6
    github.com/hashicorp/boundary/internal/cmd.Run(...)
            /go/src/github.com/hashicorp/boundary/internal/cmd/main.go:92
    main.main()
            /go/src/github.com/hashicorp/boundary/cmd/boundary/main.go:13 +0xc9