### PR TITLE
docs(db): fix comments on kms database tables

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/30/04_kms_keys.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/30/04_kms_keys.up.sql
@@ -101,6 +101,7 @@ create table kms_data_key_version (
   constraint kms_data_key_version_data_key_id_version_uq
     unique(data_key_id, version)
 );
+-- Comment fixed in 57/01_fix_comments.up.sql
 comment on table kms_data_key is
   'kms_data_key_version contains versions of a kms_data_key (dek aka data keys)';
 

--- a/internal/db/schema/migrations/oss/postgres/57/01_fix_comments.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/57/01_fix_comments.up.sql
@@ -15,4 +15,10 @@ begin;
   comment on table auth_oidc_account is
     'auth_oidc_account entries are subtypes of auth_account and represent an oidc account.';
 
+  -- Fixes incorrect comments in 30/04_kms_keys.up.sql
+  comment on table kms_data_key is
+    'kms_data_key contains deks (data keys) for specific purposes';
+  comment on table kms_data_key_version is
+    'kms_data_key_version contains versions of a kms_data_key (dek aka data keys)';
+
 commit;


### PR DESCRIPTION
Fixes the comments on the kms_data_key and kms_data_key_version tables.