### PR TITLE
Add key version rewrapping function registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20220914160710-1c6d04de2431
 	github.com/hashicorp/nodeenrollment v0.1.17
 	github.com/kelseyhightower/envconfig v1.4.0
+	golang.org/x/exp v0.0.0-20220921164117-439092de6870
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1383,6 +1383,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220921164117-439092de6870 h1:j8b6j9gzSigH28O5SjSpQSSh9lFd6f5D/q0aHjNTulc=
+golang.org/x/exp v0.0.0-20220921164117-439092de6870/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/internal/kms/rewrapping.go
+++ b/internal/kms/rewrapping.go
@@ -1,0 +1,26 @@
+package kms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"golang.org/x/exp/maps"
+)
+
+type RewrapFn func(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kms *Kms) error
+
+var tableNameToRewrapFn = map[string]RewrapFn{}
+
+// RegisterTableRewrapFn registers a function to be used to rewrap data in a specific table with a new key
+func RegisterTableRewrapFn(tableName string, rewrapFn RewrapFn) {
+	if _, ok := tableNameToRewrapFn[tableName]; ok {
+		panic(fmt.Sprintf("rewrap function for table name %q already exists", tableName))
+	}
+	tableNameToRewrapFn[tableName] = rewrapFn
+}
+
+// ListTablesSupportingRewrap lists all the table names registered with a rewrap function
+func ListTablesSupportingRewrap() []string {
+	return maps.Keys(tableNameToRewrapFn)
+}


### PR DESCRIPTION
The new RegisterTableRewrapFn can be used by a domain to register a callback to use when rewrapping data in a specific table name.