### PR TITLE
Bump Go version to v1.18.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18.1"
+          go-version: "1.18.3"
       - name: get product version
         id: get-product-version
         run: |
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18.1"
+          go-version: "1.18.3"
       - name: Get product edition
         id: get-product-edition
         run: |
@@ -88,7 +88,7 @@ jobs:
       matrix:
         goos: [ freebsd, windows, netbsd, openbsd, solaris ]
         goarch: [ "386", "amd64", "arm" ]
-        go: [ "1.18.1" ]
+        go: [ "1.18.3" ]
         exclude:
           - goos: solaris
             goarch: 386
@@ -149,7 +149,7 @@ jobs:
       matrix:
         goos: [linux]
         goarch: ["arm", "arm64", "386", "amd64"]
-        go: [ "1.18.1" ]
+        go: [ "1.18.3" ]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -235,7 +235,7 @@ jobs:
       matrix:
         goos: [ darwin ]
         goarch: [ "amd64", "arm64" ]
-        go: [ "1.18.1" ]
+        go: [ "1.18.3" ]
       fail-fast: true
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
 

--- a/ci/goinstall.sh
+++ b/ci/goinstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION="1.18.1"
+VERSION="1.18.3"
 
 [ -z "$GOROOT" ] && GOROOT="$HOME/.go"
 [ -z "$GOPATH" ] && GOPATH="$HOME/go"

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -95,9 +95,9 @@ func Open(dbType DbType, connectionUrl string, opt ...Option) (*DB, error) {
 		wrappedOpts = append(wrappedOpts, dbw.WithLogger(opts.withGormFormatter))
 	}
 	if opts.withMaxOpenConnections > 0 {
-        if opts.withMaxOpenConnections < 5 {
-		    return nil, fmt.Errorf("max_open_connections cannot be below 5")
-        }
+		if opts.withMaxOpenConnections < 5 {
+			return nil, fmt.Errorf("max_open_connections cannot be below 5")
+		}
 		wrappedOpts = append(wrappedOpts, dbw.WithMaxOpenConnections(opts.withMaxOpenConnections))
 	}
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -22,7 +22,7 @@ func TestOpen(t *testing.T) {
 	type args struct {
 		dbType        DbType
 		connectionUrl string
-        opt []Option
+		opt           []Option
 	}
 	tests := []struct {
 		name    string
@@ -50,7 +50,7 @@ func TestOpen(t *testing.T) {
 			args: args{
 				dbType:        Postgres,
 				connectionUrl: "",
-                opt: []Option{WithMaxOpenConnections(3)},
+				opt:           []Option{WithMaxOpenConnections(3)},
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
Go 1.18.3 has some security patches over 1.18.1.

See https://go.dev/doc/devel/release#go1.18.minor