### PR TITLE
kms: Add ListKeys method

### DIFF
--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -228,6 +228,17 @@ func (k *Kms) CreateKeys(ctx context.Context, scopeId string, opt ...Option) err
 	return nil
 }
 
+// ListKeys lists all keys in the scope.
+// Options are ignored.
+func (k *Kms) ListKeys(ctx context.Context, scopeId string, opt ...Option) ([]wrappingKms.Key, error) {
+	const op = "kms.(Kms).ListKeys"
+	keys, err := k.underlying.ListKeys(ctx, scopeId)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
+	return keys, nil
+}
+
 // VerifyGlobalRoot will verify that the global root wrapper is reasonable.
 func (k *Kms) VerifyGlobalRoot(ctx context.Context) error {
 	const op = "kms.(Kms).VerifyGlobalRoot"

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -190,7 +190,7 @@ func (k *Kms) ReconcileKeys(ctx context.Context, randomReader io.Reader, opt ...
 	return nil
 }
 
-// CreateKeys creates the root key and DEKs returns a map of the new keys.
+// CreateKeys creates the root key and DEKs.
 // Supports the WithRandomReader(...) and WithReaderWriter(...) options.
 // When WithReaderWriter(...) is used the caller is responsible for managing the
 // transaction which allows this capability to be shared with the iam repo when

--- a/internal/kms/kms_test.go
+++ b/internal/kms/kms_test.go
@@ -168,6 +168,27 @@ func Test_NewUsingReaderWriter(t *testing.T) {
 	}
 }
 
+func Test_ListKeys(t *testing.T) {
+	t.Parallel()
+	testCtx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	extWrapper := db.TestWrapper(t)
+	kmsCache := TestKms(t, conn, extWrapper)
+	err := kmsCache.CreateKeys(testCtx, "global")
+	require.NoError(t, err)
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		keys, err := kmsCache.ListKeys(testCtx, "global")
+		require.NoError(t, err)
+		require.Len(t, keys, 7)
+	})
+	t.Run("unknown-scope", func(t *testing.T) {
+		t.Parallel()
+		_, err := kmsCache.ListKeys(testCtx, "myscope")
+		assert.ErrorIs(t, err, dbw.ErrRecordNotFound)
+	})
+}
+
 type invalidReader struct {
 	db.Reader
 }


### PR DESCRIPTION
The new ListKeys method wraps the underlying KMS wrapper, returning all the keys in the scope specified.