### PR TITLE
Store cert private key, encrypt tofu token

### DIFF
--- a/internal/daemon/cluster/handlers/worker_service_test.go
+++ b/internal/daemon/cluster/handlers/worker_service_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/boundary/internal/authtoken"
 	credstatic "github.com/hashicorp/boundary/internal/credential/static"
 	"github.com/hashicorp/boundary/internal/daemon/cluster/handlers"
@@ -22,10 +21,12 @@ import (
 	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/internal/target/tcp"
 	"github.com/hashicorp/boundary/internal/types/scope"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/targets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh/testdata"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestLookupSession(t *testing.T) {
@@ -145,6 +146,11 @@ func TestLookupSession(t *testing.T) {
 			name:      "Valid",
 			sessionId: sess.PublicId,
 			want: &pbs.LookupSessionResponse{
+				Authorization: &targets.SessionAuthorizationData{
+					SessionId:   sess.PublicId,
+					Certificate: sess.Certificate,
+					PrivateKey:  sess.CertificatePrivateKey,
+				},
 				ConnectionLimit: 1,
 				ConnectionsLeft: 1,
 				Version:         1,
@@ -160,6 +166,11 @@ func TestLookupSession(t *testing.T) {
 			name:      "Valid-with-worker-creds",
 			sessionId: sessWithCreds.PublicId,
 			want: &pbs.LookupSessionResponse{
+				Authorization: &targets.SessionAuthorizationData{
+					SessionId:   sessWithCreds.PublicId,
+					Certificate: sessWithCreds.Certificate,
+					PrivateKey:  sessWithCreds.CertificatePrivateKey,
+				},
 				ConnectionLimit: 1,
 				ConnectionsLeft: 1,
 				Version:         1,
@@ -192,9 +203,8 @@ func TestLookupSession(t *testing.T) {
 				cmp.Diff(
 					tc.want,
 					got,
-					cmpopts.IgnoreUnexported(pbs.LookupSessionResponse{},
-						pbs.Credential{}, pbs.UsernamePassword{}, pbs.SshPrivateKey{}),
-					cmpopts.IgnoreFields(pbs.LookupSessionResponse{}, "Expiration", "Authorization"),
+					protocmp.Transform(),
+					protocmp.IgnoreFields(&pbs.LookupSessionResponse{}, "expiration"),
 				),
 			)
 		})

--- a/internal/daemon/controller/controller.go
+++ b/internal/daemon/controller/controller.go
@@ -347,6 +347,9 @@ func New(ctx context.Context, conf *Config) (*Controller, error) {
 		return target.NewRepository(ctx, dbase, dbase, c.kms, o...)
 	}
 	c.SessionRepoFn = func(opt ...session.Option) (*session.Repository, error) {
+		// Always add a secure random reader to the new session repository.
+		// Add it as the first option so that it can be overridden by users.
+		opt = append([]session.Option{session.WithRandomReader(c.conf.SecureRandomReader)}, opt...)
 		return session.NewRepository(ctx, dbase, dbase, c.kms, opt...)
 	}
 	c.ConnectionRepoFn = func() (*session.ConnectionRepository, error) {

--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -841,7 +841,7 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 	if err != nil {
 		return nil, err
 	}
-	sess, privKey, err := sessionRepo.CreateSession(ctx, wrapper, sess, workerList(selectedWorkers).addresses())
+	sess, err = sessionRepo.CreateSession(ctx, wrapper, sess, workerList(selectedWorkers).addresses())
 	if err != nil {
 		return nil, err
 	}
@@ -937,7 +937,7 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 		CreatedTime:     sess.CreateTime.GetTimestamp(),
 		Type:            t.GetType().String(),
 		Certificate:     sess.Certificate,
-		PrivateKey:      privKey,
+		PrivateKey:      sess.CertificatePrivateKey,
 		HostId:          chosenEndpoint.HostId,
 		Endpoint:        endpointUrl.String(),
 		WorkerInfo:      workerList(selectedWorkers).workerInfos(),

--- a/internal/db/schema/migrations/oss/postgres/44/04_sessions.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/44/04_sessions.up.sql
@@ -59,6 +59,7 @@ begin;
   $$ language plpgsql;
 
   -- Replaces view from 34/04_views.up.sql
+  -- Replaced in 56/06_add_session_private_key_column
   drop view session_list;
   create view session_list as
   select

--- a/internal/db/schema/migrations/oss/postgres/56/06_add_session_private_key_column.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/56/06_add_session_private_key_column.up.sql
@@ -1,0 +1,48 @@
+begin;
+
+  -- nullable because it will not be set for sessions that are active
+  -- during the upgrade to this version.
+  alter table session add column certificate_private_key bytea null;
+
+  -- Replaces the view created in 44/05_session_list_no_connections
+  drop view session_list;
+  create view session_list as
+  select
+    s.public_id,
+    s.user_id,
+    s.host_id,
+    s.target_id,
+    s.host_set_id,
+    s.auth_token_id,
+    s.project_id,
+    s.certificate,
+    s.certificate_private_key,
+    s.expiration_time,
+    s.connection_limit,
+    s.tofu_token,
+    s.key_id,
+    s.termination_reason,
+    s.version,
+    s.create_time,
+    s.update_time,
+    s.endpoint,
+    s.worker_filter,
+    ss.state,
+    ss.previous_end_time,
+    ss.start_time,
+    ss.end_time,
+    sc.public_id as connection_id,
+    sc.client_tcp_address,
+    sc.client_tcp_port,
+    sc.endpoint_tcp_address,
+    sc.endpoint_tcp_port,
+    sc.bytes_up,
+    sc.bytes_down,
+    sc.closed_reason
+  from session s
+    join session_state ss on
+      s.public_id = ss.session_id
+    left join session_connection sc on
+      s.public_id = sc.session_id;
+
+commit;

--- a/internal/db/schema/migrations/oss/postgres_40_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_40_01_test.go
@@ -280,7 +280,7 @@ values
 	sessionId := "s_AgLzPhDINE"
 	future := time.Now().Add(time.Hour)
 	expirationTime := fmt.Sprintf("%v-%d-%v %v:%v:%v.000", future.Year(), future.Month(), future.Day(), future.Hour(), future.Minute(), future.Second())
-	_, cert, err := session.TestCert(wrapper, uId, sessionId)
+	_, cert, err := session.TestCert(sessionId)
 	require.NoError(t, err)
 	num, err = rw.Exec(ctx, `
 	insert into session

--- a/internal/db/schema/migrations/oss/postgres_56_02_test.go
+++ b/internal/db/schema/migrations/oss/postgres_56_02_test.go
@@ -9,9 +9,8 @@ import (
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/db/common"
 	"github.com/hashicorp/boundary/internal/db/schema"
-	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
-	"github.com/hashicorp/boundary/internal/session"
+	"github.com/hashicorp/boundary/internal/types/scope"
 	"github.com/hashicorp/boundary/testing/dbtest"
 	"github.com/stretchr/testify/require"
 )
@@ -65,12 +64,9 @@ func TestMigrations_NewForeignKeys(t *testing.T) {
 
 	// Create project
 	wrapper := db.TestWrapper(t)
-	iamRepo := iam.TestRepo(t, conn, wrapper)
 	kmsCache := kms.TestKms(t, conn, wrapper)
-
-	// Create a session
-	sess := session.TestSession(t, conn, wrapper, session.TestSessionParams(t, conn, wrapper, iamRepo))
-	_ = sess
+	err = kmsCache.CreateKeys(ctx, scope.Global.String())
+	require.NoError(t, err)
 
 	// Create a password account
 	pwam := password.TestAuthMethod(t, conn, "global")

--- a/internal/session/options.go
+++ b/internal/session/options.go
@@ -138,6 +138,8 @@ func WithPermissions(p *perms.UserPermissions) Option {
 
 // WithIgnoreDecryptionFailures is used to ignore decryption
 // failures when doing lookups. This should be used sparingly.
+// It is currently only used to allow a user to cancel a session
+// in the presence of a undecryptable TOFU token.
 func WithIgnoreDecryptionFailures(ignoreFailures bool) Option {
 	return func(o *options) {
 		o.withIgnoreDecryptionFailures = ignoreFailures

--- a/internal/session/options.go
+++ b/internal/session/options.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"crypto/rand"
+	"io"
 	"time"
 
 	"github.com/hashicorp/boundary/internal/db"
@@ -35,11 +37,13 @@ type options struct {
 	withTerminated               bool
 	withPermissions              *perms.UserPermissions
 	withIgnoreDecryptionFailures bool
+	withRandomReader             io.Reader
 }
 
 func getDefaultOptions() options {
 	return options{
 		withWorkerStateDelay: 10 * time.Second,
+		withRandomReader:     rand.Reader,
 	}
 }
 
@@ -137,5 +141,13 @@ func WithPermissions(p *perms.UserPermissions) Option {
 func WithIgnoreDecryptionFailures(ignoreFailures bool) Option {
 	return func(o *options) {
 		o.withIgnoreDecryptionFailures = ignoreFailures
+	}
+}
+
+// WithRandomReader is used to configure the random source
+// to use when generating secrets. Defaults to crypto/rand.Reader.
+func WithRandomReader(rand io.Reader) Option {
+	return func(o *options) {
+		o.withRandomReader = rand
 	}
 }

--- a/internal/session/options.go
+++ b/internal/session/options.go
@@ -22,18 +22,19 @@ type Option func(*options)
 
 // options = how options are represented
 type options struct {
-	withLimit             int
-	withOrderByCreateTime db.OrderBy
-	withProjectIds        []string
-	withUserId            string
-	withExpirationTime    *timestamp.Timestamp
-	withTestTofu          []byte
-	withListingConvert    bool
-	withSessionIds        []string
-	withDbOpts            []db.Option
-	withWorkerStateDelay  time.Duration
-	withTerminated        bool
-	withPermissions       *perms.UserPermissions
+	withLimit                    int
+	withOrderByCreateTime        db.OrderBy
+	withProjectIds               []string
+	withUserId                   string
+	withExpirationTime           *timestamp.Timestamp
+	withTestTofu                 []byte
+	withListingConvert           bool
+	withSessionIds               []string
+	withDbOpts                   []db.Option
+	withWorkerStateDelay         time.Duration
+	withTerminated               bool
+	withPermissions              *perms.UserPermissions
+	withIgnoreDecryptionFailures bool
 }
 
 func getDefaultOptions() options {
@@ -128,5 +129,13 @@ func WithTerminated(withTerminated bool) Option {
 func WithPermissions(p *perms.UserPermissions) Option {
 	return func(o *options) {
 		o.withPermissions = p
+	}
+}
+
+// WithIgnoreDecryptionFailures is used to ignore decryption
+// failures when doing lookups. This should be used sparingly.
+func WithIgnoreDecryptionFailures(ignoreFailures bool) Option {
+	return func(o *options) {
+		o.withIgnoreDecryptionFailures = ignoreFailures
 	}
 }

--- a/internal/session/options_test.go
+++ b/internal/session/options_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/boundary/internal/db"
@@ -73,6 +74,21 @@ func Test_GetOpts(t *testing.T) {
 		opts := getOpts(WithSessionIds("s_1", "s_2", "s_3"))
 		testOpts := getDefaultOptions()
 		testOpts.withSessionIds = []string{"s_1", "s_2", "s_3"}
+		assert.Equal(opts, testOpts)
+	})
+	t.Run("WithIgnoreDecryptionFailures", func(t *testing.T) {
+		assert := assert.New(t)
+		opts := getOpts(WithIgnoreDecryptionFailures(true))
+		testOpts := getDefaultOptions()
+		testOpts.withIgnoreDecryptionFailures = true
+		assert.Equal(opts, testOpts)
+	})
+	t.Run("WithRandomReader", func(t *testing.T) {
+		assert := assert.New(t)
+		reader := strings.NewReader("notrandom")
+		opts := getOpts(WithRandomReader(reader))
+		testOpts := getDefaultOptions()
+		testOpts.withRandomReader = reader
 		assert.Equal(opts, testOpts)
 	})
 }

--- a/internal/session/query.go
+++ b/internal/session/query.go
@@ -443,7 +443,7 @@ values
 `
 )
 
-func batchInsertsessionCredentialDynamic(creds []*DynamicCredential) (string, []interface{}, error) {
+func batchInsertSessionCredentialDynamic(creds []*DynamicCredential) (string, []interface{}, error) {
 	if len(creds) <= 0 {
 		return "", nil, fmt.Errorf("empty slice of DynamicCredential, cannot build query")
 	}

--- a/internal/session/repository.go
+++ b/internal/session/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/boundary/internal/perms"
 	"github.com/hashicorp/boundary/internal/types/action"
 	"github.com/hashicorp/boundary/internal/types/resource"
+	"github.com/hashicorp/boundary/internal/util"
 )
 
 // Clonable provides a cloning interface
@@ -29,21 +31,23 @@ type Repository struct {
 
 	// defaultLimit provides a default for limiting the number of results returned from the repo
 	defaultLimit int
-
-	permissions *perms.UserPermissions
+	permissions  *perms.UserPermissions
+	randomReader io.Reader
 }
 
 // RepositoryFactory is a function that creates a Repository.
 type RepositoryFactory func(opt ...Option) (*Repository, error)
 
-// NewRepository creates a new session Repository. Supports the options: WithLimit
-// which sets a default limit on results returned by repo operations.
+// NewRepository creates a new session Repository. Supports the options:
+//   - WithLimit, which sets a default limit on results returned by repo operations.
+//   - WithPermissions
+//   - WithRandomReader
 func NewRepository(ctx context.Context, r db.Reader, w db.Writer, kms *kms.Kms, opt ...Option) (*Repository, error) {
 	const op = "session.NewRepository"
-	if r == nil {
+	if util.IsNil(r) {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "nil reader")
 	}
-	if w == nil {
+	if util.IsNil(w) {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "nil writer")
 	}
 	if kms == nil {
@@ -69,6 +73,7 @@ func NewRepository(ctx context.Context, r db.Reader, w db.Writer, kms *kms.Kms, 
 		kms:          kms,
 		defaultLimit: opts.withLimit,
 		permissions:  opts.withPermissions,
+		randomReader: opts.withRandomReader,
 	}, nil
 }
 

--- a/internal/session/repository.go
+++ b/internal/session/repository.go
@@ -134,40 +134,36 @@ func (r *Repository) convertToSessions(ctx context.Context, sessionList []*sessi
 			}
 			prevSessionId = sv.PublicId
 			workingSession = &Session{
-				PublicId:          sv.PublicId,
-				UserId:            sv.UserId,
-				HostId:            sv.HostId,
-				TargetId:          sv.TargetId,
-				HostSetId:         sv.HostSetId,
-				AuthTokenId:       sv.AuthTokenId,
-				ProjectId:         sv.ProjectId,
-				Certificate:       sv.Certificate,
-				ExpirationTime:    sv.ExpirationTime,
-				CtTofuToken:       sv.CtTofuToken,
-				TofuToken:         sv.TofuToken, // will always be nil since it's not stored in the database.
-				TerminationReason: sv.TerminationReason,
-				CreateTime:        sv.CreateTime,
-				UpdateTime:        sv.UpdateTime,
-				Version:           sv.Version,
-				Endpoint:          sv.Endpoint,
-				ConnectionLimit:   sv.ConnectionLimit,
-				KeyId:             sv.KeyId,
+				PublicId:                sv.PublicId,
+				UserId:                  sv.UserId,
+				HostId:                  sv.HostId,
+				TargetId:                sv.TargetId,
+				HostSetId:               sv.HostSetId,
+				AuthTokenId:             sv.AuthTokenId,
+				ProjectId:               sv.ProjectId,
+				Certificate:             sv.Certificate,
+				CtCertificatePrivateKey: sv.CtCertificatePrivateKey,
+				CertificatePrivateKey:   sv.CertificatePrivateKey, // will always be nil since it's not stored in the database.
+				ExpirationTime:          sv.ExpirationTime,
+				CtTofuToken:             sv.CtTofuToken,
+				TofuToken:               sv.TofuToken, // will always be nil since it's not stored in the database.
+				TerminationReason:       sv.TerminationReason,
+				CreateTime:              sv.CreateTime,
+				UpdateTime:              sv.UpdateTime,
+				Version:                 sv.Version,
+				Endpoint:                sv.Endpoint,
+				ConnectionLimit:         sv.ConnectionLimit,
+				KeyId:                   sv.KeyId,
 			}
 			if opts.withListingConvert {
-				workingSession.CtTofuToken = nil // CtTofuToken should not returned in lists
-				workingSession.TofuToken = nil   // TofuToken should not returned in lists
-				workingSession.KeyId = ""        // KeyId should not be returned in lists
+				workingSession.CtCertificatePrivateKey = nil // CtCertificatePrivateKey should not returned in lists
+				workingSession.CertificatePrivateKey = nil   // CertificatePrivateKey should not returned in lists
+				workingSession.CtTofuToken = nil             // CtTofuToken should not returned in lists
+				workingSession.TofuToken = nil               // TofuToken should not returned in lists
+				workingSession.KeyId = ""                    // KeyId should not be returned in lists
 			} else {
-				if len(workingSession.CtTofuToken) > 0 {
-					databaseWrapper, err := r.kms.GetWrapper(ctx, workingSession.ProjectId, kms.KeyPurposeDatabase)
-					if err != nil {
-						return nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to get database wrapper"))
-					}
-					if err := workingSession.decrypt(ctx, databaseWrapper); err != nil {
-						return nil, errors.Wrap(ctx, err, op, errors.WithMsg("cannot decrypt session value"))
-					}
-				} else {
-					workingSession.CtTofuToken = nil
+				if err := decryptAndMaybeUpdateSession(ctx, r.kms, workingSession, r.writer); err != nil {
+					return nil, errors.Wrap(ctx, err, op)
 				}
 			}
 		}

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -66,7 +66,7 @@ func (r *Repository) CreateSession(ctx context.Context, sessionWrapper wrapping.
 		return nil, errors.Wrap(ctx, err, op)
 	}
 
-	privKey, certBytes, err := newCert(ctx, sessionWrapper, newSession.UserId, id, workerAddresses, newSession.ExpirationTime.Timestamp.AsTime())
+	privKey, certBytes, err := newCert(ctx, sessionWrapper, newSession.UserId, id, workerAddresses, newSession.ExpirationTime.Timestamp.AsTime(), r.randomReader)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}

--- a/internal/session/repository_session_test.go
+++ b/internal/session/repository_session_test.go
@@ -392,6 +392,33 @@ func TestRepository_CreateSession(t *testing.T) {
 					c := TestSessionParams(t, conn, wrapper, iamRepo)
 					return c
 				}(),
+				workerAddresses: nil,
+			},
+			wantErr:     true,
+			wantIsError: errors.InvalidParameter,
+		},
+		{
+			name: "empty-expiration-time",
+			args: args{
+				composedOf: func() ComposedOf {
+					c := TestSessionParams(t, conn, wrapper, iamRepo)
+					c.ExpirationTime = nil
+					return c
+				}(),
+				workerAddresses: nil,
+			},
+			wantErr:     true,
+			wantIsError: errors.InvalidParameter,
+		},
+		{
+			name: "zero-expiration-time",
+			args: args{
+				composedOf: func() ComposedOf {
+					c := TestSessionParams(t, conn, wrapper, iamRepo)
+					c.ExpirationTime = timestamp.New(time.Time{})
+					return c
+				}(),
+				workerAddresses: nil,
 			},
 			wantErr:     true,
 			wantIsError: errors.InvalidParameter,
@@ -696,7 +723,7 @@ func TestRepository_TerminateCompletedSessions(t *testing.T) {
 	connRepo, err := NewConnectionRepository(ctx, rw, rw, kms)
 	require.NoError(t, err)
 
-	setupFn := func(limit int32, expireIn time.Duration, leaveOpen bool) *Session {
+	setupFn := func(t testing.TB, limit int32, expireIn time.Duration, leaveOpen bool) *Session {
 		require.NotEqualf(t, int32(0), limit, "setupFn: limit cannot be zero")
 		exp := timestamppb.New(time.Now().Add(expireIn))
 		composedOf := TestSessionParams(t, conn, wrapper, iamRepo)
@@ -727,23 +754,23 @@ func TestRepository_TerminateCompletedSessions(t *testing.T) {
 	}
 	tests := []struct {
 		name    string
-		setup   func() testArgs
+		setup   func(testing.TB) testArgs
 		wantErr bool
 	}{
 		{
 			name: "sessions-with-closed-connections",
-			setup: func() testArgs {
+			setup: func(t testing.TB) testArgs {
 				cnt := 1
 				wantTermed := map[string]TerminationReason{}
 				sessions := make([]*Session, 0, 5)
 				for i := 0; i < cnt; i++ {
 					// make one with closed connections
-					s := setupFn(1, time.Hour+1, false)
+					s := setupFn(t, 1, time.Hour+1, false)
 					wantTermed[s.PublicId] = ConnectionLimit
 					sessions = append(sessions, s)
 
 					// make one with connection left open
-					s2 := setupFn(1, time.Hour+1, true)
+					s2 := setupFn(t, 1, time.Hour+1, true)
 					sessions = append(sessions, s2)
 				}
 				return testArgs{
@@ -754,13 +781,13 @@ func TestRepository_TerminateCompletedSessions(t *testing.T) {
 		},
 		{
 			name: "sessions-with-open-and-closed-connections",
-			setup: func() testArgs {
+			setup: func(t testing.TB) testArgs {
 				cnt := 5
 				wantTermed := map[string]TerminationReason{}
 				sessions := make([]*Session, 0, 5)
 				for i := 0; i < cnt; i++ {
 					// make one with closed connections
-					s := setupFn(2, time.Hour+1, false)
+					s := setupFn(t, 2, time.Hour+1, false)
 					_ = TestConnection(t, conn, s.PublicId, "127.0.0.1", 22, "127.0.0.1", 222, "127.0.0.1")
 					sessions = append(sessions, s)
 					wantTermed[s.PublicId] = ConnectionLimit
@@ -773,7 +800,7 @@ func TestRepository_TerminateCompletedSessions(t *testing.T) {
 		},
 		{
 			name: "sessions-with-no-connections",
-			setup: func() testArgs {
+			setup: func(t testing.TB) testArgs {
 				cnt := 5
 				sessions := make([]*Session, 0, 5)
 				for i := 0; i < cnt; i++ {
@@ -788,11 +815,11 @@ func TestRepository_TerminateCompletedSessions(t *testing.T) {
 		},
 		{
 			name: "sessions-with-open-connections",
-			setup: func() testArgs {
+			setup: func(t testing.TB) testArgs {
 				cnt := 5
 				sessions := make([]*Session, 0, 5)
 				for i := 0; i < cnt; i++ {
-					s := setupFn(1, time.Hour+1, true)
+					s := setupFn(t, 1, time.Hour+1, true)
 					sessions = append(sessions, s)
 				}
 				return testArgs{
@@ -803,15 +830,15 @@ func TestRepository_TerminateCompletedSessions(t *testing.T) {
 		},
 		{
 			name: "expired-sessions",
-			setup: func() testArgs {
+			setup: func(t testing.TB) testArgs {
 				cnt := 5
 				wantTermed := map[string]TerminationReason{}
 				sessions := make([]*Session, 0, 5)
 				for i := 0; i < cnt; i++ {
 					// make one with closed connections
-					s := setupFn(1, time.Millisecond+1, false)
+					s := setupFn(t, 1, time.Millisecond+1, false)
 					// make one with connection left open
-					s2 := setupFn(1, time.Millisecond+1, true)
+					s2 := setupFn(t, 1, time.Millisecond+1, true)
 					sessions = append(sessions, s, s2)
 					wantTermed[s.PublicId] = TimedOut
 				}
@@ -823,18 +850,18 @@ func TestRepository_TerminateCompletedSessions(t *testing.T) {
 		},
 		{
 			name: "canceled-sessions-with-closed-connections",
-			setup: func() testArgs {
+			setup: func(t testing.TB) testArgs {
 				cnt := 1
 				wantTermed := map[string]TerminationReason{}
 				sessions := make([]*Session, 0, 5)
 				for i := 0; i < cnt; i++ {
 					// make one with limit of 3 and closed connections
-					s := setupFn(3, time.Hour+1, false)
+					s := setupFn(t, 3, time.Hour+1, false)
 					wantTermed[s.PublicId] = SessionCanceled
 					sessions = append(sessions, s)
 
 					// make one with connection left open
-					s2 := setupFn(1, time.Hour+1, true)
+					s2 := setupFn(t, 1, time.Hour+1, true)
 					sessions = append(sessions, s2)
 
 					// now cancel the sessions
@@ -851,15 +878,15 @@ func TestRepository_TerminateCompletedSessions(t *testing.T) {
 		},
 		{
 			name: "sessions-with-unlimited-connections",
-			setup: func() testArgs {
+			setup: func(t testing.TB) testArgs {
 				cnt := 5
 				wantTermed := map[string]TerminationReason{}
 				sessions := make([]*Session, 0, 5)
 				for i := 0; i < cnt; i++ {
 					// make one with unlimited connections
-					s := setupFn(-1, time.Hour+1, false)
+					s := setupFn(t, -1, time.Hour+1, false)
 					// make one with limit of one all connections closed
-					s2 := setupFn(1, time.Hour+1, false)
+					s2 := setupFn(t, 1, time.Hour+1, false)
 					sessions = append(sessions, s, s2)
 					wantTermed[s2.PublicId] = ConnectionLimit
 				}
@@ -874,7 +901,7 @@ func TestRepository_TerminateCompletedSessions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			db.TestDeleteWhere(t, conn, func() interface{} { i := AllocSession(); return &i }(), "1=1")
-			args := tt.setup()
+			args := tt.setup(t)
 
 			got, err := repo.TerminateCompletedSessions(context.Background())
 			if tt.wantErr {
@@ -1231,7 +1258,7 @@ func TestRepository_CancelSessionViaFKNull(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
-			s, _, err := repo.LookupSession(context.Background(), tt.cancelFk.s.PublicId)
+			s, _, err := repo.LookupSession(context.Background(), tt.cancelFk.s.PublicId, WithIgnoreDecryptionFailures(true))
 			require.NoError(err)
 			require.NotNil(s)
 			require.NotNil(s.States)
@@ -1250,7 +1277,7 @@ func TestRepository_CancelSessionViaFKNull(t *testing.T) {
 			require.NoError(err)
 			require.Equal(1, rowsDeleted)
 
-			s, _, err = repo.LookupSession(context.Background(), tt.cancelFk.s.PublicId)
+			s, _, err = repo.LookupSession(context.Background(), tt.cancelFk.s.PublicId, WithIgnoreDecryptionFailures(true))
 			require.NoError(err)
 			require.NotNil(s)
 			require.NotNil(s.States)
@@ -1648,4 +1675,100 @@ func TestRepository_deleteTerminated(t *testing.T) {
 			assert.Equal(t, tc.expected, c)
 		})
 	}
+}
+
+func Test_decryptAndMaybeUpdateSession(t *testing.T) {
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	kmsRepo := kms.TestKms(t, conn, wrapper)
+	iamRepo := iam.TestRepo(t, conn, wrapper)
+	ctx := context.Background()
+
+	t.Run("errors-with-invalid-kms", func(t *testing.T) {
+		s := TestDefaultSession(t, conn, wrapper, iamRepo)
+		err := decryptAndMaybeUpdateSession(ctx, nil, s, rw)
+		require.Error(t, err)
+	})
+	t.Run("errors-with-invalid-session", func(t *testing.T) {
+		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, nil, rw)
+		require.Error(t, err)
+	})
+	t.Run("errors-with-invalid-writer", func(t *testing.T) {
+		s := TestDefaultSession(t, conn, wrapper, iamRepo)
+		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, nil)
+		require.Error(t, err)
+	})
+	t.Run("errors-with-invalid-session-project-id", func(t *testing.T) {
+		s := TestDefaultSession(t, conn, wrapper, iamRepo)
+		s.ProjectId = ""
+		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		require.Error(t, err)
+	})
+	t.Run("errors-with-invalid-session-key-id", func(t *testing.T) {
+		s := TestDefaultSession(t, conn, wrapper, iamRepo)
+		s.KeyId = ""
+		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		require.Error(t, err)
+	})
+	t.Run("errors-with-invalid-session-user-id", func(t *testing.T) {
+		s := TestDefaultSession(t, conn, wrapper, iamRepo)
+		s.UserId = ""
+		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		require.Error(t, err)
+	})
+	t.Run("errors-with-invalid-session-public-id", func(t *testing.T) {
+		s := TestDefaultSession(t, conn, wrapper, iamRepo)
+		s.PublicId = ""
+		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		require.Error(t, err)
+	})
+	t.Run("session-with-local-session-key-succeeds", func(t *testing.T) {
+		s := TestDefaultSession(t, conn, wrapper, iamRepo)
+		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		require.NoError(t, err)
+	})
+	t.Run("session-with-derived-session-key-succeeds", func(t *testing.T) {
+		s := TestDefaultSession(t, conn, wrapper, iamRepo)
+		s.CtCertificatePrivateKey = nil
+		s.CertificatePrivateKey = nil
+		s.TofuToken = nil
+		s.CtTofuToken = nil
+		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		require.NoError(t, err)
+	})
+	t.Run("session-with-derived-session-key-and-tofu-token-succeeds", func(t *testing.T) {
+		s := TestDefaultSession(t, conn, wrapper, iamRepo)
+		s.CtCertificatePrivateKey = nil
+		s.CertificatePrivateKey = nil
+		s.TofuToken = []byte("A token")
+		actualKeyId := s.KeyId
+		databaseWrapper, err := kmsRepo.GetWrapper(ctx, s.ProjectId, kms.KeyPurposeDatabase)
+		require.NoError(t, err)
+		err = s.encrypt(ctx, databaseWrapper)
+		require.NoError(t, err)
+		s.KeyId = actualKeyId // Restore this as the encrypt call above will overwrite it.
+		err = decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		require.NoError(t, err)
+	})
+	t.Run("session-with-derived-session-key-and-tofu-token-cannot-be-decrypted", func(t *testing.T) {
+		s := TestDefaultSession(t, conn, wrapper, iamRepo)
+		s.CtCertificatePrivateKey = nil
+		s.CertificatePrivateKey = nil
+		s.TofuToken = []byte("A token")
+		actualKeyId := s.KeyId
+		databaseWrapper, err := kmsRepo.GetWrapper(ctx, s.ProjectId, kms.KeyPurposeDatabase)
+		require.NoError(t, err)
+		err = s.encrypt(ctx, databaseWrapper)
+		require.NoError(t, err)
+		databaseKeyId := s.KeyId
+		err = kmsRepo.RotateKeys(ctx, s.ProjectId)
+		require.NoError(t, err)
+		ok, err := kmsRepo.DestroyKeyVersion(ctx, s.ProjectId, databaseKeyId)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		s.KeyId = actualKeyId // Restore this as the encrypt call above will overwrite it.
+		err = decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		require.ErrorContains(t, err, "You may need to recreate your session")
+	})
 }

--- a/internal/session/repository_test.go
+++ b/internal/session/repository_test.go
@@ -1,10 +1,15 @@
 package session
 
 import (
+	"crypto/rand"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/perms"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -17,11 +22,13 @@ func TestNewRepository(t *testing.T) {
 	wrapper := db.TestWrapper(t)
 	testKms := kms.TestKms(t, conn, wrapper)
 	ctx := context.Background()
+	testReader := strings.NewReader("notrandom")
 
 	type args struct {
-		r db.Reader
-		w db.Writer
-		k *kms.Kms
+		r    db.Reader
+		w    db.Writer
+		k    *kms.Kms
+		opts []Option
 	}
 	tests := []struct {
 		name          string
@@ -37,11 +44,14 @@ func TestNewRepository(t *testing.T) {
 				w: rw,
 				k: testKms,
 			},
-			want: func() *Repository {
-				ret, err := NewRepository(ctx, rw, rw, testKms)
-				require.NoError(t, err)
-				return ret
-			}(),
+			want: &Repository{
+				reader:       rw,
+				writer:       rw,
+				kms:          testKms,
+				defaultLimit: db.DefaultLimit,
+				permissions:  nil,
+				randomReader: rand.Reader,
+			},
 			wantErr: false,
 		},
 		{
@@ -64,11 +74,33 @@ func TestNewRepository(t *testing.T) {
 			wantErr:       true,
 			wantErrString: "session.NewRepository: nil reader: parameter violation: error #100",
 		},
+		{
+			name: "providing-options",
+			args: args{
+				r: rw,
+				w: rw,
+				k: testKms,
+				opts: []Option{
+					WithLimit(100),
+					WithPermissions(&perms.UserPermissions{}),
+					WithRandomReader(testReader),
+				},
+			},
+			want: &Repository{
+				reader:       rw,
+				writer:       rw,
+				kms:          testKms,
+				defaultLimit: 100,
+				permissions:  &perms.UserPermissions{},
+				randomReader: testReader,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
-			got, err := NewRepository(ctx, tt.args.r, tt.args.w, tt.args.k)
+			got, err := NewRepository(ctx, tt.args.r, tt.args.w, tt.args.k, tt.args.opts...)
 			if tt.wantErr {
 				require.Error(err)
 				assert.Equal(tt.wantErrString, err.Error())
@@ -78,4 +110,59 @@ func TestNewRepository(t *testing.T) {
 			assert.Equal(tt.want, got)
 		})
 	}
+}
+
+func TestRepository_convertToSessions(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	rootWrapper := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, rootWrapper)
+	kmsCache := kms.TestKms(t, conn, rootWrapper)
+	repo, err := NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	composedOf := TestSessionParams(t, conn, rootWrapper, iamRepo)
+	sess, err := New(composedOf)
+	require.NoError(t, err)
+	sessionWrapper, err := kmsCache.GetWrapper(ctx, sess.ProjectId, kms.KeyPurposeSessions)
+	require.NoError(t, err)
+	sess, err = repo.CreateSession(ctx, sessionWrapper, sess, []string{"0.0.0.0"})
+	require.NoError(t, err)
+
+	query := fmt.Sprintf(sessionList, "", "", "", "")
+	rows, err := rw.Query(ctx, query, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := rows.Close()
+		require.NoError(t, err)
+	})
+
+	var sessionsList []*sessionListView
+	for rows.Next() {
+		var s sessionListView
+		err := rw.ScanRows(ctx, rows, &s)
+		require.NoError(t, err)
+		sessionsList = append(sessionsList, &s)
+	}
+
+	t.Run("without-options", func(t *testing.T) {
+		sessions, err := repo.convertToSessions(ctx, sessionsList)
+		require.NoError(t, err)
+		assert.Len(t, sessions, 1)
+		assert.Equal(t, sessions[0], sess)
+	})
+
+	t.Run("converting-for-list", func(t *testing.T) {
+		sessions, err := repo.convertToSessions(ctx, sessionsList, withListingConvert(true))
+		require.NoError(t, err)
+		assert.Len(t, sessions, 1)
+		sess := sess.Clone().(*Session)
+		// Check that encrypted values are redacted
+		sess.CtCertificatePrivateKey = nil
+		sess.CertificatePrivateKey = nil
+		sess.CtTofuToken = nil
+		sess.TofuToken = nil
+		sess.KeyId = ""
+		assert.Equal(t, sessions[0], sess)
+	})
 }

--- a/internal/session/rewrapping_test.go
+++ b/internal/session/rewrapping_test.go
@@ -37,11 +37,11 @@ func TestRewrap_sessionCredentialRewrapFn(t *testing.T) {
 	})
 	t.Run("success", func(t *testing.T) {
 		conn, _ := db.TestSetup(t, "postgres")
-		wrapper := db.TestWrapper(t)
-		kmsCache := kms.TestKms(t, conn, wrapper)
+		rootWrapper := db.TestWrapper(t)
+		kmsCache := kms.TestKms(t, conn, rootWrapper)
 		rw := db.New(conn)
 
-		org, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+		org, prj := iam.TestScopes(t, iam.TestRepo(t, conn, rootWrapper))
 		at := authtoken.TestAuthToken(t, conn, kmsCache, org.GetPublicId())
 		uId := at.GetIamUserId()
 		hc := static.TestCatalogs(t, conn, prj.GetPublicId(), 1)[0]
@@ -49,7 +49,7 @@ func TestRewrap_sessionCredentialRewrapFn(t *testing.T) {
 		h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 		static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
 		tar := tcp.TestTarget(ctx, t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
-		sess := TestSession(t, conn, wrapper, ComposedOf{
+		sess := TestSession(t, conn, rootWrapper, ComposedOf{
 			UserId:      uId,
 			HostId:      h.GetPublicId(),
 			TargetId:    tar.GetPublicId(),
@@ -65,14 +65,14 @@ func TestRewrap_sessionCredentialRewrapFn(t *testing.T) {
 		}
 
 		kmsWrapper, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		assert.NoError(t, cred.encrypt(ctx, kmsWrapper))
-		assert.NoError(t, rw.Create(ctx, cred))
+		require.NoError(t, cred.encrypt(ctx, kmsWrapper))
+		require.NoError(t, rw.Create(ctx, cred))
 
 		// now things are stored in the db, we can rotate and rewrap
-		assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
-		assert.NoError(t, sessionCredentialRewrapFn(ctx, cred.KeyId, prj.PublicId, rw, rw, kmsCache))
+		require.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
+		require.NoError(t, sessionCredentialRewrapFn(ctx, cred.KeyId, prj.PublicId, rw, rw, kmsCache))
 
 		// now we pull the credential back from the db, decrypt it with the new key, and ensure things match
 		got := &credential{
@@ -80,23 +80,23 @@ func TestRewrap_sessionCredentialRewrapFn(t *testing.T) {
 		}
 		// this is the best way we have to query for this. there's only one index on this table and it's on session id and sha256. since we're testing there should be no others.
 		rows, err := rw.Query(ctx, `select credential, key_id, credential_sha256 from session_credential where session_id = ?`, []interface{}{got.SessionId})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		rowCount := 0
 
 		for rows.Next() {
 			rowCount++
-			assert.NoError(t, rows.Scan(&got.CtCredential, &got.KeyId, &got.CredentialSha256))
+			require.NoError(t, rows.Scan(&got.CtCredential, &got.KeyId, &got.CredentialSha256))
 		}
 		assert.Equal(t, 1, rowCount)
 
 		kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.KeyId))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// decrypt with the new key version and check to make sure things match
-		assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
+		require.NoError(t, got.decrypt(ctx, kmsWrapper2))
 		assert.NotEmpty(t, got.KeyId)
 		assert.NotEqual(t, cred.KeyId, got.KeyId)
 		assert.Equal(t, newKeyVersionId, got.KeyId)
@@ -125,11 +125,11 @@ func TestRewrap_sessionRewrapFn(t *testing.T) {
 	})
 	t.Run("success", func(t *testing.T) {
 		conn, _ := db.TestSetup(t, "postgres")
-		wrapper := db.TestWrapper(t)
-		kmsCache := kms.TestKms(t, conn, wrapper)
+		rootWrapper := db.TestWrapper(t)
+		kmsCache := kms.TestKms(t, conn, rootWrapper)
 		rw := db.New(conn)
 
-		org, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+		org, prj := iam.TestScopes(t, iam.TestRepo(t, conn, rootWrapper))
 		at := authtoken.TestAuthToken(t, conn, kmsCache, org.GetPublicId())
 		uId := at.GetIamUserId()
 		hc := static.TestCatalogs(t, conn, prj.GetPublicId(), 1)[0]
@@ -137,9 +137,7 @@ func TestRewrap_sessionRewrapFn(t *testing.T) {
 		h := static.TestHosts(t, conn, hc.GetPublicId(), 1)[0]
 		static.TestSetMembers(t, conn, hs.GetPublicId(), []*static.Host{h})
 		tar := tcp.TestTarget(ctx, t, conn, prj.GetPublicId(), "test", target.WithHostSources([]string{hs.GetPublicId()}))
-		kmsWrapper, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase)
-		assert.NoError(t, err)
-		session := TestSession(t, conn, kmsWrapper, ComposedOf{
+		session := TestSession(t, conn, rootWrapper, ComposedOf{
 			UserId:      uId,
 			HostId:      h.GetPublicId(),
 			TargetId:    tar.GetPublicId(),
@@ -150,27 +148,29 @@ func TestRewrap_sessionRewrapFn(t *testing.T) {
 		})
 		// you cannot create a session with a pre-populated token, so do it in an update
 		session.TofuToken = []byte("token")
-		assert.NoError(t, session.encrypt(ctx, kmsWrapper))
-		_, err = rw.Update(ctx, session, []string{"CtTofuToken", "KeyId"}, nil)
-		assert.NoError(t, err)
+		sessionWrapper, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeSessions)
+		require.NoError(t, err)
+		require.NoError(t, session.encrypt(ctx, sessionWrapper))
+		_, err = rw.Update(ctx, session, []string{"CtTofuToken", "CertificatePrivateKey", "KeyId"}, nil)
+		require.NoError(t, err)
 
 		// now things are stored in the db, we can rotate and rewrap
-		assert.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
-		assert.NoError(t, sessionRewrapFn(ctx, session.KeyId, prj.PublicId, rw, rw, kmsCache))
+		require.NoError(t, kmsCache.RotateKeys(ctx, prj.PublicId))
+		require.NoError(t, sessionRewrapFn(ctx, session.KeyId, prj.PublicId, rw, rw, kmsCache))
 
 		// now we pull the session back from the db, decrypt it with the new key, and ensure things match
 		got := &Session{}
 		got.PublicId = session.PublicId
-		assert.NoError(t, rw.LookupById(ctx, got))
+		require.NoError(t, rw.LookupById(ctx, got))
 
-		kmsWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase, kms.WithKeyId(got.KeyId))
-		assert.NoError(t, err)
+		sessionWrapper2, err := kmsCache.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeSessions, kms.WithKeyId(got.KeyId))
+		require.NoError(t, err)
 
-		newKeyVersionId, err := kmsWrapper2.KeyId(ctx)
-		assert.NoError(t, err)
+		newKeyVersionId, err := sessionWrapper2.KeyId(ctx)
+		require.NoError(t, err)
 
 		// decrypt with the new key version and check to make sure things match
-		assert.NoError(t, got.decrypt(ctx, kmsWrapper2))
+		require.NoError(t, got.decrypt(ctx, sessionWrapper2))
 		assert.NotEmpty(t, got.KeyId)
 		assert.NotEqual(t, session.KeyId, got.KeyId)
 		assert.Equal(t, newKeyVersionId, got.KeyId)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/x509"
 	"testing"
 	"time"
@@ -185,7 +186,7 @@ func TestSession_Create(t *testing.T) {
 				got.PublicId = id
 				wrapper, err := kmsCache.GetWrapper(ctx, tt.args.composedOf.ProjectId, kms.KeyPurposeSessions)
 				require.NoError(err)
-				privKey, certBytes, err := newCert(ctx, wrapper, got.UserId, id, tt.args.addresses, composedOf.ExpirationTime.Timestamp.AsTime())
+				privKey, certBytes, err := newCert(ctx, wrapper, got.UserId, id, tt.args.addresses, composedOf.ExpirationTime.Timestamp.AsTime(), rand.Reader)
 				if tt.wantAddrErr {
 					require.Error(err)
 					assert.True(errors.Match(errors.T(tt.wantIsErr), err))

--- a/internal/session/testing.go
+++ b/internal/session/testing.go
@@ -87,7 +87,7 @@ func TestSession(t testing.TB, conn *db.DB, rootWrapper wrapping.Wrapper, c Comp
 	kmsCache := kms.TestKms(t, conn, rootWrapper)
 	wrapper, err := kmsCache.GetWrapper(ctx, c.ProjectId, kms.KeyPurposeSessions)
 	require.NoError(err)
-	privateKey, certBytes, err := newCert(ctx, wrapper, c.UserId, id, []string{"127.0.0.1", "localhost"}, c.ExpirationTime.Timestamp.AsTime(), rand.Reader)
+	privateKey, certBytes, err := newCert(ctx, id, []string{"127.0.0.1", "localhost"}, c.ExpirationTime.Timestamp.AsTime(), rand.Reader)
 	require.NoError(err)
 	s.Certificate = certBytes
 	s.CertificatePrivateKey = privateKey
@@ -188,6 +188,6 @@ func TestTofu(t testing.TB) []byte {
 // TestCert is a temporary test func that intentionally doesn't take testing.T
 // as a parameter.  It's currently used in controller.jobTestingHandler() and
 // should be deprecated once that function is refactored to use sessions properly.
-func TestCert(wrapper wrapping.Wrapper, userId, jobId string) (ed25519.PrivateKey, []byte, error) {
-	return newCert(context.Background(), wrapper, userId, jobId, []string{"127.0.0.1", "localhost"}, time.Now().Add(5*time.Minute), rand.Reader)
+func TestCert(jobId string) (ed25519.PrivateKey, []byte, error) {
+	return newCert(context.Background(), jobId, []string{"127.0.0.1", "localhost"}, time.Now().Add(5*time.Minute), rand.Reader)
 }

--- a/internal/session/testing.go
+++ b/internal/session/testing.go
@@ -68,7 +68,7 @@ func TestState(t testing.TB, conn *db.DB, sessionId string, state Status) *State
 
 // TestSession creates a test session composed of c in the repository. Options
 // are passed into New, and withServerId is handled locally.
-func TestSession(t testing.TB, conn *db.DB, wrapper wrapping.Wrapper, c ComposedOf, opt ...Option) *Session {
+func TestSession(t testing.TB, conn *db.DB, rootWrapper wrapping.Wrapper, c ComposedOf, opt ...Option) *Session {
 	t.Helper()
 	ctx := context.Background()
 	opts := getOpts(opt...)
@@ -83,12 +83,14 @@ func TestSession(t testing.TB, conn *db.DB, wrapper wrapping.Wrapper, c Composed
 	id, err := newId()
 	require.NoError(err)
 	s.PublicId = id
-	_, certBytes, err := newCert(ctx, wrapper, c.UserId, id, []string{"127.0.0.1", "localhost"}, c.ExpirationTime.Timestamp.AsTime())
+	kmsCache := kms.TestKms(t, conn, rootWrapper)
+	wrapper, err := kmsCache.GetWrapper(ctx, c.ProjectId, kms.KeyPurposeSessions)
+	require.NoError(err)
+	privateKey, certBytes, err := newCert(ctx, wrapper, c.UserId, id, []string{"127.0.0.1", "localhost"}, c.ExpirationTime.Timestamp.AsTime())
 	require.NoError(err)
 	s.Certificate = certBytes
-	if len(s.TofuToken) != 0 {
-		err = s.encrypt(ctx, wrapper)
-	}
+	s.CertificatePrivateKey = privateKey
+	err = s.encrypt(ctx, wrapper)
 	require.NoError(err)
 	err = rw.Create(ctx, s, opts.withDbOpts...)
 	if e, ok := err.(*errors.Err); err != nil && ok && e.Code == errors.NotUnique {

--- a/internal/session/testing.go
+++ b/internal/session/testing.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/rand"
 	"testing"
 	"time"
 
@@ -86,7 +87,7 @@ func TestSession(t testing.TB, conn *db.DB, rootWrapper wrapping.Wrapper, c Comp
 	kmsCache := kms.TestKms(t, conn, rootWrapper)
 	wrapper, err := kmsCache.GetWrapper(ctx, c.ProjectId, kms.KeyPurposeSessions)
 	require.NoError(err)
-	privateKey, certBytes, err := newCert(ctx, wrapper, c.UserId, id, []string{"127.0.0.1", "localhost"}, c.ExpirationTime.Timestamp.AsTime())
+	privateKey, certBytes, err := newCert(ctx, wrapper, c.UserId, id, []string{"127.0.0.1", "localhost"}, c.ExpirationTime.Timestamp.AsTime(), rand.Reader)
 	require.NoError(err)
 	s.Certificate = certBytes
 	s.CertificatePrivateKey = privateKey
@@ -188,5 +189,5 @@ func TestTofu(t testing.TB) []byte {
 // as a parameter.  It's currently used in controller.jobTestingHandler() and
 // should be deprecated once that function is refactored to use sessions properly.
 func TestCert(wrapper wrapping.Wrapper, userId, jobId string) (ed25519.PrivateKey, []byte, error) {
-	return newCert(context.Background(), wrapper, userId, jobId, []string{"127.0.0.1", "localhost"}, time.Now().Add(5*time.Minute))
+	return newCert(context.Background(), wrapper, userId, jobId, []string{"127.0.0.1", "localhost"}, time.Now().Add(5*time.Minute), rand.Reader)
 }

--- a/internal/session/testing_test.go
+++ b/internal/session/testing_test.go
@@ -80,12 +80,9 @@ func Test_TestWorker(t *testing.T) {
 
 func Test_TestCert(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
-	wrapper := db.TestWrapper(t)
-	userId, err := db.NewPublicId(iam.UserPrefix)
-	require.NoError(err)
 	sessionId, err := newId()
 	require.NoError(err)
-	key, cert, err := TestCert(wrapper, userId, sessionId)
+	key, cert, err := TestCert(sessionId)
 	require.NoError(err)
 	assert.NotNil(key)
 	assert.NotNil(cert)


### PR DESCRIPTION
Previously, we would derive a session certificate private key from the session key used in each project, and not store the key. We would also encrypt the tofu token with the database key but not store a reference to this key in the database.

This change fixes this by replacing our key derivation with a key generation step, and instead store the generated key, encrypted, in the database. We also ensure that any new tofu tokens are encrypted with the same key.

To handle existing sessions, we lazily rewrite the sessions whenever a user lists them. There is a minor risk that a user could end up destroying the database key that encrypts the tofu token before that session has been rewrapped, but this is going to be rare and temporary.