### PR TITLE
docs(db): fix comments on database domain types

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/0/01_domain_types.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/0/01_domain_types.up.sql
@@ -18,6 +18,7 @@ create domain wt_scope_id as text
 check(
   length(trim(value)) > 10 or value = 'global'
 );
+-- Comment fixed in 57/01_fix_comments.up.sql
 comment on domain wt_scope_id is
 '"global" or random ID generated with github.com/hashicorp/go-secure-stdlib/base62';
 
@@ -25,6 +26,7 @@ create domain wt_user_id as text not null
 check(
   length(trim(value)) > 10 or value = 'u_anon' or value = 'u_auth' or value = 'u_recovery'
 );
+-- Comment fixed in 57/01_fix_comments.up.sql
 comment on domain wt_scope_id is
 '"u_anon", "u_auth", or random ID generated with github.com/hashicorp/go-secure-stdlib/base62';
 
@@ -32,6 +34,7 @@ create domain wt_role_id as text not null
 check(
   length(trim(value)) > 10
 );
+-- Comment fixed in 57/01_fix_comments.up.sql
 comment on domain wt_scope_id is
 'Random ID generated with github.com/hashicorp/go-secure-stdlib/base62';
 

--- a/internal/db/schema/migrations/oss/postgres/57/01_fix_comments.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/57/01_fix_comments.up.sql
@@ -21,4 +21,14 @@ begin;
   comment on table kms_data_key_version is
     'kms_data_key_version contains versions of a kms_data_key (dek aka data keys)';
 
+  -- Fixes incorrect comments in 0/01_domain_types.up.sql
+  comment on domain wt_scope_id is
+    '"global" or random ID generated with github.com/hashicorp/go-secure-stdlib/base62';
+
+  comment on domain wt_user_id is
+    '"u_anon", "u_auth", or random ID generated with github.com/hashicorp/go-secure-stdlib/base62';
+
+  comment on domain wt_role_id is
+    'Random ID generated with github.com/hashicorp/go-secure-stdlib/base62';
+
 commit;


### PR DESCRIPTION
Fixes the comments on the wt_scope_id, wt_user_id, and wt_role_id domain types.