### PR TITLE
chore(targets): Improve help and errors around ssh targets

### DIFF
--- a/internal/cmd/commands/targetscmd/ssh_funcs.go
+++ b/internal/cmd/commands/targetscmd/ssh_funcs.go
@@ -14,6 +14,7 @@ func init() {
 	extraSshActionsFlagsMapFunc = extraSshActionsFlagsMapFuncImpl
 	extraSshFlagsFunc = extraSshFlagsFuncImpl
 	extraSshFlagsHandlingFunc = extraSshFlagsHandlingFuncImpl
+	extraSshSynopsisFunc = extraSshSynopsisFuncImpl
 }
 
 func extraSshActionsFlagsMapFuncImpl() map[string][]string {
@@ -151,4 +152,8 @@ func extraSshFlagsHandlingFuncImpl(c *SshCommand, _ *base.FlagSets, opts *[]targ
 	}
 
 	return true
+}
+
+func extraSshSynopsisFuncImpl(_ *SshCommand) string {
+	return "Create a ssh-type target (HCP only)"
 }

--- a/internal/daemon/worker/handler.go
+++ b/internal/daemon/worker/handler.go
@@ -184,7 +184,7 @@ func (w *Worker) handleProxy(listenerCfg *listenerutil.ListenerConfig, sessionMa
 		endpointUrl, err := url.Parse(sess.GetEndpoint())
 		if err != nil {
 			event.WriteError(ctx, op, err, event.WithInfoMsg("worker failed to parse target endpoint", "endpoint", sess.GetEndpoint()))
-			if err = conn.Close(websocket.StatusProtocolError, "unsupported-protocol"); err != nil {
+			if err = conn.Close(websocket.StatusProtocolError, "unable to parse endpoint"); err != nil {
 				event.WriteError(ctx, op, err, event.WithInfoMsg("error closing client connection"))
 			}
 			return
@@ -192,7 +192,7 @@ func (w *Worker) handleProxy(listenerCfg *listenerutil.ListenerConfig, sessionMa
 		handleProxyFn, err := proxyHandlers.GetHandler(endpointUrl.Scheme)
 		if err != nil {
 			event.WriteError(ctx, op, err, event.WithInfoMsg("worker received request for unsupported protocol", "protocol", endpointUrl.Scheme))
-			if err = conn.Close(websocket.StatusProtocolError, "unsupported-protocol"); err != nil {
+			if err = conn.Close(websocket.StatusProtocolError, fmt.Sprintf("worker does not support %q type", endpointUrl.Scheme)); err != nil {
 				event.WriteError(ctx, op, err, event.WithInfoMsg("error closing client connection"))
 			}
 			return


### PR DESCRIPTION
Output from CLI target help
```
$ boundary targets update
Usage: boundary targets update [type] [sub command] [options] [args]

  This command allows update operations on Boundary target resources. Example:

    Update a tcp-type target:

      $ boundary targets update tcp -id ttcp_1234567890 -name devops -description "For DevOps usage"

  Please see the typed subcommand help for detailed usage information.

Subcommands:
    ssh    Create a ssh-type target (HCP only)
    tcp    Update a tcp-type target

$ boundary targets create
Usage: boundary targets create [type] [sub command] [options] [args]

  This command allows create operations on Boundary target resources. Example:

    Create a tcp-type target:

      $ boundary targets create tcp -name prodops -description "For ProdOps usage"

  Please see the typed subcommand help for detailed usage information.

Subcommands:
    ssh    Create a ssh-type target (HCP only)
    tcp    Create a tcp-type target
```