### PR TITLE
Enos: add additional guards before authentication

### DIFF
--- a/enos/templates/get-token.sh
+++ b/enos/templates/get-token.sh
@@ -21,11 +21,8 @@ function retry {
   return 0
 }
 
-# make sure the ALB is up and passing healthchecks
-retry 10 curl -s -o /dev/null ${BOUNDARY_ADDR}
-
 # make sure boundary is connected to DB (unauthenticated endpoint)
-retry 10 boundary auth-methods list > /dev/null
+retry 10 ${BOUNDARY_PATH}/boundary auth-methods list > /dev/null
 
 export BP="${PASSWORD}"
 ${BOUNDARY_PATH}/boundary authenticate password -auth-method-id=${METHOD_ID} -login-name=${LOGIN_NAME} -password=env://BP -token-name=none -format=json -keyring-type=none

--- a/enos/templates/get-token.sh
+++ b/enos/templates/get-token.sh
@@ -24,5 +24,8 @@ function retry {
 # make sure the ALB is up and passing healthchecks
 retry 10 curl -s -o /dev/null ${BOUNDARY_ADDR}
 
+# make sure boundary is connected to DB (unauthenticated endpoint)
+retry 10 boundary auth-methods list > /dev/null
+
 export BP="${PASSWORD}"
 ${BOUNDARY_PATH}/boundary authenticate password -auth-method-id=${METHOD_ID} -login-name=${LOGIN_NAME} -password=env://BP -token-name=none -format=json -keyring-type=none


### PR DESCRIPTION
Previously, we would see failures when the ALB in front of a cluster was alive and passing healthchecks, but the database behind had not been initialized yet.  This adds a check with an unauth'd call to `auth-methods list` to validate the DB is up before auth.