### PR TITLE
add codeowners to protect release dirs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# release configuration
+
+/.release/                              @hashicorp/release-engineering @hashicorp/github-secure-boundary
+/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-secure-boundary


### PR DESCRIPTION
Locks down changes to release directories so that they require approval from release engineering, and so they have service account rights for pipeline runs and backport-assistant functionality.