### PR TITLE
Allow a worker to use KMS auth but accept PKI for proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require github.com/hashicorp/go-dbw v0.0.0-20220412153211-c470aec9369f // this i
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20220515130442-cac0b5ac133b
-	github.com/hashicorp/nodeenrollment v0.1.0
+	github.com/hashicorp/nodeenrollment v0.1.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -740,8 +740,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/nodeenrollment v0.1.0 h1:mhMVbrHM6NTDcpte/mOilP3Fd/HrcctshGs4/82EO6U=
-github.com/hashicorp/nodeenrollment v0.1.0/go.mod h1:LIPKi+g0g/vl3xhpbzugCalHSxX1PMeqnatkAsxRgyM=
+github.com/hashicorp/nodeenrollment v0.1.1 h1:tDR6UPJKrMDHAwLyeyFMRX5G2E1Hu6gi9/m1qrdXET0=
+github.com/hashicorp/nodeenrollment v0.1.1/go.mod h1:LIPKi+g0g/vl3xhpbzugCalHSxX1PMeqnatkAsxRgyM=
 github.com/hashicorp/vault/api v1.3.1 h1:pkDkcgTh47PRjY1NEFeofqR4W/HkNUi9qIakESO2aRM=
 github.com/hashicorp/vault/api v1.3.1/go.mod h1:QeJoWxMFt+MsuWcYhmwRLwKEXrjwAFFywzhptMsTIUw=
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -126,6 +126,10 @@ type Server struct {
 	DevTargetSessionConnectionLimit  int
 	DevLoopbackHostPluginId          string
 
+	// DevUsePkiForUpstream is a hint that we are in dev mode and have a worker
+	// auth KMS but want to use PKI for upstream connections
+	DevUsePkiForUpstream bool
+
 	EnabledPlugins []EnabledPlugin
 	HostPlugins    map[string]plgpb.HostPluginServiceClient
 

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -494,7 +494,7 @@ func (c *Command) Run(args []string) int {
 			return base.CommandCliError
 		}
 
-		if c.WorkerAuthKms == nil && c.worker.WorkerAuthRegistrationRequest != "" {
+		if c.worker.WorkerAuthRegistrationRequest != "" {
 			c.InfoKeys = append(c.InfoKeys, "worker auth registration request")
 			c.Info["worker auth registration request"] = c.worker.WorkerAuthRegistrationRequest
 			c.InfoKeys = append(c.InfoKeys, "worker auth current key id")
@@ -677,14 +677,6 @@ func (c *Command) StartWorker() error {
 		return fmt.Errorf("Error initializing worker: %w", err)
 	}
 
-	if c.WorkerAuthKms == nil {
-		if c.worker.WorkerAuthStorage == nil {
-			return fmt.Errorf("No worker auth KMS specified and no worker auth storage found")
-		}
-		c.InfoKeys = append(c.InfoKeys, "worker auth storage path")
-		c.Info["worker auth storage path"] = c.worker.WorkerAuthStorage.BaseDir()
-	}
-
 	if err := c.worker.Start(); err != nil {
 		retErr := fmt.Errorf("Error starting worker: %w", err)
 		if err := c.worker.Shutdown(); err != nil {
@@ -692,6 +684,14 @@ func (c *Command) StartWorker() error {
 			retErr = fmt.Errorf("Error shutting down worker: %w", err)
 		}
 		return retErr
+	}
+
+	if c.WorkerAuthKms == nil || c.DevUsePkiForUpstream {
+		if c.worker.WorkerAuthStorage == nil {
+			return fmt.Errorf("No worker auth storage found")
+		}
+		c.InfoKeys = append(c.InfoKeys, "worker auth storage path")
+		c.Info["worker auth storage path"] = c.worker.WorkerAuthStorage.BaseDir()
 	}
 
 	return nil

--- a/internal/daemon/worker/controller_connection.go
+++ b/internal/daemon/worker/controller_connection.go
@@ -84,7 +84,7 @@ func (w *Worker) controllerDialerFunc() func(context.Context, string) (net.Conn,
 		var conn net.Conn
 		var err error
 		switch {
-		case w.conf.WorkerAuthKms != nil:
+		case w.conf.WorkerAuthKms != nil && !w.conf.DevUsePkiForUpstream:
 			conn, err = w.v1KmsAuthDialFn(ctx, addr)
 		default:
 			conn, err = protocol.Dial(ctx, w.WorkerAuthStorage, addr, nodeenrollment.WithWrapper(w.conf.WorkerAuthStorageKms))

--- a/internal/daemon/worker/testing.go
+++ b/internal/daemon/worker/testing.go
@@ -258,6 +258,10 @@ func NewTestWorker(t testing.TB, opts *TestWorkerOpts) *TestWorker {
 			Name: opts.Name,
 		}
 	}
+	if opts.WorkerAuthStoragePath != "" {
+		opts.Config.Worker.AuthStoragePath = opts.WorkerAuthStoragePath
+		tw.b.DevUsePkiForUpstream = true
+	}
 	tw.name = opts.Config.Worker.Name
 
 	serverName, err := os.Hostname()


### PR DESCRIPTION
This essentially worked for non-dev mode before but would create storage
directories that weren't actually used or needed, and it didn't work in
dev mode because it made assumptions about the presence of a worker auth
kms or not. This fixes those behaviors.