### PR TITLE
fix(error) validate credential store id when creating static cred

### DIFF
--- a/internal/daemon/controller/handlers/credentials/credential_service.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service.go
@@ -539,7 +539,7 @@ func validateCreateRequest(req *pbs.CreateCredentialRequest) error {
 		if req.Item.GetType() != static.UsernamePasswordSubtype.String() {
 			badFields[globals.TypeField] = fmt.Sprintf("Unsupported credential type %q", req.Item.GetType())
 		}
-		if req.Item.GetCredentialStoreId() == "" {
+		if !handlers.ValidId(handlers.Id(req.Item.GetCredentialStoreId()), static.CredentialStorePrefix) {
 			badFields[globals.CredentialStoreIdField] = "This field must be a valid credential store id."
 		}
 

--- a/internal/daemon/controller/handlers/credentials/credential_service_test.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service_test.go
@@ -347,6 +347,21 @@ func TestCreate(t *testing.T) {
 			err: handlers.ApiErrorWithCode(codes.InvalidArgument),
 		},
 		{
+			name: "Invalid Credential Store Id",
+			req: &pbs.CreateCredentialRequest{Item: &pb.Credential{
+				CredentialStoreId: "p_invalidid",
+				Type:              static.UsernamePasswordSubtype.String(),
+				Attrs: &pb.Credential_UsernamePasswordAttributes{
+					UsernamePasswordAttributes: &pb.UsernamePasswordAttributes{
+						Username: wrapperspb.String("username"),
+						Password: wrapperspb.String("password"),
+					},
+				},
+			}},
+			res: nil,
+			err: handlers.ApiErrorWithCode(codes.InvalidArgument),
+		},
+		{
 			name: "Can't specify Created Time",
 			req: &pbs.CreateCredentialRequest{Item: &pb.Credential{
 				CredentialStoreId: store.GetPublicId(),


### PR DESCRIPTION
Passing in an invalid resource type into the -credential-store-id arg when creating a static credential returns the incorrect error type. The actual error is a 404 Resource Not Found, but the expected error type is a 400 Bad Request. The reason why this bug is occurring is because we are not checking the prefix on the -credential-store-id arg.

Example Command:

```
boundary credentials create username-password -credential-store-id cred_PnlQZvgQ74 -username admin -password password
```

Actual Output:
```
Error from controller when performing create on username_password-type credential

Error information:
  Kind:                NotFound
  Message:             Resource not found.
  Status:              404
  context:             Error from controller when performing create on username_password-type credential
```

Expected Output:

```
Error from controller when performing create on username_password-type credential

Error information:
  Kind:                InvalidArgument
  Message:             Error in provided request.
  Status:              400
  context:             Error from controller when performing create on username_password-type credential

  Field-specific Errors:
    Name:              -credential-store-id
      Error:           This field must be a valid credential store id.
```