### PR TITLE
Enos: break out init job, cleanup

### DIFF
--- a/enos/modules/aws_nomad/nomad-instances.tf
+++ b/enos/modules/aws_nomad/nomad-instances.tf
@@ -157,6 +157,10 @@ resource "enos_file" "nomad_client_config" {
 
 
 resource "enos_remote_exec" "install_docker" {
+  # This uses apt so we need to block until deps are done
+  depends_on = [
+    enos_remote_exec.install_dependencies
+  ]
   for_each = aws_instance.nomad_instance
 
   scripts = [abspath("${path.module}/../../templates/install-docker.sh")]

--- a/enos/modules/aws_nomad/variables.tf
+++ b/enos/modules/aws_nomad/variables.tf
@@ -117,7 +117,7 @@ variable "consul_log_dir" {
 variable "dependencies_to_install" {
   type        = list(string)
   description = "A list of dependencies to install"
-  default     = []
+  default     = ["jq"]
 }
 
 variable "nomad_cluster_tag" {

--- a/enos/modules/nomad_job/configs/init.nomad
+++ b/enos/modules/nomad_job/configs/init.nomad
@@ -1,71 +1,44 @@
 variable "db_username" {
   description = "The boundary database username"
-  type = string
+  type        = string
 }
 
 variable "db_password" {
   description = "The boundary database password"
-  type = string
+  type        = string
 }
 
 variable "db_address" {
   description = "The boundary database address"
-  type = string
+  type        = string
 }
 
 variable "db_name" {
   description = "The name of the boundary database to connect to when initializing boundary"
-  type = string
+  type        = string
 }
 
-variable "count" {
-  description = "Number of controllers to create"
-  type = number
-  default = 3
-}
-
-job "controller" {
+job "init" {
   datacenters = ["dc1"]
-
-  group "controller" {
-    count = var.count
-
-    restart {
-      attempts = 3
-      delay    = "30s"
-    }
-
-    network {
-      port "api" {
-        static = 9200
-      }
-      port "cluster" {
-        static = 9201
-      }
-      port "proxy" {
-        static = 9202
-      }
-      port "ops" {
-        static = 9203
-      }
-    }
-
-    task "controller" {
+  type        = "batch"
+  group "init" {
+    task "init" {
       driver = "docker"
 
       config {
         image          = "hashicorp/boundary"
-        ports          = ["api", "cluster", "ops"]
         auth_soft_fail = true
+        command        = "boundary"
+        args           = ["database", "init", "-config", "/boundary/config.hcl", "-format", "json"]
       }
 
       env {
         BOUNDARY_POSTGRES_URL = format("postgresql://%s:%s@%s:5432/%s?sslmode=disable", var.db_username, var.db_password, var.db_address, var.db_name)
       }
 
-      resources {
-        cpu    = 500
-        memory = 256
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
       }
     }
   }

--- a/enos/templates/install-docker.sh
+++ b/enos/templates/install-docker.sh
@@ -1,6 +1,33 @@
 #!/usr/bin/env bash
 
 set -e pipefail
+
+function retry {
+  local retries=$1
+  shift
+  local count=0
+
+  until "$@"; do
+    exit=$?
+    wait=$((2 ** count))
+    count=$((count + 1))
+    if [ "$count" -lt "$retries" ]; then
+      sleep "$wait"
+    else
+      return "$exit"
+    fi
+  done
+
+  return 0
+}
+
+
 # Get us some docker
-curl -fsSL https://get.docker.com -o get-docker.sh
-sudo sh get-docker.sh
+if [ -f /etc/debian_version ]; then
+  # Make sure cloud-init is not modifying our sources list while we're trying
+  # to install.
+  retry 7 grep ec2 /etc/apt/sources.list
+  retry 5 sudo apt update
+  curl -fsSL https://get.docker.com -o get-docker.sh
+  sudo sh get-docker.sh
+fi


### PR DESCRIPTION
* Move jq deps to our earlier dependency installation
* Add more guards around installation
* Try and make job module more generic-er for the future
* Make controller group count configurable