### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Formatted all Protobuf files
+f69fbf22552deac9ec81503d629fb70919acabdb


### PR DESCRIPTION
This lets us ignore large changes in blame. Use it to ignore the Protobuf file formatter commit.

See https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
for more information.