### PR TITLE
Fix two items:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Canonical reference for changes, improvements, and bugfixes for Boundary.
 
+## Next
+
+### Bug Fixes
+
+* sessions: Fix workers not being in random order when returned to clients at
+  `authorize-session` time, which could allow one worker to bear the majority of
+  sessions ([PR](https://github.com/hashicorp/boundary/pull/2544))
+* workers: In some error conditions when sending status to controllers, errors
+  could be written to stdout along with a message that they could not
+  successfully be evented instead of being written to the event log
+  ([PR](https://github.com/hashicorp/boundary/pull/2544))
+
 ## 0.11.0 (2022/09/27)
 
 ### Known Issues
@@ -20,7 +32,6 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### Bug Fixes
 
-* Fix bug preventing delete of org. ([PR](https://github.com/hashicorp/boundary/pull/2465)
 * scopes: Organizations could be prevented from being deleted if some resources
     remained ([PR](https://github.com/hashicorp/boundary/pull/2465))
 * workers: Authentication rotation could occur prior to the expected time

--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -703,6 +703,11 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 			"No workers are available to handle this session, or all have been filtered.")
 	}
 
+	// Randomize the workers
+	rand.Shuffle(len(selectedWorkers), func(i, j int) {
+		selectedWorkers[i], selectedWorkers[j] = selectedWorkers[j], selectedWorkers[i]
+	})
+
 	requestedId := req.GetHostId()
 	staticHostRepo, err := s.staticHostRepoFn()
 	if err != nil {

--- a/internal/daemon/worker/status.go
+++ b/internal/daemon/worker/status.go
@@ -158,7 +158,7 @@ func (w *Worker) sendWorkerStatus(cancelCtx context.Context, sessionManager sess
 	keyId := w.WorkerAuthCurrentKeyId.Load()
 
 	if w.conf.RawConfig.Worker.Name == "" && keyId == "" {
-		event.WriteError(statusCtx, op, errors.New("worker name and keyId are both empty; one is needed to identify a worker"),
+		event.WriteError(cancelCtx, op, errors.New("worker name and keyId are both empty; one is needed to identify a worker"),
 			event.WithInfoMsg("error making status request to controller"))
 	}
 	versionInfo := version.Get()
@@ -176,7 +176,7 @@ func (w *Worker) sendWorkerStatus(cancelCtx context.Context, sessionManager sess
 		UpdateTags: w.updateTags.Load(),
 	})
 	if err != nil {
-		event.WriteError(statusCtx, op, err, event.WithInfoMsg("error making status request to controller"))
+		event.WriteError(cancelCtx, op, err, event.WithInfoMsg("error making status request to controller"))
 		// Check for last successful status. Ignore nil last status, this probably
 		// means that we've never connected to a controller, and as such probably
 		// don't have any sessions to worry about anyway.
@@ -186,7 +186,7 @@ func (w *Worker) sendWorkerStatus(cancelCtx context.Context, sessionManager sess
 		// scenario, as there will be no way we can really tell if these
 		// connections should continue to exist.
 		if isPastGrace, lastStatusTime, gracePeriod := w.isPastGrace(); isPastGrace {
-			event.WriteError(statusCtx, op,
+			event.WriteError(cancelCtx, op,
 				errors.New("status error grace period has expired, canceling all sessions on worker"),
 				event.WithInfo("last_status_time", lastStatusTime.String(), "grace_period", gracePeriod),
 			)
@@ -275,7 +275,7 @@ func (w *Worker) sendWorkerStatus(cancelCtx context.Context, sessionManager sess
 				sessionId := sessInfo.GetSessionId()
 				si := sessionManager.Get(sessionId)
 				if si == nil {
-					event.WriteError(statusCtx, op, errors.New("session change requested but could not find local information for it"), event.WithInfo("session_id", sessionId))
+					event.WriteError(cancelCtx, op, errors.New("session change requested but could not find local information for it"), event.WithInfo("session_id", sessionId))
 					continue
 				}
 				si.ApplyLocalStatus(sessInfo.GetStatus())
@@ -284,7 +284,7 @@ func (w *Worker) sendWorkerStatus(cancelCtx context.Context, sessionManager sess
 				// the request.
 				for _, conn := range sessInfo.GetConnections() {
 					if err := si.ApplyLocalConnectionStatus(conn.GetConnectionId(), conn.GetStatus()); err != nil {
-						event.WriteError(statusCtx, op, err, event.WithInfo("connection_id", conn.GetConnectionId()))
+						event.WriteError(cancelCtx, op, err, event.WithInfo("connection_id", conn.GetConnectionId()))
 					}
 				}
 			}


### PR DESCRIPTION
* Randomize order of worker output. This uses the standard rand.Shuffle() call; cribbed from https://pkg.go.dev/math/rand#example-Shuffle
* Have some error/eventing in the worker status path use the base context instead of the status-call-specific context to allow eventing after a timeout event