### PR TITLE
Fix pull-down placement

### DIFF
--- a/website/content/docs/concepts/filtering/events.mdx
+++ b/website/content/docs/concepts/filtering/events.mdx
@@ -5,11 +5,9 @@ description: |-
   How to filter events emitted by Boundary.
 ---
 
-This page describes how to filter events written to Boundary event sinks.
-
-~> **Note:** This feature was introduced in Boundary 0.5.0.
-
 # Event Filtering
+
+This page describes how to filter events written to Boundary event sinks.
 
 Starting in Boundary 0.5.0, a variety of event types (error, observation,
 system, etc) are emitted from Boundary.   Boundary events can be emitted in

--- a/website/content/docs/concepts/filtering/oidc-managed-groups.mdx
+++ b/website/content/docs/concepts/filtering/oidc-managed-groups.mdx
@@ -5,15 +5,15 @@ description: |-
   How to configure filters for managed groups within the OIDC auth method.
 ---
 
+[filter syntax]: /docs/concepts/filtering
+
+# OIDC Managed Groups Filtering
+
 This page describes how to use filters with OIDC managed groups. It assumes that
 the reader is familiar with the general [filter syntax][] as well as with
 [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html).
 
 ~> **Note:** This feature was introduced in Boundary 0.3.0.
-
-[filter syntax]: /docs/concepts/filtering
-
-# OIDC Managed Groups Filtering
 
 Currently, two blocks of data are available for these filters:
 

--- a/website/content/docs/concepts/filtering/resource-listing.mdx
+++ b/website/content/docs/concepts/filtering/resource-listing.mdx
@@ -5,14 +5,14 @@ description: |-
   How to use filter list responses coming back from Boundary.
 ---
 
+# List Filtering
+
 This page describes how to use filters when listing resources. This can be used
 to reduce the returned set of resources when performing a list operation.
 
 ~> **Note:** This feature is intended to provide a userful service to clients; it does not
 affect the database queries generated for the operation and as such is not
 designed to provide greater efficiency.
-
-# List Filtering
 
 Starting in Boundary 0.1.8, when running a list action, a filter can be
 specified. It uses the standard [filter syntax](/docs/concepts/filtering) used

--- a/website/content/docs/concepts/filtering/worker-tags.mdx
+++ b/website/content/docs/concepts/filtering/worker-tags.mdx
@@ -5,12 +5,12 @@ description: |-
   How to use worker tags to control which workers can handle a given resource.
 ---
 
+# Worker Tags
+
 This page describes how to use worker tags and filters to control which workers
 are allowed to handle a given resource. This can be used to control traffic
 locality. As an example, this can be used to ensure that traffic going into a
 public cloud is only handled by workers running within that same cloud.
-
-# Worker Tags
 
 Starting in Boundary 0.1.5, a worker can be configured with a set of key/value
 tags in its configuration file. The keys and values can be any lower-cased


### PR DESCRIPTION
Per a Slack conversation:
https://hashicorp.slack.com/archives/C8DK5PR0B/p1668182567733029

Some of the pages in the Boundary docs have content above the H1 heading. Per Kyle McDonald, this is causing the version pull-down to overlap content and there is an upcoming rule that will warn that all pages must begin with an H1. 

<img width="745" alt="image" src="https://user-images.githubusercontent.com/76443935/201420354-8e7e2f9d-e9ec-4d60-a959-6cc9b677b2fe.png">

This PR moves the H1 heading above any other content. The following pages in the Filtering section all have this issue:

- [OIDC managed groups](https://developer.hashicorp.com/boundary/docs/concepts/filtering/oidc-managed-groups)
- [Resource Listing](https://developer.hashicorp.com/boundary/docs/concepts/filtering/resource-listing)
- [Worker Tags](https://developer.hashicorp.com/boundary/docs/concepts/filtering/worker-tags)
- [Events](https://developer.hashicorp.com/boundary/docs/concepts/filtering/events)