### PR TITLE
fix(target): Correctly return egress credentials assocaited with target

### DIFF
--- a/internal/cmd/commands/targetscmd/funcs.go
+++ b/internal/cmd/commands/targetscmd/funcs.go
@@ -702,23 +702,6 @@ func printItemTable(result api.GenericResult) string {
 	}
 
 	var credentialSourceMaps map[credential.Purpose][]map[string]interface{}
-	if len(item.ApplicationCredentialSources) > 0 {
-		if credentialSourceMaps == nil {
-			credentialSourceMaps = make(map[credential.Purpose][]map[string]interface{})
-		}
-		var applicationCredentialSourceMaps []map[string]interface{}
-		for _, lib := range item.ApplicationCredentialSources {
-			m := map[string]interface{}{
-				"ID":                  lib.Id,
-				"Credential Store ID": lib.CredentialStoreId,
-			}
-			applicationCredentialSourceMaps = append(applicationCredentialSourceMaps, m)
-		}
-		credentialSourceMaps[credential.ApplicationPurpose] = applicationCredentialSourceMaps
-		if l := len("Credential Store ID"); l > maxLength {
-			maxLength = l
-		}
-	}
 	if len(item.ApplicationCredentialLibraries) > 0 {
 		if credentialSourceMaps == nil {
 			credentialSourceMaps = make(map[credential.Purpose][]map[string]interface{})
@@ -732,6 +715,40 @@ func printItemTable(result api.GenericResult) string {
 			applicationCredentialSourceMaps = append(applicationCredentialSourceMaps, m)
 		}
 		credentialSourceMaps[credential.ApplicationPurpose] = applicationCredentialSourceMaps
+		if l := len("Credential Store ID"); l > maxLength {
+			maxLength = l
+		}
+	}
+	if len(item.ApplicationCredentialSources) > 0 {
+		if credentialSourceMaps == nil {
+			credentialSourceMaps = make(map[credential.Purpose][]map[string]interface{})
+		}
+		var applicationCredentialSourceMaps []map[string]interface{}
+		for _, source := range item.ApplicationCredentialSources {
+			m := map[string]interface{}{
+				"ID":                  source.Id,
+				"Credential Store ID": source.CredentialStoreId,
+			}
+			applicationCredentialSourceMaps = append(applicationCredentialSourceMaps, m)
+		}
+		credentialSourceMaps[credential.ApplicationPurpose] = applicationCredentialSourceMaps
+		if l := len("Credential Store ID"); l > maxLength {
+			maxLength = l
+		}
+	}
+	if len(item.EgressCredentialSources) > 0 {
+		if credentialSourceMaps == nil {
+			credentialSourceMaps = make(map[credential.Purpose][]map[string]interface{})
+		}
+		var egressCredentialSourceMaps []map[string]interface{}
+		for _, source := range item.EgressCredentialSources {
+			m := map[string]interface{}{
+				"ID":                  source.Id,
+				"Credential Store ID": source.CredentialStoreId,
+			}
+			egressCredentialSourceMaps = append(egressCredentialSourceMaps, m)
+		}
+		credentialSourceMaps[credential.EgressPurpose] = egressCredentialSourceMaps
 		if l := len("Credential Store ID"); l > maxLength {
 			maxLength = l
 		}
@@ -775,17 +792,22 @@ func printItemTable(result api.GenericResult) string {
 		}
 	}
 
-	if len(credentialSourceMaps) > 0 {
-		if appMap := credentialSourceMaps[credential.ApplicationPurpose]; len(appMap) > 0 {
+	for purpose, sources := range credentialSourceMaps {
+		switch purpose {
+		case credential.ApplicationPurpose:
 			ret = append(ret,
 				"  Application Credential Sources:",
 			)
-			for _, m := range appMap {
-				ret = append(ret,
-					base.WrapMap(4, maxLength, m),
-					"",
-				)
-			}
+		case credential.EgressPurpose:
+			ret = append(ret,
+				"  Egress Credential Sources:",
+			)
+		}
+		for _, m := range sources {
+			ret = append(ret,
+				base.WrapMap(4, maxLength, m),
+				"",
+			)
 		}
 	}
 
@@ -951,8 +973,8 @@ func exampleOutput() string {
 				HostCatalogId: "hcst_1234567890",
 			},
 		},
-		ApplicationCredentialLibraryIds: []string{"clvlt_1234567890", "clvlt_0987654321"},
-		ApplicationCredentialLibraries: []*targets.CredentialLibrary{
+		ApplicationCredentialSourceIds: []string{"clvlt_1234567890", "clvlt_0987654321"},
+		ApplicationCredentialSources: []*targets.CredentialSource{
 			{
 				Id:                "clvlt_1234567890",
 				CredentialStoreId: "csvlt_1234567890",

--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -1631,45 +1631,56 @@ func toProto(ctx context.Context, in target.Target, hostSources []target.HostSou
 			})
 		}
 	}
-	if outputFields.Has(globals.ApplicationCredentialLibraryIdsField) {
-		for _, cs := range credSources {
-			out.ApplicationCredentialLibraryIds = append(out.ApplicationCredentialLibraryIds, cs.Id())
+
+	var appCredSources, egressCredSources []*pb.CredentialSource
+	var appCredSourceIds, egressCredSourceIds []string
+	var appCredLibraries []*pb.CredentialLibrary
+
+	for _, cs := range credSources {
+		switch cs.CredentialPurpose() {
+		case credential.ApplicationPurpose:
+			appCredSourceIds = append(appCredSourceIds, cs.Id())
+			appCredSources = append(appCredSources, &pb.CredentialSource{
+				Id:                cs.Id(),
+				CredentialStoreId: cs.CredentialStoreId(),
+			})
+
+			// ApplicationCredentialLibrariesField is deprecated and should only be populated
+			// for application purpose
+			appCredLibraries = append(appCredLibraries, &pb.CredentialLibrary{
+				Id:                cs.Id(),
+				CredentialStoreId: cs.CredentialStoreId(),
+			})
+
+		case credential.EgressPurpose:
+			egressCredSources = append(egressCredSources, &pb.CredentialSource{
+				Id:                cs.Id(),
+				CredentialStoreId: cs.CredentialStoreId(),
+			})
+			egressCredSourceIds = append(egressCredSourceIds, cs.Id())
+
+		default:
+			return nil, errors.New(ctx, errors.Internal, op, fmt.Sprintf("unrecognized purpose %q for credential source on target", cs.CredentialPurpose()))
 		}
+	}
+
+	if outputFields.Has(globals.ApplicationCredentialLibraryIdsField) {
+		out.ApplicationCredentialLibraryIds = appCredSourceIds
 	}
 	if outputFields.Has(globals.ApplicationCredentialSourceIdsField) {
-		for _, cs := range credSources {
-			out.ApplicationCredentialSourceIds = append(out.ApplicationCredentialSourceIds, cs.Id())
-		}
+		out.ApplicationCredentialSourceIds = appCredSourceIds
 	}
 	if outputFields.Has(globals.ApplicationCredentialLibrariesField) {
-		for _, cs := range credSources {
-			switch credential.Purpose(cs.CredentialPurpose()) {
-			case credential.ApplicationPurpose:
-				out.ApplicationCredentialLibraries = append(out.ApplicationCredentialLibraries, &pb.CredentialLibrary{
-					Id:                cs.Id(),
-					CredentialStoreId: cs.CredentialStoreId(),
-				})
-			case credential.IngressPurpose, credential.EgressPurpose:
-				// TODO: When we support other purposes add them to different fields here.
-			default:
-				return nil, errors.New(ctx, errors.Internal, op, fmt.Sprintf("unrecognized purpose %q for credential source on target", cs.CredentialPurpose()))
-			}
-		}
+		out.ApplicationCredentialLibraries = appCredLibraries
 	}
 	if outputFields.Has(globals.ApplicationCredentialSourcesField) {
-		for _, cs := range credSources {
-			switch credential.Purpose(cs.CredentialPurpose()) {
-			case credential.ApplicationPurpose:
-				out.ApplicationCredentialSources = append(out.ApplicationCredentialSources, &pb.CredentialSource{
-					Id:                cs.Id(),
-					CredentialStoreId: cs.CredentialStoreId(),
-				})
-			case credential.IngressPurpose, credential.EgressPurpose:
-				// TODO: When we support other purposes add them to different fields here.
-			default:
-				return nil, errors.New(ctx, errors.Internal, op, fmt.Sprintf("unrecognized purpose %q for credential source on target", cs.CredentialPurpose()))
-			}
-		}
+		out.ApplicationCredentialSources = appCredSources
+	}
+	if outputFields.Has(globals.EgressCredentialSourceIdsField) {
+		out.EgressCredentialSourceIds = egressCredSourceIds
+	}
+	if outputFields.Has(globals.EgressCredentialSourcesField) {
+		out.EgressCredentialSources = egressCredSources
 	}
 	if outputFields.Has(globals.AttributesField) {
 		if err := subtypeRegistry.setAttributes(in.GetType(), in, &out); err != nil {


### PR DESCRIPTION
Validated manually as well (note I removed the checks to stop egress credential on TCP for validation):

```
boundary targets read -id ttcp_1234567890

Target information:
  Created Time:               Thu, 09 Jun 2022 16:59:29 PDT
  Description:                Provides an initial target in Boundary
  ID:                         ttcp_1234567890
  Name:                       Generated target
  Session Connection Limit:   -1
  Session Max Seconds:        28800
  Type:                       tcp
  Updated Time:               Thu, 09 Jun 2022 16:59:49 PDT
  Version:                    4

  Scope:
    ID:                       p_1234567890
    Name:                     Generated project scope
    Parent Scope ID:          o_1234567890
    Type:                     project

  Authorized Actions:
    no-op
    read
    update
    delete
    add-host-sets
    set-host-sets
    remove-host-sets
    add-host-sources
    set-host-sources
    remove-host-sources
    add-credential-libraries
    set-credential-libraries
    remove-credential-libraries
    add-credential-sources
    set-credential-sources
    remove-credential-sources
    authorize-session

  Host Sources:
    Host Catalog ID:          hcst_1234567890
    ID:                       hsst_1234567890

  Application Credential Sources:
    Credential Store ID:      cs_79ElccRW6U
    ID:                       cred_k6WoKHTwZt

  Egress Credential Sources:
    Credential Store ID:      cs_79ElccRW6U
    ID:                       cred_k6WoKHTwZt

  Attributes:
    Default Port:             22
```

Outout as JSON
```
$ boundary targets read -id ttcp_1234567890 -format=json | jq .
{
  "status_code": 200,
  "item": {
    "id": "ttcp_1234567890",
    "scope_id": "p_1234567890",
    "scope": {
      "id": "p_1234567890",
      "type": "project",
      "name": "Generated project scope",
      "description": "Provides an initial project scope in Boundary",
      "parent_scope_id": "o_1234567890"
    },
    "name": "Generated target",
    "description": "Provides an initial target in Boundary",
    "created_time": "2022-06-09T23:59:29.898639Z",
    "updated_time": "2022-06-09T23:59:49.304727Z",
    "version": 4,
    "type": "tcp",
    "host_set_ids": [
      "hsst_1234567890"
    ],
    "host_sets": [
      {
        "id": "hsst_1234567890",
        "host_catalog_id": "hcst_1234567890"
      }
    ],
    "host_source_ids": [
      "hsst_1234567890"
    ],
    "host_sources": [
      {
        "id": "hsst_1234567890",
        "host_catalog_id": "hcst_1234567890"
      }
    ],
    "session_max_seconds": 28800,
    "session_connection_limit": -1,
    "application_credential_source_ids": [
      "cred_k6WoKHTwZt"
    ],
    "application_credential_sources": [
      {
        "id": "cred_k6WoKHTwZt",
        "credential_store_id": "cs_79ElccRW6U"
      }
    ],
    "egress_credential_source_ids": [
      "cred_k6WoKHTwZt"
    ],
    "egress_credential_sources": [
      {
        "id": "cred_k6WoKHTwZt",
        "credential_store_id": "cs_79ElccRW6U"
      }
    ],
    "attributes": {
      "default_port": 22
    },
    "authorized_actions": [
      "no-op",
      "read",
      "update",
      "delete",
      "add-host-sets",
      "set-host-sets",
      "remove-host-sets",
      "add-host-sources",
      "set-host-sources",
      "remove-host-sources",
      "add-credential-libraries",
      "set-credential-libraries",
      "remove-credential-libraries",
      "add-credential-sources",
      "set-credential-sources",
      "remove-credential-sources",
      "authorize-session"
    ]
  }
}
```