### PR TITLE
docs(db): fix comments on database functions

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/12/01_timestamp_sub_funcs.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/12/01_timestamp_sub_funcs.up.sql
@@ -1,5 +1,9 @@
 begin;
 
+  -- The 'comment on function' statements below are not for the functions in the
+  -- file. They incorrectly override the comments for functions declared in
+  -- 7/01_functions.up.sql. Fixes are contained in 57/01_fix_comments.up.sql.
+
     create function wt_sub_seconds(sec integer, ts timestamp with time zone) returns timestamp with time zone
     as $$
     select ts - sec * '1 second'::interval;

--- a/internal/db/schema/migrations/oss/postgres/57/01_fix_comments.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/57/01_fix_comments.up.sql
@@ -1,0 +1,12 @@
+begin;
+
+  -- Restores the correct comments originally defined in 7/01_functions.up.sql
+  -- but incorrectly overridden in 12/01_timestamp_sub_funcs.up.sql.
+  comment on function wt_add_seconds is 'wt_add_seconds returns ts + sec.';
+  comment on function wt_add_seconds_to_now is 'wt_add_seconds_to_now returns current_timestamp + sec.';
+
+  -- Sets comments for functions defined in 12/01_timestamp_sub_funcs.up.sql.
+  comment on function wt_sub_seconds is 'wt_sub_seconds returns ts - sec.';
+  comment on function wt_sub_seconds_from_now is 'wt_sub_seconds_from_now returns current_timestamp - sec.';
+
+commit;

--- a/internal/db/schema/migrations/oss/postgres/7/01_functions.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/7/01_functions.up.sql
@@ -1,5 +1,8 @@
 begin;
 
+  -- Comments for the functions below were incorrectly overridden in
+  -- 12/01_timestamp_sub_funcs.up.sql but fixed in 57/01_fix_comments.up.sql.
+
     create function wt_add_seconds(sec integer, ts timestamp with time zone) returns timestamp with time zone
     as $$
     select ts + sec * '1 second'::interval;


### PR DESCRIPTION
Fixes the comments on functions wt_add_seconds, wt_add_seconds_to_now, wt_sub_seconds, and wt_sub_seconds_from_now which were the tragic victims of a copypasta error.