### PR TITLE
fix(worker): Verify contents of loaded session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   ([PR](https://github.com/hashicorp/boundary/pull/2553))
 * sessions: Fixed a panic in a controller when a worker is deleted while
   sessions are ongoing ([PR](https://github.com/hashicorp/boundary/pull/2612))
+* sessions: Fixed a panic in a worker when a user with an active
+  session is deleted ([PR](https://github.com/hashicorp/boundary/pull/2629))
 
 ### Deprecations/Changes
 

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -600,10 +600,10 @@ func (w *Worker) getSessionTls(sessionManager session.Manager) func(hello *tls.C
 		if sess.GetCertificate() == nil {
 			return nil, fmt.Errorf("requested session has no certifificate")
 		}
-		if sess.GetCertificate().Raw == nil {
+		if len(sess.GetCertificate().Raw) == 0 {
 			return nil, fmt.Errorf("requested session has no certificate DER")
 		}
-		if sess.GetPrivateKey() == nil {
+		if len(sess.GetPrivateKey()) == 0 {
 			return nil, fmt.Errorf("requested session has no private key")
 		}
 

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -597,6 +597,16 @@ func (w *Worker) getSessionTls(sessionManager session.Manager) func(hello *tls.C
 			return nil, fmt.Errorf("error refreshing session: %w", err)
 		}
 
+		if sess.GetCertificate() == nil {
+			return nil, fmt.Errorf("requested session has no certifificate")
+		}
+		if sess.GetCertificate().Raw == nil {
+			return nil, fmt.Errorf("requested session has no certificate DER")
+		}
+		if sess.GetPrivateKey() == nil {
+			return nil, fmt.Errorf("requested session has no private key")
+		}
+
 		certPool := x509.NewCertPool()
 		certPool.AddCert(sess.GetCertificate())
 


### PR DESCRIPTION
Previously, it was possible for an empty private key to be used when the session had no user or project associated with it. The new checks guarantee that we will fail gracefully in these cases.