### PR TITLE
scheduler: log details when starting scheduler

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -184,12 +184,17 @@ func (s *Scheduler) RunNow() {
 
 func (s *Scheduler) start(ctx context.Context) {
 	const op = "scheduler.(Scheduler).start"
+	event.WriteSysEvent(ctx, op, "scheduling loop running",
+		"server id", s.serverId,
+		"run interval", s.runJobsInterval.String(),
+		"run limit", s.runJobsLimit)
 	timer := time.NewTimer(0)
 	var wg sync.WaitGroup
 	for {
 		select {
 		case <-ctx.Done():
-			event.WriteSysEvent(ctx, op, "scheduling loop received shutdown, waiting for jobs to finish", "server id", s.serverId)
+			event.WriteSysEvent(ctx, op, "scheduling loop received shutdown, waiting for jobs to finish",
+				"server id", s.serverId)
 			wg.Wait()
 			event.WriteSysEvent(ctx, op, "scheduling loop shutting down", "server id", s.serverId)
 			return
@@ -282,6 +287,10 @@ func (s *Scheduler) runJob(ctx context.Context, wg *sync.WaitGroup, r *job.Run) 
 
 func (s *Scheduler) monitorJobs(ctx context.Context) {
 	const op = "scheduler.(Scheduler).monitorJobs"
+	event.WriteSysEvent(ctx, op, "monitor loop running",
+		"server id", s.serverId,
+		"monitor interval", s.monitorInterval.String(),
+		"interrupt threshold", s.interruptThreshold.String())
 	timer := time.NewTimer(0)
 	for {
 		select {


### PR DESCRIPTION
We log when the scheduling and monitor loop go down so it makes sense to log when they start. Also since these values are configurable it is good to log:
```
{
  "id": "AguTiArdEX",
  "source": "https://hashicorp.com/boundary/louisruch-C02DF0BSML85/controller+worker",
  "specversion": "1.0",
  "type": "system",
  "data": {
    "version": "v0.1",
    "op": "scheduler.(Scheduler).monitorJobs",
    "data": {
      "interrupt threshold": "5m0s",
      "monitor interval": "30s",
      "msg": "monitor loop running",
      "server id": "dev-controller"
    }
  },
  "datacontentype": "text/plain",
  "time": "2022-09-15T08:29:42.078339-07:00"
}
{
  "id": "LvcWbEfftP",
  "source": "https://hashicorp.com/boundary/louisruch-C02DF0BSML85/controller+worker",
  "specversion": "1.0",
  "type": "system",
  "data": {
    "version": "v0.1",
    "op": "scheduler.(Scheduler).start",
    "data": {
      "msg": "scheduling loop running",
      "run interval": "1m0s",
      "run limit": -1,
      "server id": "dev-controller"
    }
  },
  "datacontentype": "text/plain",
  "time": "2022-09-15T08:29:42.078515-07:00"
}
```