### PR TITLE
Fork pgtap-docker to support arm64

### DIFF
--- a/internal/db/sqltest/Makefile
+++ b/internal/db/sqltest/Makefile
@@ -5,7 +5,7 @@ CWD := $(shell pwd)
 # Version of postgres docker image for test database
 PG_DOCKER_TAG ?= 13-alpine
 # Version of pg_tap docker image
-PG_TAP_DOCKER_TAG ?= pg13
+PG_TAP_DOCKER_TAG ?= 13
 SQL_TEST_DB_PORT ?=
 DOCKER_ARGS ?=
 ifneq ($(strip $(SQL_TEST_DB_PORT)),)
@@ -29,7 +29,7 @@ POSTGRES_DOCKER_IMAGE_BASE ?= postgres
 
 POSTGRES_DOCKER_IMAGE := $(POSTGRES_DOCKER_IMAGE_BASE):$(PG_DOCKER_TAG)
 
-PG_TAP_DOCKER_IMAGE_BASE ?= subzerocloud/pgtap
+PG_TAP_DOCKER_IMAGE_BASE ?= hashicorpboundary/pgtap
 PG_TAP_DOCKER_IMAGE := $(PG_TAP_DOCKER_IMAGE_BASE):$(PG_TAP_DOCKER_TAG)
 
 SQL_TEST_CONTAINER_NAME ?= boundary-sql-tests
@@ -61,7 +61,7 @@ test:
 		-e TESTS="$(PROVE_OPTS) $(dockerized_tests)" \
 		-v "$(CWD)/tests":/test \
 		$(PG_TAP_DOCKER_IMAGE); \
-		(ret=$$?; docker stop $(SQL_TEST_CONTAINER_NAME) &>/dev/null && docker rm -v $(SQL_TEST_CONTAINER_NAME) &>/dev/null && exit $$ret)
+		(ret=$$?; docker stop $(SQL_TEST_CONTAINER_NAME) &>/dev/null && docker logs $(SQL_TEST_CONTAINER_NAME) && docker rm -v $(SQL_TEST_CONTAINER_NAME) &>/dev/null && exit $$ret)
 
 database-up:
 	@echo Using $(POSTGRES_DOCKER_IMAGE)

--- a/testing/dbtest/pgtap-docker/Dockerfile
+++ b/testing/dbtest/pgtap-docker/Dockerfile
@@ -1,0 +1,33 @@
+ARG PG_VERSION
+FROM postgres:${PG_VERSION}-alpine
+
+ARG PG_VERSION
+ARG PGTAP_VERSION=v1.2.0
+
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.8/main'>> /etc/apk/repositories \
+    && echo 'http://dl-cdn.alpinelinux.org/alpine/v3.6/main'>> /etc/apk/repositories \
+    && apk add --no-cache --update curl wget git openssl \
+      build-base make perl perl-dev
+
+# install pg_prove
+RUN cpan TAP::Parser::SourceHandler::pgTAP
+
+# install pgtap
+RUN git clone https://github.com/theory/pgtap.git \
+    && cd pgtap && git checkout tags/$PGTAP_VERSION \
+    && make
+
+COPY test.sh /test.sh
+RUN chmod +x /test.sh
+
+WORKDIR /
+
+ENV DATABASE="" \
+    HOST=db \
+    PORT=5432 \
+    USER="postgres" \
+    PASSWORD="" \
+    TESTS="/test/*.sql"
+
+ENTRYPOINT ["/test.sh"]
+CMD [""]

--- a/testing/dbtest/pgtap-docker/Dockerfile
+++ b/testing/dbtest/pgtap-docker/Dockerfile
@@ -10,7 +10,8 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.8/main'>> /etc/apk/repositorie
       build-base make perl perl-dev
 
 # install pg_prove
-RUN cpan TAP::Parser::SourceHandler::pgTAP
+RUN PERL_MM_USE_DEFAULT=1 cpan -T TAP::Harness::JUnit \
+  && PERL_MM_USE_DEFAULT=1 cpan -T TAP::Parser::SourceHandler::pgTAP
 
 # install pgtap
 RUN git clone https://github.com/theory/pgtap.git \

--- a/testing/dbtest/pgtap-docker/LICENSE
+++ b/testing/dbtest/pgtap-docker/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 LREN CHUV
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/testing/dbtest/pgtap-docker/Makefile
+++ b/testing/dbtest/pgtap-docker/Makefile
@@ -1,17 +1,18 @@
-REGISTRY_NAME?=docker.io/hashicorpboundary
-TEST_IMAGE_NAME=pgtap
-PG_VERSION=13
+REGISTRY_NAME ?= docker.io/hashicorpboundary
+TEST_IMAGE_NAME = pgtap
+PG_VERSION ?= 13
 
 # Before running this target a builder instance needs to be setup, ie:
 #  docker buildx create --driver docker-container --use
+.PHONY: docker-build
 docker-build:
 	docker buildx build \
 		--platform linux/amd64,linux/arm64 \
-		--push \
 		-t $(REGISTRY_NAME)/$(TEST_IMAGE_NAME):$(PG_VERSION) \
 		--build-arg PG_VERSION=$(PG_VERSION) \
 		-f Dockerfile .
 
+.PHONY: docker-load
 docker-load:
 	docker buildx build \
 		--load \

--- a/testing/dbtest/pgtap-docker/Makefile
+++ b/testing/dbtest/pgtap-docker/Makefile
@@ -1,0 +1,20 @@
+REGISTRY_NAME?=docker.io/hashicorpboundary
+TEST_IMAGE_NAME=pgtap
+PG_VERSION=13
+
+# Before running this target a builder instance needs to be setup, ie:
+#  docker buildx create --driver docker-container --use
+docker-build:
+	docker buildx build \
+		--platform linux/amd64,linux/arm64 \
+		--push \
+		-t $(REGISTRY_NAME)/$(TEST_IMAGE_NAME):$(PG_VERSION) \
+		--build-arg PG_VERSION=$(PG_VERSION) \
+		-f Dockerfile .
+
+docker-load:
+	docker buildx build \
+		--load \
+		-t $(REGISTRY_NAME)/$(TEST_IMAGE_NAME):$(PG_VERSION) \
+		--build-arg PG_VERSION=$(PG_VERSION) \
+		-f Dockerfile .

--- a/testing/dbtest/pgtap-docker/README.md
+++ b/testing/dbtest/pgtap-docker/README.md
@@ -1,0 +1,7 @@
+# pgtap-docker
+
+The code in this folder is a hard fork of https://github.com/subzerocloud/pgtap-docker.
+The LICENSE included at the root of this folder apply to the contents of this folder ONLY.
+
+The code is changed to support building the docker image for multiple Docker platforms (e.g. linux/arm64)
+and to update versions and remove deprecated fields.

--- a/testing/dbtest/pgtap-docker/test.sh
+++ b/testing/dbtest/pgtap-docker/test.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+function usage() { echo "Usage: $0 -h host -d database -p port -u username -w password -t 'tests/*.sql'" 1>&2; exit 1; }
+
+while getopts d:h:p:u:w:b:n:t: OPTION
+do
+  case $OPTION in
+    d)
+      DATABASE=$OPTARG
+      ;;
+    h)
+      HOST=$OPTARG
+      ;;
+    p)
+      PORT=$OPTARG
+      ;;
+    u)
+      USER=$OPTARG
+      ;;
+    w)
+      PASSWORD=$OPTARG
+      ;;
+    t)
+      TESTS=$OPTARG
+      ;;
+    H)
+      usage
+      ;;
+  esac
+done
+
+echo "Waiting for database..."
+timeout 240s sh -c "until pg_isready -h $HOST -p $PORT; do sleep 1; done"
+echo
+
+echo "Running tests: $TESTS"
+# install pgtap
+PGPASSWORD=$PASSWORD psql -q -h $HOST -p $PORT -d $DATABASE -U $USER -f /pgtap/sql/pgtap.sql
+
+rc=$?
+# exit if pgtap failed to install
+if [[ $rc != 0 ]] ; then
+  echo "pgTap was not installed properly. Unable to run tests!"
+  exit $rc
+fi
+# run the tests
+PGPASSWORD=$PASSWORD pg_prove -h $HOST -p $PORT -d $DATABASE -U $USER $TESTS
+rc=$?
+# uninstall pgtap
+PGPASSWORD=$PASSWORD psql -q -h $HOST -p $PORT -d $DATABASE -U $USER -f /pgtap/sql/uninstall_pgtap.sql > /dev/null 2>&1
+# exit with return code of the tests
+exit $rc


### PR DESCRIPTION
This forks pgtap-docker and builds the image locally, and updates our references to use our forked image. The old repository is archived: https://github.com/subzerocloud/pgtap-docker