### PR TITLE
fix(test): Retry websocket connection due to flaky failure

### DIFF
--- a/internal/cmd/commands/server/worker_shutdown_reload_test.go
+++ b/internal/cmd/commands/server/worker_shutdown_reload_test.go
@@ -99,7 +99,9 @@ func TestServer_ShutdownWorker(t *testing.T) {
 	sConn.TestSendRecvAll(t)
 
 	// Shutdown the worker and close the connection, as the worker will otherwise wait for it to close.
-	sConn.Close()
+	err = sConn.Close()
+	require.NoError(err)
+
 	workerCmd.ShutdownCh <- struct{}{}
 	if <-workerCodeChan != 0 {
 		output := workerCmd.UI.(*cli.MockUi).ErrorWriter.String() + workerCmd.UI.(*cli.MockUi).OutputWriter.String()


### PR DESCRIPTION
We have observed several unit tests occasionally fail when trying to read a handshake due to the following error:
```
worker_shutdown_reload_test.go:148: 
         Error Trace:	testing_helper.go:138
                                 testing_helper.go:312
                                 worker_shutdown_reload_test.go:148
         Error:      	Received unexpected error:
                        failed to read protobuf message: failed to get reader: received close frame: status = StatusProtocolError and reason = "received header with unexpected rsv bits set: false:false:true"
         Test:       	TestServer_ShutdownWorker
--- FAIL: TestServer_ShutdownWorker (1.78s)
```
This also occurs in `TestWorkerSessionProxyMultipleConnections` and `TestSessionCleanup/default/multi_controller`.

After an investigation, it's still unclear how this happens. The `wspb.Write` seemed to work ok, but the `Read` contained some unexpected data.

We are opting to retry the websocket connection to mitigate the flakiness.