### PR TITLE
Fix incorrect use of loop variable in parallel tests

### DIFF
--- a/internal/daemon/controller/handlers/managed_groups/validate_test.go
+++ b/internal/daemon/controller/handlers/managed_groups/validate_test.go
@@ -78,6 +78,7 @@ func TestValidateCreateRequest(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			req := &pbs.CreateManagedGroupRequest{Item: tc.item}
@@ -126,6 +127,7 @@ func TestValidateUpdateRequest(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateUpdateRequest(tc.req)


### PR DESCRIPTION
This fixes occurences of a loop variable being captured in parallel
tests. With the previous code, only the last test case is actually
exercised. To work around this problem, we create a local copy of the
range variable before the parallel test, as suggested in the
documentation for the `testing` package:

https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks

Issues were found automatically using the `loopvarcapture` linter.