### PR TITLE
fix(org): Address bug that prevented deleting an org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## Next
 
+### Bug Fixes
+
+* Fix bug preventing delete of org. ([PR](https://github.com/hashicorp/boundary/pull/2465)
+
 ### New and Improved
 
 * workers: Added the ability to read and reinitialize the Worker certificate
@@ -28,6 +32,12 @@ grant strings in very rare circumstances as the `-sources` actions replaced the
 
 ## 0.10.5 (2022/09/13)
 
+### Known Issues
+
+* There is bug that prevents deleting an org in some circumstances. This can be
+  worked around by first deleting all projects in the org, then deleting the
+  org. This will be fixed in 0.11.0.
+
 ### Bug Fixes
 
 * grants: Properly resolve "only self" for permissions. When generating
@@ -41,6 +51,12 @@ grant strings in very rare circumstances as the `-sources` actions replaced the
   results ([PR](https://github.com/hashicorp/boundary/pull/2448)).
 
 ## 0.10.4 (2022/09/13)
+
+### Known Issues
+
+* There is bug that prevents deleting an org in some circumstances. This can be
+  worked around by first deleting all projects in the org, then deleting the
+  org. This will be fixed in 0.11.0.
 
 ### New and Improved
 
@@ -102,6 +118,12 @@ grant strings in very rare circumstances as the `-sources` actions replaced the
 
 ## 0.10.3 (2022/08/30)
 
+### Known Issues
+
+* There is bug that prevents deleting an org in some circumstances. This can be
+  worked around by first deleting all projects in the org, then deleting the
+  org. This will be fixed in 0.11.0.
+
 ### Bug Fixes
 
 * db: Fix an issue with migrations failing due to not updating the project_id
@@ -110,6 +132,12 @@ grant strings in very rare circumstances as the `-sources` actions replaced the
   [PR](https://github.com/hashicorp/boundary/pull/2407)).
 
 ## 0.10.2 (2022/08/23)
+
+### Known Issues
+
+* There is bug that prevents deleting an org in some circumstances. This can be
+  worked around by first deleting all projects in the org, then deleting the
+  org. This will be fixed in 0.11.0.
 
 ### Security
 

--- a/internal/db/schema/migrations/oss/postgres/54/02_session_defer.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/54/02_session_defer.up.sql
@@ -1,0 +1,8 @@
+begin;
+  alter table session alter constraint target_fkey                deferrable initially deferred;
+  alter table session alter constraint session_auth_token_id_fkey deferrable initially deferred;
+  alter table session alter constraint iam_scope_project_fkey     deferrable initially deferred;
+  alter table session alter constraint session_host_id_fkey       deferrable initially deferred;
+  alter table session alter constraint session_host_set_id_fkey   deferrable initially deferred;
+  alter table session alter constraint session_user_id_fkey       deferrable initially deferred;
+end;

--- a/internal/db/sqltest/Makefile
+++ b/internal/db/sqltest/Makefile
@@ -18,6 +18,7 @@ endif
 PROVE_OPTS ?=
 
 TESTS ?= tests/setup/*.sql \
+		 tests/org/*.sql \
 		 tests/wh/*/*.sql \
 		 tests/sentinel/*.sql \
 		 tests/credential/*/*.sql \

--- a/internal/db/sqltest/initdb.d/04_foodtruck_persona.sql
+++ b/internal/db/sqltest/initdb.d/04_foodtruck_persona.sql
@@ -1,0 +1,107 @@
+begin;
+  -- This persona is setup primary to test a delete org case
+
+  -- Add organizations
+  insert into iam_scope
+    (parent_id, type,  public_id,      name)
+  values
+    ('global',  'org', 'o__foodtruck', 'Best Tacos');
+
+  -- Add projects to the organizations
+  insert into iam_scope
+    (parent_id,      type,      public_id,      name)
+  values
+    ('o__foodtruck', 'project', 'p______tacos', 'Tacos'),
+    ('o__foodtruck', 'project', 'p_____nachos', 'Nachos');
+
+  -- Host Catalog, Host, Host Set
+  insert into static_host_catalog
+    (project_id,     public_id,      name)
+  values
+    ('p______tacos', 'c____t-sthcl', 'Tacos Food Truck Static Catalog');
+
+  insert into static_host
+    (catalog_id,     public_id,      address)
+  values
+    ('c____t-sthcl', 'h______t__01', '1.taco.foodtruck');
+
+  insert into static_host_set
+    (catalog_id,     public_id,      name)
+  values
+    ('c____t-sthcl', 's____1t-sths', 'Taco Food Truck Static Set 1');
+
+  insert into static_host_set_member
+    ( host_id,        set_id,         catalog_id)
+  values
+    ( 'h______t__01', 's____1t-sths', 'c____t-sthcl');
+
+  -- Target
+  insert into target_tcp
+    (project_id, public_id, name)
+  values
+    ('p______tacos', 't__________t', 'Taco Food Truck Target');
+
+  insert into target_host_set
+    (project_id,     target_id,      host_set_id)
+  values
+    ('p______tacos', 't__________t', 's____1t-sths');
+
+  -- Add password auth method to organizations
+  insert into auth_password_conf
+    (password_method_id, private_id)
+  values
+    ('apm_foodtruc', 'apmc_foodtru');
+
+  -- Auth method and account
+  insert into auth_password_method
+    (scope_id, public_id, password_conf_id, name)
+  values
+    ('o__foodtruck', 'apm_foodtruc', 'apmc_foodtru', 'Food Truck Auth Password');
+
+  insert into auth_password_account
+    (auth_method_id, public_id, login_name)
+  values
+    ('apm_foodtruc', 'apa______jim', 'jim'),
+    ('apm_foodtruc', 'apa______bob', 'bob');
+
+  -- Add organization users
+  insert into iam_user
+    (scope_id,       public_id,      name)
+  values
+    ('o__foodtruck', 'u________jim', 'Jim'),
+    ('o__foodtruck', 'u________bob', 'Bob');
+
+  update auth_account set iam_user_id = 'u________jim' where public_id = 'apa______jim';
+  update auth_account set iam_user_id = 'u________bob' where public_id = 'apa______bob';
+
+  insert into auth_token
+    (key_id, auth_account_id, public_id, token)
+  values
+    ('key', 'apa______jim', 'tok______jim', 'tok______jim'::bytea),
+    ('key', 'apa______bob', 'tok______bob', 'tok______bob'::bytea);
+
+  -- Roles
+  insert into iam_role
+    (scope_id, grant_scope_id, public_id, name)
+  values
+    ('p______tacos', 'p______tacos', 'r_pp___tacos', 'Tacos');
+
+  insert into iam_role_grant
+    (role_id,        canonical_grant,                              raw_grant)
+  values
+    ('r_pp___tacos', 'id=*;type=*;actions=read:self,list',         'id=*;type=*;actions=read:self,list'),
+    ('r_pp___tacos', 'id=*;type=target;actions=authorize-session', 'id=*;type=target;actions=authorize-session'),
+    ('r_pp___tacos', 'id=*;type=session;actions=cancel:self',      'id=*;type=session;actions=cancel:self');
+
+  insert into iam_user_role
+    (role_id,        principal_id)
+  values
+    ('r_pp___tacos', 'u________jim'),
+    ('r_pp___tacos', 'u________bob');
+
+  insert into session
+    ( project_id,     target_id,      host_set_id,    host_id,        user_id,        auth_token_id,  certificate,  endpoint, public_id)
+  values
+    ('p______tacos', 't__________t', 's____1t-sths', 'h______t__01', 'u________jim', 'tok______jim', 'abc'::bytea, 'ep1',    's1_______jim');
+
+commit;

--- a/internal/db/sqltest/tests/org/org-delete.sql
+++ b/internal/db/sqltest/tests/org/org-delete.sql
@@ -1,0 +1,15 @@
+-- org-delete tests:
+--  deleting an org
+
+begin;
+  select plan(1);
+
+  prepare delete_org as
+    delete from iam_scope
+     where type = 'org'
+       and public_id = 'o__foodtruck';
+
+  select lives_ok('delete_org');
+
+  select * from finish();
+rollback;

--- a/internal/db/sqltest/tests/wh/session/update_state.sql
+++ b/internal/db/sqltest/tests/wh/session/update_state.sql
@@ -15,7 +15,7 @@ begin;
     termination_reason = 'closed by end-user'
   where public_id = 's1_____clare';
 
-  select is(count(*),                4::bigint)                from wh_session_accumulating_fact;
+  select is(count(*),                1::bigint)                from wh_session_accumulating_fact where session_id = 's1_____clare';
   select is(total_bytes_up,          10::wh_bytes_transmitted) from wh_session_accumulating_fact where session_id = 's1_____clare';
   select is(total_bytes_down,        5::wh_bytes_transmitted)  from wh_session_accumulating_fact where session_id = 's1_____clare';
   select is(session_terminated_time, now()::wh_timestamp)      from wh_session_accumulating_fact where session_id = 's1_____clare';


### PR DESCRIPTION
The schema changes introduced in 0.10.2 introduced a bug where an org
could not be deleted if there was a session for an org scoped user. It
would result in an error like:

    scope.(Service).deleteFromRepo: unable to delete scope: \
        iam.(Repository).DeleteScope: failed for o_VkNy46KwfS: \
        iam.(Repository).delete: db.DoTx: iam.(Repository).delete: \
        db.Delete: insert or update on table "session" violates foreign key constraint "target_fkey": integrity violation: error #1003

A worker around would be to first delete all projects in the org, then
finally delete the org.

This fix adds a regression test to the sqltests and updates several
constraints on the session table to be deferrable. Since the org delete
is a single transaction, this allows all of the necessary resources to
be deleted before attempting to enforce these constrains.

See: https://www.postgresql.org/docs/current/sql-set-constraints.html
Blame: 3a28ab614