### PR TITLE
chore: bump UI commit to latest

### DIFF
--- a/internal/ui/VERSION
+++ b/internal/ui/VERSION
@@ -1,4 +1,4 @@
-3deec2ed502db3443a2fe512630c339e5009f4c4
+fce82c6d9fe92062e6aec20919ed41ad255deaae
 # This file determines the version of the UI to embed in the boundary binary.
 # Update this file by running 'make update-ui-version' from the root of this repo.
 # Set UI_COMMITISH when running the above target to update to a specific version.


### PR DESCRIPTION
Bumps the UI version to the latest commit in [boundary-ui](https://github.com/hashicorp/boundary-ui).