### PR TITLE
Docs install dir

### DIFF
--- a/website/content/docs/getting-started/installing/production.mdx
+++ b/website/content/docs/getting-started/installing/production.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # Production Installation
 
-Installing Boundary in a production setting requires prerequisits for infrastructure. At the most basic level, Boundary operators should run a minimum of 3 controllers and 3 workers. Running 3 of each server type gives a fundamental level of high availability for the control plane (controller), as well as bandwidth for number of sessions on the data plane (worker). Both server type should be ran in a fault tolerant setting, that is, in a self-healing environment such as an auto-scaling group. The documentation here does not cover self-healing infrastructure and assumes the operator has their preferred scheduling methods for these environments.
+Installing Boundary in a production setting requires prerequisites for infrastructure. At the most basic level, Boundary operators should run a minimum of 3 controllers and 3 workers. Running 3 of each server type gives a fundamental level of high availability for the control plane (controller), as well as bandwidth for number of sessions on the data plane (worker). Both server type should be ran in a fault tolerant setting, that is, in a self-healing environment such as an auto-scaling group. The documentation here does not cover self-healing infrastructure and assumes the operator has their preferred scheduling methods for these environments.
 
 ## Network Requirements
 
@@ -42,7 +42,7 @@ For general configuration, we recommend the following:
 
 ### Controller Configuration
 
-When running Boundary controller as a service we recommend storing the file at `/etc/boundary-controller.hcl`. A `boundary` user and group should exist to manage this configuration file and to further restrict who can read and modify it.
+When running Boundary controller as a service we recommend storing the file at `/etc/boundary.d/boundary-controller.hcl`. A `boundary` user and group should exist to manage this configuration file and to further restrict who can read and modify it.
 
 Example controller configuration:
 
@@ -158,7 +158,7 @@ name must be unique!
 
 `TYPE` below can be either `worker` or `controller`.
 
-1. `/etc/boundary-${TYPE}.hcl`: Configuration file for the boundary service
+1. `/etc/boundary.d/boundary-${TYPE}.hcl`: Configuration file for the boundary service
    See above example configurations.
 
 2. `/usr/local/bin/boundary`: The Boundary binary
@@ -172,7 +172,7 @@ name must be unique!
 Description=${NAME} ${TYPE}
 
 [Service]
-ExecStart=/usr/local/bin/${NAME} ${TYPE} -config /etc/${NAME}-${TYPE}.hcl
+ExecStart=/usr/local/bin/${NAME} ${TYPE} -config /etc/boundary.d/${NAME}-${TYPE}.hcl
 User=boundary
 Group=boundary
 LimitMEMLOCK=infinity
@@ -194,12 +194,15 @@ systemd unit file and enables it at startup:
 TYPE=$1
 NAME=boundary
 
+chmod 0755 /usr/local/bin/boundary
+mkdir -pm 0755 /etc/boundary.d
+
 sudo cat << EOF > /etc/systemd/system/${NAME}-${TYPE}.service
 [Unit]
 Description=${NAME} ${TYPE}
 
 [Service]
-ExecStart=/usr/local/bin/${NAME} ${TYPE} -config /etc/${NAME}-${TYPE}.hcl
+ExecStart=/usr/local/bin/${NAME} ${TYPE} -config /etc/boundary.d/${NAME}-${TYPE}.hcl
 User=boundary
 Group=boundary
 LimitMEMLOCK=infinity
@@ -213,14 +216,14 @@ EOF
 # Add the boundary system user and group to ensure we have a no-login
 # user capable of owning and running Boundary
 sudo adduser --system --group boundary || true
-sudo chown boundary:boundary /etc/${NAME}-${TYPE}.hcl
+sudo chown boundary:boundary /etc/boundary.d/${NAME}-${TYPE}.hcl
 sudo chown boundary:boundary /usr/local/bin/boundary
 
 # Make sure to initialize the DB before starting the service. This will result in
 # a database already initialized warning if another controller or worker has done this
 # already, making it a lazy, best effort initialization
 if [ "${TYPE}" = "controller" ]; then
-  sudo /usr/local/bin/boundary database init -config /etc/${NAME}-${TYPE}.hcl || true
+  sudo /usr/local/bin/boundary database init -config /etc/boundary.d/${NAME}-${TYPE}.hcl || true
 fi
 
 sudo chmod 664 /etc/systemd/system/${NAME}-${TYPE}.service

--- a/website/content/docs/installing/high-availability.mdx
+++ b/website/content/docs/installing/high-availability.mdx
@@ -44,6 +44,6 @@ For general configuration, we recommend the following:
 
 ### Controller Configuration
 
-When running Boundary controller as a service we recommend storing the file at `/etc/boundary-controller.hcl`. A `boundary` user and group should exist to manage this configuration file and to further restrict who can read and modify it.
+When running Boundary controller as a service we recommend storing the file at `/etc/boundary.d/boundary-controller.hcl`. A `boundary` user and group should exist to manage this configuration file and to further restrict who can read and modify it.
 
 For detailed configuration options, see our [configuration docs](/docs/configuration).

--- a/website/content/docs/installing/no-gen-resources.mdx
+++ b/website/content/docs/installing/no-gen-resources.mdx
@@ -123,7 +123,7 @@ $ boundary database init \
    -skip-host-resources-creation \
    -skip-scopes-creation \
    -skip-target-creation \
-   -config /etc/boundary.hcl
+   -config /etc/boundary.d/boundary-controller.hcl
 ```
 
 When you start Boundary, you will effectively have a blank sheet to work against. The initial migrations in the database have been run (note that this includes creating special users like `u_anon` and the `global` scope) and the internal keyrings have been initialized. From here, it's required that

--- a/website/content/docs/installing/systemd.mdx
+++ b/website/content/docs/installing/systemd.mdx
@@ -13,7 +13,7 @@ This section covers how to install Boundary under the [systemd](https://systemd.
 
 `TYPE` below can be either `worker` or `controller` if you want to run them independently, e.g. for high availability. If you want to run combined nodes, modify as desired.
 
-1. `/etc/boundary-${TYPE}.hcl`: Configuration file for the boundary service.
+1. `/etc/boundary.d/boundary-${TYPE}.hcl`: Configuration file for the boundary service.
 
 2. `/usr/local/bin/boundary`: The Boundary binary, which can be built from the [source](https://github.com/hashicorp/boundary) or downloaded from our [release page](https://www.boundaryproject.io/downloads).
 
@@ -30,7 +30,7 @@ We recommend running Boundary as a non-root user and using this user to manage t
 Description=${NAME} ${TYPE}
 
 [Service]
-ExecStart=/usr/local/bin/${NAME} server -config /etc/${NAME}-${TYPE}.hcl
+ExecStart=/usr/local/bin/${NAME} server -config /etc/boundary.d/${NAME}-${TYPE}.hcl
 User=boundary
 Group=boundary
 LimitMEMLOCK=infinity
@@ -54,12 +54,15 @@ systemd unit file, and enables it at startup:
 TYPE=$1
 NAME=boundary
 
+chmod 0755 /usr/local/bin/boundary
+mkdir -pm 0755 /etc/boundary.d
+
 sudo cat << EOF > /etc/systemd/system/${NAME}-${TYPE}.service
 [Unit]
 Description=${NAME} ${TYPE}
 
 [Service]
-ExecStart=/usr/local/bin/${NAME} server -config /etc/${NAME}-${TYPE}.hcl
+ExecStart=/usr/local/bin/${NAME} server -config /etc/boundary.d/${NAME}-${TYPE}.hcl
 User=boundary
 Group=boundary
 LimitMEMLOCK=infinity
@@ -73,14 +76,14 @@ EOF
 # Add the boundary system user and group to ensure we have a no-login
 # user capable of owning and running Boundary
 sudo adduser --system --group boundary || true
-sudo chown boundary:boundary /etc/${NAME}-${TYPE}.hcl
+sudo chown boundary:boundary /etc/boundary.d/${NAME}-${TYPE}.hcl
 sudo chown boundary:boundary /usr/local/bin/boundary
 
 # Make sure to initialize the DB before starting the service. This will result in
 # a database already initialized warning if another controller or worker has done this
 # already, making it a lazy, best effort initialization
 if [ "${TYPE}" = "controller" ]; then
-  sudo /usr/local/bin/boundary database init -config /etc/${NAME}-${TYPE}.hcl || true
+  sudo /usr/local/bin/boundary database init -config /etc/boundary.d/${NAME}-${TYPE}.hcl || true
 fi
 
 sudo chmod 664 /etc/systemd/system/${NAME}-${TYPE}.service


### PR DESCRIPTION
This PR updates these files to recommend installing boundary HCL config files in `/etc/boundary.d/`

- website/content/docs/installing/high-availability.mdx
- website/content/docs/installing/no-gen-resources.mdx

In addition to the new directory, these files also add changes to the "all-in-one" installation script to create the `/etc/boundary.d/` and set 0755 perms on `/etc/boundary.d` and `/usr/local/bin/boundary`, like most vault installations recommend.

- website/content/docs/installing/systemd.mdx
- website/content/docs/getting-started/installing/production.mdx