### PR TITLE
fix(perms): Properly resolve "only self" for permissions

### DIFF
--- a/internal/perms/acl.go
+++ b/internal/perms/acl.go
@@ -241,6 +241,7 @@ func (a ACL) ListPermissions(requestedScopes map[string]*scopes.ScopeInfo, reque
 			ScopeId:  scopeId,
 			Resource: requestedType,
 			Action:   action.List,
+			OnlySelf: true, // default to only self to be restrictive
 		}
 
 		// Get grants for a specific scope id from the source of truth.
@@ -275,7 +276,7 @@ func (a ACL) ListPermissions(requestedScopes map[string]*scopes.ScopeInfo, reque
 					excludeList = append(excludeList, aa)
 				}
 			}
-			p.OnlySelf = excludeList.OnlySelf()
+			p.OnlySelf = p.OnlySelf && excludeList.OnlySelf()
 
 			switch grant.id {
 			case "*":

--- a/internal/perms/acl_test.go
+++ b/internal/perms/acl_test.go
@@ -619,18 +619,18 @@ func TestACL_ListPermissions(t *testing.T) {
 				{
 					scope: "o_1",
 					grants: []string{
-						"id=*;type=session;actions=read:self",
-						"id=*;type=*;actions=list,read",
+						"id=*;type=*;actions=*",
+						"id=*;type=session;actions=cancel:self,list,read:self",
 					},
 				},
 			},
 			scopes:       map[string]*scopes.ScopeInfo{"o_1": nil},
-			resourceType: resource.Target,
-			actionSet:    action.ActionSet{action.List, action.Read},
+			resourceType: resource.Session,
+			actionSet:    action.ActionSet{action.NoOp, action.Read, action.ReadSelf, action.Cancel, action.CancelSelf},
 			expPermissions: []Permission{
 				{
 					ScopeId:     "o_1",
-					Resource:    resource.Target,
+					Resource:    resource.Session,
 					Action:      action.List,
 					ResourceIds: nil,
 					OnlySelf:    false,


### PR DESCRIPTION
When generating permissions from the grants, if a single grant was
limited to the set of "self" actions, the permission would be marked as
only self, even if additional grants were given for non-self actions.
This would result in the generated permissions being more limiting then
they should be based on the grants. This only impacts the sessions list
endpoint. It would result in users that have been granted access to list
other user's sessions to be unable to see these results in the list
results.