### PR TITLE
Use an atomic.Pointer to store wrapped DB objects

### DIFF
--- a/internal/cmd/commands/server/listener_reload_test.go
+++ b/internal/cmd/commands/server/listener_reload_test.go
@@ -12,7 +12,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -88,7 +87,7 @@ func TestServer_ReloadListener(t *testing.T) {
 	wd, _ := os.Getwd()
 	wd += "/test-fixtures/reload/"
 
-	td, err := ioutil.TempDir("", "boundary-test-")
+	td, err := os.MkdirTemp("", "boundary-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,15 +112,15 @@ func TestServer_ReloadListener(t *testing.T) {
 	require.NoError(err)
 
 	// Setup initial certs
-	inBytes, err := ioutil.ReadFile(wd + "bundle1.pem")
+	inBytes, err := os.ReadFile(wd + "bundle1.pem")
 	require.NoError(err)
-	require.NoError(ioutil.WriteFile(td+"/bundle.pem", inBytes, 0o777))
+	require.NoError(os.WriteFile(td+"/bundle.pem", inBytes, 0o777))
 
 	relHcl := fmt.Sprintf(reloadConfig, cmd.DatabaseUrl, controllerKey, workerAuthKey, recoveryKey, td, td)
-	require.NoError(ioutil.WriteFile(td+"/reload.hcl", []byte(relHcl), 0o777))
+	require.NoError(os.WriteFile(td+"/reload.hcl", []byte(relHcl), 0o777))
 
 	// Populate CA pool
-	inBytes, _ = ioutil.ReadFile(td + "/bundle.pem")
+	inBytes, _ = os.ReadFile(td + "/bundle.pem")
 	certPool := x509.NewCertPool()
 	require.True(certPool.AppendCertsFromPEM(inBytes))
 
@@ -155,9 +154,9 @@ func TestServer_ReloadListener(t *testing.T) {
 
 	testCertificateSerial("142541707881583626546634262782315760343015820827")
 
-	inBytes, err = ioutil.ReadFile(wd + "bundle2.pem")
+	inBytes, err = os.ReadFile(wd + "bundle2.pem")
 	require.NoError(err)
-	require.NoError(ioutil.WriteFile(td+"/bundle.pem", inBytes, 0o777))
+	require.NoError(os.WriteFile(td+"/bundle.pem", inBytes, 0o777))
 
 	cmd.SighupCh <- struct{}{}
 	select {

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -911,7 +911,7 @@ func (c *Command) reloadControllerDatabase(newConfig *config.Config) error {
 
 	// Release old database shared lock and close old database object.
 	_ = oldDbSchemaManager.Close(c.Context)
-	_ = oldDbCloseFn(c.Context)
+	oldDbCloseFn(c.Context)
 
 	return nil
 }

--- a/internal/db/changesafe_reader_writer.go
+++ b/internal/db/changesafe_reader_writer.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/hashicorp/go-dbw"
+)
+
+var (
+	_ dbw.Reader = (*changeSafeDbwReader)(nil)
+	_ dbw.Writer = (*changeSafeDbwWriter)(nil)
+)
+
+// changeSafeDbwReader is a type that wraps a *db.Db as a dbw.Reader and ensures
+// that uses of the underlying database follows changes to the connection.
+type changeSafeDbwReader struct {
+	db *Db
+}
+
+func NewChangeSafeDbwReader(underlying *Db) dbw.Reader {
+	return &changeSafeDbwReader{db: underlying}
+}
+
+func (r *changeSafeDbwReader) LookupBy(ctx context.Context, resource any, opt ...dbw.Option) error {
+	return dbw.New(r.db.underlying.wrapped.Load()).LookupBy(ctx, resource, opt...)
+}
+
+func (r *changeSafeDbwReader) LookupByPublicId(ctx context.Context, resource dbw.ResourcePublicIder, opt ...dbw.Option) error {
+	return dbw.New(r.db.underlying.wrapped.Load()).LookupByPublicId(ctx, resource, opt...)
+}
+
+func (r *changeSafeDbwReader) LookupWhere(ctx context.Context, resource any, where string, args []any, opt ...dbw.Option) error {
+	return dbw.New(r.db.underlying.wrapped.Load()).LookupWhere(ctx, resource, where, args, opt...)
+}
+
+func (r *changeSafeDbwReader) Query(ctx context.Context, sql string, values []any, opt ...dbw.Option) (*sql.Rows, error) {
+	return dbw.New(r.db.underlying.wrapped.Load()).Query(ctx, sql, values, opt...)
+}
+
+func (r *changeSafeDbwReader) ScanRows(rows *sql.Rows, result any) error {
+	return dbw.New(r.db.underlying.wrapped.Load()).ScanRows(rows, result)
+}
+
+func (r *changeSafeDbwReader) SearchWhere(ctx context.Context, resources any, where string, args []any, opt ...dbw.Option) error {
+	return dbw.New(r.db.underlying.wrapped.Load()).SearchWhere(ctx, resources, where, args, opt...)
+}
+
+// changeSafeDbwWriter is a type that wraps a *db.Db as a dbw.Writer and ensures
+// that uses of the underlying database follows changes to the connection.
+type changeSafeDbwWriter struct {
+	db *Db
+}
+
+func NewChangeSafeDbwWriter(underlying *Db) dbw.Writer {
+	return &changeSafeDbwWriter{db: underlying}
+}
+
+func (w *changeSafeDbwWriter) Begin(ctx context.Context) (*dbw.RW, error) {
+	return dbw.New(w.db.underlying.wrapped.Load()).Begin(ctx)
+}
+
+func (w *changeSafeDbwWriter) Commit(ctx context.Context) error {
+	return dbw.New(w.db.underlying.wrapped.Load()).Commit(ctx)
+}
+
+func (w *changeSafeDbwWriter) Create(ctx context.Context, i any, opt ...dbw.Option) error {
+	return dbw.New(w.db.underlying.wrapped.Load()).Create(ctx, i, opt...)
+}
+
+func (w *changeSafeDbwWriter) CreateItems(ctx context.Context, createItems []any, opt ...dbw.Option) error {
+	return dbw.New(w.db.underlying.wrapped.Load()).CreateItems(ctx, createItems, opt...)
+}
+
+func (w *changeSafeDbwWriter) Delete(ctx context.Context, i any, opt ...dbw.Option) (int, error) {
+	return dbw.New(w.db.underlying.wrapped.Load()).Delete(ctx, i, opt...)
+}
+
+func (w *changeSafeDbwWriter) DeleteItems(ctx context.Context, deleteItems []any, opt ...dbw.Option) (int, error) {
+	return dbw.New(w.db.underlying.wrapped.Load()).DeleteItems(ctx, deleteItems, opt...)
+}
+
+func (w *changeSafeDbwWriter) DoTx(ctx context.Context, retryErrorsMatchingFn func(error) bool, retries uint, backOff dbw.Backoff, handler dbw.TxHandler) (dbw.RetryInfo, error) {
+	return dbw.New(w.db.underlying.wrapped.Load()).DoTx(ctx, retryErrorsMatchingFn, retries, backOff, handler)
+}
+
+func (w *changeSafeDbwWriter) Exec(ctx context.Context, sql string, values []any, opt ...dbw.Option) (int, error) {
+	return dbw.New(w.db.underlying.wrapped.Load()).Exec(ctx, sql, values, opt...)
+}
+
+func (w *changeSafeDbwWriter) Query(ctx context.Context, sql string, values []any, opt ...dbw.Option) (*sql.Rows, error) {
+	return dbw.New(w.db.underlying.wrapped.Load()).Query(ctx, sql, values, opt...)
+}
+
+func (w *changeSafeDbwWriter) Rollback(ctx context.Context) error {
+	return dbw.New(w.db.underlying.wrapped.Load()).Rollback(ctx)
+}
+
+func (w *changeSafeDbwWriter) ScanRows(rows *sql.Rows, result any) error {
+	return dbw.New(w.db.underlying.wrapped.Load()).ScanRows(rows, result)
+}
+
+func (w *changeSafeDbwWriter) Update(ctx context.Context, i interface{}, fieldMaskPaths []string, setToNullPaths []string, opt ...dbw.Option) (int, error) {
+	return dbw.New(w.db.underlying.wrapped.Load()).Update(ctx, i, fieldMaskPaths, setToNullPaths, opt...)
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/observability/event"
 	"github.com/hashicorp/go-dbw"
 	_ "github.com/jackc/pgx/v4"
 	"gorm.io/driver/postgres"
@@ -42,42 +44,49 @@ func StringToDbType(dialect string) (DbType, error) {
 
 // DB is a wrapper around the ORM
 type DB struct {
-	mu      sync.Mutex
-	wrapped *dbw.DB
+	wrapped *atomic.Pointer[dbw.DB]
 }
 
-type closeDbFn func(context.Context) error
+type closeDbFn func(context.Context)
+
+var CloseSwappedDbDuration = 5 * time.Minute
 
 // Swap replaces *DB's underlying database object with the one from `newDB`.
 // It returns a function that calls Close() on the outgoing database object.
 // Note: Swap does not verify the incoming *DB object is correctly set-up.
 func (db *DB) Swap(ctx context.Context, newDB *DB) (closeDbFn, error) {
-	if newDB == nil || newDB.wrapped == nil {
+	const op = "db.(DB).Swap"
+	if newDB == nil || newDB.wrapped == nil || newDB.wrapped.Load() == nil {
 		return nil, fmt.Errorf("no new db object present")
 	}
-	if db.wrapped == nil {
+	if db == nil || db.wrapped == nil || db.wrapped.Load() == nil {
 		// TBD: We could be helpful here and set the new DB instead of err?
 		return nil, fmt.Errorf("no current db is present to swap, aborting")
 	}
 
 	// Grab the old db to allow for cleanup after swap.
-	oldDbw := *db.wrapped
-	closeOldDbFn := func(ctx context.Context) error { return oldDbw.Close(ctx) }
-
-	// Replace the current DB value with the new one.
-	// Note: It's important that the pointer doesn't change, rather the value
-	// the pointer points to. Changing the pointer itself does not update the
-	// references in the other objects (repo functions, etc).
-	db.mu.Lock()
-	*db.wrapped = *newDB.wrapped
-	db.mu.Unlock()
+	oldDbw := db.wrapped.Swap(newDB.wrapped.Load())
+	closeOldDbFn := func(ctx context.Context) {
+		go func() {
+			t := time.NewTimer(CloseSwappedDbDuration)
+			select {
+			case <-t.C:
+				if err := oldDbw.Close(ctx); err != nil {
+					event.WriteError(ctx, op, errors.Wrap(ctx, err, op))
+				}
+			case <-ctx.Done():
+				t.Stop()
+				event.WriteError(ctx, op, fmt.Errorf("context canceled before old database connection was closed, aborting"))
+			}
+		}()
+	}
 
 	return closeOldDbFn, nil
 }
 
 // Debug will enable/disable debug info for the connection
 func (db *DB) Debug(on bool) {
-	db.wrapped.Debug(on)
+	db.wrapped.Load().Debug(on)
 }
 
 // SqlDB returns the underlying sql.DB
@@ -90,7 +99,7 @@ func (d *DB) SqlDB(ctx context.Context) (*sql.DB, error) {
 	if d.wrapped == nil {
 		return nil, errors.New(ctx, errors.Internal, op, "missing underlying database")
 	}
-	return d.wrapped.SqlDB(ctx)
+	return d.wrapped.Load().SqlDB(ctx)
 }
 
 // Close the underlying sql.DB
@@ -99,7 +108,7 @@ func (d *DB) Close(ctx context.Context) error {
 	if d.wrapped == nil {
 		return errors.New(ctx, errors.Internal, op, "missing underlying database")
 	}
-	return d.wrapped.Close(ctx)
+	return d.wrapped.Load().Close(ctx)
 }
 
 // Open a database connection which is long-lived. The options of
@@ -150,5 +159,7 @@ func Open(ctx context.Context, dbType DbType, connectionUrl string, opt ...Optio
 		sdb.SetConnMaxIdleTime(*opts.withConnMaxIdleTimeDuration)
 	}
 
-	return &DB{wrapped: wrapped}, nil
+	ret := &DB{wrapped: new(atomic.Pointer[dbw.DB])}
+	ret.wrapped.Store(wrapped)
+	return ret, nil
 }

--- a/internal/db/read_writer_oplog.go
+++ b/internal/db/read_writer_oplog.go
@@ -166,7 +166,7 @@ func (rw *Db) getTicketFor(ctx context.Context, aggregateName string) (*store.Ti
 	if rw.underlying == nil {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("%s: underlying db missing", aggregateName), errors.WithoutEvent())
 	}
-	ticketer, err := oplog.NewTicketer(ctx, rw.underlying.wrapped, oplog.WithAggregateNames(true))
+	ticketer, err := oplog.NewTicketer(ctx, rw.UnderlyingDB()(), oplog.WithAggregateNames(true))
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("%s: unable to get Ticketer", aggregateName)), errors.WithoutEvent())
 	}
@@ -246,7 +246,7 @@ func (rw *Db) addOplogForItems(ctx context.Context, opType OpType, opts Options,
 	if err != nil {
 		return errors.Wrap(ctx, err, op, errors.WithMsg("oplog validation failed"), errors.WithoutEvent())
 	}
-	ticketer, err := oplog.NewTicketer(ctx, rw.underlying.wrapped, oplog.WithAggregateNames(true))
+	ticketer, err := oplog.NewTicketer(ctx, rw.UnderlyingDB()(), oplog.WithAggregateNames(true))
 	if err != nil {
 		return errors.Wrap(ctx, err, op, errors.WithMsg("unable to get Ticketer"), errors.WithoutEvent())
 	}
@@ -262,7 +262,7 @@ func (rw *Db) addOplogForItems(ctx context.Context, opType OpType, opts Options,
 	}
 	if err := entry.WriteEntryWith(
 		ctx,
-		&oplog.Writer{DB: rw.underlying.wrapped},
+		&oplog.Writer{DB: rw.UnderlyingDB()()},
 		ticket,
 		oplogMsgs...,
 	); err != nil {
@@ -281,7 +281,7 @@ func (rw *Db) addOplog(ctx context.Context, opType OpType, opts Options, ticket 
 	if ticket == nil {
 		return errors.New(ctx, errors.InvalidParameter, op, "missing ticket", errors.WithoutEvent())
 	}
-	ticketer, err := oplog.NewTicketer(ctx, rw.underlying.wrapped, oplog.WithAggregateNames(true))
+	ticketer, err := oplog.NewTicketer(ctx, rw.UnderlyingDB()(), oplog.WithAggregateNames(true))
 	if err != nil {
 		return errors.Wrap(ctx, err, op, errors.WithMsg("unable to get Ticketer"), errors.WithoutEvent())
 	}
@@ -301,7 +301,7 @@ func (rw *Db) addOplog(ctx context.Context, opType OpType, opts Options, ticket 
 	}
 	err = entry.WriteEntryWith(
 		ctx,
-		&oplog.Writer{DB: rw.underlying.wrapped},
+		&oplog.Writer{DB: rw.UnderlyingDB()()},
 		ticket,
 		msg,
 	)
@@ -330,7 +330,7 @@ func (rw *Db) WriteOplogEntryWith(ctx context.Context, wrapper wrapping.Wrapper,
 	if len(metadata) == 0 {
 		return errors.New(ctx, errors.InvalidParameter, op, "missing metadata")
 	}
-	ticketer, err := oplog.NewTicketer(ctx, rw.underlying.wrapped, oplog.WithAggregateNames(true))
+	ticketer, err := oplog.NewTicketer(ctx, rw.UnderlyingDB()(), oplog.WithAggregateNames(true))
 	if err != nil {
 		return errors.Wrap(ctx, err, op, errors.WithMsg("unable to get Ticketer"))
 	}
@@ -347,7 +347,7 @@ func (rw *Db) WriteOplogEntryWith(ctx context.Context, wrapper wrapping.Wrapper,
 	}
 	err = entry.WriteEntryWith(
 		ctx,
-		&oplog.Writer{DB: rw.underlying.wrapped},
+		&oplog.Writer{DB: rw.UnderlyingDB()()},
 		ticket,
 		msgs...,
 	)

--- a/internal/kms/kms_ext_test.go
+++ b/internal/kms/kms_ext_test.go
@@ -229,7 +229,7 @@ func TestKms_GetWrapper(t *testing.T) {
 	conn, _ := db.TestSetup(t, "postgres")
 	rootWrapper := db.TestWrapper(t)
 	kmsCache := kms.TestKms(t, conn, rootWrapper)
-	kmsCache.CreateKeys(testCtx, "global")
+	require.NoError(t, kmsCache.CreateKeys(testCtx, "global"))
 	tests := []struct {
 		name            string
 		kms             *kms.Kms
@@ -289,7 +289,7 @@ func TestKms_CreateKeys(t *testing.T) {
 	conn, _ := db.TestSetup(t, "postgres")
 	rootWrapper := db.TestWrapper(t)
 	kmsCache := kms.TestKms(t, conn, rootWrapper)
-	kmsCache.CreateKeys(testCtx, "global")
+	require.NoError(t, kmsCache.CreateKeys(testCtx, "global"))
 	rw := db.New(conn)
 
 	tests := []struct {


### PR DESCRIPTION
This allows atomically swapping to the new object. A timeout is introduced so that if the object is swapped after the existing one has been looked up it isn't immediately invalidated. The timeout is arbitrary but has been set to five minutes as anything running that long probably _should_ be interrupted.

This could be done with mutexes to avoid the arbitrary timeout, but that carries its own risk: if a write lock is attempted to be acquired while a query is holding a read lock, the write lock will block, and any subsequent read locks will also block since write locks take priority. As a result, if a query is long-running or timing out, all other queries in the system will become blocked. Our default user request timeout is 90 seconds and some jobs have no timeout at all, so this is not a purely theoretical concern, even if it's unlikely. So for the moment, using an atomic pointer feels gross but safer.