### PR TITLE
Ensure all secret updates include key ID

### DIFF
--- a/internal/auth/oidc/repository_auth_method_update.go
+++ b/internal/auth/oidc/repository_auth_method_update.go
@@ -227,10 +227,10 @@ func (r *Repository) UpdateAuthMethod(ctx context.Context, am *AuthMethod, versi
 	// ClientSecret is a bit odd, because it uses the Struct wrapping, we need
 	// to add the encrypted fields to the dbMask or nullFields
 	if strutil.StrListContains(filteredDbMask, ClientSecretField) {
-		filteredDbMask = append(filteredDbMask, CtClientSecretField, ClientSecretHmacField)
+		filteredDbMask = append(filteredDbMask, CtClientSecretField, ClientSecretHmacField, KeyIdField)
 	}
 	if strutil.StrListContains(filteredNullFields, ClientSecretField) {
-		filteredNullFields = append(filteredNullFields, CtClientSecretField, ClientSecretHmacField)
+		filteredNullFields = append(filteredNullFields, CtClientSecretField, ClientSecretHmacField, KeyIdField)
 	}
 
 	databaseWrapper, err := r.kms.GetWrapper(ctx, origAm.ScopeId, kms.KeyPurposeDatabase)

--- a/internal/auth/password/repository_password.go
+++ b/internal/auth/password/repository_password.go
@@ -81,7 +81,7 @@ func (r *Repository) Authenticate(ctx context.Context, scopeId, authMethodId, lo
 			return acct.Account, errors.Wrap(ctx, err, op, errors.WithCode(errors.Encrypt), errors.WithMsg("update credential"))
 		}
 
-		fields := []string{"CtSalt", "DerivedKey", "PasswordConfId"}
+		fields := []string{"CtSalt", "DerivedKey", "PasswordConfId", "KeyId"}
 		metadata := cred.oplog(oplog.OpType_OP_TYPE_UPDATE)
 
 		_, err = r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{},

--- a/internal/credential/static/repository_credential.go
+++ b/internal/credential/static/repository_credential.go
@@ -410,7 +410,7 @@ func (r *Repository) UpdateUsernamePasswordCredential(ctx context.Context,
 			}
 
 			// Set PasswordHmac and CtPassword masks for update.
-			dbMask = append(dbMask, "PasswordHmac", "CtPassword")
+			dbMask = append(dbMask, "PasswordHmac", "CtPassword", "KeyId")
 		}
 	}
 
@@ -531,6 +531,7 @@ func (r *Repository) UpdateSshPrivateKeyCredential(ctx context.Context,
 				}
 			}
 
+			dbMask = append(dbMask, "KeyId")
 			if strings.EqualFold(privateKeyField, f) {
 				// Set PrivateKeyHmac and PrivateKeyEncrypted masks for update.
 				dbMask = append(dbMask, "PrivateKeyHmac", "PrivateKeyEncrypted")
@@ -672,7 +673,7 @@ func (r *Repository) UpdateJsonCredential(ctx context.Context,
 		}
 
 		// Set ObjectHmac and ObjectEncrypted masks for update.
-		dbMask = append(dbMask, "ObjectHmac", "ObjectEncrypted")
+		dbMask = append(dbMask, "ObjectHmac", "ObjectEncrypted", "KeyId")
 	}
 
 	oplogWrapper, err := r.kms.GetWrapper(ctx, projectId, kms.KeyPurposeOplog)

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -493,7 +493,7 @@ func (r *Repository) ActivateSession(ctx context.Context, sessionId string, sess
 			if err := updatedSession.encrypt(ctx, databaseWrapper); err != nil {
 				return errors.Wrap(ctx, err, op)
 			}
-			rowsUpdated, err := w.Update(ctx, &updatedSession, []string{"CtTofuToken"}, nil)
+			rowsUpdated, err := w.Update(ctx, &updatedSession, []string{"CtTofuToken", "KeyId"}, nil)
 			if err != nil {
 				return errors.Wrap(ctx, err, op)
 			}

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -493,7 +493,7 @@ func (r *Repository) ActivateSession(ctx context.Context, sessionId string, sess
 			if err := updatedSession.encrypt(ctx, databaseWrapper); err != nil {
 				return errors.Wrap(ctx, err, op)
 			}
-			rowsUpdated, err := w.Update(ctx, &updatedSession, []string{"CtTofuToken", "KeyId"}, nil)
+			rowsUpdated, err := w.Update(ctx, &updatedSession, []string{"CtTofuToken"}, nil)
 			if err != nil {
 				return errors.Wrap(ctx, err, op)
 			}


### PR DESCRIPTION
When updating a secret, it is paramount that the key ID is also updated, as it is the only means we have of ensuring that we only destroy keys once there is no more data associated with the key.

I used three different methods for finding instances of secret updates:

1. Audit all uses of `(db.Writer).Update` manually for updates of secrets.
2. (As a backup) audit all uses of `kms.GetWrapper(ctx, <scopeId>, kms.KeyPurpose)` for all key purposes.
3. (As a backup) search for all instances of `update xxx set` to find any extra SQL literal statements.

The test I've added shows a scenario where we would end up with irrecoverable data without these fixes.