### PR TITLE
fix(session): Always invoke all parts of session cancel trigger

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/56/02_add_data_key_foreign_key_references.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/56/02_add_data_key_foreign_key_references.up.sql
@@ -39,23 +39,29 @@ begin;
   create or replace function cancel_session_with_null_fk() returns trigger
   as $$
   begin
-   case 
-      when new.user_id is null then
-        perform cancel_session(new.public_id);
-      when new.host_id is null then
-        perform cancel_session(new.public_id);
-      when new.target_id is null then
-        perform cancel_session(new.public_id);
-      when new.host_set_id is null then
-        perform cancel_session(new.public_id);
-      when new.auth_token_id is null then
-        perform cancel_session(new.public_id);
-      when new.project_id is null then
-        -- Setting the key_id to null will allow the scope
-        -- to cascade delete its keys.
-        new.key_id = null;
-        perform cancel_session(new.public_id);
-    end case;
+    -- Note that we need each of these to run in case
+    -- more than one of them is null.
+    if new.user_id is null then
+      perform cancel_session(new.public_id);
+    end if;
+    if new.host_id is null then
+      perform cancel_session(new.public_id);
+    end if;
+    if new.target_id is null then
+      perform cancel_session(new.public_id);
+    end if;
+    if new.host_set_id is null then
+      perform cancel_session(new.public_id);
+    end if;
+    if new.auth_token_id is null then
+      perform cancel_session(new.public_id);
+    end if;
+    if new.project_id is null then
+      -- Setting the key_id to null will allow the scope
+      -- to cascade delete its keys.
+      new.key_id = null;
+      perform cancel_session(new.public_id);
+    end if;
     return new;
   end;
   $$ language plpgsql;


### PR DESCRIPTION
The session cancelation trigger would not set the key_id to null appropriately if another one of the fields on the session was already null, since that case statement would be matched first. The new structure matches all statements, in case any of them have special logic (such as in the project case).