### PR TITLE
cli(workers): Add extra help func

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1030,6 +1030,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 			}, nil
 		},
 
+		"workers": func() (cli.Command, error) {
+			return &workerscmd.Command{
+				Command: base.NewCommand(ui),
+			}, nil
+		},
 		"workers create": func() (cli.Command, error) {
 			return &workerscmd.Command{
 				Command: base.NewCommand(ui),

--- a/internal/cmd/commands/workerscmd/funcs.go
+++ b/internal/cmd/commands/workerscmd/funcs.go
@@ -9,6 +9,27 @@ import (
 	"github.com/hashicorp/boundary/internal/cmd/base"
 )
 
+func (c *Command) extraHelpFunc(helpMap map[string]func() string) string {
+	var helpStr string
+	switch c.Func {
+	case "":
+		return base.WrapForHelpText([]string{
+			"Usage: boundary workers [sub command] [options] [args]",
+			"",
+			"  This command allows operations on Boundary worker resources. Example:",
+			"",
+			"    Read a worker:",
+			"",
+			`      $ boundary workers read -id w_1234567890`,
+			"",
+			"  Please see the workers subcommand help for detailed usage information.",
+		})
+	default:
+		helpStr = helpMap[c.Func]()
+	}
+	return helpStr + c.Flags().Help()
+}
+
 func (c *Command) printListTable(items []*workers.Worker) string {
 	if len(items) == 0 {
 		return "No workers found"

--- a/internal/cmd/commands/workerscmd/workers.gen.go
+++ b/internal/cmd/commands/workerscmd/workers.gen.go
@@ -79,7 +79,7 @@ func (c *Command) Help() string {
 
 	default:
 
-		helpStr = helpMap["base"]()
+		helpStr = c.extraHelpFunc(helpMap)
 
 	}
 

--- a/internal/cmd/common/help.go
+++ b/internal/cmd/common/help.go
@@ -38,6 +38,7 @@ func HelpMap(resType string) map[string]func() string {
 		resource.Host.String():        "h",
 		resource.Session.String():     "s",
 		resource.Target.String():      "t",
+		resource.Worker.String():      "w",
 	}
 	return map[string]func() string{
 		"base": func() string {

--- a/internal/cmd/gencli/input.go
+++ b/internal/cmd/gencli/input.go
@@ -458,6 +458,7 @@ var inputStructs = map[string][]*cmdInfo{
 			ResourceType:     resource.Worker.String(),
 			Pkg:              "workers",
 			StdActions:       []string{"read", "update", "delete", "list"},
+			HasExtraHelpFunc: true,
 			HasId:            true,
 			Container:        "Scope",
 			HasName:          true,


### PR DESCRIPTION
Current output of `boundary --help` 
<img width="681" alt="Screen Shot 2022-06-15 at 9 57 24 AM" src="https://user-images.githubusercontent.com/3497566/173850393-fdf47603-5da1-42cf-80f8-8f62747711ef.png">

Comparison of `boundary workers --help` vs `boundary hosts --help`

<img width="652" alt="Screen Shot 2022-06-15 at 9 58 01 AM" src="https://user-images.githubusercontent.com/3497566/173850634-c326c5bc-6ec2-407e-997e-ad732fecf4b3.png">


CLI after changes in this PR- `boundary --help`  has a value populated for workers, and `boundary workers --help` has an example
<img width="687" alt="Screen Shot 2022-06-15 at 10 17 29 AM" src="https://user-images.githubusercontent.com/3497566/173850811-f354900e-7f28-4144-ab16-6a22cc1c61e0.png">

