### PR TITLE
test: Use tparse to simplify test failure analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,10 @@ jobs:
         name: Initialize Test Database
     - run:
         command: |
+          make tools
+        name: Install tools
+    - run:
+        command: |
           make test-ci
         name: Run Acceptance Tests
         no_output_timeout: 15m
@@ -349,17 +353,6 @@ workflows:
 #         resource_class: medium
 #         working_directory: ~/boundary
 # jobs:
-#     algolia-index:
-#         docker:
-#             - image: docker.mirror.hashicorp.services/node:12
-#         steps:
-#             - checkout
-#             - run:
-#                 command: |-
-#                     cd website/
-#                     npm install
-#                     node scripts/index_search_content.js
-#                 name: Push content to Algolia Index
 #     build:
 #         executor: go-machine
 #         steps:
@@ -371,6 +364,10 @@ workflows:
 #                     make DOCKER_ARGS='-d' PG_OPTS='-c shared_buffers=256MB -c max_connections=200000' -C testing/dbtest/docker database-up
 #                     until pg_isready -h 127.0.0.1; do docker container inspect boundary-sql-tests &> /dev/null || exit -1; sleep 1; done
 #                 name: Initialize Test Database
+#             - run:
+#                 command: |
+#                     make tools
+#                 name: Install tools
 #             - run:
 #                 command: |
 #                     make test-ci
@@ -455,11 +452,6 @@ workflows:
 #                             - 11-alpine
 #                             - 12-alpine
 #                             - 13-alpine
-#             - algolia-index:
-#                 filters:
-#                     branches:
-#                         only:
-#                             - stable-website
 #             - make-gen-deltas
 #     trigger-merge-to-ent:
 #         jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,14 +130,14 @@ jobs:
         name: Install go
     - run:
         command: |
+          make tools
+        name: Install tools
+    - run:
+        command: |
           which pg_isready || sudo apt-get update && sudo apt-get install -y postgresql-client
           make DOCKER_ARGS='-d' PG_OPTS='-c shared_buffers=256MB -c max_connections=200000' -C testing/dbtest/docker database-up
           until pg_isready -h 127.0.0.1; do docker container inspect boundary-sql-tests &> /dev/null || exit -1; sleep 1; done
         name: Initialize Test Database
-    - run:
-        command: |
-          make tools
-        name: Install tools
     - run:
         command: |
           make test-ci
@@ -358,16 +358,13 @@ workflows:
 #         steps:
 #             - checkout
 #             - install-go
+#             - install-tools
 #             - run:
 #                 command: |
 #                     which pg_isready || sudo apt-get update && sudo apt-get install -y postgresql-client
 #                     make DOCKER_ARGS='-d' PG_OPTS='-c shared_buffers=256MB -c max_connections=200000' -C testing/dbtest/docker database-up
 #                     until pg_isready -h 127.0.0.1; do docker container inspect boundary-sql-tests &> /dev/null || exit -1; sleep 1; done
 #                 name: Initialize Test Database
-#             - run:
-#                 command: |
-#                     make tools
-#                 name: Install tools
 #             - run:
 #                 command: |
 #                     make test-ci

--- a/.circleci/config/jobs/build.yml
+++ b/.circleci/config/jobs/build.yml
@@ -2,16 +2,13 @@ executor: go-machine
 steps:
 - checkout
 - install-go
+- install-tools
 - run:
     name: "Initialize Test Database"
     command: |
       which pg_isready || sudo apt-get update && sudo apt-get install -y postgresql-client
       make DOCKER_ARGS='-d' PG_OPTS='-c shared_buffers=256MB -c max_connections=200000' -C testing/dbtest/docker database-up
       until pg_isready -h 127.0.0.1; do docker container inspect boundary-sql-tests &> /dev/null || exit -1; sleep 1; done
-- run:
-    name: "Install tools"
-    command: |
-      make tools
 - run:
     name: "Run Acceptance Tests"
     no_output_timeout: 15m

--- a/.circleci/config/jobs/build.yml
+++ b/.circleci/config/jobs/build.yml
@@ -9,6 +9,10 @@ steps:
       make DOCKER_ARGS='-d' PG_OPTS='-c shared_buffers=256MB -c max_connections=200000' -C testing/dbtest/docker database-up
       until pg_isready -h 127.0.0.1; do docker container inspect boundary-sql-tests &> /dev/null || exit -1; sleep 1; done
 - run:
+    name: "Install tools"
+    command: |
+      make tools
+- run:
     name: "Run Acceptance Tests"
     no_output_timeout: 15m
     command: |

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ generate-database-dumps:
 test-ci: export CI_BUILD=1
 test-ci:
 	CGO_ENABLED=$(CGO_ENABLED) BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/build.sh'"
-	~/.go/bin/go test ./... -v $(TESTARGS) -json -timeout 120m | tparse -all
+	~/.go/bin/go test ./... -v $(TESTARGS) -json -cover -timeout 120m | tparse
 
 .PHONY: test-sql
 test-sql:
@@ -238,7 +238,7 @@ test-sql:
 
 .PHONY: test
 test:
-	go test ./... -timeout 30m
+	go test ./... -timeout 30m -json -cover | tparse -follow
 
 .PHONY: test-sdk
 test-sdk:

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ cli:
 tools:
 	go generate -tags tools tools/tools.go
 	go install github.com/bufbuild/buf/cmd/buf@v1.3.1
+	go install github.com/mfridman/tparse@v0.10.3
 
 .PHONY: cleangen
 cleangen:
@@ -141,12 +142,12 @@ protobuild:
 	@protoc-go-inject-tag -input=./internal/auth/store/account.pb.go
 	@protoc-go-inject-tag -input=./internal/auth/password/store/password.pb.go
 	@protoc-go-inject-tag -input=./internal/auth/password/store/argon2.pb.go
-	@protoc-go-inject-tag -input=./internal/kms/store/root_key.pb.go	
-	@protoc-go-inject-tag -input=./internal/kms/store/database_key.pb.go	
-	@protoc-go-inject-tag -input=./internal/kms/store/oplog_key.pb.go	
-	@protoc-go-inject-tag -input=./internal/kms/store/token_key.pb.go	
+	@protoc-go-inject-tag -input=./internal/kms/store/root_key.pb.go
+	@protoc-go-inject-tag -input=./internal/kms/store/database_key.pb.go
+	@protoc-go-inject-tag -input=./internal/kms/store/oplog_key.pb.go
+	@protoc-go-inject-tag -input=./internal/kms/store/token_key.pb.go
 	@protoc-go-inject-tag -input=./internal/kms/store/session_key.pb.go
-	@protoc-go-inject-tag -input=./internal/kms/store/oidc_key.pb.go		
+	@protoc-go-inject-tag -input=./internal/kms/store/oidc_key.pb.go
 	@protoc-go-inject-tag -input=./internal/target/store/target.pb.go
 	@protoc-go-inject-tag -input=./internal/target/targettest/store/target.pb.go
 	@protoc-go-inject-tag -input=./internal/target/tcp/store/target.pb.go
@@ -229,7 +230,7 @@ generate-database-dumps:
 test-ci: export CI_BUILD=1
 test-ci:
 	CGO_ENABLED=$(CGO_ENABLED) BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/build.sh'"
-	~/.go/bin/go test ./... -v $(TESTARGS) -timeout 120m
+	~/.go/bin/go test ./... -v $(TESTARGS) -json -timeout 120m | tparse -all
 
 .PHONY: test-sql
 test-sql:


### PR DESCRIPTION
The tparse library adds a nice summary of the test output,
which should hopefully make it easier to find errors in the tests.