### PR TITLE
Add schema for new kms destruction jobs

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/55/03_create_kms_key_destructions.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/55/03_create_kms_key_destructions.up.sql
@@ -1,0 +1,109 @@
+begin;
+
+  create table kms_data_key_version_destruction_job (
+    key_id kms_private_id primary key -- one job per key version
+      references kms_data_key_version (private_id)
+        on delete cascade -- Note: instead of restrict, we cascade the delete to this job when the key version is deleted
+        on update cascade,
+    create_time wt_timestamp not null
+  );
+  comment on table kms_data_key_version_destruction_job is
+    'Table holding running and pending data key version destruction jobs';
+
+  create trigger immutable_columns before update on kms_data_key_version_destruction_job
+    for each row execute procedure immutable_columns('key_id', 'create_time');
+
+
+  create table kms_data_key_version_destruction_job_run (
+    key_id kms_private_id not null
+      references kms_data_key_version_destruction_job (key_id)
+        on delete cascade
+        on update cascade,
+    table_name text not null,
+    total_count int not null
+      constraint total_count_cannot_be_negative
+        check (total_count > 0), -- Must not be 0
+    completed_count int not null default 0
+      constraint completed_count_cannot_be_negative
+        check (completed_count >= 0),
+    is_running boolean not null default false,
+    
+    primary key (key_id, table_name),
+    constraint completed_count_less_than_equal_to_total_count
+      check (completed_count <= total_count),
+    constraint is_running_only_when_not_completed
+      check ((completed_count < total_count) or (completed_count = total_count and not is_running))
+  );
+  comment on table kms_data_key_version_destruction_job_run is
+    'Table holding per-table runs of data key version destruction jobs';
+
+  create trigger immutable_columns before update on kms_data_key_version_destruction_job_run
+    for each row execute procedure immutable_columns('key_id', 'table_name', 'total_count');
+
+  create unique index kms_data_key_version_destruction_job_run_is_running_uq
+    on kms_data_key_version_destruction_job_run (is_running) where is_running = true; -- allow only one running run
+
+  -- A view that holds all the names of tables that reference the
+  -- data_key_version.private_id column as a foreign key.
+  -- Excludes tables that should not be used in a job run.
+  create view kms_data_key_version_destruction_job_run_allowed_table_name as
+    select distinct
+      r.table_name
+    from
+      information_schema.constraint_column_usage          u
+    inner join information_schema.referential_constraints fk
+      on u.constraint_catalog = fk.unique_constraint_catalog and
+        u.constraint_schema = fk.unique_constraint_schema and
+        u.constraint_name = fk.unique_constraint_name
+    inner join information_schema.key_column_usage        r
+      on r.constraint_catalog = fk.constraint_catalog and
+        r.constraint_schema = fk.constraint_schema and
+        r.constraint_name = fk.constraint_name
+    where
+      u.column_name = 'private_id' and
+      u.table_name = 'kms_data_key_version' and
+      -- These tables reference the right column, but are not allowed as a destruction
+      -- job run table name.
+      r.table_name not in ('oplog_entry', 'kms_data_key_version_destruction_job');
+
+  create function table_name_valid() returns trigger
+  as $$
+  begin
+    if new.table_name not in (select * from kms_data_key_version_destruction_job_run_allowed_table_name) then
+      raise exception 'invalid table name % (must be table that references kms_data_key_version.private_id)', new.table_name;
+    end if;
+    return new;
+  end;
+  $$ language plpgsql;
+  comment on function table_name_valid is
+    'Function used to determine whether a table name is valid for a destruction job run';
+
+  create trigger table_name_valid before insert on kms_data_key_version_destruction_job_run
+    for each row execute procedure table_name_valid();
+  
+
+  -- Used to list progress of all destruction jobs
+  create view kms_data_key_version_destruction_job_progress as
+    select
+      j.key_id,
+      rk.scope_id,
+      j.create_time,
+      case
+        when bool_or(r.is_running) then 'running'
+        when sum(r.total_count) = sum(r.completed_count) then 'completed'
+        else 'pending'
+      end status,
+      sum(r.completed_count) as completed_count,
+      sum(r.total_count) as total_count
+    from kms_data_key_version_destruction_job           j
+    inner join kms_data_key_version_destruction_job_run r
+      on j.key_id = r.key_id
+    inner join kms_data_key_version                     dkv
+      on j.key_id = dkv.private_id
+    inner join kms_data_key                             dk
+      on dkv.data_key_id = dk.private_id
+    inner join kms_root_key                             rk
+      on dk.root_key_id = rk.private_id
+    group by (j.key_id, rk.scope_id);
+
+commit;

--- a/internal/db/schema/migrations/oss/postgres/55/03_create_kms_key_destructions.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/55/03_create_kms_key_destructions.up.sql
@@ -75,11 +75,11 @@ begin;
     return new;
   end;
   $$ language plpgsql;
-  comment on function table_name_valid is
+  comment on function kms_data_key_table_name_valid is
     'Function used to determine whether a table name is valid for a destruction job run';
 
-  create trigger table_name_valid before insert on kms_data_key_version_destruction_job_run
-    for each row execute procedure table_name_valid();
+  create trigger kms_data_key_table_name_valid before insert on kms_data_key_version_destruction_job_run
+    for each row execute procedure kms_data_key_table_name_valid();
   
 
   -- Used to list progress of all destruction jobs

--- a/internal/db/schema/migrations/oss/postgres/55/03_create_kms_key_destructions.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/55/03_create_kms_key_destructions.up.sql
@@ -20,10 +20,10 @@ begin;
         on delete cascade
         on update cascade,
     table_name text not null,
-    total_count int not null
+    total_count bigint not null
       constraint total_count_cannot_be_negative
         check (total_count > 0), -- Must not be 0
-    completed_count int not null default 0
+    completed_count bigint not null default 0
       constraint completed_count_cannot_be_negative
         check (completed_count >= 0),
     is_running boolean not null default false,
@@ -66,10 +66,10 @@ begin;
       -- job run table name.
       r.table_name not in ('oplog_entry', 'kms_data_key_version_destruction_job');
 
-  create function table_name_valid() returns trigger
+  create function kms_data_key_table_name_valid() returns trigger
   as $$
   begin
-    if new.table_name not in (select * from kms_data_key_version_destruction_job_run_allowed_table_name) then
+    if new.table_name not in (select table_name from kms_data_key_version_destruction_job_run_allowed_table_name) then
       raise exception 'invalid table name % (must be table that references kms_data_key_version.private_id)', new.table_name;
     end if;
     return new;

--- a/internal/db/sqltest/Makefile
+++ b/internal/db/sqltest/Makefile
@@ -24,7 +24,8 @@ TESTS ?= tests/setup/*.sql \
 		 tests/credential/*/*.sql \
 		 tests/session/*.sql \
 		 tests/target/*.sql \
-		 tests/controller/*.sql
+		 tests/controller/*.sql \
+		 tests/kms/*.sql
 
 POSTGRES_DOCKER_IMAGE_BASE ?= postgres
 

--- a/internal/db/sqltest/initdb.d/03_widgets_persona.sql
+++ b/internal/db/sqltest/initdb.d/03_widgets_persona.sql
@@ -115,6 +115,16 @@ begin;
     values
       ('kdkv___widget', 'kdk____widget', 'krkv___widget',     'kdk____widget'::bytea);
 
+    insert into kms_data_key_version_destruction_job
+      (key_id)
+    values
+      ('kdkv___widget');
+
+    insert into kms_data_key_version_destruction_job_run
+      (key_id, table_name, total_count)
+    values
+      ('kdkv___widget', 'auth_token', 100);
+  
   end;
   $$ language plpgsql;
 

--- a/internal/db/sqltest/tests/kms/kms_data_key_destruction_job.sql
+++ b/internal/db/sqltest/tests/kms/kms_data_key_destruction_job.sql
@@ -112,7 +112,7 @@ begin;
     select key_id, scope_id, status, completed_count, total_count from kms_data_key_version_destruction_job_progress;
   select results_eq(
     'list_progress',
-    $$VALUES ('kdkv___widget'::kms_private_id,'o_____widget'::kms_scope_id,'running',100::bigint,200::bigint)$$
+    $$VALUES ('kdkv___widget'::kms_private_id,'o_____widget'::kms_scope_id,'running',100::numeric,200::numeric)$$
   );
 
   -- Should succed when setting completed_count=total_count and is_running=false
@@ -127,7 +127,7 @@ begin;
   -- Progress should report 'completed' as all of the completed_count=total_count
   select results_eq(
     'list_progress',
-    $$VALUES ('kdkv___widget'::kms_private_id,'o_____widget'::kms_scope_id,'completed',200::bigint,200::bigint)$$
+    $$VALUES ('kdkv___widget'::kms_private_id,'o_____widget'::kms_scope_id,'completed',200::numeric,200::numeric)$$
   );
 
   select * from finish();

--- a/internal/db/sqltest/tests/kms/kms_data_key_destruction_job.sql
+++ b/internal/db/sqltest/tests/kms/kms_data_key_destruction_job.sql
@@ -1,0 +1,134 @@
+begin;
+  select plan(16);
+  select wtt_load('widgets', 'iam', 'kms');
+
+  -- Should fail when inserting an unknown key_id
+  prepare job_insert_unknown_key_id as
+    insert into kms_data_key_version_destruction_job
+      (key_id)
+    values
+      ('kdkv___unknown');
+  select throws_ok('job_insert_unknown_key_id', '23503', null, 'insert of unknown key_id in kms_data_key_version_destruction_job succeeded');
+
+  -- Should fail when inserting an already existing key_id
+  prepare insert_already_existing_key_id as
+    insert into kms_data_key_version_destruction_job
+      (key_id)
+    values
+      ('kdkv___widget');
+  select throws_ok('insert_already_existing_key_id', '23505', null, 'insert of duplicate key_id in kms_data_key_version_destruction_job succeeded');
+  
+  -- Should succeed when inserting new key_id
+  prepare insert_new_key_id as
+    insert into kms_data_key_version_destruction_job
+      (key_id)
+    values
+      ('kdkv_______colors');
+  select lives_ok('insert_new_key_id', 'insert of valid key_id in kms_data_key_version_destruction_job failed');
+
+  -- Should fail when inserting an unknown key_id
+  prepare run_insert_unknown_key_id as
+    insert into kms_data_key_version_destruction_job_run
+      (key_id, table_name, total_count)
+    values
+      ('kdkv___unknown', 'auth_token', 100);
+  select throws_ok('run_insert_unknown_key_id', '23503', null, 'insert of unknown key_id in kms_data_key_version_destruction_job_run succeeded');
+
+  -- Should fail when inserting an unknown table_name
+  prepare run_insert_unknown_table_name as
+    insert into kms_data_key_version_destruction_job_run
+      (key_id, table_name, total_count)
+    values
+      ('kdkv___widget', 'unknown_table', 100);
+  select throws_ok('run_insert_unknown_table_name', 'P0001', null, 'insert of unknown table_name in kms_data_key_version_destruction_job_run succeeded');
+
+  -- Should fail when inserting a duplicate (key_id, table_name) tuple
+  prepare run_insert_duplicate_key_id_table_name as
+    insert into kms_data_key_version_destruction_job_run
+      (key_id, table_name, total_count)
+    values
+      ('kdkv___widget', 'auth_token', 100);
+  select throws_ok('run_insert_duplicate_key_id_table_name', '23505', null, 'insert of duplicate (key_id, table_name) tuple in kms_data_key_version_destruction_job_run succeeded');
+
+  -- Should succeed when inserting a new, valid, (key_id, table_name) tuple
+  prepare run_insert_key_id_table_name as
+    insert into kms_data_key_version_destruction_job_run
+      (key_id, table_name, total_count)
+    values
+      ('kdkv___widget', 'auth_oidc_method', 100);
+  select lives_ok('run_insert_key_id_table_name', 'insert of valid (key_id, table_name) tuple in kms_data_key_version_destruction_job_run failed');
+
+  -- Should fail when setting completed_count > total_count
+  prepare run_update_invalid_completed_count as
+    update kms_data_key_version_destruction_job_run set
+      completed_count=101
+    where
+      key_id='kdkv___widget' and table_name='auth_oidc_method';
+  select throws_ok('run_update_invalid_completed_count', '23514', null, 'setting completed_count > total_count in kms_data_key_version_destruction_job_run succeeded');
+  
+  -- Should succeed to set is_running to true
+  prepare run_update_is_running as
+    update kms_data_key_version_destruction_job_run set
+      is_running=true
+    where
+      key_id='kdkv___widget' and table_name='auth_oidc_method';
+  select lives_ok('run_update_is_running', 'setting is_running=true with no other run running in kms_data_key_version_destruction_job_run failed');
+
+  -- Should fail to set is_running to true while another run is running
+  prepare run_update_invalid_is_running as
+    update kms_data_key_version_destruction_job_run set
+      is_running=true
+    where
+      key_id='kdkv___widget' and table_name='auth_token';
+  select throws_ok('run_update_invalid_is_running', '23505', null, 'setting is_running=true while another run is running in kms_data_key_version_destruction_job_run succeeded');
+
+  -- Should fail to set completed_count=total_count without also setting is_running=false
+  prepare run_update_completed_count_without_is_running as
+    update kms_data_key_version_destruction_job_run set
+      completed_count=100
+    where
+      key_id='kdkv___widget' and table_name='auth_oidc_method';
+  select throws_ok('run_update_completed_count_without_is_running','23514', null, 'setting completed_count=total_count without also setting is_running=false in kms_data_key_version_destruction_job_run succeeded');
+
+  -- Should succed when setting completed_count=total_count and is_running=false
+  prepare run_update_completed_count_and_is_running as
+    update kms_data_key_version_destruction_job_run set
+      completed_count=100,
+      is_running=false
+    where
+      key_id='kdkv___widget' and table_name='auth_oidc_method';
+  select lives_ok('run_update_completed_count_and_is_running', 'setting completed_count=total_count and is_running=false kms_data_key_version_destruction_job_run failed');
+
+  -- Should succeed to set is_running to true when no other run is running
+  prepare run_update_is_running_after_other_finished as
+    update kms_data_key_version_destruction_job_run set
+      is_running=true
+    where
+      key_id='kdkv___widget' and table_name='auth_token';
+  select lives_ok('run_update_is_running_after_other_finished', 'setting is_running=true while no other run is running in kms_data_key_version_destruction_job_run failed');
+
+  -- Progress should report 'running' as one of the runs is running
+  prepare list_progress as
+    select key_id, scope_id, status, completed_count, total_count from kms_data_key_version_destruction_job_progress;
+  select results_eq(
+    'list_progress',
+    $$VALUES ('kdkv___widget'::kms_private_id,'o_____widget'::kms_scope_id,'running',100::bigint,200::bigint)$$
+  );
+
+  -- Should succed when setting completed_count=total_count and is_running=false
+  prepare run_update_completed_count_and_is_running_again as
+    update kms_data_key_version_destruction_job_run set
+      completed_count=100,
+      is_running=false
+    where
+      key_id='kdkv___widget' and table_name='auth_token';
+  select lives_ok('run_update_completed_count_and_is_running_again', 'setting completed_count=total_count and is_running=false kms_data_key_version_destruction_job_run failed');
+
+  -- Progress should report 'completed' as all of the completed_count=total_count
+  select results_eq(
+    'list_progress',
+    $$VALUES ('kdkv___widget'::kms_private_id,'o_____widget'::kms_scope_id,'completed',200::bigint,200::bigint)$$
+  );
+
+  select * from finish();
+rollback;


### PR DESCRIPTION
The schema lets us manage destruction jobs per-table while providing a guarantee that only one run is running at a time.