### PR TITLE
Add parsepath logic to password in various places

### DIFF
--- a/internal/cmd/commands/accountscmd/funcs.go
+++ b/internal/cmd/commands/accountscmd/funcs.go
@@ -143,7 +143,7 @@ func extraFlagsHandlingFuncImpl(c *Command, _ *base.FlagSets, opts *[]accounts.O
 		default:
 			password, err := parseutil.ParsePath(c.flagPassword)
 			if err != nil && err.Error() != parseutil.ErrNotAUrl.Error() {
-				c.UI.Error("Error parsing password flag: " + err.Error())
+				c.UI.Error(fmt.Sprintf("Error parsing password flag: %v", err))
 				return false
 			}
 			c.flagPassword = password
@@ -166,7 +166,7 @@ func extraFlagsHandlingFuncImpl(c *Command, _ *base.FlagSets, opts *[]accounts.O
 		default:
 			password, err := parseutil.ParsePath(c.flagCurrentPassword)
 			if err != nil && err.Error() != parseutil.ErrNotAUrl.Error() {
-				c.UI.Error("Error parsing current password flag: " + err.Error())
+				c.UI.Error(fmt.Sprintf("Error parsing current password flag: %v", err))
 				return false
 			}
 			c.flagCurrentPassword = password
@@ -198,7 +198,7 @@ func extraFlagsHandlingFuncImpl(c *Command, _ *base.FlagSets, opts *[]accounts.O
 		default:
 			password, err := parseutil.ParsePath(c.flagNewPassword)
 			if err != nil && err.Error() != parseutil.ErrNotAUrl.Error() {
-				c.UI.Error("Error parsing new password flag: " + err.Error())
+				c.UI.Error(fmt.Sprintf("Error parsing new password flag: %v", err))
 				return false
 			}
 			c.flagNewPassword = password

--- a/internal/cmd/commands/accountscmd/password_funcs.go
+++ b/internal/cmd/commands/accountscmd/password_funcs.go
@@ -119,7 +119,7 @@ func extraPasswordFlagsHandlingFuncImpl(c *PasswordCommand, _ *base.FlagSets, op
 		default:
 			password, err := parseutil.ParsePath(c.flagPassword)
 			if err != nil && err.Error() != parseutil.ErrNotAUrl.Error() {
-				c.UI.Error("Error parsing password flag: " + err.Error())
+				c.UI.Error(fmt.Sprintf("Error parsing password flag: %v", err))
 				return false
 			}
 			*opts = append(*opts, accounts.WithPasswordAccountPassword(password))

--- a/internal/cmd/commands/authenticate/password.go
+++ b/internal/cmd/commands/authenticate/password.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/authmethods"
 	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/password"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/go-wordwrap"
@@ -56,21 +57,21 @@ func (c *PasswordCommand) Flags() *base.FlagSets {
 		Name:   "login-name",
 		Target: &c.flagLoginName,
 		EnvVar: envLoginName,
-		Usage:  "The login name corresponding to an account within the given auth method",
+		Usage:  "The login name corresponding to an account within the given auth method.",
 	})
 
 	f.StringVar(&base.StringVar{
 		Name:   "password",
 		Target: &c.flagPassword,
 		EnvVar: envPassword,
-		Usage:  "The password associated with the login name",
+		Usage:  "The password associated with the login name. If blank, the command will prompt for the password to be entered interactively in a non-echoing way. Otherwise, this can refer to a file on disk (file://) from which a password will be read; an env var (env://) from which the password will be read; or a string containing the password.",
 	})
 
 	f.StringVar(&base.StringVar{
 		Name:   "auth-method-id",
 		EnvVar: "BOUNDARY_AUTH_METHOD_ID",
 		Target: &c.FlagAuthMethodId,
-		Usage:  "The auth-method resource to use for the operation",
+		Usage:  "The auth-method resource to use for the operation.",
 	})
 
 	return set
@@ -101,7 +102,8 @@ func (c *PasswordCommand) Run(args []string) int {
 		return base.CommandUserError
 	}
 
-	if c.flagPassword == "" {
+	switch c.flagPassword {
+	case "":
 		fmt.Print("Password is not set as flag or in env, please enter it now (will be hidden): ")
 		value, err := password.Read(os.Stdin)
 		fmt.Print("\n")
@@ -110,6 +112,14 @@ func (c *PasswordCommand) Run(args []string) int {
 			return base.CommandUserError
 		}
 		c.flagPassword = strings.TrimSpace(value)
+
+	default:
+		password, err := parseutil.ParsePath(c.flagPassword)
+		if err != nil && err.Error() != parseutil.ErrNotAUrl.Error() {
+			c.UI.Error("Error parsing password flag: " + err.Error())
+			return base.CommandUserError
+		}
+		c.flagPassword = password
 	}
 
 	client, err := c.Client(base.WithNoTokenScope(), base.WithNoTokenValue())

--- a/internal/cmd/commands/authenticate/password.go
+++ b/internal/cmd/commands/authenticate/password.go
@@ -116,7 +116,7 @@ func (c *PasswordCommand) Run(args []string) int {
 	default:
 		password, err := parseutil.ParsePath(c.flagPassword)
 		if err != nil && err.Error() != parseutil.ErrNotAUrl.Error() {
-			c.UI.Error("Error parsing password flag: " + err.Error())
+			c.UI.Error(fmt.Sprintf("Error parsing password flag: %v", err))
 			return base.CommandUserError
 		}
 		c.flagPassword = password


### PR DESCRIPTION
* Account password create/set/change
* Authenticate

Also fixes a bug where confirmation on a change-password call would run
for the current password instead of the new one.