### PR TITLE
Remove `-token` flag

### DIFF
--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -93,7 +93,6 @@ type Command struct {
 	flagTLSInsecure   bool
 
 	flagFormat           string
-	FlagToken            string
 	FlagTokenName        string
 	FlagKeyringType      string
 	FlagRecoveryConfig   string
@@ -274,9 +273,6 @@ func (c *Command) Client(opt ...Option) (*api.Client, error) {
 
 		c.client.SetRecoveryKmsWrapper(wrapper)
 
-	case c.FlagToken != "":
-		c.client.SetToken(c.FlagToken)
-
 	case c.client.Token() == "" && strings.ToLower(c.FlagKeyringType) != "none":
 		keyringType, tokenName, err := c.DiscoverKeyringTokenInfo()
 		if err != nil {
@@ -395,13 +391,6 @@ func (c *Command) FlagSet(bit FlagSetBit) *FlagSets {
 				Default: "auto",
 				EnvVar:  EnvKeyringType,
 				Usage:   `The type of keyring to use. Defaults to "auto" which will use the Windows credential manager, OSX keychain, or cross-platform password store depending on platform. Set to "none" to disable keyring functionality. Available types, depending on platform, are: "wincred", "keychain", "pass", and "secret-service".`,
-			})
-
-			f.StringVar(&StringVar{
-				Name:   "token",
-				Target: &c.FlagToken,
-				EnvVar: envToken,
-				Usage:  `If specified, the given value will be used as the token for the call. Overrides the "token-name" parameter.`,
 			})
 
 			f.StringVar(&StringVar{


### PR DESCRIPTION
Token values can be shown in output of `ps` and so, and we support env
vars and keyrings, so remove it.