### PR TITLE
bug(cmd): Ensure RunShutdownFuncs is called when an early error occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### Bug Fixes
 
+* cli: Correctly cleanup plugins after exiting `boundary dev`, `boundary server`
+  and `boundary database init`
+  ([Issue](https://github.com/hashicorp/boundary/issues/2332),
+  [PR](https://github.com/hashicorp/boundary/pull/2333)).
 * `boundary accounts change-password`: Fixed being prompted for confirmation of
   the current password instead of the new one
   ([PR](https://github.com/hashicorp/boundary/pull/2325))

--- a/internal/cmd/commands/database/init.go
+++ b/internal/cmd/commands/database/init.go
@@ -177,6 +177,12 @@ func (c *InitCommand) Run(args []string) (retCode int) {
 		return result
 	}
 
+	defer func() {
+		if err := c.RunShutdownFuncs(); err != nil {
+			c.UI.Error(fmt.Errorf("Error running shutdown tasks: %w", err).Error())
+		}
+	}()
+
 	if c.configWrapperCleanupFunc != nil {
 		defer func() {
 			if err := c.configWrapperCleanupFunc(); err != nil {

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -382,6 +382,12 @@ func (c *Command) Run(args []string) int {
 	const op = "dev.(Command).Run"
 	c.CombineLogs = c.flagCombineLogs
 
+	defer func() {
+		if err := c.RunShutdownFuncs(); err != nil {
+			c.UI.Error(fmt.Errorf("Error running shutdown tasks: %w", err).Error())
+		}
+	}()
+
 	var err error
 
 	f := c.Flags()
@@ -614,12 +620,6 @@ func (c *Command) Run(args []string) int {
 		c.UI.Error(fmt.Errorf("Error storing PID: %w", err).Error())
 		return base.CommandUserError
 	}
-
-	defer func() {
-		if err := c.RunShutdownFuncs(); err != nil {
-			c.UI.Error(fmt.Errorf("Error running shutdown tasks: %w", err).Error())
-		}
-	}()
 
 	var opts []base.Option
 	if c.flagCreateLoopbackHostPlugin {

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -138,6 +138,12 @@ func (c *Command) AutocompleteFlags() complete.Flags {
 func (c *Command) Run(args []string) int {
 	c.CombineLogs = c.flagCombineLogs
 
+	defer func() {
+		if err := c.RunShutdownFuncs(); err != nil {
+			c.UI.Error(fmt.Errorf("Error running shutdown tasks: %w", err).Error())
+		}
+	}()
+
 	if result := c.ParseFlagsAndConfig(args); result > 0 {
 		return result
 	}
@@ -470,12 +476,6 @@ func (c *Command) Run(args []string) int {
 			return base.CommandCliError
 		}
 	}
-
-	defer func() {
-		if err := c.RunShutdownFuncs(); err != nil {
-			c.UI.Error(fmt.Errorf("Error running shutdown tasks: %w", err).Error())
-		}
-	}()
 
 	if c.Config.Controller != nil {
 		c.EnabledPlugins = append(c.EnabledPlugins, base.EnabledPluginHostAws, base.EnabledPluginHostAzure)


### PR DESCRIPTION
Fixes #2332

- `database init` was not calling cleanup at all
- `server` and `dev` only called it after setting up listeners but if we error before then we never cleanup