### PR TITLE
fix(cmd): boundary connect SSH depending on a host id for ssh aliasing

### DIFF
--- a/internal/cmd/commands/connect/ssh.go
+++ b/internal/cmd/commands/connect/ssh.go
@@ -63,7 +63,16 @@ func (s *sshFlags) buildArgs(c *Command, port, ip, _ string, creds credentials) 
 		case "tcp":
 			// SSH detects a host key change when the localhost proxy port changes
 			// This uses the host ID instead of 'localhost:port'.
-			args = append(args, "-o", fmt.Sprintf("HostKeyAlias=%s", c.sessionAuthzData.GetHostId()))
+			if len(c.sessionAuthzData.GetHostId()) > 0 {
+				args = append(args, "-o", fmt.Sprintf("HostKeyAlias=%s", c.sessionAuthzData.GetHostId()))
+			} else {
+				// In cases where the Target has no host sources and has an
+				// address directly attached to it, we have no Host Id. Use
+				// Target Id instead. Only one address can ever be present on a
+				// target, and no other host sources may be present at the same
+				// time, so this is a reasonable alternative.
+				args = append(args, "-o", fmt.Sprintf("HostKeyAlias=%s", c.sessionAuthzData.GetTargetId()))
+			}
 		case "ssh":
 			args = append(args, "-o", "NoHostAuthenticationForLocalhost=yes")
 		}


### PR DESCRIPTION
Targets are not guaranteed to have Host Ids anymore, so we now use Target Id when a Host Id is not present.