### PR TITLE
fix(Makefile): mount `/../internal/gen`

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -1,5 +1,9 @@
 .DEFAULT_GOAL := website
 
+# "developer" | "io"
+PREVIEW_MODE?=io
+REPO?=boundary
+
 PWD=$$(pwd)
 DOCKER_IMAGE="hashicorp/dev-portal"
 DOCKER_IMAGE_LOCAL="dev-portal-local"
@@ -10,11 +14,12 @@ DOCKER_RUN_FLAGS=-it \
 		--volume "$(PWD)/content:/app/content" \
 		--volume "$(PWD)/public:/app/public" \
 		--volume "$(PWD)/data:/app/data" \
+		--volume "$(PWD)/../internal/gen:/internal/gen" \
 		--volume "$(PWD)/redirects.js:/app/redirects.js" \
 		--volume "next-dir:/app/website-preview/.next" \
 		--volume "$(PWD)/.env:/app/.env" \
-		-e "REPO=boundary" \
-		-e "PREVIEW_MODE=io"
+		-e "REPO=$(REPO)" \
+		-e "PREVIEW_MODE=$(PREVIEW_MODE)"
 
 # Default: run this if working on the website locally to run in watch mode.
 .PHONY: website


### PR DESCRIPTION
# Description

This fixes both `io` and `developer` local preview not having a `controller.swagger.json` present in the Docker container.

<img width="927" alt="CleanShot 2022-09-16 at 10 58 58@2x" src="https://user-images.githubusercontent.com/26389321/190669496-1a2e0b69-7fb1-4860-b016-b1280c2382d1.png">

## Testing

```bash
# in ./website
make website/build-local && make website/local
# visit localhost:3000/api-docs

make website/build-local && PREVIEW_MODE=developer make website/local
# visit localhost:3000/boundary/api-docs
```
