### PR TITLE
feat: Stop enos jobs from failing CI pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,3 +359,5 @@ jobs:
       artifact-name: "boundary_${{ needs.product-metadata.outputs.product-version }}_linux_amd64.zip"
       go-version: ${{ needs.product-metadata.outputs.go-version }}
     secrets: inherit
+    # Enos jobs are still a bit flaky, ensure they don't fail the workflow.
+    continue-on-failure: true


### PR DESCRIPTION
Enos jobs are still a bit unstable, we should use them as
advisory for now. When they have gained more stability,
we can let them fail pipelines again.

Uses https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error