### PR TITLE
Bump Go version to v1.18.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18.3"
+          go-version: "1.18.4"
       - name: get product version
         id: get-product-version
         run: |
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18.3"
+          go-version: "1.18.4"
       - name: Get product edition
         id: get-product-edition
         run: |
@@ -101,7 +101,7 @@ jobs:
       matrix:
         goos: [ freebsd, windows, netbsd, openbsd, solaris ]
         goarch: [ "386", "amd64", "arm" ]
-        go: [ "1.18.3" ]
+        go: [ "1.18.4" ]
         exclude:
           - goos: solaris
             goarch: 386
@@ -162,7 +162,7 @@ jobs:
       matrix:
         goos: [linux]
         goarch: ["arm", "arm64", "386", "amd64"]
-        go: [ "1.18.3" ]
+        go: [ "1.18.4" ]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -248,7 +248,7 @@ jobs:
       matrix:
         goos: [ darwin ]
         goarch: [ "amd64", "arm64" ]
-        go: [ "1.18.3" ]
+        go: [ "1.18.4" ]
       fail-fast: true
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
 

--- a/ci/goinstall.sh
+++ b/ci/goinstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION="1.18.3"
+VERSION="1.18.4"
 
 [ -z "$GOROOT" ] && GOROOT="$HOME/.go"
 [ -z "$GOPATH" ] && GOPATH="$HOME/go"


### PR DESCRIPTION
Go 1.18.4 has some security patches over 1.18.3.

[Go Release Change Logs](https://go.dev/doc/devel/release#go1.18.minor)
