### PR TITLE
Update googleapis/grpc-gateway dependency

### DIFF
--- a/internal/proto/buf.lock
+++ b/internal/proto/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 2e5a74aea1fe426793444954adff3419
+    commit: 62f35d8aed1149c291d606d958a7ce32
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    commit: f85c60ac38544f2d8f346491c9d916e5
+    commit: bc28b723cd774c32b6fbc77621518765


### PR DESCRIPTION
This fixes some CI issues. See https://docs.buf.build/faq#googleapis-failure for more information. There are no functional changes here, since any effect of the update would only be seen through changes in generated files, of which there are none.