### PR TITLE
fix: return an error for vault tokens that will expire before the scheduler can run

### DIFF
--- a/internal/credential/vault/repository_credential_store.go
+++ b/internal/credential/vault/repository_credential_store.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/internal/db"
@@ -119,7 +118,7 @@ func (r *Repository) CreateCredentialStore(ctx context.Context, cs *CredentialSt
 
 	runJobsInterval := r.scheduler.GetRunJobsInterval()
 	if token.expiration <= runJobsInterval {
-		return nil, errors.Wrap(ctx, fmt.Errorf("scheduler interval must be greater than token ttl. scheduler jobs interval value: %s seconds", strconv.FormatFloat(runJobsInterval.Seconds(), 'f', -1, 64)), op)
+		return nil, errors.Wrap(ctx, fmt.Errorf("scheduler interval must be greater than token ttl. scheduler jobs interval value: %s", runJobsInterval.String()), op)
 	}
 
 	oplogWrapper, err := r.kms.GetWrapper(ctx, cs.ProjectId, kms.KeyPurposeOplog)
@@ -513,7 +512,7 @@ func (r *Repository) UpdateCredentialStore(ctx context.Context, cs *CredentialSt
 		}
 		runJobsInterval := r.scheduler.GetRunJobsInterval()
 		if token.expiration <= runJobsInterval {
-			return nil, db.NoRowsAffected, errors.Wrap(ctx, fmt.Errorf("scheduler interval must be greater than token ttl. scheduler jobs interval value: %s seconds", strconv.FormatFloat(runJobsInterval.Seconds(), 'f', -1, 64)), op)
+			return nil, db.NoRowsAffected, errors.Wrap(ctx, fmt.Errorf("scheduler interval must be greater than token ttl. scheduler jobs interval value: %s", runJobsInterval.String()), op)
 		}
 		// encrypt token
 		if err := token.encrypt(ctx, databaseWrapper); err != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -333,3 +333,7 @@ func (s *Scheduler) updateRunningJobProgress(ctx context.Context, j *runningJob)
 
 	return nil
 }
+
+func (s *Scheduler) GetRunJobsInterval() time.Duration {
+	return s.runJobsInterval
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -334,6 +334,9 @@ func (s *Scheduler) updateRunningJobProgress(ctx context.Context, j *runningJob)
 	return nil
 }
 
+// GetRunJobsInterval returns the value runJobsInterval,
+// which represents an interval at which the scheduler
+// will query the repository for jobs to run.
 func (s *Scheduler) GetRunJobsInterval() time.Duration {
 	return s.runJobsInterval
 }


### PR DESCRIPTION
### Summary:

Currently the Vault credential store API accepts any token TTL, we validate the TTL and store the next renewal time during create and update. We should return an error if that TTL cannot be honored due to the scheduler interval for running jobs.

### Fix:

Now we compare the ttl value to the runJobsInterval value and return an error to the user when we cannot honor the token renewal.

### Error Output:
`scheduler interval must be greater than token ttl. scheduler jobs interval value: 2s`