### PR TITLE
(test) added more context to error details for cli commands

### DIFF
--- a/internal/tests/api/accounts/account_test.go
+++ b/internal/tests/api/accounts/account_test.go
@@ -398,5 +398,14 @@ func TestErrorsOidc(t *testing.T) {
 		accounts.WithPasswordAccountLoginName("foo"),
 	)
 	require.Error(err)
-	require.JSONEq(err.Error(), `{"kind":"InvalidArgument", "message":"Error in provided request.", "details":{"request_fields":[{"name":"attributes", "description":"Attribute fields do not match the expected format."}]}}`)
+	require.JSONEq(err.Error(), `{
+		"details": {
+			"request_fields": [{
+				"description": "Attribute fields do not match the expected format: unknown field \"login_name\".",
+				"name": "attributes"
+			}]
+		},
+		"kind": "InvalidArgument",
+		"message": "Error in provided request."
+	}`)
 }


### PR DESCRIPTION
### Issue:

[Issue-4694](https://hashicorp.atlassian.net/browse/ICU-4694)

### Summary:

If I invoke the command:

`boundary authenticate password -auth-method-id ampwd_1234567890 -login-name admin -password password`

this is the error output:

```
Error from controller when performing authentication

Error information:
  Kind:                InvalidArgument
  Message:             Error in provided request.
  Status:              400
  context:             Error from controller when performing authentication

  Field-specific Errors:
    Name:              -attributes
      Error:           Attribute fields do not match the expected format.
```

The real issue is that the prefix `ampwd` is not an existing sub-type for auth methods. The problem is that the error response does not make this intent clear to the user.

### Bug Fix:
 
Here is how the error message looks now after updating the interceptor code.

```
Error from controller when performing authentication

Error information:
  Kind:                InvalidArgument
  Message:             Error in provided request.
  Status:              400
  context:             Error from controller when performing authentication

  Field-specific Errors:
    Name:              -attributes
      Error:           Attribute fields do not match the expected format: unknown auth method subtype in ID "ampwd_1234567890".
```

### Concerns:

After looking at a good chunk of the code, it seems safe to assume that the return error messages will follow the same format. 

Generic Example: `{key}: {value}` Where key is the operation details and the value is the error details.

Example From The Command Invoked In This PR:
`authmethod.transformAuthenticateRequestAttributes: unknown auth method subtype in ID "ampwd_1234567890"`

In the case where the error message does not follow the expected key value format, I returned the full error message as shown above.

