### PR TITLE
Fix dev Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,7 @@ DEV_DOCKER_GOARCH ?= amd64
 # Builds from the locally generated binary in ./bin/
 docker-build-dev: export GOOS=$(DEV_DOCKER_GOOS)
 docker-build-dev: export GOARCH=$(DEV_DOCKER_GOARCH)
+docker-build-dev: export DEV_BUILD="dev-build"
 docker-build-dev: build
 	docker build \
 		--tag $(IMAGE_TAG_DEV) \

--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,8 @@ DEV_DOCKER_GOARCH ?= amd64
 docker-build-dev: export GOOS=$(DEV_DOCKER_GOOS)
 docker-build-dev: export GOARCH=$(DEV_DOCKER_GOARCH)
 docker-build-dev: export DEV_BUILD="dev-build"
-docker-build-dev: build
+docker-build-dev: export BOUNDARY_BUILD_WITH_CONTROLLER=1
+docker-build-dev: build-with-controller
 	docker build \
 		--tag $(IMAGE_TAG_DEV) \
 		--target=dev \

--- a/Makefile
+++ b/Makefile
@@ -324,9 +324,7 @@ DEV_DOCKER_GOARCH ?= amd64
 # Builds from the locally generated binary in ./bin/
 docker-build-dev: export GOOS=$(DEV_DOCKER_GOOS)
 docker-build-dev: export GOARCH=$(DEV_DOCKER_GOARCH)
-docker-build-dev: export DEV_BUILD="dev-build"
-docker-build-dev: export BOUNDARY_BUILD_WITH_CONTROLLER=1
-docker-build-dev: build-with-controller
+docker-build-dev: build
 	docker build \
 		--tag $(IMAGE_TAG_DEV) \
 		--target=dev \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -77,16 +77,3 @@ fi
 # Done!
 echo "==> Results:"
 ls -hl bin/
-
-# Printing the Boundary version will fail if cross compiling for a dev Docker build
-if [ "${DEV_BUILD}x" != "x" ]; then
-    exit 0
-fi
-
-# Print the version output for just linux_amd64.
-# Since we run this script in CI, and our CI build jobs run on linux runners, 
-# We can only check the version output for a subset of builds
-if [ "${GOOS}" == "linux" ] && [ "${GOARCH}" == "amd64" ]; then
-    echo "==> Version Info:"
-    bin/boundary version
-fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -78,6 +78,11 @@ fi
 echo "==> Results:"
 ls -hl bin/
 
+# Printing the Boundary version will fail if cross compiling for a dev Docker build
+if [ "${DEV_BUILD}x" != "x" ]; then
+    exit 0
+fi
+
 # Print the version output for just linux_amd64.
 # Since we run this script in CI, and our CI build jobs run on linux runners, 
 # We can only check the version output for a subset of builds


### PR DESCRIPTION
`make docker-build-dev` cross-compiles for linux amd64 and fails when printing the Boundary version.  This PR removes the version print.