### PR TITLE
enos: don't fail fast in enos integration matrix

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -22,6 +22,7 @@ jobs:
     # Enos jobs are still a bit flaky, ensure they don't fail the workflow.
     continue-on-error: true
     strategy:
+      fail-fast: false # don't fail as that can skip required cleanup steps for jobs
       matrix:
         include:
           - test: smoke


### PR DESCRIPTION
Disable the fail-fast feature for the matrix strategy. This prevents a
single failure to cascade to all jobs in the matrix. This prevents cases
where other jobs fail before they're able to clean up resources.

Signed-off-by: Ryan Cragun <me@ryan.ec>