### PR TITLE
Create new "previous-root" key purpose for root key migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 * sessions: Fixed a bug where reading a session after its associated project
   had been deleted would result in an error
   ([PR](https://github.com/hashicorp/boundary/pull/2615))
+* config: Fixed a bug where supplying multiple KMS blocks with the same purpose
+  would silently ignore all but the last block
+  ([PR](https://github.com/hashicorp/boundary/pull/2639))
 
 ### Deprecations/Changes
 

--- a/globals/kms.go
+++ b/globals/kms.go
@@ -2,6 +2,7 @@ package globals
 
 const (
 	KmsPurposeRoot              = "root"
+	KmsPurposePreviousRoot      = "previous-root"
 	KmsPurposeWorkerAuth        = "worker-auth"
 	KmsPurposeWorkerAuthStorage = "worker-auth-storage"
 	KmsPurposeRecovery          = "recovery"

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require github.com/hashicorp/go-dbw v0.0.0-20220910135738-ed4505749995
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20220914160710-1c6d04de2431
+	github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20221122211539-47c893099f13
 	github.com/hashicorp/nodeenrollment v0.1.17
 	github.com/kelseyhightower/envconfig v1.4.0
 	golang.org/x/exp v0.0.0-20220921164117-439092de6870

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/hashicorp/go-bexpr v0.1.10
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-hclog v1.2.2
-	github.com/hashicorp/go-kms-wrapping/v2 v2.0.6-0.20220722192355-a843f53fa48d
+	github.com/hashicorp/go-kms-wrapping/v2 v2.0.6-0.20221122211539-47c893099f13
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/go-rootcerts v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -681,6 +681,8 @@ github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-kms-wrapping/entropy v0.1.0/go.mod h1:d1g9WGtAunDNpek8jUIEJnBlbgKS1N2Q61QkHiZyR1g=
 github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20220914160710-1c6d04de2431 h1:2fmBl291s44mKzvBjF1TfqJgw1GHk97jxkGbalp4TEM=
 github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20220914160710-1c6d04de2431/go.mod h1:qbLdiZhFd182vRSOlhBV/OarUcJVTOF2WklPwHs8mYQ=
+github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20221122211539-47c893099f13 h1:486QccSsJAKonkWSZmBn5GWzZCW3UV3OwMoOGUXJBO4=
+github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20221122211539-47c893099f13/go.mod h1:qbLdiZhFd182vRSOlhBV/OarUcJVTOF2WklPwHs8mYQ=
 github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.2 h1:it114Kjpk79JVh6AfxFMP5oi1gb+RPzcSLiG3zF/J0w=
 github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.2/go.mod h1:b9mq0bG5xJ10ZcTEQJLZ22O9y71hIt2MGTLqROA/SAM=
 github.com/hashicorp/go-kms-wrapping/v2 v2.0.6-0.20220722192355-a843f53fa48d h1:mOtPXWIp4cWKNt9S55IuYAdyUgNtCfUAEVIjcXDx59E=

--- a/go.sum
+++ b/go.sum
@@ -679,14 +679,12 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-kms-wrapping/entropy v0.1.0/go.mod h1:d1g9WGtAunDNpek8jUIEJnBlbgKS1N2Q61QkHiZyR1g=
-github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20220914160710-1c6d04de2431 h1:2fmBl291s44mKzvBjF1TfqJgw1GHk97jxkGbalp4TEM=
-github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20220914160710-1c6d04de2431/go.mod h1:qbLdiZhFd182vRSOlhBV/OarUcJVTOF2WklPwHs8mYQ=
 github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20221122211539-47c893099f13 h1:486QccSsJAKonkWSZmBn5GWzZCW3UV3OwMoOGUXJBO4=
 github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20221122211539-47c893099f13/go.mod h1:qbLdiZhFd182vRSOlhBV/OarUcJVTOF2WklPwHs8mYQ=
 github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.2 h1:it114Kjpk79JVh6AfxFMP5oi1gb+RPzcSLiG3zF/J0w=
 github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.2/go.mod h1:b9mq0bG5xJ10ZcTEQJLZ22O9y71hIt2MGTLqROA/SAM=
-github.com/hashicorp/go-kms-wrapping/v2 v2.0.6-0.20220722192355-a843f53fa48d h1:mOtPXWIp4cWKNt9S55IuYAdyUgNtCfUAEVIjcXDx59E=
-github.com/hashicorp/go-kms-wrapping/v2 v2.0.6-0.20220722192355-a843f53fa48d/go.mod h1:sDQAfwJGv25uGPZA04x87ERglCG6avnRcBT9wYoMII8=
+github.com/hashicorp/go-kms-wrapping/v2 v2.0.6-0.20221122211539-47c893099f13 h1:4YewFQjQJNAzXtahRax77IFi0emoYvPZGESfi+KCpGg=
+github.com/hashicorp/go-kms-wrapping/v2 v2.0.6-0.20221122211539-47c893099f13/go.mod h1:sDQAfwJGv25uGPZA04x87ERglCG6avnRcBT9wYoMII8=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=

--- a/internal/cmd/base/server_test.go
+++ b/internal/cmd/base/server_test.go
@@ -70,6 +70,11 @@ func TestServer_SetupKMSes_Purposes(t *testing.T) {
 			wantErrContains: fmt.Sprintf("KMS block contains '%s' without '%s'", globals.KmsPurposePreviousRoot, globals.KmsPurposeRoot),
 		},
 		{
+			name:            "root and previous in the same stanza",
+			purposes:        []string{globals.KmsPurposeRoot, globals.KmsPurposePreviousRoot},
+			wantErrContains: fmt.Sprintf("KMS blocks with purposes '%s' and '%s' must have different key IDs", globals.KmsPurposeRoot, globals.KmsPurposePreviousRoot),
+		},
+		{
 			name:            "duplicate root purposes",
 			purposes:        []string{globals.KmsPurposeRoot, globals.KmsPurposeRoot},
 			wantErrContains: fmt.Sprintf("Duplicate KMS block for purpose '%s'", globals.KmsPurposeRoot),

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -623,27 +623,27 @@ func (b *Server) SetupKMSes(ctx context.Context, ui cli.Ui, config *config.Confi
 			switch purpose {
 			case globals.KmsPurposePreviousRoot:
 				if previousRootKms != nil {
-					return fmt.Errorf("Duplicate KMS block for purpose '%s'", purpose)
+					return fmt.Errorf("Duplicate KMS block for purpose '%s'. You may need to remove all but the last KMS block for this purpose.", purpose)
 				}
 				previousRootKms = wrapper
 			case globals.KmsPurposeRoot:
 				if b.RootKms != nil {
-					return fmt.Errorf("Duplicate KMS block for purpose '%s'", purpose)
+					return fmt.Errorf("Duplicate KMS block for purpose '%s'. You may need to remove all but the last KMS block for this purpose.", purpose)
 				}
 				b.RootKms = wrapper
 			case globals.KmsPurposeWorkerAuth:
 				if b.WorkerAuthKms != nil {
-					return fmt.Errorf("Duplicate KMS block for purpose '%s'", purpose)
+					return fmt.Errorf("Duplicate KMS block for purpose '%s'. You may need to remove all but the last KMS block for this purpose.", purpose)
 				}
 				b.WorkerAuthKms = wrapper
 			case globals.KmsPurposeWorkerAuthStorage:
 				if b.WorkerAuthStorageKms != nil {
-					return fmt.Errorf("Duplicate KMS block for purpose '%s'", purpose)
+					return fmt.Errorf("Duplicate KMS block for purpose '%s'. You may need to remove all but the last KMS block for this purpose.", purpose)
 				}
 				b.WorkerAuthStorageKms = wrapper
 			case globals.KmsPurposeRecovery:
 				if b.RecoveryKms != nil {
-					return fmt.Errorf("Duplicate KMS block for purpose '%s'", purpose)
+					return fmt.Errorf("Duplicate KMS block for purpose '%s'. You may need to remove all but the last KMS block for this purpose.", purpose)
 				}
 				b.RecoveryKms = wrapper
 			case globals.KmsPurposeConfig:

--- a/internal/cmd/commands/server/listener_reload_test.go
+++ b/internal/cmd/commands/server/listener_reload_test.go
@@ -88,9 +88,7 @@ func TestServer_ReloadListener(t *testing.T) {
 	wd += "/test-fixtures/reload/"
 
 	td, err := os.MkdirTemp("", "boundary-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 	defer os.RemoveAll(td)
 
 	controllerKey := config.DevKeyGeneration()
@@ -103,13 +101,16 @@ func TestServer_ReloadListener(t *testing.T) {
 		UseDevAuthMethod:  true,
 		UseDevTarget:      true,
 	})
+	// Unset auto-created KMSes that are overwritten by config on startup
+	cmd.RootKms = nil
+	cmd.WorkerAuthKms = nil
+	cmd.RecoveryKms = nil
 
 	defer func() {
 		if cmd.DevDatabaseCleanupFunc != nil {
 			require.NoError(cmd.DevDatabaseCleanupFunc())
 		}
 	}()
-	require.NoError(err)
 
 	// Setup initial certs
 	inBytes, err := os.ReadFile(wd + "bundle1.pem")

--- a/website/content/docs/concepts/security/data-encryption.mdx
+++ b/website/content/docs/concepts/security/data-encryption.mdx
@@ -20,7 +20,7 @@ Worker](/docs/configuration/worker/pki-worker) for storage of authentication
 keys. It is optional for PKI workers; if not specified the authentication keys
 will not be encrypted on disk. This is not used by KMS workers.
 
-## The `rootKey` KMS Key and Per-Scope KEK/DEKs <sup>OSS Only</sup>
+## The `root` KMS Key and Per-Scope KEK/DEKs <sup>OSS Only</sup>
 
 Following best practices of using different encryption keys for different
 purposes, Boundary has a number of encryption keys generated within each scope.
@@ -29,11 +29,11 @@ data. You can create new key versions by _rotating_ the keys. A key version
 can be destroyed, which will re-encrypt any existing data before destroying the
 key material permanently.
 
-The `rootKey` KMS key acts as a KEK (Key Encrypting Key) for the scope-specific
-KEKs (also referred to as the scope's `rootKey` key). The scope's `rootKey` KEK
+The `root` KMS key acts as a KEK (Key Encrypting Key) for the scope-specific
+KEKs (also referred to as the scope's `root` key). The scope's `root` KEK
 and the various DEKs (Data Encryption Keys) are created when a scope is created.
-The DEKs are encrypted with the scope's `rootKey` KEK, and this is in turn
-encrypted with the KMS key marked for the `rootKey` purpose.
+The DEKs are encrypted with the scope's `root` KEK, and this is in turn
+encrypted with the KMS key marked for the `root` purpose.
 
 The current scoped DEKs and their purposes are detailed below:
 
@@ -104,6 +104,13 @@ $ boundary scopes list-key-version-destruction-jobs -scope-id p_A4jfDjZ9jf
 
 Once the job disappears from this list, the associated key version will have
 been destroyed and any existing data will have been re-encrypted.
+
+## The `previous-root` KMS key <sup>OSS Only</sup>
+
+The `previous-root` KMS key is used when migrating to a new `root` key. Adding
+it to your configuration will inform the Controller to use it for decrypting
+the existing information in the database, allowing you to rotate and rewrap
+the KEKs to complete the migration to the new root key.
 
 ## The `worker-auth` KMS Key <sup>OSS Only</sup>
 

--- a/website/content/docs/concepts/security/data-encryption.mdx
+++ b/website/content/docs/concepts/security/data-encryption.mdx
@@ -108,9 +108,9 @@ been destroyed and any existing data will have been re-encrypted.
 ## The `previous-root` KMS key <sup>OSS Only</sup>
 
 The `previous-root` KMS key is used when migrating to a new `root` key. Adding
-it to your configuration will inform the Controller to use it for decrypting
-the existing information in the database, allowing you to rotate and rewrap
-the KEKs to complete the migration to the new root key.
+the `previous-root` KMS key to your configuration informs the Controller to use
+it for decrypting the existing information in the database, allowing you to
+rotate and rewrap the KEKs to complete the migration to the new root key.
 
 ## The `worker-auth` KMS Key <sup>OSS Only</sup>
 

--- a/website/content/docs/configuration/kms/aead.mdx
+++ b/website/content/docs/configuration/kms/aead.mdx
@@ -21,7 +21,8 @@ kms "aead" {
 }
 ```
 
-- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `root`, `recovery`, or `config`.
+- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
+   `root`, `previous-root`, `recovery`, or `config`.
 
 - `aead_type` - The type of encryption this KMS uses. Currently only `aes-gcm` is implemented.
 

--- a/website/content/docs/configuration/kms/alicloudkms.mdx
+++ b/website/content/docs/configuration/kms/alicloudkms.mdx
@@ -31,7 +31,8 @@ kms "alicloudkms" {
 
 These parameters apply to the `kms` stanza in the Boundary configuration file:
 
-- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `root`, `recovery`, or `config`.
+- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
+   `root`, `previous-root`, `recovery`, or `config`.
 
 - `region` `(string: <required> "us-east-1")`: The AliCloud region where the encryption key
   lives. May also be specified by the `ALICLOUD_REGION`

--- a/website/content/docs/configuration/kms/awskms.mdx
+++ b/website/content/docs/configuration/kms/awskms.mdx
@@ -30,8 +30,8 @@ kms "awskms" {
 
 These parameters apply to the `kms` stanza in the Boundary configuration file:
 
-- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `root`,
-  `recovery`, or `config`.
+- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
+   `root`, `previous-root`, `recovery`, or `config`.
 
 - `region` `(string: "us-east-1")`: The AWS region where the encryption key
   lives. If not provided, may be populated from the `AWS_REGION` or

--- a/website/content/docs/configuration/kms/azurekeyvault.mdx
+++ b/website/content/docs/configuration/kms/azurekeyvault.mdx
@@ -32,7 +32,8 @@ kms "azurekeyvault" {
 
 These parameters apply to the `kms` stanza in the Vault configuration file:
 
-- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `root`, `recovery`, or `config`.
+- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
+   `root`, `previous-root`, `recovery`, or `config`.
 
 - `tenant_id` `(string: <required>)`: The tenant id for the Azure Active Directory organization. May
   also be specified by the `AZURE_TENANT_ID` environment variable.

--- a/website/content/docs/configuration/kms/gcpckms.mdx
+++ b/website/content/docs/configuration/kms/gcpckms.mdx
@@ -31,7 +31,8 @@ kms "gcpckms" {
 
 These parameters apply to the `kms` stanza in the Boundary configuration file:
 
-- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `root`, `recovery`, or `config`.
+- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
+   `root`, `previous-root`, `recovery`, or `config`.
 
 - `credentials` `(string: <required>)`: The path to the credentials JSON file
   to use. May be also specified by the `GOOGLE_CREDENTIALS` or

--- a/website/content/docs/configuration/kms/index.mdx
+++ b/website/content/docs/configuration/kms/index.mdx
@@ -7,9 +7,7 @@ description: |-
 
 # `kms` Stanza
 
-The `kms` stanza configures Boundary kms-specific parameters. Multiple stanzas
-of the same `purpose` are merged, with the last one specified being used for
-encryption. All specified stanzas are available for decryption.
+The `kms` stanza configures Boundary kms-specific parameters.
 
 For more examples, please choose a specific KMS technology from the sidebar.
 

--- a/website/content/docs/configuration/kms/index.mdx
+++ b/website/content/docs/configuration/kms/index.mdx
@@ -9,7 +9,7 @@ description: |-
 
 The `kms` stanza configures Boundary kms-specific parameters. Multiple stanzas
 of the same `purpose` are merged, with the last one specified being used for
-encryption, and all specified being available for decryption.
+encryption. All specified stanzas are available for decryption.
 
 For more examples, please choose a specific KMS technology from the sidebar.
 

--- a/website/content/docs/configuration/kms/index.mdx
+++ b/website/content/docs/configuration/kms/index.mdx
@@ -7,7 +7,9 @@ description: |-
 
 # `kms` Stanza
 
-The `kms` stanza configures Boundary kms-specific parameters.
+The `kms` stanza configures Boundary kms-specific parameters. Multiple stanzas
+of the same `purpose` are merged, with the last one specified being used for
+encryption, and all specified being available for decryption.
 
 For more examples, please choose a specific KMS technology from the sidebar.
 

--- a/website/content/docs/configuration/kms/ocikms.mdx
+++ b/website/content/docs/configuration/kms/ocikms.mdx
@@ -30,7 +30,8 @@ kms "ocikms" {
 
 These parameters apply to the `kms` stanza in the Boundary configuration file:
 
-- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `root`, `recovery`, or `config`.
+- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
+   `root`, `previous-root`, `recovery`, or `config`.
 - `key_id` `(string: <required>)`: The OCI KMS key ID to use.
 - `crypto_endpoint` `(string: <required>)`: The OCI KMS cryptographic endpoint (or data plane endpoint)
   to be used to make OCI KMS encryption/decryption requests.

--- a/website/content/docs/configuration/kms/transit.mdx
+++ b/website/content/docs/configuration/kms/transit.mdx
@@ -41,8 +41,8 @@ kms "transit" {
 
 These parameters apply to the `kms` stanza in the Vault configuration file:
 
-- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `root`,
-  `recovery`, or `config`.
+- `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
+   `root`, `previous-root`, `recovery`, or `config`.
 
 - `address` `(string: <required>)`: The full address to the Vault cluster.
   This may also be specified by the `VAULT_ADDR` environment variable.


### PR DESCRIPTION
The new purpose combined with the `root` purpose lets a user migrate from one root key to another. This also adds errors for existing duplicate purposes.

I have tested this change manually with `boundary-local-env`.