### PR TITLE
feat(metric): adds active connections gauge metric for controller and worker clusters 

### DIFF
--- a/internal/daemon/controller/listeners.go
+++ b/internal/daemon/controller/listeners.go
@@ -232,13 +232,13 @@ func (c *Controller) configureForCluster(ln *base.ServerListener) (func(), error
 			}
 		}()
 		go func() {
-			err := handleSecondaryConnection(c.baseContext, multiplexingReverseGrpcListener, c.downstreamRoutes, -1)
+			err := handleSecondaryConnection(c.baseContext, metric.InstrumentClusterTrackingListener(reverseGrpcListener, "reverse-grpc"), c.downstreamRoutes, -1)
 			if err != nil {
 				event.WriteError(c.baseContext, op, err, event.WithInfoMsg("handleSecondaryConnection error"))
 			}
 		}()
 		go func() {
-			err := ln.GrpcServer.Serve(multiplexingAuthedListener)
+			err := ln.GrpcServer.Serve(metric.InstrumentClusterTrackingListener(multiplexingAuthedListener, "grpc"))
 			if err != nil {
 				event.WriteError(c.baseContext, op, err, event.WithInfoMsg("multiplexingAuthedListener error"))
 			}

--- a/internal/daemon/metric/initialize_metrics.go
+++ b/internal/daemon/metric/initialize_metrics.go
@@ -15,12 +15,13 @@ import (
 )
 
 const (
-	LabelGrpcService = "grpc_service"
-	LabelGrpcMethod  = "grpc_method"
-	LabelGrpcCode    = "grpc_code"
-	LabelHttpPath    = "path"
-	LabelHttpMethod  = "method"
-	LabelHttpCode    = "code"
+	LabelConnectionPurpose = "purpose"
+	LabelGrpcService       = "grpc_service"
+	LabelGrpcMethod        = "grpc_method"
+	LabelGrpcCode          = "grpc_code"
+	LabelHttpPath          = "path"
+	LabelHttpMethod        = "method"
+	LabelHttpCode          = "code"
 
 	invalidPathValue = "invalid"
 )
@@ -89,11 +90,11 @@ func InitializeGrpcCollectorsFromPackage(r prometheus.Registerer, v prometheus.O
 // InitializeGrpcCollectorsFromServer registers and zeroes a Prometheus
 // histogram, finding all service and method labels from the provided gRPC
 // server.
-func InitializeGrpcCollectorsFromServer(r prometheus.Registerer, v prometheus.ObserverVec, server *grpc.Server, codes []codes.Code) {
+func InitializeGrpcCollectorsFromServer(r prometheus.Registerer, v prometheus.ObserverVec, g prometheus.GaugeVec, server *grpc.Server, codes []codes.Code) {
 	if r == nil {
 		return
 	}
-	r.MustRegister(v)
+	r.MustRegister(v, g)
 
 	for serviceName, info := range server.GetServiceInfo() {
 		for _, mInfo := range info.Methods {

--- a/internal/daemon/metric/instrument_handlers.go
+++ b/internal/daemon/metric/instrument_handlers.go
@@ -4,7 +4,9 @@ package metric
 
 import (
 	"context"
+	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/boundary/internal/errors"
@@ -93,6 +95,37 @@ func NewGrpcRequestRecorder(fullMethodName string, reqLatency prometheus.Observe
 func (r requestRecorder) Record(err error) {
 	r.labels[LabelGrpcCode] = StatusFromError(err).Code().String()
 	r.reqLatency.With(r.labels).Observe(time.Since(r.start).Seconds())
+}
+
+type connectionTrackingListener struct {
+	net.Listener
+	connCount prometheus.Gauge
+}
+
+// NewConnectionTrackingListener registers a new Prometheus gauge with an unique connection type label
+// and wraps an existing listener to track when connections are accepted and closed.
+func NewConnectionTrackingListener(l net.Listener, g prometheus.Gauge) *connectionTrackingListener {
+	return &connectionTrackingListener{Listener: l, connCount: g}
+}
+
+type connectionTrackingListenerConn struct {
+	net.Conn
+	dec   sync.Once
+	gauge prometheus.Gauge
+}
+
+func (c *connectionTrackingListenerConn) Close() error {
+	c.dec.Do(func() { c.gauge.Dec() })
+	return c.Conn.Close()
+}
+
+func (l *connectionTrackingListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	l.connCount.Inc()
+	return &connectionTrackingListenerConn{Conn: conn, gauge: l.connCount}, nil
 }
 
 // StatusFromError retrieves the *status.Status from the provided error.  It'll

--- a/internal/daemon/metric/instrument_handlers_test.go
+++ b/internal/daemon/metric/instrument_handlers_test.go
@@ -2,7 +2,9 @@ package metric
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -25,6 +27,183 @@ var grpcRequestLatency prometheus.ObserverVec = prometheus.NewHistogramVec(
 	},
 	ListGrpcLabels,
 )
+
+type testPrometheusGauge struct {
+	prometheus.Metric
+	prometheus.Collector
+
+	incCalledN int
+	decCalledN int
+	t          *testing.T
+}
+
+func (tpg *testPrometheusGauge) Set(float64) { tpg.t.Fatal("testPrometheusGauge Set() called") }
+func (tpg *testPrometheusGauge) Inc()        { tpg.incCalledN++ }
+func (tpg *testPrometheusGauge) Dec()        { tpg.decCalledN++ }
+func (tpg *testPrometheusGauge) Add(float64) { tpg.t.Fatal("testPrometheusGauge Add() called") }
+func (tpg *testPrometheusGauge) Sub(float64) { tpg.t.Fatal("testPrometheusGauge Sub() called") }
+func (tpg *testPrometheusGauge) SetToCurrentTime() {
+	tpg.t.Fatal("testPrometheusGauge SetToCurrentTime() called")
+}
+
+type testListener struct {
+	net.Listener
+	lastClientConn net.Conn
+}
+
+func (l *testListener) Accept() (net.Conn, error) {
+	s, c := net.Pipe()
+	l.lastClientConn = c
+	return s, nil
+}
+
+func (l *testListener) Close() error {
+	return l.lastClientConn.Close()
+}
+
+type erroringAcceptListener struct {
+	net.Listener
+}
+
+func (l *erroringAcceptListener) Accept() (net.Conn, error) {
+	return nil, errors.New("error for testcase")
+}
+
+type erroringCloseListener struct {
+	net.Listener
+	lastClientConn net.Conn
+}
+
+func (l *erroringCloseListener) Accept() (net.Conn, error) {
+	s, c := net.Pipe()
+	l.lastClientConn = c
+	return &erroringConn{Conn: s}, nil
+}
+
+type erroringConn struct {
+	net.Conn
+}
+
+func (c *erroringConn) Close() error {
+	c.Conn.Close()
+	return errors.New("error for testcase")
+}
+
+func TestNewConnectionTrackingListener(t *testing.T) {
+	t.Run("accept-err",
+		func(t *testing.T) {
+			tpg := &testPrometheusGauge{t: t}
+			el := &erroringAcceptListener{}
+			ctl := NewConnectionTrackingListener(el, tpg)
+			require.NotNil(t, ctl)
+
+			cc, err := ctl.Accept()
+			assert.Nil(t, cc)
+			assert.Contains(t, "error for testcase", err.Error())
+		})
+	t.Run("accept-multiple",
+		func(t *testing.T) {
+			tpg := &testPrometheusGauge{t: t}
+			n := 10
+			for i := 0; i < n; i++ {
+				l := &testListener{}
+				ctl := NewConnectionTrackingListener(l, tpg)
+				require.NotNil(t, ctl)
+				cc, err := ctl.Accept()
+				assert.NotNil(t, cc)
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, n, tpg.incCalledN)
+		})
+	t.Run("close-err",
+		func(t *testing.T) {
+			tpg := &testPrometheusGauge{t: t}
+			el := &erroringCloseListener{}
+			ctl := NewConnectionTrackingListener(el, tpg)
+			require.NotNil(t, ctl)
+
+			cc, err := ctl.Accept()
+			require.NotNil(t, cc)
+			require.NoError(t, err)
+			assert.Equal(t, 1, tpg.incCalledN)
+
+			assert.Error(t, cc.Close())
+			assert.Equal(t, 1, tpg.decCalledN)
+		})
+	t.Run("close-repeat-calls",
+		func(t *testing.T) {
+			tpg := &testPrometheusGauge{t: t}
+			l := &testListener{}
+			ctl := NewConnectionTrackingListener(l, tpg)
+			require.NotNil(t, ctl)
+
+			cc, err := ctl.Accept()
+			require.Nil(t, err)
+			require.NotNil(t, cc)
+			assert.Equal(t, 0, tpg.decCalledN)
+
+			for i := 0; i <= 5; i++ {
+				assert.NoError(t, cc.Close())
+			}
+			assert.Equal(t, 1, tpg.decCalledN)
+		})
+	t.Run("inc-dec",
+		func(t *testing.T) {
+			tpg := &testPrometheusGauge{t: t}
+			l := &testListener{}
+
+			ctl := NewConnectionTrackingListener(l, tpg)
+			require.NotNil(t, ctl)
+			assert.Equal(t, 0, tpg.incCalledN)
+
+			cc, err := ctl.Accept()
+			require.Nil(t, err)
+			require.NotNil(t, cc)
+			assert.Equal(t, 1, tpg.incCalledN)
+
+			require.NoError(t, cc.Close())
+			assert.Equal(t, 1, tpg.decCalledN)
+		},
+	)
+	t.Run("more-inc-dec",
+		func(t *testing.T) {
+			tpg := &testPrometheusGauge{t: t}
+			l1 := &testListener{}
+			l2 := &testListener{}
+			l3 := &testListener{}
+
+			ctl1 := NewConnectionTrackingListener(l1, tpg)
+			require.NotNil(t, ctl1)
+			assert.Equal(t, 0, tpg.incCalledN)
+
+			cc1, err := ctl1.Accept()
+			require.Nil(t, err)
+			require.NotNil(t, cc1)
+			assert.Equal(t, 1, tpg.incCalledN)
+
+			ctl2 := NewConnectionTrackingListener(l2, tpg)
+			require.NotNil(t, ctl2)
+			cc2, err := ctl2.Accept()
+			require.Nil(t, err)
+			require.NotNil(t, cc2)
+			assert.Equal(t, 2, tpg.incCalledN)
+
+			require.NoError(t, cc1.Close())
+			require.NoError(t, cc2.Close())
+			assert.Equal(t, 2, tpg.decCalledN)
+
+			ctl3 := NewConnectionTrackingListener(l3, tpg)
+			require.NotNil(t, ctl3)
+			cc3, err := ctl3.Accept()
+			require.Nil(t, err)
+			require.NotNil(t, cc3)
+			assert.Equal(t, 3, tpg.incCalledN)
+
+			require.NoError(t, cc3.Close())
+			assert.Equal(t, 3, tpg.decCalledN)
+		},
+	)
+}
 
 func TestNewStatsHandler(t *testing.T) {
 	cases := []struct {

--- a/internal/daemon/worker/internal/metric/cluster_server.go
+++ b/internal/daemon/worker/internal/metric/cluster_server.go
@@ -2,6 +2,7 @@ package metric
 
 import (
 	"context"
+	"net"
 
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/daemon/metric"
@@ -24,10 +25,20 @@ var grpcServerRequestLatency prometheus.ObserverVec = prometheus.NewHistogramVec
 		Namespace: globals.MetricNamespace,
 		Subsystem: workerClusterSubsystem,
 		Name:      "grpc_request_duration_seconds",
-		Help:      "Histogram of latencies for gRPC requests between the a worker server and a worker client.",
+		Help:      "Histogram of latencies for gRPC requests between a worker server and a worker client.",
 		Buckets:   prometheus.DefBuckets,
 	},
 	metric.ListGrpcLabels,
+)
+
+var activeConnections = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: globals.MetricNamespace,
+		Subsystem: workerClusterSubsystem,
+		Name:      "active_connections",
+		Help:      "Count of active network connections to this worker server.",
+	},
+	[]string{metric.LabelConnectionPurpose},
 )
 
 // All the codes expected to be returned by boundary or the grpc framework to
@@ -42,6 +53,11 @@ var expectedGrpcCodes = []codes.Code{
 	codes.Unavailable, codes.Unauthenticated,
 }
 
+func InstrumentWorkerClusterTrackingListener(l net.Listener, purpose string) net.Listener {
+	p := prometheus.Labels{metric.LabelConnectionPurpose: purpose}
+	return metric.NewConnectionTrackingListener(l, activeConnections.With(p))
+}
+
 // InstrumentClusterStatsHandler returns a gRPC stats.Handler which observes
 // cluster-specific metrics for a gRPC server.
 func InstrumentClusterStatsHandler(ctx context.Context) (stats.Handler, error) {
@@ -52,5 +68,5 @@ func InstrumentClusterStatsHandler(ctx context.Context) (stats.Handler, error) {
 // prometheus register and initializes them to 0 for all possible label
 // combinations.
 func InitializeClusterServerCollectors(r prometheus.Registerer, server *grpc.Server) {
-	metric.InitializeGrpcCollectorsFromServer(r, grpcServerRequestLatency, server, expectedGrpcCodes)
+	metric.InitializeGrpcCollectorsFromServer(r, grpcServerRequestLatency, *activeConnections, server, expectedGrpcCodes)
 }

--- a/internal/daemon/worker/listeners.go
+++ b/internal/daemon/worker/listeners.go
@@ -200,8 +200,8 @@ func (w *Worker) configureForWorker(ln *base.ServerListener, logger *log.Logger,
 	return func() {
 		go w.workerAuthSplitListener.Start()
 		go httpServer.Serve(proxyListener)
-		go ln.GrpcServer.Serve(eventingListener)
-		go handleSecondaryConnection(cancelCtx, reverseGrpcListener, w.downstreamRoutes, -1)
+		go ln.GrpcServer.Serve(metric.InstrumentWorkerClusterTrackingListener(eventingListener, "grpc"))
+		go handleSecondaryConnection(cancelCtx, metric.InstrumentWorkerClusterTrackingListener(reverseGrpcListener, "reverse-grpc"), w.downstreamRoutes, -1)
 	}, nil
 }
 


### PR DESCRIPTION
redoing PR https://github.com/hashicorp/boundary/pull/2582/ with non-messed-up git history