### PR TITLE
bump up ui commit

### DIFF
--- a/internal/ui/VERSION
+++ b/internal/ui/VERSION
@@ -1,4 +1,4 @@
-42169b070c083fd5be863fe5c7be16d96adf2b9b
+65efe5848134955369f855195d8c569eaa492431
 # This file determines the version of the UI to embed in the boundary binary.
 # Update this file by running 'make update-ui-version' from the root of this repo.
 # Set UI_COMMITISH when running the above target to update to a specific version.


### PR DESCRIPTION
Bumps the UI version to the latest commit in [boundary-ui](https://github.com/hashicorp/boundary-ui).