### PR TITLE
Clarify audit logging file sink doc

### DIFF
--- a/website/content/docs/configuration/events/file.mdx
+++ b/website/content/docs/configuration/events/file.mdx
@@ -16,7 +16,8 @@ sink {
     event_types = ["observation"]
     format = "cloudevents-json"
     file {
-      file_name = "file-name"
+      path = "/var/log/boundary"
+      file_name = "events.ndjson"
     }
   }
 ```
@@ -33,14 +34,14 @@ These parameters are shared across all sink types: [common sink parameters](/doc
 
 These parameters are only valid for a `file` sink.
 
-- `path` - Specifies the file path for the sink.
-
 - `file_name` - Specifies the file name for the sink.
 
-- `rotate_bytes` - Specifies the number of bytes that should trigger rotation of
+- `path` - Optionally specifies the file path for the sink.
+
+- `rotate_bytes` - Optionally specifies the number of bytes that should trigger rotation of
   a file sink.
 
-- `rotate_duration` - Specifies how often a file sink should be rotated.
+- `rotate_duration` - Optionally specifies how often a file sink should be rotated.
 
-- `rotate_max_files` - Specifies how many historical rotated files should be kept
+- `rotate_max_files` - Optionally specifies how many historical rotated files should be kept
   for a file sink.

--- a/website/content/docs/configuration/events/overview.mdx
+++ b/website/content/docs/configuration/events/overview.mdx
@@ -27,7 +27,8 @@ events {
     event_types = ["observation"]
     format = "cloudevents-json"
     file {
-      file_name = "file-name"
+      path = "/var/log/boundary"
+      file_name = "events.ndjson"
     }
   }
 }


### PR DESCRIPTION
Including the "path" in the file example makes it clear that you need to use both of these.