### PR TITLE
Extend enos-run.yml to cover E2E testing

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -25,8 +25,11 @@ jobs:
       fail-fast: false # don't fail as that can skip required cleanup steps for jobs
       matrix:
         include:
-          - test: smoke
-          - test: cli_ui
+          - filter: 'integration test:smoke'
+          - filter: 'integration test:cli_ui'
+          - filter: 'e2e_credential_vault'
+          - filter: 'e2e_host_aws'
+          - filter: 'e2e_host_static'
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}
@@ -44,14 +47,12 @@ jobs:
           # it changes the output to text when we expect it to be JSON.
           terraform_wrapper: false
       - name: Import GPG key for Boundary pass keystore
-        if: matrix.test == 'cli_ui'
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
         with:
           gpg_private_key: ${{ secrets.ENOS_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.ENOS_GPG_PASSPHRASE }}
       - name: Trust the pass keystore GPG key
-        if: matrix.test == 'cli_ui'
         id: trust_gpg
         run: |
           gpg -a --encrypt -r ${{ secrets.ENOS_GPG_UID }} --trust-model always
@@ -75,47 +76,57 @@ jobs:
           mkdir -p ./enos/support
           echo "${{ secrets.ENOS_CI_SSH_KEY }}" > ./enos/support/private_key.pem
           chmod 600 ./enos/support/private_key.pem
-      - name: Set up Bats CLI UI tests dependency cache
-        if: matrix.test == 'cli_ui'
+      - name: Set up dependency cache
         id: dep-cache
         uses: actions/cache@v3
         with:
-          path: /tmp/bats-cli-ui-deps
-          key: enos-bats-cli-ui-deps-jq-1.6-password-store-1.7.4
+          path: /tmp/test-deps
+          key: enos-test-deps-jq-1.6-password-store-1.7.4-vault-1.11.4
+      - name: Debug dep-cache
+        run: |
+          mkdir -p /tmp/test-deps
+          ls -la /tmp/test-deps
       - name: Set up Node for Bats install
-        if: matrix.test == 'cli_ui'
+        if: matrix.filter == 'integration test:cli_ui'
         uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Install Bats via NPM
-        if: matrix.test == 'cli_ui'
+        if: matrix.filter == 'integration test:cli_ui'
         # Use npm so this workflow is portable on multiple runner distros
         run: npm install --location=global bats
       - name: Download jq for Bats CLI UI tests
-        if: matrix.test == 'cli_ui' && steps.dep-cache.outputs.cache-hit != 'true'
+        if: steps.dep-cache.outputs.cache-hit != 'true'
         # NOTE: if you update the jq version make sure to update the dep cache key
         run: |
-          mkdir -p /tmp/bats-cli-ui-deps
-          wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /tmp/bats-cli-ui-deps/jq-bin
+          mkdir -p /tmp/test-deps
+          wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /tmp/test-deps/jq-bin
       - name: Install jq for Bats CLI UI tests
-        if: matrix.test == 'cli_ui'
+        if: matrix.filter == 'integration test:cli_ui'
         run: |
-          chmod +x /tmp/bats-cli-ui-deps/jq-bin
-          sudo cp /tmp/bats-cli-ui-deps/jq-bin /usr/local/bin/jq
+          chmod +x /tmp/test-deps/jq-bin
+          sudo cp /tmp/test-deps/jq-bin /usr/local/bin/jq
       - name: Download and unzip pass for Boundary keyring
-        if: matrix.test == 'cli_ui' && steps.dep-cache.outputs.cache-hit != 'true'
+        if: steps.dep-cache.outputs.cache-hit != 'true'
         # NOTE: if you update the password store version make sure to update the dep cache key
         run: |
-          mkdir -p /tmp/bats-cli-ui-deps/pass
-          wget https://git.zx2c4.com/password-store/snapshot/password-store-1.7.4.tar.xz -O /tmp/bats-cli-ui-deps/pass/pass.tar.xz
-          cd /tmp/bats-cli-ui-deps/pass
+          mkdir -p /tmp/test-deps/pass
+          wget https://git.zx2c4.com/password-store/snapshot/password-store-1.7.4.tar.xz -O /tmp/test-deps/pass/pass.tar.xz
+          cd /tmp/test-deps/pass
           tar -xvf pass.tar.xz
       - name: Install pass for Boundary keyring
-        if: matrix.test == 'cli_ui'
         run: |
-          cd /tmp/bats-cli-ui-deps/pass/password-store-1.7.4
+          cd /tmp/test-deps/pass/password-store-1.7.4
           sudo make install
           pass init ${{ secrets.ENOS_GPG_UID }}
+      - name: Download Vault AMD64 binary for integration testing
+        if: steps.dep-cache.outputs.cache-hit != 'true'
+        run: |
+          wget https://releases.hashicorp.com/vault/1.11.4/vault_1.11.4_linux_amd64.zip -O /tmp/test-deps/vault.zip
+      - name: Install Vault for integration testing
+        if: matrix.filter == 'e2e_credential_vault'
+        run: |
+          unzip /tmp/test-deps/vault.zip -d /usr/local/bin
       - name: Download Linux AMD64 Boundary bundle
         id: download
         uses: actions/download-artifact@v3
@@ -137,12 +148,13 @@ jobs:
           ENOS_VAR_local_boundary_dir: ./support/
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
+          ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
           # Skip a few known failing bats tests
           ENOS_VAR_skip_failing_bats_tests: "true"
         run: |
           mkdir -p ./enos/terraform-plugin-cache
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
-          enos scenario run --timeout 60m0s --chdir ./enos integration test:${{ matrix.test}} builder:crt
+          enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.filter }} builder:crt
       - name: Retry Enos scenario
         id: run_retry
         if: steps.run.outcome == 'failure'
@@ -153,13 +165,13 @@ jobs:
           ENOS_VAR_local_boundary_dir: ./support/
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
+          ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
           # Skip a few known failing bats tests
           ENOS_VAR_skip_failing_bats_tests: "true"
         run: |
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
-          enos scenario run --timeout 60m0s --chdir ./enos integration test:${{ matrix.test}} builder:crt
+          enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.filter }} builder:crt
       - name: Destroy Enos scenario
-        if: ${{ always() }}
         env:
           ENOS_VAR_aws_region: us-east-1
           ENOS_VAR_aws_ssh_keypair_name: enos-ci-ssh-key
@@ -167,11 +179,12 @@ jobs:
           ENOS_VAR_local_boundary_dir: ./support/
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
+          ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
           # Skip a few known failing bats tests
           ENOS_VAR_skip_failing_bats_tests: "true"
         run: |
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
-          enos scenario destroy --timeout 60m0s --chdir ./enos integration test:${{ matrix.test}} builder:crt
+          enos scenario destroy --timeout 60m0s --chdir ./enos ${{ matrix.filter }} builder:crt
       - name: Output debug information on failure
         if: ${{ failure() }}
         run: |

--- a/enos/enos-scenario-e2e-credential-vault.hcl
+++ b/enos/enos-scenario-e2e-credential-vault.hcl
@@ -131,7 +131,7 @@ scenario "e2e_credential_vault" {
       auth_password            = step.create_boundary_cluster.auth_password
       local_boundary_dir       = local.local_boundary_dir
       aws_ssh_private_key_path = local.aws_ssh_private_key_path
-      target_ips               = step.create_target.target_ips
+      target_ip                = step.create_target.target_ips[0]
       target_user              = "ubuntu"
       vault_addr               = step.create_vault_cluster.instance_public_ips[0]
       vault_root_token         = step.create_vault_cluster.vault_root_token

--- a/enos/enos-scenario-e2e-host-static.hcl
+++ b/enos/enos-scenario-e2e-host-static.hcl
@@ -108,7 +108,7 @@ scenario "e2e_host_static" {
       auth_password            = step.create_boundary_cluster.auth_password
       local_boundary_dir       = local.local_boundary_dir
       aws_ssh_private_key_path = local.aws_ssh_private_key_path
-      target_ips               = step.create_target.target_ips
+      target_ip                = step.create_target.target_ips[0]
       target_user              = "ubuntu"
     }
   }

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -38,10 +38,10 @@ variable "aws_ssh_private_key_path" {
   description = "Local Path to key used to SSH onto created hosts"
   type        = string
 }
-variable "target_ips" {
-  description = "List of IP Addresses of created hosts"
-  type        = list(string)
-  default     = [""]
+variable "target_ip" {
+  description = "IP address of target"
+  type        = string
+  default     = ""
 }
 variable "vault_addr" {
   description = "URL of Vault instance"
@@ -101,7 +101,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_PASSWORD_AUTH_METHOD_ID   = var.auth_method_id,
     E2E_PASSWORD_ADMIN_LOGIN_NAME = var.auth_login_name,
     E2E_PASSWORD_ADMIN_PASSWORD   = var.auth_password,
-    E2E_TARGET_IP                 = var.target_ips[0],
+    E2E_TARGET_IP                 = var.target_ip,
     E2E_SSH_USER                  = var.target_user,
     E2E_SSH_KEY_PATH              = local.aws_ssh_private_key_path,
     VAULT_ADDR                    = local.vault_addr,


### PR DESCRIPTION
This PR is related to adding a GitHub Action workflow that executes the Enos End to End scenario.

We have chosen to add on to the existing Enos Run workflow that also runs integration tests. In the process, we have inverted some logic that previously checked the affirmative case of "a" and now checks the negative case of "b". This was necessary to add more than 2 types of filters to the workflow.

Additionally, another deviation from previous implementations is that we will only run the Destroy step if either the Run or its retry step have failed. This is because `enos scenario run` will execute a destroy action if it completes its apply action successfully.

Other than that, the only other change is that we have added a new filter to the existing scenario in order to execute this new scenario.