### PR TITLE
log(vault): Log formatted duration instead of nanoseconds

### DIFF
--- a/internal/credential/vault/repository_credentials.go
+++ b/internal/credential/vault/repository_credentials.go
@@ -47,7 +47,7 @@ func (r *Repository) Issue(ctx context.Context, sessionId string, requests []cre
 				fmt.Errorf("WARNING: credential will expire before job scheduler can run"),
 				event.WithInfo("credential_public_id", cred.GetPublicId()),
 				event.WithInfo("credential_library_public_id", lib.GetPublicId()),
-				event.WithInfo("runJobsInterval", runJobsInterval),
+				event.WithInfo("runJobsInterval", runJobsInterval.String()),
 			)
 		}
 


### PR DESCRIPTION
Logs being outputted are:
```
{"id":"emh1hZlzfl","source":"https://hashicorp.com/boundary/louisruch-C02DF0BSML85/controller+worker","specversion":"1.0","type":"error","data":{"error":"WARNING: credential will expire before job scheduler can run","error_fields":{},"id":"e_UmCnoQYSkb","version":"v0.1","op":"vault.(Repository).Issue","request_info":{"id":"gtraceid_45EE3dmtLXHqArr18oXF","method":"POST","path":"/v1/targets/ttcp_yQ3Uqi9m3b:authorize-session","public_id":"at_hTNClxu0se","client_ip":"127.0.0.1"},"info":{"runJobsInterval":36000000000000}},"datacontentype":"application/cloudevents","time":"2022-09-21T11:22:50.984607-07:00"}
```