### PR TITLE
Worker graceful shutdown

### DIFF
--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -76,9 +76,10 @@ var reRemoveWhitespace = regexp.MustCompile(`[\s]+`)
 var DevOnlyControllerFlags = func(*Command, *FlagSet) {}
 
 type Command struct {
-	Context    context.Context
-	UI         cli.Ui
-	ShutdownCh chan struct{}
+	Context       context.Context
+	ContextCancel context.CancelFunc
+	UI            cli.Ui
+	ShutdownCh    chan struct{}
 
 	flags     *FlagSets
 	flagsOnce sync.Once
@@ -149,11 +150,12 @@ func NewCommand(ui cli.Ui) *Command {
 
 // New returns a new instance of a base.Command type that does not intercept the shutdown channel
 func NewServerCommand(ui cli.Ui) *Command {
-	ctx, _ := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	ret := &Command{
-		UI:         ui,
-		ShutdownCh: MakeShutdownCh(),
-		Context:    ctx,
+		UI:            ui,
+		ShutdownCh:    MakeShutdownCh(),
+		Context:       ctx,
+		ContextCancel: cancel,
 	}
 
 	return ret

--- a/internal/cmd/base/dev.go
+++ b/internal/cmd/base/dev.go
@@ -371,18 +371,8 @@ func (b *Server) createInitialOidcAuthMethod(ctx context.Context) (*oidc.AuthMet
 		}
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		select {
-		case <-b.ShutdownCh:
-			cancel()
-		case <-cancelCtx.Done():
-		}
-	}()
-
 	b.DevOidcSetup.authMethod, err = oidcRepo.CreateAuthMethod(
-		cancelCtx,
+		ctx,
 		authMethod,
 		oidc.WithPublicId(b.DevOidcAuthMethodId))
 	if err != nil {
@@ -402,7 +392,7 @@ func (b *Server) createInitialOidcAuthMethod(ctx context.Context) (*oidc.AuthMet
 				return fmt.Errorf("error generating %s oidc account: %w", typ, err)
 			}
 			acct, err = oidcRepo.CreateAccount(
-				cancelCtx,
+				ctx,
 				b.DevOidcSetup.authMethod.GetScopeId(),
 				acct,
 				oidc.WithPublicId(accountId),
@@ -417,11 +407,11 @@ func (b *Server) createInitialOidcAuthMethod(ctx context.Context) (*oidc.AuthMet
 				return fmt.Errorf("unable to create iam repo: %w", err)
 			}
 
-			u, _, err := iamRepo.LookupUser(cancelCtx, userId)
+			u, _, err := iamRepo.LookupUser(ctx, userId)
 			if err != nil {
 				return fmt.Errorf("error looking up %s user: %w", typ, err)
 			}
-			if _, err = iamRepo.AddUserAccounts(cancelCtx, u.GetPublicId(), u.GetVersion(), []string{acct.GetPublicId()}); err != nil {
+			if _, err = iamRepo.AddUserAccounts(ctx, u.GetPublicId(), u.GetVersion(), []string{acct.GetPublicId()}); err != nil {
 				return fmt.Errorf("error associating initial %s user with account: %w", typ, err)
 			}
 

--- a/internal/cmd/base/initial_resources.go
+++ b/internal/cmd/base/initial_resources.go
@@ -32,15 +32,6 @@ func (b *Server) CreateInitialLoginRole(ctx context.Context) (*iam.Role, error) 
 	); err != nil {
 		return nil, fmt.Errorf("error adding config keys to kms: %w", err)
 	}
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		select {
-		case <-b.ShutdownCh:
-			cancel()
-		case <-cancelCtx.Done():
-		}
-	}()
 
 	iamRepo, err := iam.NewRepository(rw, rw, kmsCache, iam.WithRandomReader(b.SecureRandomReader))
 	if err != nil {
@@ -54,11 +45,11 @@ func (b *Server) CreateInitialLoginRole(ctx context.Context) (*iam.Role, error) 
 	if err != nil {
 		return nil, fmt.Errorf("error creating in memory role for generated grants: %w", err)
 	}
-	role, err := iamRepo.CreateRole(cancelCtx, pr)
+	role, err := iamRepo.CreateRole(ctx, pr)
 	if err != nil {
 		return nil, fmt.Errorf("error creating role for default generated grants: %w", err)
 	}
-	if _, err := iamRepo.AddRoleGrants(cancelCtx, role.PublicId, role.Version, []string{
+	if _, err := iamRepo.AddRoleGrants(ctx, role.PublicId, role.Version, []string{
 		"id=*;type=scope;actions=list,no-op",
 		"id=*;type=auth-method;actions=authenticate,list",
 		"id={{account.id}};actions=read,change-password",
@@ -66,7 +57,7 @@ func (b *Server) CreateInitialLoginRole(ctx context.Context) (*iam.Role, error) 
 	}); err != nil {
 		return nil, fmt.Errorf("error creating grant for default generated grants: %w", err)
 	}
-	if _, err := iamRepo.AddPrincipalRoles(cancelCtx, role.PublicId, role.Version+1, []string{auth.AnonymousUserId}, nil); err != nil {
+	if _, err := iamRepo.AddPrincipalRoles(ctx, role.PublicId, role.Version+1, []string{auth.AnonymousUserId}, nil); err != nil {
 		return nil, fmt.Errorf("error adding principal to role for default generated grants: %w", err)
 	}
 
@@ -106,17 +97,7 @@ func (b *Server) CreateInitialPasswordAuthMethod(ctx context.Context) (*password
 		}
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		select {
-		case <-b.ShutdownCh:
-			cancel()
-		case <-cancelCtx.Done():
-		}
-	}()
-
-	am, err := pwRepo.CreateAuthMethod(cancelCtx, authMethod,
+	am, err := pwRepo.CreateAuthMethod(ctx, authMethod,
 		password.WithPublicId(b.DevPasswordAuthMethodId))
 	if err != nil {
 		return nil, nil, fmt.Errorf("error saving auth method to the db: %w", err)
@@ -165,7 +146,7 @@ func (b *Server) CreateInitialPasswordAuthMethod(ctx context.Context) (*password
 			return nil, fmt.Errorf("error creating new in memory password auth account: %w", err)
 		}
 		acct, err = pwRepo.CreateAccount(
-			cancelCtx,
+			ctx,
 			scope.Global.String(),
 			acct,
 			password.WithPassword(loginPassword),
@@ -201,10 +182,10 @@ func (b *Server) CreateInitialPasswordAuthMethod(ctx context.Context) (*password
 		if err != nil {
 			return nil, fmt.Errorf("error creating in memory user: %w", err)
 		}
-		if u, err = iamRepo.CreateUser(cancelCtx, u, opts...); err != nil {
+		if u, err = iamRepo.CreateUser(ctx, u, opts...); err != nil {
 			return nil, fmt.Errorf("error creating initial %s user: %w", typeStr, err)
 		}
-		if _, err = iamRepo.AddUserAccounts(cancelCtx, u.GetPublicId(), u.GetVersion(), []string{acct.GetPublicId()}); err != nil {
+		if _, err = iamRepo.AddUserAccounts(ctx, u.GetPublicId(), u.GetVersion(), []string{acct.GetPublicId()}); err != nil {
 			return nil, fmt.Errorf("error associating initial %s user with account: %w", typeStr, err)
 		}
 		if !admin {
@@ -218,14 +199,14 @@ func (b *Server) CreateInitialPasswordAuthMethod(ctx context.Context) (*password
 		if err != nil {
 			return nil, fmt.Errorf("error creating in memory role for generated grants: %w", err)
 		}
-		defPermsRole, err := iamRepo.CreateRole(cancelCtx, pr)
+		defPermsRole, err := iamRepo.CreateRole(ctx, pr)
 		if err != nil {
 			return nil, fmt.Errorf("error creating role for default generated grants: %w", err)
 		}
-		if _, err := iamRepo.AddRoleGrants(cancelCtx, defPermsRole.PublicId, defPermsRole.Version, []string{"id=*;type=*;actions=*"}); err != nil {
+		if _, err := iamRepo.AddRoleGrants(ctx, defPermsRole.PublicId, defPermsRole.Version, []string{"id=*;type=*;actions=*"}); err != nil {
 			return nil, fmt.Errorf("error creating grant for default generated grants: %w", err)
 		}
-		if _, err := iamRepo.AddPrincipalRoles(cancelCtx, defPermsRole.PublicId, defPermsRole.Version+1, []string{u.GetPublicId()}, nil); err != nil {
+		if _, err := iamRepo.AddPrincipalRoles(ctx, defPermsRole.PublicId, defPermsRole.Version+1, []string{u.GetPublicId()}, nil); err != nil {
 			return nil, fmt.Errorf("error adding principal to role for default generated grants: %w", err)
 		}
 		return u, nil
@@ -282,16 +263,6 @@ func (b *Server) CreateInitialScopes(ctx context.Context) (*iam.Scope, *iam.Scop
 		return nil, nil, fmt.Errorf("error adding config keys to kms: %w", err)
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		select {
-		case <-b.ShutdownCh:
-			cancel()
-		case <-cancelCtx.Done():
-		}
-	}()
-
 	iamRepo, err := iam.NewRepository(rw, rw, kmsCache)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating scopes repository: %w", err)
@@ -314,7 +285,7 @@ func (b *Server) CreateInitialScopes(ctx context.Context) (*iam.Scope, *iam.Scop
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating new in memory org scope: %w", err)
 	}
-	orgScope, err = iamRepo.CreateScope(cancelCtx, orgScope, b.DevUserId, opts...)
+	orgScope, err = iamRepo.CreateScope(ctx, orgScope, b.DevUserId, opts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error saving org scope to the db: %w", err)
 	}
@@ -337,7 +308,7 @@ func (b *Server) CreateInitialScopes(ctx context.Context) (*iam.Scope, *iam.Scop
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating new in memory project scope: %w", err)
 	}
-	projScope, err = iamRepo.CreateScope(cancelCtx, projScope, b.DevUserId, opts...)
+	projScope, err = iamRepo.CreateScope(ctx, projScope, b.DevUserId, opts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error saving project scope to the db: %w", err)
 	}
@@ -361,16 +332,6 @@ func (b *Server) CreateInitialHostResources(ctx context.Context) (*static.HostCa
 		return nil, nil, nil, fmt.Errorf("error adding config keys to kms: %w", err)
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		select {
-		case <-b.ShutdownCh:
-			cancel()
-		case <-cancelCtx.Done():
-		}
-	}()
-
 	staticRepo, err := static.NewRepository(rw, rw, kmsCache)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error creating static repository: %w", err)
@@ -392,7 +353,7 @@ func (b *Server) CreateInitialHostResources(ctx context.Context) (*static.HostCa
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error creating in memory host catalog: %w", err)
 	}
-	if hc, err = staticRepo.CreateCatalog(cancelCtx, hc, opts...); err != nil {
+	if hc, err = staticRepo.CreateCatalog(ctx, hc, opts...); err != nil {
 		return nil, nil, nil, fmt.Errorf("error saving host catalog to the db: %w", err)
 	}
 	b.InfoKeys = append(b.InfoKeys, "generated host catalog id")
@@ -418,7 +379,7 @@ func (b *Server) CreateInitialHostResources(ctx context.Context) (*static.HostCa
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error creating in memory host: %w", err)
 	}
-	if h, err = staticRepo.CreateHost(cancelCtx, b.DevProjectId, h, opts...); err != nil {
+	if h, err = staticRepo.CreateHost(ctx, b.DevProjectId, h, opts...); err != nil {
 		return nil, nil, nil, fmt.Errorf("error saving host to the db: %w", err)
 	}
 	b.InfoKeys = append(b.InfoKeys, "generated host id")
@@ -440,14 +401,14 @@ func (b *Server) CreateInitialHostResources(ctx context.Context) (*static.HostCa
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error creating in memory host set: %w", err)
 	}
-	if hs, err = staticRepo.CreateSet(cancelCtx, b.DevProjectId, hs, opts...); err != nil {
+	if hs, err = staticRepo.CreateSet(ctx, b.DevProjectId, hs, opts...); err != nil {
 		return nil, nil, nil, fmt.Errorf("error saving host set to the db: %w", err)
 	}
 	b.InfoKeys = append(b.InfoKeys, "generated host set id")
 	b.Info["generated host set id"] = b.DevHostSetId
 
 	// Associate members
-	if _, err := staticRepo.AddSetMembers(cancelCtx, b.DevProjectId, b.DevHostSetId, hs.GetVersion(), []string{h.GetPublicId()}); err != nil {
+	if _, err := staticRepo.AddSetMembers(ctx, b.DevProjectId, b.DevHostSetId, hs.GetVersion(), []string{h.GetPublicId()}); err != nil {
 		return nil, nil, nil, fmt.Errorf("error associating host set to host in the db: %w", err)
 	}
 
@@ -467,16 +428,6 @@ func (b *Server) CreateInitialTarget(ctx context.Context) (target.Target, error)
 	); err != nil {
 		return nil, fmt.Errorf("error adding config keys to kms: %w", err)
 	}
-
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		select {
-		case <-b.ShutdownCh:
-			cancel()
-		case <-cancelCtx.Done():
-		}
-	}()
 
 	targetRepo, err := target.NewRepository(ctx, rw, rw, kmsCache)
 	if err != nil {
@@ -505,7 +456,7 @@ func (b *Server) CreateInitialTarget(ctx context.Context) (target.Target, error)
 	if err != nil {
 		return nil, fmt.Errorf("error creating in memory target: %w", err)
 	}
-	tt, _, _, err := targetRepo.CreateTarget(cancelCtx, t, opts...)
+	tt, _, _, err := targetRepo.CreateTarget(ctx, t, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error saving target to the db: %w", err)
 	}
@@ -559,18 +510,18 @@ func (b *Server) CreateInitialTarget(ctx context.Context) (target.Target, error)
 		if err != nil {
 			return nil, fmt.Errorf("error creating in memory role for generated grants: %w", err)
 		}
-		sessionRole, err := iamRepo.CreateRole(cancelCtx, pr)
+		sessionRole, err := iamRepo.CreateRole(ctx, pr)
 		if err != nil {
 			return nil, fmt.Errorf("error creating role for unprivileged user generated grants: %w", err)
 		}
-		if _, err := iamRepo.AddRoleGrants(cancelCtx,
+		if _, err := iamRepo.AddRoleGrants(ctx,
 			sessionRole.PublicId,
 			sessionRole.Version,
 			[]string{fmt.Sprintf("id=%s;actions=authorize-session", b.DevTargetId)},
 		); err != nil {
 			return nil, fmt.Errorf("error creating grant for unprivileged user generated grants: %w", err)
 		}
-		if _, err := iamRepo.AddPrincipalRoles(cancelCtx, sessionRole.PublicId, sessionRole.Version+1, []string{b.DevUnprivilegedUserId}, nil); err != nil {
+		if _, err := iamRepo.AddPrincipalRoles(ctx, sessionRole.PublicId, sessionRole.Version+1, []string{b.DevUnprivilegedUserId}, nil); err != nil {
 			return nil, fmt.Errorf("error adding principal to role for unprivileged user generated grants: %w", err)
 		}
 	}
@@ -599,16 +550,6 @@ func (b *Server) RegisterHostPlugin(ctx context.Context, name string, plg plgpb.
 		return nil, fmt.Errorf("error adding config keys to kms: %w", err)
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		select {
-		case <-b.ShutdownCh:
-			cancel()
-		case <-cancelCtx.Done():
-		}
-	}()
-
 	hpRepo, err := hostplugin.NewRepository(rw, rw, kmsCache)
 	if err != nil {
 		return nil, fmt.Errorf("error creating host plugin repository: %w", err)
@@ -622,7 +563,7 @@ func (b *Server) RegisterHostPlugin(ctx context.Context, name string, plg plgpb.
 	if plugin == nil {
 		opt = append(opt, hostplugin.WithName(name))
 		plugin = hostplugin.NewPlugin(opt...)
-		plugin, err = hpRepo.CreatePlugin(cancelCtx, plugin, opt...)
+		plugin, err = hpRepo.CreatePlugin(ctx, plugin, opt...)
 		if err != nil {
 			return nil, fmt.Errorf("error creating host plugin: %w", err)
 		}

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -729,17 +729,7 @@ func (b *Server) CreateGlobalKmsKeys(ctx context.Context) error {
 		return fmt.Errorf("error adding config keys to kms: %w", err)
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		select {
-		case <-b.ShutdownCh:
-			cancel()
-		case <-cancelCtx.Done():
-		}
-	}()
-
-	if err = kmsCache.CreateKeys(cancelCtx, scope.Global.String(), kms.WithRandomReader(b.SecureRandomReader)); err != nil {
+	if err = kmsCache.CreateKeys(ctx, scope.Global.String(), kms.WithRandomReader(b.SecureRandomReader)); err != nil {
 		return fmt.Errorf("error creating global scope kms keys: %w", err)
 	}
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -38,14 +38,14 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 	Commands = map[string]cli.CommandFactory{
 		"server": func() (cli.Command, error) {
 			return &server.Command{
-				Server:    base.NewServer(base.NewCommand(serverCmdUi)),
+				Server:    base.NewServer(base.NewServerCommand(serverCmdUi)),
 				SighupCh:  base.MakeSighupCh(),
 				SigUSR2Ch: MakeSigUSR2Ch(),
 			}, nil
 		},
 		"dev": func() (cli.Command, error) {
 			return &dev.Command{
-				Server:    base.NewServer(base.NewCommand(serverCmdUi)),
+				Server:    base.NewServer(base.NewServerCommand(serverCmdUi)),
 				SighupCh:  base.MakeSighupCh(),
 				SigUSR2Ch: MakeSigUSR2Ch(),
 			}, nil

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -870,8 +870,8 @@ func (c *Command) Run(args []string) int {
 		count := atm.LoadUint32(&shutdownTriggerCount)
 		switch {
 		case count == 1:
+			c.ContextCancel()
 			go func() {
-				c.ContextCancel()
 				if c.Config.Controller != nil {
 					c.opsServer.WaitIfHealthExists(c.Config.Controller.GracefulShutdownWaitDuration, c.UI)
 				}

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -924,7 +924,6 @@ func (c *Command) Run(args []string) int {
 				break
 			}
 		}
-
 	}
 
 	return base.CommandSuccess

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -887,7 +887,7 @@ func (c *Command) Run(args []string) int {
 			}()
 		case count == 2 && !c.flagControllerOnly:
 			go func() {
-				if c.Config.Worker != nil && !workerShutdownDone.Load() {
+				if !workerShutdownDone.Load() {
 					workerShutdownOnce.Do(workerShutdownFunc)
 				}
 				if c.Config.Controller != nil && !controllerShutdownDone.Load() {

--- a/internal/cmd/commands/server/controller_db_swap_test.go
+++ b/internal/cmd/commands/server/controller_db_swap_test.go
@@ -215,7 +215,7 @@ func TestReloadControllerDatabase(t *testing.T) {
 	require.NoError(t, row.Scan(&lock))
 	require.Equal(t, 1, lock)
 
-	close(cmd.ShutdownCh)
+	cmd.ShutdownCh <- struct{}{}
 	wg.Wait()
 }
 
@@ -316,8 +316,8 @@ func TestReloadControllerDatabase_InvalidNewDatabaseState(t *testing.T) {
 	require.NoError(t, row.Err())
 	require.NoError(t, row.Scan(&lock))
 	require.Equal(t, 1, lock)
-
-	close(cmd.ShutdownCh)
+	
+	cmd.ShutdownCh <- struct{}{}
 	wg.Wait()
 }
 

--- a/internal/cmd/commands/server/controller_db_swap_test.go
+++ b/internal/cmd/commands/server/controller_db_swap_test.go
@@ -316,7 +316,7 @@ func TestReloadControllerDatabase_InvalidNewDatabaseState(t *testing.T) {
 	require.NoError(t, row.Err())
 	require.NoError(t, row.Scan(&lock))
 	require.Equal(t, 1, lock)
-	
+
 	cmd.ShutdownCh <- struct{}{}
 	wg.Wait()
 }

--- a/internal/cmd/commands/server/listener_reload_test.go
+++ b/internal/cmd/commands/server/listener_reload_test.go
@@ -167,7 +167,7 @@ func TestServer_ReloadListener(t *testing.T) {
 
 	testCertificateSerial("193080739105342897219784862820114567438786419504")
 
-	close(cmd.ShutdownCh)
+	cmd.ShutdownCh <- struct{}{}
 
 	wg.Wait()
 }

--- a/internal/cmd/commands/server/listener_reload_test.go
+++ b/internal/cmd/commands/server/listener_reload_test.go
@@ -158,18 +158,15 @@ func TestServer_ReloadListener(t *testing.T) {
 	require.NoError(err)
 	require.NoError(os.WriteFile(td+"/bundle.pem", inBytes, 0o777))
 
-	fmt.Println("Invoking sighup ch")
 	cmd.SighupCh <- struct{}{}
 	select {
 	case <-cmd.reloadedCh:
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timeout")
 	}
-	fmt.Println("after sighup ch")
+
 	testCertificateSerial("193080739105342897219784862820114567438786419504")
 
-	fmt.Println("Invoking shutdown ch")
 	cmd.ShutdownCh <- struct{}{}
-
 	wg.Wait()
 }

--- a/internal/cmd/commands/server/listener_reload_test.go
+++ b/internal/cmd/commands/server/listener_reload_test.go
@@ -158,15 +158,17 @@ func TestServer_ReloadListener(t *testing.T) {
 	require.NoError(err)
 	require.NoError(os.WriteFile(td+"/bundle.pem", inBytes, 0o777))
 
+	fmt.Println("Invoking sighup ch")
 	cmd.SighupCh <- struct{}{}
 	select {
 	case <-cmd.reloadedCh:
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timeout")
 	}
-
+	fmt.Println("after sighup ch")
 	testCertificateSerial("193080739105342897219784862820114567438786419504")
 
+	fmt.Println("Invoking shutdown ch")
 	cmd.ShutdownCh <- struct{}{}
 
 	wg.Wait()

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	sync "sync/atomic"
 	"time"
 
 	"github.com/hashicorp/boundary/globals"
@@ -668,81 +669,74 @@ func (c *Command) WaitForInterrupt() int {
 
 	// On first interrupt, enter graceful shutdown for controllers and workers (workers wait for connections to drain)
 	// On second interrupt, force controller shutdown and send workers into shutdown (stop all connections)
-	// On third interrupt, force worker shutdown
-	gracefulShutdownTriggered := false
-	workerShutdownTriggered := false
-
-	// Add a force-shutdown goroutine to consume another interrupt
-	abortForceShutdownCh := make(chan struct{})
-	defer close(abortForceShutdownCh)
+	// On third+ interrupt, force worker shutdown
+	shutdownDone := false
+	shutdownTriggerCount := uint32(0)
 
 	runShutdownLogic := func() {
-		go func() {
-			for {
-				select {
-				case <-c.ShutdownCh:
-					if !workerShutdownTriggered && c.Config.Worker != nil {
-						workerShutdownTriggered = true
-						if err := c.worker.Shutdown(); err != nil {
-							c.UI.Error(fmt.Errorf("Error shutting down worker: %w", err).Error())
-						}
-						os.Exit(base.CommandSuccess)
+		if sync.LoadUint32(&shutdownTriggerCount) == 1 {
+			go func() {
+				if c.Config.Controller != nil && c.opsServer != nil {
+					c.opsServer.WaitIfHealthExists(c.Config.Controller.GracefulShutdownWaitDuration, c.UI)
+				}
+
+				if c.Config.Worker != nil {
+					if err := c.worker.GracefulShutdown(); err != nil {
+						c.UI.Error(fmt.Errorf("Error shutting down worker gracefully: %w", err).Error())
 					}
+					if err := c.worker.Shutdown(); err != nil {
+						c.UI.Error(fmt.Errorf("Error shutting down worker: %w", err).Error())
+					}
+				}
+
+				if c.Config.Controller != nil {
+					if err := c.controller.Shutdown(); err != nil {
+						c.UI.Error(fmt.Errorf("Error shutting down controller: %w", err).Error())
+					}
+				}
+
+				if c.opsServer != nil {
+					err := c.opsServer.Shutdown()
+					if err != nil {
+						c.UI.Error(fmt.Errorf("Failed to shutdown ops listeners: %w", err).Error())
+					}
+				}
+				shutdownDone = true
+			}()
+		}
+
+		if sync.LoadUint32(&shutdownTriggerCount) == 2 && c.Config.Worker != nil {
+			go func() {
+				if c.Config.Worker != nil {
+					if err := c.worker.Shutdown(); err != nil {
+						c.UI.Error(fmt.Errorf("Error shutting down worker: %w", err).Error())
+					}
+					shutdownDone = true
+				} else {
 					c.UI.Error("Forcing shutdown")
 					os.Exit(base.CommandUserError)
-
-				case <-c.ServerSideShutdownCh:
-					// Drain connections in case this is hit more than once
-
-				case <-abortForceShutdownCh:
-					// No-op, we just use this to shut down the goroutine
-					return
 				}
-			}
-		}()
-
-		if c.Config.Controller != nil && c.opsServer != nil {
-			c.opsServer.WaitIfHealthExists(c.Config.Controller.GracefulShutdownWaitDuration, c.UI)
+			}()
 		}
 
-		// Do worker shutdown
-		if c.Config.Worker != nil {
-			if err := c.worker.GracefulShutdown(); err != nil {
-				c.UI.Error(fmt.Errorf("Error shutting down worker gracefully: %w", err).Error())
-			}
-			if !workerShutdownTriggered {
-				workerShutdownTriggered = true
-				if err := c.worker.Shutdown(); err != nil {
-					c.UI.Error(fmt.Errorf("Error shutting down worker: %w", err).Error())
-				}
-			}
+		if sync.LoadUint32(&shutdownTriggerCount) > 2 {
+			go func() {
+				c.UI.Error("Forcing shutdown")
+				os.Exit(base.CommandUserError)
+			}()
 		}
-
-		// Do controller shutdown
-		if c.Config.Controller != nil {
-			if err := c.controller.Shutdown(); err != nil {
-				c.UI.Error(fmt.Errorf("Error shutting down controller: %w", err).Error())
-			}
-		}
-
-		if c.opsServer != nil {
-			err := c.opsServer.Shutdown()
-			if err != nil {
-				c.UI.Error(fmt.Errorf("Error shutting down ops listeners: %w", err).Error())
-			}
-		}
-
-		gracefulShutdownTriggered = true
 	}
 
-	for !gracefulShutdownTriggered {
+	for !shutdownDone {
 		select {
 		case <-c.ServerSideShutdownCh:
 			c.UI.Output("==> Boundary server self-terminating")
+			sync.AddUint32(&shutdownTriggerCount, 1)
 			runShutdownLogic()
 
 		case <-c.ShutdownCh:
 			c.UI.Output("==> Boundary server shutdown triggered, interrupt again to force")
+			sync.AddUint32(&shutdownTriggerCount, 1)
 			runShutdownLogic()
 
 		case <-c.SighupCh:
@@ -797,6 +791,10 @@ func (c *Command) WaitForInterrupt() int {
 			buf := make([]byte, 32*1024*1024)
 			n := runtime.Stack(buf[:], true)
 			event.WriteSysEvent(context.TODO(), op, "goroutine trace", "stack", string(buf[:n]))
+		default:
+			if shutdownDone {
+				break
+			}
 		}
 	}
 

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -679,7 +679,6 @@ func (c *Command) WaitForInterrupt() int {
 	runShutdownLogic := func() {
 		go func() {
 			for {
-				event.WriteSysEvent(c.Context, op, "waiting in this dang loop")
 				select {
 				case <-c.ShutdownCh:
 					if !workerShutdownTriggered && c.Config.Worker != nil {

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -669,12 +669,13 @@ func (c *Command) WaitForInterrupt() int {
 	const op = "server.(Command).WaitForInterrupt"
 
 	var controllerShutdownDone atm.Bool
-	var workerShutdownDone atm.Bool
 	controllerShutdownDone.Store(false)
-
+	if c.Config.Controller == nil {
+		controllerShutdownDone.Store(true)
+	}
+	var workerShutdownDone atm.Bool
+	workerShutdownDone.Store(false)
 	if c.Config.Worker == nil {
-		workerShutdownDone.Store(false)
-	} else {
 		workerShutdownDone.Store(true)
 	}
 
@@ -701,6 +702,10 @@ func (c *Command) WaitForInterrupt() int {
 		} else {
 			controllerShutdownDone.Store(true)
 		}
+		err := c.opsServer.Shutdown()
+		if err != nil {
+			c.UI.Error(fmt.Errorf("Failed to shutdown ops listeners: %w", err).Error())
+		}
 	}
 
 	runShutdownLogic := func() {
@@ -708,21 +713,20 @@ func (c *Command) WaitForInterrupt() int {
 		switch {
 		case count == 1:
 			go func() {
+				c.ContextCancel()
 				if c.Config.Controller != nil && c.opsServer != nil {
 					c.opsServer.WaitIfHealthExists(c.Config.Controller.GracefulShutdownWaitDuration, c.UI)
 				}
 
 				if c.Config.Worker != nil {
+					c.UI.Output("==> Boundary server graceful shutdown triggered, interrupt again to enter shutdown")
 					workerGracefulShutdownFunc()
+				} else {
+					c.UI.Output("==> Boundary server shutdown triggered, interrupt again to force")
 				}
 
-				controllerOnce.Do(controllerShutdownFunc)
-
-				if c.opsServer != nil {
-					err := c.opsServer.Shutdown()
-					if err != nil {
-						c.UI.Error(fmt.Errorf("Failed to shutdown ops listeners: %w", err).Error())
-					}
+				if c.Config.Controller != nil {
+					controllerOnce.Do(controllerShutdownFunc)
 				}
 			}()
 
@@ -731,20 +735,14 @@ func (c *Command) WaitForInterrupt() int {
 				if c.Config.Worker != nil && !workerShutdownDone.Load() {
 					workerShutdownOnce.Do(workerShutdownFunc)
 				}
-				if !controllerShutdownDone.Load() {
+				if c.Config.Controller != nil && !controllerShutdownDone.Load() {
 					controllerOnce.Do(controllerShutdownFunc)
-				}
-				if workerShutdownDone.Load() && controllerShutdownDone.Load() {
-					c.UI.Error("Forcing shutdown")
-					os.Exit(base.CommandUserError)
 				}
 			}()
 
-		case count > 2:
-			go func() {
-				c.UI.Error("Forcing shutdown")
-				os.Exit(base.CommandUserError)
-			}()
+		case count >= 2:
+			c.UI.Error("Forcing shutdown")
+			os.Exit(base.CommandCliError)
 		}
 	}
 
@@ -756,7 +754,6 @@ func (c *Command) WaitForInterrupt() int {
 			runShutdownLogic()
 
 		case <-c.ShutdownCh:
-			c.UI.Output("==> Boundary server shutdown triggered, interrupt again to force")
 			atm.AddUint32(&shutdownTriggerCount, 1)
 			runShutdownLogic()
 

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -816,10 +816,8 @@ func (c *Command) WaitForInterrupt() int {
 			n := runtime.Stack(buf[:], true)
 			event.WriteSysEvent(context.TODO(), op, "goroutine trace", "stack", string(buf[:n]))
 
-		case <-time.After(10 * time.Millisecond):
-			if workerShutdownDone.Load() && controllerShutdownDone.Load() {
-				break
-			}
+		case <-c.Context.Done():
+			break
 		}
 	}
 

--- a/internal/cmd/commands/server/server_test.go
+++ b/internal/cmd/commands/server/server_test.go
@@ -46,7 +46,7 @@ func testServerCommand(t *testing.T, opts testServerCommandOpts) *Command {
 	require := require.New(t)
 	t.Helper()
 	cmd := &Command{
-		Server:     base.NewServer(base.NewCommand(cli.NewMockUi())),
+		Server:     base.NewServer(base.NewServerCommand(cli.NewMockUi())),
 		SighupCh:   base.MakeSighupCh(),
 		startedCh:  make(chan struct{}),
 		reloadedCh: make(chan struct{}, 5),

--- a/internal/cmd/commands/server/worker_initial_upstreams_reload_test.go
+++ b/internal/cmd/commands/server/worker_initial_upstreams_reload_test.go
@@ -135,7 +135,6 @@ pollSecondController:
 		}
 	}
 
-	close(cmd.ShutdownCh)
-
+	cmd.ShutdownCh <- struct{}{}
 	wg.Wait()
 }

--- a/internal/cmd/commands/server/worker_shutdown_reload_test.go
+++ b/internal/cmd/commands/server/worker_shutdown_reload_test.go
@@ -98,13 +98,13 @@ func TestServer_ShutdownWorker(t *testing.T) {
 	t.Log("running initial send/recv test")
 	sConn.TestSendRecvAll(t)
 
-	// Now, shut the worker down.
-	close(workerCmd.ShutdownCh)
+	// Shutdown the worker and close the connection, as the worker will otherwise wait for it to close.
+	sConn.Close()
+	workerCmd.ShutdownCh <- struct{}{}
 	if <-workerCodeChan != 0 {
 		output := workerCmd.UI.(*cli.MockUi).ErrorWriter.String() + workerCmd.UI.(*cli.MockUi).OutputWriter.String()
 		require.FailNow(output, "command exited with non-zero error code")
 	}
-
 	// Connection should fail, and the session should be closed on the DB.
 	sConn.TestSendRecvFail(t)
 	sess.ExpectConnectionStateOnController(ctx, t, testController.Controller().ConnectionRepoFn, session.StatusClosed)

--- a/internal/cmd/commands/server/worker_tags_reload_test.go
+++ b/internal/cmd/commands/server/worker_tags_reload_test.go
@@ -130,7 +130,7 @@ func TestServer_ReloadWorkerTags(t *testing.T) {
 	time.Sleep(10 * time.Second)
 	fetchWorkerTags("test", "foo", []string{"bar", "baz"})
 
-	close(cmd.ShutdownCh)
+	cmd.ShutdownCh <- struct{}{}
 
 	wg.Wait()
 }

--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -286,8 +286,11 @@ func (tc *TestController) buildClient() {
 // done
 func (tc *TestController) Shutdown() {
 	tc.shutdownOnce.Do(func() {
+		// TODO update this as well
+
 		if tc.b != nil {
-			close(tc.b.ShutdownCh)
+			//close(tc.b.ShutdownCh)
+			tc.b.ContextCancel()
 		}
 
 		tc.cancel()
@@ -492,10 +495,14 @@ func TestControllerConfig(t testing.TB, ctx context.Context, tc *TestController,
 		opts = new(TestControllerOpts)
 	}
 
+	// TODO populate context cancel with cancelable context
+	ctxTest, cancel := context.WithCancel(context.Background())
+
 	// Base server
 	tc.b = base.NewServer(&base.Command{
-		Context:    ctx,
-		ShutdownCh: make(chan struct{}),
+		Context:       ctxTest,
+		ContextCancel: cancel,
+		ShutdownCh:    make(chan struct{}),
 	})
 
 	// Get dev config, or use a provided one

--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -286,10 +286,7 @@ func (tc *TestController) buildClient() {
 // done
 func (tc *TestController) Shutdown() {
 	tc.shutdownOnce.Do(func() {
-		// TODO update this as well
-
 		if tc.b != nil {
-			//close(tc.b.ShutdownCh)
 			tc.b.ContextCancel()
 		}
 

--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -492,7 +492,6 @@ func TestControllerConfig(t testing.TB, ctx context.Context, tc *TestController,
 		opts = new(TestControllerOpts)
 	}
 
-	// TODO populate context cancel with cancelable context
 	ctxTest, cancel := context.WithCancel(context.Background())
 
 	// Base server

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -453,6 +453,8 @@ func (w *Worker) GracefulShutdown() error {
 		activeConnectionCount = w.activeConnectionCount()
 	}
 	event.WriteSysEvent(w.baseContext, op, "worker connections have drained")
+
+	time.Sleep(time.Second * 10)
 	return nil
 }
 

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -467,6 +467,8 @@ func (w *Worker) Shutdown() error {
 		return nil
 	}
 	event.WriteSysEvent(w.baseContext, op, "worker shutting down")
+
+	// Set state to shutdown
 	w.operationalState.Store(server.ShutdownOperationalState)
 
 	// Stop listeners first to prevent new connections to the

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -448,7 +448,7 @@ func (w *Worker) GracefulShutdown() error {
 
 	// Wait for connections to drain
 	for w.hasActiveConnection() {
-		time.Sleep(time.Second)
+		time.Sleep(time.Millisecond * 250)
 	}
 	event.WriteSysEvent(w.baseContext, op, "worker connections have drained")
 

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -452,8 +452,6 @@ func (w *Worker) GracefulShutdown() error {
 	}
 	event.WriteSysEvent(w.baseContext, op, "worker connections have drained")
 
-	// TODO remove this is jsut for local testing
-	//time.Sleep(time.Second * 10)
 	return nil
 }
 

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -453,8 +453,6 @@ func (w *Worker) GracefulShutdown() error {
 		activeConnectionCount = w.activeConnectionCount()
 	}
 	event.WriteSysEvent(w.baseContext, op, "worker connections have drained")
-
-	time.Sleep(time.Second * 10)
 	return nil
 }
 

--- a/internal/tests/helper/testing_helper.go
+++ b/internal/tests/helper/testing_helper.go
@@ -347,7 +347,6 @@ func (c *TestSessionConnection) testSendRecv(t *testing.T) bool {
 		err := binary.Write(c.conn, binary.LittleEndian, i)
 		if err != nil {
 			t.Log("received error during write", "err", err)
-			fmt.Println(err.Error())
 			if errors.Is(err, net.ErrClosed) ||
 				errors.Is(err, io.EOF) ||
 				errors.Is(err, websocket.CloseError{Code: websocket.StatusPolicyViolation, Reason: "timed out"}) ||

--- a/internal/tests/helper/testing_helper.go
+++ b/internal/tests/helper/testing_helper.go
@@ -301,6 +301,11 @@ type TestSessionConnection struct {
 	conn net.Conn
 }
 
+// Close a test connection
+func (t *TestSessionConnection) Close() error {
+	return t.conn.Close()
+}
+
 // Connect returns a TestSessionConnection for a TestSession. Check
 // the unexported connect method for the lower-level details.
 func (s *TestSession) Connect(
@@ -342,9 +347,11 @@ func (c *TestSessionConnection) testSendRecv(t *testing.T) bool {
 		err := binary.Write(c.conn, binary.LittleEndian, i)
 		if err != nil {
 			t.Log("received error during write", "err", err)
+			fmt.Println(err.Error())
 			if errors.Is(err, net.ErrClosed) ||
 				errors.Is(err, io.EOF) ||
-				errors.Is(err, websocket.CloseError{Code: websocket.StatusPolicyViolation, Reason: "timed out"}) {
+				errors.Is(err, websocket.CloseError{Code: websocket.StatusPolicyViolation, Reason: "timed out"}) ||
+				errors.Is(err, websocket.CloseError{Code: websocket.StatusNormalClosure, Reason: ""}) {
 				return false
 			}
 


### PR DESCRIPTION
- Changed the shutdown channel so that it stays open to listen for more interrupts
- Addition of worker graceful shutdown- on first ctrl+c, worker will start graceful shutdown (waiting for active connections to drain). Second will cause the worker to move on to shutdown. Third will force shutdown immediately.