### PR TITLE
Update Boundary network requirements

### DIFF
--- a/website/content/docs/getting-started/installing/production.mdx
+++ b/website/content/docs/getting-started/installing/production.mdx
@@ -12,9 +12,8 @@ Installing Boundary in a production setting requires prerequisits for infrastruc
 ## Network Requirements
 
 - Client -> Controller port is :9200
-- Controller -> Worker port is :9201
-- Client must have access to Controller on :9200
-- :9201 must be open between Worker and Controller
+- Worker -> Controller port is :9201
+- Client -> Worker port is :9202
 - Workers must have a route and port access to the targets which they service
 
 ## Architecture


### PR DESCRIPTION
Per the following Slack conversation, the Boundary Network Requirements are incorrect:

https://hashicorp.slack.com/archives/C016ZKNM05T/p1668000335382949

This pull request:

- Removes redundant entries for ports 9200 and 9201
    - The Slack conversation mentioned that the client -> controller info re. port 9200 is repeated, but I think this is redundant as well: `:9201 must be open between Worker and Controller`. Please correct me if I am wrong.
- Adds the Client to Worker traffic with a required port of 9202
- Fixes the direction of the traffic flow from Worker -> Controller

Asana task: https://app.asana.com/0/563192436488770/1203340202571850/f