### PR TITLE
fix(cli) check error value from command func

### DIFF
--- a/internal/cmd/commands/accountscmd/accounts.gen.go
+++ b/internal/cmd/commands/accountscmd/accounts.gen.go
@@ -317,8 +317,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/accountscmd/accounts.gen.go
+++ b/internal/cmd/commands/accountscmd/accounts.gen.go
@@ -313,16 +313,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/accountscmd/accounts.gen.go
+++ b/internal/cmd/commands/accountscmd/accounts.gen.go
@@ -232,31 +232,32 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = accountsClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "delete":
 		deleteResult, err = accountsClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = accountsClient.List(c.Context, c.FlagAuthMethodId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, accountsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -309,6 +310,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/accountscmd/oidc_accounts.gen.go
+++ b/internal/cmd/commands/accountscmd/oidc_accounts.gen.go
@@ -252,16 +252,16 @@ func (c *OidcCommand) Run(args []string) int {
 }
 
 func (c *OidcCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/accountscmd/oidc_accounts.gen.go
+++ b/internal/cmd/commands/accountscmd/oidc_accounts.gen.go
@@ -256,8 +256,7 @@ func (c *OidcCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/accountscmd/oidc_accounts.gen.go
+++ b/internal/cmd/commands/accountscmd/oidc_accounts.gen.go
@@ -204,27 +204,25 @@ func (c *OidcCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = accountsClient.Create(c.Context, c.FlagAuthMethodId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = accountsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraOidcActions(c, resp, item, err, accountsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomOidcActionOutput(c)
@@ -251,6 +249,19 @@ func (c *OidcCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *OidcCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/accountscmd/password_accounts.gen.go
+++ b/internal/cmd/commands/accountscmd/password_accounts.gen.go
@@ -256,8 +256,7 @@ func (c *PasswordCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/accountscmd/password_accounts.gen.go
+++ b/internal/cmd/commands/accountscmd/password_accounts.gen.go
@@ -252,16 +252,16 @@ func (c *PasswordCommand) Run(args []string) int {
 }
 
 func (c *PasswordCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/accountscmd/password_accounts.gen.go
+++ b/internal/cmd/commands/accountscmd/password_accounts.gen.go
@@ -204,27 +204,25 @@ func (c *PasswordCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = accountsClient.Create(c.Context, c.FlagAuthMethodId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = accountsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraPasswordActions(c, resp, item, err, accountsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomPasswordActionOutput(c)
@@ -251,6 +249,19 @@ func (c *PasswordCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *PasswordCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/authmethodscmd/authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/authmethods.gen.go
@@ -199,31 +199,32 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = authmethodsClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "delete":
 		deleteResult, err = authmethodsClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = authmethodsClient.List(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, authmethodsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -276,6 +277,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/authmethodscmd/authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/authmethods.gen.go
@@ -284,8 +284,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/authmethodscmd/authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/authmethods.gen.go
@@ -280,16 +280,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/authmethodscmd/oidc_authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/oidc_authmethods.gen.go
@@ -265,16 +265,16 @@ func (c *OidcCommand) Run(args []string) int {
 }
 
 func (c *OidcCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/authmethodscmd/oidc_authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/oidc_authmethods.gen.go
@@ -217,27 +217,25 @@ func (c *OidcCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = authmethodsClient.Create(c.Context, "oidc", c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = authmethodsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraOidcActions(c, resp, item, err, authmethodsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomOidcActionOutput(c)
@@ -264,6 +262,19 @@ func (c *OidcCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *OidcCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/authmethodscmd/oidc_authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/oidc_authmethods.gen.go
@@ -269,8 +269,7 @@ func (c *OidcCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/authmethodscmd/password_authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/password_authmethods.gen.go
@@ -209,27 +209,25 @@ func (c *PasswordCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = authmethodsClient.Create(c.Context, "password", c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = authmethodsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraPasswordActions(c, resp, item, err, authmethodsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomPasswordActionOutput(c)
@@ -256,6 +254,19 @@ func (c *PasswordCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *PasswordCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/authmethodscmd/password_authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/password_authmethods.gen.go
@@ -261,8 +261,7 @@ func (c *PasswordCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/authmethodscmd/password_authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/password_authmethods.gen.go
@@ -257,16 +257,16 @@ func (c *PasswordCommand) Run(args []string) int {
 }
 
 func (c *PasswordCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/authtokenscmd/authtokens.gen.go
+++ b/internal/cmd/commands/authtokenscmd/authtokens.gen.go
@@ -275,16 +275,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/authtokenscmd/authtokens.gen.go
+++ b/internal/cmd/commands/authtokenscmd/authtokens.gen.go
@@ -194,31 +194,32 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = authtokensClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "delete":
 		deleteResult, err = authtokensClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = authtokensClient.List(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, authtokensClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -271,6 +272,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/authtokenscmd/authtokens.gen.go
+++ b/internal/cmd/commands/authtokenscmd/authtokens.gen.go
@@ -279,8 +279,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/credentiallibrariescmd/credentiallibraries.gen.go
+++ b/internal/cmd/commands/credentiallibrariescmd/credentiallibraries.gen.go
@@ -275,16 +275,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/credentiallibrariescmd/credentiallibraries.gen.go
+++ b/internal/cmd/commands/credentiallibrariescmd/credentiallibraries.gen.go
@@ -194,31 +194,32 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = credentiallibrariesClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "delete":
 		deleteResult, err = credentiallibrariesClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = credentiallibrariesClient.List(c.Context, c.FlagCredentialStoreId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, credentiallibrariesClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -271,6 +272,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/credentiallibrariescmd/credentiallibraries.gen.go
+++ b/internal/cmd/commands/credentiallibrariescmd/credentiallibraries.gen.go
@@ -279,8 +279,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/credentiallibrariescmd/vault_credentiallibraries.gen.go
+++ b/internal/cmd/commands/credentiallibrariescmd/vault_credentiallibraries.gen.go
@@ -204,29 +204,25 @@ func (c *VaultCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = credentiallibrariesClient.Create(c.Context, c.FlagCredentialStoreId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = credentiallibrariesClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraVaultActions(c, resp, item, err, credentiallibrariesClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			opts = append(opts, base.WithAttributeFieldPrefix("vault"))
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomVaultActionOutput(c)
@@ -253,6 +249,19 @@ func (c *VaultCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *VaultCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/credentiallibrariescmd/vault_credentiallibraries.gen.go
+++ b/internal/cmd/commands/credentiallibrariescmd/vault_credentiallibraries.gen.go
@@ -256,8 +256,7 @@ func (c *VaultCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/credentiallibrariescmd/vault_credentiallibraries.gen.go
+++ b/internal/cmd/commands/credentiallibrariescmd/vault_credentiallibraries.gen.go
@@ -252,16 +252,16 @@ func (c *VaultCommand) Run(args []string) int {
 }
 
 func (c *VaultCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/credentialscmd/credentials.gen.go
+++ b/internal/cmd/commands/credentialscmd/credentials.gen.go
@@ -275,16 +275,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/credentialscmd/credentials.gen.go
+++ b/internal/cmd/commands/credentialscmd/credentials.gen.go
@@ -194,31 +194,32 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = credentialsClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "delete":
 		deleteResult, err = credentialsClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = credentialsClient.List(c.Context, c.FlagCredentialStoreId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, credentialsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -271,6 +272,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/credentialscmd/credentials.gen.go
+++ b/internal/cmd/commands/credentialscmd/credentials.gen.go
@@ -279,8 +279,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/credentialscmd/ssh-private-key_credentials.gen.go
+++ b/internal/cmd/commands/credentialscmd/ssh-private-key_credentials.gen.go
@@ -252,16 +252,16 @@ func (c *SshPrivateKeyCommand) Run(args []string) int {
 }
 
 func (c *SshPrivateKeyCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/credentialscmd/ssh-private-key_credentials.gen.go
+++ b/internal/cmd/commands/credentialscmd/ssh-private-key_credentials.gen.go
@@ -256,8 +256,7 @@ func (c *SshPrivateKeyCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/credentialscmd/username-password_credentials.gen.go
+++ b/internal/cmd/commands/credentialscmd/username-password_credentials.gen.go
@@ -256,8 +256,7 @@ func (c *UsernamePasswordCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/credentialscmd/username-password_credentials.gen.go
+++ b/internal/cmd/commands/credentialscmd/username-password_credentials.gen.go
@@ -252,16 +252,16 @@ func (c *UsernamePasswordCommand) Run(args []string) int {
 }
 
 func (c *UsernamePasswordCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/credentialscmd/username-password_credentials.gen.go
+++ b/internal/cmd/commands/credentialscmd/username-password_credentials.gen.go
@@ -204,29 +204,25 @@ func (c *UsernamePasswordCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = credentialsClient.Create(c.Context, "username_password", c.FlagCredentialStoreId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = credentialsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraUsernamePasswordActions(c, resp, item, err, credentialsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			opts = append(opts, base.WithAttributeFieldPrefix("username_password"))
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomUsernamePasswordActionOutput(c)
@@ -253,6 +249,19 @@ func (c *UsernamePasswordCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *UsernamePasswordCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/credentialstorescmd/credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/credentialstores.gen.go
@@ -284,8 +284,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/credentialstorescmd/credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/credentialstores.gen.go
@@ -280,16 +280,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/credentialstorescmd/credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/credentialstores.gen.go
@@ -199,31 +199,32 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = credentialstoresClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "delete":
 		deleteResult, err = credentialstoresClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = credentialstoresClient.List(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, credentialstoresClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -276,6 +277,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/credentialstorescmd/static_credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/static_credentialstores.gen.go
@@ -259,8 +259,7 @@ func (c *StaticCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/credentialstorescmd/static_credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/static_credentialstores.gen.go
@@ -207,29 +207,25 @@ func (c *StaticCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = credentialstoresClient.Create(c.Context, "static", c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = credentialstoresClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraStaticActions(c, resp, item, err, credentialstoresClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			opts = append(opts, base.WithAttributeFieldPrefix("static"))
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomStaticActionOutput(c)
@@ -256,6 +252,19 @@ func (c *StaticCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *StaticCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/credentialstorescmd/static_credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/static_credentialstores.gen.go
@@ -255,16 +255,16 @@ func (c *StaticCommand) Run(args []string) int {
 }
 
 func (c *StaticCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/credentialstorescmd/vault_credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/vault_credentialstores.gen.go
@@ -209,29 +209,25 @@ func (c *VaultCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = credentialstoresClient.Create(c.Context, "vault", c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = credentialstoresClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraVaultActions(c, resp, item, err, credentialstoresClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			opts = append(opts, base.WithAttributeFieldPrefix("vault"))
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomVaultActionOutput(c)
@@ -258,6 +254,19 @@ func (c *VaultCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *VaultCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/credentialstorescmd/vault_credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/vault_credentialstores.gen.go
@@ -257,16 +257,16 @@ func (c *VaultCommand) Run(args []string) int {
 }
 
 func (c *VaultCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/credentialstorescmd/vault_credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/vault_credentialstores.gen.go
@@ -261,8 +261,7 @@ func (c *VaultCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/groupscmd/groups.gen.go
+++ b/internal/cmd/commands/groupscmd/groups.gen.go
@@ -364,16 +364,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/groupscmd/groups.gen.go
+++ b/internal/cmd/commands/groupscmd/groups.gen.go
@@ -368,8 +368,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/groupscmd/groups.gen.go
+++ b/internal/cmd/commands/groupscmd/groups.gen.go
@@ -267,41 +267,48 @@ func (c *Command) Run(args []string) int {
 
 	case "create":
 		createResult, err = groupsClient.Create(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "read":
 		readResult, err = groupsClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "update":
 		updateResult, err = groupsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	case "delete":
 		deleteResult, err = groupsClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = groupsClient.List(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, groupsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -354,6 +361,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/hostcatalogscmd/hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/hostcatalogs.gen.go
@@ -284,8 +284,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/hostcatalogscmd/hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/hostcatalogs.gen.go
@@ -199,31 +199,32 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = hostcatalogsClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "delete":
 		deleteResult, err = hostcatalogsClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = hostcatalogsClient.List(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, hostcatalogsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -276,6 +277,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/hostcatalogscmd/hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/hostcatalogs.gen.go
@@ -280,16 +280,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/hostcatalogscmd/plugin_hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/plugin_hostcatalogs.gen.go
@@ -254,27 +254,25 @@ func (c *PluginCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = hostcatalogsClient.Create(c.Context, "plugin", c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = hostcatalogsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraPluginActions(c, resp, item, err, hostcatalogsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomPluginActionOutput(c)
@@ -301,6 +299,19 @@ func (c *PluginCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *PluginCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/hostcatalogscmd/plugin_hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/plugin_hostcatalogs.gen.go
@@ -302,16 +302,16 @@ func (c *PluginCommand) Run(args []string) int {
 }
 
 func (c *PluginCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/hostcatalogscmd/plugin_hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/plugin_hostcatalogs.gen.go
@@ -306,8 +306,7 @@ func (c *PluginCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/hostcatalogscmd/static_hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/static_hostcatalogs.gen.go
@@ -207,27 +207,25 @@ func (c *StaticCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = hostcatalogsClient.Create(c.Context, "static", c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = hostcatalogsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraStaticActions(c, resp, item, err, hostcatalogsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomStaticActionOutput(c)
@@ -254,6 +252,19 @@ func (c *StaticCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *StaticCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/hostcatalogscmd/static_hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/static_hostcatalogs.gen.go
@@ -259,8 +259,7 @@ func (c *StaticCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/hostcatalogscmd/static_hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/static_hostcatalogs.gen.go
@@ -255,16 +255,16 @@ func (c *StaticCommand) Run(args []string) int {
 }
 
 func (c *StaticCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/hostscmd/hosts.gen.go
+++ b/internal/cmd/commands/hostscmd/hosts.gen.go
@@ -295,8 +295,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/hostscmd/hosts.gen.go
+++ b/internal/cmd/commands/hostscmd/hosts.gen.go
@@ -291,16 +291,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/hostscmd/hosts.gen.go
+++ b/internal/cmd/commands/hostscmd/hosts.gen.go
@@ -210,31 +210,32 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = hostsClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "delete":
 		deleteResult, err = hostsClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = hostsClient.List(c.Context, c.FlagHostCatalogId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, hostsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -287,6 +288,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/hostscmd/static_hosts.gen.go
+++ b/internal/cmd/commands/hostscmd/static_hosts.gen.go
@@ -252,16 +252,16 @@ func (c *StaticCommand) Run(args []string) int {
 }
 
 func (c *StaticCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/hostscmd/static_hosts.gen.go
+++ b/internal/cmd/commands/hostscmd/static_hosts.gen.go
@@ -256,8 +256,7 @@ func (c *StaticCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/hostscmd/static_hosts.gen.go
+++ b/internal/cmd/commands/hostscmd/static_hosts.gen.go
@@ -204,27 +204,25 @@ func (c *StaticCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = hostsClient.Create(c.Context, c.FlagHostCatalogId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = hostsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraStaticActions(c, resp, item, err, hostsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomStaticActionOutput(c)
@@ -251,6 +249,19 @@ func (c *StaticCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *StaticCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/hostsetscmd/hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/hostsets.gen.go
@@ -240,31 +240,32 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = hostsetsClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "delete":
 		deleteResult, err = hostsetsClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = hostsetsClient.List(c.Context, c.FlagHostCatalogId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, hostsetsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -317,6 +318,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/hostsetscmd/hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/hostsets.gen.go
@@ -325,8 +325,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/hostsetscmd/hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/hostsets.gen.go
@@ -321,16 +321,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/hostsetscmd/plugin_hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/plugin_hostsets.gen.go
@@ -274,8 +274,7 @@ func (c *PluginCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/hostsetscmd/plugin_hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/plugin_hostsets.gen.go
@@ -270,16 +270,16 @@ func (c *PluginCommand) Run(args []string) int {
 }
 
 func (c *PluginCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/hostsetscmd/static_hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/static_hostsets.gen.go
@@ -250,16 +250,16 @@ func (c *StaticCommand) Run(args []string) int {
 }
 
 func (c *StaticCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/hostsetscmd/static_hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/static_hostsets.gen.go
@@ -202,27 +202,25 @@ func (c *StaticCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = hostsetsClient.Create(c.Context, c.FlagHostCatalogId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = hostsetsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraStaticActions(c, resp, item, err, hostsetsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomStaticActionOutput(c)
@@ -249,6 +247,19 @@ func (c *StaticCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *StaticCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/hostsetscmd/static_hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/static_hostsets.gen.go
@@ -254,8 +254,7 @@ func (c *StaticCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/managedgroupscmd/managedgroups.gen.go
+++ b/internal/cmd/commands/managedgroupscmd/managedgroups.gen.go
@@ -295,8 +295,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/managedgroupscmd/managedgroups.gen.go
+++ b/internal/cmd/commands/managedgroupscmd/managedgroups.gen.go
@@ -291,16 +291,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/managedgroupscmd/managedgroups.gen.go
+++ b/internal/cmd/commands/managedgroupscmd/managedgroups.gen.go
@@ -210,31 +210,32 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = managedgroupsClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "delete":
 		deleteResult, err = managedgroupsClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = managedgroupsClient.List(c.Context, c.FlagAuthMethodId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, managedgroupsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -287,6 +288,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/managedgroupscmd/oidc_managedgroups.gen.go
+++ b/internal/cmd/commands/managedgroupscmd/oidc_managedgroups.gen.go
@@ -252,16 +252,16 @@ func (c *OidcCommand) Run(args []string) int {
 }
 
 func (c *OidcCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/managedgroupscmd/oidc_managedgroups.gen.go
+++ b/internal/cmd/commands/managedgroupscmd/oidc_managedgroups.gen.go
@@ -204,27 +204,25 @@ func (c *OidcCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = managedgroupsClient.Create(c.Context, c.FlagAuthMethodId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = managedgroupsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraOidcActions(c, resp, item, err, managedgroupsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomOidcActionOutput(c)
@@ -251,6 +249,19 @@ func (c *OidcCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *OidcCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/managedgroupscmd/oidc_managedgroups.gen.go
+++ b/internal/cmd/commands/managedgroupscmd/oidc_managedgroups.gen.go
@@ -256,8 +256,7 @@ func (c *OidcCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/rolescmd/roles.gen.go
+++ b/internal/cmd/commands/rolescmd/roles.gen.go
@@ -388,16 +388,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/rolescmd/roles.gen.go
+++ b/internal/cmd/commands/rolescmd/roles.gen.go
@@ -392,8 +392,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/scopescmd/scopes.gen.go
+++ b/internal/cmd/commands/scopescmd/scopes.gen.go
@@ -344,8 +344,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/scopescmd/scopes.gen.go
+++ b/internal/cmd/commands/scopescmd/scopes.gen.go
@@ -243,41 +243,48 @@ func (c *Command) Run(args []string) int {
 
 	case "create":
 		createResult, err = scopesClient.Create(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "read":
 		readResult, err = scopesClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "update":
 		updateResult, err = scopesClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	case "delete":
 		deleteResult, err = scopesClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = scopesClient.List(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, scopesClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -330,6 +337,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/scopescmd/scopes.gen.go
+++ b/internal/cmd/commands/scopescmd/scopes.gen.go
@@ -340,16 +340,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/sessionscmd/funcs.go
+++ b/internal/cmd/commands/sessionscmd/funcs.go
@@ -90,6 +90,9 @@ func executeExtraActionsImpl(c *Command, origResp *api.Response, origItem *sessi
 	switch c.Func {
 	case "cancel":
 		result, err := sessionClient.Cancel(c.Context, c.FlagId, version, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	}
 	return origResp, origItem, origItems, origError

--- a/internal/cmd/commands/sessionscmd/sessions.gen.go
+++ b/internal/cmd/commands/sessionscmd/sessions.gen.go
@@ -271,8 +271,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/sessionscmd/sessions.gen.go
+++ b/internal/cmd/commands/sessionscmd/sessions.gen.go
@@ -267,16 +267,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/sessionscmd/sessions.gen.go
+++ b/internal/cmd/commands/sessionscmd/sessions.gen.go
@@ -206,27 +206,25 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = sessionsClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "list":
 		listResult, err = sessionsClient.List(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, sessionsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -266,6 +264,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/targetscmd/funcs.go
+++ b/internal/cmd/commands/targetscmd/funcs.go
@@ -466,30 +466,57 @@ func executeExtraActionsImpl(c *Command, origResp *api.Response, origItem *targe
 	switch c.Func {
 	case "add-host-sets":
 		result, err := targetClient.AddHostSets(c.Context, c.FlagId, version, c.flagHostSets, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "remove-host-sets":
 		result, err := targetClient.RemoveHostSets(c.Context, c.FlagId, version, c.flagHostSets, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "set-host-sets":
 		result, err := targetClient.SetHostSets(c.Context, c.FlagId, version, c.flagHostSets, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "add-host-sources":
 		result, err := targetClient.AddHostSources(c.Context, c.FlagId, version, c.flagHostSources, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "remove-host-sources":
 		result, err := targetClient.RemoveHostSources(c.Context, c.FlagId, version, c.flagHostSources, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "set-host-sources":
 		result, err := targetClient.SetHostSources(c.Context, c.FlagId, version, c.flagHostSources, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "add-credential-sources":
 		result, err := targetClient.AddCredentialSources(c.Context, c.FlagId, version, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "remove-credential-sources":
 		result, err := targetClient.RemoveCredentialSources(c.Context, c.FlagId, version, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "set-credential-sources":
 		result, err := targetClient.SetCredentialSources(c.Context, c.FlagId, version, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "authorize-session":
 		var err error

--- a/internal/cmd/commands/targetscmd/ssh_targets.gen.go
+++ b/internal/cmd/commands/targetscmd/ssh_targets.gen.go
@@ -261,8 +261,7 @@ func (c *SshCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/targetscmd/ssh_targets.gen.go
+++ b/internal/cmd/commands/targetscmd/ssh_targets.gen.go
@@ -209,27 +209,25 @@ func (c *SshCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = targetsClient.Create(c.Context, "ssh", c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = targetsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraSshActions(c, resp, item, err, targetsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomSshActionOutput(c)
@@ -256,6 +254,19 @@ func (c *SshCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *SshCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/targetscmd/ssh_targets.gen.go
+++ b/internal/cmd/commands/targetscmd/ssh_targets.gen.go
@@ -257,16 +257,16 @@ func (c *SshCommand) Run(args []string) int {
 }
 
 func (c *SshCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/targetscmd/targets.gen.go
+++ b/internal/cmd/commands/targetscmd/targets.gen.go
@@ -375,16 +375,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/targetscmd/targets.gen.go
+++ b/internal/cmd/commands/targetscmd/targets.gen.go
@@ -379,8 +379,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/targetscmd/targets.gen.go
+++ b/internal/cmd/commands/targetscmd/targets.gen.go
@@ -294,31 +294,32 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = targetsClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "delete":
 		deleteResult, err = targetsClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = targetsClient.List(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, targetsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -371,6 +372,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/targetscmd/tcp_targets.gen.go
+++ b/internal/cmd/commands/targetscmd/tcp_targets.gen.go
@@ -209,27 +209,25 @@ func (c *TcpCommand) Run(args []string) int {
 
 	case "create":
 		createResult, err = targetsClient.Create(c.Context, "tcp", c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "update":
 		updateResult, err = targetsClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	}
 
 	resp, item, err = executeExtraTcpActions(c, resp, item, err, targetsClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomTcpActionOutput(c)
@@ -256,6 +254,19 @@ func (c *TcpCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *TcpCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/targetscmd/tcp_targets.gen.go
+++ b/internal/cmd/commands/targetscmd/tcp_targets.gen.go
@@ -261,8 +261,7 @@ func (c *TcpCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/targetscmd/tcp_targets.gen.go
+++ b/internal/cmd/commands/targetscmd/tcp_targets.gen.go
@@ -257,16 +257,16 @@ func (c *TcpCommand) Run(args []string) int {
 }
 
 func (c *TcpCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/userscmd/users.gen.go
+++ b/internal/cmd/commands/userscmd/users.gen.go
@@ -364,16 +364,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/userscmd/users.gen.go
+++ b/internal/cmd/commands/userscmd/users.gen.go
@@ -368,8 +368,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/userscmd/users.gen.go
+++ b/internal/cmd/commands/userscmd/users.gen.go
@@ -267,41 +267,48 @@ func (c *Command) Run(args []string) int {
 
 	case "create":
 		createResult, err = usersClient.Create(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = createResult.GetResponse()
 		item = createResult.GetItem()
 
 	case "read":
 		readResult, err = usersClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "update":
 		updateResult, err = usersClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	case "delete":
 		deleteResult, err = usersClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = usersClient.List(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, usersClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -354,6 +361,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/workerscmd/worker-led_workers.gen.go
+++ b/internal/cmd/commands/workerscmd/worker-led_workers.gen.go
@@ -226,16 +226,16 @@ func (c *WorkerLedCommand) Run(args []string) int {
 }
 
 func (c *WorkerLedCommand) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/workerscmd/worker-led_workers.gen.go
+++ b/internal/cmd/commands/workerscmd/worker-led_workers.gen.go
@@ -230,8 +230,7 @@ func (c *WorkerLedCommand) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/commands/workerscmd/worker-led_workers.gen.go
+++ b/internal/cmd/commands/workerscmd/worker-led_workers.gen.go
@@ -195,16 +195,8 @@ func (c *WorkerLedCommand) Run(args []string) int {
 	}
 
 	resp, item, err = executeExtraWorkerLedActions(c, resp, item, err, workersClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomWorkerLedActionOutput(c)
@@ -231,6 +223,19 @@ func (c *WorkerLedCommand) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *WorkerLedCommand) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/workerscmd/workers.gen.go
+++ b/internal/cmd/commands/workerscmd/workers.gen.go
@@ -320,16 +320,16 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (

--- a/internal/cmd/commands/workerscmd/workers.gen.go
+++ b/internal/cmd/commands/workerscmd/workers.gen.go
@@ -231,36 +231,40 @@ func (c *Command) Run(args []string) int {
 
 	case "read":
 		readResult, err = workersClient.Read(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = readResult.GetResponse()
 		item = readResult.GetItem()
 
 	case "update":
 		updateResult, err = workersClient.Update(c.Context, c.FlagId, version, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = updateResult.GetResponse()
 		item = updateResult.GetItem()
 
 	case "delete":
 		deleteResult, err = workersClient.Delete(c.Context, c.FlagId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = deleteResult.GetResponse()
 
 	case "list":
 		listResult, err = workersClient.List(c.Context, c.FlagScopeId, opts...)
+		if exitCode := c.checkFuncError(err); exitCode > 0 {
+			return exitCode
+		}
 		resp = listResult.GetResponse()
 		items = listResult.GetItems()
 
 	}
 
 	resp, item, items, err = executeExtraActions(c, resp, item, items, err, workersClient, version, opts)
-
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if exitCode := c.checkFuncError(err); exitCode > 0 {
+		return exitCode
 	}
 
 	output, err := printCustomActionOutput(c)
@@ -313,6 +317,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return base.CommandSuccess
+}
+
+func (c *Command) checkFuncError(err error) int {
+	if err != nil {
+		if apiErr := api.AsServerError(err); apiErr != nil {
+			var opts []base.Option
+			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+			return base.CommandApiError
+		}
+		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+		return base.CommandCliError
+	}
+	return 0
 }
 
 var (

--- a/internal/cmd/commands/workerscmd/workers.gen.go
+++ b/internal/cmd/commands/workerscmd/workers.gen.go
@@ -324,8 +324,7 @@ func (c *Command) checkFuncError(err error) int {
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/gencli/templates.go
+++ b/internal/cmd/gencli/templates.go
@@ -526,8 +526,7 @@ func (c *{{ camelCase .SubActionPrefix }}Command) checkFuncError(err error) int 
 		return 0
 	}
 	if apiErr := api.AsServerError(err); apiErr != nil {
-		var opts []base.Option
-		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural))
 		return base.CommandApiError
 	}
 	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))

--- a/internal/cmd/gencli/templates.go
+++ b/internal/cmd/gencli/templates.go
@@ -522,16 +522,16 @@ func (c *{{ camelCase .SubActionPrefix }}Command) Run(args []string) int {
 }
 
 func (c *{{ camelCase .SubActionPrefix }}Command) checkFuncError(err error) int {
-	if err != nil {
-		if apiErr := api.AsServerError(err); apiErr != nil {
-			var opts []base.Option
-			c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
-			return base.CommandApiError
-		}
-		c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
-		return base.CommandCliError
+	if err == nil {
+		return 0
 	}
-	return 0
+	if apiErr := api.AsServerError(err); apiErr != nil {
+		var opts []base.Option
+		c.PrintApiError(apiErr, fmt.Sprintf("Error from controller when performing %s on %s", c.Func, c.plural), opts...)
+		return base.CommandApiError
+	}
+	c.PrintCliError(fmt.Errorf("Error trying to %s %s: %s", c.Func, c.plural, err.Error()))
+	return base.CommandCliError
 }
 
 var (


### PR DESCRIPTION
### Summary:

In the code snippet below, we were getting panics from `resp = readResult.GetResponse()` because we weren't checking the err value until after the switch statement for c.Func.

```
readResult, err = authmethodsClient.Read(c.Context, c.FlagId, opts...)
resp = readResult.GetResponse()
item = readResult.GetItem()
```

### Changes:

I added a helper function called checkFuncError(), which is now being used to check the error values before setting the resp & item variables.

```
readResult, err = authmethodsClient.Read(c.Context, c.FlagId, opts...)
if exitCode := c.checkFuncError(err); exitCode > 0 {
	return exitCode
}
resp = readResult.GetResponse()
item = readResult.GetItem()
```

I also updated the target & sessions `executeExtraActionsImpl` func to check the error value. Example:

```
result, err := targetClient.AddHostSets(c.Context, c.FlagId, version, c.flagHostSets, opts...)
if err != nil {
        return nil, nil, nil, err
}
return result.GetResponse(), result.GetItem(), nil, err
```


### bats test output:

```
auth_token.bats
 ✓ boundary/token: can login as unpriv user
 ✓ boundary/token: can read own token with no id given
 ✓ boundary/token: can read own token with self given
 ✓ boundary/token: can read own token id given
 ✓ boundary/token: can delete own token with no id given
 ✓ boundary/token: can delete own token with self given
 ✓ boundary/token: can delete own token with id given
 ✓ boundary/token/logout: can logout
credential_stores.bats
 ✓ boundary/login: can login as default user
 ✓ boundary/credential-stores: can create test static store in default project
 ✓ boundary/credential-stores: can not create already created test static store
 ✓ boundary/credential-stores: can read test static store
 ✓ boundary/credential-stores: can delete test static store
 ✓ boundary/credential-stores: can not read deleted test static store
credentials.bats
 ✓ boundary/login: can login as default user
 ✓ boundary/credential-stores: can create credentials-test-store static store in default project
 ✓ boundary/credentials: can create test credential in credentials-test-store store
 ✓ boundary/credentials: can not create already created test credential
 ✓ boundary/credentials: can read test credential
 ✓ boundary/credentials: can delete test credential
 ✓ boundary/credential-stores: can not read deleted test credential
groups.bats
 ✓ boundary/login: can login as default user
 ✓ boundary/groups: can add test group
 ✓ boundary/groups: can not add already created test group
 ✓ boundary/groups: can read test group
 ✓ boundary/groups: the test group contains default authorized-actions
 ✓ boundary/group/add-members: can associate test group with default user
 ✓ boundary/group/add-members: test group contains default user
 ✓ boundary/group: can delete test group
 ✓ boundary/groups: can not read deleted test group
host_catalogs.bats
 ✓ boundary/login: can login as default user
 ✓ boundary/host-catalogs: can create test host catalog in default project scope
 ✓ boundary/host-catalogs: can not create already created test host catalog in default project scope
 ✓ boundary/host-catalogs: can read test host catalog in default project scope
 ✓ boundary/host-catalogs: the test host catalog contains default authorized-actions
 ✓ boundary/host-catalogs: can delete test host in default project scope
 ✓ boundary/host-catalogs: can not read deleted test host in default project scope
host_sets.bats
 ✓ boundary/login: can login as default user
 ✓ boundary/host-sets: can add test host set to default host catalog
 ✓ boundary/host-sets: can not add already created test host set
 ✓ boundary/host-sets: can read test host set
 ✓ boundary/host-sets: the test host set contains default authorized-actions
 ✓ boundary/host-set/add-host: can associate test host set with default host
 ✓ boundary/host-set/add-host: test host set contains default host
 ✓ boundary/host-set: can delete test host set
 ✓ boundary/host-set: can not delete already deleted test host set
 ✓ boundary/host-sets: can not read deleted test host set
hosts.bats
 ✓ boundary/login: can login as default user
 ✓ boundary/hosts: can create test host in default host catalog
 ✓ boundary/hosts: can not add already created test host in default host catalog
 ✓ boundary/hosts: can read test host
 ✓ boundary/hosts: the test host contains default authorized-actions
 ✓ boundary/host: can delete test host
 ✓ boundary/hosts: can not read deleted test host
roles.bats
 ✓ boundary/login: can login as default principal
 ✓ boundary/roles: can add test role to global scope granting rights in default org scope
 ✓ boundary/roles: can not add already created test role
 ✓ boundary/roles: can read test role
 ✓ boundary/roles: the test role contains default authorized-actions
 ✓ boundary/role/add-principals: can associate test role with default principal
 ✓ boundary/role/add-principals: test role contains default principal
 ✓ boundary/role/remove-principals: can remove default principal from test role
 ✓ boundary/role/remove-principals: test role no longer contains default principal
 ✓ boundary/role/add-grants: can associate test role with id=*;type=*;actions=create,read,update,delete,list grant
 ✓ boundary/role/add-grantss: test role contains id=*;type=*;actions=create,read,update,delete,list grant
 ✓ boundary/role/remove-grants: can remove id=*;type=*;actions=create,read,update,delete,list grant from test role
 ✓ boundary/role/remove-grants: test role no longer contains id=*;type=*;actions=create,read,update,delete,list grant
 ✓ boundary/role: can delete test role
 ✓ boundary/roles: can not read deleted test role
scopes.bats
 ✓ boundary/login: can login as default user
 ✓ boundary/scopes: can create test_org organization level scope
 ✓ boundary/scopes: can read test_org organization level scope
 ✓ boundary/scopes: the test_org scope contains default org authorized-actions
 ✓ boundary/scopes: can create test_project project level scope
 ✓ boundary/scopes: can read test_project project level scope
 ✓ boundary/scopes: the test_project scope contains default project authorized-actions
 ✓ boundary/scopes: can delete test_project project level scope
 ✓ boundary/scopes: can not read deleted test_project project level scope
 ✓ boundary/scopes: can delete test_org organization level scope
 ✓ boundary/scopes: can not read deleted test_org organization level scope
sessions.bats
 ✓ boundary/session: admin user can connect to default target
 ✓ boundary/session/connect: unpriv user can connect to default target
 ✓ boundary/session: verify admin and unpriv user see different counts
 ✓ boundary/session: verify read and cancellation permissions on admin session
 ✓ boundary/session: verify read and cancellation permissions on unpriv session
target.bats
 ✓ boundary/login: can login as admin user
 ✓ boundary/target/connect: admin user can connect to default target
 ✓ boundary/target: admin user can read default target
 ✓ boundary/login: can login as unpriv user
 ✓ boundary/target/connect: unpriv user can connect to default target
 ✓ boundary/target: unpriv user can not read default target
 ✓ boundary/login: login back in as admin user
 ✓ boundary/target: admin user can create target
 ✓ boundary/target: admin user can not create already created target
 ✓ boundary/target: admin user can read created target
 ✓ boundary/target: the test target contains default authorized-actions
 ✓ boundary/target: admin user can add default host set to created target
 ✓ boundary/target: created target has default host set
 ✓ boundary/target/connect: default user can connect to created target
 ✓ boundary/target: default user can delete target
 ✓ boundary/target: default user can not read deleted target
target_credential_sources.bats
 ✓ boundary/login: can login as admin user
 ✓ boundary/credential-stores: can create test-for-add-credential-sources static store in default project
 ✓ boundary/credentials: can create first-credential credential in test-for-add-credential-sources store
 ✓ boundary/target: can add first-credential credential source
 ✓ boundary/target: validate only first-credential credential source present
 ✓ boundary/target: cannot add duplicate credential source
 ✓ boundary/target: can delete first-credential credential source
 ✓ boundary/target: validate first-credential credential source removed
 ✓ boundary/credentials: can create additional credentials in test-for-add-credential-sources store
 ✓ boundary/target: can add multiple credential sources
 ✓ boundary/target: validate added credential sources present
 ✓ boundary/target: can delete multiple credential sources
 ✓ boundary/target: validate third-credential credential source present
 ✓ boundary/target: validate deleted credential sources not present
 ✓ boundary/target: can set multiple credential sources
 ✓ boundary/target: validate set credential sources present
 ✓ boundary/target: can set just first-credential credential source
 ✓ boundary/target: validate first-credential credential source present
 ✓ boundary/target: validate not set credential sources not present
user.bats
 ✓ boundary/login: can login as default user
 ✓ boundary/users: can add test user
 ✓ boundary/users: can not add already created test user
 ✓ boundary/users: can read test user
 ✓ boundary/users: the test user contains default authorized-actions
 ✓ boundary/account/password: can add test account
 ✓ boundary/account/password: can not add already created test account
 ✓ boundary/account/password: can read created test account
 ✓ boundary/user/account-add: can associate test account with test user
 ✓ boundary/login: can login as test user
 ✓ boundary/user: can delete test user
 ✓ boundary/users: can not read deleted test user
 ✓ boundary/account/password: can delete test account
version.bats
 ✓ boundary/version: can run version command
 ✓ boundary/version: version output is valid
 ✓ boundary/version: revision output is valid

136 tests, 0 failures
```