### PR TITLE
bug(workers): Create worker-led panics on invalid token

### DIFF
--- a/internal/cmd/commands/authmethodscmd/oidc_funcs.go
+++ b/internal/cmd/commands/authmethodscmd/oidc_funcs.go
@@ -291,7 +291,10 @@ func executeExtraOidcActionsImpl(c *OidcCommand, origResp *api.Response, origIte
 			opts = append(opts, authmethods.WithOidcAuthMethodDisableDiscoveredConfigValidation(true))
 		}
 		result, err := amClient.ChangeState(c.Context, c.FlagId, version, c.flagState, opts...)
-		return result.GetResponse(), result.GetItem(), err
+		if err != nil {
+			return nil, nil, err
+		}
+		return result.GetResponse(), result.GetItem(), nil
 	}
 	return origResp, origItem, origError
 }

--- a/internal/cmd/commands/workerscmd/worker-led_funcs.go
+++ b/internal/cmd/commands/workerscmd/worker-led_funcs.go
@@ -58,7 +58,10 @@ func executeExtraWorkerLedActionsImpl(c *WorkerLedCommand, origResp *api.Respons
 	switch c.Func {
 	case "create":
 		result, err := workerClient.CreateWorkerLed(c.Context, c.flagWorkerGeneratedAuthToken, c.FlagScopeId, opts...)
-		return result.GetResponse(), result.GetItem(), err
+		if err != nil {
+			return nil, nil, err
+		}
+		return result.GetResponse(), result.GetItem(), nil
 	}
 	return origResp, origItem, origError
 }


### PR DESCRIPTION
Fix panic if invalid token is passed:
```
% boundary workers create worker-led -worker-generated-auth-token=bogus
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x10533ce24]

goroutine 1 [running]:
github.com/hashicorp/boundary/internal/cmd/commands/workerscmd.executeExtraWorkerLedActionsImpl(0x14000b6cfc0?, 0x0?, 0x10535e532?, {0x0?, 0x0?}, 0x18?, 0xc0fb18?, {0x0?, 0x14000c0fb88?, 0x1044c4f20?})
	/boundary/internal/cmd/commands/workerscmd/worker-led_funcs.go:67 +0x84
```