### PR TITLE
Propagate plugin execution dir to CreatePlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   See Deprecations/Changes for some additional details.
   [PR](https://github.com/hashicorp/boundary/pull/2160).
 
+### Bug Fixes
+
+* The plugin execution_dir configuration parameter is now respected.
+  [PR](https://github.com/hashicorp/boundary/pull/2183).
+
 ### Deprecations/Changes
 
 * Credential Libraries: The `user_password` credential type has been renamed to

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -555,6 +555,7 @@ func (b *Server) SetupKMSes(ctx context.Context, ui cli.Ui, config *config.Confi
 				configutil.WithPluginOptions(
 					pluginutil.WithPluginsMap(kms_plugin_assets.BuiltinKmsPlugins()),
 					pluginutil.WithPluginsFilesystem(kms_plugin_assets.KmsPluginPrefix, kms_plugin_assets.FileSystem()),
+					pluginutil.WithPluginExecutionDirectory(config.Plugins.ExecutionDir),
 				),
 				configutil.WithLogger(pluginLogger.Named(kms.Type).With("purpose", purpose)),
 			)

--- a/sdk/plugins/host/load.go
+++ b/sdk/plugins/host/load.go
@@ -60,7 +60,7 @@ func CreateHostPlugin(
 	}
 
 	// Create the plugin and cleanup func
-	plugClient, cleanup, err := pluginutil.CreatePlugin(pluginMap[pluginType])
+	plugClient, cleanup, err := pluginutil.CreatePlugin(pluginMap[pluginType], opts.withPluginOptions...)
 	if err != nil {
 		return nil, cleanup, err
 	}

--- a/sdk/wrapper/wrapper.go
+++ b/sdk/wrapper/wrapper.go
@@ -3,16 +3,42 @@ package wrapper
 import (
 	"context"
 	"fmt"
+	"os"
 
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	configutil "github.com/hashicorp/go-secure-stdlib/configutil/v2"
+	"github.com/hashicorp/go-secure-stdlib/pluginutil/v2"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
+	"github.com/hashicorp/hcl"
 )
+
+// pluginsConfig is used to pre-parse any plugins stanza
+// in the configuration file, so that we can use the correct
+// configuration when creating the KMS plugin for reading the
+// rest of the config.
+type pluginsConfig struct {
+	Plugins struct {
+		ExecutionDir string `hcl:"execution_dir"`
+	} `hcl:"plugins"`
+}
 
 func GetWrapperFromPath(ctx context.Context, path, purpose string, opt ...configutil.Option) (wrapping.Wrapper, func() error, error) {
 	kmses, err := configutil.LoadConfigKMSes(path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error parsing config file: %w", err)
+	}
+	hclBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error reading config file: %w", err)
+	}
+	pluginsConfig, err := parsePluginsConfig(string(hclBytes))
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error parsing plugins stanza in config file: %w", err)
+	}
+	if pluginsConfig.Plugins.ExecutionDir != "" {
+		// Note, this is safe to use because configutil.WithPluginOptions invocations
+		// are additive with each other.
+		opt = append(opt, configutil.WithPluginOptions(pluginutil.WithPluginExecutionDirectory(pluginsConfig.Plugins.ExecutionDir)))
 	}
 
 	return getWrapper(ctx, kmses, purpose, opt...)
@@ -22,6 +48,15 @@ func GetWrapperFromHcl(ctx context.Context, inHcl, purpose string, opt ...config
 	kmses, err := configutil.ParseKMSes(inHcl)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error parsing KMS HCL: %w", err)
+	}
+	pluginsConfig, err := parsePluginsConfig(inHcl)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error parsing plugins stanza in config file: %w", err)
+	}
+	if pluginsConfig.Plugins.ExecutionDir != "" {
+		// Note, this is safe to use because configutil.WithPluginOptions invocations
+		// are additive with each other.
+		opt = append(opt, configutil.WithPluginOptions(pluginutil.WithPluginExecutionDirectory(pluginsConfig.Plugins.ExecutionDir)))
 	}
 
 	return getWrapper(ctx, kmses, purpose, opt...)
@@ -53,4 +88,12 @@ func getWrapper(ctx context.Context, kmses []*configutil.KMS, purpose string, op
 	}
 
 	return wrapper, cleanup, nil
+}
+
+func parsePluginsConfig(inHcl string) (*pluginsConfig, error) {
+	var conf pluginsConfig
+	if err := hcl.Decode(&conf, inHcl); err != nil {
+		return nil, err
+	}
+	return &conf, nil
 }


### PR DESCRIPTION
## [fix: Propagate plugin options to CreatePlugin](https://github.com/hashicorp/boundary/pull/2183/commits/4fb90e069237a322af0fa8b74357d8d86a45f58d)

Plugin options were previously only applied to the
BuildPluginMap call, resulting in the plugin
execution_dir variable being ineffective.

Also add a test to verify functionality

## [fix: Support plugin execution_dir for all plugins](https://github.com/hashicorp/boundary/pull/2183/commits/ae912db88c8802e05d1b5ff0d2169d07cdeee052)

Previously, only external host plugins would respect
the plugin execution dir. Now, all uses of the embedded
plugins respect the configuration.