### PR TITLE
Docs deploy and login updates

### DIFF
--- a/website/content/docs/getting-started/connect-to-target.mdx
+++ b/website/content/docs/getting-started/connect-to-target.mdx
@@ -5,7 +5,7 @@ description: |-
   Connecting to your first target
 ---
 
-## Connect to Your First Target
+# Connect to Your First Target
 
 The [Quick setup
 wizard](/docs/getting-started/deploy-and-login#login-to-hcp-boundary)
@@ -20,6 +20,8 @@ provided during setup. When `boundary connect` is executed against the **EC2 Ins
 authenticated proxy to the host is established on the target's default port.
 
 ![Setup Wizard](/img/quick-start-targets.png)
+
+## Connect using the CLI
 
 To connect to the initial EC2 Instances target:
 

--- a/website/content/docs/getting-started/deploy-and-login.mdx
+++ b/website/content/docs/getting-started/deploy-and-login.mdx
@@ -43,8 +43,8 @@ To deploy an HCP Boundary instance:
 1. Navigate to [HashiCorp Cloud Platform](https://portal.cloud.hashicorp.com/)
    and login using your credentials.
 
-1. Click the **Boundary (Beta)** tab, and then and click **Deploy Boundary** on
-   the right-hand pane.
+1. Click the **Boundary** tab, and then and click **Deploy Boundary** on the
+   right-hand pane.
 
 1. Fill out the following form details:
 

--- a/website/content/docs/getting-started/deploy-and-login.mdx
+++ b/website/content/docs/getting-started/deploy-and-login.mdx
@@ -113,8 +113,8 @@ HCP Boundary instance.
 
 ```shell-session
 $ boundary authenticate password \
-   -auth-method-id=COPIED_AUTH_ID \
-   -login-name=ADMIN_USERNAME
+   -auth-method-id=<boundary-auth-method-id> \
+   -login-name=<boundary-admin-username>
 ```
 
 You are now logged into your HCP Boundary instance's Global scope via the CLI.

--- a/website/content/docs/getting-started/deploy-and-login.mdx
+++ b/website/content/docs/getting-started/deploy-and-login.mdx
@@ -5,6 +5,8 @@ description: |-
   How to deploy HCP Boundary services and login for the first time.
 ---
 
+## Deploy HCP Boundary and Login
+
 HCP Boundary provides secure access to remote hosts and infrastructure
 endpoints. Boundary enables secure connectivity to cloud service catalogs,
 on-premise infrastructure, and Kubernetes clusters without needing to manage any
@@ -29,7 +31,7 @@ If you prefer to get started on your local machine, refer to [Run and Login in
 Dev Mode](/docs/oss/installing/run-and-login). For more information on Boundary
 OSS and self-managed installations, refer to [Boundary OSS](/docs/oss).
 
-# Deploy an HCP Boundary Instance
+## Deploy an HCP Boundary Cluster
 
 HCP Boundary is a fully-managed cloud-based workflow. It enables secure access
 to remote hosts and critical systems across cloud service catalogs, on-premises

--- a/website/content/docs/getting-started/deploy-and-login.mdx
+++ b/website/content/docs/getting-started/deploy-and-login.mdx
@@ -5,7 +5,7 @@ description: |-
   How to deploy HCP Boundary services and login for the first time.
 ---
 
-## Deploy HCP Boundary and Login
+# Deploy HCP Boundary and Login
 
 HCP Boundary provides secure access to remote hosts and infrastructure
 endpoints. Boundary enables secure connectivity to cloud service catalogs,

--- a/website/content/docs/getting-started/deploy-and-login.mdx
+++ b/website/content/docs/getting-started/deploy-and-login.mdx
@@ -33,11 +33,6 @@ OSS and self-managed installations, refer to [Boundary OSS](/docs/oss).
 
 ## Deploy an HCP Boundary Cluster
 
-HCP Boundary is a fully-managed cloud-based workflow. It enables secure access
-to remote hosts and critical systems across cloud service catalogs, on-premises
-infrastructure, and Kubernetes clusters without needing to manage any of the
-underlying systems or operations.
-
 To deploy an HCP Boundary instance:
 
 1. Navigate to [HashiCorp Cloud Platform](https://portal.cloud.hashicorp.com/)

--- a/website/content/docs/getting-started/deploy-and-login.mdx
+++ b/website/content/docs/getting-started/deploy-and-login.mdx
@@ -102,13 +102,13 @@ authenticate to HCP Boundary using the CLI.
 
 1. In the HCP Boundary portal, open the **Boundary Overview** page, and click
 the **copy icon** in the **Copy this into Boundary Desktop** section. This
-copies your environment’s Boundary **Origin URL**.
+copies your environment’s Boundary **Cluster URL**.
 
 1. Open a terminal session and set the `BOUNDARY_ADDR` environment variable to
-the copied origin URL.
+the copied Cluster URL.
 
 ```shell-session
-$ export BOUNDARY_ADDR=<boundary-origin-url>
+$ export BOUNDARY_ADDR=<boundary-cluster-url>
 ```
 
 1. Log in with the administrator credentials you created when you deployed the
@@ -147,15 +147,15 @@ connect to HCP Boundary.
 To get started with Boundary Desktop:
 
 1. Install Boundary Desktop.
-1. Enter your HCP Boundary instance’s origin URL.
+1. Enter your HCP Boundary instance’s Cluster URL.
 1. Enter the login name and password.
 
 To authenticate using the Boundary desktop client, launch Boundary desktop
-client and connect to boundary to using your environment's **Origin URL**.
+client and connect to boundary to using your environment's **Cluster URL**.
 
-You can find your environment’s origin url In the HCP portal. Open the
+You can find your environment’s Cluster URL In the HCP portal. Open the
 **Boundary Overview** page and click the **copy icon** in the **Copy this into
-Boundary Desktop** section. This copies your environment’s Boundary **Origin
+Boundary Desktop** section. This copies your environment’s Boundary **Cluster
 URL**.
 
 The admin username and password from instance creation can be used for initial
@@ -185,7 +185,7 @@ Boundary](https://registry.terraform.io/providers/hashicorp/boundary):
 
 ```hcl
 provider "boundary" {
-    base_url             = "hcp-boundary-origin-url"
+    base_url             = "hcp-boundary-cluster-url"
     auth_method_id       = "auth-method-id"
     auth_method_username = "admin-username"
     auth_method_password = "admin-password"
@@ -196,7 +196,7 @@ To find your environment’s `base_url`:
 
 1. In the HCP portal, open the **Boundary Overview** page.
 1. Click the **copy icon** in the **Copy this into Boundary Desktop** section.
-   This copies your environment’s Boundary **Origin URL**.
+   This copies your environment’s Boundary **Cluster URL**.
 
 To find your environment’s default `auth_method_id`:
 


### PR DESCRIPTION
This PR updates the `/docs/getting-started/deploy-and-login` page:

- fixes h1 header issue
- replaces Origin URL with Cluster URL
- removes references to Beta
- removes content duplicated in the dev-portal page sub-heading
- fixes various code snippet styles

This PR updates the `/docs/getting-started/connect-to-target` page:

- Changes the header to an h1
- Adds an additional section header for clarity