### PR TITLE
Clean up some dev config kms code

### DIFF
--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -263,7 +263,6 @@ func DevKeyGeneration() string {
 func DevController() (*Config, error) {
 	controllerKey := DevKeyGeneration()
 	workerAuthKey := DevKeyGeneration()
-	workerAuthStorageKey := DevKeyGeneration()
 	recoveryKey := DevKeyGeneration()
 
 	hclStr := fmt.Sprintf(devConfig+devControllerExtraConfig, controllerKey, workerAuthKey, recoveryKey)
@@ -274,7 +273,6 @@ func DevController() (*Config, error) {
 	parsed.DevController = true
 	parsed.DevControllerKey = controllerKey
 	parsed.DevWorkerAuthKey = workerAuthKey
-	parsed.DevWorkerAuthStorageKey = workerAuthStorageKey
 	parsed.DevRecoveryKey = recoveryKey
 	return parsed, nil
 }

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -58,13 +58,6 @@ kms "aead" {
 }
 
 kms "aead" {
-    purpose = "worker-auth-storage"
-	aead_type = "aes-gcm"
-	key = "%s"
-	key_id = "global_worker-auth-storage"
-}
-
-kms "aead" {
 	purpose = "recovery"
 	aead_type = "aes-gcm"
 	key = "%s"
@@ -100,6 +93,13 @@ worker {
 	tags {
 		type = ["dev", "local"]
 	}
+}
+
+kms "aead" {
+    purpose = "worker-auth-storage"
+	aead_type = "aes-gcm"
+	key = "%s"
+	key_id = "worker-auth-storage"
 }
 `
 )
@@ -232,7 +232,9 @@ type Plugins struct {
 // DevWorker is a Config that is used for dev mode of Boundary
 // workers
 func DevWorker() (*Config, error) {
-	parsed, err := Parse(devConfig + devWorkerExtraConfig)
+	workerAuthStorageKey := DevKeyGeneration()
+	hclStr := fmt.Sprintf(devConfig+devWorkerExtraConfig, workerAuthStorageKey)
+	parsed, err := Parse(hclStr)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing dev config: %w", err)
 	}
@@ -264,7 +266,7 @@ func DevController() (*Config, error) {
 	workerAuthStorageKey := DevKeyGeneration()
 	recoveryKey := DevKeyGeneration()
 
-	hclStr := fmt.Sprintf(devConfig+devControllerExtraConfig, controllerKey, workerAuthKey, workerAuthStorageKey, recoveryKey)
+	hclStr := fmt.Sprintf(devConfig+devControllerExtraConfig, controllerKey, workerAuthKey, recoveryKey)
 	parsed, err := Parse(hclStr)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing dev config: %w", err)
@@ -282,7 +284,7 @@ func DevCombined() (*Config, error) {
 	workerAuthKey := DevKeyGeneration()
 	workerAuthStorageKey := DevKeyGeneration()
 	recoveryKey := DevKeyGeneration()
-	hclStr := fmt.Sprintf(devConfig+devControllerExtraConfig+devWorkerExtraConfig, controllerKey, workerAuthKey, workerAuthStorageKey, recoveryKey)
+	hclStr := fmt.Sprintf(devConfig+devControllerExtraConfig+devWorkerExtraConfig, controllerKey, workerAuthKey, recoveryKey, workerAuthStorageKey)
 	parsed, err := Parse(hclStr)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing dev config: %w", err)

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -63,14 +63,6 @@ func TestDevController(t *testing.T) {
 				},
 				{
 					Type:    "aead",
-					Purpose: []string{"worker-auth-storage"},
-					Config: map[string]string{
-						"aead_type": "aes-gcm",
-						"key_id":    "global_worker-auth-storage",
-					},
-				},
-				{
-					Type:    "aead",
 					Purpose: []string{"recovery"},
 					Config: map[string]string{
 						"aead_type": "aes-gcm",
@@ -92,11 +84,9 @@ func TestDevController(t *testing.T) {
 	exp.Seals[0].Config["key"] = actual.Seals[0].Config["key"]
 	exp.Seals[1].Config["key"] = actual.Seals[1].Config["key"]
 	exp.Seals[2].Config["key"] = actual.Seals[2].Config["key"]
-	exp.Seals[3].Config["key"] = actual.Seals[3].Config["key"]
 	exp.DevControllerKey = actual.Seals[0].Config["key"]
 	exp.DevWorkerAuthKey = actual.Seals[1].Config["key"]
-	exp.DevWorkerAuthStorageKey = actual.Seals[2].Config["key"]
-	exp.DevRecoveryKey = actual.Seals[3].Config["key"]
+	exp.DevRecoveryKey = actual.Seals[2].Config["key"]
 
 	assert.Equal(t, exp, actual)
 
@@ -188,6 +178,16 @@ func TestDevWorker(t *testing.T) {
 					Purpose: []string{"proxy"},
 				},
 			},
+			Seals: []*configutil.KMS{
+				{
+					Type:    "aead",
+					Purpose: []string{"worker-auth-storage"},
+					Config: map[string]string{
+						"aead_type": "aes-gcm",
+						"key_id":    "worker-auth-storage",
+					},
+				},
+			},
 		},
 		Worker: &Worker{
 			Name:                "w_1234567890",
@@ -201,6 +201,7 @@ func TestDevWorker(t *testing.T) {
 	}
 
 	exp.Listeners[0].RawConfig = actual.Listeners[0].RawConfig
+	exp.Seals[0].Config["key"] = actual.Seals[0].Config["key"]
 	exp.Worker.TagsRaw = actual.Worker.TagsRaw
 	assert.Equal(t, exp, actual)
 
@@ -221,6 +222,7 @@ func TestDevWorker(t *testing.T) {
 	actual, err = Parse(devConfig + devWorkerKeyValueConfig)
 	assert.NoError(t, err)
 	exp.Listeners[0].RawConfig = actual.Listeners[0].RawConfig
+	exp.Seals = nil
 	exp.Worker.TagsRaw = actual.Worker.TagsRaw
 	assert.Equal(t, exp, actual)
 
@@ -354,18 +356,18 @@ func TestDevCombined(t *testing.T) {
 				},
 				{
 					Type:    "aead",
-					Purpose: []string{"worker-auth-storage"},
-					Config: map[string]string{
-						"aead_type": "aes-gcm",
-						"key_id":    "global_worker-auth-storage",
-					},
-				},
-				{
-					Type:    "aead",
 					Purpose: []string{"recovery"},
 					Config: map[string]string{
 						"aead_type": "aes-gcm",
 						"key_id":    "global_recovery",
+					},
+				},
+				{
+					Type:    "aead",
+					Purpose: []string{"worker-auth-storage"},
+					Config: map[string]string{
+						"aead_type": "aes-gcm",
+						"key_id":    "worker-auth-storage",
 					},
 				},
 			},
@@ -396,8 +398,8 @@ func TestDevCombined(t *testing.T) {
 	exp.Seals[3].Config["key"] = actual.Seals[3].Config["key"]
 	exp.DevControllerKey = actual.Seals[0].Config["key"]
 	exp.DevWorkerAuthKey = actual.Seals[1].Config["key"]
-	exp.DevWorkerAuthStorageKey = actual.Seals[2].Config["key"]
-	exp.DevRecoveryKey = actual.Seals[3].Config["key"]
+	exp.DevRecoveryKey = actual.Seals[2].Config["key"]
+	exp.DevWorkerAuthStorageKey = actual.Seals[3].Config["key"]
 	exp.Worker.TagsRaw = actual.Worker.TagsRaw
 	assert.Equal(t, exp, actual)
 }

--- a/internal/daemon/worker/auth_rotation_test.go
+++ b/internal/daemon/worker/auth_rotation_test.go
@@ -85,7 +85,7 @@ func TestRotationTicking(t *testing.T) {
 	require.NoError(err)
 	assert.Len(auths, 1)
 	// Fetch creds and store current key
-	currNodeCreds, err := types.LoadNodeCredentials(w.Context(), w.Worker().WorkerAuthStorage, nodeenrollment.CurrentId)
+	currNodeCreds, err := types.LoadNodeCredentials(w.Context(), w.Worker().WorkerAuthStorage, nodeenrollment.CurrentId, nodeenrollment.WithWrapper(w.Config().WorkerAuthStorageKms))
 	require.NoError(err)
 	currKey := currNodeCreds.CertificatePublicKeyPkix
 
@@ -101,7 +101,7 @@ func TestRotationTicking(t *testing.T) {
 		assert.Len(auths, i)
 
 		// Fetch creds and compare current key
-		currNodeCreds, err := types.LoadNodeCredentials(w.Context(), w.Worker().WorkerAuthStorage, nodeenrollment.CurrentId)
+		currNodeCreds, err := types.LoadNodeCredentials(w.Context(), w.Worker().WorkerAuthStorage, nodeenrollment.CurrentId, nodeenrollment.WithWrapper(w.Config().WorkerAuthStorageKms))
 		require.NoError(err)
 		assert.NotEqual(currKey, currNodeCreds.CertificatePublicKeyPkix)
 		currKey = currNodeCreds.CertificatePublicKeyPkix

--- a/internal/daemon/worker/testing.go
+++ b/internal/daemon/worker/testing.go
@@ -225,6 +225,7 @@ func NewTestWorker(t testing.TB, opts *TestWorkerOpts) *TestWorker {
 	// Base server
 	tw.b = base.NewServer(nil)
 	tw.b.Command = &base.Command{
+		Context:    ctx,
 		ShutdownCh: make(chan struct{}),
 	}
 

--- a/internal/daemon/worker/testing_test.go
+++ b/internal/daemon/worker/testing_test.go
@@ -112,7 +112,12 @@ func TestTestWorker_WorkerAuthStorageKms(t *testing.T) {
 			tw := NewTestWorker(t, &TestWorkerOpts{
 				WorkerAuthStorageKms: tt.wrapper,
 			})
-			require.Equal(tt.wrapper, tw.Config().WorkerAuthStorageKms)
+			if tt.wrapper == nil {
+				// DevWorker config will create one
+				require.NotNil(tw.Config().WorkerAuthStorageKms)
+			} else {
+				require.Equal(tt.wrapper, tw.Config().WorkerAuthStorageKms)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Although it didn't matter in the combined state, the KMS for auth
storage was not actually being set properly if only a worker was being
instantiated.