### PR TITLE
Respect max open connection limits in migrate and init

### DIFF
--- a/internal/cmd/commands/database/funcs.go
+++ b/internal/cmd/commands/database/funcs.go
@@ -16,7 +16,7 @@ import (
 // We expect the database already to be initialized iff initialized is set to true.
 // Returns a cleanup function which must be called even if an error is returned and
 // an error code where a non-zero value indicates an error happened.
-func migrateDatabase(ctx context.Context, ui cli.Ui, dialect, u string, initialized bool) (func(), int) {
+func migrateDatabase(ctx context.Context, ui cli.Ui, dialect, u string, initialized bool, maxOpenConns int) (func(), int) {
 	noop := func() {}
 	// This database is used to keep an exclusive lock on the database for the
 	// remainder of the command
@@ -25,6 +25,7 @@ func migrateDatabase(ctx context.Context, ui cli.Ui, dialect, u string, initiali
 		ui.Error(fmt.Errorf("Error establishing db connection: %w", err).Error())
 		return noop, 2
 	}
+	dBase.SetMaxOpenConns(maxOpenConns)
 	if err := dBase.PingContext(ctx); err != nil {
 		ui.Error(fmt.Sprintf("Unable to connect to the database at %q", u))
 		return noop, 2

--- a/internal/cmd/commands/database/init.go
+++ b/internal/cmd/commands/database/init.go
@@ -239,6 +239,8 @@ func (c *InitCommand) Run(args []string) (retCode int) {
 		return base.CommandUserError
 	}
 
+	c.DatabaseMaxOpenConnections = c.Config.Controller.Database.MaxOpenConnections
+
 	var migrationUrlToParse string
 	if c.Config.Controller.Database.MigrationUrl != "" {
 		migrationUrlToParse = c.Config.Controller.Database.MigrationUrl
@@ -262,7 +264,7 @@ func (c *InitCommand) Run(args []string) (retCode int) {
 		return base.CommandUserError
 	}
 
-	clean, errCode := migrateDatabase(c.Context, c.UI, dialect, migrationUrl, false)
+	clean, errCode := migrateDatabase(c.Context, c.UI, dialect, migrationUrl, false, c.DatabaseMaxOpenConnections)
 	defer clean()
 	switch errCode {
 	case 0:

--- a/internal/cmd/commands/database/migrate.go
+++ b/internal/cmd/commands/database/migrate.go
@@ -259,7 +259,7 @@ plugins {
 		return base.CommandUserError
 	}
 
-	clean, errCode := migrateDatabase(c.Context, c.UI, dialect, migrationUrl, true)
+	clean, errCode := migrateDatabase(c.Context, c.UI, dialect, migrationUrl, true, c.Config.Controller.Database.MaxOpenConnections)
 	defer clean()
 	if errCode != 0 {
 		return errCode


### PR DESCRIPTION
## [fix(cmd): Respect DB max open connections](https://github.com/hashicorp/boundary/commit/0b81e1505264081c7c5f65f1999eb32d0772052e)

Both the init and migrate commands were ignoring
the configured max_open_connections database
setting. This fix ensures that both commands
respect the limits.