### PR TITLE
[CI-Only] Support per-commit dev images and fossa scanning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,11 +304,9 @@ jobs:
     env:
       repo: ${{ github.event.repository.name }}
       version: ${{ needs.get-product-version.outputs.product-version }}
+      minor-version: ${{ needs.get-product-version.outputs.product-minor-version }}
     steps:
       - uses: actions/checkout@v3
-      - name: Replace + in version
-        run: |
-          echo "dockerversion=$(echo ${{ needs.get-product-version.outputs.product-version }} | sed 's/+ent/-ent/g')" >> $GITHUB_ENV
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:
@@ -316,10 +314,10 @@ jobs:
           target: default
           arch: ${{ matrix.arch }}
           tags: |
-            docker.io/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
-            public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
+            docker.io/hashicorp/${{ env.repo }}:${{ env.version }}
+            public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.version }}
           # Per-commit dev images follow the naming convention MAJOR.MINOR-dev
           # And MAJOR.MINOR-dev-$COMMITSHA
           dev_tags: |
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.product-minor-version }}-dev
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.product-minor-version }}-dev-${{ github.sha }}
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
           make version
           VERSION=$(make version)
           MINOR_VERSION=${VERSION%.*}
+          echo "::set-output name=product-version::$VERSION"
+          echo "::set-output name=product-minor-version::$MINOR_VERSION"
 
   verify-product-version:
     needs: get-product-version
@@ -40,285 +42,285 @@ jobs:
           echo product-version: ${{ needs.get-product-version.outputs.product-version }}
           echo minor-version: ${{ needs.get-product-version.outputs.minor-version }}
 
-  # generate-metadata-file:
-  #   needs: get-product-version
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
-  #   steps:
-  #     - name: 'Checkout directory'
-  #       uses: actions/checkout@v3
-  #     - name: Generate metadata file
-  #       id: generate-metadata-file
-  #       uses: hashicorp/actions-generate-metadata@main
-  #       with:
-  #         version: ${{ needs.get-product-version.outputs.product-version }}
-  #         product: ${{ env.PKG_NAME }}
+  generate-metadata-file:
+    needs: get-product-version
+    runs-on: ubuntu-latest
+    outputs:
+      filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
+    steps:
+      - name: 'Checkout directory'
+        uses: actions/checkout@v3
+      - name: Generate metadata file
+        id: generate-metadata-file
+        uses: hashicorp/actions-generate-metadata@main
+        with:
+          version: ${{ needs.get-product-version.outputs.product-version }}
+          product: ${{ env.PKG_NAME }}
 
-  #     - uses: actions/upload-artifact@v3
-  #       with:
-  #         name: metadata.json
-  #         path: ${{ steps.generate-metadata-file.outputs.filepath }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: metadata.json
+          path: ${{ steps.generate-metadata-file.outputs.filepath }}
 
-  # set-ld-flags:
-  #   needs: get-product-version
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     ldflags: ${{ steps.generate-ld-flags.outputs.ldflags }}
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: 'Generate ld flags'
-  #       id: generate-ld-flags
-  #       run: |
-  #         project="$(go list -m)"
-  #         sha="$(git rev-parse HEAD)"
-  #         echo "::set-output name=ldflags::"-s -w -X \'$project/version.GitCommit=$sha\'""
+  set-ld-flags:
+    needs: get-product-version
+    runs-on: ubuntu-latest
+    outputs:
+      ldflags: ${{ steps.generate-ld-flags.outputs.ldflags }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Generate ld flags'
+        id: generate-ld-flags
+        run: |
+          project="$(go list -m)"
+          sha="$(git rev-parse HEAD)"
+          echo "::set-output name=ldflags::"-s -w -X \'$project/version.GitCommit=$sha\'""
 
-  # get-product-edition:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     product-edition: ${{ steps.get-product-edition.outputs.product-edition}}
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Setup Go
-  #       uses: actions/setup-go@v3
-  #       with:
-  #         go-version: "1.18.3"
-  #     - name: Get product edition
-  #       id: get-product-edition
-  #       run: |
-  #         make edition
-  #         echo "::set-output name=product-edition::$(make edition)"
-
-
-  # build-other:
-  #   needs:
-  #     - get-product-version
-  #     - get-product-edition
-  #     - set-ld-flags
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       goos: [ freebsd, windows, netbsd, openbsd, solaris ]
-  #       goarch: [ "386", "amd64", "arm" ]
-  #       go: [ "1.18.3" ]
-  #       exclude:
-  #         - goos: solaris
-  #           goarch: 386
-  #         - goos: solaris
-  #           goarch: arm
-  #         - goos: windows
-  #           goarch: arm
-  #     fail-fast: true
-
-  #   name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-  #   env:
-  #     GOPRIVATE: "github.com/hashicorp"
-  #     GO111MODULE: on
-  #     LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Setup go
-  #       uses: actions/setup-go@v3
-  #       with:
-  #         go-version: ${{ matrix.go }}
-  #     - name: Setup Git
-  #       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-  #     - name: Set sha
-  #       id: set-sha
-  #       run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
-  #     - name: Download UI artifact
-  #       uses: dawidd6/action-download-artifact@v2
-  #       with:
-  #         workflow: build-admin-ui.yaml
-  #         commit: ${{ steps.set-sha.outputs.sha }}
-  #         repo: "hashicorp/boundary-ui"
-  #         name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
-  #         path: internal/ui/.tmp/boundary-ui/ui/admin/dist
-  #     - name: Go Build
-  #       env:
-  #         GOOS: ${{ matrix.goos }}
-  #         GOARCH: ${{ matrix.goarch }}
-  #         CGO_ENABLED: 0
-  #       run: |
-  #         mkdir -p dist out
-  #         unset GOPATH;
-  #         # Build plugins
-  #         ./scripts/plugins.sh
-  #         go build -v -tags "ui" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
-  #         zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
-  #     - uses: actions/upload-artifact@v3
-  #       with:
-  #         name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-  #         path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-
-  # build-linux:
-  #   needs:
-  #     - get-product-version
-  #     - get-product-edition
-  #     - set-ld-flags
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       goos: [linux]
-  #       goarch: ["arm", "arm64", "386", "amd64"]
-  #       go: [ "1.18.3" ]
-  #     fail-fast: true
-
-  #   name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-
-  #   env:
-  #     GOPRIVATE: "github.com/hashicorp"
-  #     GO111MODULE: on
-  #     LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Setup Git
-  #       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-  #     - name: Setup go
-  #       uses: actions/setup-go@v3
-  #       with:
-  #         go-version: ${{ matrix.go }}
-  #     - name: Set sha
-  #       id: set-sha
-  #       run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
-  #     - name: Download UI artifact
-  #       uses: dawidd6/action-download-artifact@v2
-  #       with:
-  #         workflow: build-admin-ui.yaml
-  #         commit: ${{ steps.set-sha.outputs.sha }}
-  #         repo: "hashicorp/boundary-ui"
-  #         name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
-  #         path: internal/ui/.tmp/boundary-ui/ui/admin/dist
-  #     - name: Go Build
-  #       env:
-  #         GOOS: ${{ matrix.goos }}
-  #         GOARCH: ${{ matrix.goarch }}
-  #         CGO_ENABLED: 0
-  #       run: |
-  #         mkdir -p dist out
-  #         unset GOPATH;
-  #         # Build plugins
-  #         ./scripts/plugins.sh
-  #         go build -v -tags "ui" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
-  #         zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
-  #     - uses: actions/upload-artifact@v3
-  #       with:
-  #         name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-  #         path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-
-  #     - name: Linux Packaging
-  #       uses: hashicorp/actions-packaging-linux@v1
-  #       with:
-  #         name: ${{ github.event.repository.name }}
-  #         description: "HashiCorp Boundary - Identity-based access management for dynamic infrastructure"
-  #         arch: ${{ matrix.goarch }}
-  #         version: ${{ needs.get-product-version.outputs.product-version }}
-  #         maintainer: "HashiCorp"
-  #         homepage: "https://github.com/hashicorp/boundary"
-  #         license: "MPL-2.0"
-  #         binary: "dist/${{ env.PKG_NAME }}"
-  #         deb_depends: "openssl"
-  #         rpm_depends: "openssl"
-  #         config_dir: ".release/linux/package/"
-  #         preinstall: ".release/linux/preinst"
-  #         postremove: ".release/linux/postrm"
-  #     - name: Add Linux Package names to env
-  #       run: |
-  #         echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
-  #         echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
-  #     - uses: actions/upload-artifact@v3
-  #       with:
-  #         name: ${{ env.RPM_PACKAGE }}
-  #         path: out/${{ env.RPM_PACKAGE }}
-  #     - uses: actions/upload-artifact@v3
-  #       with:
-  #         name: ${{ env.DEB_PACKAGE }}
-  #         path: out/${{ env.DEB_PACKAGE }}
+  get-product-edition:
+    runs-on: ubuntu-latest
+    outputs:
+      product-edition: ${{ steps.get-product-edition.outputs.product-edition}}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.18.3"
+      - name: Get product edition
+        id: get-product-edition
+        run: |
+          make edition
+          echo "::set-output name=product-edition::$(make edition)"
 
 
-  # build-darwin:
-  #   needs:
-  #     - get-product-version
-  #     - get-product-edition
-  #     - set-ld-flags
-  #   runs-on: macos-latest
-  #   strategy:
-  #     matrix:
-  #       goos: [ darwin ]
-  #       goarch: [ "amd64", "arm64" ]
-  #       go: [ "1.18.3" ]
-  #     fail-fast: true
-  #   name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+  build-other:
+    needs:
+      - get-product-version
+      - get-product-edition
+      - set-ld-flags
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [ freebsd, windows, netbsd, openbsd, solaris ]
+        goarch: [ "386", "amd64", "arm" ]
+        go: [ "1.18.3" ]
+        exclude:
+          - goos: solaris
+            goarch: 386
+          - goos: solaris
+            goarch: arm
+          - goos: windows
+            goarch: arm
+      fail-fast: true
 
-  #   env:
-  #     GOPRIVATE: "github.com/hashicorp"
-  #     GO111MODULE: on
-  #     LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
+    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+    env:
+      GOPRIVATE: "github.com/hashicorp"
+      GO111MODULE: on
+      LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Setup Git
+        run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+      - name: Set sha
+        id: set-sha
+        run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
+      - name: Download UI artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-admin-ui.yaml
+          commit: ${{ steps.set-sha.outputs.sha }}
+          repo: "hashicorp/boundary-ui"
+          name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
+          path: internal/ui/.tmp/boundary-ui/ui/admin/dist
+      - name: Go Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          mkdir -p dist out
+          unset GOPATH;
+          # Build plugins
+          ./scripts/plugins.sh
+          go build -v -tags "ui" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
+          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Setup go
-  #       uses: actions/setup-go@v3
-  #       with:
-  #         go-version: ${{ matrix.go }}
-  #     - name: Set sha
-  #       id: set-sha
-  #       run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
-  #     - name: Download UI artifact
-  #       uses: dawidd6/action-download-artifact@v2
-  #       with:
-  #         workflow: build-admin-ui.yaml
-  #         commit: ${{ steps.set-sha.outputs.sha }}
-  #         repo: "hashicorp/boundary-ui"
-  #         name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
-  #         path: internal/ui/.tmp/boundary-ui/ui/admin/dist
-  #     - name: Go Build
-  #       env:
-  #         GOOS: ${{ matrix.goos }}
-  #         GOARCH: ${{ matrix.goarch }}
-  #         CGO_ENABLED: 0
-  #       run: |
-  #         mkdir -p dist out
-  #         unset GOPATH;
-  #         # Build plugins
-  #         ./scripts/plugins.sh
-  #         go build -v -tags "ui netcgo" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
-  #         zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
-  #     - uses: actions/upload-artifact@v3
-  #       with:
-  #         name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-  #         path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+  build-linux:
+    needs:
+      - get-product-version
+      - get-product-edition
+      - set-ld-flags
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux]
+        goarch: ["arm", "arm64", "386", "amd64"]
+        go: [ "1.18.3" ]
+      fail-fast: true
 
-  # build-docker:
-  #   name: Docker ${{ matrix.arch }} build
-  #   needs:
-  #     - get-product-version
-  #     - build-linux
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       arch: ["arm", "arm64", "386", "amd64"]
-  #   env:
-  #     repo: ${{ github.event.repository.name }}
-  #     version: ${{ needs.get-product-version.outputs.product-version }}
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Replace + in version
-  #       run: |
-  #         echo "dockerversion=$(echo ${{ needs.get-product-version.outputs.product-version }} | sed 's/+ent/-ent/g')" >> $GITHUB_ENV
-  #     - name: Docker Build (Action)
-  #       uses: hashicorp/actions-docker-build@v1
-  #       with:
-  #         version: ${{ env.version }}
-  #         target: default
-  #         arch: ${{ matrix.arch }}
-  #         tags: |
-  #           docker.io/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
-  #           public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
-  #         # Per-commit dev images follow the naming convention MAJOR.MINOR-dev
-  #         # And MAJOR.MINOR-dev-$COMMITSHA
-  #         dev_tags: |
-  #           docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev
-  #           docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}
+    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+
+    env:
+      GOPRIVATE: "github.com/hashicorp"
+      GO111MODULE: on
+      LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Git
+        run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Set sha
+        id: set-sha
+        run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
+      - name: Download UI artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-admin-ui.yaml
+          commit: ${{ steps.set-sha.outputs.sha }}
+          repo: "hashicorp/boundary-ui"
+          name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
+          path: internal/ui/.tmp/boundary-ui/ui/admin/dist
+      - name: Go Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          mkdir -p dist out
+          unset GOPATH;
+          # Build plugins
+          ./scripts/plugins.sh
+          go build -v -tags "ui" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
+          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+
+      - name: Linux Packaging
+        uses: hashicorp/actions-packaging-linux@v1
+        with:
+          name: ${{ github.event.repository.name }}
+          description: "HashiCorp Boundary - Identity-based access management for dynamic infrastructure"
+          arch: ${{ matrix.goarch }}
+          version: ${{ needs.get-product-version.outputs.product-version }}
+          maintainer: "HashiCorp"
+          homepage: "https://github.com/hashicorp/boundary"
+          license: "MPL-2.0"
+          binary: "dist/${{ env.PKG_NAME }}"
+          deb_depends: "openssl"
+          rpm_depends: "openssl"
+          config_dir: ".release/linux/package/"
+          preinstall: ".release/linux/preinst"
+          postremove: ".release/linux/postrm"
+      - name: Add Linux Package names to env
+        run: |
+          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
+          echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.RPM_PACKAGE }}
+          path: out/${{ env.RPM_PACKAGE }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.DEB_PACKAGE }}
+          path: out/${{ env.DEB_PACKAGE }}
+
+
+  build-darwin:
+    needs:
+      - get-product-version
+      - get-product-edition
+      - set-ld-flags
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        goos: [ darwin ]
+        goarch: [ "amd64", "arm64" ]
+        go: [ "1.18.3" ]
+      fail-fast: true
+    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+
+    env:
+      GOPRIVATE: "github.com/hashicorp"
+      GO111MODULE: on
+      LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Set sha
+        id: set-sha
+        run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
+      - name: Download UI artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-admin-ui.yaml
+          commit: ${{ steps.set-sha.outputs.sha }}
+          repo: "hashicorp/boundary-ui"
+          name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
+          path: internal/ui/.tmp/boundary-ui/ui/admin/dist
+      - name: Go Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          mkdir -p dist out
+          unset GOPATH;
+          # Build plugins
+          ./scripts/plugins.sh
+          go build -v -tags "ui netcgo" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
+          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+
+  build-docker:
+    name: Docker ${{ matrix.arch }} build
+    needs:
+      - get-product-version
+      - build-linux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["arm", "arm64", "386", "amd64"]
+    env:
+      repo: ${{ github.event.repository.name }}
+      version: ${{ needs.get-product-version.outputs.product-version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Replace + in version
+        run: |
+          echo "dockerversion=$(echo ${{ needs.get-product-version.outputs.product-version }} | sed 's/+ent/-ent/g')" >> $GITHUB_ENV
+      - name: Docker Build (Action)
+        uses: hashicorp/actions-docker-build@v1
+        with:
+          version: ${{ env.version }}
+          target: default
+          arch: ${{ matrix.arch }}
+          tags: |
+            docker.io/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
+            public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
+          # Per-commit dev images follow the naming convention MAJOR.MINOR-dev
+          # And MAJOR.MINOR-dev-$COMMITSHA
+          dev_tags: |
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,288 +30,294 @@ jobs:
           make version
           VERSION=$(make version)
           MINOR_VERSION=${VERSION%.*}
-          echo "::set-output name=product-version::$VERSION"
-          echo "::set-output name=product-minor-version::$MINOR_VERSION"
 
-  generate-metadata-file:
-    needs: get-product-version
+  verify-product-version:
     runs-on: ubuntu-latest
-    outputs:
-      filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
-      - name: 'Checkout directory'
-        uses: actions/checkout@v3
-      - name: Generate metadata file
-        id: generate-metadata-file
-        uses: hashicorp/actions-generate-metadata@main
-        with:
-          version: ${{ needs.get-product-version.outputs.product-version }}
-          product: ${{ env.PKG_NAME }}
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: metadata.json
-          path: ${{ steps.generate-metadata-file.outputs.filepath }}
-
-  set-ld-flags:
-    needs: get-product-version
-    runs-on: ubuntu-latest
-    outputs:
-      ldflags: ${{ steps.generate-ld-flags.outputs.ldflags }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: 'Generate ld flags'
-        id: generate-ld-flags
+      - name: Verify version strings
         run: |
-          project="$(go list -m)"
-          sha="$(git rev-parse HEAD)"
-          echo "::set-output name=ldflags::"-s -w -X \'$project/version.GitCommit=$sha\'""
+          echo product-version: ${{ needs.get-product-version.outputs.product-version }}
+          echo minor-version: ${{ needs.get-product-version.outputs.minor-version }}
 
-  get-product-edition:
-    runs-on: ubuntu-latest
-    outputs:
-      product-edition: ${{ steps.get-product-edition.outputs.product-edition}}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.18.3"
-      - name: Get product edition
-        id: get-product-edition
-        run: |
-          make edition
-          echo "::set-output name=product-edition::$(make edition)"
+  # generate-metadata-file:
+  #   needs: get-product-version
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
+  #   steps:
+  #     - name: 'Checkout directory'
+  #       uses: actions/checkout@v3
+  #     - name: Generate metadata file
+  #       id: generate-metadata-file
+  #       uses: hashicorp/actions-generate-metadata@main
+  #       with:
+  #         version: ${{ needs.get-product-version.outputs.product-version }}
+  #         product: ${{ env.PKG_NAME }}
 
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         name: metadata.json
+  #         path: ${{ steps.generate-metadata-file.outputs.filepath }}
 
-  build-other:
-    needs:
-      - get-product-version
-      - get-product-edition
-      - set-ld-flags
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [ freebsd, windows, netbsd, openbsd, solaris ]
-        goarch: [ "386", "amd64", "arm" ]
-        go: [ "1.18.3" ]
-        exclude:
-          - goos: solaris
-            goarch: 386
-          - goos: solaris
-            goarch: arm
-          - goos: windows
-            goarch: arm
-      fail-fast: true
+  # set-ld-flags:
+  #   needs: get-product-version
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     ldflags: ${{ steps.generate-ld-flags.outputs.ldflags }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: 'Generate ld flags'
+  #       id: generate-ld-flags
+  #       run: |
+  #         project="$(go list -m)"
+  #         sha="$(git rev-parse HEAD)"
+  #         echo "::set-output name=ldflags::"-s -w -X \'$project/version.GitCommit=$sha\'""
 
-    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-    env:
-      GOPRIVATE: "github.com/hashicorp"
-      GO111MODULE: on
-      LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go }}
-      - name: Setup Git
-        run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-      - name: Set sha
-        id: set-sha
-        run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
-      - name: Download UI artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: build-admin-ui.yaml
-          commit: ${{ steps.set-sha.outputs.sha }}
-          repo: "hashicorp/boundary-ui"
-          name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
-          path: internal/ui/.tmp/boundary-ui/ui/admin/dist
-      - name: Go Build
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 0
-        run: |
-          mkdir -p dist out
-          unset GOPATH;
-          # Build plugins
-          ./scripts/plugins.sh
-          go build -v -tags "ui" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
-          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-
-  build-linux:
-    needs:
-      - get-product-version
-      - get-product-edition
-      - set-ld-flags
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux]
-        goarch: ["arm", "arm64", "386", "amd64"]
-        go: [ "1.18.3" ]
-      fail-fast: true
-
-    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-
-    env:
-      GOPRIVATE: "github.com/hashicorp"
-      GO111MODULE: on
-      LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Git
-        run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
-      - name: Setup go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go }}
-      - name: Set sha
-        id: set-sha
-        run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
-      - name: Download UI artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: build-admin-ui.yaml
-          commit: ${{ steps.set-sha.outputs.sha }}
-          repo: "hashicorp/boundary-ui"
-          name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
-          path: internal/ui/.tmp/boundary-ui/ui/admin/dist
-      - name: Go Build
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 0
-        run: |
-          mkdir -p dist out
-          unset GOPATH;
-          # Build plugins
-          ./scripts/plugins.sh
-          go build -v -tags "ui" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
-          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-
-      - name: Linux Packaging
-        uses: hashicorp/actions-packaging-linux@v1
-        with:
-          name: ${{ github.event.repository.name }}
-          description: "HashiCorp Boundary - Identity-based access management for dynamic infrastructure"
-          arch: ${{ matrix.goarch }}
-          version: ${{ needs.get-product-version.outputs.product-version }}
-          maintainer: "HashiCorp"
-          homepage: "https://github.com/hashicorp/boundary"
-          license: "MPL-2.0"
-          binary: "dist/${{ env.PKG_NAME }}"
-          deb_depends: "openssl"
-          rpm_depends: "openssl"
-          config_dir: ".release/linux/package/"
-          preinstall: ".release/linux/preinst"
-          postremove: ".release/linux/postrm"
-      - name: Add Linux Package names to env
-        run: |
-          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
-          echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.RPM_PACKAGE }}
-          path: out/${{ env.RPM_PACKAGE }}
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.DEB_PACKAGE }}
-          path: out/${{ env.DEB_PACKAGE }}
+  # get-product-edition:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     product-edition: ${{ steps.get-product-edition.outputs.product-edition}}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Setup Go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: "1.18.3"
+  #     - name: Get product edition
+  #       id: get-product-edition
+  #       run: |
+  #         make edition
+  #         echo "::set-output name=product-edition::$(make edition)"
 
 
-  build-darwin:
-    needs:
-      - get-product-version
-      - get-product-edition
-      - set-ld-flags
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        goos: [ darwin ]
-        goarch: [ "amd64", "arm64" ]
-        go: [ "1.18.3" ]
-      fail-fast: true
-    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+  # build-other:
+  #   needs:
+  #     - get-product-version
+  #     - get-product-edition
+  #     - set-ld-flags
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       goos: [ freebsd, windows, netbsd, openbsd, solaris ]
+  #       goarch: [ "386", "amd64", "arm" ]
+  #       go: [ "1.18.3" ]
+  #       exclude:
+  #         - goos: solaris
+  #           goarch: 386
+  #         - goos: solaris
+  #           goarch: arm
+  #         - goos: windows
+  #           goarch: arm
+  #     fail-fast: true
 
-    env:
-      GOPRIVATE: "github.com/hashicorp"
-      GO111MODULE: on
-      LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
+  #   name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+  #   env:
+  #     GOPRIVATE: "github.com/hashicorp"
+  #     GO111MODULE: on
+  #     LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Setup go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: ${{ matrix.go }}
+  #     - name: Setup Git
+  #       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+  #     - name: Set sha
+  #       id: set-sha
+  #       run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
+  #     - name: Download UI artifact
+  #       uses: dawidd6/action-download-artifact@v2
+  #       with:
+  #         workflow: build-admin-ui.yaml
+  #         commit: ${{ steps.set-sha.outputs.sha }}
+  #         repo: "hashicorp/boundary-ui"
+  #         name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
+  #         path: internal/ui/.tmp/boundary-ui/ui/admin/dist
+  #     - name: Go Build
+  #       env:
+  #         GOOS: ${{ matrix.goos }}
+  #         GOARCH: ${{ matrix.goarch }}
+  #         CGO_ENABLED: 0
+  #       run: |
+  #         mkdir -p dist out
+  #         unset GOPATH;
+  #         # Build plugins
+  #         ./scripts/plugins.sh
+  #         go build -v -tags "ui" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
+  #         zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+  #         path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go }}
-      - name: Set sha
-        id: set-sha
-        run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
-      - name: Download UI artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: build-admin-ui.yaml
-          commit: ${{ steps.set-sha.outputs.sha }}
-          repo: "hashicorp/boundary-ui"
-          name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
-          path: internal/ui/.tmp/boundary-ui/ui/admin/dist
-      - name: Go Build
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 0
-        run: |
-          mkdir -p dist out
-          unset GOPATH;
-          # Build plugins
-          ./scripts/plugins.sh
-          go build -v -tags "ui netcgo" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
-          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+  # build-linux:
+  #   needs:
+  #     - get-product-version
+  #     - get-product-edition
+  #     - set-ld-flags
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       goos: [linux]
+  #       goarch: ["arm", "arm64", "386", "amd64"]
+  #       go: [ "1.18.3" ]
+  #     fail-fast: true
 
-  build-docker:
-    name: Docker ${{ matrix.arch }} build
-    needs:
-      - get-product-version
-      - build-linux
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: ["arm", "arm64", "386", "amd64"]
-    env:
-      repo: ${{ github.event.repository.name }}
-      version: ${{ needs.get-product-version.outputs.product-version }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Replace + in version
-        run: |
-          echo "dockerversion=$(echo ${{ needs.get-product-version.outputs.product-version }} | sed 's/+ent/-ent/g')" >> $GITHUB_ENV
-      - name: Docker Build (Action)
-        uses: hashicorp/actions-docker-build@v1
-        with:
-          version: ${{ env.version }}
-          target: default
-          arch: ${{ matrix.arch }}
-          tags: |
-            docker.io/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
-            public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
-          # Per-commit dev images follow the naming convention MAJOR.MINOR-dev
-          # And MAJOR.MINOR-dev-$COMMITSHA
-          dev_tags: |
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}
+  #   name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+
+  #   env:
+  #     GOPRIVATE: "github.com/hashicorp"
+  #     GO111MODULE: on
+  #     LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Setup Git
+  #       run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
+  #     - name: Setup go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: ${{ matrix.go }}
+  #     - name: Set sha
+  #       id: set-sha
+  #       run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
+  #     - name: Download UI artifact
+  #       uses: dawidd6/action-download-artifact@v2
+  #       with:
+  #         workflow: build-admin-ui.yaml
+  #         commit: ${{ steps.set-sha.outputs.sha }}
+  #         repo: "hashicorp/boundary-ui"
+  #         name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
+  #         path: internal/ui/.tmp/boundary-ui/ui/admin/dist
+  #     - name: Go Build
+  #       env:
+  #         GOOS: ${{ matrix.goos }}
+  #         GOARCH: ${{ matrix.goarch }}
+  #         CGO_ENABLED: 0
+  #       run: |
+  #         mkdir -p dist out
+  #         unset GOPATH;
+  #         # Build plugins
+  #         ./scripts/plugins.sh
+  #         go build -v -tags "ui" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
+  #         zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+  #         path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+
+  #     - name: Linux Packaging
+  #       uses: hashicorp/actions-packaging-linux@v1
+  #       with:
+  #         name: ${{ github.event.repository.name }}
+  #         description: "HashiCorp Boundary - Identity-based access management for dynamic infrastructure"
+  #         arch: ${{ matrix.goarch }}
+  #         version: ${{ needs.get-product-version.outputs.product-version }}
+  #         maintainer: "HashiCorp"
+  #         homepage: "https://github.com/hashicorp/boundary"
+  #         license: "MPL-2.0"
+  #         binary: "dist/${{ env.PKG_NAME }}"
+  #         deb_depends: "openssl"
+  #         rpm_depends: "openssl"
+  #         config_dir: ".release/linux/package/"
+  #         preinstall: ".release/linux/preinst"
+  #         postremove: ".release/linux/postrm"
+  #     - name: Add Linux Package names to env
+  #       run: |
+  #         echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
+  #         echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         name: ${{ env.RPM_PACKAGE }}
+  #         path: out/${{ env.RPM_PACKAGE }}
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         name: ${{ env.DEB_PACKAGE }}
+  #         path: out/${{ env.DEB_PACKAGE }}
+
+
+  # build-darwin:
+  #   needs:
+  #     - get-product-version
+  #     - get-product-edition
+  #     - set-ld-flags
+  #   runs-on: macos-latest
+  #   strategy:
+  #     matrix:
+  #       goos: [ darwin ]
+  #       goarch: [ "amd64", "arm64" ]
+  #       go: [ "1.18.3" ]
+  #     fail-fast: true
+  #   name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+
+  #   env:
+  #     GOPRIVATE: "github.com/hashicorp"
+  #     GO111MODULE: on
+  #     LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Setup go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: ${{ matrix.go }}
+  #     - name: Set sha
+  #       id: set-sha
+  #       run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
+  #     - name: Download UI artifact
+  #       uses: dawidd6/action-download-artifact@v2
+  #       with:
+  #         workflow: build-admin-ui.yaml
+  #         commit: ${{ steps.set-sha.outputs.sha }}
+  #         repo: "hashicorp/boundary-ui"
+  #         name: admin-ui-${{ needs.get-product-edition.outputs.product-edition }}
+  #         path: internal/ui/.tmp/boundary-ui/ui/admin/dist
+  #     - name: Go Build
+  #       env:
+  #         GOOS: ${{ matrix.goos }}
+  #         GOARCH: ${{ matrix.goarch }}
+  #         CGO_ENABLED: 0
+  #       run: |
+  #         mkdir -p dist out
+  #         unset GOPATH;
+  #         # Build plugins
+  #         ./scripts/plugins.sh
+  #         go build -v -tags "ui netcgo" -ldflags "${{ env.LD_FLAGS }}" -o dist/ ./cmd/boundary
+  #         zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+  #         path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+
+  # build-docker:
+  #   name: Docker ${{ matrix.arch }} build
+  #   needs:
+  #     - get-product-version
+  #     - build-linux
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       arch: ["arm", "arm64", "386", "amd64"]
+  #   env:
+  #     repo: ${{ github.event.repository.name }}
+  #     version: ${{ needs.get-product-version.outputs.product-version }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Replace + in version
+  #       run: |
+  #         echo "dockerversion=$(echo ${{ needs.get-product-version.outputs.product-version }} | sed 's/+ent/-ent/g')" >> $GITHUB_ENV
+  #     - name: Docker Build (Action)
+  #       uses: hashicorp/actions-docker-build@v1
+  #       with:
+  #         version: ${{ env.version }}
+  #         target: default
+  #         arch: ${{ matrix.arch }}
+  #         tags: |
+  #           docker.io/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
+  #           public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
+  #         # Per-commit dev images follow the naming convention MAJOR.MINOR-dev
+  #         # And MAJOR.MINOR-dev-$COMMITSHA
+  #         dev_tags: |
+  #           docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev
+  #           docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,8 @@ jobs:
       - name: get product version
         id: get-product-version
         run: |
-          make version
-          export VERSION=$(make version)
-          export MINOR_VERSION=${VERSION%.*}
+          VERSION=$(make version)
+          MINOR_VERSION=${VERSION%.*}
           echo "::set-output name=product-version::$VERSION"
           echo "::set-output name=product-minor-version::$MINOR_VERSION"
 
@@ -40,7 +39,7 @@ jobs:
       - name: Verify version strings
         run: |
           echo product-version: ${{ needs.get-product-version.outputs.product-version }}
-          echo minor-version: ${{ needs.get-product-version.outputs.minor-version }}
+          echo minor-version: ${{ needs.get-product-version.outputs.product-minor-version }}
 
   generate-metadata-file:
     needs: get-product-version
@@ -322,5 +321,5 @@ jobs:
           # Per-commit dev images follow the naming convention MAJOR.MINOR-dev
           # And MAJOR.MINOR-dev-$COMMITSHA
           dev_tags: |
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.product-minor-version }}-dev
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.product-minor-version }}-dev-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
           MINOR_VERSION=${VERSION%.*}
 
   verify-product-version:
+    needs: get-product-version
     runs-on: ubuntu-latest
     steps:
       - name: Verify version strings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     branches:
       # Push events on main branch
       - 'main'
+      - support-devtags-and-fossa
 
 env:
   PKG_NAME: "boundary"
@@ -16,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
+      product-minor-version: ${{ steps.get-product-version.outputs.product-minor-version }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup go
@@ -26,7 +28,10 @@ jobs:
         id: get-product-version
         run: |
           make version
-          echo "::set-output name=product-version::$(make version)"
+          VERSION=$(make version)
+          MINOR_VERSION=${VERSION%.*}
+          echo "::set-output name=product-version::$VERSION"
+          echo "::set-output name=product-minor-version::$MINOR_VERSION"
 
   generate-metadata-file:
     needs: get-product-version
@@ -305,3 +310,8 @@ jobs:
           tags: |
             docker.io/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
             public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
+          # Per-commit dev images follow the naming convention MAJOR.MINOR-dev
+          # And MAJOR.MINOR-dev-$COMMITSHA
+           dev_tags: |
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,6 +312,6 @@ jobs:
             public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.dockerversion }}
           # Per-commit dev images follow the naming convention MAJOR.MINOR-dev
           # And MAJOR.MINOR-dev-$COMMITSHA
-           dev_tags: |
+          dev_tags: |
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
         id: get-product-version
         run: |
           make version
-          VERSION=$(make version)
-          MINOR_VERSION=${VERSION%.*}
+          export VERSION=$(make version)
+          export MINOR_VERSION=${VERSION%.*}
           echo "::set-output name=product-version::$VERSION"
           echo "::set-output name=product-minor-version::$MINOR_VERSION"
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -13,6 +13,7 @@ project "boundary" {
 
     release_branches = [
       "main",
+      "support-devtags-and-fossa"
     ]
   }
 }
@@ -171,6 +172,29 @@ event "verify" {
 
   notification {
     on = "fail"
+  }
+}
+
+event "promote-dev-docker" {
+  depends = ["verify"]
+  action "promote-dev-docker" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-dev-docker"
+    depends = ["verify"]
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "fossa-scan" {
+  depends = ["promote-dev-docker"]
+  action "fossa-scan" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "fossa-scan"
   }
 }
 


### PR DESCRIPTION
### Description

This is a set of two CI-only changes:

1. FOSSA scanning- This opts boundary into a new workflow in the CRT pipeline called fossa-scan. The fossa-scan workflow will pass regardless of any dependency licensing issues raised by fossa, but failures will be raised in #proj-oss-compliance-scanning. This will allow us to triage issues to share with the legal team, who will reach out to Boundary directly if there are questions about any dependencies. 

2. DEV TAGS- This opts boundary into a new workflow in the CRT pipeline called promote-dev-docker. Dev docker images will be built and tagged, signed/scanned, and pushed to the `hashicorppreview/boundary` repository on DockerHub whenever a commit is made to the default or active release branches. [The repo is publicly available here.](https://hub.docker.com/r/hashicorppreview/boundary) Dev tags will follow a standard naming convention that we have rolled out to other projects. For example, on branch `release/0.8.x`, dev images will be tagged `hashicorppreview/boundary:0.8-dev` and `hashicorppreview/boundary:0.8-dev-$COMMITSHA`. `hashicorppreview/boundary:0.8-dev` will be kept up to date with the latest builds from branch `release/0.8.x` for folks looking to grab the latest docker image from the tip of an active release branch or `main`. You can view the docker image built/pushed from this branch here: https://hub.docker.com/r/hashicorppreview/boundary/tags. 

### Testing & Reproduction steps

1. The fossa-scan workflow ran on my commit here https://github.com/hashicorp/boundary/runs/7312073531 and this produced the fossa report available here https://github.com/hashicorp/crt-workflows-common/actions/runs/2660093600. The scan raised a few new issues that the legal team will look into here: https://hashicorp.slack.com/archives/C01JSHNP10B/p1657670937387859. 

2. The docker dev images from my commit are available here: https://hub.docker.com/r/hashicorppreview/boundary/tags. Note that vulnerability scanning is turned on in `hashicorppreview`, and there are a number of vulns appearing for this build: https://hub.docker.com/layers/hashicorppreview/boundary/0.9-dev-a8f8b5eb8d5ea2392cbca5bdc40941e7d31f148b/images/sha256-65ece09899e672c78e083819bf6dd28553cf991c656907933b14a20d141e4bef?context=repo&tab=vulnerabilities. 
