### PR TITLE
Ensure initial upstreams is empty before hcpb worker listing

### DIFF
--- a/internal/daemon/worker/status.go
+++ b/internal/daemon/worker/status.go
@@ -207,7 +207,7 @@ func (w *Worker) sendWorkerStatus(cancelCtx context.Context, sessionManager sess
 		for _, v := range result.CalculatedUpstreams {
 			addrs = append(addrs, v.Address)
 		}
-	} else if w.conf.RawConfig.HcpbClusterId != "" {
+	} else if w.conf.RawConfig.HcpbClusterId != "" && len(w.conf.RawConfig.Worker.InitialUpstreams) == 0 {
 		// This is a worker that is one hop away from managed workers, so attempt to get that list
 		hcpbWorkersCtx, hcpbWorkersCancel := context.WithTimeout(cancelCtx, common.StatusTimeout)
 		defer hcpbWorkersCancel()


### PR DESCRIPTION
The intention of the code was to have one-hop-away workers list KMS
workers to get initial upstreams, and have other workers continue using
what was in their config file. However, nothing stops people from having
initial_upstreams but _also_ adding a cluster ID in their config file,
in which case we'd always run this check and replace the config-set
initial upstreams. So, ensure the config-set initial upstreams is also
len zero.