### PR TITLE
Add logging to journal for systemd

### DIFF
--- a/.release/linux/package/usr/lib/systemd/system/boundary.service
+++ b/.release/linux/package/usr/lib/systemd/system/boundary.service
@@ -18,6 +18,8 @@ Restart=on-failure
 RestartSec=5
 TimeoutStopSec=30
 LimitMEMLOCK=infinity
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Right now no logs are visible for a boundary instance run via systemd. This PR adds 2 lines to the unit file to log stdout and stderr to journal, so that the logs can be seen with e.g.

```
journalctl -u boundary@pki-worker.service
```

That is, if one manually implements the PR https://github.com/hashicorp/boundary/pull/2268 which btw really should be merged asap, since right now boundary via systemd is essentially not working, unless one puts the config file one wants to run to `/etc/boundary.d/.hcl`, which would be a dangerous botch job.