### PR TITLE
Silence events from DB errors

### DIFF
--- a/internal/db/read_writer.go
+++ b/internal/db/read_writer.go
@@ -543,5 +543,5 @@ func wrapError(ctx context.Context, err error, op string, errOpts ...errors.Opti
 		errOpts = append(errOpts, errors.WithCode(errors.InvalidFieldMask))
 	}
 
-	return errors.Wrap(ctx, err, errors.Op(op), errOpts...)
+	return errors.Wrap(ctx, err, errors.Op(op), append(errOpts, errors.WithoutEvent())...)
 }


### PR DESCRIPTION
If callers want errors to create events, they can do so by wrapping the error. Sometimes we don't want db
errors to be events, and before this there was no way to suppress them.