### PR TITLE
Fix harmless but nasty-looking error

### DIFF
--- a/internal/daemon/controller/controller.go
+++ b/internal/daemon/controller/controller.go
@@ -305,6 +305,17 @@ func New(ctx context.Context, conf *Config) (*Controller, error) {
 		return servers.NewRepositoryStorage(ctx, dbase, dbase, c.kms)
 	}
 
+	// Check that credentials are available at startup, to avoid some harmless
+	// but nasty-looking errors
+	serversRepo, err := servers.NewRepositoryStorage(ctx, dbase, dbase, c.kms)
+	if err != nil {
+		return nil, fmt.Errorf("unable to instantiate worker auth repository: %w", err)
+	}
+	err = servers.RotateRoots(ctx, serversRepo)
+	if err != nil {
+		return nil, fmt.Errorf("unable to ensure worker auth roots exist: %w", err)
+	}
+
 	return c, nil
 }
 


### PR DESCRIPTION
If a worker starts up and tries to connect to a controller before the
controller has a chance for its rotate roots job to run, it'll spit out
a nasty-looking error. It's harmless (things just retry and then work)
but scary (`tls: internal error`).

Rotating at creation time ensures that it's ready by the time a worker
is able to perform any connection against the cluster port.