### PR TITLE
Build docker dev images for specified platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,11 +332,14 @@ DEV_DOCKER_GOARCH ?= amd64
 docker-build-dev: export GOOS=$(DEV_DOCKER_GOOS)
 docker-build-dev: export GOARCH=$(DEV_DOCKER_GOARCH)
 docker-build-dev: build
-	docker build \
+	docker buildx build \
+		--load \
+		--platform $(DEV_DOCKER_GOOS)/$(DEV_DOCKER_GOARCH) \
 		--tag $(IMAGE_TAG_DEV) \
 		--target=dev \
 		--build-arg=boundary \
 		.
+	@echo "Successfully built $(IMAGE_TAG_DEV)"
 
 .NOTPARALLEL:
 

--- a/testing/dbtest/docker/Makefile
+++ b/testing/dbtest/docker/Makefile
@@ -15,8 +15,6 @@ dockerfiles = $(wildcard Dockerfile.*)
 docker-buildxs = $(patsubst Dockerfile.%,%-buildx, $(dockerfiles))
 docker-load-buildxs = $(patsubst Dockerfile.%,%-load-buildx, $(dockerfiles))
 
-# Before running this target a builder instance needs to be setup, ie:
-#  docker buildx create --driver docker-container --use
 docker-build: ${docker-buildxs}
 
 ${docker-buildxs}: %-buildx:


### PR DESCRIPTION
Previously, building this target on an ARM machine would produce an image with a amd64 binary inside an arm OS.

Note: there's no need for the user to explicitly run `docker buildx create --driver docker-container --use` in my testing, docker automatically creates a builder if there is none:

```
$ make docker-load 
docker buildx build \
        --load \
        -t docker.io/hashicorpboundary/postgres:11-alpine \
        -f Dockerfile.11-alpine .
[+] Building 3.6s (11/11) FINISHED                                                                                                                                                                                                                                                                                                                                   
 => [internal] booting buildkit                                                                                                                                                                                                                                                                                                                                 1.8s
 => => pulling image moby/buildkit:buildx-stable-1                                                                                                                                                                                                                                                                                                              1.3s
 => => creating container buildx_buildkit_zen_pare0                                                                                                                                                                                                                                                                                                             0.5s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                               0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                 0.0s
 => [internal] load build definition from Dockerfile.11-alpine
```