### PR TITLE
fix(bats): Fix flakiness in sessions.bats tests

### DIFF
--- a/internal/tests/cli/boundary/_connect.bash
+++ b/internal/tests/cli/boundary/_connect.bash
@@ -1,4 +1,5 @@
 function connect_nc() {
   local id=$1
+  # Note: When this command returns, the session immediately goes into a "canceling" state
   echo "foo" | boundary connect -exec nc -target-id $id -- {{boundary.ip}} {{boundary.port}}
 }

--- a/internal/tests/cli/boundary/_sessions.bash
+++ b/internal/tests/cli/boundary/_sessions.bash
@@ -1,11 +1,11 @@
 load _authorized_actions
 
-function list_sessions() {
-  boundary sessions list -scope-id $1 -format json
+function list_sessions_include_terminated() {
+  boundary sessions list -scope-id $1 -include-terminated -format json
 }
 
-function count_sessions() {
-  list_sessions $1 | jq '.items | length'
+function count_sessions_include_terminated() {
+  list_sessions_include_terminated $1 | jq '.items | length'
 }
 
 function cancel_session() {

--- a/internal/tests/cli/boundary/sessions.bats
+++ b/internal/tests/cli/boundary/sessions.bats
@@ -7,6 +7,7 @@ load _helpers
 
 @test "boundary/session: admin user can connect to default target" {
   run login $DEFAULT_LOGIN
+  echo "$output"
   [ "$status" -eq 0 ]
 
   run connect_nc $DEFAULT_TARGET
@@ -21,11 +22,11 @@ load _helpers
 
 @test "boundary/session/connect: unpriv user can connect to default target" {
   run login $DEFAULT_UNPRIVILEGED_LOGIN
-  echo $output
+  echo "$output"
   [ "$status" -eq 0 ]
 
   run connect_nc $DEFAULT_TARGET
-  echo $output
+  echo "$output"
   [ "$status" -eq 0 ]
 
   # Run twice so we have two values for later testing
@@ -39,15 +40,18 @@ load _helpers
 # So for now, verify they're not the same.
 @test "boundary/session: verify admin and unpriv user see different counts" {
   run login $DEFAULT_UNPRIVILEGED_LOGIN
+  echo "$output"
   [ "$status" -eq 0 ]
 
-  run count_sessions $DEFAULT_P_ID
+  run count_sessions_include_terminated $DEFAULT_P_ID
+  echo "Number of sessions (unpriv): $output"
   [ "$status" -eq 0 ]
   unpriv_sessions="$output"
 
   run login $DEFAULT_LOGIN
   [ "$status" -eq 0 ]
-  run count_sessions $DEFAULT_P_ID
+  run count_sessions_include_terminated $DEFAULT_P_ID
+  echo "Number of sessions (admin): $output"
   [ "$status" -eq 0 ]
   admin_sessions="$output"
 
@@ -57,8 +61,10 @@ load _helpers
 @test "boundary/session: verify read and cancellation permissions on admin session" {
   # Find an admin session
   run login $DEFAULT_LOGIN
+  echo "$output"
   [ "$status" -eq 0 ]
-  run list_sessions $DEFAULT_P_ID
+  run list_sessions_include_terminated $DEFAULT_P_ID
+  echo "$output"
   [ "$status" -eq 0 ]
   id=$(echo "$output" | jq -r "[.items[]|select(.user_id == \"$DEFAULT_USER\")][0].id")
 
@@ -74,19 +80,20 @@ load _helpers
   run login $DEFAULT_LOGIN
   [ "$status" -eq 0 ]
   run read_session $id
+  echo "$output"
   [ "$status" -eq 0 ]
-  echo $output
+  echo "$output"
   run cancel_session $id
   [ "$status" -eq 0 ]
-  echo $output
+  echo "$output"
 }
 
 @test "boundary/session: verify read and cancellation permissions on unpriv session" {
   # Find an unpriv session
   run login $DEFAULT_UNPRIVILEGED_LOGIN
   [ "$status" -eq 0 ]
-  run list_sessions $DEFAULT_P_ID
-  echo $output
+  run list_sessions_include_terminated $DEFAULT_P_ID
+  echo "$output"
   [ "$status" -eq 0 ]
   id=$(echo "$output" | jq -r "[.items[]|select(.user_id == \"$DEFAULT_UNPRIVILEGED_USER\")][0].id")
 


### PR DESCRIPTION
The `sessions.bats` tests were seeing some flaky tests due to the following reasons...
```
   boundary/session: verify read and cancellation permissions on un... 93/149 ✗ boundary/session: verify read and cancellation permissions on unpriv session
   (in test file boundary/sessions.bats, line 91)
     `id=$(echo "$output" | jq -r "[.items[]|select(.user_id == \"$DEFAULT_UNPRIVILEGED_USER\")][0].id")' failed with status 5
   {"status_code":200,"items":null}
   jq: error (at <stdin>:1): Cannot iterate over null (null)
```
```
boundary/session: verify admin and unpriv user see different counts 91/149 ✗ boundary/session: verify admin and unpriv user see different counts
   (in test file boundary/sessions.bats, line 54)
     `[ "$unpriv_sessions" -lt "$admin_sessions" ]' failed
```

After some investigation, it appeared that listing sessions was not returning the expected amount back all of the time. This seems to be due to the `connect_nc` command that is currently used, which executes...
```
echo "foo" | boundary connect -exec nc -target-id $id -- {{boundary.ip}} {{boundary.port}}
```
However, when that command returns, the session immediately goes to a `canceling` state, which at some point, will enter a `terminated` state. This can cause subsequent operations to get unexpected results.

This PR changes the test to include terminated sessions when listing sessions. There will be a follow-up PR to port some of the bats tests around canceling sessions to the e2e test suite in order to more accurately test that functionality (right now, those tests are canceling sessions that are already canceling).