### PR TITLE
fix(db): update host_plugin_set to set project_id column value

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/46/02_hosts.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/46/02_hosts.up.sql
@@ -88,7 +88,7 @@ begin;
      set (project_id) =
          (select project_id
             from host_set
-           where host_set.public_id = host_plugin_set.catalog_id
+           where host_set.public_id = host_plugin_set.public_id
          )
   ;
 


### PR DESCRIPTION
### Summary:

We had a user report a [issue](https://github.com/hashicorp/boundary/issues/2349#issuecomment-1229953874) where an error occurred when applying the 0.10.2 patch. Details of the error being thrown: `project_id must not be empty: not null constraint violated: integrity violation: error #1001`. 

The cause of this error was due to a bug in this sql statement. The where clause is not comparing the correct columns to set the project_id value, which caused all the rows to have a null value for the project_id column:
```update host_plugin_set
     set (project_id) =
         (select project_id
            from host_set
           where host_set.public_id = host_plugin_set.catalog_id
         )
  ;
```
  
The fix:
```update host_plugin_set
     set (project_id) =
         (select project_id
            from host_set
           where host_set.public_id = host_plugin_set.public_id
         )
  ;
```

### Validations:

I created a aws host plugin set in both 0.9.2 & 0.10.1 and applied the patch with no issues.