### PR TITLE
Rewrapping Registered Tables Test

### DIFF
--- a/internal/credential/static/query.go
+++ b/internal/credential/static/query.go
@@ -1,0 +1,40 @@
+package static
+
+const (
+	credStaticUsernamePasswordRewrapQuery = `
+select distinct
+  userpass.public_id,
+  userpass.password_encrypted,
+  userpass.key_id
+from credential_static_username_password_credential userpass
+  inner join credential_static_store store
+    on store.public_id = userpass.store_id
+where store.project_id = ?
+  and userpass.key_id = ?;
+`
+
+	credStaticSshPrivKeyRewrapQuery = `
+select distinct
+  ssh.public_id,
+  ssh.private_key_encrypted,
+  ssh.private_key_passphrase_encrypted,
+  ssh.key_id
+from credential_static_ssh_private_key_credential ssh
+  inner join credential_static_store store
+    on store.public_id = ssh.store_id
+where store.project_id = ?
+  and ssh.key_id = ?;
+`
+
+	credStaticJsonRewrapQuery = `
+select distinct
+  json.public_id,
+  json.object_encrypted,
+  json.key_id
+from credential_static_json_credential json
+  inner join credential_static_store store
+    on store.public_id = json.store_id
+where store.project_id = ?
+  and json.key_id = ?;
+`
+)

--- a/internal/daemon/controller/rewrapping_test.go
+++ b/internal/daemon/controller/rewrapping_test.go
@@ -1,0 +1,58 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/assert"
+)
+
+func SliceContains(slice []string, item string) bool {
+	for _, i := range slice {
+		if item == i {
+			return true
+		}
+	}
+	return false
+}
+
+func Test_AllRewrapTablesRegistered(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	extWrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, extWrapper)
+
+	tables, err := kmsCache.ListDataKeyVersionReferencers(ctx)
+	assert.NoError(t, err)
+
+	var filteredTables []string
+	// there are some tables we know won't be rewrapped
+	for _, table := range tables {
+		// oplog entries cannot be rewrapped at this time
+		if table == "oplog_entry" {
+			continue
+		}
+		// kms_data_key_version_destruction_job does not contain encrypte data, only a reference to the key versions
+		if table == "kms_data_key_version_destruction_job" {
+			continue
+		}
+
+		// all other tables should be registered
+		filteredTables = append(filteredTables, table)
+	}
+
+	registeredTables := kms.ListTablesSupportingRewrap()
+
+	// first things first, make sure we have the same number of expected values.
+	assert.Equal(t, len(filteredTables), len(registeredTables), "the number of registered rewrap functions does not match the number of tables that contain encrypted data.")
+
+	// then make sure that all of the tables that need rewrap funcs registered actually have them.
+	for _, table := range filteredTables {
+		// do this in a loop so that we can explicitly call out which tables are missing, if any are.
+		assert.True(t, SliceContains(registeredTables, table), fmt.Sprintf("%s doesn't have a rewrap function registered!", table))
+	}
+}

--- a/internal/daemon/controller/rewrapping_test.go
+++ b/internal/daemon/controller/rewrapping_test.go
@@ -2,22 +2,14 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/stretchr/testify/assert"
 )
-
-func SliceContains(slice []string, item string) bool {
-	for _, i := range slice {
-		if item == i {
-			return true
-		}
-	}
-	return false
-}
 
 func Test_AllRewrapTablesRegistered(t *testing.T) {
 	t.Parallel()
@@ -36,7 +28,7 @@ func Test_AllRewrapTablesRegistered(t *testing.T) {
 		if table == "oplog_entry" {
 			continue
 		}
-		// kms_data_key_version_destruction_job does not contain encrypte data, only a reference to the key versions
+		// kms_data_key_version_destruction_job does not contain encrypted data, only a reference to the key versions
 		if table == "kms_data_key_version_destruction_job" {
 			continue
 		}
@@ -45,14 +37,5 @@ func Test_AllRewrapTablesRegistered(t *testing.T) {
 		filteredTables = append(filteredTables, table)
 	}
 
-	registeredTables := kms.ListTablesSupportingRewrap()
-
-	// first things first, make sure we have the same number of expected values.
-	assert.Equal(t, len(filteredTables), len(registeredTables), "the number of registered rewrap functions does not match the number of tables that contain encrypted data.")
-
-	// then make sure that all of the tables that need rewrap funcs registered actually have them.
-	for _, table := range filteredTables {
-		// do this in a loop so that we can explicitly call out which tables are missing, if any are.
-		assert.True(t, SliceContains(registeredTables, table), fmt.Sprintf("%s doesn't have a rewrap function registered!", table))
-	}
+	assert.Empty(t, cmp.Diff(filteredTables, kms.ListTablesSupportingRewrap(), cmpopts.SortSlices(func(i, j string) bool { return i < j })), "At least one table referencing a data key does not have a rewrapping function registered")
 }

--- a/internal/db/schema/migrations/oss/postgres/48/01_worker_auth_activation_token.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/48/01_worker_auth_activation_token.up.sql
@@ -24,6 +24,7 @@ create table worker_auth_server_led_activation_token(
 comment on table worker_auth_server_led_activation_token is
   'worker_auth_server_led_activation_token is a table where each row represents an activation token for a worker. Only one activation token is allowed per worker.';
 
+-- this trigger is updated in 56/05_mutable_ciphertext_columns.up.sql
 create trigger immutable_columns before update on worker_auth_server_led_activation_token
   for each row execute procedure immutable_columns('worker_id', 'token_id', 'creation_time_encrypted');
 

--- a/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
@@ -32,4 +32,11 @@ begin;
   create trigger immutable_columns before update on worker_auth_authorized
     for each row execute function immutable_columns('worker_key_identifier', 'worker_id', 'worker_signing_pub_key', 'worker_encryption_pub_key', 'nonce', 'create_time');
 
+
+  -- With the addition of the registered tables test, we found one more table that needs its encrypted column made mutable
+  drop trigger immutable_columns on worker_auth_server_led_activation_token;
+
+  create trigger immutable_columns before update on worker_auth_server_led_activation_token
+    for each row execute procedure immutable_columns('worker_id', 'token_id');
+
 commit;

--- a/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/56/05_mutable_ciphertext_columns.up.sql
@@ -33,7 +33,6 @@ begin;
     for each row execute function immutable_columns('worker_key_identifier', 'worker_id', 'worker_signing_pub_key', 'worker_encryption_pub_key', 'nonce', 'create_time');
 
 
-  -- With the addition of the registered tables test, we found one more table that needs its encrypted column made mutable
   drop trigger immutable_columns on worker_auth_server_led_activation_token;
 
   create trigger immutable_columns before update on worker_auth_server_led_activation_token

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -269,6 +269,26 @@ func (k *Kms) RotateKeys(ctx context.Context, scopeId string, opt ...Option) err
 	return nil
 }
 
+// ListDataKeyVersionReferencers will list the names of all tables
+// referencing the private_id column of the data key version table.
+// Supported options:
+//   - WithTx
+func (k *Kms) ListDataKeyVersionReferencers(ctx context.Context, opt ...Option) ([]string, error) {
+	const op = "kms.(Kms).ListDataKeyVersionReferencers"
+
+	opts := getOpts(opt...)
+	kmsOpts := []wrappingKms.Option{
+		// underlying key version refs function supports WithReaderWriter option, but the interfaces don't match and can't be passed
+		wrappingKms.WithTx(opts.withTx),
+	}
+
+	refs, err := k.underlying.ListDataKeyVersionReferencers(ctx, kmsOpts...)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
+	return refs, nil
+}
+
 // VerifyGlobalRoot will verify that the global root wrapper is reasonable.
 func (k *Kms) VerifyGlobalRoot(ctx context.Context) error {
 	const op = "kms.(Kms).VerifyGlobalRoot"

--- a/internal/server/query.go
+++ b/internal/server/query.go
@@ -34,4 +34,15 @@ const (
 		where worker.scope_id = ?
 			and auth.key_id = ?
 	`
+	workerAuthServerLedActivationTokenRewrapQuery = `
+		select distinct
+			auth_token.worker_id,
+			auth_token.creation_time_encrypted,
+			auth_token.key_id
+		from server_worker worker
+			inner join worker_auth_server_led_activation_token auth_token
+				on auth_token.worker_id = worker.public_id
+		where worker.scope_id = ?
+			and auth_token.key_id = ?
+	`
 )

--- a/internal/server/worker_auth_server_led_activation_token_test.go
+++ b/internal/server/worker_auth_server_led_activation_token_test.go
@@ -94,13 +94,6 @@ func TestWorkerAuthActivationTokenConstraints(t *testing.T) {
 			},
 			wantErrContains: "immutable column: worker_auth_server_led_activation_token.token_id: integrity violation",
 		},
-		{
-			name: "modify-create-time",
-			updateModifyFn: func(t *testing.T, in *WorkerAuthServerLedActivationToken) (string, []any) {
-				return "update worker_auth_server_led_activation_token set creation_time_encrypted = ? where worker_id = ?", []any{in.CreationTimeEncrypted[0:5], in.WorkerId}
-			},
-			wantErrContains: "immutable column: worker_auth_server_led_activation_token.creation_time_encrypted: integrity violation",
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
- [added new rewrapping test to check that all encrypted tables have assigned rewrapping functions](https://github.com/hashicorp/boundary/pull/2555/files#diff-deb54d5881ef6b4457f12626325966134e5902bb01da879c15278be1ec0be50b)
- [added ListDataKeyVersionReferencers function to kms](https://github.com/hashicorp/boundary/pull/2555/files#diff-65fa95abdd78accdc6b1f3ac98751fe4700c8abc1ee696b8d6ae7e5403af0831)
- added new rewrapping functions on [`credential_static_json_credential`](https://github.com/hashicorp/boundary/pull/2555/files#diff-231e7485c6e362d7d68a2bd4c5ba36aa93f2b77923cb51c656b1ecbb2d728f01R102) ([test](https://github.com/hashicorp/boundary/pull/2555/files#diff-af94db4dbe7299f4cf0e078eab23a2b9a10abf0007a9d1926589483efc4d2543)) and [`worker_auth_server_led_activation_token`](https://github.com/hashicorp/boundary/pull/2555/files#diff-fea1b2d017b7f403426fa6d599f13ff1887d46be49590033ab4a9edd5d5ca7d3) ([test](https://github.com/hashicorp/boundary/pull/2555/files#diff-43bdf027bdb2e76c372553b3c3c9e94924f7c389a70c3570e88c6197c77d27bf))
- [modified existing rewrap functions on `credential_static_username_password_credential` and `credential_static_ssh_private_key_credential` to use faster retrieval queries](https://github.com/hashicorp/boundary/pull/2555/files#diff-fe0cea8b0c88467266daedbb720cc258f14eff2392a485224d62b3798b75e42d) (found while making json cred rewrapfn)

## psql output for `credential_static_store` showing references for credential lookups:
```
boundary_test_gfmaerwwxwhtgcmv=# \d+ credential_static_store
                                Table "public.credential_static_store"
   Column    |      Type      | Collation | Nullable | Default | Storage  | Stats target | Description 
-------------+----------------+-----------+----------+---------+----------+--------------+-------------
 public_id   | wt_public_id   |           | not null |         | extended |              | 
 project_id  | wt_scope_id    |           | not null |         | extended |              | 
 name        | wt_name        |           |          |         | extended |              | 
 description | wt_description |           |          |         | extended |              | 
 create_time | wt_timestamp   |           |          |         | plain    |              | 
 update_time | wt_timestamp   |           |          |         | plain    |              | 
 version     | wt_version     |           |          |         | plain    |              | 
Indexes:
    "credential_static_store_pkey" PRIMARY KEY, btree (public_id)
    "credential_static_store_project_id_name_uq" UNIQUE CONSTRAINT, btree (project_id, name)
Foreign-key constraints:
    "credential_store_fkey" FOREIGN KEY (project_id, public_id) REFERENCES credential_store(project_id, public_id) ON UPDATE CASCADE ON DELETE CASCADE
Referenced by:
    TABLE "credential_static_username_password_credential" CONSTRAINT "credential_static_store_fkey" FOREIGN KEY (store_id) REFERENCES credential_static_store(public_id) ON UPDATE CASCADE ON DELETE CASCADE
    TABLE "credential_static_ssh_private_key_credential" CONSTRAINT "credential_static_store_fkey" FOREIGN KEY (store_id) REFERENCES credential_static_store(public_id) ON UPDATE CASCADE ON DELETE CASCADE
    TABLE "credential_static_json_credential" CONSTRAINT "credential_static_store_fkey" FOREIGN KEY (store_id) REFERENCES credential_static_store(public_id) ON UPDATE CASCADE ON DELETE CASCADE
Triggers:
    default_create_time_column BEFORE INSERT ON credential_static_store FOR EACH ROW EXECUTE PROCEDURE default_create_time()
    delete_credential_store_subtype AFTER DELETE ON credential_static_store FOR EACH ROW EXECUTE PROCEDURE delete_credential_store_subtype()
    immutable_columns BEFORE UPDATE ON credential_static_store FOR EACH ROW EXECUTE PROCEDURE immutable_columns('public_id', 'project_id', 'create_time')
    insert_credential_store_subtype BEFORE INSERT ON credential_static_store FOR EACH ROW EXECUTE PROCEDURE insert_credential_store_subtype()
    update_time_column BEFORE UPDATE ON credential_static_store FOR EACH ROW EXECUTE PROCEDURE update_time_column()
    update_version_column AFTER UPDATE ON credential_static_store FOR EACH ROW EXECUTE PROCEDURE update_version_column()
```

## Query plan(s) for old vs new credential lookup queries
new plan:
```
                                                                          QUERY PLAN                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=4.31..21.86 rows=1 width=280)
   ->  Bitmap Heap Scan on credential_static_store store  (cost=4.16..9.50 rows=2 width=32)
         Recheck Cond: ((project_id)::text = ''::text)
         ->  Bitmap Index Scan on credential_static_store_project_id_name_uq  (cost=0.00..4.16 rows=2 width=0)
               Index Cond: ((project_id)::text = ''::text)
   ->  Index Scan using credential_static_json_credential_store_id_public_id_uq on credential_static_json_credential json  (cost=0.15..6.17 rows=1 width=280)
         Index Cond: ((store_id)::text = (store.public_id)::text)
         Filter: ((key_id)::text = ''::text)
(8 rows)
```
old plan:
```
                                     QUERY PLAN                                     
------------------------------------------------------------------------------------
 Seq Scan on credential_static_json_credential  (cost=0.00..13.25 rows=1 width=280)
   Filter: ((key_id)::text = ''::text)
(2 rows)
```