### PR TITLE
fix: Move enos job attribute into enos-run workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,5 +359,3 @@ jobs:
       artifact-name: "boundary_${{ needs.product-metadata.outputs.product-version }}_linux_amd64.zip"
       go-version: ${{ needs.product-metadata.outputs.go-version }}
     secrets: inherit
-    # Enos jobs are still a bit flaky, ensure they don't fail the workflow.
-    continue-on-error: true

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   enos:
     name: Integration
+    # Enos jobs are still a bit flaky, ensure they don't fail the workflow.
+    continue-on-error: true
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Maybe this will fix it? This doesn't make any sense.

Apparently the last fix was wrong too: https://github.com/hashicorp/boundary/actions/runs/2879194545. I think this should be it!