### PR TITLE
fix actions-docker-build invocation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     # Sequence of patterns matched against refs/heads
-    branches:    
+    branches:
       # Push events on main branch
       - 'main'
 
@@ -60,7 +60,7 @@ jobs:
           project="$(go list -m)"
           sha="$(git rev-parse HEAD)"
           echo "::set-output name=ldflags::"-s -w -X \'$project/version.GitCommit=$sha\'""
-  
+
   get-product-edition:
     runs-on: ubuntu-latest
     outputs:
@@ -79,7 +79,7 @@ jobs:
 
 
   build-other:
-    needs: 
+    needs:
       - get-product-version
       - get-product-edition
       - set-ld-flags
@@ -140,7 +140,7 @@ jobs:
           path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
   build-linux:
-    needs: 
+    needs:
       - get-product-version
       - get-product-edition
       - set-ld-flags
@@ -226,7 +226,7 @@ jobs:
 
 
   build-darwin:
-    needs: 
+    needs:
       - get-product-version
       - get-product-edition
       - set-ld-flags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,6 @@ jobs:
           version: ${{ env.version }}
           target: default
           arch: ${{ matrix.arch }}
-          zip_artifact_name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
           tags: |
             docker.io/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
             public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.dockerversion }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: build
 
 on:
+  pull_request:
   push:
     # Sequence of patterns matched against refs/heads
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,7 @@ jobs:
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:
-          version: ${{ env.dockerversion }}
+          version: ${{ env.version }}
           target: default
           arch: ${{ matrix.arch }}
           zip_artifact_name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip


### PR DESCRIPTION
The intention for the `version` input is for it to find the correct zip artifact name, so it shouldn't be the `dockerversion`, that's only needed for the tags. This also means no need to explicitly config the zip artifact name.