### PR TITLE
Enable Iron Bank integration

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -291,3 +291,16 @@ event "post-publish-website" {
     on = "always"
   }
 }
+
+event "update-ironbank" {
+  depends = ["post-publish-website"]
+  action "update-ironbank" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "update-ironbank"
+  }
+
+  notification {
+    on = "fail"
+  }
+}


### PR DESCRIPTION
Enables CRT's Iron Bank updates after linux artifacts are published.