### PR TITLE
Fix validation function panic

### DIFF
--- a/internal/daemon/controller/handlers/managed_groups/managed_group_service.go
+++ b/internal/daemon/controller/handlers/managed_groups/managed_group_service.go
@@ -601,12 +601,13 @@ func validateCreateRequest(req *pbs.CreateManagedGroupRequest) error {
 			attrs := req.GetItem().GetOidcManagedGroupAttributes()
 			if attrs == nil {
 				badFields[globals.AttributesField] = "Attribute fields is required."
-			}
-			if attrs.Filter == "" {
-				badFields[attrFilterField] = "This field is required."
 			} else {
-				if _, err := bexpr.CreateEvaluator(attrs.Filter); err != nil {
-					badFields[attrFilterField] = fmt.Sprintf("Error evaluating submitted filter expression: %v.", err)
+				if attrs.Filter == "" {
+					badFields[attrFilterField] = "This field is required."
+				} else {
+					if _, err := bexpr.CreateEvaluator(attrs.Filter); err != nil {
+						badFields[attrFilterField] = fmt.Sprintf("Error evaluating submitted filter expression: %v.", err)
+					}
 				}
 			}
 		default:

--- a/internal/daemon/controller/handlers/managed_groups/validate_test.go
+++ b/internal/daemon/controller/handlers/managed_groups/validate_test.go
@@ -49,7 +49,7 @@ func TestValidateCreateRequest(t *testing.T) {
 				AuthMethodId: oidc.AuthMethodPrefix + "_1234567890",
 				Attrs:        nil,
 			},
-			errContains: fieldError(attrFilterField, "This field is required."),
+			errContains: fieldError(globals.AttributesField, "Attribute fields is required."),
 		},
 		{
 			name: "bad oidc attributes",


### PR DESCRIPTION
The logic would panic if no attributes were specified. Ensure that attributes are non-nil before checking any sub fields.