### PR TITLE
docs(db): fix comments on oidc database tables

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/2/04_oidc.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/2/04_oidc.up.sql
@@ -158,6 +158,7 @@ create table auth_oidc_account (
     constraint auth_oidc_account_auth_method_id_public_id_uq
       unique(auth_method_id, public_id)
 );
+-- Comment fixed in 57/01_fix_comments.up.sql
 comment on table auth_oidc_method is
 'auth_oidc_account entries are subtypes of auth_account and represent an oidc account.';
 

--- a/internal/db/schema/migrations/oss/postgres/57/01_fix_comments.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/57/01_fix_comments.up.sql
@@ -9,4 +9,10 @@ begin;
   comment on function wt_sub_seconds is 'wt_sub_seconds returns ts - sec.';
   comment on function wt_sub_seconds_from_now is 'wt_sub_seconds_from_now returns current_timestamp - sec.';
 
+  -- Fixes incorrect comments in 2/04_oidc.up.sql
+  comment on table auth_oidc_method is
+    'auth_oidc_method entries are the current oidc auth methods configured for existing scopes.';
+  comment on table auth_oidc_account is
+    'auth_oidc_account entries are subtypes of auth_account and represent an oidc account.';
+
 commit;


### PR DESCRIPTION
Fixes the comments on the auth_oidc_method and auth_oidc_account tables.