### PR TITLE
test(e2e): Add test that creates a role for a group

### DIFF
--- a/testing/internal/e2e/boundary/role.go
+++ b/testing/internal/e2e/boundary/role.go
@@ -1,0 +1,56 @@
+package boundary
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/boundary/api/roles"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+// CreateNewRoleCli creates a new role using the cli.
+// Returns the id of the new role.
+func CreateNewRoleCli(t testing.TB, ctx context.Context, scopeId string) string {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"roles", "create",
+			"-scope-id", scopeId,
+			"-name", "e2e Role",
+			"-format", "json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var newRoleResult roles.RoleCreateResult
+	err := json.Unmarshal(output.Stdout, &newRoleResult)
+	require.NoError(t, err)
+
+	newRoleId := newRoleResult.Item.Id
+	t.Logf("Created Role: %s", newRoleId)
+	return newRoleId
+}
+
+// AddGrantToRoleCli adds a grant/permission to a role using the cli
+func AddGrantToRoleCli(t testing.TB, ctx context.Context, roleId string, grant string) {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"roles", "add-grants",
+			"-id", roleId,
+			"-grant", grant,
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+}
+
+// AddPrincipalToRoleCli adds a user/group to a role using the cli
+func AddPrincipalToRoleCli(t testing.TB, ctx context.Context, roleId string, principal string) {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"roles", "add-principals",
+			"-id", roleId,
+			"-principal", principal,
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+}


### PR DESCRIPTION
This PR adds another test to the e2e test suite that is similar to the test added here: https://github.com/hashicorp/boundary/pull/2559. This test does the following...
- creates a new user
- attempts to connect to a target without the right permissions
- create a role/grant
- create a new group and apply 
- add the user to the group
- confirms user can start a session
- confirms admin can cancel the session

This is different than the existing test in that the existing test creates a user and adds the role to the user (as opposed to a group). 
