### PR TITLE
doc: Add link to generated API docs on API page

### DIFF
--- a/website/content/docs/api-clients/api.mdx
+++ b/website/content/docs/api-clients/api.mdx
@@ -12,6 +12,7 @@ Boundary's API is a JSON-based HTTP API that adheres to a set of standards that 
 Before reading this page, it is useful to understand Boundary's [domain model](/docs/concepts/domain-model) to be aware of the terminology used here.
 
 Boundary's API is also described via OpenAPI v2; the version corresponding to any tag of Boundary's source code can be found in Boundary's [GitHub repository](https://github.com/hashicorp/boundary/blob/main/internal/gen/controller.swagger.json).
+A rendered version of this generated API definition can be found on the [API page](/api-docs).
 
 Boundary's current API version is 1; all API paths begin with `/v1/`.
 

--- a/website/content/docs/api-clients/api.mdx
+++ b/website/content/docs/api-clients/api.mdx
@@ -12,7 +12,8 @@ Boundary's API is a JSON-based HTTP API that adheres to a set of standards that 
 Before reading this page, it is useful to understand Boundary's [domain model](/docs/concepts/domain-model) to be aware of the terminology used here.
 
 Boundary's API is also described via OpenAPI v2; the version corresponding to any tag of Boundary's source code can be found in Boundary's [GitHub repository](https://github.com/hashicorp/boundary/blob/main/internal/gen/controller.swagger.json).
-A rendered version of this generated API definition can be found on the [API page](/api-docs).
+
+-> **NOTE:** A rendered version of this generated API definition can be found on the [API page](/api-docs).
 
 Boundary's current API version is 1; all API paths begin with `/v1/`.
 


### PR DESCRIPTION
This makes it easier to find the generated API docs from the API description page.