### PR TITLE
Bump Go to latest 1.17(.9)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.17.5"
+          go-version: "1.17.9"
       - name: get product version
         id: get-product-version
         run: |
@@ -70,7 +70,7 @@ jobs:
       matrix:
         goos: [ freebsd, windows, netbsd, openbsd, solaris ]
         goarch: [ "386", "amd64", "arm" ]
-        go: [ "1.17.5" ]
+        go: [ "1.17.9" ]
         exclude:
           - goos: solaris
             goarch: 386
@@ -130,7 +130,7 @@ jobs:
       matrix:
         goos: [linux]
         goarch: ["arm", "arm64", "386", "amd64"]
-        go: [ "1.17.5" ]
+        go: [ "1.17.9" ]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -215,7 +215,7 @@ jobs:
       matrix:
         goos: [ darwin ]
         goarch: [ "amd64", "arm64" ]
-        go: [ "1.17.5" ]
+        go: [ "1.17.9" ]
       fail-fast: true
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
 

--- a/ci/goinstall.sh
+++ b/ci/goinstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION="1.17.5"
+VERSION="1.17.9"
 
 [ -z "$GOROOT" ] && GOROOT="$HOME/.go"
 [ -z "$GOPATH" ] && GOPATH="$HOME/go"


### PR DESCRIPTION
This fixes security issues and other bugs so we should do so before our next release.