### PR TITLE
Fix eventing and worker name setup

### DIFF
--- a/internal/cmd/commands/database/init.go
+++ b/internal/cmd/commands/database/init.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/cmd/base"
@@ -191,17 +192,12 @@ func (c *InitCommand) Run(args []string) (retCode int) {
 		return base.CommandCliError
 	}
 
-	var serverName string
-	switch {
-	case c.Config.Controller == nil:
-		serverName = "boundary-database-init"
-	default:
-		if _, err := c.Config.Controller.InitNameIfEmpty(); err != nil {
-			c.UI.Error(err.Error())
-			return base.CommandCliError
-		}
-		serverName = c.Config.Controller.Name + "/boundary-database-init"
+	serverName, err := os.Hostname()
+	if err != nil {
+		c.UI.Error(fmt.Errorf("Unable to determine hostname: %w", err).Error())
+		return base.CommandCliError
 	}
+	serverName = fmt.Sprintf("%s/boundary-database-init", serverName)
 	if err := c.SetupEventing(c.Logger, c.StderrLock, serverName, base.WithEventerConfig(c.Config.Eventing)); err != nil {
 		c.UI.Error(err.Error())
 		return base.CommandCliError

--- a/internal/cmd/commands/database/migrate.go
+++ b/internal/cmd/commands/database/migrate.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/cmd/base"
@@ -148,17 +149,13 @@ func (c *MigrateCommand) Run(args []string) (retCode int) {
 		c.UI.Error(err.Error())
 		return base.CommandCliError
 	}
-	var serverName string
-	switch {
-	case c.Config.Controller == nil:
-		serverName = "boundary-database-migrate"
-	default:
-		if _, err := c.Config.Controller.InitNameIfEmpty(); err != nil {
-			c.UI.Error(err.Error())
-			return base.CommandCliError
-		}
-		serverName = c.Config.Controller.Name + "/boundary-database-migrate"
+
+	serverName, err := os.Hostname()
+	if err != nil {
+		c.UI.Error(fmt.Errorf("Unable to determine hostname: %w", err).Error())
+		return base.CommandCliError
 	}
+	serverName = fmt.Sprintf("%s/boundary-database-migrate", serverName)
 	if err := c.srv.SetupEventing(
 		c.srv.Logger,
 		c.srv.StderrLock,

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -164,14 +164,21 @@ type Controller struct {
 	SchedulerRunJobInterval time.Duration `hcl:"-"`
 }
 
-func (c *Controller) InitNameIfEmpty() (string, error) {
+func (c *Controller) InitNameIfEmpty() error {
 	if c == nil {
-		return "", fmt.Errorf("controller config is empty")
+		return fmt.Errorf("controller config is empty")
 	}
-	if err := initNameIfEmpty(&c.Name); err != nil {
-		return "", fmt.Errorf("error auto-generating controller name: %w", err)
+	if c.Name != "" {
+		return nil
 	}
-	return c.Name, nil
+
+	var err error
+	c.Name, err = db.NewPublicId("c")
+	if err != nil {
+		return fmt.Errorf("error auto-generating controller name: %w", err)
+	}
+
+	return nil
 }
 
 type Worker struct {
@@ -205,27 +212,6 @@ type Worker struct {
 
 	// AuthStoragePath represents the location a worker stores its node credentials, if set
 	AuthStoragePath string `hcl:"auth_storage_path"`
-}
-
-func (w *Worker) InitNameIfEmpty() (string, error) {
-	if w == nil {
-		return "", fmt.Errorf("worker config is empty")
-	}
-	if err := initNameIfEmpty(&w.Name); err != nil {
-		return "", fmt.Errorf("error auto-generating worker name: %w", err)
-	}
-	return w.Name, nil
-}
-
-func initNameIfEmpty(name *string) error {
-	if *name == "" {
-		var err error
-		if *name, err = db.NewPublicId("w"); err != nil {
-			return err
-		}
-		*name = strings.ToLower(*name)
-	}
-	return nil
 }
 
 type Database struct {

--- a/internal/daemon/controller/controller.go
+++ b/internal/daemon/controller/controller.go
@@ -117,7 +117,7 @@ func New(ctx context.Context, conf *Config) (*Controller, error) {
 		conf.RawConfig.Controller = new(config.Controller)
 	}
 
-	if conf.RawConfig.Controller.Name, err = conf.RawConfig.Controller.InitNameIfEmpty(); err != nil {
+	if err := conf.RawConfig.Controller.InitNameIfEmpty(); err != nil {
 		return nil, fmt.Errorf("error auto-generating controller name: %w", err)
 	}
 

--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -542,10 +543,7 @@ func TestControllerConfig(t testing.TB, ctx context.Context, tc *TestController,
 		opts.Config.Controller = new(config.Controller)
 	}
 	if opts.Config.Controller.Name == "" {
-		opts.Config.Controller.Name, err = opts.Config.Controller.InitNameIfEmpty()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, opts.Config.Controller.InitNameIfEmpty())
 	}
 	opts.Config.Controller.SchedulerRunJobInterval = opts.SchedulerRunJobInterval
 
@@ -572,7 +570,13 @@ func TestControllerConfig(t testing.TB, ctx context.Context, tc *TestController,
 		tc.b.Eventer = e
 		event.TestWithoutEventing(t) // this ensures the sys eventer will also stop eventing
 	default:
-		if err := tc.b.SetupEventing(tc.b.Logger, tc.b.StderrLock, opts.Config.Controller.Name, base.WithEventerConfig(opts.Config.Eventing)); err != nil {
+
+		serverName, err := os.Hostname()
+		if err != nil {
+			t.Fatal(err)
+		}
+		serverName = fmt.Sprintf("%s/controller", serverName)
+		if err := tc.b.SetupEventing(tc.b.Logger, tc.b.StderrLock, serverName, base.WithEventerConfig(opts.Config.Eventing)); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/daemon/worker/testing.go
+++ b/internal/daemon/worker/testing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -230,7 +231,9 @@ func NewTestWorker(t testing.TB, opts *TestWorkerOpts) *TestWorker {
 		if err != nil {
 			t.Fatal(err)
 		}
-		opts.Config.Worker.Name = opts.Name
+		if opts.Name != "" {
+			opts.Config.Worker.Name = opts.Name
+		}
 	}
 
 	if len(opts.InitialUpstreams) > 0 {
@@ -251,18 +254,18 @@ func NewTestWorker(t testing.TB, opts *TestWorkerOpts) *TestWorker {
 	tw.b.SetStatusGracePeriodDuration(opts.StatusGracePeriodDuration)
 
 	if opts.Config.Worker == nil {
-		opts.Config.Worker = new(config.Worker)
-	}
-	if opts.Config.Worker.Name == "" {
-		opts.Config.Worker.Name, err = opts.Config.Worker.InitNameIfEmpty()
-		if err != nil {
-			t.Fatal(err)
+		opts.Config.Worker = &config.Worker{
+			Name: opts.Name,
 		}
-		event.WriteSysEvent(ctx, op, "worker name generated", "name", opts.Config.Worker.Name)
 	}
 	tw.name = opts.Config.Worker.Name
 
-	if err := tw.b.SetupEventing(tw.b.Logger, tw.b.StderrLock, opts.Config.Worker.Name, base.WithEventerConfig(opts.Config.Eventing)); err != nil {
+	serverName, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverName = fmt.Sprintf("%s/worker", serverName)
+	if err := tw.b.SetupEventing(tw.b.Logger, tw.b.StderrLock, serverName, base.WithEventerConfig(opts.Config.Eventing)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -126,11 +126,6 @@ func New(conf *Config) (*Worker, error) {
 		conf.SecureRandomReader = rand.Reader
 	}
 
-	var err error
-	if conf.RawConfig.Worker.Name, err = w.conf.RawConfig.Worker.InitNameIfEmpty(); err != nil {
-		return nil, fmt.Errorf("error auto-generating worker name: %w", err)
-	}
-
 	if !conf.RawConfig.DisableMlock {
 		// Ensure our memory usage is locked into physical RAM
 		if err := mlock.LockMemory(); err != nil {
@@ -168,6 +163,7 @@ func New(conf *Config) (*Worker, error) {
 		return nil, fmt.Errorf("exactly one proxy listener is required")
 	}
 
+	var err error
 	w.WorkerAuthStorage, err = nodeefile.New(w.baseContext,
 		nodeefile.WithBaseDirectory(w.conf.RawConfig.Worker.AuthStoragePath))
 	if err != nil {


### PR DESCRIPTION
* Don't automatically create worker names, as this is now invalid for
  PKI workers
* Fix a check in dev that clears out name/description in exactly the
  wrong cases
* Change eventing setup to use a hostname-based ID instead of the name
  (which could change on every start anyways)