### PR TITLE
bug(workers): KMS workers cannot be updated

### DIFF
--- a/internal/daemon/controller/handlers/workers/worker_service_test.go
+++ b/internal/daemon/controller/handlers/workers/worker_service_test.go
@@ -869,6 +869,7 @@ func TestUpdate_KMS(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req := proto.Clone(toMerge).(*pbs.UpdateWorkerRequest)
 			proto.Merge(req, tc.req)
+			req.Item.Version = wkr.GetVersion()
 			got, gErr := workerService.UpdateWorker(auth.DisabledAuthTestContext(iamRepoFn, scope.Global.String()), req)
 			assert.Error(t, gErr)
 			assert.Nil(t, got)
@@ -900,7 +901,7 @@ func TestUpdate_BadVersion(t *testing.T) {
 	workerService, err := NewService(ctx, repoFn, iamRepoFn)
 	require.NoError(t, err, "Failed to create a new host set service.")
 
-	wkr := servers.TestKmsWorker(t, conn, wrapper)
+	wkr := servers.TestPkiWorker(t, conn, wrapper)
 
 	upTar, err := workerService.UpdateWorker(auth.DisabledAuthTestContext(iamRepoFn, proj.GetPublicId()), &pbs.UpdateWorkerRequest{
 		Id: wkr.GetPublicId(),

--- a/internal/servers/testing.go
+++ b/internal/servers/testing.go
@@ -113,10 +113,12 @@ func TestKmsWorker(t *testing.T, conn *db.DB, wrapper wrapping.Wrapper, opt ...O
 	}
 	wrk := NewWorker(scope.Global.String(),
 		WithName(name),
-		WithAddress(address))
+		WithAddress(address),
+		WithDescription(opts.withDescription))
 	wrk, err = serversRepo.UpsertWorkerStatus(ctx, wrk)
 	require.NoError(t, err)
 	require.NotNil(t, wrk)
+	require.Equal(t, "kms", wrk.Type)
 
 	if len(opts.withWorkerTags) > 0 {
 		var tags []interface{}
@@ -130,18 +132,7 @@ func TestKmsWorker(t *testing.T, conn *db.DB, wrapper wrapping.Wrapper, opt ...O
 		}
 		require.NoError(t, rw.CreateItems(ctx, tags))
 	}
-	var mask []string
-	if opts.withDescription != "" {
-		wrk.Description = opts.withDescription
-		mask = append(mask, "description")
-	}
-	if len(mask) > 0 {
-		var n int
-		wrk, n, err = serversRepo.UpdateWorker(ctx, wrk, wrk.Version, mask)
-		require.NoError(t, err)
-		require.Equal(t, 1, n)
-		require.NotNil(t, wrk)
-	}
+
 	wrk, err = serversRepo.LookupWorker(ctx, wrk.GetPublicId())
 	require.NoError(t, err)
 	return wrk


### PR DESCRIPTION
- Removes description from upsert to prevent update_version_column trigger firing
- KMS workers are invalid for Update
- Fix tests