### PR TITLE
feat(config): Add database config options for idle connection management

### DIFF
--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -410,6 +410,8 @@ func (c *Command) Run(args []string) int {
 			return base.CommandUserError
 		}
 		c.DatabaseMaxOpenConnections = c.Config.Controller.Database.MaxOpenConnections
+		c.DatabaseMaxIdleConnections = c.Config.Controller.Database.MaxIdleConnections
+		c.DatabaseConnMaxIdleTimeDuration = c.Config.Controller.Database.ConnMaxIdleTimeDuration
 
 		if err := c.ConnectToDatabase(c.Context, "postgres"); err != nil {
 			c.UI.Error(fmt.Errorf("Error connecting to database: %w", err).Error())

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -77,7 +77,7 @@ func (d *DB) Close(ctx context.Context) error {
 // Note: Consider if you need to call Close() on the returned DB.  Typically the
 // answer is no, but there are occasions when it's necessary.  See the sql.DB
 // docs for more information.
-func Open(dbType DbType, connectionUrl string, opt ...Option) (*DB, error) {
+func Open(ctx context.Context, dbType DbType, connectionUrl string, opt ...Option) (*DB, error) {
 	const op = "db.Open"
 	var dialect dbw.Dialector
 	switch dbType {
@@ -105,5 +105,19 @@ func Open(dbType DbType, connectionUrl string, opt ...Option) (*DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
+
+	sdb, err := wrapped.SqlDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.withMaxIdleConnections != nil {
+		sdb.SetMaxIdleConns(*opts.withMaxIdleConnections)
+	}
+
+	if opts.withConnMaxIdleTimeDuration != nil {
+		sdb.SetConnMaxIdleTime(*opts.withConnMaxIdleTimeDuration)
+	}
+
 	return &DB{wrapped: wrapped}, nil
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -57,7 +57,7 @@ func TestOpen(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := Open(tt.args.dbType, tt.args.connectionUrl)
+			got, err := Open(ctx, tt.args.dbType, tt.args.connectionUrl)
 			defer func() {
 				if err == nil {
 					sqlDB, err := got.SqlDB(ctx)

--- a/internal/db/option.go
+++ b/internal/db/option.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/oplog"
@@ -166,8 +167,10 @@ type Options struct {
 	// withPrngValues is used to switch the ID generation to a pseudo-random mode
 	withPrngValues []string
 
-	withGormFormatter      hclog.Logger
-	withMaxOpenConnections int
+	withGormFormatter           hclog.Logger
+	withMaxOpenConnections      int
+	withMaxIdleConnections      *int
+	withConnMaxIdleTimeDuration *time.Duration
 
 	// withDebug indicates that the given operation should invoke Gorm's debug
 	// mode
@@ -189,11 +192,13 @@ func getDefaultOptions() Options {
 			wrapper:  nil,
 			metadata: oplog.Metadata{},
 		},
-		withLookup:         false,
-		WithFieldMaskPaths: []string{},
-		WithNullPaths:      []string{},
-		WithLimit:          0,
-		WithVersion:        nil,
+		withLookup:                  false,
+		WithFieldMaskPaths:          []string{},
+		WithNullPaths:               []string{},
+		WithLimit:                   0,
+		WithVersion:                 nil,
+		withMaxIdleConnections:      nil,
+		withConnMaxIdleTimeDuration: nil,
 	}
 }
 
@@ -306,11 +311,29 @@ func WithGormFormatter(l hclog.Logger) Option {
 	}
 }
 
-// WithMaxOpenConnections specifices and optional max open connections for the
+// WithMaxOpenConnections specifies an optional max open connections for the
 // database
 func WithMaxOpenConnections(max int) Option {
 	return func(o *Options) {
 		o.withMaxOpenConnections = max
+	}
+}
+
+// WithMaxIdleConnections specifies an optional max idle connections for the
+// database.
+// This corresponds with: https://pkg.go.dev/database/sql#DB.SetMaxIdleConns
+func WithMaxIdleConnections(max *int) Option {
+	return func(o *Options) {
+		o.withMaxIdleConnections = max
+	}
+}
+
+// WithConnMaxIdleTimeDuration specifies an optional connection max idle time
+// for the database.
+// This corresponds with: https://pkg.go.dev/database/sql#DB.SetConnMaxIdleTime
+func WithConnMaxIdleTimeDuration(max *time.Duration) Option {
+	return func(o *Options) {
+		o.withConnMaxIdleTimeDuration = max
 	}
 }
 

--- a/internal/db/option_test.go
+++ b/internal/db/option_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/boundary/internal/oplog"
 	"github.com/hashicorp/go-hclog"
@@ -190,6 +191,26 @@ func Test_getOpts(t *testing.T) {
 		assert.Equal(opts, testOpts)
 		opts = GetOpts(WithMaxOpenConnections(22))
 		testOpts.withMaxOpenConnections = 22
+		assert.Equal(opts, testOpts)
+	})
+	t.Run("WithMaxIdleConnections", func(t *testing.T) {
+		assert := assert.New(t)
+		opts := GetOpts()
+		testOpts := getDefaultOptions()
+		assert.Equal(opts, testOpts)
+		ic := 22
+		opts = GetOpts(WithMaxIdleConnections(&ic))
+		testOpts.withMaxIdleConnections = &ic
+		assert.Equal(opts, testOpts)
+	})
+	t.Run("WithConnMaxIdleTimeDuration", func(t *testing.T) {
+		assert := assert.New(t)
+		opts := GetOpts()
+		testOpts := getDefaultOptions()
+		assert.Equal(opts, testOpts)
+		d := time.Minute * 5
+		opts = GetOpts(WithConnMaxIdleTimeDuration(&d))
+		testOpts.withConnMaxIdleTimeDuration = &d
 		assert.Equal(opts, testOpts)
 	})
 	t.Run("WithDebug", func(t *testing.T) {

--- a/internal/db/schema/migrations/oss/postgres_26_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_26_01_test.go
@@ -55,7 +55,7 @@ func TestMigrations_WareHouse_HostAddresses(t *testing.T) {
 	// get a connection
 	dbType, err := db.StringToDbType(dialect)
 	require.NoError(t, err)
-	conn, err := db.Open(dbType, u)
+	conn, err := db.Open(ctx, dbType, u)
 	require.NoError(t, err)
 	rw := db.New(conn)
 

--- a/internal/db/schema/migrations/oss/postgres_30_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_30_01_test.go
@@ -58,7 +58,7 @@ func TestMigrations_KMS_Refactor(t *testing.T) {
 	// get a connection
 	dbType, err := db.StringToDbType(dialect)
 	require.NoError(t, err)
-	conn, err := db.Open(dbType, u)
+	conn, err := db.Open(ctx, dbType, u)
 	require.NoError(t, err)
 	rw := db.New(conn)
 
@@ -97,7 +97,7 @@ func TestMigrations_KMS_Refactor(t *testing.T) {
 		// get a new connection
 		dbType, err := db.StringToDbType(dialect)
 		require.NoError(t, err)
-		conn, err := db.Open(dbType, u)
+		conn, err := db.Open(ctx, dbType, u)
 		require.NoError(t, err)
 		rw := db.New(conn)
 

--- a/internal/db/schema/migrations/oss/postgres_32_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_32_01_test.go
@@ -57,7 +57,7 @@ func TestMigrations_user_password_Migration(t *testing.T) {
 	// get a connection
 	dbType, err := db.StringToDbType(dialect)
 	require.NoError(t, err)
-	conn, err := db.Open(dbType, u)
+	conn, err := db.Open(ctx, dbType, u)
 	require.NoError(t, err)
 	rw := db.New(conn)
 

--- a/internal/db/testing.go
+++ b/internal/db/testing.go
@@ -58,7 +58,7 @@ func TestSetup(t testing.TB, dialect string, opt ...TestOption) (*DB, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db, err := Open(dbType, url)
+	db, err := Open(ctx, dbType, url)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/website/content/docs/configuration/controller.mdx
+++ b/website/content/docs/configuration/controller.mdx
@@ -35,18 +35,41 @@ description will be read.
     Boundary will not be able to connect by default. To run Boundary without a TLS connection
     to Postgres (not recommended for production usage), add the `sslmode=disable` parameter to
     your connection string, such as `url = "postgresql://postgres:boundary@192.168.1.1:5432/boundary?sslmode=disable"`
+    This value can refer to a file on disk (file://) from which a URL will be read; an env
+    var (env://) from which the URL will be read; or a direct database URL (postgres://).
   - `migration_url` - Can be used to specify a different URL for migrations, as that
     usually requires higher privileges.
+    This value can refer to a file on disk (file://) from which a URL will be read; an env
+    var (env://) from which the URL will be read; or a direct database URL (postgres://).
   - `max_open_connections` - Can be used to control the maximum number of
     connections that can be opened by the controller.
     The minimum number of connections required is 5.
-    Setting this value to 0 will allow the controller to open as many
-    connections as needed. This value can be a string representing the max number of connections, can refer to a file
-    on disk (file://) from which the number of connections will be read; or an env var (env://) from which the
-    number of connections will be read.
-
-  Either URL can refer to a file on disk (file://) from which a URL will be read; an env
-  var (env://) from which the URL will be read; or a direct database URL (postgres://).
+    Setting this value to 0 will allow the controller to open as many connections as needed.
+    This value can be a string or an integer representing the max number of connections,
+    or a string that can refer to a file
+    on disk (file://) from which the number of connections will be read,
+    or an env var (env://) from which the number of connections will be read.
+  - `max_idle_connections` - Can be used to control the maximum number of
+    idle connections in the idle connection pool.
+    If `max_open_connections` is greater than 0 but less than
+    `max_idle_connections`, then `max_idle_connections` will be reduced to match the `max_open_connections` limit. 
+    Setting this value to 0 will mean that no idle connections are retained.
+    If not set or set to less than 0, the default
+    [sql.DB](https://pkg.go.dev/database/sql#DB.SetMaxIdleConns) setting will be used.
+    This value can be a string or an integer representing the max number of connections,
+    or a string that can refer to a file on disk (file://) from which the number of connections will be read,
+    or an env var (env://) from which the number of connections will be read.
+  - `max_idle_time` - Can be used to control the maximum amount of time
+    a connection may be idle.
+    Setting this value to 0 will mean that connections are not closed due to a
+    connections idle time.
+    If not set or set to less than 0, the default
+    [sql.DB](https://pkg.go.dev/database/sql#DB.SetConnMaxIdleTime) setting will be used.
+    This value can be a string representing the duration,
+    or a string that can refer to a file on disk (file://) from which the duration will be read,
+    or an env var (env://) from which the duration will be read.
+    Valid time units are anything specified by Golang's
+    [ParseDuration()](https://golang.org/pkg/time/#ParseDuration) method.
 
 - `public_cluster_addr` - Specifies the public host or IP address (and
   optionally port) at which the controller can be reached _by workers_. This will


### PR DESCRIPTION
This adds two new config options for the `database` stanza:

- `max_idle_connections`
- `max_idle_time`

These correspond to settings for the underlying `sql.DB` instance. They
can be used to have finer control over the controller's database
connection pool. For example this can be used to mitigate the high
connection overhead when connecting to postgres by setting a high
`max_idle_connections` and either setting `max_idle_time` to zero or to
a high duration.

Alternatively, if using a connection pool like pgpool-II or pgbouncer,
`max_idle_connections` can be set to 0.

See:
    https://pkg.go.dev/database/sql#DB.SetMaxIdleConns
    https://pkg.go.dev/database/sql#DB.SetConnMaxIdleTime
    https://www.pgpool.net/mediawiki/index.php/Main_Page
    https://www.pgbouncer.org/