### PR TITLE
Add scopeId to RewrapFn

### DIFF
--- a/internal/kms/rewrapping.go
+++ b/internal/kms/rewrapping.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-type RewrapFn func(ctx context.Context, dataKeyVersionId string, reader db.Reader, writer db.Writer, kms *Kms) error
+type RewrapFn func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms *Kms) error
 
 var tableNameToRewrapFn = map[string]RewrapFn{}
 


### PR DESCRIPTION
This makes it much easier for rewrap functions to look up the correct wrapper and limit the number of rows searched.