### PR TITLE
test(e2e): Add `ssh localhost` test

### DIFF
--- a/testing/internal/e2e/tests/static/connect_localhost_test.go
+++ b/testing/internal/e2e/tests/static/connect_localhost_test.go
@@ -1,0 +1,119 @@
+package static_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/boundary/api/sessions"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCliConnectTargetWithLocalhost(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+	c, err := loadConfig()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	boundary.AuthenticateAdminCli(t, ctx)
+	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
+	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
+	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)
+	newHostId := boundary.CreateNewHostCli(t, ctx, newHostCatalogId, c.TargetIp)
+	boundary.AddHostToHostSetCli(t, ctx, newHostSetId, newHostId)
+	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
+	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
+
+	// Start a session
+	ctxCancel, cancel := context.WithCancel(context.Background())
+	port := "12345"
+	cmdChan := make(chan *e2e.CommandResult)
+	go func() {
+		t.Log("Starting session...")
+		cmdChan <- e2e.RunCommand(ctxCancel, "boundary",
+			e2e.WithArgs(
+				"connect",
+				"-target-id", newTargetId,
+				"-listen-port", port,
+				"-format", "json",
+			),
+		)
+	}()
+	t.Cleanup(cancel)
+
+	// Wait for session to appear
+	err = backoff.RetryNotify(
+		func() error {
+			output := e2e.RunCommand(ctx, "boundary",
+				e2e.WithArgs("sessions", "list", "-scope-id", newProjectId, "-format", "json"),
+			)
+			if output.Err != nil {
+				return backoff.Permanent(errors.New(string(output.Stderr)))
+			}
+
+			var sessionListResult sessions.SessionListResult
+			err = json.Unmarshal(output.Stdout, &sessionListResult)
+			if err != nil {
+				return backoff.Permanent(err)
+			}
+
+			sessionCount := len(sessionListResult.Items)
+			if sessionCount == 0 {
+				return errors.New("No items are appearing in the session list")
+			}
+
+			t.Logf("Found %d session(s)", sessionCount)
+			if sessionCount != 1 {
+				return backoff.Permanent(errors.New("Only one session was expected to be found"))
+			}
+
+			return nil
+		},
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
+		func(err error, td time.Duration) {
+			t.Logf("%s. Retrying...", err.Error())
+		},
+	)
+	require.NoError(t, err)
+
+	// Connect to target and print host's IP address
+	output := e2e.RunCommand(ctx, "ssh",
+		e2e.WithArgs(
+			"localhost",
+			"-p", port,
+			"-l", c.TargetSshUser,
+			"-i", c.TargetSshKeyPath,
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "IdentitiesOnly=yes", // forces the use of the provided key
+			"hostname -i",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	require.Equal(t, c.TargetIp, strings.TrimSpace(string(output.Stdout)))
+
+	// Cancel session
+	cancel()
+
+	// Check output from session
+	select {
+	case output := <-cmdChan:
+		type connectOutput struct {
+			Port int
+		}
+		var response connectOutput
+		err = json.Unmarshal(output.Stdout, &response)
+		require.NoError(t, err)
+		require.Equal(t, port, fmt.Sprint(response.Port))
+	case <-time.After(time.Second * 5):
+		t.Fatal("Timed out waiting for session command to exit")
+	}
+}


### PR DESCRIPTION
This PR adds another test case that starts a `boundary connect` followed by a `ssh localhost -p PORT` to connect to the target. This is another common way that users access targets.