### PR TITLE
fix(build): Run plugin script directly instead of with sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
           mkdir -p dist out
           unset GOPATH;
           # Build plugins
-          sh ./scripts/plugins.sh
+          ./scripts/plugins.sh
           go build -v -tags "ui" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
       - uses: actions/upload-artifact@v2
@@ -190,7 +190,7 @@ jobs:
           mkdir -p dist out
           unset GOPATH;
           # Build plugins
-          sh ./scripts/plugins.sh
+          ./scripts/plugins.sh
           go build -v -tags "ui" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
       - uses: actions/upload-artifact@v2
@@ -283,7 +283,7 @@ jobs:
           mkdir -p dist out
           unset GOPATH;
           # Build plugins
-          sh ./scripts/plugins.sh
+          ./scripts/plugins.sh
           go build -v -tags "ui netcgo" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
These github actions run on Ubuntu based machine. Ubuntu by default links
`/bin/sh` to dash. So by invoking the plugin.sh script as `/bin/sh ./plugins.sh` 
the script would run under `dash` despite the shebang line. A recent change
that unified some of the build process, introduced additional bashisms into
this script which is caused the build to fail.

This updated the build system to just run the script directly, which will
honor the shebang line. This seems like the best approach since the ubuntu
machine has bash and the shebang line points to bash, so it is natural for
developers to assume bashisms will work.

See:
  f370abc1dace6f28b2de81d079de86a98a2bfd93
  https://github.com/actions/virtual-environments/blob/ubuntu20/20220410.2/images/linux/Ubuntu2004-Readme.md
  https://wiki.ubuntu.com/DashAsBinSh