### PR TITLE
cli(ssh): Do not print private key if consumed

### DIFF
--- a/internal/cmd/commands/connect/postgres.go
+++ b/internal/cmd/commands/connect/postgres.go
@@ -2,7 +2,6 @@ package connect
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -51,7 +50,7 @@ func (p *postgresFlags) defaultExec() string {
 	return strings.ToLower(p.flagPostgresStyle)
 }
 
-func (p *postgresFlags) buildArgs(c *Command, port, ip, addr string, creds credentials) (args, envs []string, retCreds credentials, retErr error) {
+func (p *postgresFlags) buildArgs(c *Command, port, ip, _ string, creds credentials) (args, envs []string, retCreds credentials, retErr error) {
 	var username, password string
 
 	retCreds = creds
@@ -80,7 +79,7 @@ func (p *postgresFlags) buildArgs(c *Command, port, ip, addr string, creds crede
 		}
 
 		if password != "" {
-			passfile, err := ioutil.TempFile("", "*")
+			passfile, err := os.CreateTemp("", "*")
 			if err != nil {
 				return nil, nil, credentials{}, fmt.Errorf("Error saving postgres password to tmp file: %w", err)
 			}

--- a/internal/cmd/commands/connect/ssh.go
+++ b/internal/cmd/commands/connect/ssh.go
@@ -3,7 +3,6 @@ package connect
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -45,7 +44,7 @@ func (s *sshFlags) defaultExec() string {
 	return strings.ToLower(s.flagSshStyle)
 }
 
-func (s *sshFlags) buildArgs(c *Command, port, ip, addr string, creds credentials) (args, envs []string, retCreds credentials, retErr error) {
+func (s *sshFlags) buildArgs(c *Command, port, ip, _ string, creds credentials) (args, envs []string, retCreds credentials, retErr error) {
 	var username string
 	retCreds = creds
 
@@ -97,7 +96,7 @@ func (s *sshFlags) buildArgs(c *Command, port, ip, addr string, creds credential
 	}
 
 	// Check if we got credentials to attempt to use for ssh or putty,
-	// sshpass style has already be handled above as username password.
+	// sshpass style has already been handled above as username password.
 	switch strings.ToLower(s.flagSshStyle) {
 	case "putty", "ssh":
 
@@ -120,8 +119,9 @@ func (s *sshFlags) buildArgs(c *Command, port, ip, addr string, creds credential
 				delete(cred.raw.Credential, "username")
 				delete(cred.raw.Credential, "private_key")
 			}
+			retCreds.sshPrivateKey[0] = cred
 
-			pkFile, err := ioutil.TempFile("", "*")
+			pkFile, err := os.CreateTemp("", "*")
 			if err != nil {
 				return nil, nil, credentials{}, fmt.Errorf("Error saving ssh private key to tmp file: %w", err)
 			}


### PR DESCRIPTION
Came up during a demo, I see we mark the copied cred as consumed but never set it in the returned creds