### PR TITLE
Update Root Cert Proto Definition

### DIFF
--- a/internal/proto/controller/storage/servers/store/v1/root_certificate.proto
+++ b/internal/proto/controller/storage/servers/store/v1/root_certificate.proto
@@ -34,7 +34,7 @@ message RootCertificate {
   storage.timestamp.v1.Timestamp not_valid_after = 40;
 
   // The public key associated with this certificate
-  // @inject_tag: `gorm:"not_null"`
+  // @inject_tag: `gorm:"primary_key"`
   bytes public_key = 50;
 
   // The private key associated with this certificate

--- a/internal/server/store/root_certificate.pb.go
+++ b/internal/server/store/root_certificate.pb.go
@@ -99,8 +99,8 @@ type RootCertificate struct {
 	// Not valid after is the timestamp at which this certificate's validity period ends
 	NotValidAfter *timestamp.Timestamp `protobuf:"bytes,40,opt,name=not_valid_after,json=notValidAfter,proto3" json:"not_valid_after,omitempty"`
 	// The public key associated with this certificate
-	// @inject_tag: `gorm:"not_null"`
-	PublicKey []byte `protobuf:"bytes,50,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty" gorm:"not_null"`
+	// @inject_tag: `gorm:"primary_key"`
+	PublicKey []byte `protobuf:"bytes,50,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty" gorm:"primary_key"`
 	// The private key associated with this certificate
 	// This is a ciphertext field
 	// @inject_tag: `gorm:"not_null"`

--- a/internal/server/workerauth_store_test.go
+++ b/internal/server/workerauth_store_test.go
@@ -218,8 +218,7 @@ func TestRootCertStore(t *testing.T) {
 				assert.Empty(cmp.Diff(tt.expectedRootCert, cert, protocmp.Transform()))
 			}
 
-			deleteWhere := `state = ?`
-			deleted, err := rw.Delete(ctx, &RootCertificate{}, db.WithWhere(deleteWhere, cert.State))
+			deleted, err := rw.Exec(ctx, `delete from worker_auth_ca_certificate where state = ?`, []interface{}{cert.State})
 			assert.NoError(err)
 			assert.Equal(1, deleted)
 		})


### PR DESCRIPTION
update root cert proto definition to properly identify public_key as the table primary key

the [pk already exists](https://github.com/hashicorp/boundary/blob/main/internal/db/schema/migrations/oss/postgres/34/03_worker_authentication.up.sql#L53) in sql, just not in the proto file