### PR TITLE
Add config key to the promote-staging event

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -162,6 +162,7 @@ event "promote-staging" {
     organization = "hashicorp"
     repository = "crt-workflows-common"
     workflow = "promote-staging"
+    config = "release-metadata.hcl"
   }
 
   notification {


### PR DESCRIPTION
We need to pass the release-metadata.hcl file to the promote-staging workflow.