### PR TITLE
feat(metric): adds active connections gauge metric for controller and worker clusters

### DIFF
--- a/internal/daemon/controller/internal/metric/cluster.go
+++ b/internal/daemon/controller/internal/metric/cluster.go
@@ -2,6 +2,7 @@ package metric
 
 import (
 	"context"
+	"net"
 
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/daemon/metric"
@@ -33,6 +34,17 @@ var grpcRequestLatency prometheus.ObserverVec = prometheus.NewHistogramVec(
 	metric.ListGrpcLabels,
 )
 
+// grpcActiveConnections keeps a count of the current active connections to a controller.
+var grpcActiveConnections = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: globals.MetricNamespace,
+		Subsystem: clusterSubSystem,
+		Name:      "grpc_active_connections",
+		Help:      "Count of active connections to this controller.",
+	},
+	[]string{metric.LabelConnectionPurpose},
+)
+
 // All the codes expected to be returned by boundary or the grpc framework to
 // requests to the cluster server.
 var expectedGrpcCodes = []codes.Code{
@@ -45,6 +57,10 @@ var expectedGrpcCodes = []codes.Code{
 	codes.Unavailable, codes.Unauthenticated,
 }
 
+func InstrumentClusterTrackingListener(l net.Listener, purpose string) net.Listener {
+	return metric.NewConnectionTrackingListener(l, grpcActiveConnections, prometheus.Labels{metric.LabelConnectionPurpose: purpose})
+}
+
 // InstrumentClusterStatsHandler returns a gRPC stats.Handler which observes
 // cluster specific metrics. Use with the cluster gRPC server.
 func InstrumentClusterStatsHandler(ctx context.Context) (stats.Handler, error) {
@@ -55,5 +71,5 @@ func InstrumentClusterStatsHandler(ctx context.Context) (stats.Handler, error) {
 // prometheus register and initializes them to 0 for all possible label
 // combinations.
 func InitializeClusterCollectors(r prometheus.Registerer, server *grpc.Server) {
-	metric.InitializeGrpcCollectorsFromServer(r, grpcRequestLatency, server, expectedGrpcCodes)
+	metric.InitializeGrpcCollectorsFromServer(r, grpcRequestLatency, *grpcActiveConnections, server, expectedGrpcCodes)
 }

--- a/internal/daemon/controller/listeners.go
+++ b/internal/daemon/controller/listeners.go
@@ -232,13 +232,13 @@ func (c *Controller) configureForCluster(ln *base.ServerListener) (func(), error
 			}
 		}()
 		go func() {
-			err := handleSecondaryConnection(c.baseContext, multiplexingReverseGrpcListener, c.downstreamRoutes, -1)
+			err := handleSecondaryConnection(c.baseContext, metric.InstrumentClusterTrackingListener(reverseGrpcListener, "reverse-grpc"), c.downstreamRoutes, -1)
 			if err != nil {
 				event.WriteError(c.baseContext, op, err, event.WithInfoMsg("handleSecondaryConnection error"))
 			}
 		}()
 		go func() {
-			err := ln.GrpcServer.Serve(multiplexingAuthedListener)
+			err := ln.GrpcServer.Serve(metric.InstrumentClusterTrackingListener(multiplexingAuthedListener, "grpc"))
 			if err != nil {
 				event.WriteError(c.baseContext, op, err, event.WithInfoMsg("multiplexingAuthedListener error"))
 			}

--- a/internal/daemon/metric/initialize_metrics.go
+++ b/internal/daemon/metric/initialize_metrics.go
@@ -15,12 +15,13 @@ import (
 )
 
 const (
-	LabelGrpcService = "grpc_service"
-	LabelGrpcMethod  = "grpc_method"
-	LabelGrpcCode    = "grpc_code"
-	LabelHttpPath    = "path"
-	LabelHttpMethod  = "method"
-	LabelHttpCode    = "code"
+	LabelConnectionPurpose = "purpose"
+	LabelGrpcService       = "grpc_service"
+	LabelGrpcMethod        = "grpc_method"
+	LabelGrpcCode          = "grpc_code"
+	LabelHttpPath          = "path"
+	LabelHttpMethod        = "method"
+	LabelHttpCode          = "code"
 
 	invalidPathValue = "invalid"
 )
@@ -89,11 +90,11 @@ func InitializeGrpcCollectorsFromPackage(r prometheus.Registerer, v prometheus.O
 // InitializeGrpcCollectorsFromServer registers and zeroes a Prometheus
 // histogram, finding all service and method labels from the provided gRPC
 // server.
-func InitializeGrpcCollectorsFromServer(r prometheus.Registerer, v prometheus.ObserverVec, server *grpc.Server, codes []codes.Code) {
+func InitializeGrpcCollectorsFromServer(r prometheus.Registerer, v prometheus.ObserverVec, g prometheus.GaugeVec, server *grpc.Server, codes []codes.Code) {
 	if r == nil {
 		return
 	}
-	r.MustRegister(v)
+	r.MustRegister(v, g)
 
 	for serviceName, info := range server.GetServiceInfo() {
 		for _, mInfo := range info.Methods {

--- a/internal/daemon/metric/instrument_handlers.go
+++ b/internal/daemon/metric/instrument_handlers.go
@@ -4,7 +4,9 @@ package metric
 
 import (
 	"context"
+	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/boundary/internal/errors"
@@ -93,6 +95,42 @@ func NewGrpcRequestRecorder(fullMethodName string, reqLatency prometheus.Observe
 func (r requestRecorder) Record(err error) {
 	r.labels[LabelGrpcCode] = StatusFromError(err).Code().String()
 	r.reqLatency.With(r.labels).Observe(time.Since(r.start).Seconds())
+}
+
+type connectionTrackingListener struct {
+	net.Listener
+	connCount prometheus.Gauge
+}
+
+// NewConnectionTrackingListener registers a new Prometheus gauge with an unique connection type label
+// and wraps an existing listener to track when connections are accepted and closed.
+func NewConnectionTrackingListener(l net.Listener, g *prometheus.GaugeVec, connType prometheus.Labels) *connectionTrackingListener {
+	return newConnectionTrackingListener(l, g.With(connType))
+}
+
+// This is a separate function for testing purposes
+func newConnectionTrackingListener(l net.Listener, g prometheus.Gauge) *connectionTrackingListener {
+	return &connectionTrackingListener{Listener: l, connCount: g}
+}
+
+type connectionTrackingListenerConn struct {
+	net.Conn
+	dec   sync.Once
+	gauge prometheus.Gauge
+}
+
+func (c *connectionTrackingListenerConn) Close() error {
+	c.dec.Do(func() { c.gauge.Dec() })
+	return c.Conn.Close()
+}
+
+func (l *connectionTrackingListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	l.connCount.Inc()
+	return &connectionTrackingListenerConn{Conn: conn, gauge: l.connCount}, nil
 }
 
 // StatusFromError retrieves the *status.Status from the provided error.  It'll

--- a/internal/daemon/worker/listeners.go
+++ b/internal/daemon/worker/listeners.go
@@ -199,9 +199,9 @@ func (w *Worker) configureForWorker(ln *base.ServerListener, logger *log.Logger,
 
 	return func() {
 		go w.workerAuthSplitListener.Start()
-		go httpServer.Serve(proxyListener)
-		go ln.GrpcServer.Serve(eventingListener)
-		go handleSecondaryConnection(cancelCtx, reverseGrpcListener, w.downstreamRoutes, -1)
+		go httpServer.Serve(metric.InstrumentWorkerClusterTrackingListener(proxyListener, "proxy"))
+		go ln.GrpcServer.Serve(metric.InstrumentWorkerClusterTrackingListener(eventingListener, "grpc"))
+		go handleSecondaryConnection(cancelCtx, metric.InstrumentWorkerClusterTrackingListener(reverseGrpcListener, "reverse-grpc"), w.downstreamRoutes, -1)
 	}, nil
 }
 


### PR DESCRIPTION
adds listener wrappers with prometheus gauges around

- controller listeners: "reverse-grpc" `reverseGrpcListener`, "grpc" `multiplexingAuthedListener`
- worker listeners: "proxy" `proxyListener`, "grpc" `eventingListener`, "reverse-grpc" `reverseGrpcListener`

The "purpose" label in quotes is used to distinguish connection types. Naming values are up for discussion. 