### PR TITLE
fix(cli) check error value in executeExtraActionsImpl funcs

### DIFF
--- a/internal/cmd/commands/accountscmd/funcs.go
+++ b/internal/cmd/commands/accountscmd/funcs.go
@@ -178,9 +178,15 @@ func executeExtraActionsImpl(c *Command, origResp *api.Response, origItem *accou
 	switch c.Func {
 	case "set-password":
 		result, err := accountClient.SetPassword(c.Context, c.FlagId, c.flagPassword, version, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "change-password":
 		result, err := accountClient.ChangePassword(c.Context, c.FlagId, c.flagCurrentPassword, c.flagNewPassword, version, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	}
 	return origResp, origItem, origItems, origError

--- a/internal/cmd/commands/groupscmd/funcs.go
+++ b/internal/cmd/commands/groupscmd/funcs.go
@@ -132,12 +132,21 @@ func executeExtraActionsImpl(c *Command, origResp *api.Response, origItem *group
 	switch c.Func {
 	case "add-members":
 		result, err := groupClient.AddMembers(c.Context, c.FlagId, version, c.flagMembers, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "set-members":
 		result, err := groupClient.SetMembers(c.Context, c.FlagId, version, c.flagMembers, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "remove-members":
 		result, err := groupClient.RemoveMembers(c.Context, c.FlagId, version, c.flagMembers, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	}
 	return origResp, origItem, origItems, origError

--- a/internal/cmd/commands/hostsetscmd/funcs.go
+++ b/internal/cmd/commands/hostsetscmd/funcs.go
@@ -164,12 +164,21 @@ func executeExtraActionsImpl(c *Command, origResp *api.Response, origItem *hosts
 	switch c.Func {
 	case "add-hosts":
 		result, err := hostsetClient.AddHosts(c.Context, c.FlagId, version, c.flagHosts, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "remove-hosts":
 		result, err := hostsetClient.RemoveHosts(c.Context, c.FlagId, version, c.flagHosts, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "set-hosts":
 		result, err := hostsetClient.SetHosts(c.Context, c.FlagId, version, c.flagHosts, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	}
 	return origResp, origItem, origItems, origError

--- a/internal/cmd/commands/rolescmd/funcs.go
+++ b/internal/cmd/commands/rolescmd/funcs.go
@@ -230,21 +230,39 @@ func executeExtraActionsImpl(c *Command, origResp *api.Response, origItem *roles
 	switch c.Func {
 	case "add-principals":
 		result, err := roleClient.AddPrincipals(c.Context, c.FlagId, version, c.flagPrincipals, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "set-principals":
 		result, err := roleClient.SetPrincipals(c.Context, c.FlagId, version, c.flagPrincipals, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "remove-principals":
 		result, err := roleClient.RemovePrincipals(c.Context, c.FlagId, version, c.flagPrincipals, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "add-grants":
 		result, err := roleClient.AddGrants(c.Context, c.FlagId, version, c.flagGrants, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "set-grants":
 		result, err := roleClient.SetGrants(c.Context, c.FlagId, version, c.flagGrants, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "remove-grants":
 		result, err := roleClient.RemoveGrants(c.Context, c.FlagId, version, c.flagGrants, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	}
 	return origResp, origItem, origItems, origError

--- a/internal/cmd/commands/userscmd/funcs.go
+++ b/internal/cmd/commands/userscmd/funcs.go
@@ -131,12 +131,21 @@ func executeExtraActionsImpl(c *Command, origResp *api.Response, origItem *users
 	switch c.Func {
 	case "add-accounts":
 		result, err := userClient.AddAccounts(c.Context, c.FlagId, version, c.flagAccounts, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "set-accounts":
 		result, err := userClient.SetAccounts(c.Context, c.FlagId, version, c.flagAccounts, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	case "remove-accounts":
 		result, err := userClient.RemoveAccounts(c.Context, c.FlagId, version, c.flagAccounts, opts...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		return result.GetResponse(), result.GetItem(), nil, err
 	}
 	return origResp, origItem, origItems, origError


### PR DESCRIPTION
### Summary:

In the code snippet below, we were getting panics from `result.GetResponse()` because we weren't checking the err value. When an error value is returned, then result is nil, which causes a panic.

### Fix:

```
func executeExtraActionsImpl(c *Command, origResp *api.Response, origItem *users.User, origItems []*users.User, origError error, userClient *users.Client, version uint32, opts []users.Option) (*api.Response, *users.User, []*users.User, error) {
	switch c.Func {
	case "add-accounts":
		result, err := userClient.AddAccounts(c.Context, c.FlagId, version, c.flagAccounts, opts...)
		if err != nil {
			return nil, nil, nil, err
		}
		return result.GetResponse(), result.GetItem(), nil, err
	case "set-accounts":
		result, err := userClient.SetAccounts(c.Context, c.FlagId, version, c.flagAccounts, opts...)
		if err != nil {
			return nil, nil, nil, err
		}
		return result.GetResponse(), result.GetItem(), nil, err
	case "remove-accounts":
		result, err := userClient.RemoveAccounts(c.Context, c.FlagId, version, c.flagAccounts, opts...)
		if err != nil {
			return nil, nil, nil, err
		}
		return result.GetResponse(), result.GetItem(), nil, err
	}
	return origResp, origItem, origItems, origError
}
```