### PR TITLE
tighten access to /boundary/config.hcl in container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ADD bin/boundary /bin/boundary
 RUN mkdir /boundary/
 ADD .release/docker/config.hcl /boundary/config.hcl
 RUN chown -R boundary:boundary /boundary/
+RUN chmod -R 640 /boundary/*
 
 EXPOSE 9200 9201 9202
 VOLUME /boundary/
@@ -71,6 +72,7 @@ RUN set -eux && \
 COPY .release/docker/config.hcl /boundary/config.hcl
 
 RUN chown -R boundary:boundary /boundary/ 
+RUN chmod -R 640 /boundary/*
 
 EXPOSE 9200 9201 9202
 VOLUME /boundary/
@@ -114,6 +116,7 @@ COPY .release/docker/config.hcl /boundary/config.hcl
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
 
 RUN chown -R ${NAME}:${NAME} /boundary
+RUN chmod -R 640 /boundary/*
 
 EXPOSE 9200 9201 9202
 VOLUME /boundary/


### PR DESCRIPTION
The container image published at https://hub.docker.com/r/hashicorp/boundary has broad read permissions for the `/boundary/` directory, which may contain sensitive configuration information.

```
/ # ls -al /boundary/
total 12
drwxr-xr-x    2 boundary boundary      4096 Sep 19 17:29 .
drwxr-xr-x    1 root     root          4096 Sep 19 17:29 ..
-rw-r--r--    1 boundary boundary      2222 Sep 14 00:39 config.hcl
```

This sets more restrictive permissions for files in that directory.