### PR TITLE
test(targets): Prevent panic due to non-deterministic order

### DIFF
--- a/internal/tests/api/targets/target_test.go
+++ b/internal/tests/api/targets/target_test.go
@@ -179,11 +179,11 @@ func TestList(t *testing.T) {
 		require.NoError(err)
 		expected[i] = tcr.Item
 	}
+	filterItem := expected[3]
 	ul, err = tarClient.List(tc.Context(), proj.GetPublicId())
 	require.NoError(err)
 	assert.ElementsMatch(comparableSlice(expected), comparableSlice(ul.Items))
 
-	filterItem := ul.Items[3]
 	ul, err = tarClient.List(tc.Context(), proj.GetPublicId(),
 		targets.WithFilter(fmt.Sprintf(`"/item/id"==%q`, filterItem.Id)))
 	require.NoError(err)


### PR DESCRIPTION
This test was using the third element in the result from a list request
to craft the input for the next assertion. However, one of the test
targets that is created does not have a default port set. Since the
target list call is not ordered, sometimes this element could be the
third element and a panic would result when default port interface was
converted to a float64.

This fixes the panic like:

    --- FAIL: TestList (1.31s)
    panic: interface conversion: interface {} is nil, not float64 [recovered]
            panic: interface conversion: interface {} is nil, not float64

    goroutine 1694 [running]:
    testing.tRunner.func1.2({0x14b2320, 0xc002f486f0})
        /prefix/usr/lib/go/src/testing/testing.go:1389 +0x24e
    testing.tRunner.func1()
        /prefix/usr/lib/go/src/testing/testing.go:1392 +0x39f
    panic({0x14b2320, 0xc002f486f0})
        /prefix/usr/lib/go/src/runtime/panic.go:838 +0x207
    github.com/hashicorp/boundary/internal/tests/api/targets_test.TestList(0xc000f81380)
        /go/src/github.com/hashicorp/boundary/internal/tests/api/targets/target_test.go:193 +0x174b
    testing.tRunner(0xc000f81380, 0x2b933a8)
        /prefix/usr/lib/go/src/testing/testing.go:1439 +0x102
    created by testing.(*T).Run
        /prefix/usr/lib/go/src/testing/testing.go:1486 +0x35f
    FAIL    github.com/hashicorp/boundary/internal/tests/api/targets    5.742s
    FAIL

Refs: #2003