### PR TITLE
Support building docker images on M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,10 +316,13 @@ docker-multiarch-build:
 		--platform linux/amd64,linux/arm64 \
 		.
 
+DEV_DOCKER_GOOS ?= linux
+DEV_DOCKER_GOARCH ?= amd64
+
 .PHONY: docker-build-dev
 # Builds from the locally generated binary in ./bin/
-docker-build-dev: export GOOS=linux
-docker-build-dev: export GOARCH=amd64
+docker-build-dev: export GOOS=$(DEV_DOCKER_GOOS)
+docker-build-dev: export GOARCH=$(DEV_DOCKER_GOARCH)
 docker-build-dev: build
 	docker build \
 		--tag $(IMAGE_TAG_DEV) \


### PR DESCRIPTION
Now developers on the M1 can use
```
DEV_DOCKER_GOARCH=arm64 make docker-build-dev
```