### PR TITLE
fix(event): Remove wrapper validation

### DIFF
--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -211,6 +211,9 @@ func (b *Server) SetupEventing(logger hclog.Logger, serializationLock *sync.Mute
 		serializationLock,
 		serverName,
 		*opts.withEventerConfig,
+		// Note: this may be nil at this point, it is updated later on in SetupKMSes.
+		// There is a cyclic dependency between the eventer and the wrapper, so we instantiate
+		// the eventer with a nil wrapper until we have a wrapper to use.
 		event.WithAuditWrapper(opts.withEventWrapper),
 		event.WithGating(opts.withEventGating))
 	if err != nil {

--- a/internal/observability/event/audit_config.go
+++ b/internal/observability/event/audit_config.go
@@ -46,14 +46,7 @@ func (ac *AuditConfig) Validate() error {
 		return fmt.Errorf("%s: %w", op, err)
 	}
 
-	if ac.wrapper == nil {
-		for _, filterOperation := range ac.FilterOverrides {
-			switch filterOperation {
-			case EncryptOperation, HmacSha256Operation:
-				return fmt.Errorf("%s: missing wrapper and %s filter operation requires a wrapper: %w", op, filterOperation, ErrInvalidParameter)
-			}
-		}
-	}
+	// Note: we don't validate the wrapper here because it may not be set yet.
 
 	return nil
 }

--- a/internal/observability/event/audit_config_test.go
+++ b/internal/observability/event/audit_config_test.go
@@ -44,46 +44,8 @@ func TestAuditConfig_Validate(t *testing.T) {
 			wantErrContains: "invalid filter override operation (invalid-operation)",
 		},
 		{
-			name: "missing-wrapper-with-hmac-filter",
-			ac: &AuditConfig{
-				FilterOverrides: AuditFilterOperations{
-					SensitiveClassification: HmacSha256Operation,
-				},
-			},
-			wantIsError:     ErrInvalidParameter,
-			wantErrContains: "hmac-sha256 filter operation requires a wrapper",
-		},
-		{
-			name: "missing-wrapper-with-encrypt-filter",
-			ac: &AuditConfig{
-				FilterOverrides: AuditFilterOperations{
-					SensitiveClassification: EncryptOperation,
-				},
-			},
-			wantIsError:     ErrInvalidParameter,
-			wantErrContains: "encrypt filter operation requires a wrapper",
-		},
-		{
 			name: "valid-default",
 			ac:   DefaultAuditConfig(),
-		},
-		{
-			name: "valid-with-required-wrapper-for-encrypt",
-			ac: &AuditConfig{
-				wrapper: testWrapper(t),
-				FilterOverrides: AuditFilterOperations{
-					SensitiveClassification: EncryptOperation,
-				},
-			},
-		},
-		{
-			name: "valid-with-required-wrapper-for-hmac",
-			ac: &AuditConfig{
-				wrapper: testWrapper(t),
-				FilterOverrides: AuditFilterOperations{
-					SensitiveClassification: HmacSha256Operation,
-				},
-			},
 		},
 	}
 	for _, tt := range tests {
@@ -115,12 +77,6 @@ func TestNewAuditConfig(t *testing.T) {
 		wantIsError     error
 		wantErrContains string
 	}{
-		{
-			name:            "missing-required-wrapper",
-			opts:            []Option{WithFilterOperations(filterOps)},
-			wantIsError:     ErrInvalidParameter,
-			wantErrContains: "missing wrapper",
-		},
 		{
 			name: "valid-default",
 			want: DefaultAuditConfig(),

--- a/internal/observability/event/eventer_test.go
+++ b/internal/observability/event/eventer_test.go
@@ -385,34 +385,7 @@ func Test_NewEventer(t *testing.T) {
 		wantErrContains string
 	}{
 		{
-			name: "missing-require-wrapper",
-			config: func() EventerConfig {
-				cfg := EventerConfig{
-					AuditEnabled: true,
-					Sinks: []*SinkConfig{
-						{
-							Name:       "test",
-							EventTypes: []Type{AuditType},
-							Type:       StderrSink,
-							Format:     JSONHclogSinkFormat,
-							AuditConfig: &AuditConfig{
-								FilterOverrides: AuditFilterOperations{
-									SensitiveClassification: EncryptOperation,
-								},
-							},
-						},
-					},
-				}
-				return cfg
-			}(),
-			lock:            testLock,
-			logger:          testLogger,
-			serverName:      "missing-required-wrapper",
-			wantErrIs:       ErrInvalidParameter,
-			wantErrContains: "missing wrapper and encrypt filter operation requires a wrapper",
-		},
-		{
-			name: "valid-audit-config-with-wrapper",
+			name: "valid-audit-configr",
 			config: func() EventerConfig {
 				cfg := EventerConfig{
 					AuditEnabled: true,
@@ -435,7 +408,7 @@ func Test_NewEventer(t *testing.T) {
 			opts:       []Option{WithAuditWrapper(twrapper)},
 			lock:       testLock,
 			logger:     testLogger,
-			serverName: "valid-audit-config-with-wrapper",
+			serverName: "valid-audit-config",
 			want: &Eventer{
 				logger:         testLogger,
 				gatedQueueLock: new(sync.Mutex),


### PR DESCRIPTION
The wrapper is sometimes unset at the time when the
audit config is validated, so it is impossible for us
to validate that a valid wrapper is configured. The wrapper
is configured by later setup steps because of a dependency
on the eventer in our KMS setup.