### PR TITLE
Add client next protos to KMS connection info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require github.com/hashicorp/go-dbw v0.0.0-20220412153211-c470aec9369f // this i
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20220515130442-cac0b5ac133b
-	github.com/hashicorp/nodeenrollment v0.1.6
+	github.com/hashicorp/nodeenrollment v0.1.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -740,8 +740,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/nodeenrollment v0.1.6 h1:TAOpvU7y28vRB1Nk7pzfUPuJxX07SwBZwTJQgPQQbPI=
-github.com/hashicorp/nodeenrollment v0.1.6/go.mod h1:LIPKi+g0g/vl3xhpbzugCalHSxX1PMeqnatkAsxRgyM=
+github.com/hashicorp/nodeenrollment v0.1.7 h1:t6BD0DXzIXwPdcmR15M3YLttQPgnJYq0D8w+v3k/Nd0=
+github.com/hashicorp/nodeenrollment v0.1.7/go.mod h1:LIPKi+g0g/vl3xhpbzugCalHSxX1PMeqnatkAsxRgyM=
 github.com/hashicorp/vault/api v1.3.1 h1:pkDkcgTh47PRjY1NEFeofqR4W/HkNUi9qIakESO2aRM=
 github.com/hashicorp/vault/api v1.3.1/go.mod h1:QeJoWxMFt+MsuWcYhmwRLwKEXrjwAFFywzhptMsTIUw=
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=

--- a/internal/daemon/controller/intercepting_listener.go
+++ b/internal/daemon/controller/intercepting_listener.go
@@ -127,8 +127,9 @@ func (m *interceptingListener) Accept() (net.Conn, error) {
 		}
 		workerInfo := workerInfoRaw.(*workerAuthEntry)
 		workerInfo.conn = tlsConn
+		m.c.workerAuthCache.Delete(string(nonce))
 		event.WriteSysEvent(ctx, op, "worker successfully authed", "name", workerInfo.Name, "description", workerInfo.Description, "proxy_address", workerInfo.ProxyAddress)
-		return tlsConn, nil
+		return protocol.NewConn(tlsConn, workerInfo.clientNextProtos), nil
 
 	default:
 		return nil, newTempError(errors.New("unable to authenticate incoming connection"))


### PR DESCRIPTION
This builds on the previous change in the nodeenrollment library to
allow KMS connections to store incoming ALPN NextProto information.