### PR TITLE
address op state review feedback

### DIFF
--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -813,7 +813,7 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 	// worker IDs below is used to contain their IDs in the same order. This is
 	// used to fetch tags for filtering. But we avoid allocation unless we
 	// actually need it.
-	selectedWorkers, err := serversRepo.ListWorkers(ctx, []string{scope.Global.String()}, server.WithExcludeShutdownWorkers(true))
+	selectedWorkers, err := serversRepo.ListWorkers(ctx, []string{scope.Global.String()}, server.WithActiveWorkers(true))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/schema/migrations/oss/postgres/51/01_server_worker_release_version.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/51/01_server_worker_release_version.up.sql
@@ -9,7 +9,7 @@ alter table server_worker
 
 drop view server_worker_aggregate;
 
--- Updates view created in 34/04_views.up.sql
+-- Updated in 52/01_worker_operational_state.up.sql
 create view server_worker_aggregate as
 with worker_config_tags(worker_id, source, tags) as (
   select

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -44,7 +44,7 @@ type options struct {
 	WithCreateControllerLedActivationToken bool
 	withReleaseVersion                     string
 	withOperationalState                   string
-	withExcludeShutdownWorkers             bool
+	withActiveWorkers                      bool
 }
 
 func getDefaultOptions() options {
@@ -215,9 +215,9 @@ func WithOperationalState(state string) Option {
 	}
 }
 
-// WithExcludeShutdownWorkers provides an optional to filter out workers in shutdown
-func WithExcludeShutdownWorkers(exclude bool) Option {
+// WithActiveWorkers provides an optional filter to only include active workers
+func WithActiveWorkers(withActive bool) Option {
 	return func(o *options) {
-		o.withExcludeShutdownWorkers = exclude
+		o.withActiveWorkers = withActive
 	}
 }

--- a/internal/server/options_test.go
+++ b/internal/server/options_test.go
@@ -198,8 +198,8 @@ func Test_GetOpts(t *testing.T) {
 	})
 	t.Run("WithExcludeShutdown", func(t *testing.T) {
 		opts := getDefaultOptions()
-		assert.Empty(t, opts.withExcludeShutdownWorkers)
-		opts = GetOpts(WithExcludeShutdownWorkers(true))
-		assert.Equal(t, true, opts.withExcludeShutdownWorkers)
+		assert.Empty(t, opts.withActiveWorkers)
+		opts = GetOpts(WithActiveWorkers(true))
+		assert.Equal(t, true, opts.withActiveWorkers)
 	})
 }

--- a/internal/server/repository_worker.go
+++ b/internal/server/repository_worker.go
@@ -200,7 +200,7 @@ func (r *Repository) ListWorkers(ctx context.Context, scopeIds []string, opt ...
 	if opts.withExcludeShutdownWorkers {
 		// If a worker has a version, it must be active. If it's an older worker (no release version), we'll include it for
 		// backwards compatibilty
-		where = append(where, fmt.Sprintf("(operational_state = '%s' or (release_version = '') IS NOT FALSE)", ActiveOperationalState.String()))
+		where = append(where, fmt.Sprintf("(operational_state = '%s' or length(trim(release_version)) = 0 or release_version is null)", ActiveOperationalState.String()))
 	}
 
 	limit := r.defaultLimit

--- a/internal/server/repository_worker.go
+++ b/internal/server/repository_worker.go
@@ -198,8 +198,9 @@ func (r *Repository) ListWorkers(ctx context.Context, scopeIds []string, opt ...
 	}
 
 	if opts.withExcludeShutdownWorkers {
-		where = append(where, "operational_state not in (?)")
-		whereArgs = append(whereArgs, ShutdownOperationalState.String())
+		// If a worker has a version, it must be active. If it's an older worker (no release version), we'll include it for
+		// backwards compatibilty
+		where = append(where, fmt.Sprintf("(operational_state = '%s' or length(trim(release_version)) = 0)", ActiveOperationalState.String()))
 	}
 
 	limit := r.defaultLimit

--- a/internal/server/repository_worker.go
+++ b/internal/server/repository_worker.go
@@ -200,7 +200,7 @@ func (r *Repository) ListWorkers(ctx context.Context, scopeIds []string, opt ...
 	if opts.withExcludeShutdownWorkers {
 		// If a worker has a version, it must be active. If it's an older worker (no release version), we'll include it for
 		// backwards compatibilty
-		where = append(where, fmt.Sprintf("(operational_state = '%s' or length(trim(release_version)) = 0)", ActiveOperationalState.String()))
+		where = append(where, fmt.Sprintf("(operational_state = '%s' or (release_version = '') IS NOT FALSE)", ActiveOperationalState.String()))
 	}
 
 	limit := r.defaultLimit

--- a/internal/server/repository_worker.go
+++ b/internal/server/repository_worker.go
@@ -164,7 +164,7 @@ func lookupWorker(ctx context.Context, reader db.Reader, id string) (*Worker, er
 // then the last status update time is ignored.
 // If WithLimit < 0, then unlimited results are returned. If WithLimit == 0, then
 // default limits are used for results.
-// Also supports: WithWorkerType, WithExcludeShutdownWorkers
+// Also supports: WithWorkerType, WithActiveWorkers
 func (r *Repository) ListWorkers(ctx context.Context, scopeIds []string, opt ...Option) ([]*Worker, error) {
 	const op = "server.(Repository).ListWorkers"
 	switch {
@@ -197,10 +197,9 @@ func (r *Repository) ListWorkers(ctx context.Context, scopeIds []string, opt ...
 		return nil, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("unknown worker type %v", opts.withWorkerType))
 	}
 
-	if opts.withExcludeShutdownWorkers {
-		// If a worker has a version, it must be active. If it's an older worker (no release version), we'll include it for
-		// backwards compatibilty
-		where = append(where, fmt.Sprintf("(operational_state = '%s' or length(trim(release_version)) = 0 or release_version is null)", ActiveOperationalState.String()))
+	if opts.withActiveWorkers {
+		where = append(where, "operational_state = ?")
+		whereArgs = append(whereArgs, ActiveOperationalState.String())
 	}
 
 	limit := r.defaultLimit

--- a/internal/server/repository_worker_test.go
+++ b/internal/server/repository_worker_test.go
@@ -714,11 +714,24 @@ func TestListWorkers_WithExcludeShutdown(t *testing.T) {
 	require.NoError(err)
 	require.Len(result, 1)
 
-	// Upsert with an empty string release version and no state
+	// Upsert with an empty string release version and no state and expect to get a hit- test backwards compatibility
 	_, err = serversRepo.UpsertWorkerStatus(ctx,
 		server.NewWorker(scope.Global.String(),
 			server.WithName(worker3.GetName()),
 			server.WithAddress(worker3.GetAddress()),
+			server.WithReleaseVersion("")),
+		server.WithPublicId(worker3.GetPublicId()))
+	require.NoError(err)
+	result, err = serversRepo.ListWorkers(ctx, []string{scope.Global.String()}, server.WithExcludeShutdownWorkers(true))
+	require.NoError(err)
+	require.Len(result, 1)
+
+	// Upsert with active status and empty string version and expect to get a hit- test backwards compatibility
+	_, err = serversRepo.UpsertWorkerStatus(ctx,
+		server.NewWorker(scope.Global.String(),
+			server.WithName(worker3.GetName()),
+			server.WithAddress(worker3.GetAddress()),
+			server.WithOperationalState(server.ActiveOperationalState.String()),
 			server.WithReleaseVersion("")),
 		server.WithPublicId(worker3.GetPublicId()))
 	require.NoError(err)

--- a/internal/server/repository_worker_test.go
+++ b/internal/server/repository_worker_test.go
@@ -297,7 +297,7 @@ func TestUpsertWorkerStatus(t *testing.T) {
 		// update again with a shutdown state
 		wStatus3 := server.NewWorker(scope.Global.String(),
 			server.WithAddress("new_address"), server.WithName("config_name1"),
-			server.WithOperationalState("shutdown"))
+			server.WithOperationalState("shutdown"), server.WithReleaseVersion("Boundary v0.11.0"))
 		worker, err = repo.UpsertWorkerStatus(ctx, wStatus3)
 		require.NoError(t, err)
 		assert.Greater(t, worker.GetLastStatusTime().AsTime(), worker.GetCreateTime().AsTime())
@@ -455,7 +455,8 @@ func TestUpsertWorkerStatus(t *testing.T) {
 	t.Run("add another status", func(t *testing.T) {
 		anotherStatus := server.NewWorker(scope.Global.String(),
 			server.WithName("another_test_worker"),
-			server.WithAddress("address"))
+			server.WithAddress("address"),
+			server.WithReleaseVersion("Boundary v0.11.0"))
 		_, err = repo.UpsertWorkerStatus(ctx, anotherStatus)
 		require.NoError(t, err)
 
@@ -468,7 +469,8 @@ func TestUpsertWorkerStatus(t *testing.T) {
 		anotherStatus := server.NewWorker(scope.Global.String(),
 			server.WithName("another_test_worker"),
 			server.WithAddress("address"),
-			server.WithOperationalState("shutdown"))
+			server.WithOperationalState("shutdown"),
+			server.WithReleaseVersion("Boundary v0.11.0"))
 		_, err = repo.UpsertWorkerStatus(ctx, anotherStatus)
 		require.NoError(t, err)
 

--- a/internal/server/repository_worker_test.go
+++ b/internal/server/repository_worker_test.go
@@ -645,7 +645,7 @@ func TestListWorkers(t *testing.T) {
 	}
 }
 
-func TestListWorkers_WithExcludeShutdown(t *testing.T) {
+func TestListWorkers_WithActiveWorkers(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	conn, _ := db.TestSetup(t, "postgres")

--- a/internal/server/repository_worker_test.go
+++ b/internal/server/repository_worker_test.go
@@ -703,11 +703,23 @@ func TestListWorkers_WithExcludeShutdown(t *testing.T) {
 	require.NoError(err)
 	require.Len(result, 0)
 
-	// Upsert without a release version or state and expect to get a hit- test backwards compatibility
+	// Upsert without a release version (nil version) or state and expect to get a hit- test backwards compatibility
 	_, err = serversRepo.UpsertWorkerStatus(ctx,
 		server.NewWorker(scope.Global.String(),
 			server.WithName(worker3.GetName()),
 			server.WithAddress(worker3.GetAddress())),
+		server.WithPublicId(worker3.GetPublicId()))
+	require.NoError(err)
+	result, err = serversRepo.ListWorkers(ctx, []string{scope.Global.String()}, server.WithExcludeShutdownWorkers(true))
+	require.NoError(err)
+	require.Len(result, 1)
+
+	// Upsert with an empty string release version and no state
+	_, err = serversRepo.UpsertWorkerStatus(ctx,
+		server.NewWorker(scope.Global.String(),
+			server.WithName(worker3.GetName()),
+			server.WithAddress(worker3.GetAddress()),
+			server.WithReleaseVersion("")),
 		server.WithPublicId(worker3.GetPublicId()))
 	require.NoError(err)
 	result, err = serversRepo.ListWorkers(ctx, []string{scope.Global.String()}, server.WithExcludeShutdownWorkers(true))


### PR DESCRIPTION
Add view migration comment
Only use active workers for the target service; allow workers in an unknown state if they have no release version for backwards compatibility.