### PR TITLE
bug(server): Start ops listener even if controller is nil

### DIFF
--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -527,15 +527,13 @@ func (c *Command) Run(args []string) int {
 		return base.CommandCliError
 	}
 
-	if c.controller != nil {
-		opsServer, err := ops.NewServer(c.Logger, c.controller, c.Listeners...)
-		if err != nil {
-			c.UI.Error(err.Error())
-			return base.CommandCliError
-		}
-		c.opsServer = opsServer
-		c.opsServer.Start()
+	opsServer, err := ops.NewServer(c.Logger, c.controller, c.Listeners...)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return base.CommandCliError
 	}
+	c.opsServer = opsServer
+	c.opsServer.Start()
 
 	// Inform any tests that the server is ready
 	if c.startedCh != nil {


### PR DESCRIPTION
#2288 introduced some safety precautions for a nil controller, this included not starting an ops listener if the controller was nil. However, the current `ops.NewServer` code is valid for a nil controller (i.e. a worker only definition). In this state it starts a `/metrics` endpoint ([see](https://github.com/hashicorp/boundary/blob/main/internal/cmd/ops/server.go#L133)) which is used by HCPb to check the worker health and to not keep restarting it 