### PR TITLE
Unset session key ID when deleting the scope, ignore decryption when session has no project or user

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/44/04_sessions.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/44/04_sessions.up.sql
@@ -12,6 +12,7 @@ begin;
   ;
 
   -- Replaces trigger from 01/50_session.up.sql
+  -- Replaced in 56/02_add_data_key_foreign_key_references
   create or replace function cancel_session_with_null_fk() returns trigger
   as $$
   begin

--- a/internal/session/options.go
+++ b/internal/session/options.go
@@ -30,7 +30,6 @@ type options struct {
 	withUserId                   string
 	withExpirationTime           *timestamp.Timestamp
 	withTestTofu                 []byte
-	withListingConvert           bool
 	withSessionIds               []string
 	withDbOpts                   []db.Option
 	withWorkerStateDelay         time.Duration
@@ -97,12 +96,6 @@ func WithTestTofu(tofu []byte) Option {
 func WithSessionIds(ids ...string) Option {
 	return func(o *options) {
 		o.withSessionIds = ids
-	}
-}
-
-func withListingConvert(withListingConvert bool) Option {
-	return func(o *options) {
-		o.withListingConvert = withListingConvert
 	}
 }
 

--- a/internal/session/repository.go
+++ b/internal/session/repository.go
@@ -113,9 +113,8 @@ func (r *Repository) listPermissionWhereClauses() ([]string, []interface{}) {
 	return where, args
 }
 
-func (r *Repository) convertToSessions(ctx context.Context, sessionList []*sessionListView, opt ...Option) ([]*Session, error) {
+func (r *Repository) convertToSessions(ctx context.Context, sessionList []*sessionListView) ([]*Session, error) {
 	const op = "session.(Repository).convertToSessions"
-	opts := getOpts(opt...)
 
 	if len(sessionList) == 0 {
 		return nil, nil
@@ -147,29 +146,18 @@ func (r *Repository) convertToSessions(ctx context.Context, sessionList []*sessi
 				AuthTokenId:             sv.AuthTokenId,
 				ProjectId:               sv.ProjectId,
 				Certificate:             sv.Certificate,
-				CtCertificatePrivateKey: sv.CtCertificatePrivateKey,
-				CertificatePrivateKey:   sv.CertificatePrivateKey, // will always be nil since it's not stored in the database.
+				CtCertificatePrivateKey: nil, // CtCertificatePrivateKey should not be returned in lists
+				CertificatePrivateKey:   nil, // CertificatePrivateKey should not be returned in lists
 				ExpirationTime:          sv.ExpirationTime,
-				CtTofuToken:             sv.CtTofuToken,
-				TofuToken:               sv.TofuToken, // will always be nil since it's not stored in the database.
+				CtTofuToken:             nil, // CtTofuToken should not be returned in lists
+				TofuToken:               nil, // TofuToken should not be returned in lists
 				TerminationReason:       sv.TerminationReason,
 				CreateTime:              sv.CreateTime,
 				UpdateTime:              sv.UpdateTime,
 				Version:                 sv.Version,
 				Endpoint:                sv.Endpoint,
 				ConnectionLimit:         sv.ConnectionLimit,
-				KeyId:                   sv.KeyId,
-			}
-			if opts.withListingConvert {
-				workingSession.CtCertificatePrivateKey = nil // CtCertificatePrivateKey should not returned in lists
-				workingSession.CertificatePrivateKey = nil   // CertificatePrivateKey should not returned in lists
-				workingSession.CtTofuToken = nil             // CtTofuToken should not returned in lists
-				workingSession.TofuToken = nil               // TofuToken should not returned in lists
-				workingSession.KeyId = ""                    // KeyId should not be returned in lists
-			} else {
-				if err := decryptAndMaybeUpdateSession(ctx, r.kms, workingSession, r.writer); err != nil {
-					return nil, errors.Wrap(ctx, err, op)
-				}
+				KeyId:                   "", // KeyId should not be returned in lists
 			}
 		}
 

--- a/internal/session/repository_session_test.go
+++ b/internal/session/repository_session_test.go
@@ -1200,6 +1200,22 @@ func TestRepository_CancelSessionViaFKNull(t *testing.T) {
 			}(),
 		},
 		{
+			name: "Scope",
+			cancelFk: func() cancelFk {
+				s := setupFn()
+
+				t := &iam.Scope{
+					Scope: &iamStore.Scope{
+						PublicId: s.ProjectId,
+					},
+				}
+				return cancelFk{
+					s:      s,
+					fkType: t,
+				}
+			}(),
+		},
+		{
 			name: "HostSet",
 			cancelFk: func() cancelFk {
 				s := setupFn()

--- a/internal/session/repository_test.go
+++ b/internal/session/repository_test.go
@@ -145,24 +145,14 @@ func TestRepository_convertToSessions(t *testing.T) {
 		sessionsList = append(sessionsList, &s)
 	}
 
-	t.Run("without-options", func(t *testing.T) {
-		sessions, err := repo.convertToSessions(ctx, sessionsList)
-		require.NoError(t, err)
-		assert.Len(t, sessions, 1)
-		assert.Equal(t, sessions[0], sess)
-	})
-
-	t.Run("converting-for-list", func(t *testing.T) {
-		sessions, err := repo.convertToSessions(ctx, sessionsList, withListingConvert(true))
-		require.NoError(t, err)
-		assert.Len(t, sessions, 1)
-		sess := sess.Clone().(*Session)
-		// Check that encrypted values are redacted
-		sess.CtCertificatePrivateKey = nil
-		sess.CertificatePrivateKey = nil
-		sess.CtTofuToken = nil
-		sess.TofuToken = nil
-		sess.KeyId = ""
-		assert.Equal(t, sessions[0], sess)
-	})
+	sessions, err := repo.convertToSessions(ctx, sessionsList)
+	require.NoError(t, err)
+	assert.Len(t, sessions, 1)
+	// Check that encrypted values are redacted
+	sess.CtCertificatePrivateKey = nil
+	sess.CertificatePrivateKey = nil
+	sess.CtTofuToken = nil
+	sess.TofuToken = nil
+	sess.KeyId = ""
+	assert.Equal(t, sessions[0], sess)
 }


### PR DESCRIPTION
Unsetting the key ID allows the session to live beyond the lifetime of the scope, while allowing the scope to cascade delete its keys.

We also stop decrypting session fields if the session is missing a project or user, since decryption cannot always succeed in these cases.

Note that removing the relationship to the key means that the encrypted data in the (now canceled) session may become unrecoverable. This is an acceptable consequence of this change.