### PR TITLE
update Dockerfile to use more recent Alpine 3.13 releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 
 
 # Development docker image
-FROM docker.mirror.hashicorp.services/alpine:3.13.6 as dev
+FROM docker.mirror.hashicorp.services/alpine:3.13 as dev
 
 RUN set -eux && \
     addgroup boundary && \
@@ -33,7 +33,7 @@ CMD ["server", "-config", "/boundary/config.hcl"]
 
 
 # Official docker image that uses binaries from releases.hashicorp.com
-FROM docker.mirror.hashicorp.services/alpine:3.13.6 as official
+FROM docker.mirror.hashicorp.services/alpine:3.13 as official
 
 ARG PRODUCT_VERSION
 
@@ -82,7 +82,7 @@ CMD ["server", "-config", "/boundary/config.hcl"]
 
 # Production docker image
 # Remember, this cannot be built locally
-FROM docker.mirror.hashicorp.services/alpine:3.13.6 as default
+FROM docker.mirror.hashicorp.services/alpine:3.13 as default
 
 ARG BIN_NAME
 # NAME and PRODUCT_VERSION are the name of the software in releases.hashicorp.com


### PR DESCRIPTION
The container image published at https://hub.docker.com/r/hashicorp/boundary is based on an older Alpine 3.13.6 release with a number of known CVEs. The most recent version in that branch is 3.13.12.

This moves to using the `3.13` tag, which will automatically adopt new minor Alpine releases as they are published.

(Per https://alpinelinux.org/releases/, 3.13 is supported until November 2022; we can handle moving to a newer major release separately.)