### PR TITLE
Fix error validation code in attr parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   ([PR](https://github.com/hashicorp/boundary/pull/2351)).
 * Managed Groups: Fix an issue where the `filter` field is not sent by
   admin UI ([PR](https://github.com/hashicorp/boundary-ui/pull/1238)).
-
+* Plugins: Fixes regression from 0.9.0 causing a failure to start when using
+  multiple KMS blocks of the same type
+  ([PR1](https://github.com/hashicorp/go-secure-stdlib/pull/43),
+  [PR2](https://github.com/hashicorp/boundary/pull/2346))
+* CLI: Fixed errors related to URL detection when passing in `-attr` or
+  `-secret` values that contained colons
+  ([PR](https://github.com/hashicorp/boundary/pull/2353))
 
 ## 0.10.0 (2022/08/10)
 

--- a/internal/cmd/base/flags.go
+++ b/internal/cmd/base/flags.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -854,7 +855,7 @@ func (c *combinedSliceValue) Set(val string) error {
 	}
 
 	var err error
-	if ret.Value, err = parseutil.ParsePath(ret.Value); err != nil && err != parseutil.ErrNotAUrl {
+	if ret.Value, err = parseutil.ParsePath(ret.Value); err != nil && !errors.Is(err, parseutil.ErrNotAUrl) {
 		return fmt.Errorf("error checking if value is a path: %w", err)
 	}
 

--- a/internal/cmd/common/flags_test.go
+++ b/internal/cmd/common/flags_test.go
@@ -121,6 +121,17 @@ func TestPopulateAttrFlags(t *testing.T) {
 			args:        []string{"-num-attr", "fo.oo-o.o=5"},
 			expectedErr: "invalid value",
 		},
+		{
+			name: "colon-in-segment",
+			args: []string{"-attr", "filter=tagName eq 'application:south-seas'"},
+			expected: []base.CombinedSliceFlagValue{
+				{
+					Name:  "attr",
+					Keys:  []string{"filter"},
+					Value: "tagName eq 'application:south-seas'",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
For a flag type used for attributes/secrets, values have always been
able to be used with env:// or file:// format, but the error check to
see whether the value was successfully parsed was doing a simple string
equality rather than `errors.Is`. As a result a value containing a colon
would trip up this check and cause an error, rather than allowing it to
be used as a bare value.

Fixes ICU-5629