### PR TITLE
docs: Remove redundant word

### DIFF
--- a/website/content/docs/what-is-boundary.mdx
+++ b/website/content/docs/what-is-boundary.mdx
@@ -18,7 +18,7 @@ HashiCorp Boundary is a tool for managing identity-based access for modern, dyna
 Boundary's foundation is based on the following important concepts.
 
 - **Zero Trust Security:** Zero-Trust is an identity-based access model where the user access is continuously authenticated. Access is only authorized when the established rules and policies tied to the user’s identity are verified.
-- **Consistent Workflow for Access:** Once the user is verified and granted access, Boundary securely connects the user securely to their infrastructure regardless of cloud platform, target environment, or identity provider. This foundation provides continuous user authentication and authorization workflows within ephemeral sessions, which administrators can monitor and manage securely.
+- **Consistent Workflow for Access:** Once the user is verified and granted access, Boundary securely connects the user to their infrastructure regardless of cloud platform, target environment, or identity provider. This foundation provides continuous user authentication and authorization workflows within ephemeral sessions, which administrators can monitor and manage securely.
 - **Extensibility with the Ecosystem:** Modern organizations often require a multilayered access matrix constructed of identity providers, policy engines, secrets management tools, target types, and cloud providers that integrate and allow users to reside within access workflows requiring vendor lock-in. Boundary does not require vendor lock-in and supports the user's vendor-of-choice.
 
 ![Boundary workflow](/img/boundary.png)


### PR DESCRIPTION
in the topic "[What is Boundary](https://developer.hashicorp.com/boundary/docs/what-is-boundary)", the bullet point for _Consistent Workflow for Access_ uses the word "securely" twice:

> Boundary securely connects the user securely to their infrastructure regardless of cloud platform

This PR suggests removing the second instance.