### PR TITLE
Add support static credentials in DeleteCredentialSource and SetCredentialSource 

### DIFF
--- a/internal/tests/api/targets/target_test.go
+++ b/internal/tests/api/targets/target_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/credentiallibraries"
+	"github.com/hashicorp/boundary/api/credentials"
 	"github.com/hashicorp/boundary/api/credentialstores"
 	"github.com/hashicorp/boundary/api/hostcatalogs"
 	"github.com/hashicorp/boundary/api/hostsets"
@@ -66,11 +67,7 @@ func TestHostSetASD(t *testing.T) {
 	assert.Empty(tar.Item.HostSetIds)
 }
 
-func defaultCredLibrary(r *credentiallibraries.CredentialLibrary) *targets.CredentialLibrary {
-	return &targets.CredentialLibrary{Id: r.Id, CredentialStoreId: r.CredentialStoreId}
-}
-
-func TestCredentialLibraryASD(t *testing.T) {
+func TestCredentialSourcesASD(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 	tc := controller.NewTestController(t, nil)
 	defer tc.Shutdown()
@@ -82,44 +79,85 @@ func TestCredentialLibraryASD(t *testing.T) {
 	client := tc.Client().Clone()
 	client.SetToken(token.Token)
 
-	cs, err := credentialstores.NewClient(client).Create(tc.Context(), "vault", proj.GetPublicId(),
+	csVault, err := credentialstores.NewClient(client).Create(tc.Context(), "vault", proj.GetPublicId(),
 		credentialstores.WithVaultCredentialStoreAddress(vaultServ.Addr), credentialstores.WithVaultCredentialStoreToken(vaultTok))
 	require.NoError(err)
-	require.NotNil(cs)
+	require.NotNil(csVault)
 
 	lClient := credentiallibraries.NewClient(client)
-	r1, err := lClient.Create(tc.Context(), cs.Item.Id, credentiallibraries.WithVaultCredentialLibraryPath("something1"))
+	lib1, err := lClient.Create(tc.Context(), csVault.Item.Id, credentiallibraries.WithVaultCredentialLibraryPath("something1"))
 	require.NoError(err)
-	require.NotNil(r1)
+	require.NotNil(lib1)
 
-	r2, err := lClient.Create(tc.Context(), cs.Item.Id, credentiallibraries.WithVaultCredentialLibraryPath("something2"))
+	lib2, err := lClient.Create(tc.Context(), csVault.Item.Id, credentiallibraries.WithVaultCredentialLibraryPath("something2"))
 	require.NoError(err)
-	require.NotNil(r1)
+	require.NotNil(lib2)
+
+	csStatic, err := credentialstores.NewClient(client).Create(tc.Context(), "static", proj.GetPublicId())
+	require.NoError(err)
+	require.NotNil(csStatic)
+
+	cClient := credentials.NewClient(client)
+	cOpts := []credentials.Option{credentials.WithUsernamePasswordCredentialUsername("user"), credentials.WithUsernamePasswordCredentialPassword("pass")}
+	cred, err := cClient.Create(tc.Context(), "username_password", csStatic.Item.Id, cOpts...)
+	require.NoError(err)
+	require.NotNil(cred)
 
 	tarClient := targets.NewClient(client)
 	tar, err := tarClient.Create(tc.Context(), "tcp", proj.GetPublicId(), targets.WithName("foo"))
 	require.NoError(err)
 	require.NotNil(tar)
-	assert.Empty(tar.Item.ApplicationCredentialLibraryIds)
+	assert.Empty(tar.Item.ApplicationCredentialSourceIds)
 
-	tar, err = tarClient.AddCredentialLibraries(tc.Context(), tar.Item.Id, tar.Item.Version, targets.WithApplicationCredentialLibraryIds([]string{r1.Item.Id}))
+	// Add first Vault library
+	tar, err = tarClient.AddCredentialSources(tc.Context(), tar.Item.Id, tar.Item.Version,
+		targets.WithApplicationCredentialSourceIds([]string{lib1.Item.Id}))
 	require.NoError(err)
 	require.NotNil(tar)
-	assert.ElementsMatch(tar.Item.ApplicationCredentialLibraryIds, []string{r1.Item.Id})
-	assert.ElementsMatch(tar.Item.ApplicationCredentialLibraries, []*targets.CredentialLibrary{defaultCredLibrary(r1.Item)})
+	assert.ElementsMatch(tar.Item.ApplicationCredentialSourceIds, []string{lib1.Item.Id})
+	assert.ElementsMatch(tar.Item.ApplicationCredentialSources, []*targets.CredentialSource{
+		{
+			Id:                lib1.Item.Id,
+			CredentialStoreId: csVault.Item.Id,
+		},
+	})
 
-	tar, err = tarClient.SetCredentialLibraries(tc.Context(), tar.Item.Id, tar.Item.Version,
-		targets.WithApplicationCredentialLibraryIds([]string{r2.Item.Id}))
+	// Set second Vault library and a static credential
+	tar, err = tarClient.SetCredentialSources(tc.Context(), tar.Item.Id, tar.Item.Version,
+		targets.WithApplicationCredentialSourceIds([]string{lib2.Item.Id, cred.Item.Id}))
 	require.NoError(err)
 	require.NotNil(tar)
-	assert.ElementsMatch(tar.Item.ApplicationCredentialLibraryIds, []string{r2.Item.Id})
-	assert.ElementsMatch(tar.Item.ApplicationCredentialLibraries, []*targets.CredentialLibrary{defaultCredLibrary(r2.Item)})
+	assert.ElementsMatch(tar.Item.ApplicationCredentialSourceIds, []string{lib2.Item.Id, cred.Item.Id})
+	assert.ElementsMatch(tar.Item.ApplicationCredentialSources, []*targets.CredentialSource{
+		{
+			Id:                lib2.Item.Id,
+			CredentialStoreId: csVault.Item.Id,
+		},
+		{
+			Id:                cred.Item.Id,
+			CredentialStoreId: csStatic.Item.Id,
+		},
+	})
 
-	tar, err = tarClient.RemoveCredentialLibraries(tc.Context(), tar.Item.Id, tar.Item.Version,
-		targets.WithApplicationCredentialLibraryIds([]string{r2.Item.Id}))
+	// Remove second Vault library
+	tar, err = tarClient.RemoveCredentialSources(tc.Context(), tar.Item.Id, tar.Item.Version,
+		targets.WithApplicationCredentialSourceIds([]string{lib2.Item.Id}))
 	require.NoError(err)
 	require.NotNil(tar)
-	assert.Empty(tar.Item.ApplicationCredentialLibraryIds)
+	assert.ElementsMatch(tar.Item.ApplicationCredentialSourceIds, []string{cred.Item.Id})
+	assert.ElementsMatch(tar.Item.ApplicationCredentialSources, []*targets.CredentialSource{
+		{
+			Id:                cred.Item.Id,
+			CredentialStoreId: csStatic.Item.Id,
+		},
+	})
+
+	// Set empty credential sources
+	tar, err = tarClient.SetCredentialSources(tc.Context(), tar.Item.Id, tar.Item.Version,
+		targets.WithApplicationCredentialSourceIds([]string{}))
+	require.NoError(err)
+	require.NotNil(tar)
+	assert.Empty(tar.Item.ApplicationCredentialSourceIds)
 }
 
 func TestList(t *testing.T) {

--- a/internal/tests/cli/boundary/_target_credential_sources.bash
+++ b/internal/tests/cli/boundary/_target_credential_sources.bash
@@ -1,0 +1,52 @@
+load _authorized_actions
+
+function add_target_application_credential_sources() {
+  for i in "${@:2}"
+  do
+    cred+="-application-credential-source $i "
+  done
+
+  boundary targets add-credential-sources -id $1 $cred
+}
+
+function remove_target_application_credential_sources() {
+  for i in "${@:2}"
+  do
+    cred+="-application-credential-source $i "
+  done
+
+  boundary targets remove-credential-sources -id $1 $cred
+}
+
+function set_target_application_credential_sources() {
+  for i in "${@:2}"
+  do
+    cred+="-application-credential-source $i "
+  done
+
+  boundary targets set-credential-sources -id $1 $cred
+}
+
+function validate_credential_sources() {
+  targetData=$(boundary targets read -id $1 -format json)
+  for i in "${@:2}"
+  do
+    if ! echo "$targetData" | grep -q $i; then
+      echo "Credential source id '$i' not found on target"
+      echo "$targetData"
+      exit 1
+    fi
+  done
+}
+
+function validate_credential_sources_not_present() {
+  targetData=$(boundary targets read -id $1 -format json)
+  for i in "${@:2}"
+  do
+    if echo "$targetData" | grep -q $i; then
+      echo "Credential source id '$i' unexpectedly found on target"
+      echo "$targetData"
+      exit 1
+    fi
+  done
+}

--- a/internal/tests/cli/boundary/target_credential_sources.bats
+++ b/internal/tests/cli/boundary/target_credential_sources.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+
+load _auth
+load _connect
+load _targets
+load _helpers
+load _credential_stores
+load _credentials
+load _target_credential_sources
+
+export NEW_STORE='test-for-add-credential-sources'
+export NEW_CREDENTIAL='first-credential'
+export NEW_CREDENTIAL1='second-credential'
+export NEW_CREDENTIAL2='third-credential'
+
+@test "boundary/login: can login as admin user" {
+  run login $DEFAULT_LOGIN
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/credential-stores: can create $NEW_STORE static store in default project" {
+  run create_static_credential_store $NEW_STORE $DEFAULT_P_ID
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/credentials: can create $NEW_CREDENTIAL credential in $NEW_STORE store" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  run create_username_password_credential $NEW_CREDENTIAL $csid 'username' 'password'
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: can add $NEW_CREDENTIAL credential source" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  run add_target_application_credential_sources $DEFAULT_TARGET $cid
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate only $NEW_CREDENTIAL credential source present" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  run validate_credential_sources $DEFAULT_TARGET $cid
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: cannot add duplicate credential source" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  run add_target_application_credential_sources $DEFAULT_TARGET $cid
+  echo "$output"
+  [ "$status" -eq 1 ]
+}
+
+@test "boundary/target: can delete $NEW_CREDENTIAL credential source" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  run remove_target_application_credential_sources $DEFAULT_TARGET $cid
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate $NEW_CREDENTIAL credential source removed" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  run validate_credential_sources_not_present $DEFAULT_TARGET $cid
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/credentials: can create additional credentials in $NEW_STORE store" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  run create_username_password_credential $NEW_CREDENTIAL1 $csid 'username' 'password'
+  echo "$output"
+  [ "$status" -eq 0 ]
+
+  run create_username_password_credential $NEW_CREDENTIAL2 $csid 'username' 'password'
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: can add multiple credential sources" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  local cid1=$(credential_id $NEW_CREDENTIAL1 $csid)
+  local cid2=$(credential_id $NEW_CREDENTIAL2 $csid)
+  run add_target_application_credential_sources $DEFAULT_TARGET $cid $cid1 $cid2
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate added credential sources present" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  local cid1=$(credential_id $NEW_CREDENTIAL1 $csid)
+  local cid2=$(credential_id $NEW_CREDENTIAL2 $csid)
+  run validate_credential_sources $DEFAULT_TARGET $cid $cid1 $cid2
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: can delete multiple credential sources" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  local cid1=$(credential_id $NEW_CREDENTIAL1 $csid)
+  run remove_target_application_credential_sources $DEFAULT_TARGET $cid $cid1
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate $NEW_CREDENTIAL2 credential source present" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid2=$(credential_id $NEW_CREDENTIAL2 $csid)
+  run validate_credential_sources $DEFAULT_TARGET $cid2
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate deleted credential sources not present" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  local cid1=$(credential_id $NEW_CREDENTIAL $csid)
+  run validate_credential_sources_not_present $DEFAULT_TARGET $cid $cid1
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: can set multiple credential sources" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  local cid1=$(credential_id $NEW_CREDENTIAL1 $csid)
+  local cid2=$(credential_id $NEW_CREDENTIAL2 $csid)
+  run set_target_application_credential_sources $DEFAULT_TARGET $cid $cid1 $cid2
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate set credential sources present" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  local cid1=$(credential_id $NEW_CREDENTIAL1 $csid)
+  local cid2=$(credential_id $NEW_CREDENTIAL2 $csid)
+  run validate_credential_sources $DEFAULT_TARGET $cid2
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: can set just $NEW_CREDENTIAL credential source" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  run set_target_application_credential_sources $DEFAULT_TARGET $cid
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate $NEW_CREDENTIAL credential source present" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid=$(credential_id $NEW_CREDENTIAL $csid)
+  run validate_credential_sources $DEFAULT_TARGET $cid
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate not set credential sources not present" {
+  local csid=$(credential_store_id $NEW_STORE $DEFAULT_P_ID)
+  local cid1=$(credential_id $NEW_CREDENTIAL1 $csid)
+  local cid2=$(credential_id $NEW_CREDENTIAL2 $csid)
+  run validate_credential_sources_not_present $DEFAULT_TARGET $cid1 $cid2
+  echo "$output"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Results from running the new bats tests:

```
bats -p boundary/target_credential_sources.bats
 ✓ boundary/login: can login as admin user
 ✓ boundary/credential-stores: can create test-for-add-credential-sources static store in default project
 ✓ boundary/credentials: can create first-credential credential in test-for-add-credential-sources store
 ✓ boundary/target: can add first-credential credential source
 ✓ boundary/target: validate only first-credential credential source present
 ✓ boundary/target: cannot add duplicate credential source
 ✓ boundary/target: can delete first-credential credential source
 ✓ boundary/target: validate first-credential credential source removed
 ✓ boundary/credentials: can create additional credentials in test-for-add-credential-sources store
 ✓ boundary/target: can add multiple credential sources
 ✓ boundary/target: validate added credential sources present
 ✓ boundary/target: can delete multiple credential sources
 ✓ boundary/target: validate third-credential credential source present
 ✓ boundary/target: validate deleted credential sources not present
 ✓ boundary/target: can set multiple credential sources
 ✓ boundary/target: validate set credential sources present
 ✓ boundary/target: can set just first-credential credential source
 ✓ boundary/target: validate first-credential credential source present
 ✓ boundary/target: validate not set credential sources not present

19 tests, 0 failures
```