### PR TITLE
refact(all): Replace uses of fmt.Sprintf("%d", x)

### DIFF
--- a/internal/auth/oidc/repository_auth_method.go
+++ b/internal/auth/oidc/repository_auth_method.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/internal/db"
@@ -87,7 +88,7 @@ func (r *Repository) upsertAccount(ctx context.Context, am *AuthMethod, IdTokenC
 		if err != nil {
 			return nil, errors.Wrap(ctx, err, op)
 		}
-		columns, values = append(columns, "token_claims"), append(values, sql.Named(fmt.Sprintf("%d", len(values)+1), string(marshaledTokenClaims)))
+		columns, values = append(columns, "token_claims"), append(values, sql.Named(strconv.Itoa(len(values)+1), string(marshaledTokenClaims)))
 		conflictClauses = append(conflictClauses, fmt.Sprintf("token_claims = @%d", len(values)))
 		fieldMasks = append(fieldMasks, TokenClaimsField)
 	}
@@ -96,7 +97,7 @@ func (r *Repository) upsertAccount(ctx context.Context, am *AuthMethod, IdTokenC
 		if err != nil {
 			return nil, errors.Wrap(ctx, err, op)
 		}
-		columns, values = append(columns, "userinfo_claims"), append(values, sql.Named(fmt.Sprintf("%d", len(values)+1), string(marshaledAccessTokenClaims)))
+		columns, values = append(columns, "userinfo_claims"), append(values, sql.Named(strconv.Itoa(len(values)+1), string(marshaledAccessTokenClaims)))
 		conflictClauses = append(conflictClauses, fmt.Sprintf("userinfo_claims = @%d", len(values)))
 		fieldMasks = append(fieldMasks, UserinfoClaimsField)
 	}
@@ -114,10 +115,10 @@ func (r *Repository) upsertAccount(ctx context.Context, am *AuthMethod, IdTokenC
 	switch {
 	case AccessTokenClaims[fromName] != nil:
 		foundName = AccessTokenClaims[fromName]
-		columns, values = append(columns, "full_name"), append(values, sql.Named(fmt.Sprintf("%d", len(values)+1), foundName))
+		columns, values = append(columns, "full_name"), append(values, sql.Named(strconv.Itoa(len(values)+1), foundName))
 	case IdTokenClaims[fromName] != nil:
 		foundName = IdTokenClaims[fromName]
-		columns, values = append(columns, "full_name"), append(values, sql.Named(fmt.Sprintf("%d", len(values)+1), foundName))
+		columns, values = append(columns, "full_name"), append(values, sql.Named(strconv.Itoa(len(values)+1), foundName))
 	}
 	if foundName != nil {
 		acctForOplog.FullName = foundName.(string)
@@ -132,10 +133,10 @@ func (r *Repository) upsertAccount(ctx context.Context, am *AuthMethod, IdTokenC
 	switch {
 	case AccessTokenClaims[fromEmail] != nil:
 		foundEmail = AccessTokenClaims[fromEmail]
-		columns, values = append(columns, "email"), append(values, sql.Named(fmt.Sprintf("%d", len(values)+1), foundEmail))
+		columns, values = append(columns, "email"), append(values, sql.Named(strconv.Itoa(len(values)+1), foundEmail))
 	case IdTokenClaims[fromEmail] != nil:
 		foundEmail = IdTokenClaims[fromEmail]
-		columns, values = append(columns, "email"), append(values, sql.Named(fmt.Sprintf("%d", len(values)+1), foundEmail))
+		columns, values = append(columns, "email"), append(values, sql.Named(strconv.Itoa(len(values)+1), foundEmail))
 	}
 	if foundEmail != nil {
 		acctForOplog.Email = foundEmail.(string)

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -319,7 +319,7 @@ func (b *Server) StorePidFile(pidPath string) error {
 
 	// Write out the PID
 	pid := os.Getpid()
-	_, err = pidFile.WriteString(fmt.Sprintf("%d", pid))
+	_, err = pidFile.WriteString(strconv.Itoa(pid))
 	if err != nil {
 		return fmt.Errorf("could not write to pid file: %w", err)
 	}
@@ -459,7 +459,7 @@ func (b *Server) SetupListeners(ui cli.Ui, config *configutil.SharedConfig, allo
 			}
 
 			if lnConfig.XForwardedForHopSkips > 0 {
-				props["x_forwarded_for_hop_skips"] = fmt.Sprintf("%d", lnConfig.XForwardedForHopSkips)
+				props["x_forwarded_for_hop_skips"] = strconv.Itoa(lnConfig.XForwardedForHopSkips)
 			}
 		}
 
@@ -473,7 +473,7 @@ func (b *Server) SetupListeners(ui cli.Ui, config *configutil.SharedConfig, allo
 			lnConfig.MaxRequestSize = globals.DefaultMaxRequestSize
 		}
 		// TODO: We don't actually limit this yet.
-		// props["max_request_size"] = fmt.Sprintf("%d", lnConfig.MaxRequestSize)
+		// props["max_request_size"] = strconv.Itoa(lnConfig.MaxRequestSize)
 
 		if lnConfig.MaxRequestDuration == 0 {
 			lnConfig.MaxRequestDuration = globals.DefaultMaxRequestDuration

--- a/internal/credential/vault/private_library.go
+++ b/internal/credential/vault/private_library.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -306,7 +307,7 @@ func (r *Repository) getPrivateLibraries(ctx context.Context, requests []credent
 
 	var params []interface{}
 	for idx, v := range libIds {
-		params = append(params, sql.Named(fmt.Sprintf("%d", idx+1), v))
+		params = append(params, sql.Named(strconv.Itoa(idx+1), v))
 	}
 	rows, err := r.reader.Query(ctx, query, params)
 	if err != nil {

--- a/internal/host/static/repository_host_set_member.go
+++ b/internal/host/static/repository_host_set_member.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
@@ -345,7 +346,7 @@ func (r *Repository) changes(ctx context.Context, setId string, hostIds []string
 	var params []interface{}
 	params = append(params, sql.Named("1", setId))
 	for idx, v := range hostIds {
-		params = append(params, sql.Named(fmt.Sprintf("%d", idx+2), v))
+		params = append(params, sql.Named(strconv.Itoa(idx+2), v))
 	}
 	rows, err := r.reader.Query(ctx, query, params)
 	if err != nil {

--- a/internal/servers/controller/handlers/authmethods/oidc_test.go
+++ b/internal/servers/controller/handlers/authmethods/oidc_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -164,20 +165,20 @@ func TestList_FilterNonPublic(t *testing.T) {
 
 	// 1 Public
 	i := 0
-	oidcam := oidc.TestAuthMethod(t, conn, databaseWrapper, o.GetPublicId(), oidc.ActivePublicState, "alice_rp", "secret", oidc.WithDescription(fmt.Sprintf("%d", i)),
+	oidcam := oidc.TestAuthMethod(t, conn, databaseWrapper, o.GetPublicId(), oidc.ActivePublicState, "alice_rp", "secret", oidc.WithDescription(strconv.Itoa(i)),
 		oidc.WithIssuer(oidc.TestConvertToUrls(t, fmt.Sprintf("https://alice%d.com", i))[0]), oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://api.com")[0]), oidc.WithSigningAlgs(oidc.EdDSA))
 	i++
 	iam.TestSetPrimaryAuthMethod(t, iamRepo, o, oidcam.GetPublicId())
 
 	// 4 private
 	for ; i < 4; i++ {
-		_ = oidc.TestAuthMethod(t, conn, databaseWrapper, o.GetPublicId(), oidc.ActivePrivateState, "alice_rp", "secret", oidc.WithDescription(fmt.Sprintf("%d", i)),
+		_ = oidc.TestAuthMethod(t, conn, databaseWrapper, o.GetPublicId(), oidc.ActivePrivateState, "alice_rp", "secret", oidc.WithDescription(strconv.Itoa(i)),
 			oidc.WithIssuer(oidc.TestConvertToUrls(t, fmt.Sprintf("https://alice%d.com", i))[0]), oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://api.com")[0]), oidc.WithSigningAlgs(oidc.EdDSA))
 	}
 
 	// 5 inactive
 	for ; i < 10; i++ {
-		_ = oidc.TestAuthMethod(t, conn, databaseWrapper, o.GetPublicId(), oidc.InactiveState, "alice_rp", "secret", oidc.WithDescription(fmt.Sprintf("%d", i)),
+		_ = oidc.TestAuthMethod(t, conn, databaseWrapper, o.GetPublicId(), oidc.InactiveState, "alice_rp", "secret", oidc.WithDescription(strconv.Itoa(i)),
 			oidc.WithIssuer(oidc.TestConvertToUrls(t, fmt.Sprintf("https://alice%d.com", i))[0]), oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://api.com")[0]))
 	}
 
@@ -229,7 +230,7 @@ func TestList_FilterNonPublic(t *testing.T) {
 				return gotSorted[i].GetDescription().GetValue() < gotSorted[j].GetDescription().GetValue()
 			})
 			for i := 0; i < tc.respCount; i++ {
-				assert.Equal(t, fmt.Sprintf("%d", i), gotSorted[i].GetDescription().GetValue(), "Auth method with description '%d' missing", i)
+				assert.Equal(t, strconv.Itoa(i), gotSorted[i].GetDescription().GetValue(), "Auth method with description '%d' missing", i)
 			}
 		})
 	}

--- a/internal/session/repository_connection.go
+++ b/internal/session/repository_connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -426,7 +427,7 @@ func (r *ConnectionRepository) closeOrphanedConnections(ctx context.Context, wor
 		params := make([]string, len(reportedConnections))
 		for i, connId := range reportedConnections {
 			params[i] = fmt.Sprintf("@%d", i)
-			args = append(args, sql.Named(fmt.Sprintf("%d", i), connId))
+			args = append(args, sql.Named(strconv.Itoa(i), connId))
 		}
 		notInClause = fmt.Sprintf(notInClause, strings.Join(params, ","))
 	}

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -6,6 +6,7 @@ import (
 	"crypto/subtle"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/internal/boundary"
@@ -220,12 +221,12 @@ func (r *Repository) FetchAuthzProtectedEntitiesByScope(ctx context.Context, sco
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "no scopes given")
 	case 1:
 		inClauseCnt += 1
-		where, args = fmt.Sprintf("where scope_id = @%d", inClauseCnt), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), scopeIds[0]))
+		where, args = fmt.Sprintf("where scope_id = @%d", inClauseCnt), append(args, sql.Named(strconv.Itoa(inClauseCnt), scopeIds[0]))
 	default:
 		idsInClause := make([]string, 0, len(scopeIds))
 		for _, id := range scopeIds {
 			inClauseCnt += 1
-			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), id))
+			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), id))
 		}
 		where = fmt.Sprintf("where scope_id in (%s)", strings.Join(idsInClause, ","))
 	}
@@ -263,38 +264,38 @@ func (r *Repository) ListSessions(ctx context.Context, opt ...Option) ([]*Sessio
 	case 0:
 	case 1:
 		inClauseCnt += 1
-		where, args = append(where, fmt.Sprintf("scope_id = @%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), opts.withScopeIds[0]))
+		where, args = append(where, fmt.Sprintf("scope_id = @%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), opts.withScopeIds[0]))
 	default:
 		idsInClause := make([]string, 0, len(opts.withScopeIds))
 		for _, id := range opts.withScopeIds {
 			inClauseCnt += 1
-			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), id))
+			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), id))
 		}
 		where = append(where, fmt.Sprintf("scope_id in (%s)", strings.Join(idsInClause, ",")))
 	}
 
 	if opts.withUserId != "" {
 		inClauseCnt += 1
-		where, args = append(where, fmt.Sprintf("user_id = @%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), opts.withUserId))
+		where, args = append(where, fmt.Sprintf("user_id = @%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), opts.withUserId))
 	}
 
 	switch len(opts.withSessionIds) {
 	case 0:
 	case 1:
 		inClauseCnt += 1
-		where, args = append(where, fmt.Sprintf("s.public_id = @%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), opts.withSessionIds[0]))
+		where, args = append(where, fmt.Sprintf("s.public_id = @%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), opts.withSessionIds[0]))
 	default:
 		idsInClause := make([]string, 0, len(opts.withSessionIds))
 		for _, id := range opts.withSessionIds {
 			inClauseCnt += 1
-			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), id))
+			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), id))
 		}
 		where = append(where, fmt.Sprintf("s.public_id in (%s)", strings.Join(idsInClause, ",")))
 	}
 
 	if opts.withServerId != "" {
 		inClauseCnt += 1
-		where, args = append(where, fmt.Sprintf("server_id = @%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), opts.withServerId))
+		where, args = append(where, fmt.Sprintf("server_id = @%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), opts.withServerId))
 	}
 
 	var limit string
@@ -665,7 +666,7 @@ func (r *Repository) checkIfNoLongerActive(ctx context.Context, reportedSessions
 	params := make([]string, len(reportedSessions))
 	for i, sessId := range reportedSessions {
 		params[i] = fmt.Sprintf("@%d", i)
-		args = append(args, sql.Named(fmt.Sprintf("%d", i), sessId))
+		args = append(args, sql.Named(strconv.Itoa(i), sessId))
 	}
 	inClause = fmt.Sprintf(inClause, strings.Join(params, ","))
 

--- a/internal/target/repository.go
+++ b/internal/target/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/internal/boundary"
@@ -156,13 +157,13 @@ func (r *Repository) FetchAuthzProtectedEntitiesByScope(ctx context.Context, sco
 	case 1:
 		if scopeIds[0] != scope.Global.String() {
 			inClauseCnt += 1
-			where, args = fmt.Sprintf("where scope_id = @%d", inClauseCnt), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), scopeIds[0]))
+			where, args = fmt.Sprintf("where scope_id = @%d", inClauseCnt), append(args, sql.Named(strconv.Itoa(inClauseCnt), scopeIds[0]))
 		}
 	default:
 		idsInClause := make([]string, 0, len(scopeIds))
 		for _, id := range scopeIds {
 			inClauseCnt += 1
-			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), id))
+			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), id))
 		}
 		where = fmt.Sprintf("where scope_id in (%s)", strings.Join(idsInClause, ","))
 	}
@@ -204,12 +205,12 @@ func (r *Repository) ListTargets(ctx context.Context, opt ...Option) ([]Target, 
 	case 0:
 	case 1:
 		inClauseCnt += 1
-		where, args = append(where, fmt.Sprintf("scope_id = @%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), opts.WithScopeIds[0]))
+		where, args = append(where, fmt.Sprintf("scope_id = @%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), opts.WithScopeIds[0]))
 	default:
 		idsInClause := make([]string, 0, len(opts.WithScopeIds))
 		for _, id := range opts.WithScopeIds {
 			inClauseCnt += 1
-			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), id))
+			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), id))
 		}
 		where = append(where, fmt.Sprintf("scope_id in (%s)", strings.Join(idsInClause, ",")))
 	}
@@ -218,19 +219,19 @@ func (r *Repository) ListTargets(ctx context.Context, opt ...Option) ([]Target, 
 	case 0:
 	case 1:
 		inClauseCnt += 1
-		where, args = append(where, fmt.Sprintf("public_id = @%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), opts.WithTargetIds[0]))
+		where, args = append(where, fmt.Sprintf("public_id = @%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), opts.WithTargetIds[0]))
 	default:
 		idsInClause := make([]string, 0, len(opts.WithTargetIds))
 		for _, id := range opts.WithTargetIds {
 			inClauseCnt += 1
-			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), id))
+			idsInClause, args = append(idsInClause, fmt.Sprintf("@%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), id))
 		}
 		where = append(where, fmt.Sprintf("public_id in (%s)", strings.Join(idsInClause, ",")))
 	}
 
 	if opts.WithType != "" {
 		inClauseCnt += 1
-		where, args = append(where, fmt.Sprintf("type = @%d", inClauseCnt)), append(args, sql.Named(fmt.Sprintf("%d", inClauseCnt), opts.WithType.String()))
+		where, args = append(where, fmt.Sprintf("type = @%d", inClauseCnt)), append(args, sql.Named(strconv.Itoa(inClauseCnt), opts.WithType.String()))
 	}
 
 	var foundTargets []*targetView

--- a/internal/target/repository_credential_source.go
+++ b/internal/target/repository_credential_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/internal/credential"
@@ -403,7 +404,7 @@ func (r *Repository) changes(ctx context.Context, targetId string, cls []*Creden
 	var params []interface{}
 	params = append(params, sql.Named("target_id", targetId), sql.Named("purpose", purpose))
 	for idx, cl := range cls {
-		params = append(params, sql.Named(fmt.Sprintf("%d", idx+1), cl.CredentialLibraryId))
+		params = append(params, sql.Named(strconv.Itoa(idx+1), cl.CredentialLibraryId))
 		inClauseSpots = append(inClauseSpots, fmt.Sprintf("@%d", idx+1))
 	}
 	inClause := strings.Join(inClauseSpots, ",")

--- a/internal/tests/api/scopes/scope_test.go
+++ b/internal/tests/api/scopes/scope_test.go
@@ -3,6 +3,7 @@ package scopes_test
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/boundary/api"
@@ -31,7 +32,7 @@ func TestList(t *testing.T) {
 
 	expected := make([]*scopes.Scope, 10)
 	for i := 0; i < 10; i++ {
-		scr, err := scps.Create(tc.Context(), org.GetPublicId(), scopes.WithName(fmt.Sprintf("%d", i)))
+		scr, err := scps.Create(tc.Context(), org.GetPublicId(), scopes.WithName(strconv.Itoa(i)))
 		require.NoError(err)
 		expected[i] = scr.Item
 	}


### PR DESCRIPTION
This is just a less efficient and clear way of converting
an integer to a string than strconv.Itoa.