### PR TITLE
Add worker creation ACLs

### DIFF
--- a/internal/daemon/controller/handlers/scopes/scope_service.go
+++ b/internal/daemon/controller/handlers/scopes/scope_service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/sessions"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/targets"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/users"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/workers"
 	"github.com/hashicorp/boundary/internal/errors"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
@@ -63,6 +64,7 @@ var (
 			resource.Role:       roles.CollectionActions,
 			resource.Scope:      CollectionActions,
 			resource.User:       users.CollectionActions,
+			resource.Worker:     workers.CollectionActions,
 		},
 
 		scope.Org.String(): {

--- a/internal/daemon/controller/handlers/scopes/scope_service_test.go
+++ b/internal/daemon/controller/handlers/scopes/scope_service_test.go
@@ -95,6 +95,12 @@ var globalAuthorizedCollectionActions = map[string]*structpb.ListValue{
 			structpb.NewStringValue("list"),
 		},
 	},
+	"workers": {
+		Values: []*structpb.Value{
+			structpb.NewStringValue("create:worker-request"),
+			structpb.NewStringValue("list"),
+		},
+	},
 }
 
 var orgAuthorizedCollectionActions = map[string]*structpb.ListValue{

--- a/internal/daemon/controller/handlers/workers/worker_service.go
+++ b/internal/daemon/controller/handlers/workers/worker_service.go
@@ -36,7 +36,7 @@ var (
 	// CollectionActions contains the set of actions that can be performed on
 	// this collection
 	CollectionActions = action.ActionSet{
-		action.Create,
+		action.CreateWorkerRequest,
 		action.List,
 	}
 )

--- a/internal/perms/acl_test.go
+++ b/internal/perms/acl_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/boundary/internal/intglobals"
 	"github.com/hashicorp/boundary/internal/types/action"
 	"github.com/hashicorp/boundary/internal/types/resource"
+	"github.com/hashicorp/boundary/internal/types/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -313,6 +314,36 @@ func Test_ACLAllowed(t *testing.T) {
 			actionsAuthorized: []actionAuthorized{
 				{action: action.Read},
 				{action: action.ReadSelf, authorized: true},
+			},
+		},
+		{
+			name:     "create worker with create",
+			resource: Resource{ScopeId: scope.Global.String(), Type: resource.Worker},
+			scopeGrants: []scopeGrant{
+				{
+					scope: scope.Global.String(),
+					grants: []string{
+						"type=worker;actions=create",
+					},
+				},
+			},
+			actionsAuthorized: []actionAuthorized{
+				{action: action.CreateWorkerRequest, authorized: true},
+			},
+		},
+		{
+			name:     "create worker with request only",
+			resource: Resource{ScopeId: scope.Global.String(), Type: resource.Worker},
+			scopeGrants: []scopeGrant{
+				{
+					scope: scope.Global.String(),
+					grants: []string{
+						"type=worker;actions=create:worker-request",
+					},
+				},
+			},
+			actionsAuthorized: []actionAuthorized{
+				{action: action.CreateWorkerRequest, authorized: true},
 			},
 		},
 	}

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -74,6 +74,20 @@ func (g Grant) Actions() (typs []action.Type, strs []string) {
 	return
 }
 
+// hasActionOrSubaction checks whether a grant's action set contains the given
+// action or contains an action that is a subaction of the passed-in parameter.
+// This is used for validation checking of parsed grants. N.B.: this is the
+// opposite check of action.Type.IsActionOrParent, which is why the ordering is
+// reversed going into that call.
+func (g Grant) hasActionOrSubaction(act action.Type) bool {
+	for k := range g.actions {
+		if act.IsActionOrParent(k) {
+			return true
+		}
+	}
+	return false
+}
+
 func (g Grant) clone() *Grant {
 	ret := &Grant{
 		scope: g.scope,
@@ -376,12 +390,12 @@ func Parse(scopeId, grantString string, opt ...Option) (Grant, error) {
 						return Grant{}, errors.NewDeprecated(errors.InvalidParameter, op, "parsed grant string contains no actions or output fields")
 					}
 				case 1:
-					if !grant.actions[action.Create] &&
-						!grant.actions[action.List] {
+					if !grant.hasActionOrSubaction(action.Create) &&
+						!grant.hasActionOrSubaction(action.List) {
 						return Grant{}, errors.NewDeprecated(errors.InvalidParameter, op, "parsed grant string contains non-create or non-list action in a format that only allows these")
 					}
 				case 2:
-					if !grant.actions[action.Create] || !grant.actions[action.List] {
+					if !grant.hasActionOrSubaction(action.Create) || !grant.hasActionOrSubaction(action.List) {
 						return Grant{}, errors.NewDeprecated(errors.InvalidParameter, op, "parsed grant string contains non-create or non-list action in a format that only allows these")
 					}
 				default:
@@ -411,6 +425,7 @@ func Parse(scopeId, grantString string, opt ...Option) (Grant, error) {
 				results := acl.Allowed(r, k)
 				if results.Authorized {
 					allowed = true
+					break
 				}
 			}
 			if !allowed {
@@ -429,7 +444,7 @@ func Parse(scopeId, grantString string, opt ...Option) (Grant, error) {
 func (g Grant) validateType() error {
 	const op = "perms.(Grant).validateType"
 	switch g.typ {
-	case resource.Controller, resource.Worker:
+	case resource.Controller:
 		return errors.NewDeprecated(errors.InvalidParameter, op, fmt.Sprintf("unknown type specifier %q", g.typ))
 	}
 	return nil

--- a/internal/perms/grants_test.go
+++ b/internal/perms/grants_test.go
@@ -110,7 +110,7 @@ func Test_ValidateType(t *testing.T) {
 	var g Grant
 	for i := resource.Unknown; i <= resource.CredentialLibrary; i++ {
 		g.typ = i
-		if i == resource.Controller || i == resource.Worker {
+		if i == resource.Controller {
 			assert.Error(t, g.validateType())
 		} else {
 			assert.NoError(t, g.validateType())
@@ -702,6 +702,55 @@ func Test_Parse(t *testing.T) {
 				require.NoError(err)
 				assert.Equal(test.expected, grant)
 			}
+		})
+	}
+}
+
+func TestHasActionOrSubaction(t *testing.T) {
+	tests := []struct {
+		name string
+		base []action.Type
+		act  action.Type
+		want bool
+	}{
+		{
+			name: "no actions",
+			base: []action.Type{},
+			act:  action.Read,
+		},
+		{
+			name: "has direct action",
+			base: []action.Type{action.Cancel, action.Read},
+			act:  action.Read,
+			want: true,
+		},
+		{
+			name: "has parent action",
+			base: []action.Type{action.Cancel, action.ReadSelf},
+			act:  action.Read,
+			want: true,
+		},
+		{
+			name: "has direct sub action",
+			base: []action.Type{action.Cancel, action.ReadSelf},
+			act:  action.ReadSelf,
+			want: true,
+		},
+		{
+			name: "has sub action needs parent",
+			base: []action.Type{action.Cancel, action.Read},
+			act:  action.ReadSelf,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := Grant{
+				actions: make(map[action.Type]bool),
+			}
+			for _, act := range tt.base {
+				g.actions[act] = true
+			}
+			assert.Equal(t, tt.want, g.hasActionOrSubaction(tt.act))
 		})
 	}
 }

--- a/internal/types/action/action.go
+++ b/internal/types/action/action.go
@@ -1,12 +1,12 @@
 package action
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
-// Type defines a type for the Actions of Resources
-// actions are also stored as a lookup db table named iam_action
 type Type uint
 
-// not using iota intentionally, since the values are stored in the db as well.
 const (
 	Unknown                   Type = 0
 	List                      Type = 1
@@ -53,6 +53,7 @@ const (
 	AddHostSources            Type = 42
 	SetHostSources            Type = 43
 	RemoveHostSources         Type = 44
+	CreateWorkerRequest       Type = 45
 )
 
 var Map = map[string]Type{
@@ -100,6 +101,7 @@ var Map = map[string]Type{
 	AddHostSources.String():            AddHostSources,
 	SetHostSources.String():            SetHostSources,
 	RemoveHostSources.String():         RemoveHostSources,
+	CreateWorkerRequest.String():       CreateWorkerRequest,
 }
 
 func (a Type) String() string {
@@ -149,7 +151,18 @@ func (a Type) String() string {
 		"add-host-sources",
 		"set-host-sources",
 		"remove-host-sources",
+		"create:worker-request",
 	}[a]
+}
+
+// IsActionOrParent tests whether the given action is either the same as the
+// suspect or is a parent of the suspect. This is used in some parts of ACL
+// checking.
+func (act Type) IsActionOrParent(suspect Type) bool {
+	if act == suspect {
+		return true
+	}
+	return strings.HasPrefix(suspect.String(), fmt.Sprintf("%s:", act.String()))
 }
 
 // ActionSet stores a slice of action types

--- a/internal/types/action/action_test.go
+++ b/internal/types/action/action_test.go
@@ -95,6 +95,10 @@ func TestAction(t *testing.T) {
 			action: NoOp,
 			want:   "no-op",
 		},
+		{
+			action: CreateWorkerRequest,
+			want:   "create:worker-request",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
@@ -213,6 +217,43 @@ func TestOnlySelf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, tt.actions.OnlySelf())
+		})
+	}
+}
+
+func TestIsActionOrParent(t *testing.T) {
+	tests := []struct {
+		name string
+		base Type
+		comp Type
+		want bool
+	}{
+		{
+			name: "same",
+			base: Cancel,
+			comp: Cancel,
+			want: true,
+		},
+		{
+			name: "different",
+			base: Cancel,
+			comp: Read,
+		},
+		{
+			name: "different base and comp",
+			base: List,
+			comp: CancelSelf,
+		},
+		{
+			name: "same base and comp",
+			base: Cancel,
+			comp: CancelSelf,
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.base.IsActionOrParent(tt.comp))
 		})
 	}
 }

--- a/internal/types/resource/resource.go
+++ b/internal/types/resource/resource.go
@@ -28,7 +28,7 @@ const (
 	// NOTE: When adding a new type, be sure to update:
 	//
 	// * The Grant.validateType function and test
-	// * The perms.topLevelTypes function
+	// * The perms.topLevelType function
 	// * The scopes service collection actions for appropriate scopes
 )
 


### PR DESCRIPTION
This is a bit more than simply adding the action; we had some
checks to ensure that list/create could only happen/not happen
in some cases and those had to be modified to account for
subactions.