### PR TITLE
Upgrade configutil dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2
-	github.com/hashicorp/go-secure-stdlib/configutil/v2 v2.0.2
+	github.com/hashicorp/go-secure-stdlib/configutil/v2 v2.0.4
 	github.com/hashicorp/go-secure-stdlib/gatedwriter v0.1.1
 	github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.1
 	github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -700,8 +700,8 @@ github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR3
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.1/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 h1:ET4pqyjiGmY09R5y+rSd70J2w45CtbWDNvGqWp/R3Ng=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
-github.com/hashicorp/go-secure-stdlib/configutil/v2 v2.0.2 h1:6xJeN1uZlNTIKpa1+mbEUzk+jDkSxqeRUTVf7nbnebs=
-github.com/hashicorp/go-secure-stdlib/configutil/v2 v2.0.2/go.mod h1:VlXiTm4IXctuHjpiHT4sLsUkFv91F+9B9CwOgpqveH4=
+github.com/hashicorp/go-secure-stdlib/configutil/v2 v2.0.4 h1:WSluQBp6dNGdqeciGwTWeYDUVbq0Hiw/SigGQPAeOQc=
+github.com/hashicorp/go-secure-stdlib/configutil/v2 v2.0.4/go.mod h1:QBMYnRoWszJPLWzQvS3KsvyTsS7upY4dIbagkp4N7iY=
 github.com/hashicorp/go-secure-stdlib/gatedwriter v0.1.1 h1:9um9R8i0+HbRHS9d64kdvWR0/LJvo12sIonvR9zr1+U=
 github.com/hashicorp/go-secure-stdlib/gatedwriter v0.1.1/go.mod h1:6RoRTSMDK2H/rKh3P/JIsk1tK8aatKTt3JyvIopi3GQ=
 github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.1 h1:IJgULbAXuvWxzKFfu+Au1FUmHIJulS6N4F7Hkn+Kck0=


### PR DESCRIPTION
This includes https://github.com/hashicorp/go-secure-stdlib/pull/41, which fixes https://discuss.hashicorp.com/t/latest-boundary-versions-ignoring-plugins-execution-dir/41281