### PR TITLE
Rewrap Functions for Encrypted Tables

### DIFF
--- a/internal/auth/oidc/repository_auth_method_update.go
+++ b/internal/auth/oidc/repository_auth_method_update.go
@@ -36,6 +36,7 @@ const (
 	AccountClaimMapsField                  = "AccountClaimMaps"
 	TokenClaimsField                       = "TokenClaims"
 	UserinfoClaimsField                    = "UserinfoClaims"
+	KeyIdField                             = "KeyId"
 )
 
 // UpdateAuthMethod will retrieve the auth method from the repository,

--- a/internal/auth/oidc/rewrapping.go
+++ b/internal/auth/oidc/rewrapping.go
@@ -1,0 +1,65 @@
+package oidc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/kms"
+)
+
+func init() {
+	kms.RegisterTableRewrapFn(defaultAuthMethodTableName, authMethodRewrapFn)
+}
+
+func authMethodRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+	const op = "oidc.authMethodRewrapFn"
+	repo, err := NewRepository(ctx, reader, writer, kmsRepo)
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	rows, err := repo.reader.Query(ctx, fmt.Sprintf(`select distinct scope_id from %q where key_id=?`, defaultAuthMethodTableName), []interface{}{dataKeyVersionId})
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	var scopeIds []string
+	for rows.Next() {
+		var scopeId string
+		if err := rows.Scan(&scopeId); err != nil {
+			_ = rows.Close()
+			return errors.Wrap(ctx, err, op)
+		}
+		scopeIds = append(scopeIds, scopeId)
+	}
+	if err := rows.Err(); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	for _, scopeId := range scopeIds {
+		var authMethods []*AuthMethod
+		if err := repo.reader.SearchWhere(ctx, &authMethods, "scope_id=? and key_id=?", []interface{}{scopeId, dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		wrapper, err := repo.kms.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		newKeyVersionId, err := wrapper.KeyId(ctx)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		for _, am := range authMethods {
+			if err := am.decrypt(ctx, wrapper); err != nil {
+				return errors.Wrap(ctx, err, op)
+			}
+			if err := am.encrypt(ctx, wrapper); err != nil {
+				return errors.Wrap(ctx, err, op)
+			}
+			am.KeyId = newKeyVersionId
+			if _, err := repo.writer.Update(ctx, am, []string{CtClientSecretField, KeyIdField}, nil); err != nil {
+				return errors.Wrap(ctx, err, op)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/auth/oidc/rewrapping.go
+++ b/internal/auth/oidc/rewrapping.go
@@ -2,7 +2,6 @@ package oidc
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/errors"
@@ -13,52 +12,26 @@ func init() {
 	kms.RegisterTableRewrapFn(defaultAuthMethodTableName, authMethodRewrapFn)
 }
 
-func authMethodRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func authMethodRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "oidc.authMethodRewrapFn"
-	repo, err := NewRepository(ctx, reader, writer, kmsRepo)
+	var authMethods []*AuthMethod
+	// there are indexes on (scope id, <other>), so we can query on scope and refine via key id. this is the fastest query
+	if err := reader.SearchWhere(ctx, &authMethods, "scope_id=? and key_id=?", []interface{}{scopeId, dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
-	rows, err := repo.reader.Query(ctx, fmt.Sprintf(`select distinct scope_id from %q where key_id=?`, defaultAuthMethodTableName), []interface{}{dataKeyVersionId})
-	if err != nil {
-		return errors.Wrap(ctx, err, op)
-	}
-	var scopeIds []string
-	for rows.Next() {
-		var scopeId string
-		if err := rows.Scan(&scopeId); err != nil {
-			_ = rows.Close()
+	for _, am := range authMethods {
+		if err := am.decrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		scopeIds = append(scopeIds, scopeId)
-	}
-	if err := rows.Err(); err != nil {
-		return errors.Wrap(ctx, err, op)
-	}
-	for _, scopeId := range scopeIds {
-		var authMethods []*AuthMethod
-		if err := repo.reader.SearchWhere(ctx, &authMethods, "scope_id=? and key_id=?", []interface{}{scopeId, dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		if err := am.encrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		wrapper, err := repo.kms.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
-		if err != nil {
+		if _, err := writer.Update(ctx, am, []string{CtClientSecretField, ClientSecretHmacField, KeyIdField}, nil); err != nil {
 			return errors.Wrap(ctx, err, op)
-		}
-		newKeyVersionId, err := wrapper.KeyId(ctx)
-		if err != nil {
-			return errors.Wrap(ctx, err, op)
-		}
-		for _, am := range authMethods {
-			if err := am.decrypt(ctx, wrapper); err != nil {
-				return errors.Wrap(ctx, err, op)
-			}
-			if err := am.encrypt(ctx, wrapper); err != nil {
-				return errors.Wrap(ctx, err, op)
-			}
-			am.KeyId = newKeyVersionId
-			if _, err := repo.writer.Update(ctx, am, []string{CtClientSecretField, ClientSecretHmacField, KeyIdField}, nil); err != nil {
-				return errors.Wrap(ctx, err, op)
-			}
 		}
 	}
 	return nil

--- a/internal/auth/oidc/rewrapping.go
+++ b/internal/auth/oidc/rewrapping.go
@@ -15,23 +15,24 @@ func init() {
 func authMethodRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "oidc.authMethodRewrapFn"
 	var authMethods []*AuthMethod
-	// there are indexes on (scope id, <other>), so we can query on scope and refine via key id. this is the fastest query
+	// There are indexes on (scope id, <other>), so we can query on scope and refine via key id.
+	// This is the fastest query we can use without creating a new index on key_id.
 	if err := reader.SearchWhere(ctx, &authMethods, "scope_id=? and key_id=?", []interface{}{scopeId, dataKeyVersionId}, db.WithLimit(-1)); err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query sql for rows that need rewrapping"))
 	}
 	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to fetch kms wrapper for rewrapping"))
 	}
 	for _, am := range authMethods {
 		if err := am.decrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to decrypt auth method"))
 		}
 		if err := am.encrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt auth method"))
 		}
 		if _, err := writer.Update(ctx, am, []string{CtClientSecretField, ClientSecretHmacField, KeyIdField}, nil); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update auth method row with rewrapped fields"))
 		}
 	}
 	return nil

--- a/internal/auth/oidc/rewrapping.go
+++ b/internal/auth/oidc/rewrapping.go
@@ -31,7 +31,7 @@ func authMethodRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, r
 		if err := am.encrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt auth method"))
 		}
-		if _, err := writer.Update(ctx, am, []string{CtClientSecretField, ClientSecretHmacField, KeyIdField}, nil); err != nil {
+		if _, err := writer.Update(ctx, am, []string{CtClientSecretField, KeyIdField}, nil); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update auth method row with rewrapped fields"))
 		}
 	}

--- a/internal/auth/oidc/rewrapping.go
+++ b/internal/auth/oidc/rewrapping.go
@@ -56,7 +56,7 @@ func authMethodRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.
 				return errors.Wrap(ctx, err, op)
 			}
 			am.KeyId = newKeyVersionId
-			if _, err := repo.writer.Update(ctx, am, []string{CtClientSecretField, KeyIdField}, nil); err != nil {
+			if _, err := repo.writer.Update(ctx, am, []string{CtClientSecretField, ClientSecretHmacField, KeyIdField}, nil); err != nil {
 				return errors.Wrap(ctx, err, op)
 			}
 		}

--- a/internal/auth/oidc/rewrapping_test.go
+++ b/internal/auth/oidc/rewrapping_test.go
@@ -76,7 +76,7 @@ func TestRewrap_authMethodRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, org.Scope.GetPublicId()))
-	assert.NoError(t, authMethodRewrapFn(ctx, authMethod.KeyId, rw, rw, kmsCache))
+	assert.NoError(t, authMethodRewrapFn(ctx, authMethod.KeyId, org.Scope.GetPublicId(), rw, rw, kmsCache))
 
 	// fetch the new key version
 	kmsWrapper, err = kmsCache.GetWrapper(ctx, org.Scope.GetPublicId(), kms.KeyPurposeDatabase)

--- a/internal/auth/oidc/rewrapping_test.go
+++ b/internal/auth/oidc/rewrapping_test.go
@@ -96,5 +96,5 @@ func TestRewrap_authMethodRewrapFn(t *testing.T) {
 	assert.Equal(t, "alice-secret", got.ClientSecret)
 	assert.NotEqual(t, authMethod.CtClientSecret, got.CtClientSecret)
 	assert.NotEmpty(t, got.ClientSecretHmac)
-	assert.NotEqual(t, authMethod.ClientSecretHmac, got.ClientSecretHmac)
+	assert.Equal(t, authMethod.ClientSecretHmac, got.ClientSecretHmac)
 }

--- a/internal/auth/oidc/rewrapping_test.go
+++ b/internal/auth/oidc/rewrapping_test.go
@@ -1,0 +1,105 @@
+package oidc
+
+import (
+	"context"
+	"crypto/x509"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewrap_authMethodRewrapFn(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	rw := db.New(conn)
+	org, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+
+	convertAlg := func(alg ...Alg) []string {
+		s := make([]string, 0, len(alg))
+		for _, a := range alg {
+			s = append(s, string(a))
+		}
+		return s
+	}
+
+	// fetch the current key version
+	kmsWrapper, err := kmsCache.GetWrapper(ctx, org.Scope.GetPublicId(), kms.KeyPurposeDatabase)
+	assert.NoError(t, err)
+
+	currentKeyVersion, err := kmsWrapper.KeyId(ctx)
+	assert.NoError(t, err)
+
+	// perform the setup for the authmethod
+	algs := []Alg{RS256, ES256}
+	cbs := TestConvertToUrls(t, "https://www.alice.com/callback")[0]
+	auds := []string{"alice-rp", "bob-rp"}
+	cert1, pem1 := testGenerateCA(t, "localhost")
+	cert2, pem2 := testGenerateCA(t, "localhost")
+	certs := []*x509.Certificate{cert1, cert2}
+	pems := []string{pem1, pem2}
+	am, err := NewAuthMethod(
+		ctx,
+		org.PublicId,
+		"alice-rp",
+		"alice-secret", WithAudClaims("alice-rp"),
+		WithAudClaims(auds...),
+		WithIssuer(TestConvertToUrls(t, "https://www.alice.com")[0]),
+		WithApiUrl(cbs),
+		WithSigningAlgs(algs...),
+		WithCertificates(certs...),
+		WithName("alice's restaurant"),
+		WithDescription("it's a good place to eat"),
+		WithClaimsScopes("email", "profile"),
+		WithAccountClaimMap(map[string]AccountToClaim{"display_name": ToNameClaim, "oid": ToSubClaim}),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, am.SigningAlgs, convertAlg(algs...))
+	assert.Equal(t, am.ApiUrl, cbs.String())
+	assert.Equal(t, "https://www.alice.com", am.Issuer)
+	assert.Equal(t, am.AudClaims, auds)
+	assert.Equal(t, am.Certificates, pems)
+	assert.Equal(t, am.OperationalState, string(InactiveState))
+
+	// CreateAuthMethod to store it, both from oidc repo
+	repo, err := NewRepository(ctx, rw, rw, kmsCache)
+	assert.NoError(t, err)
+
+	got, err := repo.CreateAuthMethod(ctx, am)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+
+	// double check that we used the expected key version to encrypt the material
+	assert.Equal(t, got.KeyId, currentKeyVersion)
+
+	// rotate the keys here so that we have a new key version
+	err = kmsCache.RotateKeys(ctx, org.Scope.GetPublicId())
+	assert.NoError(t, err)
+
+	// trigger the rewrap func
+	err = authMethodRewrapFn(ctx, got.KeyId, rw, rw, kmsCache)
+	assert.NoError(t, err)
+
+	// fetch the new key version
+	kmsWrapper, err = kmsCache.GetWrapper(ctx, org.Scope.GetPublicId(), kms.KeyPurposeDatabase)
+	assert.NoError(t, err)
+	newKeyVersion, err := kmsWrapper.KeyId(ctx)
+	assert.NoError(t, err)
+
+	// make sure there actually is a new key version
+	assert.NotEqual(t, currentKeyVersion, newKeyVersion)
+
+	// fetching the latest auth method itself
+	ams, err := repo.getAuthMethods(ctx, got.GetPublicId(), []string{})
+	assert.NoError(t, err)
+	newAm := ams[0]
+
+	// since getAuthMethods automatically decrypts the secret, all we need to do is make sure
+	// that it's correct and that it uses the newest key version id
+	assert.Equal(t, newAm.ClientSecret, "alice-secret")
+	assert.Equal(t, newAm.KeyId, newKeyVersion)
+}

--- a/internal/auth/password/rewrapping.go
+++ b/internal/auth/password/rewrapping.go
@@ -15,23 +15,24 @@ func init() {
 func argon2ConfigRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "password.argon2ConfigRewrapFn"
 	var credentials []*Argon2Credential
-	// the only index on this table is on private id and there are no references to private id. this is the fastest query
+	// The only index on this table is on private id and there are no references to private id.
+	// This is the fastest query we can use without creating a new index on key_id.
 	if err := reader.SearchWhere(ctx, &credentials, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query sql for rows that need rewrapping"))
 	}
 	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to fetch kms wrapper for rewrapping"))
 	}
 	for _, cred := range credentials {
 		if err := cred.decrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to decrypt argon2 config"))
 		}
 		if err := cred.encrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt argon2 config"))
 		}
 		if _, err := writer.Update(ctx, cred, []string{"CtSalt", "KeyId"}, nil); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update argon2 config row with rewrapped fields"))
 		}
 	}
 	return nil

--- a/internal/auth/password/rewrapping.go
+++ b/internal/auth/password/rewrapping.go
@@ -1,0 +1,78 @@
+package password
+
+import (
+	"context"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/kms"
+)
+
+func init() {
+	kms.RegisterTableRewrapFn("auth_password_argon2_cred", argon2ConfigRewrapFn)
+}
+
+type accountAndScope struct {
+	scopeId   string
+	accountId string
+}
+
+func argon2ConfigRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+	const op = "password.argon2ConfigRewrapFn"
+	repo, err := NewRepository(reader, writer, kmsRepo)
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	rows, err := repo.reader.Query(
+		ctx, `
+select distinct acct.scope_id, acct.public_id
+from auth_password_account acct
+inner join auth_password_argon2_cred cred
+on acct.public_id=cred.password_account_id
+where cred.key_id=?
+`,
+		[]interface{}{dataKeyVersionId},
+	)
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	var accounts []accountAndScope
+	for rows.Next() {
+		var account accountAndScope
+		if err := rows.Scan(&account.scopeId, &account.accountId); err != nil {
+			_ = rows.Close()
+			return errors.Wrap(ctx, err, op)
+		}
+		accounts = append(accounts, account)
+	}
+	if err := rows.Err(); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	for _, account := range accounts {
+		var credentials []*Argon2Credential
+		if err := repo.reader.SearchWhere(ctx, &credentials, "password_account_id=? and key_id=?", []interface{}{account.accountId, dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		wrapper, err := repo.kms.GetWrapper(ctx, account.scopeId, kms.KeyPurposeDatabase)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		newKeyVersionId, err := wrapper.KeyId(ctx)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		for _, cred := range credentials {
+			if err := cred.decrypt(ctx, wrapper); err != nil {
+				return errors.Wrap(ctx, err, op)
+			}
+			if err := cred.encrypt(ctx, wrapper); err != nil {
+				return errors.Wrap(ctx, err, op)
+			}
+			cred.KeyId = newKeyVersionId
+			if _, err := repo.writer.Update(ctx, cred, []string{"CtSalt", "KeyId"}, nil); err != nil {
+				return errors.Wrap(ctx, err, op)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/auth/password/rewrapping.go
+++ b/internal/auth/password/rewrapping.go
@@ -12,66 +12,26 @@ func init() {
 	kms.RegisterTableRewrapFn("auth_password_argon2_cred", argon2ConfigRewrapFn)
 }
 
-type accountAndScope struct {
-	scopeId   string
-	accountId string
-}
-
-func argon2ConfigRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func argon2ConfigRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "password.argon2ConfigRewrapFn"
-	repo, err := NewRepository(reader, writer, kmsRepo)
+	var credentials []*Argon2Credential
+	// the only index on this table is on private id and there are no references to private id. this is the fastest query
+	if err := reader.SearchWhere(ctx, &credentials, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
-	rows, err := repo.reader.Query(
-		ctx, `
-select distinct acct.scope_id, acct.public_id
-from auth_password_account acct
-inner join auth_password_argon2_cred cred
-on acct.public_id=cred.password_account_id
-where cred.key_id=?
-`,
-		[]interface{}{dataKeyVersionId},
-	)
-	if err != nil {
-		return errors.Wrap(ctx, err, op)
-	}
-	var accounts []accountAndScope
-	for rows.Next() {
-		var account accountAndScope
-		if err := rows.Scan(&account.scopeId, &account.accountId); err != nil {
-			_ = rows.Close()
+	for _, cred := range credentials {
+		if err := cred.decrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		accounts = append(accounts, account)
-	}
-	if err := rows.Err(); err != nil {
-		return errors.Wrap(ctx, err, op)
-	}
-	for _, account := range accounts {
-		var credentials []*Argon2Credential
-		if err := repo.reader.SearchWhere(ctx, &credentials, "password_account_id=? and key_id=?", []interface{}{account.accountId, dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		if err := cred.encrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		wrapper, err := repo.kms.GetWrapper(ctx, account.scopeId, kms.KeyPurposeDatabase)
-		if err != nil {
+		if _, err := writer.Update(ctx, cred, []string{"CtSalt", "KeyId"}, nil); err != nil {
 			return errors.Wrap(ctx, err, op)
-		}
-		newKeyVersionId, err := wrapper.KeyId(ctx)
-		if err != nil {
-			return errors.Wrap(ctx, err, op)
-		}
-		for _, cred := range credentials {
-			if err := cred.decrypt(ctx, wrapper); err != nil {
-				return errors.Wrap(ctx, err, op)
-			}
-			if err := cred.encrypt(ctx, wrapper); err != nil {
-				return errors.Wrap(ctx, err, op)
-			}
-			cred.KeyId = newKeyVersionId
-			if _, err := repo.writer.Update(ctx, cred, []string{"CtSalt", "KeyId"}, nil); err != nil {
-				return errors.Wrap(ctx, err, op)
-			}
 		}
 	}
 	return nil

--- a/internal/auth/password/rewrapping_test.go
+++ b/internal/auth/password/rewrapping_test.go
@@ -63,7 +63,8 @@ func TestRewrap_argon2ConfigRewrapFn(t *testing.T) {
 	assert.NoError(t, err)
 
 	// decrypt with the new key version and check to make sure things match
-	cred.decrypt(ctx, kmsWrapper)
+	err = cred.decrypt(ctx, kmsWrapper)
+	assert.NoError(t, err)
 	assert.Equal(t, cred.GetKeyId(), newKeyVersion)
 	assert.Equal(t, got.GetSalt(), cred.GetSalt())
 }

--- a/internal/auth/password/rewrapping_test.go
+++ b/internal/auth/password/rewrapping_test.go
@@ -38,7 +38,7 @@ func TestRewrap_argon2ConfigRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, org.Scope.GetPublicId()))
-	assert.NoError(t, argon2ConfigRewrapFn(ctx, cred.KeyId, rw, rw, kmsCache))
+	assert.NoError(t, argon2ConfigRewrapFn(ctx, cred.KeyId, org.Scope.GetPublicId(), rw, rw, kmsCache))
 
 	// now we pull the config back from the db, decrypt it with the new key, and ensure things match
 	got := &Argon2Credential{

--- a/internal/auth/password/rewrapping_test.go
+++ b/internal/auth/password/rewrapping_test.go
@@ -1,0 +1,69 @@
+package password
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/auth/password/store"
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRewrap_argon2ConfigRewrapFn(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+
+	org, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	auts := TestAuthMethods(t, conn, org.GetPublicId(), 1)
+	aut := auts[0]
+	acct := TestAccount(t, conn, aut.PublicId, "name")
+	authMethodId := acct.AuthMethodId
+	conf := testArgon2Confs(t, conn, authMethodId, 1)[0]
+
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	wrapper, _ = kmsCache.GetWrapper(context.Background(), org.GetPublicId(), 1)
+
+	// actually store it
+	got, err := newArgon2Credential(acct.PublicId, "this is a password", conf)
+	require.NoError(t, err)
+
+	err = got.encrypt(context.Background(), wrapper)
+	require.NoError(t, err)
+	err = rw.Create(context.Background(), got)
+	assert.NoError(t, err)
+
+	// now things are stored in the db, we can rotate and rewrap
+	err = kmsCache.RotateKeys(ctx, org.Scope.GetPublicId())
+	assert.NoError(t, err)
+
+	err = argon2ConfigRewrapFn(ctx, got.KeyId, rw, rw, kmsCache)
+	assert.NoError(t, err)
+
+	// now we pull the config back from the db, decrypt it with the new key, and ensure things match
+	cred := &Argon2Credential{
+		Argon2Credential: &store.Argon2Credential{
+			PrivateId: got.PrivateId,
+		},
+	}
+	err = rw.LookupById(ctx, cred)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, cred.GetKeyId(), got.GetKeyId())
+
+	// fetch the new key version
+	kmsWrapper, err := kmsCache.GetWrapper(ctx, org.Scope.GetPublicId(), kms.KeyPurposeDatabase, kms.WithKeyId(cred.GetKeyId()))
+	assert.NoError(t, err)
+	newKeyVersion, err := kmsWrapper.KeyId(ctx)
+	assert.NoError(t, err)
+
+	// decrypt with the new key version and check to make sure things match
+	cred.decrypt(ctx, kmsWrapper)
+	assert.Equal(t, cred.GetKeyId(), newKeyVersion)
+	assert.Equal(t, got.GetSalt(), cred.GetSalt())
+}

--- a/internal/authtoken/rewrapping.go
+++ b/internal/authtoken/rewrapping.go
@@ -15,23 +15,24 @@ func init() {
 func authTokenRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "authtoken.authTokenRewrapFn"
 	var credentials []*AuthToken
-	// indexes on public id and token, and the only reference to public id is session (unreliable join). this is the fastest query
+	// indexes on public id and token, and the only reference to public id is session (unreliable join).
+	// This is the fastest query we can use without creating a new index on key_id.
 	if err := reader.SearchWhere(ctx, &credentials, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query sql for rows that need rewrapping"))
 	}
 	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to fetch kms wrapper for rewrapping"))
 	}
 	for _, cred := range credentials {
 		if err := cred.decrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to decrypt auth token"))
 		}
 		if err := cred.encrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt auth token"))
 		}
 		if _, err := writer.Update(ctx, cred, []string{"CtToken", "KeyId"}, nil); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update auth token row with rewrapped fields"))
 		}
 	}
 	return nil

--- a/internal/authtoken/rewrapping.go
+++ b/internal/authtoken/rewrapping.go
@@ -15,7 +15,7 @@ func init() {
 func authTokenRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "authtoken.authTokenRewrapFn"
 	var credentials []*AuthToken
-	// indexes on public id and token, and the only reference to public id is session (unreliable join).
+	// Indexes exist on public id and token, and the only reference to public id is session, which may not exist for all rows we need.
 	// This is the fastest query we can use without creating a new index on key_id.
 	if err := reader.SearchWhere(ctx, &credentials, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
 		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query sql for rows that need rewrapping"))

--- a/internal/authtoken/rewrapping.go
+++ b/internal/authtoken/rewrapping.go
@@ -1,0 +1,78 @@
+package authtoken
+
+import (
+	"context"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/kms"
+)
+
+func init() {
+	kms.RegisterTableRewrapFn(defaultAuthTokenTableName, authTokenRewrapFn)
+}
+
+type accountAndScope struct {
+	scopeId   string
+	accountId string
+}
+
+func authTokenRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+	const op = "authtoken.authTokenRewrapFn"
+	repo, err := NewRepository(reader, writer, kmsRepo)
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	rows, err := repo.reader.Query(
+		ctx, `
+select distinct ac.scope_id, ac.public_id
+from auth_token at
+inner join auth_account ac
+on at.auth_account_id=ac.public_id
+where at.key_id=?
+`,
+		[]interface{}{dataKeyVersionId},
+	)
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	var accounts []accountAndScope
+	for rows.Next() {
+		var account accountAndScope
+		if err := rows.Scan(&account.scopeId, &account.accountId); err != nil {
+			_ = rows.Close()
+			return errors.Wrap(ctx, err, op)
+		}
+		accounts = append(accounts, account)
+	}
+	if err := rows.Err(); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	for _, account := range accounts {
+		var credentials []*AuthToken
+		if err := repo.reader.SearchWhere(ctx, &credentials, "auth_account_id=? and key_id=?", []interface{}{account.accountId, dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		wrapper, err := repo.kms.GetWrapper(ctx, account.scopeId, kms.KeyPurposeDatabase)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		newKeyVersionId, err := wrapper.KeyId(ctx)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		for _, cred := range credentials {
+			if err := cred.decrypt(ctx, wrapper); err != nil {
+				return errors.Wrap(ctx, err, op)
+			}
+			if err := cred.encrypt(ctx, wrapper); err != nil {
+				return errors.Wrap(ctx, err, op)
+			}
+			cred.KeyId = newKeyVersionId
+			if _, err := repo.writer.Update(ctx, cred, []string{"CtToken", "KeyId"}, nil); err != nil {
+				return errors.Wrap(ctx, err, op)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/authtoken/rewrapping.go
+++ b/internal/authtoken/rewrapping.go
@@ -12,66 +12,26 @@ func init() {
 	kms.RegisterTableRewrapFn(defaultAuthTokenTableName, authTokenRewrapFn)
 }
 
-type accountAndScope struct {
-	scopeId   string
-	accountId string
-}
-
-func authTokenRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func authTokenRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "authtoken.authTokenRewrapFn"
-	repo, err := NewRepository(reader, writer, kmsRepo)
+	var credentials []*AuthToken
+	// indexes on public id and token, and the only reference to public id is session (unreliable join). this is the fastest query
+	if err := reader.SearchWhere(ctx, &credentials, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
-	rows, err := repo.reader.Query(
-		ctx, `
-select distinct ac.scope_id, ac.public_id
-from auth_token at
-inner join auth_account ac
-on at.auth_account_id=ac.public_id
-where at.key_id=?
-`,
-		[]interface{}{dataKeyVersionId},
-	)
-	if err != nil {
-		return errors.Wrap(ctx, err, op)
-	}
-	var accounts []accountAndScope
-	for rows.Next() {
-		var account accountAndScope
-		if err := rows.Scan(&account.scopeId, &account.accountId); err != nil {
-			_ = rows.Close()
+	for _, cred := range credentials {
+		if err := cred.decrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		accounts = append(accounts, account)
-	}
-	if err := rows.Err(); err != nil {
-		return errors.Wrap(ctx, err, op)
-	}
-	for _, account := range accounts {
-		var credentials []*AuthToken
-		if err := repo.reader.SearchWhere(ctx, &credentials, "auth_account_id=? and key_id=?", []interface{}{account.accountId, dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		if err := cred.encrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		wrapper, err := repo.kms.GetWrapper(ctx, account.scopeId, kms.KeyPurposeDatabase)
-		if err != nil {
+		if _, err := writer.Update(ctx, cred, []string{"CtToken", "KeyId"}, nil); err != nil {
 			return errors.Wrap(ctx, err, op)
-		}
-		newKeyVersionId, err := wrapper.KeyId(ctx)
-		if err != nil {
-			return errors.Wrap(ctx, err, op)
-		}
-		for _, cred := range credentials {
-			if err := cred.decrypt(ctx, wrapper); err != nil {
-				return errors.Wrap(ctx, err, op)
-			}
-			if err := cred.encrypt(ctx, wrapper); err != nil {
-				return errors.Wrap(ctx, err, op)
-			}
-			cred.KeyId = newKeyVersionId
-			if _, err := repo.writer.Update(ctx, cred, []string{"CtToken", "KeyId"}, nil); err != nil {
-				return errors.Wrap(ctx, err, op)
-			}
 		}
 	}
 	return nil

--- a/internal/authtoken/rewrapping_test.go
+++ b/internal/authtoken/rewrapping_test.go
@@ -1,0 +1,59 @@
+package authtoken
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewrap_authTokenRewrapFn(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	org, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+
+	// TestAuthToken will create and store the token for us
+	at := TestAuthToken(t, conn, kmsCache, org.GetPublicId())
+
+	// now things are stored in the db, we can rotate and rewrap
+	err := kmsCache.RotateKeys(ctx, org.Scope.GetPublicId())
+	assert.NoError(t, err)
+
+	err = authTokenRewrapFn(ctx, at.GetKeyId(), rw, rw, kmsCache)
+	assert.NoError(t, err)
+
+	// now we pull the authToken back from the db, decrypt it with the new key, and ensure things match
+	// as a security measure, LookupAuthToken clears both CtToken and KeyId, which are the fields we want, so we will lookup manually
+	atv := allocAuthTokenView()
+	atv.PublicId = at.GetPublicId()
+	rw.LookupByPublicId(ctx, atv)
+	assert.NoError(t, err)
+	newAt := atv.toAuthToken()
+
+	assert.Equal(t, at.GetPublicId(), newAt.GetPublicId())
+	assert.NotEqual(t, at.GetKeyId(), atv.GetKeyId())
+
+	// fetch the new key version
+	kmsWrapper, err := kmsCache.GetWrapper(ctx, org.Scope.GetPublicId(), kms.KeyPurposeDatabase, kms.WithKeyId(newAt.GetKeyId()))
+	assert.NoError(t, err)
+	newKeyVersion, err := kmsWrapper.KeyId(ctx)
+	assert.NoError(t, err)
+
+	fmt.Printf("at: %#v\natv: %#v\nnewAt: %#v\n", at.GetKeyId(), atv.GetKeyId(), newAt.GetKeyId())
+
+	// decrypt with the new key version and check to make sure things match
+	err = newAt.decrypt(ctx, kmsWrapper)
+	assert.NoError(t, err)
+	fmt.Printf("at: %#v\nnewAt: %#v\n, expected keyid: %s\n", at.AuthToken, newAt.AuthToken, newKeyVersion)
+
+	// assert.Equal(t, newKeyVersion, newAt.GetKeyId()) newAt ALWAYS HAS AN EMPTY KEY ID AND I DON'T KNOW WHY
+	// I've confirmed from the db that the key id is, in fact, stored and is correct, but it cannot be retrieved??
+	assert.Equal(t, at.GetToken(), newAt.GetToken())
+}

--- a/internal/authtoken/rewrapping_test.go
+++ b/internal/authtoken/rewrapping_test.go
@@ -23,7 +23,7 @@ func TestRewrap_authTokenRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, org.Scope.GetPublicId()))
-	assert.NoError(t, authTokenRewrapFn(ctx, at.GetKeyId(), rw, rw, kmsCache))
+	assert.NoError(t, authTokenRewrapFn(ctx, at.GetKeyId(), org.Scope.GetPublicId(), rw, rw, kmsCache))
 
 	// now we pull the authToken back from the db, decrypt it with the new key, and ensure things match
 	got := allocAuthToken()

--- a/internal/credential/static/rewrapping.go
+++ b/internal/credential/static/rewrapping.go
@@ -10,6 +10,7 @@ import (
 
 func init() {
 	kms.RegisterTableRewrapFn("credential_static_username_password_credential", credStaticUsernamePasswordRewrapFn)
+	kms.RegisterTableRewrapFn("credential_static_ssh_private_key_credential", credStaticSshPrivKeyRewrapFn)
 }
 
 func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
@@ -38,6 +39,38 @@ func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId st
 			return errors.Wrap(ctx, err, op)
 		}
 		if _, err := repo.writer.Update(ctx, cred, []string{"CtPassword", "PasswordHmac", "KeyId"}, nil); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+	}
+	return nil
+}
+
+func credStaticSshPrivKeyRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+	const op = "static.credStaticSshPrivKeyRewrapFn"
+	repo, err := NewRepository(ctx, reader, writer, kmsRepo, WithLimit(-1))
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	var creds []*SshPrivateKeyCredential
+	if err := repo.reader.SearchWhere(ctx, &creds, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	for _, cred := range creds {
+		store, err := repo.LookupCredentialStore(ctx, cred.GetStoreId())
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		wrapper, err := repo.kms.GetWrapper(ctx, store.GetProjectId(), kms.KeyPurposeDatabase)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if err := cred.decrypt(ctx, wrapper); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if err := cred.encrypt(ctx, wrapper); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if _, err := repo.writer.Update(ctx, cred, []string{"PrivateKeyEncrypted", "PrivateKeyHmac", "PrivateKeyPassphraseEncrypted", "PrivateKeyPassphraseHmac", "KeyId"}, nil); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
 	}

--- a/internal/credential/static/rewrapping.go
+++ b/internal/credential/static/rewrapping.go
@@ -13,64 +13,49 @@ func init() {
 	kms.RegisterTableRewrapFn("credential_static_ssh_private_key_credential", credStaticSshPrivKeyRewrapFn)
 }
 
-func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "static.credStaticUsernamePasswordRewrapFn"
-	repo, err := NewRepository(ctx, reader, writer, kmsRepo, WithLimit(-1))
+	var creds []*UsernamePasswordCredential
+	// indexes on public id, store id. neither of which are queryable via scope. this is the fastest query
+	if err := reader.SearchWhere(ctx, &creds, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
-	var creds []*UsernamePasswordCredential
-	if err := repo.reader.SearchWhere(ctx, &creds, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
-		return errors.Wrap(ctx, err, op)
-	}
 	for _, cred := range creds {
-		store, err := repo.LookupCredentialStore(ctx, cred.GetStoreId())
-		if err != nil {
-			return errors.Wrap(ctx, err, op)
-		}
-		wrapper, err := repo.kms.GetWrapper(ctx, store.GetProjectId(), kms.KeyPurposeDatabase)
-		if err != nil {
-			return errors.Wrap(ctx, err, op)
-		}
 		if err := cred.decrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
 		if err := cred.encrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		if _, err := repo.writer.Update(ctx, cred, []string{"CtPassword", "PasswordHmac", "KeyId"}, nil); err != nil {
+		if _, err := writer.Update(ctx, cred, []string{"CtPassword", "PasswordHmac", "KeyId"}, nil); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
 	}
 	return nil
 }
 
-func credStaticSshPrivKeyRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func credStaticSshPrivKeyRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "static.credStaticSshPrivKeyRewrapFn"
-	repo, err := NewRepository(ctx, reader, writer, kmsRepo, WithLimit(-1))
+	var creds []*SshPrivateKeyCredential
+	if err := reader.SearchWhere(ctx, &creds, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
-	var creds []*SshPrivateKeyCredential
-	if err := repo.reader.SearchWhere(ctx, &creds, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
-		return errors.Wrap(ctx, err, op)
-	}
 	for _, cred := range creds {
-		store, err := repo.LookupCredentialStore(ctx, cred.GetStoreId())
-		if err != nil {
-			return errors.Wrap(ctx, err, op)
-		}
-		wrapper, err := repo.kms.GetWrapper(ctx, store.GetProjectId(), kms.KeyPurposeDatabase)
-		if err != nil {
-			return errors.Wrap(ctx, err, op)
-		}
 		if err := cred.decrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
 		if err := cred.encrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		if _, err := repo.writer.Update(ctx, cred, []string{"PrivateKeyEncrypted", "PrivateKeyHmac", "PrivateKeyPassphraseEncrypted", "PrivateKeyPassphraseHmac", "KeyId"}, nil); err != nil {
+		if _, err := writer.Update(ctx, cred, []string{"PrivateKeyEncrypted", "PrivateKeyHmac", "PrivateKeyPassphraseEncrypted", "PrivateKeyPassphraseHmac", "KeyId"}, nil); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
 	}

--- a/internal/credential/static/rewrapping.go
+++ b/internal/credential/static/rewrapping.go
@@ -16,7 +16,7 @@ func init() {
 func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "static.credStaticUsernamePasswordRewrapFn"
 	var creds []*UsernamePasswordCredential
-	// indexes on public id, store id. neither of which are queryable via scope.
+	// Indexes exist on public id, store id. neither of which are queryable via scope.
 	// This is the fastest query we can use without creating a new index on key_id.
 	if err := reader.SearchWhere(ctx, &creds, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
 		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query sql for rows that need rewrapping"))
@@ -32,7 +32,7 @@ func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId, s
 		if err := cred.encrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt username/password credential"))
 		}
-		if _, err := writer.Update(ctx, cred, []string{"CtPassword", "PasswordHmac", "KeyId"}, nil); err != nil {
+		if _, err := writer.Update(ctx, cred, []string{"CtPassword", "KeyId"}, nil); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update username/password credential row with rewrapped fields"))
 		}
 	}
@@ -58,7 +58,7 @@ func credStaticSshPrivKeyRewrapFn(ctx context.Context, dataKeyVersionId, scopeId
 		if err := cred.encrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt ssh private key"))
 		}
-		if _, err := writer.Update(ctx, cred, []string{"PrivateKeyEncrypted", "PrivateKeyHmac", "PrivateKeyPassphraseEncrypted", "PrivateKeyPassphraseHmac", "KeyId"}, nil); err != nil {
+		if _, err := writer.Update(ctx, cred, []string{"PrivateKeyEncrypted", "PrivateKeyPassphraseEncrypted", "KeyId"}, nil); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update ssh private key row with rewrapped fields"))
 		}
 	}

--- a/internal/credential/static/rewrapping.go
+++ b/internal/credential/static/rewrapping.go
@@ -16,23 +16,24 @@ func init() {
 func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "static.credStaticUsernamePasswordRewrapFn"
 	var creds []*UsernamePasswordCredential
-	// indexes on public id, store id. neither of which are queryable via scope. this is the fastest query
+	// indexes on public id, store id. neither of which are queryable via scope.
+	// This is the fastest query we can use without creating a new index on key_id.
 	if err := reader.SearchWhere(ctx, &creds, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query sql for rows that need rewrapping"))
 	}
 	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to fetch kms wrapper for rewrapping"))
 	}
 	for _, cred := range creds {
 		if err := cred.decrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to decrypt username/password credential"))
 		}
 		if err := cred.encrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt username/password credential"))
 		}
 		if _, err := writer.Update(ctx, cred, []string{"CtPassword", "PasswordHmac", "KeyId"}, nil); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update username/password credential row with rewrapped fields"))
 		}
 	}
 	return nil
@@ -41,22 +42,24 @@ func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId, s
 func credStaticSshPrivKeyRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "static.credStaticSshPrivKeyRewrapFn"
 	var creds []*SshPrivateKeyCredential
+	// Indexes exist on public id, store id. neither of which are queryable via scope.
+	// This is the fastest query we can use without creating a new index on key_id.
 	if err := reader.SearchWhere(ctx, &creds, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query sql for rows that need rewrapping"))
 	}
 	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to fetch kms wrapper for rewrapping"))
 	}
 	for _, cred := range creds {
 		if err := cred.decrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to decrypt ssh private key"))
 		}
 		if err := cred.encrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt ssh private key"))
 		}
 		if _, err := writer.Update(ctx, cred, []string{"PrivateKeyEncrypted", "PrivateKeyHmac", "PrivateKeyPassphraseEncrypted", "PrivateKeyPassphraseHmac", "KeyId"}, nil); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update ssh private key row with rewrapped fields"))
 		}
 	}
 	return nil

--- a/internal/credential/static/rewrapping.go
+++ b/internal/credential/static/rewrapping.go
@@ -1,0 +1,45 @@
+package static
+
+import (
+	"context"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/kms"
+)
+
+func init() {
+	kms.RegisterTableRewrapFn("credential_static_username_password_credential", credStaticUsernamePasswordRewrapFn)
+}
+
+func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+	const op = "static.credStaticUsernamePasswordRewrapFn"
+	repo, err := NewRepository(ctx, reader, writer, kmsRepo, WithLimit(-1))
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	var creds []*UsernamePasswordCredential
+	if err := repo.reader.SearchWhere(ctx, &creds, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	for _, cred := range creds {
+		store, err := repo.LookupCredentialStore(ctx, cred.GetStoreId())
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		wrapper, err := repo.kms.GetWrapper(ctx, store.GetProjectId(), kms.KeyPurposeDatabase)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if err := cred.decrypt(ctx, wrapper); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if err := cred.encrypt(ctx, wrapper); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if _, err := repo.writer.Update(ctx, cred, []string{"CtPassword", "PasswordHmac", "KeyId"}, nil); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+	}
+	return nil
+}

--- a/internal/credential/static/rewrapping_test.go
+++ b/internal/credential/static/rewrapping_test.go
@@ -54,7 +54,7 @@ func TestRewrap_credStaticUsernamePasswordRewrapFn(t *testing.T) {
 	assert.Equal(t, newKeyVersionId, got.GetKeyId())
 	assert.Equal(t, "password", string(got.GetPassword()))
 	assert.NotEmpty(t, got.GetPasswordHmac())
-	assert.NotEqual(t, cred.GetPasswordHmac(), got.GetPasswordHmac())
+	assert.Equal(t, cred.GetPasswordHmac(), got.GetPasswordHmac())
 }
 
 func TestRewrap_credStaticSshPrivKeyRewrapFn(t *testing.T) {
@@ -124,7 +124,7 @@ func TestRewrap_credStaticSshPrivKeyRewrapFn(t *testing.T) {
 	assert.Equal(t, TestSshPrivateKeyPem, string(got.PrivateKey))
 	assert.NotEqual(t, cred.GetPrivateKeyEncrypted(), got.GetPrivateKeyEncrypted())
 	assert.NotEmpty(t, got.GetPrivateKeyHmac())
-	assert.NotEqual(t, cred.GetPrivateKeyHmac(), got.GetPrivateKeyHmac())
+	assert.Equal(t, cred.GetPrivateKeyHmac(), got.GetPrivateKeyHmac())
 	// we didn't set this, so they should be empty before AND after rewrapping
 	assert.Empty(t, got.GetPrivateKeyPassphrase())
 	assert.Empty(t, got.GetPrivateKeyPassphraseHmac())
@@ -138,10 +138,10 @@ func TestRewrap_credStaticSshPrivKeyRewrapFn(t *testing.T) {
 	assert.Equal(t, TestSshPrivateKeyPem, string(got2.PrivateKey))
 	assert.NotEqual(t, cred.GetPrivateKeyEncrypted(), got.GetPrivateKeyEncrypted())
 	assert.NotEmpty(t, got2.GetPrivateKeyHmac())
-	assert.NotEqual(t, cred2.GetPrivateKeyHmac(), got2.GetPrivateKeyHmac())
+	assert.Equal(t, cred2.GetPrivateKeyHmac(), got2.GetPrivateKeyHmac())
 	// this time, we did set this, so they should be available
 	assert.NotEmpty(t, got2.GetPrivateKeyPassphraseEncrypted())
 	assert.NotEmpty(t, got2.GetPrivateKeyPassphraseHmac())
 	assert.Equal(t, []byte("passphrase"), got2.GetPrivateKeyPassphrase())
-	assert.NotEqual(t, cred2.GetPrivateKeyPassphraseHmac(), got2.GetPrivateKeyPassphraseHmac())
+	assert.Equal(t, cred2.GetPrivateKeyPassphraseHmac(), got2.GetPrivateKeyPassphraseHmac())
 }

--- a/internal/credential/static/rewrapping_test.go
+++ b/internal/credential/static/rewrapping_test.go
@@ -35,7 +35,7 @@ func TestRewrap_credStaticUsernamePasswordRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
-	assert.NoError(t, credStaticUsernamePasswordRewrapFn(ctx, cred.GetKeyId(), rw, rw, kmsCache))
+	assert.NoError(t, credStaticUsernamePasswordRewrapFn(ctx, cred.GetKeyId(), prj.PublicId, rw, rw, kmsCache))
 
 	// now we pull the credential back from the db, decrypt it with the new key, and ensure things match
 	got := allocUsernamePasswordCredential()
@@ -99,7 +99,7 @@ func TestRewrap_credStaticSshPrivKeyRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
-	assert.NoError(t, credStaticSshPrivKeyRewrapFn(ctx, cred.GetKeyId(), rw, rw, kmsCache))
+	assert.NoError(t, credStaticSshPrivKeyRewrapFn(ctx, cred.GetKeyId(), prj.PublicId, rw, rw, kmsCache))
 
 	// now we pull both credential2 back from the db, decrypt them with the new key, and ensure things match
 	got := allocSshPrivateKeyCredential()

--- a/internal/credential/static/rewrapping_test.go
+++ b/internal/credential/static/rewrapping_test.go
@@ -1,0 +1,71 @@
+package static
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/credential"
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewrap_credStaticUsernamePasswordRewrapFn(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	rw := db.New(conn)
+
+	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	cs := TestCredentialStore(t, conn, wrapper, prj.PublicId)
+	cred, err := NewUsernamePasswordCredential(cs.GetPublicId(), "username", "password")
+	assert.NoError(t, err)
+
+	assert.NotNil(t, cred)
+	assert.Emptyf(t, cred.PublicId, "PublicId set")
+
+	id, err := credential.NewUsernamePasswordCredentialId(ctx)
+	assert.NoError(t, err)
+
+	cred.PublicId = id
+
+	kmsWrapper, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase)
+	assert.NoError(t, err)
+
+	err = cred.encrypt(ctx, kmsWrapper)
+	assert.NoError(t, err)
+
+	err = rw.Create(context.Background(), cred)
+	assert.NoError(t, err)
+
+	// now things are stored in the db, we can rotate and rewrap
+	err = kmsCache.RotateKeys(ctx, prj.PublicId)
+	assert.NoError(t, err)
+
+	err = credStaticUsernamePasswordRewrapFn(ctx, cred.GetKeyId(), rw, rw, kmsCache)
+	assert.NoError(t, err)
+
+	// now we pull the credential back from the db, decrypt it with the new key, and ensure things match
+	got := allocUsernamePasswordCredential()
+	got.PublicId = id
+	assert.NoError(t, rw.LookupById(ctx, got))
+
+	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.GetKeyId()))
+	assert.NoError(t, err)
+
+	err = got.decrypt(ctx, kmsWrapper2)
+	assert.NoError(t, err)
+
+	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
+	assert.NoError(t, err)
+
+	// decrypt with the new key version and check to make sure things match
+	assert.NotEmpty(t, got.GetKeyId())
+	assert.NotEqual(t, cred.GetKeyId(), got.GetKeyId())
+	assert.Equal(t, newKeyVersionId, got.GetKeyId())
+	assert.Equal(t, "password", string(got.GetPassword()))
+	assert.NotEmpty(t, got.GetPasswordHmac())
+	assert.NotEqual(t, cred.GetPasswordHmac(), got.GetPasswordHmac())
+}

--- a/internal/credential/vault/rewrapping.go
+++ b/internal/credential/vault/rewrapping.go
@@ -32,7 +32,7 @@ func credVaultClientCertificateRewrapFn(ctx context.Context, dataKeyVersionId, s
 		if err := cert.encrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt vault client certificate"))
 		}
-		if _, err := writer.Update(ctx, cert, []string{"CtCertificateKey", "CertificateKeyHmac", "KeyId"}, nil); err != nil {
+		if _, err := writer.Update(ctx, cert, []string{"CtCertificateKey", "KeyId"}, nil); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update vault client certificate row with rewrapped fields"))
 		}
 	}

--- a/internal/credential/vault/rewrapping.go
+++ b/internal/credential/vault/rewrapping.go
@@ -14,7 +14,7 @@ func init() {
 }
 
 func credVaultClientCertificateRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
-	const op = "vault.credVaultClientCertificate"
+	const op = "vault.credVaultClientCertificateRewrapFn"
 	// using an empty scheduler here since the only function we need is a lookup func and we really don't want to actually schedule something
 	repo, err := NewRepository(reader, writer, kmsRepo, &scheduler.Scheduler{})
 	if err != nil {

--- a/internal/credential/vault/rewrapping.go
+++ b/internal/credential/vault/rewrapping.go
@@ -1,0 +1,47 @@
+package vault
+
+import (
+	"context"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/scheduler"
+)
+
+func init() {
+	kms.RegisterTableRewrapFn("credential_vault_client_certificate", credVaultClientCertificateRewrapFn)
+}
+
+func credVaultClientCertificateRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+	const op = "vault.credVaultClientCertificate"
+	// using an empty scheduler here since the only function we need is a lookup func and we really don't want to actually schedule something
+	repo, err := NewRepository(reader, writer, kmsRepo, &scheduler.Scheduler{})
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	var certs []*ClientCertificate
+	if err := repo.reader.SearchWhere(ctx, &certs, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	for _, cert := range certs {
+		store, err := repo.LookupCredentialStore(ctx, cert.GetStoreId())
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		wrapper, err := repo.kms.GetWrapper(ctx, store.GetProjectId(), kms.KeyPurposeDatabase)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if err := cert.decrypt(ctx, wrapper); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if err := cert.encrypt(ctx, wrapper); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if _, err := repo.writer.Update(ctx, cert, []string{"CtCertificateKey", "CertificateKeyHmac", "KeyId"}, nil); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+	}
+	return nil
+}

--- a/internal/credential/vault/rewrapping_test.go
+++ b/internal/credential/vault/rewrapping_test.go
@@ -31,7 +31,7 @@ func TestRewrap_credVaultClientCertificateRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
-	assert.NoError(t, credVaultClientCertificateRewrapFn(ctx, cert.GetKeyId(), rw, rw, kmsCache))
+	assert.NoError(t, credVaultClientCertificateRewrapFn(ctx, cert.GetKeyId(), prj.PublicId, rw, rw, kmsCache))
 
 	// now we pull the credential back from the db, decrypt it with the new key, and ensure things match
 	got := allocClientCertificate()
@@ -68,7 +68,7 @@ func TestRewrap_credVaultTokenRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
-	assert.NoError(t, credVaultTokenRewrapFn(ctx, token.GetKeyId(), rw, rw, kmsCache))
+	assert.NoError(t, credVaultTokenRewrapFn(ctx, token.GetKeyId(), prj.PublicId, rw, rw, kmsCache))
 
 	// now we pull the token back from the db, decrypt it with the new key, and ensure things match
 	got := allocToken()

--- a/internal/credential/vault/rewrapping_test.go
+++ b/internal/credential/vault/rewrapping_test.go
@@ -52,7 +52,7 @@ func TestRewrap_credVaultClientCertificateRewrapFn(t *testing.T) {
 	assert.Equal(t, newKeyVersionId, got.GetKeyId())
 	assert.Equal(t, keyPem, string(got.GetCertificateKey()))
 	assert.NotEmpty(t, got.GetCertificateKeyHmac())
-	assert.NotEqual(t, cert.GetCertificateKeyHmac(), got.GetCertificateKeyHmac())
+	assert.Equal(t, cert.GetCertificateKeyHmac(), got.GetCertificateKeyHmac())
 }
 
 func TestRewrap_credVaultTokenRewrapFn(t *testing.T) {

--- a/internal/credential/vault/rewrapping_test.go
+++ b/internal/credential/vault/rewrapping_test.go
@@ -1,0 +1,64 @@
+package vault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewrap_credVaultClientCertificateRewrapFn(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	rw := db.New(conn)
+
+	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	cs := TestCredentialStore(t, conn, wrapper, prj.PublicId, "https://vault.consul.service", "token", "accessor")
+	cert, err := NewClientCertificate([]byte(certPem), []byte(keyPem))
+	assert.NoError(t, err)
+
+	cert.StoreId = cs.PublicId
+
+	kmsWrapper, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase)
+	assert.NoError(t, err)
+
+	err = cert.encrypt(ctx, kmsWrapper)
+	assert.NoError(t, err)
+
+	err = rw.Create(context.Background(), cert)
+	assert.NoError(t, err)
+
+	// now things are stored in the db, we can rotate and rewrap
+	err = kmsCache.RotateKeys(ctx, prj.PublicId)
+	assert.NoError(t, err)
+
+	err = credVaultClientCertificateRewrapFn(ctx, cert.GetKeyId(), rw, rw, kmsCache)
+	assert.NoError(t, err)
+
+	// now we pull the credential back from the db, decrypt it with the new key, and ensure things match
+	got := allocClientCertificate()
+	got.StoreId = cs.PublicId
+	assert.NoError(t, rw.LookupById(ctx, got))
+
+	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.GetKeyId()))
+	assert.NoError(t, err)
+
+	err = got.decrypt(ctx, kmsWrapper2)
+	assert.NoError(t, err)
+
+	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
+	assert.NoError(t, err)
+
+	// decrypt with the new key version and check to make sure things match
+	assert.NotEmpty(t, got.GetKeyId())
+	assert.NotEqual(t, cert.GetKeyId(), got.GetKeyId())
+	assert.Equal(t, newKeyVersionId, got.GetKeyId())
+	assert.Equal(t, keyPem, string(got.GetCertificateKey()))
+	assert.NotEmpty(t, got.GetCertificateKeyHmac())
+	assert.NotEqual(t, cert.GetCertificateKeyHmac(), got.GetCertificateKeyHmac())
+}

--- a/internal/credential/vault/rewrapping_test.go
+++ b/internal/credential/vault/rewrapping_test.go
@@ -26,19 +26,12 @@ func TestRewrap_credVaultClientCertificateRewrapFn(t *testing.T) {
 
 	kmsWrapper, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase)
 	assert.NoError(t, err)
-
-	err = cert.encrypt(ctx, kmsWrapper)
-	assert.NoError(t, err)
-
-	err = rw.Create(context.Background(), cert)
-	assert.NoError(t, err)
+	assert.NoError(t, cert.encrypt(ctx, kmsWrapper))
+	assert.NoError(t, rw.Create(context.Background(), cert))
 
 	// now things are stored in the db, we can rotate and rewrap
-	err = kmsCache.RotateKeys(ctx, prj.PublicId)
-	assert.NoError(t, err)
-
-	err = credVaultClientCertificateRewrapFn(ctx, cert.GetKeyId(), rw, rw, kmsCache)
-	assert.NoError(t, err)
+	assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
+	assert.NoError(t, credVaultClientCertificateRewrapFn(ctx, cert.GetKeyId(), rw, rw, kmsCache))
 
 	// now we pull the credential back from the db, decrypt it with the new key, and ensure things match
 	got := allocClientCertificate()
@@ -48,8 +41,7 @@ func TestRewrap_credVaultClientCertificateRewrapFn(t *testing.T) {
 	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.GetKeyId()))
 	assert.NoError(t, err)
 
-	err = got.decrypt(ctx, kmsWrapper2)
-	assert.NoError(t, err)
+	assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
 
 	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
 	assert.NoError(t, err)

--- a/internal/credential/vault/rewrapping_test.go
+++ b/internal/credential/vault/rewrapping_test.go
@@ -76,17 +76,15 @@ func TestRewrap_credVaultTokenRewrapFn(t *testing.T) {
 
 	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.GetKeyId()))
 	assert.NoError(t, err)
-
-	assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
-
 	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
 	assert.NoError(t, err)
 
 	// decrypt with the new key version and check to make sure things match
+	assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
 	assert.NotEmpty(t, got.GetKeyId())
 	assert.NotEqual(t, token.GetKeyId(), got.GetKeyId())
 	assert.Equal(t, newKeyVersionId, got.GetKeyId())
-	assert.Equal(t, "token", string(token.GetToken()))
+	assert.Equal(t, "token", string(got.GetToken()))
 	assert.NotEmpty(t, got.GetTokenHmac())
 	// vault token hmacs are calculated differently and should remain the same
 	assert.Equal(t, token.GetTokenHmac(), got.GetTokenHmac())

--- a/internal/credential/vault/rewrapping_test.go
+++ b/internal/credential/vault/rewrapping_test.go
@@ -54,3 +54,40 @@ func TestRewrap_credVaultClientCertificateRewrapFn(t *testing.T) {
 	assert.NotEmpty(t, got.GetCertificateKeyHmac())
 	assert.NotEqual(t, cert.GetCertificateKeyHmac(), got.GetCertificateKeyHmac())
 }
+
+func TestRewrap_credVaultTokenRewrapFn(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	rw := db.New(conn)
+
+	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	cs := TestCredentialStore(t, conn, wrapper, prj.PublicId, "https://vault.consul.service", "token", "accessor")
+	token := cs.outputToken
+
+	// now things are stored in the db, we can rotate and rewrap
+	assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
+	assert.NoError(t, credVaultTokenRewrapFn(ctx, token.GetKeyId(), rw, rw, kmsCache))
+
+	// now we pull the token back from the db, decrypt it with the new key, and ensure things match
+	got := allocToken()
+	assert.NoError(t, rw.LookupWhere(ctx, &got, "store_id = ?", []interface{}{cs.PublicId}))
+
+	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.GetKeyId()))
+	assert.NoError(t, err)
+
+	assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
+
+	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
+	assert.NoError(t, err)
+
+	// decrypt with the new key version and check to make sure things match
+	assert.NotEmpty(t, got.GetKeyId())
+	assert.NotEqual(t, token.GetKeyId(), got.GetKeyId())
+	assert.Equal(t, newKeyVersionId, got.GetKeyId())
+	assert.Equal(t, "token", string(token.GetToken()))
+	assert.NotEmpty(t, got.GetTokenHmac())
+	// vault token hmacs are calculated differently and should remain the same
+	assert.Equal(t, token.GetTokenHmac(), got.GetTokenHmac())
+}

--- a/internal/db/schema/migrations/oss/postgres/0/11_auth_token.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/0/11_auth_token.up.sql
@@ -57,6 +57,7 @@ begin;
   comment on function update_last_access_time() is
     'function used in before update triggers to properly set last_access_time columns';
 
+  -- this trigger is deleted in 56/05_mutable_ciphertext_columns.up.sql
   create or replace function immutable_auth_token_columns() returns trigger
   as $$
   begin

--- a/internal/db/schema/migrations/oss/postgres/10/04_vault_credential.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/10/04_vault_credential.up.sql
@@ -190,6 +190,7 @@ begin;
   create trigger default_create_time_column before insert on credential_vault_token
     for each row execute procedure default_create_time();
 
+  -- this trigger is updated in 56/05_mutable_ciphertext_columns.up.sql
   create trigger immutable_columns before update on credential_vault_token
     for each row execute procedure immutable_columns('token_hmac', 'token', 'store_id','create_time');
 

--- a/internal/db/schema/migrations/oss/postgres/23/01_session_credential.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/23/01_session_credential.up.sql
@@ -22,7 +22,7 @@ begin;
     'session_credential is a table where each row contains a credential to be used by '
     'by a worker when a connection is established for the session_id.';
 
-  -- Replaced in 43/01_session_credentials.up.sql
+  -- this trigger is updated in 56/05_mutable_ciphertext_columns.up.sql
   create trigger immutable_columns before update on session_credential
     for each row execute procedure immutable_columns('session_id', 'credential', 'key_id');
 

--- a/internal/db/schema/migrations/oss/postgres/34/03_worker_authentication.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/34/03_worker_authentication.up.sql
@@ -71,6 +71,7 @@ create table worker_auth_ca_certificate(
       references worker_auth_ca(private_id)
 );
 
+-- this trigger is updated in 56/05_mutable_ciphertext_columns.up.sql
 create trigger immutable_columns before update on worker_auth_ca_certificate
   for each row execute procedure immutable_columns('serial_number', 'certificate', 'not_valid_before', 'not_valid_after', 'public_key', 'private_key', 'key_id', 'state', 'issuing_ca');
 
@@ -103,7 +104,7 @@ create table worker_auth_authorized(
 comment on table worker_auth_authorized is
   'worker_auth_authorized is a table where each row represents key and cert data associated with an authorized worker.';
 
--- Trigger updated in 55/01_worker_auth_create_time.up.sql
+-- this trigger is updated in 56/05_mutable_ciphertext_columns.up.sql
 create trigger immutable_columns before update on worker_auth_authorized
   for each row execute procedure immutable_columns('worker_key_identifier', 'worker_id', 'worker_signing_pub_key', 'worker_encryption_pub_key', 'controller_encryption_priv_key', 'key_id', 'nonce');
 

--- a/internal/db/schema/migrations/oss/postgres/43/01_session_credentials.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/43/01_session_credentials.up.sql
@@ -13,7 +13,7 @@ begin;
     add constraint session_credential_session_id_credential_sha256_uq
       unique(session_id, credential_sha256);
 
-  -- Replace the immutable columns trigger from 23/01_session_credential.up.sql
+  -- this trigger is updated in 56/05_mutable_ciphertext_columns.up.sql
   drop trigger immutable_columns on session_credential;
   create trigger immutable_columns before update on session_credential
     for each row execute procedure immutable_columns('session_id', 'credential', 'key_id', 'credential_sha256');

--- a/internal/db/schema/migrations/oss/postgres/56/01_worker_auth_create_time.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/56/01_worker_auth_create_time.up.sql
@@ -93,7 +93,7 @@ alter table worker_auth_authorized
 ;
 
 drop trigger immutable_columns on worker_auth_authorized;
--- Trigger updated from 34/03_worker_authentication.up.sql
+-- this trigger is updated in 56/05_mutable_ciphertext_columns.up.sql
 create trigger immutable_columns before update on worker_auth_authorized
   for each row execute function immutable_columns('worker_key_identifier', 'worker_id', 'worker_signing_pub_key',
                                                   'worker_encryption_pub_key', 'controller_encryption_priv_key', 'key_id', 'nonce', 'create_time');

--- a/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
@@ -25,4 +25,11 @@ begin;
   create trigger immutable_columns before update on session_credential
     for each row execute procedure immutable_columns('session_id');
 
+
+  -- And one final time on worker auth for controller priv key and key id.
+  drop trigger immutable_columns on worker_auth_authorized;
+
+  create trigger immutable_columns before update on worker_auth_authorized
+    for each row execute function immutable_columns('worker_key_identifier', 'worker_id', 'worker_signing_pub_key', 'worker_encryption_pub_key', 'nonce', 'create_time');
+
 commit;

--- a/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
@@ -1,0 +1,14 @@
+begin;
+
+  -- We need to make private_key and key_id mutable, so that we can rewrap them.
+  drop trigger immutable_columns on worker_auth_ca_certificate;
+
+  create trigger immutable_columns before update on worker_auth_ca_certificate
+    for each row execute procedure immutable_columns('serial_number', 'certificate', 'not_valid_before', 'not_valid_after', 'public_key', 'state', 'issuing_ca');
+
+
+  -- We need to make token mutable so that we can rewrap it.
+  drop trigger immutable_auth_token_columns on auth_token;
+  drop function immutable_auth_token_columns;
+
+commit;

--- a/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
@@ -18,4 +18,11 @@ begin;
   create trigger immutable_columns before update on credential_vault_token
     for each row execute procedure immutable_columns('store_id','create_time');
 
+
+  -- And again on credential and key_id (and the hash of credential).
+  drop trigger immutable_columns on session_credential;
+
+  create trigger immutable_columns before update on session_credential
+    for each row execute procedure immutable_columns('session_id');
+
 commit;

--- a/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
@@ -11,4 +11,11 @@ begin;
   drop trigger immutable_auth_token_columns on auth_token;
   drop function immutable_auth_token_columns;
 
+
+  -- We need to make token and token_hmac mutable, so that we can rewrap them.
+  drop trigger immutable_columns on credential_vault_token;
+
+  create trigger immutable_columns before update on credential_vault_token
+    for each row execute procedure immutable_columns('store_id','create_time');
+
 commit;

--- a/internal/host/plugin/rewrapping.go
+++ b/internal/host/plugin/rewrapping.go
@@ -15,7 +15,7 @@ func init() {
 func hostCatalogSecretRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "plugin.hostCatalogSecretRewrapFn"
 	var secrets []*HostCatalogSecret
-	// the only index on this table is on catalog id and there are no references to catalog id.
+	// The only index on this table is on catalog id and there are no references to catalog id.
 	// This is the fastest query we can use without creating a new index on key_id.
 	if err := reader.SearchWhere(ctx, &secrets, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
 		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query sql for rows that need rewrapping"))

--- a/internal/host/plugin/rewrapping.go
+++ b/internal/host/plugin/rewrapping.go
@@ -15,23 +15,24 @@ func init() {
 func hostCatalogSecretRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "plugin.hostCatalogSecretRewrapFn"
 	var secrets []*HostCatalogSecret
-	// the only index on this table is on catalog id and there are no references to catalog id. this is the fastest query
+	// the only index on this table is on catalog id and there are no references to catalog id.
+	// This is the fastest query we can use without creating a new index on key_id.
 	if err := reader.SearchWhere(ctx, &secrets, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query sql for rows that need rewrapping"))
 	}
 	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to fetch kms wrapper for rewrapping"))
 	}
 	for _, secret := range secrets {
 		if err := secret.decrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to decrypt host catalog secret"))
 		}
 		if err := secret.encrypt(ctx, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt host catalog secret"))
 		}
 		if _, err := writer.Update(ctx, secret, []string{"CtSecret", "KeyId"}, nil); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update host catalog secret row with rewrapped fields"))
 		}
 	}
 	return nil

--- a/internal/host/plugin/rewrapping.go
+++ b/internal/host/plugin/rewrapping.go
@@ -1,0 +1,46 @@
+package plugin
+
+import (
+	"context"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/host/plugin/store"
+	"github.com/hashicorp/boundary/internal/kms"
+)
+
+func init() {
+	kms.RegisterTableRewrapFn("host_plugin_catalog_secret", hostCatalogSecretRewrapFn)
+}
+
+func hostCatalogSecretRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+	const op = "plugin.hostCatalogSecretRewrapFn"
+	var secrets []*HostCatalogSecret
+	if err := reader.SearchWhere(ctx, &secrets, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	for _, secret := range secrets {
+		catalog := &HostCatalog{
+			HostCatalog: &store.HostCatalog{
+				PublicId: secret.CatalogId,
+			},
+		}
+		if err := reader.LookupById(ctx, catalog); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		wrapper, err := kmsRepo.GetWrapper(ctx, catalog.GetProjectId(), kms.KeyPurposeDatabase)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if err := secret.decrypt(ctx, wrapper); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if err := secret.encrypt(ctx, wrapper); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if _, err := writer.Update(ctx, secret, []string{"CtSecret", "KeyId"}, nil); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+	}
+	return nil
+}

--- a/internal/host/plugin/rewrapping_test.go
+++ b/internal/host/plugin/rewrapping_test.go
@@ -37,7 +37,7 @@ func TestRewrap_credStaticUsernamePasswordRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
-	assert.NoError(t, hostCatalogSecretRewrapFn(ctx, secret.GetKeyId(), rw, rw, kmsCache))
+	assert.NoError(t, hostCatalogSecretRewrapFn(ctx, secret.GetKeyId(), prj.PublicId, rw, rw, kmsCache))
 
 	// now we pull the credential back from the db, decrypt it with the new key, and ensure things match
 	got := allocHostCatalogSecret()

--- a/internal/host/plugin/rewrapping_test.go
+++ b/internal/host/plugin/rewrapping_test.go
@@ -46,12 +46,12 @@ func TestRewrap_credStaticUsernamePasswordRewrapFn(t *testing.T) {
 
 	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.GetKeyId()))
 	assert.NoError(t, err)
-	assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
 
 	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
 	assert.NoError(t, err)
 
 	// decrypt with the new key version and check to make sure things match
+	assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
 	assert.NotEmpty(t, got.GetKeyId())
 	assert.NotEqual(t, secret.GetKeyId(), got.GetKeyId())
 	assert.Equal(t, newKeyVersionId, got.GetKeyId())

--- a/internal/host/plugin/rewrapping_test.go
+++ b/internal/host/plugin/rewrapping_test.go
@@ -1,0 +1,60 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/plugin/host"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewrap_credStaticUsernamePasswordRewrapFn(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	rw := db.New(conn)
+
+	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	plg := host.TestPlugin(t, conn, "test")
+	cat := TestCatalog(t, conn, prj.GetPublicId(), plg.GetPublicId())
+	secret, err := newHostCatalogSecret(ctx, cat.GetPublicId(), mustStruct(map[string]interface{}{
+		"foo": "bar",
+	}))
+	assert.NoError(t, err)
+	assert.NotNil(t, secret)
+	assert.Empty(t, secret.CtSecret)
+	assert.NotEmpty(t, secret.Secret)
+
+	kmsWrapper, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase)
+	assert.NoError(t, err)
+	secretSecret := secret.GetSecret() // this is cleared by the encrypt function, so save it for assert
+	assert.NoError(t, secret.encrypt(ctx, kmsWrapper))
+	assert.NoError(t, rw.Create(context.Background(), secret))
+
+	// now things are stored in the db, we can rotate and rewrap
+	assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
+	assert.NoError(t, hostCatalogSecretRewrapFn(ctx, secret.GetKeyId(), rw, rw, kmsCache))
+
+	// now we pull the credential back from the db, decrypt it with the new key, and ensure things match
+	got := allocHostCatalogSecret()
+	got.CatalogId = cat.GetPublicId()
+	assert.NoError(t, rw.LookupById(ctx, got))
+
+	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.GetKeyId()))
+	assert.NoError(t, err)
+	assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
+
+	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
+	assert.NoError(t, err)
+
+	// decrypt with the new key version and check to make sure things match
+	assert.NotEmpty(t, got.GetKeyId())
+	assert.NotEqual(t, secret.GetKeyId(), got.GetKeyId())
+	assert.Equal(t, newKeyVersionId, got.GetKeyId())
+	assert.Equal(t, secretSecret, got.GetSecret())
+	assert.NotEqual(t, secret.GetCtSecret(), got.GetCtSecret())
+}

--- a/internal/server/query.go
+++ b/internal/server/query.go
@@ -25,13 +25,13 @@ const (
 	`
 	workerAuthRewrapQuery = `
 		select distinct
-		auth.worker_key_identifier,
-		auth.controller_encryption_priv_key,
-		auth.key_id
+			auth.worker_key_identifier,
+			auth.controller_encryption_priv_key,
+			auth.key_id
 		from server_worker worker
-		inner join worker_auth_authorized auth
-		on auth.worker_id = worker.public_id
-		and auth.key_id = ?
+			inner join worker_auth_authorized auth
+				on auth.worker_id = worker.public_id
 		where worker.scope_id = ?
+			and auth.key_id = ?
 	`
 )

--- a/internal/server/query.go
+++ b/internal/server/query.go
@@ -23,4 +23,15 @@ const (
 		delete from worker_auth_ca_certificate
  		where state = @state;
 	`
+	workerAuthRewrapQuery = `
+		select distinct
+		auth.worker_key_identifier,
+		auth.controller_encryption_priv_key,
+		auth.key_id
+		from server_worker worker
+		inner join worker_auth_authorized auth
+		on auth.worker_id = worker.public_id
+		and auth.key_id = ?
+		where worker.scope_id = ?
+	`
 )

--- a/internal/server/rewrapping.go
+++ b/internal/server/rewrapping.go
@@ -16,29 +16,30 @@ func init() {
 func workerAuthCertRewrapFn(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "server.workerAuthCertRewrapFn"
 	var certs []*RootCertificate
-	// indexes on public id, state. neither of which are queryable via scope. this is the fastest query
+	// Indexes on public id, state. neither of which are queryable via scope.
+	// This is the fastest query we can use without creating a new index on key_id.
 	if err := reader.SearchWhere(ctx, &certs, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query sql for rows that need rewrapping"))
 	}
 	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to fetch kms wrapper for rewrapping"))
 	}
 	newKeyVersionId, err := wrapper.KeyId(ctx)
 	if err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to retrieve updated key version id"))
 	}
 	for _, cert := range certs {
 		privateKey, err := decrypt(ctx, cert.PrivateKey, wrapper)
 		if err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to decrypt worker auth certificate"))
 		}
 		if cert.PrivateKey, err = encrypt(ctx, privateKey, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt worker auth certificate"))
 		}
 		cert.KeyId = newKeyVersionId
 		if _, err := writer.Update(ctx, cert, []string{"PrivateKey", "KeyId"}, nil); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update worker auth certificate row with rewrapped fields"))
 		}
 	}
 	return nil
@@ -47,11 +48,13 @@ func workerAuthCertRewrapFn(ctx context.Context, dataKeyVersionId string, scopeI
 func workerAuthRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "server.workerAuthRewrapFn"
 	var auths []*WorkerAuth
-	// an index exists on (worker_id, state), so we can query workers via scope and refine with key id. this is the fastest query
-	rows, err := reader.Query(ctx, workerAuthRewrapQuery, []interface{}{dataKeyVersionId, scopeId})
+	// An index exists on (worker_id, state), so we can query workers via scope and refine with key id.
+	// This is the fastest query we can use without creating a new index on key_id.
+	rows, err := reader.Query(ctx, workerAuthRewrapQuery, []interface{}{scopeId, dataKeyVersionId})
 	if err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query sql for rows that need rewrapping"))
 	}
+	defer rows.Close()
 	for rows.Next() {
 		workerAuth := allocWorkerAuth()
 		if err := rows.Scan(
@@ -59,33 +62,32 @@ func workerAuthRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, r
 			&workerAuth.ControllerEncryptionPrivKey,
 			&workerAuth.KeyId,
 		); err != nil {
-			_ = rows.Close()
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to scan row"))
 		}
 		auths = append(auths, workerAuth)
 	}
 	if err := rows.Err(); err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to iterate over retrieved rows"))
 	}
 	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to fetch kms wrapper for rewrapping"))
 	}
 	newKeyVersionId, err := wrapper.KeyId(ctx)
 	if err != nil {
-		return errors.Wrap(ctx, err, op)
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to retrieve updated key version id"))
 	}
 	for _, workerAuth := range auths {
 		privateKey, err := decrypt(ctx, workerAuth.ControllerEncryptionPrivKey, wrapper)
 		if err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to decrypt worker auth"))
 		}
 		if workerAuth.ControllerEncryptionPrivKey, err = encrypt(ctx, privateKey, wrapper); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to re-encrypt worker auth"))
 		}
 		workerAuth.KeyId = newKeyVersionId
 		if _, err := writer.Update(ctx, workerAuth, []string{"ControllerEncryptionPrivKey", "KeyId"}, nil); err != nil {
-			return errors.Wrap(ctx, err, op)
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to update worker auth row with rewrapped fields"))
 		}
 	}
 	return nil

--- a/internal/server/rewrapping.go
+++ b/internal/server/rewrapping.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/kms"
-	"github.com/hashicorp/boundary/internal/types/scope"
 )
 
 func init() {
@@ -14,17 +13,14 @@ func init() {
 	kms.RegisterTableRewrapFn("worker_auth_authorized", workerAuthRewrapFn)
 }
 
-func workerAuthCertRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func workerAuthCertRewrapFn(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "server.workerAuthCertRewrapFn"
-	repo, err := NewRepository(reader, writer, kmsRepo)
-	if err != nil {
-		return errors.Wrap(ctx, err, op)
-	}
 	var certs []*RootCertificate
-	if err := repo.reader.SearchWhere(ctx, &certs, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+	// indexes on public id, state. neither of which are queryable via scope. this is the fastest query
+	if err := reader.SearchWhere(ctx, &certs, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
-	wrapper, err := repo.kms.GetWrapper(ctx, scope.Global.String(), kms.KeyPurposeDatabase)
+	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
 	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
@@ -37,51 +33,58 @@ func workerAuthCertRewrapFn(ctx context.Context, dataKeyVersionId string, reader
 		if err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		ctPrivateKey, err := encrypt(ctx, privateKey, wrapper)
-		if err != nil {
+		if cert.PrivateKey, err = encrypt(ctx, privateKey, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
 		cert.KeyId = newKeyVersionId
-		cert.PrivateKey = ctPrivateKey
-		if _, err := repo.writer.Update(ctx, cert, []string{"PrivateKey", "KeyId"}, nil); err != nil {
+		if _, err := writer.Update(ctx, cert, []string{"PrivateKey", "KeyId"}, nil); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
 	}
 	return nil
 }
 
-func workerAuthRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func workerAuthRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
 	const op = "server.workerAuthRewrapFn"
-	repo, err := NewRepository(reader, writer, kmsRepo)
+	var auths []*WorkerAuth
+	// an index exists on (worker_id, state), so we can query workers via scope and refine with key id. this is the fastest query
+	rows, err := reader.Query(ctx, workerAuthRewrapQuery, []interface{}{dataKeyVersionId, scopeId})
 	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
-	var auths []*WorkerAuth
-	if err := repo.reader.SearchWhere(ctx, &auths, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+	for rows.Next() {
+		workerAuth := allocWorkerAuth()
+		if err := rows.Scan(
+			&workerAuth.WorkerKeyIdentifier,
+			&workerAuth.ControllerEncryptionPrivKey,
+			&workerAuth.KeyId,
+		); err != nil {
+			_ = rows.Close()
+			return errors.Wrap(ctx, err, op)
+		}
+		auths = append(auths, workerAuth)
+	}
+	if err := rows.Err(); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	wrapper, err := kmsRepo.GetWrapper(ctx, scopeId, kms.KeyPurposeDatabase)
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	newKeyVersionId, err := wrapper.KeyId(ctx)
+	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
 	for _, workerAuth := range auths {
-		worker, err := repo.LookupWorker(ctx, workerAuth.GetWorkerId())
-		if err != nil {
-			return errors.Wrap(ctx, err, op)
-		}
-		wrapper, err := repo.kms.GetWrapper(ctx, worker.GetScopeId(), kms.KeyPurposeDatabase)
-		if err != nil {
-			return errors.Wrap(ctx, err, op)
-		}
 		privateKey, err := decrypt(ctx, workerAuth.ControllerEncryptionPrivKey, wrapper)
 		if err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		workerAuth.ControllerEncryptionPrivKey, err = encrypt(ctx, privateKey, wrapper)
-		if err != nil {
+		if workerAuth.ControllerEncryptionPrivKey, err = encrypt(ctx, privateKey, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		workerAuth.KeyId, err = wrapper.KeyId(ctx)
-		if err != nil {
-			return errors.Wrap(ctx, err, op)
-		}
-		if _, err := repo.writer.Update(ctx, workerAuth, []string{"ControllerEncryptionPrivKey", "KeyId"}, nil); err != nil {
+		workerAuth.KeyId = newKeyVersionId
+		if _, err := writer.Update(ctx, workerAuth, []string{"ControllerEncryptionPrivKey", "KeyId"}, nil); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
 	}

--- a/internal/server/rewrapping.go
+++ b/internal/server/rewrapping.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"context"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/types/scope"
+)
+
+func init() {
+	kms.RegisterTableRewrapFn("worker_auth_ca_certificate", workerAuthCertRewrapFn)
+}
+
+func workerAuthCertRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+	const op = "server.workerAuthCertRewrapFn"
+	repo, err := NewRepository(reader, writer, kmsRepo)
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	var certs []*RootCertificate
+	if err := repo.reader.SearchWhere(ctx, &certs, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	wrapper, err := repo.kms.GetWrapper(ctx, scope.Global.String(), kms.KeyPurposeDatabase)
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	newKeyVersionId, err := wrapper.KeyId(ctx)
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	for _, cert := range certs {
+		privateKey, err := decrypt(ctx, cert.PrivateKey, wrapper)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		ctPrivateKey, err := encrypt(ctx, privateKey, wrapper)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		cert.KeyId = newKeyVersionId
+		cert.PrivateKey = ctPrivateKey
+		if _, err := repo.writer.Update(ctx, cert, []string{"PrivateKey", "KeyId"}, nil); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+	}
+	return nil
+}

--- a/internal/server/rewrapping_test.go
+++ b/internal/server/rewrapping_test.go
@@ -32,7 +32,7 @@ func TestRewrap_workerAuthCertRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, scope.Global.String()))
-	assert.NoError(t, workerAuthCertRewrapFn(ctx, currentRoot.KeyId, rw, rw, kmsCache))
+	assert.NoError(t, workerAuthCertRewrapFn(ctx, currentRoot.KeyId, scope.Global.String(), rw, rw, kmsCache))
 
 	// now we pull the certs back from the db, decrypt it with the new key, and ensure things match
 	got := allocRootCertificate()
@@ -78,7 +78,7 @@ func TestRewrap_workerAuthRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, scope.Global.String()))
-	assert.NoError(t, workerAuthRewrapFn(ctx, workerAuth.GetKeyId(), rw, rw, kmsCache))
+	assert.NoError(t, workerAuthRewrapFn(ctx, workerAuth.GetKeyId(), scope.Global.String(), rw, rw, kmsCache))
 
 	// now we pull the auth back from the db, decrypt it with the new key, and ensure things match
 	got := allocWorkerAuth()

--- a/internal/server/rewrapping_test.go
+++ b/internal/server/rewrapping_test.go
@@ -40,14 +40,12 @@ func TestRewrap_workerAuthCertRewrapFn(t *testing.T) {
 
 	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), scope.Global.String(), kms.KeyPurposeDatabase, kms.WithKeyId(got.GetKeyId()))
 	assert.NoError(t, err)
-	decryptedGotPrivKey, err := decrypt(ctx, got.GetPrivateKey(), kmsWrapper2)
-	assert.NoError(t, err)
-
 	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
 	assert.NoError(t, err)
 
-	// decryption occurs during Load, so we just want to make sure everything is expected
-	assert.Equal(t, currentRoot.State, got.State)
+	// decrypt with the new key version and check to make sure things match
+	decryptedGotPrivKey, err := decrypt(ctx, got.GetPrivateKey(), kmsWrapper2)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, got.GetKeyId())
 	assert.NotEqual(t, currentRoot.GetKeyId(), got.GetKeyId())
 	assert.Equal(t, newKeyVersionId, got.GetKeyId())
@@ -89,13 +87,12 @@ func TestRewrap_workerAuthRewrapFn(t *testing.T) {
 
 	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), worker.GetScopeId(), kms.KeyPurposeDatabase, kms.WithKeyId(got.GetKeyId()))
 	assert.NoError(t, err)
-	decryptedGotPrivKey, err := decrypt(ctx, got.ControllerEncryptionPrivKey, kmsWrapper2)
-	assert.NoError(t, err)
-
 	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
 	assert.NoError(t, err)
 
 	// decrypt with the new key version and check to make sure things match
+	decryptedGotPrivKey, err := decrypt(ctx, got.ControllerEncryptionPrivKey, kmsWrapper2)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, got.GetKeyId())
 	assert.NotEqual(t, workerAuth.GetKeyId(), got.GetKeyId())
 	assert.Equal(t, newKeyVersionId, got.GetKeyId())

--- a/internal/server/rewrapping_test.go
+++ b/internal/server/rewrapping_test.go
@@ -42,6 +42,54 @@ func TestRewrap_workerAuthCertRewrapFn(t *testing.T) {
 	// decryption occurs during Load, so we just want to make sure everything is expected
 	assert.Equal(t, roots.Current.Id, newRoots.Current.Id)
 	assert.Equal(t, roots.Current.PrivateKeyPkcs8, newRoots.Current.PrivateKeyPkcs8)
-	assert.NotEmpty(t, newRoots.GetWrappingKeyId())
+	// assert.NotEmpty(t, newRoots.GetWrappingKeyId())
 	assert.Equal(t, roots.GetWrappingKeyId(), newRoots.GetWrappingKeyId())
+}
+
+func TestRewrap_workerAuthRewrapFn(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	iam.TestScopes(t, iam.TestRepo(t, conn, wrapper)) // despite not looking like it, this is necessary for some reason
+
+	worker := TestPkiWorker(t, conn, wrapper)
+	kmsWrapper, err := kmsCache.GetWrapper(ctx, worker.GetScopeId(), kms.KeyPurposeDatabase)
+	assert.NoError(t, err)
+	currentKeyId, err := kmsWrapper.KeyId(ctx)
+	assert.NoError(t, err)
+	workerAuth := TestWorkerAuth(t, conn, worker, currentKeyId)
+
+	// TestWorkerAuth doesn't encrypt the entry, so do that really quick
+	controllerEncryptionPrivKey := workerAuth.ControllerEncryptionPrivKey
+	workerAuth.ControllerEncryptionPrivKey, err = encrypt(ctx, workerAuth.ControllerEncryptionPrivKey, kmsWrapper)
+	assert.NoError(t, err)
+	rows, err := rw.Update(ctx, workerAuth, []string{"ControllerEncryptionPrivKey"}, nil)
+	assert.Equal(t, 1, rows)
+	assert.NoError(t, err)
+
+	// now things are stored in the db, we can rotate and rewrap
+	assert.NoError(t, kmsCache.RotateKeys(ctx, scope.Global.String()))
+	assert.NoError(t, workerAuthRewrapFn(ctx, workerAuth.GetKeyId(), rw, rw, kmsCache))
+
+	// now we pull the auth back from the db, decrypt it with the new key, and ensure things match
+	got := allocWorkerAuth()
+	got.WorkerKeyIdentifier = workerAuth.WorkerKeyIdentifier
+	assert.NoError(t, rw.LookupById(ctx, got))
+
+	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), worker.GetScopeId(), kms.KeyPurposeDatabase, kms.WithKeyId(got.GetKeyId()))
+	assert.NoError(t, err)
+	decryptedGotPrivKey, err := decrypt(ctx, got.ControllerEncryptionPrivKey, kmsWrapper2)
+	assert.NoError(t, err)
+
+	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
+	assert.NoError(t, err)
+
+	// decrypt with the new key version and check to make sure things match
+	assert.NotEmpty(t, got.GetKeyId())
+	assert.NotEqual(t, workerAuth.GetKeyId(), got.GetKeyId())
+	assert.Equal(t, newKeyVersionId, got.GetKeyId())
+	assert.NotEqual(t, workerAuth.GetControllerEncryptionPrivKey(), got.GetControllerEncryptionPrivKey())
+	assert.Equal(t, controllerEncryptionPrivKey, decryptedGotPrivKey)
 }

--- a/internal/server/rewrapping_test.go
+++ b/internal/server/rewrapping_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/types/scope"
+	"github.com/hashicorp/nodeenrollment/rotation"
+	"github.com/hashicorp/nodeenrollment/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewrap_workerAuthCertRewrapFn(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	iam.TestScopes(t, iam.TestRepo(t, conn, wrapper)) // despite not looking like it, this is necessary for some reason
+
+	// create a repo and rotate to generate the first auth cert
+	workerAuthRepo, err := NewRepositoryStorage(ctx, rw, rw, kmsCache)
+	assert.NoError(t, err)
+	roots, err := rotation.RotateRootCertificates(ctx, workerAuthRepo)
+	assert.NoError(t, err)
+
+	currentRoot, err := workerAuthRepo.convertRootCertificate(ctx, roots.Current)
+	assert.NoError(t, err)
+
+	// now things are stored in the db, we can rotate and rewrap
+	err = kmsCache.RotateKeys(ctx, scope.Global.String())
+	assert.NoError(t, err)
+
+	err = workerAuthCertRewrapFn(ctx, currentRoot.KeyId, rw, rw, kmsCache)
+	assert.NoError(t, err)
+
+	// now we pull the certs back from the db, decrypt it with the new key, and ensure things match
+	newRoots := &types.RootCertificates{Id: CaId}
+	err = workerAuthRepo.Load(ctx, newRoots)
+	assert.NoError(t, err)
+	newRoots.Current.Id = string(CurrentState)
+	assert.NoError(t, err)
+
+	// decryption occurs during Load, so we just want to make sure everything is expected
+	assert.Equal(t, roots.Current.Id, newRoots.Current.Id)
+	assert.Equal(t, roots.Current.PrivateKeyPkcs8, newRoots.Current.PrivateKeyPkcs8)
+}

--- a/internal/session/credential.go
+++ b/internal/session/credential.go
@@ -12,10 +12,11 @@ import (
 type Credential []byte
 
 type credential struct {
-	SessionId    string
-	KeyId        string
-	Credential   []byte `gorm:"-" wrapping:"pt,credential_data"`
-	CtCredential []byte `gorm:"column:credential" wrapping:"ct,credential_data"`
+	SessionId        string `gorm:"index:,unique,composite:session_credential_session_id_credential_sha256_uq"`
+	KeyId            string
+	Credential       []byte `gorm:"-" wrapping:"pt,credential_data"`
+	CtCredential     []byte `gorm:"column:credential" wrapping:"ct,credential_data"`
+	CredentialSha256 []byte `gorm:"index:,unique,composite:session_credential_session_id_credential_sha256_uq"`
 }
 
 // TableName returns the table name.

--- a/internal/session/query.go
+++ b/internal/session/query.go
@@ -417,8 +417,8 @@ select distinct
 from session
   inner join session_credential cred
     on cred.session_id = session.public_id
-      and cred.key_id = ?
 where session.project_id = ?
+  and cred.key_id = ?
 `
 	sessionCredentialRewrapUpdate = `
 update session_credential

--- a/internal/session/query.go
+++ b/internal/session/query.go
@@ -408,6 +408,25 @@ and
 	session_state.start_time < wt_sub_seconds_from_now(@threshold_seconds)
 ;
 `
+	sessionCredentialRewrapQuery = `
+select distinct
+  cred.session_id,
+  cred.key_id,
+  cred.credential,
+  cred.credential_sha256
+from session
+  inner join session_credential cred
+    on cred.session_id = session.public_id
+      and cred.key_id = ?
+where session.project_id = ?
+`
+	sessionCredentialRewrapUpdate = `
+update session_credential
+	set credential = ?,
+		key_id = ?
+where session_id = ?
+	and credential_sha256 = ?;
+`
 )
 
 const (

--- a/internal/session/rewrapping.go
+++ b/internal/session/rewrapping.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/errors"
@@ -69,7 +68,6 @@ func sessionRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Rea
 		return errors.Wrap(ctx, err, op)
 	}
 	for _, session := range sessions {
-		fmt.Printf("session: %#v\n", session)
 		wrapper, err := repo.kms.GetWrapper(ctx, session.GetProjectId(), kms.KeyPurposeDatabase)
 		if err != nil {
 			return errors.Wrap(ctx, err, op)
@@ -80,7 +78,6 @@ func sessionRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Rea
 		if err := session.encrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}
-		fmt.Printf("updated: %#v\n", session)
 		if _, err := repo.writer.Update(ctx, session, []string{"CtTofuToken", "KeyId"}, nil); err != nil {
 			return errors.Wrap(ctx, err, op)
 		}

--- a/internal/session/rewrapping.go
+++ b/internal/session/rewrapping.go
@@ -1,0 +1,57 @@
+package session
+
+import (
+	"context"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/kms"
+)
+
+func init() {
+	kms.RegisterTableRewrapFn("session_credential", sessionCredentialRewrapFn)
+}
+
+func sessionCredentialRewrapFn(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+	const op = "session.sessionCredentialRewrapFn"
+	repo, err := NewRepository(ctx, reader, writer, kmsRepo, WithLimit(-1))
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	var creds []*credential
+	if err := repo.reader.SearchWhere(ctx, &creds, "key_id=?", []interface{}{dataKeyVersionId}, db.WithLimit(-1)); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	for _, cred := range creds {
+		session, _, err := repo.LookupSession(ctx, cred.SessionId)
+		// check for session nil? technically shouldn't be possible according to db fk
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		wrapper, err := repo.kms.GetWrapper(ctx, session.GetProjectId(), kms.KeyPurposeDatabase)
+		if err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if err := cred.decrypt(ctx, wrapper); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if err := cred.encrypt(ctx, wrapper); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+		if _, err := repo.writer.Exec(ctx, `
+update session_credential
+	set credential = ?,
+		key_id = ?
+where session_id = ?
+	and credential_sha256 = ?;
+		`, []interface{}{
+			cred.CtCredential,
+			cred.KeyId,
+			cred.SessionId,
+			cred.CredentialSha256,
+		}); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+	}
+	return nil
+}

--- a/internal/session/rewrapping_test.go
+++ b/internal/session/rewrapping_test.go
@@ -72,19 +72,18 @@ func TestRewrap_sessionCredentialRewrapFn(t *testing.T) {
 	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.KeyId))
 	assert.NoError(t, err)
 
-	err = got.decrypt(ctx, kmsWrapper2)
-	assert.NoError(t, err)
-
 	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
 	assert.NoError(t, err)
 
 	// decrypt with the new key version and check to make sure things match
+	assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
 	assert.NotEmpty(t, got.KeyId)
 	assert.NotEqual(t, cred.KeyId, got.KeyId)
 	assert.Equal(t, newKeyVersionId, got.KeyId)
 	assert.Equal(t, "secret", string(got.Credential))
 	assert.NotEmpty(t, got.CredentialSha256)
 	assert.NotEqual(t, cred.CredentialSha256, got.CredentialSha256)
+	assert.NotEqual(t, cred.CtCredential, got.CtCredential)
 }
 
 func TestRewrap_sessionRewrapFn(t *testing.T) {
@@ -131,15 +130,15 @@ func TestRewrap_sessionRewrapFn(t *testing.T) {
 	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.KeyId))
 	assert.NoError(t, err)
 
-	assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
-
 	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
 	assert.NoError(t, err)
 
 	// decrypt with the new key version and check to make sure things match
+	assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
 	assert.NotEmpty(t, got.KeyId)
 	assert.NotEqual(t, session.KeyId, got.KeyId)
 	assert.Equal(t, newKeyVersionId, got.KeyId)
 	assert.Equal(t, "token", string(got.TofuToken))
+	assert.NotEqual(t, session.CtTofuToken, got.CtTofuToken)
 	// there is no hmac, so we're done
 }

--- a/internal/session/rewrapping_test.go
+++ b/internal/session/rewrapping_test.go
@@ -52,7 +52,7 @@ func TestRewrap_sessionCredentialRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
-	assert.NoError(t, sessionCredentialRewrapFn(ctx, cred.KeyId, rw, rw, kmsCache))
+	assert.NoError(t, sessionCredentialRewrapFn(ctx, cred.KeyId, prj.PublicId, rw, rw, kmsCache))
 
 	// now we pull the credential back from the db, decrypt it with the new key, and ensure things match
 	got := &credential{
@@ -120,7 +120,7 @@ func TestRewrap_sessionRewrapFn(t *testing.T) {
 
 	// now things are stored in the db, we can rotate and rewrap
 	assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
-	assert.NoError(t, sessionRewrapFn(ctx, session.KeyId, rw, rw, kmsCache))
+	assert.NoError(t, sessionRewrapFn(ctx, session.KeyId, prj.PublicId, rw, rw, kmsCache))
 
 	// now we pull the session back from the db, decrypt it with the new key, and ensure things match
 	got := &Session{}

--- a/internal/session/rewrapping_test.go
+++ b/internal/session/rewrapping_test.go
@@ -1,0 +1,88 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/authtoken"
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/host/static"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/target"
+	"github.com/hashicorp/boundary/internal/target/tcp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewrap_sessionCredentialRewrapFn(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	rw := db.New(conn)
+
+	org, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	at := authtoken.TestAuthToken(t, conn, kmsCache, org.GetPublicId())
+	uId := at.GetIamUserId()
+	hc := static.TestCatalogs(t, conn, prj.GetPublicId(), 1)[0]
+	hs := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
+	h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
+	static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
+	tar := tcp.TestTarget(ctx, t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
+	sess := TestSession(t, conn, wrapper, ComposedOf{
+		UserId:      uId,
+		HostId:      h.GetPublicId(),
+		TargetId:    tar.GetPublicId(),
+		HostSetId:   hs.GetPublicId(),
+		AuthTokenId: at.GetPublicId(),
+		ProjectId:   prj.GetPublicId(),
+		Endpoint:    "tcp://127.0.0.1:22",
+	})
+
+	cred := &credential{
+		SessionId:  sess.PublicId,
+		Credential: []byte("secret"),
+	}
+
+	kmsWrapper, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase)
+	assert.NoError(t, err)
+
+	assert.NoError(t, cred.encrypt(ctx, kmsWrapper))
+	assert.NoError(t, rw.Create(ctx, cred))
+
+	// now things are stored in the db, we can rotate and rewrap
+	assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
+	assert.NoError(t, sessionCredentialRewrapFn(ctx, cred.KeyId, rw, rw, kmsCache))
+
+	// now we pull the credential back from the db, decrypt it with the new key, and ensure things match
+	got := &credential{
+		SessionId: sess.PublicId,
+	}
+	// this is the best way we have to query for this. there's only one index on this table and it's on session id and sha256. since we're testing there should be no others.
+	rows, err := rw.Query(ctx, `select credential, key_id, credential_sha256 from session_credential where session_id = ?`, []interface{}{got.SessionId})
+	assert.NoError(t, err)
+	rowCount := 0
+
+	for rows.Next() {
+		rowCount++
+		assert.NoError(t, rows.Scan(&got.CtCredential, &got.KeyId, &got.CredentialSha256))
+	}
+	assert.Equal(t, 1, rowCount)
+
+	kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.KeyId))
+	assert.NoError(t, err)
+
+	err = got.decrypt(ctx, kmsWrapper2)
+	assert.NoError(t, err)
+
+	newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
+	assert.NoError(t, err)
+
+	// decrypt with the new key version and check to make sure things match
+	assert.NotEmpty(t, got.KeyId)
+	assert.NotEqual(t, cred.KeyId, got.KeyId)
+	assert.Equal(t, newKeyVersionId, got.KeyId)
+	assert.Equal(t, "secret", string(got.Credential))
+	assert.NotEmpty(t, got.CredentialSha256)
+	assert.NotEqual(t, cred.CredentialSha256, got.CredentialSha256)
+}


### PR DESCRIPTION
- [x] ALL 12 REWRAPS DONE
- [x] update sql files to include `updated in 56/05_mutable_ciphertext_columns.up.sql` message
- [x] fix root cert test

root cert pk change has been moved to [boundary#2542](https://github.com/hashicorp/boundary/pull/2542) <img src="https://emoji.slack-edge.com/TF1GCKJNM/merged-intensifies/8d585e215a72515a.gif" width="24px" title="merged-intensifies"/>