### PR TITLE
test(e2e): Add more checks in credential store tests

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -26,9 +26,9 @@ jobs:
       matrix:
         include:
           - filter: 'integration test:cli_ui'
-          - filter: 'e2e_credential_vault'
-          - filter: 'e2e_host_aws'
-          - filter: 'e2e_host_static'
+          - filter: 'e2e_aws'
+          - filter: 'e2e_static'
+          - filter: 'e2e_static_with_vault'
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}
@@ -123,7 +123,7 @@ jobs:
         run: |
           wget https://releases.hashicorp.com/vault/1.11.4/vault_1.11.4_linux_amd64.zip -O /tmp/test-deps/vault.zip
       - name: Install Vault for integration testing
-        if: matrix.filter == 'e2e_credential_vault'
+        if: matrix.filter == 'e2e_static_with_vault'
         run: |
           unzip /tmp/test-deps/vault.zip -d /usr/local/bin
       - name: Download Linux AMD64 Boundary bundle

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -1,4 +1,5 @@
-scenario "e2e_credential_vault" {
+# This scenario requires access to the boundary team's test AWS account
+scenario "e2e_aws" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
@@ -79,29 +80,50 @@ scenario "e2e_credential_vault" {
     }
   }
 
-  step "create_vault_cluster" {
-    module = module.vault
-    depends_on = [
-      step.create_base_infra,
-    ]
+  step "create_tag1" {
+    module = module.random_stringifier
+  }
+
+  step "create_tag1_inputs" {
+    module     = module.generate_aws_host_tag_vars
+    depends_on = [step.create_tag1]
 
     variables {
-      ami_id            = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      instance_type     = var.vault_instance_type
-      instance_count    = 1
-      kms_key_arn       = step.create_base_infra.kms_key_arn
-      storage_backend   = "raft"
-      sg_additional_ips = step.create_boundary_cluster.controller_ips
-      unseal_method     = "awskms"
-      vault_release = {
-        version = "1.12.0"
-        edition = "oss"
-      }
-      vpc_id = step.create_base_infra.vpc_id
+      tag_name  = step.create_tag1.string
+      tag_value = "true"
     }
   }
 
-  step "create_target" {
+  step "create_targets_with_tag1" {
+    module     = module.target
+    depends_on = [step.create_base_infra]
+
+    variables {
+      ami_id               = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      aws_ssh_keypair_name = var.aws_ssh_keypair_name
+      enos_user            = var.enos_user
+      instance_type        = var.target_instance_type
+      vpc_id               = step.create_base_infra.vpc_id
+      target_count         = 2
+      additional_tags      = step.create_tag1_inputs.tag_map
+    }
+  }
+
+  step "create_tag2" {
+    module = module.random_stringifier
+  }
+
+  step "create_tag2_inputs" {
+    module     = module.generate_aws_host_tag_vars
+    depends_on = [step.create_tag2]
+
+    variables {
+      tag_name  = step.create_tag2.string
+      tag_value = "test"
+    }
+  }
+
+  step "create_targets_with_tag2" {
     module     = module.target
     depends_on = [step.create_base_infra]
 
@@ -112,6 +134,27 @@ scenario "e2e_credential_vault" {
       instance_type        = var.target_instance_type
       vpc_id               = step.create_base_infra.vpc_id
       target_count         = 1
+      additional_tags      = step.create_tag2_inputs.tag_map
+    }
+  }
+
+  step "create_test_id" {
+    module = module.random_stringifier
+    variables {
+      length = 5
+    }
+  }
+
+  step "iam_setup" {
+    module = module.iam_setup
+    depends_on = [
+      step.create_base_infra,
+      step.create_test_id
+    ]
+
+    variables {
+      test_id    = step.create_test_id.string
+      test_email = var.test_email
     }
   }
 
@@ -119,22 +162,26 @@ scenario "e2e_credential_vault" {
     module = module.test_e2e
     depends_on = [
       step.create_boundary_cluster,
-      step.create_target,
-      step.create_vault_cluster
+      step.create_targets_with_tag1,
+      step.create_targets_with_tag2,
+      step.iam_setup
     ]
 
     variables {
-      test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/credential/vault"
+      test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/aws"
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name
       auth_password            = step.create_boundary_cluster.auth_password
       local_boundary_dir       = local.local_boundary_dir
       aws_ssh_private_key_path = local.aws_ssh_private_key_path
-      target_ip                = step.create_target.target_ips[0]
       target_user              = "ubuntu"
-      vault_addr               = step.create_vault_cluster.instance_public_ips[0]
-      vault_root_token         = step.create_vault_cluster.vault_root_token
+      aws_access_key_id        = step.iam_setup.access_key_id
+      aws_secret_access_key    = step.iam_setup.secret_access_key
+      aws_host_set_filter1     = step.create_tag1_inputs.tag_string
+      aws_host_set_ips1        = step.create_targets_with_tag1.target_ips
+      aws_host_set_filter2     = step.create_tag2_inputs.tag_string
+      aws_host_set_ips2        = step.create_targets_with_tag2.target_ips
     }
   }
 

--- a/enos/enos-scenario-e2e-static-with-vault.hcl
+++ b/enos/enos-scenario-e2e-static-with-vault.hcl
@@ -1,4 +1,4 @@
-scenario "e2e_host_static" {
+scenario "e2e_static_with_vault" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
@@ -79,6 +79,28 @@ scenario "e2e_host_static" {
     }
   }
 
+  step "create_vault_cluster" {
+    module = module.vault
+    depends_on = [
+      step.create_base_infra,
+    ]
+
+    variables {
+      ami_id            = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      instance_type     = var.vault_instance_type
+      instance_count    = 1
+      kms_key_arn       = step.create_base_infra.kms_key_arn
+      storage_backend   = "raft"
+      sg_additional_ips = step.create_boundary_cluster.controller_ips
+      unseal_method     = "awskms"
+      vault_release = {
+        version = "1.12.0"
+        edition = "oss"
+      }
+      vpc_id = step.create_base_infra.vpc_id
+    }
+  }
+
   step "create_target" {
     module     = module.target
     depends_on = [step.create_base_infra]
@@ -97,11 +119,12 @@ scenario "e2e_host_static" {
     module = module.test_e2e
     depends_on = [
       step.create_boundary_cluster,
-      step.create_target
+      step.create_target,
+      step.create_vault_cluster
     ]
 
     variables {
-      test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/host/static"
+      test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/static_with_vault"
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name
@@ -110,6 +133,8 @@ scenario "e2e_host_static" {
       aws_ssh_private_key_path = local.aws_ssh_private_key_path
       target_ip                = step.create_target.target_ips[0]
       target_user              = "ubuntu"
+      vault_addr               = step.create_vault_cluster.instance_public_ips[0]
+      vault_root_token         = step.create_vault_cluster.vault_root_token
     }
   }
 

--- a/enos/enos-scenario-e2e-static.hcl
+++ b/enos/enos-scenario-e2e-static.hcl
@@ -1,5 +1,4 @@
-# This scenario requires access to the boundary team's test AWS account
-scenario "e2e_host_aws" {
+scenario "e2e_static" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
@@ -80,50 +79,7 @@ scenario "e2e_host_aws" {
     }
   }
 
-  step "create_tag1" {
-    module = module.random_stringifier
-  }
-
-  step "create_tag1_inputs" {
-    module     = module.generate_aws_host_tag_vars
-    depends_on = [step.create_tag1]
-
-    variables {
-      tag_name  = step.create_tag1.string
-      tag_value = "true"
-    }
-  }
-
-  step "create_targets_with_tag1" {
-    module     = module.target
-    depends_on = [step.create_base_infra]
-
-    variables {
-      ami_id               = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      aws_ssh_keypair_name = var.aws_ssh_keypair_name
-      enos_user            = var.enos_user
-      instance_type        = var.target_instance_type
-      vpc_id               = step.create_base_infra.vpc_id
-      target_count         = 2
-      additional_tags      = step.create_tag1_inputs.tag_map
-    }
-  }
-
-  step "create_tag2" {
-    module = module.random_stringifier
-  }
-
-  step "create_tag2_inputs" {
-    module     = module.generate_aws_host_tag_vars
-    depends_on = [step.create_tag2]
-
-    variables {
-      tag_name  = step.create_tag2.string
-      tag_value = "test"
-    }
-  }
-
-  step "create_targets_with_tag2" {
+  step "create_target" {
     module     = module.target
     depends_on = [step.create_base_infra]
 
@@ -134,27 +90,6 @@ scenario "e2e_host_aws" {
       instance_type        = var.target_instance_type
       vpc_id               = step.create_base_infra.vpc_id
       target_count         = 1
-      additional_tags      = step.create_tag2_inputs.tag_map
-    }
-  }
-
-  step "create_test_id" {
-    module = module.random_stringifier
-    variables {
-      length = 5
-    }
-  }
-
-  step "iam_setup" {
-    module = module.iam_setup
-    depends_on = [
-      step.create_base_infra,
-      step.create_test_id
-    ]
-
-    variables {
-      test_id    = step.create_test_id.string
-      test_email = var.test_email
     }
   }
 
@@ -162,26 +97,19 @@ scenario "e2e_host_aws" {
     module = module.test_e2e
     depends_on = [
       step.create_boundary_cluster,
-      step.create_targets_with_tag1,
-      step.create_targets_with_tag2,
-      step.iam_setup
+      step.create_target
     ]
 
     variables {
-      test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/host/aws"
+      test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/static"
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name
       auth_password            = step.create_boundary_cluster.auth_password
       local_boundary_dir       = local.local_boundary_dir
       aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      target_ip                = step.create_target.target_ips[0]
       target_user              = "ubuntu"
-      aws_access_key_id        = step.iam_setup.access_key_id
-      aws_secret_access_key    = step.iam_setup.secret_access_key
-      aws_host_set_filter1     = step.create_tag1_inputs.tag_string
-      aws_host_set_ips1        = step.create_targets_with_tag1.target_ips
-      aws_host_set_filter2     = step.create_tag2_inputs.tag_string
-      aws_host_set_ips2        = step.create_targets_with_tag2.target_ips
     }
   }
 

--- a/testing/internal/e2e/tests/aws/dynamichostcatalog_test.go
+++ b/testing/internal/e2e/tests/aws/dynamichostcatalog_test.go
@@ -42,10 +42,10 @@ func loadConfig() (*config, error) {
 	return &c, err
 }
 
-// TestCreateAwsDynamicHostCatalogCli uses the boundary cli to create a host catalog with the AWS
+// TestCliCreateAwsDynamicHostCatalog uses the boundary cli to create a host catalog with the AWS
 // plugin. The test sets up an AWS dynamic host catalog, creates some host sets, sets up a target to
 // one of the host sets, and attempts to connect to the target.
-func TestCreateAwsDynamicHostCatalogCli(t *testing.T) {
+func TestCliCreateAwsDynamicHostCatalog(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)
@@ -263,10 +263,10 @@ func TestCreateAwsDynamicHostCatalogCli(t *testing.T) {
 	require.True(t, hostIpInList, fmt.Sprintf("Connected host (%s) is not in expected list (%s)", hostIp, targetIps1))
 }
 
-// TestCreateAwsDynamicHostCatalogApi uses the Go api to create a host catalog with the AWS plugin.
+// TestApiCreateAwsDynamicHostCatalog uses the Go api to create a host catalog with the AWS plugin.
 // The test sets up an AWS dynamic host catalog, creates a host set, and sets up a target to the
 // host set.
-func TestCreateAwsDynamicHostCatalogApi(t *testing.T) {
+func TestApiCreateAwsDynamicHostCatalog(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/static/connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/static/connect_authz_token_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestConnectTargetWithAuthzTokenCli uses the boundary cli to connect to a target using the
+// TestCliConnectTargetWithAuthzToken uses the boundary cli to connect to a target using the
 // `authz_token` option
-func TestConnectTargetWithAuthzTokenCli(t *testing.T) {
+func TestCliConnectTargetWithAuthzToken(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/static/connect_test.go
+++ b/testing/internal/e2e/tests/static/connect_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestConnectTargetCli uses the boundary cli to create a number of supporting objects
+// TestCliConnectTarget uses the boundary cli to create a number of supporting objects
 // to connect to a target. It then attempts to connect to that target and verifies that
 // the connection was successful.
-func TestConnectTargetCli(t *testing.T) {
+func TestCliConnectTarget(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)
@@ -51,26 +51,4 @@ func TestConnectTargetCli(t *testing.T) {
 	hostIp := parts[len(parts)-1]
 	require.Equal(t, c.TargetIp, hostIp, "SSH session did not return expected output")
 	t.Log("Successfully connected to target")
-}
-
-// TestCreateTargetApi uses the Go api to create a number of supporting objects
-// to connect to a target. This test does not connect to the target due to the complexity
-// when not using the cli.
-func TestCreateTargetApi(t *testing.T) {
-	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
-	require.NoError(t, err)
-
-	client, err := boundary.NewApiClient()
-	require.NoError(t, err)
-	ctx := context.Background()
-
-	newOrgId := boundary.CreateNewOrgApi(t, ctx, client)
-	newProjectId := boundary.CreateNewProjectApi(t, ctx, client, newOrgId)
-	newHostCatalogId := boundary.CreateNewHostCatalogApi(t, ctx, client, newProjectId)
-	newHostSetId := boundary.CreateNewHostSetApi(t, ctx, client, newHostCatalogId)
-	newHostId := boundary.CreateNewHostApi(t, ctx, client, newHostCatalogId, c.TargetIp)
-	boundary.AddHostToHostSetApi(t, ctx, client, newHostSetId, newHostId)
-	newTargetId := boundary.CreateNewTargetApi(t, ctx, client, newProjectId, c.TargetPort)
-	boundary.AddHostSourceToTargetApi(t, ctx, client, newTargetId, newHostSetId)
 }

--- a/testing/internal/e2e/tests/static/credential_store_test.go
+++ b/testing/internal/e2e/tests/static/credential_store_test.go
@@ -4,18 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/boundary/api/credentials"
+	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestStaticCredentialStoreCli validates various credential-store operations using the cli
-func TestStaticCredentialStoreCli(t *testing.T) {
+// TestCliStaticCredentialStore validates various credential-store operations using the cli
+func TestCliStaticCredentialStore(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)
@@ -94,4 +97,56 @@ func TestStaticCredentialStoreCli(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Logf("Successfully deleted credential store")
+}
+
+// TestApiStaticCredentialStore uses the Go api to create a credential using
+// boundary's built-in credential store. The test then attaches that credential to a target.
+func TestApiStaticCredentialStore(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+	c, err := loadConfig()
+	require.NoError(t, err)
+
+	client, err := boundary.NewApiClient()
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	newOrgId := boundary.CreateNewOrgApi(t, ctx, client)
+	newProjectId := boundary.CreateNewProjectApi(t, ctx, client, newOrgId)
+	newHostCatalogId := boundary.CreateNewHostCatalogApi(t, ctx, client, newProjectId)
+	newHostSetId := boundary.CreateNewHostSetApi(t, ctx, client, newHostCatalogId)
+	newHostId := boundary.CreateNewHostApi(t, ctx, client, newHostCatalogId, c.TargetIp)
+	boundary.AddHostToHostSetApi(t, ctx, client, newHostSetId, newHostId)
+	newTargetId := boundary.CreateNewTargetApi(t, ctx, client, newProjectId, c.TargetPort)
+	boundary.AddHostSourceToTargetApi(t, ctx, client, newTargetId, newHostSetId)
+	newCredentialStoreId := boundary.CreateNewCredentialStoreStaticApi(t, ctx, client, newProjectId)
+
+	// Create credentials
+	cClient := credentials.NewClient(client)
+	k, err := os.ReadFile(c.TargetSshKeyPath)
+	require.NoError(t, err)
+	newCredentialsResult, err := cClient.Create(ctx, "ssh_private_key", newCredentialStoreId,
+		credentials.WithSshPrivateKeyCredentialUsername(c.TargetSshUser),
+		credentials.WithSshPrivateKeyCredentialPrivateKey(string(k)),
+	)
+	require.NoError(t, err)
+	newCredentialsId := newCredentialsResult.Item.Id
+	t.Logf("Created Credentials: %s", newCredentialsId)
+
+	// Add credentials to target
+	tClient := targets.NewClient(client)
+	_, err = tClient.AddCredentialSources(ctx, newTargetId, 0,
+		targets.WithAutomaticVersioning(true),
+		targets.WithBrokeredCredentialSourceIds([]string{newCredentialsId}),
+	)
+	require.NoError(t, err)
+
+	// Authorize Session
+	newSessionAuthorizationResult, err := tClient.AuthorizeSession(ctx, newTargetId)
+	require.NoError(t, err)
+	newSessionAuthorization := newSessionAuthorizationResult.Item
+	retrievedUser := fmt.Sprintf("%s", newSessionAuthorization.Credentials[0].Credential["username"])
+	retrievedKey := fmt.Sprintf("%s", newSessionAuthorization.Credentials[0].Credential["private_key"])
+	assert.Equal(t, c.TargetSshUser, retrievedUser)
+	require.Equal(t, string(k), retrievedKey)
+	t.Log("Successfully retrieved credentials for target")
 }

--- a/testing/internal/e2e/tests/static/env_test.go
+++ b/testing/internal/e2e/tests/static/env_test.go
@@ -16,5 +16,5 @@ func loadConfig() (*config, error) {
 		return nil, err
 	}
 
-	return &c, err
+	return &c, nil
 }

--- a/testing/internal/e2e/tests/static/session_cancel_admin_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_admin_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSessionCancelAdminCli uses the boundary cli to start and then cancel a session
-func TestSessionCancelAdminCli(t *testing.T) {
+// TestCliSessionCancelAdmin uses the boundary cli to start and then cancel a session
+func TestCliSessionCancelAdmin(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/static/session_cancel_user_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_user_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSessionCancelUserCli uses the cli to create a new user and sets up the right permissions for
+// TestCliSessionCancelUser uses the cli to create a new user and sets up the right permissions for
 // the user to connect to the created target. The test also confirms that an admin can cancel the
 // user's session.
-func TestSessionCancelUserCli(t *testing.T) {
+func TestCliSessionCancelUser(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)
@@ -195,8 +195,8 @@ func TestSessionCancelUserCli(t *testing.T) {
 	t.Log("Successfully cancelled session")
 }
 
-// TestCreateUserApi uses the Go api to create a new user and add some grants to the user
-func TestCreateUserApi(t *testing.T) {
+// TestApiCreateUser uses the Go api to create a new user and add some grants to the user
+func TestApiCreateUser(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/static/session_cancel_user_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_user_test.go
@@ -106,11 +106,12 @@ func TestCliSessionCancelUser(t *testing.T) {
 	ctxCancel, cancel := context.WithCancel(context.Background())
 	errChan := make(chan *e2e.CommandResult)
 	go func() {
-		boundary.AuthenticateCli(t, ctx, acctName, acctPassword)
+		token := boundary.GetAuthenticationTokenCli(t, ctx, acctName, acctPassword)
 		t.Log("Starting session as user...")
 		errChan <- e2e.RunCommand(ctxCancel, "boundary",
 			e2e.WithArgs(
 				"connect",
+				"-token", "env://E2E_AUTH_TOKEN",
 				"-target-id", newTargetId,
 				"-exec", "/usr/bin/ssh", "--",
 				"-l", c.TargetSshUser,
@@ -122,6 +123,7 @@ func TestCliSessionCancelUser(t *testing.T) {
 				"{{boundary.ip}}",
 				"hostname -i; sleep 60",
 			),
+			e2e.WithEnv("E2E_AUTH_TOKEN", token),
 		)
 	}()
 	t.Cleanup(cancel)

--- a/testing/internal/e2e/tests/static_with_vault/connect_ssh_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_ssh_test.go
@@ -1,0 +1,154 @@
+package static_with_vault_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/boundary/api/credentiallibraries"
+	"github.com/hashicorp/boundary/api/credentialstores"
+	"github.com/hashicorp/boundary/api/targets"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/hashicorp/boundary/testing/internal/e2e/vault"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCliVaultConnectTargetWithSsh uses the boundary and vault clis to add secrets management for a
+// target. The test sets up vault as a credential store, creates a set of credentials in vault to be
+// attached to a target, and attempts to connect to that target (with the ssh option) using those
+// credentials.
+func TestCliVaultConnectTargetWithSsh(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+	c, err := loadConfig()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	boundary.AuthenticateAdminCli(t, ctx)
+	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
+	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
+	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)
+	newHostId := boundary.CreateNewHostCli(t, ctx, newHostCatalogId, c.TargetIp)
+	boundary.AddHostToHostSetCli(t, ctx, newHostSetId, newHostId)
+	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
+	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
+
+	// Configure vault
+	vaultAddr, boundaryPolicyName := vault.Setup(t)
+	output := e2e.RunCommand(ctx, "vault",
+		e2e.WithArgs("secrets", "enable", "-path="+c.VaultSecretPath, "kv-v2"),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	t.Cleanup(func() {
+		output := e2e.RunCommand(ctx, "vault",
+			e2e.WithArgs("secrets", "disable", c.VaultSecretPath),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+
+	// Create credential in vault
+	secretName := "TestCreateVaultCredentialStoreCli"
+	credentialPolicyName := vault.CreateKvPrivateKeyCredential(t, secretName, c.VaultSecretPath, c.TargetSshUser, c.TargetSshKeyPath)
+	t.Log("Created Vault Credential")
+
+	// Create vault token for boundary
+	output = e2e.RunCommand(ctx, "vault",
+		e2e.WithArgs(
+			"token", "create",
+			"-no-default-policy=true",
+			"-policy="+boundaryPolicyName,
+			"-policy="+credentialPolicyName,
+			"-orphan=true",
+			"-period=20m",
+			"-renewable=true",
+			"-format=json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var tokenCreateResult createTokenResponse
+	err = json.Unmarshal(output.Stdout, &tokenCreateResult)
+	require.NoError(t, err)
+	credStoreToken := tokenCreateResult.Auth.Client_Token
+	t.Log("Created Vault Cred Store Token")
+
+	// Create a credential store
+	output = e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"credential-stores", "create", "vault",
+			"-scope-id", newProjectId,
+			"-vault-address", vaultAddr,
+			"-vault-token", credStoreToken,
+			"-format", "json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var newCredentialStoreResult credentialstores.CredentialStoreCreateResult
+	err = json.Unmarshal(output.Stdout, &newCredentialStoreResult)
+	require.NoError(t, err)
+	newCredentialStoreId := newCredentialStoreResult.Item.Id
+	t.Logf("Created Credential Store: %s", newCredentialStoreId)
+
+	// Create a credential library
+	output = e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"credential-libraries", "create", "vault",
+			"-credential-store-id", newCredentialStoreId,
+			"-vault-path", c.VaultSecretPath+"/data/"+secretName,
+			"-name", "e2e Automated Test Vault Credential Library",
+			"-credential-type", "ssh_private_key",
+			"-format", "json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var newCredentialLibraryResult credentiallibraries.CredentialLibraryCreateResult
+	err = json.Unmarshal(output.Stdout, &newCredentialLibraryResult)
+	require.NoError(t, err)
+	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
+	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
+
+	// Add brokered credentials to target
+	output = e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"targets", "add-credential-sources",
+			"-id", newTargetId,
+			"-brokered-credential-source", newCredentialLibraryId,
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+
+	// Get credentials for target
+	output = e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs("targets", "authorize-session", "-id", newTargetId, "-format", "json"),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var newSessionAuthorizationResult targets.SessionAuthorizationResult
+	err = json.Unmarshal(output.Stdout, &newSessionAuthorizationResult)
+	require.NoError(t, err)
+
+	newSessionAuthorization := newSessionAuthorizationResult.Item
+	retrievedUser := fmt.Sprintf("%s", newSessionAuthorization.Credentials[0].Credential["username"])
+	retrievedKey := fmt.Sprintf("%s", newSessionAuthorization.Credentials[0].Credential["private_key"])
+	assert.Equal(t, c.TargetSshUser, retrievedUser)
+
+	k, err := os.ReadFile(c.TargetSshKeyPath)
+	require.NoError(t, err)
+	require.Equal(t, string(k), retrievedKey)
+	t.Log("Successfully retrieved credentials for target")
+
+	// Connect to target using ssh option
+	output = e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"connect", "ssh",
+			"-target-id", newTargetId, "--",
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "IdentitiesOnly=yes", // forces the use of the provided key
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	t.Log("Successfully connected to target")
+}

--- a/testing/internal/e2e/tests/static_with_vault/connect_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_test.go
@@ -1,4 +1,4 @@
-package vault_test
+package static_with_vault_test
 
 import (
 	"context"
@@ -43,11 +43,11 @@ type createTokenResponse struct {
 	}
 }
 
-// TestCreateVaultCredentialStoreCli uses the boundary and vault clis to add secrets management
+// TestCliVaultConnectTarget uses the boundary and vault clis to add secrets management
 // for a target. The test sets up vault as a credential store, creates a set of credentials
 // in vault to be attached to a target, and attempts to connect to that target using those
 // credentials.
-func TestCreateVaultCredentialStoreCli(t *testing.T) {
+func TestCliVaultConnectTarget(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)
@@ -64,9 +64,7 @@ func TestCreateVaultCredentialStoreCli(t *testing.T) {
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 
 	// Configure vault
-
 	vaultAddr, boundaryPolicyName := vault.Setup(t)
-
 	output := e2e.RunCommand(ctx, "vault",
 		e2e.WithArgs("secrets", "enable", "-path="+c.VaultSecretPath, "kv-v2"),
 	)
@@ -198,109 +196,4 @@ func TestCreateVaultCredentialStoreCli(t *testing.T) {
 	hostIp := parts[len(parts)-1]
 	require.Equal(t, c.TargetIp, hostIp, "SSH session did not return expected output")
 	t.Log("Successfully connected to target")
-}
-
-// TestCreateVaultCredentialStoreApi uses the Go api along with the vault cli to add secrets
-// management for a target. The test sets up vault as a credential stores and creates a set of
-// credentials in vault that is attached to a target.
-func TestCreateVaultCredentialStoreApi(t *testing.T) {
-	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
-	require.NoError(t, err)
-
-	client, err := boundary.NewApiClient()
-	require.NoError(t, err)
-	ctx := context.Background()
-
-	newOrgId := boundary.CreateNewOrgApi(t, ctx, client)
-	newProjectId := boundary.CreateNewProjectApi(t, ctx, client, newOrgId)
-	newHostCatalogId := boundary.CreateNewHostCatalogApi(t, ctx, client, newProjectId)
-	newHostSetId := boundary.CreateNewHostSetApi(t, ctx, client, newHostCatalogId)
-	newHostId := boundary.CreateNewHostApi(t, ctx, client, newHostCatalogId, c.TargetIp)
-	boundary.AddHostToHostSetApi(t, ctx, client, newHostSetId, newHostId)
-	newTargetId := boundary.CreateNewTargetApi(t, ctx, client, newProjectId, c.TargetPort)
-	boundary.AddHostSourceToTargetApi(t, ctx, client, newTargetId, newHostSetId)
-
-	// Configure vault
-	vaultAddr, boundaryPolicyName := vault.Setup(t)
-
-	output := e2e.RunCommand(ctx, "vault",
-		e2e.WithArgs("secrets", "enable", "-path="+c.VaultSecretPath, "kv-v2"),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	t.Cleanup(func() {
-		output := e2e.RunCommand(ctx, "vault",
-			e2e.WithArgs("secrets", "disable", c.VaultSecretPath),
-		)
-		require.NoError(t, output.Err, string(output.Stderr))
-	})
-
-	// Create credential in vault
-	secretName := "TestCreateVaultCredentialStoreCli"
-	credentialPolicyName := vault.CreateKvPrivateKeyCredential(t, secretName, c.VaultSecretPath, c.TargetSshUser, c.TargetSshKeyPath)
-	t.Log("Created Vault Credential")
-
-	// Create vault token for boundary
-	output = e2e.RunCommand(ctx, "vault",
-		e2e.WithArgs(
-			"token", "create",
-			"-no-default-policy=true",
-			"-policy="+boundaryPolicyName,
-			"-policy="+credentialPolicyName,
-			"-orphan=true",
-			"-period=20m",
-			"-renewable=true",
-			"-format=json",
-		),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	var tokenCreateResult createTokenResponse
-	err = json.Unmarshal(output.Stdout, &tokenCreateResult)
-	require.NoError(t, err)
-	credStoreToken := tokenCreateResult.Auth.Client_Token
-	t.Log("Created Vault Cred Store Token")
-
-	// Create a credential store
-	csClient := credentialstores.NewClient(client)
-	newCredentialStoreResult, err := csClient.Create(ctx, "vault", newProjectId,
-		credentialstores.WithVaultCredentialStoreAddress(vaultAddr),
-		credentialstores.WithVaultCredentialStoreToken(credStoreToken),
-	)
-	require.NoError(t, err)
-	newCredentialStoreId := newCredentialStoreResult.Item.Id
-	t.Logf("Created Credential Store: %s", newCredentialStoreId)
-
-	// Create a credential library
-	clClient := credentiallibraries.NewClient(client)
-	newCredentialLibraryResult, err := clClient.Create(ctx, newCredentialStoreId,
-		credentiallibraries.WithVaultCredentialLibraryPath(c.VaultSecretPath+"/data/"+secretName),
-		credentiallibraries.WithCredentialType("ssh_private_key"),
-	)
-	require.NoError(t, err)
-	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
-	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
-
-	// Add brokered credentials to target
-	tClient := targets.NewClient(client)
-	_, err = tClient.AddCredentialSources(ctx, newTargetId, 0,
-		targets.WithBrokeredCredentialSourceIds([]string{newCredentialLibraryId}),
-		targets.WithAutomaticVersioning(true),
-	)
-	require.NoError(t, err)
-
-	// Get credentials for target
-	newSessionAuthorizationResult, err := tClient.AuthorizeSession(ctx, newTargetId)
-	require.NoError(t, err)
-	newSessionAuthorization := newSessionAuthorizationResult.Item
-	retrievedUser, ok := newSessionAuthorization.Credentials[0].Credential["username"].(string)
-	require.True(t, ok)
-	assert.Equal(t, c.TargetSshUser, retrievedUser)
-
-	retrievedKey, ok := newSessionAuthorization.Credentials[0].Credential["private_key"].(string)
-	require.True(t, ok)
-	k, err := os.ReadFile(c.TargetSshKeyPath)
-	require.NoError(t, err)
-	keysMatch := string(k) == retrievedKey // This is done to prevent printing out key info
-	require.True(t, keysMatch, "Key retrieved from vault does not match expected value")
-	t.Log("Successfully retrieved credentials for target")
 }

--- a/testing/internal/e2e/tests/static_with_vault/credential_store_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/credential_store_test.go
@@ -1,0 +1,122 @@
+package static_with_vault_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/boundary/api/credentiallibraries"
+	"github.com/hashicorp/boundary/api/credentialstores"
+	"github.com/hashicorp/boundary/api/targets"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/hashicorp/boundary/testing/internal/e2e/vault"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApiVaultCredentialStore uses the Go api along with the vault cli to add secrets
+// management for a target. The test sets up vault as a credential stores and creates a set of
+// credentials in vault that is attached to a target.
+func TestApiVaultCredentialStore(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+	c, err := loadConfig()
+	require.NoError(t, err)
+
+	client, err := boundary.NewApiClient()
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	newOrgId := boundary.CreateNewOrgApi(t, ctx, client)
+	newProjectId := boundary.CreateNewProjectApi(t, ctx, client, newOrgId)
+	newHostCatalogId := boundary.CreateNewHostCatalogApi(t, ctx, client, newProjectId)
+	newHostSetId := boundary.CreateNewHostSetApi(t, ctx, client, newHostCatalogId)
+	newHostId := boundary.CreateNewHostApi(t, ctx, client, newHostCatalogId, c.TargetIp)
+	boundary.AddHostToHostSetApi(t, ctx, client, newHostSetId, newHostId)
+	newTargetId := boundary.CreateNewTargetApi(t, ctx, client, newProjectId, c.TargetPort)
+	boundary.AddHostSourceToTargetApi(t, ctx, client, newTargetId, newHostSetId)
+
+	// Configure vault
+	vaultAddr, boundaryPolicyName := vault.Setup(t)
+
+	output := e2e.RunCommand(ctx, "vault",
+		e2e.WithArgs("secrets", "enable", "-path="+c.VaultSecretPath, "kv-v2"),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	t.Cleanup(func() {
+		output := e2e.RunCommand(ctx, "vault",
+			e2e.WithArgs("secrets", "disable", c.VaultSecretPath),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+
+	// Create credential in vault
+	secretName := "TestCreateVaultCredentialStoreCli"
+	credentialPolicyName := vault.CreateKvPrivateKeyCredential(t, secretName, c.VaultSecretPath, c.TargetSshUser, c.TargetSshKeyPath)
+	t.Log("Created Vault Credential")
+
+	// Create vault token for boundary
+	output = e2e.RunCommand(ctx, "vault",
+		e2e.WithArgs(
+			"token", "create",
+			"-no-default-policy=true",
+			"-policy="+boundaryPolicyName,
+			"-policy="+credentialPolicyName,
+			"-orphan=true",
+			"-period=20m",
+			"-renewable=true",
+			"-format=json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var tokenCreateResult createTokenResponse
+	err = json.Unmarshal(output.Stdout, &tokenCreateResult)
+	require.NoError(t, err)
+	credStoreToken := tokenCreateResult.Auth.Client_Token
+	t.Log("Created Vault Cred Store Token")
+
+	// Create a credential store
+	csClient := credentialstores.NewClient(client)
+	newCredentialStoreResult, err := csClient.Create(ctx, "vault", newProjectId,
+		credentialstores.WithVaultCredentialStoreAddress(vaultAddr),
+		credentialstores.WithVaultCredentialStoreToken(credStoreToken),
+	)
+	require.NoError(t, err)
+	newCredentialStoreId := newCredentialStoreResult.Item.Id
+	t.Logf("Created Credential Store: %s", newCredentialStoreId)
+
+	// Create a credential library
+	clClient := credentiallibraries.NewClient(client)
+	newCredentialLibraryResult, err := clClient.Create(ctx, newCredentialStoreId,
+		credentiallibraries.WithVaultCredentialLibraryPath(c.VaultSecretPath+"/data/"+secretName),
+		credentiallibraries.WithCredentialType("ssh_private_key"),
+	)
+	require.NoError(t, err)
+	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
+	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
+
+	// Add brokered credentials to target
+	tClient := targets.NewClient(client)
+	_, err = tClient.AddCredentialSources(ctx, newTargetId, 0,
+		targets.WithBrokeredCredentialSourceIds([]string{newCredentialLibraryId}),
+		targets.WithAutomaticVersioning(true),
+	)
+	require.NoError(t, err)
+
+	// Get credentials for target
+	newSessionAuthorizationResult, err := tClient.AuthorizeSession(ctx, newTargetId)
+	require.NoError(t, err)
+	newSessionAuthorization := newSessionAuthorizationResult.Item
+	retrievedUser, ok := newSessionAuthorization.Credentials[0].Credential["username"].(string)
+	require.True(t, ok)
+	assert.Equal(t, c.TargetSshUser, retrievedUser)
+
+	retrievedKey, ok := newSessionAuthorization.Credentials[0].Credential["private_key"].(string)
+	require.True(t, ok)
+	k, err := os.ReadFile(c.TargetSshKeyPath)
+	require.NoError(t, err)
+	keysMatch := string(k) == retrievedKey // This is done to prevent printing out key info
+	require.True(t, keysMatch, "Key retrieved from vault does not match expected value")
+	t.Log("Successfully retrieved credentials for target")
+}

--- a/testing/internal/e2e/tests/static_with_vault/env_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/env_test.go
@@ -1,0 +1,21 @@
+package static_with_vault_test
+
+import "github.com/kelseyhightower/envconfig"
+
+type config struct {
+	TargetIp         string `envconfig:"E2E_TARGET_IP" required:"true"`    // e.g. 192.168.0.1
+	TargetSshUser    string `envconfig:"E2E_SSH_USER" required:"true"`     // e.g. ubuntu
+	TargetSshKeyPath string `envconfig:"E2E_SSH_KEY_PATH" required:"true"` // e.g. /Users/username/key.pem
+	TargetPort       string `envconfig:"E2E_SSH_PORT" default:"22"`
+	VaultSecretPath  string `envconfig:"E2E_VAULT_SECRET_PATH" default:"e2e_secrets"`
+}
+
+func loadConfig() (*config, error) {
+	var c config
+	err := envconfig.Process("", &c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}


### PR DESCRIPTION
This PR does the following
- Adds a workflow to `static/credential_store_test.go` to create a username/password credential
- Adds a check in `static/credential_store_test.go` and `static_with_vault/credential_store_test.go` to validate that `authorize-session` does not return any credentials when no credentials are associated with a target
- Adds various `connect` tests in `static_with_vault` to ensure that users can connect to targets using the various options when credentials are stored by vault
- Reorganizes the test directory to better align with enos scenarios and have more clarity for where to add tests
- Fixes a flake in `static/session_cancel_user_test.go` due to a misunderstanding in how goroutines work. Instead, the goroutine will now authenticate via token instead of utilizing the shared keyring.