### PR TITLE
fix(e2e): Add retry when checking if session is active

### DIFF
--- a/testing/internal/e2e/tests/aws/dynamichostcatalog_test.go
+++ b/testing/internal/e2e/tests/aws/dynamichostcatalog_test.go
@@ -98,7 +98,7 @@ func TestCliCreateAwsDynamicHostCatalog(t *testing.T) {
 	var actualHostSetCount1 int
 	err = backoff.RetryNotify(
 		func() error {
-			output = e2e.RunCommand(ctx, "boundary",
+			output := e2e.RunCommand(ctx, "boundary",
 				e2e.WithArgs(
 					"host-sets", "read",
 					"-id", newHostSetId1,
@@ -110,7 +110,7 @@ func TestCliCreateAwsDynamicHostCatalog(t *testing.T) {
 			}
 
 			var hostSetsReadResult hostsets.HostSetReadResult
-			err = json.Unmarshal(output.Stdout, &hostSetsReadResult)
+			err := json.Unmarshal(output.Stdout, &hostSetsReadResult)
 			if err != nil {
 				return backoff.Permanent(err)
 			}
@@ -158,7 +158,7 @@ func TestCliCreateAwsDynamicHostCatalog(t *testing.T) {
 	var actualHostSetCount2 int
 	err = backoff.RetryNotify(
 		func() error {
-			output = e2e.RunCommand(ctx, "boundary",
+			output := e2e.RunCommand(ctx, "boundary",
 				e2e.WithArgs("host-sets", "read", "-id", newHostSetId2, "-format", "json"),
 			)
 			if output.Err != nil {
@@ -166,7 +166,7 @@ func TestCliCreateAwsDynamicHostCatalog(t *testing.T) {
 			}
 
 			var hostSetsReadResult hostsets.HostSetReadResult
-			err = json.Unmarshal(output.Stdout, &hostSetsReadResult)
+			err := json.Unmarshal(output.Stdout, &hostSetsReadResult)
 			if err != nil {
 				return backoff.Permanent(err)
 			}
@@ -196,7 +196,7 @@ func TestCliCreateAwsDynamicHostCatalog(t *testing.T) {
 	var actualHostCatalogCount int
 	err = backoff.RetryNotify(
 		func() error {
-			output = e2e.RunCommand(ctx, "boundary",
+			output := e2e.RunCommand(ctx, "boundary",
 				e2e.WithArgs("hosts", "list", "-host-catalog-id", newHostCatalogId, "-format", "json"),
 			)
 			if output.Err != nil {
@@ -204,7 +204,7 @@ func TestCliCreateAwsDynamicHostCatalog(t *testing.T) {
 			}
 
 			var hostCatalogListResult hostcatalogs.HostCatalogListResult
-			err = json.Unmarshal(output.Stdout, &hostCatalogListResult)
+			err := json.Unmarshal(output.Stdout, &hostCatalogListResult)
 			if err != nil {
 				return backoff.Permanent(err)
 			}

--- a/testing/internal/e2e/tests/static/connect_localhost_test.go
+++ b/testing/internal/e2e/tests/static/connect_localhost_test.go
@@ -60,7 +60,7 @@ func TestCliConnectTargetWithLocalhost(t *testing.T) {
 			}
 
 			var sessionListResult sessions.SessionListResult
-			err = json.Unmarshal(output.Stdout, &sessionListResult)
+			err := json.Unmarshal(output.Stdout, &sessionListResult)
 			if err != nil {
 				return backoff.Permanent(err)
 			}

--- a/testing/internal/e2e/tests/static/credential_store_test.go
+++ b/testing/internal/e2e/tests/static/credential_store_test.go
@@ -111,7 +111,7 @@ func TestCliStaticCredentialStore(t *testing.T) {
 	require.NoError(t, output.Err, string(output.Stderr))
 	err = backoff.RetryNotify(
 		func() error {
-			output = e2e.RunCommand(ctx, "boundary",
+			output := e2e.RunCommand(ctx, "boundary",
 				e2e.WithArgs("credential-stores", "read", "-id", newCredentialStoreId, "-format", "json"),
 			)
 			if output.Err == nil {
@@ -119,7 +119,7 @@ func TestCliStaticCredentialStore(t *testing.T) {
 			}
 
 			var response e2e.CliError
-			err = json.Unmarshal(output.Stderr, &response)
+			err := json.Unmarshal(output.Stderr, &response)
 			require.NoError(t, err)
 			statusCode := response.Status
 			if statusCode != 404 {

--- a/testing/internal/e2e/tests/static/session_cancel_admin_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_admin_test.go
@@ -86,7 +86,7 @@ func TestCliSessionCancelAdmin(t *testing.T) {
 			// Check if session is active
 			session = sessionListResult.Items[0]
 			output = e2e.RunCommand(ctx, "boundary",
-				e2e.WithArgs("sessions", "read", "-id", session.Id),
+				e2e.WithArgs("sessions", "read", "-id", session.Id, "-format", "json"),
 			)
 			if output.Err != nil {
 				return backoff.Permanent(errors.New(string(output.Stderr)))

--- a/testing/internal/e2e/tests/static/session_cancel_group_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_group_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -135,7 +136,7 @@ func TestCliSessionCancelGroup(t *testing.T) {
 			}
 
 			var sessionListResult sessions.SessionListResult
-			err = json.Unmarshal(output.Stdout, &sessionListResult)
+			err := json.Unmarshal(output.Stdout, &sessionListResult)
 			if err != nil {
 				return backoff.Permanent(err)
 			}
@@ -161,7 +162,37 @@ func TestCliSessionCancelGroup(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, newTargetId, session.TargetId)
 	assert.Equal(t, newHostId, session.HostId)
-	require.Equal(t, "active", session.Status)
+
+	// Wait for session to be active
+	err = backoff.RetryNotify(
+		func() error {
+			output := e2e.RunCommand(ctx, "boundary",
+				e2e.WithArgs("sessions", "read", "-id", session.Id),
+			)
+			if output.Err != nil {
+				return backoff.Permanent(errors.New(string(output.Stderr)))
+			}
+
+			var sessionReadResult sessions.SessionReadResult
+			err := json.Unmarshal(output.Stdout, &sessionReadResult)
+			if err != nil {
+				return backoff.Permanent(err)
+			}
+
+			if sessionReadResult.Item.Status != "active" {
+				return errors.New(fmt.Sprintf("Waiting for session to be active... Expected: %s, Actual: %s",
+					"active",
+					sessionReadResult.Item.Status,
+				))
+			}
+
+			return nil
+		},
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
+		func(err error, td time.Duration) {
+			t.Logf("%s. Retrying...", err.Error())
+		},
+	)
 
 	// Cancel session
 	output = e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static/session_cancel_group_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_group_test.go
@@ -154,7 +154,7 @@ func TestCliSessionCancelGroup(t *testing.T) {
 			// Check if session is active
 			session = sessionListResult.Items[0]
 			output = e2e.RunCommand(ctx, "boundary",
-				e2e.WithArgs("sessions", "read", "-id", session.Id),
+				e2e.WithArgs("sessions", "read", "-id", session.Id, "-format", "json"),
 			)
 			if output.Err != nil {
 				return backoff.Permanent(errors.New(string(output.Stderr)))

--- a/testing/internal/e2e/tests/static/session_cancel_group_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_group_test.go
@@ -124,49 +124,36 @@ func TestCliSessionCancelGroup(t *testing.T) {
 	}()
 	t.Cleanup(cancel)
 
-	// Get list of sessions
+	// Wait for session to be active
 	var session *sessions.Session
 	err = backoff.RetryNotify(
 		func() error {
+			// List sessions
 			output := e2e.RunCommand(ctx, "boundary",
 				e2e.WithArgs("sessions", "list", "-scope-id", newProjectId, "-format", "json"),
 			)
 			if output.Err != nil {
 				return backoff.Permanent(errors.New(string(output.Stderr)))
 			}
-
 			var sessionListResult sessions.SessionListResult
 			err := json.Unmarshal(output.Stdout, &sessionListResult)
 			if err != nil {
 				return backoff.Permanent(err)
 			}
 
+			// Check if there is one session
 			sessionCount := len(sessionListResult.Items)
 			if sessionCount == 0 {
 				return errors.New("No items are appearing in the session list")
 			}
-
 			t.Logf("Found %d session(s)", sessionCount)
 			if sessionCount != 1 {
 				return backoff.Permanent(errors.New("Only one session was expected to be found"))
 			}
 
+			// Check if session is active
 			session = sessionListResult.Items[0]
-			return nil
-		},
-		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
-		func(err error, td time.Duration) {
-			t.Logf("%s. Retrying...", err.Error())
-		},
-	)
-	require.NoError(t, err)
-	assert.Equal(t, newTargetId, session.TargetId)
-	assert.Equal(t, newHostId, session.HostId)
-
-	// Wait for session to be active
-	err = backoff.RetryNotify(
-		func() error {
-			output := e2e.RunCommand(ctx, "boundary",
+			output = e2e.RunCommand(ctx, "boundary",
 				e2e.WithArgs("sessions", "read", "-id", session.Id),
 			)
 			if output.Err != nil {
@@ -174,7 +161,7 @@ func TestCliSessionCancelGroup(t *testing.T) {
 			}
 
 			var sessionReadResult sessions.SessionReadResult
-			err := json.Unmarshal(output.Stdout, &sessionReadResult)
+			err = json.Unmarshal(output.Stdout, &sessionReadResult)
 			if err != nil {
 				return backoff.Permanent(err)
 			}
@@ -193,6 +180,9 @@ func TestCliSessionCancelGroup(t *testing.T) {
 			t.Logf("%s. Retrying...", err.Error())
 		},
 	)
+	require.NoError(t, err)
+	assert.Equal(t, newTargetId, session.TargetId)
+	assert.Equal(t, newHostId, session.HostId)
 
 	// Cancel session
 	output = e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static/session_cancel_user_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_user_test.go
@@ -128,7 +128,7 @@ func TestCliSessionCancelUser(t *testing.T) {
 			// Check if session is active
 			session = sessionListResult.Items[0]
 			output = e2e.RunCommand(ctx, "boundary",
-				e2e.WithArgs("sessions", "read", "-id", session.Id),
+				e2e.WithArgs("sessions", "read", "-id", session.Id, "-format", "json"),
 			)
 			if output.Err != nil {
 				return backoff.Permanent(errors.New(string(output.Stderr)))

--- a/testing/internal/e2e/tests/static/session_cancel_user_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_user_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -109,7 +110,7 @@ func TestCliSessionCancelUser(t *testing.T) {
 			}
 
 			var sessionListResult sessions.SessionListResult
-			err = json.Unmarshal(output.Stdout, &sessionListResult)
+			err := json.Unmarshal(output.Stdout, &sessionListResult)
 			if err != nil {
 				return backoff.Permanent(err)
 			}
@@ -135,7 +136,37 @@ func TestCliSessionCancelUser(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, newTargetId, session.TargetId)
 	assert.Equal(t, newHostId, session.HostId)
-	require.Equal(t, "active", session.Status)
+
+	// Wait for session to be active
+	err = backoff.RetryNotify(
+		func() error {
+			output := e2e.RunCommand(ctx, "boundary",
+				e2e.WithArgs("sessions", "read", "-id", session.Id),
+			)
+			if output.Err != nil {
+				return backoff.Permanent(errors.New(string(output.Stderr)))
+			}
+
+			var sessionReadResult sessions.SessionReadResult
+			err := json.Unmarshal(output.Stdout, &sessionReadResult)
+			if err != nil {
+				return backoff.Permanent(err)
+			}
+
+			if sessionReadResult.Item.Status != "active" {
+				return errors.New(fmt.Sprintf("Waiting for session to be active... Expected: %s, Actual: %s",
+					"active",
+					sessionReadResult.Item.Status,
+				))
+			}
+
+			return nil
+		},
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
+		func(err error, td time.Duration) {
+			t.Logf("%s. Retrying...", err.Error())
+		},
+	)
 
 	// Cancel session
 	output = e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static/session_cancel_user_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_user_test.go
@@ -98,49 +98,36 @@ func TestCliSessionCancelUser(t *testing.T) {
 	}()
 	t.Cleanup(cancel)
 
-	// Get list of sessions
+	// Wait for session to be active
 	var session *sessions.Session
 	err = backoff.RetryNotify(
 		func() error {
+			// List sessions
 			output := e2e.RunCommand(ctx, "boundary",
 				e2e.WithArgs("sessions", "list", "-scope-id", newProjectId, "-format", "json"),
 			)
 			if output.Err != nil {
 				return backoff.Permanent(errors.New(string(output.Stderr)))
 			}
-
 			var sessionListResult sessions.SessionListResult
 			err := json.Unmarshal(output.Stdout, &sessionListResult)
 			if err != nil {
 				return backoff.Permanent(err)
 			}
 
+			// Check if there is one session
 			sessionCount := len(sessionListResult.Items)
 			if sessionCount == 0 {
 				return errors.New("No items are appearing in the session list")
 			}
-
 			t.Logf("Found %d session(s)", sessionCount)
 			if sessionCount != 1 {
 				return backoff.Permanent(errors.New("Only one session was expected to be found"))
 			}
 
+			// Check if session is active
 			session = sessionListResult.Items[0]
-			return nil
-		},
-		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
-		func(err error, td time.Duration) {
-			t.Logf("%s. Retrying...", err.Error())
-		},
-	)
-	require.NoError(t, err)
-	assert.Equal(t, newTargetId, session.TargetId)
-	assert.Equal(t, newHostId, session.HostId)
-
-	// Wait for session to be active
-	err = backoff.RetryNotify(
-		func() error {
-			output := e2e.RunCommand(ctx, "boundary",
+			output = e2e.RunCommand(ctx, "boundary",
 				e2e.WithArgs("sessions", "read", "-id", session.Id),
 			)
 			if output.Err != nil {
@@ -148,7 +135,7 @@ func TestCliSessionCancelUser(t *testing.T) {
 			}
 
 			var sessionReadResult sessions.SessionReadResult
-			err := json.Unmarshal(output.Stdout, &sessionReadResult)
+			err = json.Unmarshal(output.Stdout, &sessionReadResult)
 			if err != nil {
 				return backoff.Permanent(err)
 			}
@@ -167,6 +154,9 @@ func TestCliSessionCancelUser(t *testing.T) {
 			t.Logf("%s. Retrying...", err.Error())
 		},
 	)
+	require.NoError(t, err)
+	assert.Equal(t, newTargetId, session.TargetId)
+	assert.Equal(t, newHostId, session.HostId)
 
 	// Cancel session
 	output = e2e.RunCommand(ctx, "boundary",


### PR DESCRIPTION
This PR addresses a flaky failure in `TestCliSessionCancel` with the following error
```
=== RUN   TestCliSessionCancelUser
    scope.go:70: Created Org Id: o_p1imR5XwmY
    scope.go:93: Created Project Id: p_SrsSL68EJx
    host.go:79: Created Host Catalog: hcst_jqhgbzwluh
    host.go:99: Created Host Set: hsst_yuzvyNaP1J
    host.go:121: Created Host: hst_CsIzTKxZL7
    target.go:59: Created Target: ttcp_pOKJAR32eC
    account.go:75: Created Account: acctpw_2IjDCeDgs6
    user.go:56: Created User: u_MjKYLz572K
    session_cancel_user_test.go:66: Successfully received an error when connecting to target as a user without permissions
    role.go:30: Created Role: r_QTTDFPI1ru
    session_cancel_user_test.go:79: Starting session as user...
    session_cancel_user_test.go:122: Found 1 session(s)
    session_cancel_user_test.go:138: 
        	Error Trace:	/home/runner/work/boundary/boundary/testing/internal/e2e/tests/static/session_cancel_user_test.go:138
        	Error:      	Not equal: 
        	            	expected: "active"
        	            	actual  : "pending"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-active
        	            	+pending
        	Test:       	TestCliSessionCancelUser
--- FAIL: TestCliSessionCancelUser (10.31s)
```

The test tries to check if a session reads as `active` after a user starts a session. This PR adds some additional retries to ensure that it will eventually go active.