### PR TITLE
Update UI artifacts consumption

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   PKG_NAME: "boundary"
-  EDITION: oss
 
 jobs:
   get-product-version:
@@ -61,10 +60,28 @@ jobs:
           project="$(go list -m)"
           sha="$(git rev-parse HEAD)"
           echo "::set-output name=ldflags::"-s -w -X \'$project/version.GitCommit=$sha\'""
+  
+  get-product-edition:
+    runs-on: ubuntu-latest
+    outputs:
+      product-edition: ${{ steps.get-product-edition.outputs.product-edition}}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.18.1"
+      - name: Get product edition
+        id: get-product-edition
+        run: |
+          make edition
+          echo "::set-output name=product-edition::$(make edition)"
+
 
   build-other:
     needs: 
       - get-product-version
+      - get-product-edition
       - set-ld-flags
     runs-on: ubuntu-latest
     strategy:
@@ -103,7 +120,7 @@ jobs:
           workflow: build-admin-ui.yaml
           commit: ${{ steps.set-sha.outputs.sha }}
           repo: "hashicorp/boundary-ui"
-          name: admin-ui-${{ env.EDITION }}
+          name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
           path: internal/ui/.tmp/boundary-ui/ui/admin/dist
       - name: Go Build
         env:
@@ -125,6 +142,7 @@ jobs:
   build-linux:
     needs: 
       - get-product-version
+      - get-product-edition
       - set-ld-flags
     runs-on: ubuntu-latest
     strategy:
@@ -158,7 +176,7 @@ jobs:
           workflow: build-admin-ui.yaml
           commit: ${{ steps.set-sha.outputs.sha }}
           repo: "hashicorp/boundary-ui"
-          name: admin-ui-${{ env.EDITION }}
+          name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
           path: internal/ui/.tmp/boundary-ui/ui/admin/dist
       - name: Go Build
         env:
@@ -210,6 +228,7 @@ jobs:
   build-darwin:
     needs: 
       - get-product-version
+      - get-product-edition
       - set-ld-flags
     runs-on: macos-latest
     strategy:
@@ -240,7 +259,7 @@ jobs:
           workflow: build-admin-ui.yaml
           commit: ${{ steps.set-sha.outputs.sha }}
           repo: "hashicorp/boundary-ui"
-          name: admin-ui-${{ env.EDITION }}
+          name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
           path: internal/ui/.tmp/boundary-ui/ui/admin/dist
       - name: Go Build
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
     branches:    
       # Push events on main branch
       - 'main'
-      - ICU-4231-update-ui-artifacts-consumption
 
 env:
   PKG_NAME: "boundary"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,11 @@ on:
     branches:    
       # Push events on main branch
       - 'main'
+      - ICU-4231-update-ui-artifacts-consumption
 
 env:
   PKG_NAME: "boundary"
+  EDITION: oss
 
 jobs:
   get-product-version:
@@ -102,7 +104,7 @@ jobs:
           workflow: build-admin-ui.yaml
           commit: ${{ steps.set-sha.outputs.sha }}
           repo: "hashicorp/boundary-ui"
-          name: admin-ui
+          name: admin-ui-${{ env.EDITION }}
           path: internal/ui/.tmp/boundary-ui/ui/admin/dist
       - name: Go Build
         env:
@@ -157,7 +159,7 @@ jobs:
           workflow: build-admin-ui.yaml
           commit: ${{ steps.set-sha.outputs.sha }}
           repo: "hashicorp/boundary-ui"
-          name: admin-ui
+          name: admin-ui-${{ env.EDITION }}
           path: internal/ui/.tmp/boundary-ui/ui/admin/dist
       - name: Go Build
         env:
@@ -239,7 +241,7 @@ jobs:
           workflow: build-admin-ui.yaml
           commit: ${{ steps.set-sha.outputs.sha }}
           repo: "hashicorp/boundary-ui"
-          name: admin-ui
+          name: admin-ui-${{ env.EDITION }}
           path: internal/ui/.tmp/boundary-ui/ui/admin/dist
       - name: Go Build
         env:

--- a/Makefile
+++ b/Makefile
@@ -323,3 +323,13 @@ ci-verify:
 # This is used for release builds by .github/workflows/build.yml
 version:
 	@go run ./cmd/boundary version | awk '/Version Number:/ { print $$3 }'
+
+EDITION?=
+.PHONY: edition
+# This is used for release builds by .github/workflows/build.yml
+edition:
+	@if [ -z "$(EDITION)" ]; then \
+		go run ./cmd/boundary version -format=json | jq -r '.version_metadata // "oss"'; \
+	else \
+		echo $(EDITION); \
+	fi; \

--- a/internal/ui/VERSION
+++ b/internal/ui/VERSION
@@ -1,4 +1,4 @@
-8545697b430a432bd50c1bde6a080759f803f157 Add toolbar regions to align refresh button to the right (#1098)
+7e792d3f7664bf3efdf33a66539022d3f3cdaf4c Refactor UI generated artifacts creation. (#1104)
 # This file determines the version of the UI to embed in the boundary binary.
 # Update this file by running 'make update-ui-version' from the root of this repo.
 # Set UI_COMMITISH when running the above target to update to a specific version.


### PR DESCRIPTION
Update the UI artifacts consumption within the Boundary CI using a make script to get Boundary Edition.

Updated May 13.

To be aware:
- This PR updates the UI version. **Why?** In the UI we start generating both artifacts (`admin-ui-oss` and `admin-ui-enterprise`) hours before this PR. So there are no artifacts with that naming available for previous SHA's.

Screenshot of the test branch using the make script and the `get-product-edition` job and retrieving the proper UI artifact succesfully:
![Screenshot from 2022-05-13 10-46-31](https://user-images.githubusercontent.com/9775006/168339417-cb8590a9-eba5-40e1-8e34-57963ae368b4.png)

