### PR TITLE
[RELENG-20] set PRODUCT_VERSION for default docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,21 +88,21 @@ ARG BIN_NAME
 # NAME and VERSION are the name of the software in releases.hashicorp.com
 # and the version to download. Example: NAME=boundary VERSION=1.2.3.
 ARG NAME=boundary
-ARG VERSION
+ARG PRODUCT_VERSION
 # TARGETARCH and TARGETOS are set automatically when --platform is provided.
 ARG TARGETOS TARGETARCH
 
 LABEL name="Boundary" \
       maintainer="HashiCorp Boundary Team <boundary@hashicorp.com>" \
       vendor="HashiCorp" \
-      version=$VERSION \
-      release=$VERSION \
+      version=$PRODUCT_VERSION \
+      release=$PRODUCT_VERSION \
       summary="Boundary provides simple and secure access to hosts and services" \
       description="The Boundary Docker image is designed to enable practitioners to run Boundary in server mode on a container scheduler"
 
 # Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
 ENV NAME=$NAME
-ENV VERSION=$VERSION
+ENV VERSION=$PRODUCT_VERSION
 
 # Create a non-root user to run the software.
 RUN addgroup ${NAME} && adduser -s /bin/sh -S -G ${NAME} ${NAME}


### PR DESCRIPTION
In `actions-docker-build` we [pass](https://github.com/hashicorp/actions-docker-build/blob/05c370a26e61b06be46c5095d6e914c9f0ea4f3d/scripts/docker_build#L49) `PRODUCT_VERSION` to the docker build command. Since this was not set, the label did not populate properly which is used in a comparison to determine the `minor-latest` and `latest` docker image tags. 

```
docker inspect hashicorp/boundary:latest -f={{json '.Config.Labels'}} | jq 
{
  "description": "The Boundary Docker image is designed to enable practitioners to run Boundary in server mode on a container scheduler",
  "maintainer": "HashiCorp Boundary Team <boundary@hashicorp.com>",
  "name": "Boundary",
  "release": "",
  "summary": "Boundary provides simple and secure access to hosts and services",
  "vendor": "HashiCorp",
  "version": ""
}
```