### PR TITLE
chore(docker): Add dockerignore file to reduce context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**
+!bin/**
+!dist/**
+!.release/docker/**


### PR DESCRIPTION
Since the Dockerfile is now at the repository root, when running
building a docker image, the entire repository was being added to the
context sent to the docker daemon. However, only the compiled binary and
a few configs in `.release/docker` are needed to build the docker
images.

This ignore file will only send necessary fields into the context. This
helps speed up the docker image building.

For example, when building the dev image, without the ignore file:

    Sending build context to Docker daemon  2.043GB

And with this ignore file:

    Sending build context to Docker daemon  130.7MB

See:
    https://docs.docker.com/engine/reference/builder/#dockerignore-file