### PR TITLE
Remove old migration code & Avoid db test image confusion

### DIFF
--- a/testing/dbtest/docker/Makefile
+++ b/testing/dbtest/docker/Makefile
@@ -4,8 +4,8 @@ CWD := $(shell pwd)
 DOCKER_ARGS ?= -d
 
 REGISTRY_NAME?=docker.io/hashicorpboundary
-IMAGE_NAME=postgres
-IMAGE_TAG ?= $(REGISTRY_NAME)/$(IMAGE_NAME):11-alpine
+TEST_IMAGE_NAME=postgres
+TEST_IMAGE_TAG ?= $(REGISTRY_NAME)/$(TEST_IMAGE_NAME):11-alpine
 PG_OPTS ?=
 TEST_DB_PORT ?= 5432
 TEST_CONTAINER_NAME ?= boundary-sql-tests
@@ -22,11 +22,11 @@ ${docker-buildxs}: %-buildx:
 	docker buildx build \
 		--platform linux/amd64,linux/arm64 \
 		--push \
-		-t $(REGISTRY_NAME)/$(IMAGE_NAME):$* \
+		-t $(REGISTRY_NAME)/$(TEST_IMAGE_NAME):$* \
 		-f Dockerfile.$* .
 
 database-up:
-	@echo "Using image:                       $(IMAGE_TAG)"
+	@echo "Using image:                       $(TEST_IMAGE_TAG)"
 	@echo "Additional postgres configuration: $(PG_OPTS)"
 	@docker run \
 		$(DOCKER_ARGS) \
@@ -38,7 +38,7 @@ database-up:
 		-e PGDATA=/pgdata \
 		--mount type=tmpfs,destination=/pgdata \
 		-v "$(CWD)/../../../internal/db/schema/migrations":/migrations \
-		$(IMAGE_TAG) \
+		$(TEST_IMAGE_TAG) \
 		-c 'config_file=/etc/postgresql/postgresql.conf' \
 		$(PG_OPTS) 1> /dev/null
 	@echo "Container name:                    $(TEST_CONTAINER_NAME)"

--- a/testing/dbtest/docker/init-db.sh
+++ b/testing/dbtest/docker/init-db.sh
@@ -41,52 +41,19 @@ apply_migrations() {
 EOSQL
 }
 
-if [ -d /migrations/base ]; then
-    for file in $(ls -v /migrations/base/postgres/*.up.sql); do
-        echo "Applying base migration: ${file}"
-        psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password --dbname boundary_template -f "$file"
-    done
+for file in $(ls -v /migrations/base/postgres/*.up.sql); do
+    echo "Applying base migration: ${file}"
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password --dbname boundary_template -f "$file"
+done
 
-    if [ -d /migrations/oss ]; then
-        # Run oss migrations in order
-        apply_migrations "/migrations/oss";
-    fi
-
-    for d in $(find /migrations/ -mindepth 1 -maxdepth 1 -type d -not -name 'oss' -not -name 'base'); do
-        apply_migrations $d;
-    done
-else
-    # Running pre-editions, run the old way
-    version=
-
-    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password --dbname boundary_template -q <<EOSQL
-    create table boundary_schema_version (
-      version bigint primary key,
-      dirty  boolean not null
-    );
-EOSQL
-    # Run old migrations in order.
-    for file in $(ls -v /migrations/**/*.sql); do
-        psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password --dbname boundary_template -f "$file"
-
-        IFS='/'
-        read -ra PARTS <<< "$file"
-        major="10#${PARTS[2]}"
-        IFS='_'
-        read -ra MINOR_PARTS <<< "${PARTS[3]}"
-        minor="10#${MINOR_PARTS[0]}"
-        let version=${major}*1000+${minor}
-        IFS=' '
-    done
-
-    echo "setting boundary_schema_version to ${version}";
-    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password --dbname boundary_template -q <<EOSQL
-insert into boundary_schema_version
-  (version, dirty)
-values
-  (${version}, false);
-EOSQL
+if [ -d /migrations/oss ]; then
+    # Run oss migrations in order
+    apply_migrations "/migrations/oss";
 fi
+
+for d in $(find /migrations/ -mindepth 1 -maxdepth 1 -type d -not -name 'oss' -not -name 'base'); do
+    apply_migrations $d;
+done
 
 # Make database a template and prevent connections.
 psql -v "ON_ERROR_STOP=1" --username "$POSTGRES_USER" --dbname "$POSTGRES_DB"   -q <<EOSQL


### PR DESCRIPTION
## [refact(dbtest): Remove old migration code](https://github.com/hashicorp/boundary/pull/2038/commits/d1432e6d5034011f9fd31d3fe0ecd93d4a2a4f31)

This is no longer needed, so we can clean up this script a bit.

## [refact(dbtest): Change test image env var](https://github.com/hashicorp/boundary/pull/2038/commits/11f6c93304501fe5d3a6e4e9705257d4717048c2)

The existing environment variable clashes with the one used in the top level Makefile. The new name prevents confusing behavior when setting the env var and creating the test database from the root of the repository.