### PR TITLE
refact(e2e): Changes to support an automated migration test

### DIFF
--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -99,7 +99,7 @@ locals {
 
 resource "enos_local_exec" "run_e2e_test" {
   environment = {
-    E2E_TESTS                     = true,
+    E2E_TESTS                     = "true",
     BOUNDARY_ADDR                 = var.alb_boundary_api_addr,
     E2E_PASSWORD_AUTH_METHOD_ID   = var.auth_method_id,
     E2E_PASSWORD_ADMIN_LOGIN_NAME = var.auth_login_name,

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -17,6 +17,7 @@ variable "alb_boundary_api_addr" {
 variable "auth_method_id" {
   description = "Id of Auth Method used to login to Boundary instance"
   type        = string
+  default     = ""
 }
 variable "auth_login_name" {
   description = "Name of admin user"
@@ -98,6 +99,7 @@ locals {
 
 resource "enos_local_exec" "run_e2e_test" {
   environment = {
+    E2E_TESTS                     = true,
     BOUNDARY_ADDR                 = var.alb_boundary_api_addr,
     E2E_PASSWORD_AUTH_METHOD_ID   = var.auth_method_id,
     E2E_PASSWORD_ADMIN_LOGIN_NAME = var.auth_login_name,

--- a/testing/internal/e2e/README.md
+++ b/testing/internal/e2e/README.md
@@ -35,6 +35,7 @@ account.
 ### Local
 Set the appropriate environment variables...
 ```shell
+export E2E_TESTS=true  # This is needed for any e2e test. Otherwise, the test is skipped
 export BOUNDARY_ADDR=  # e.g. http://127.0.0.1:9200
 export E2E_PASSWORD_AUTH_METHOD_ID=  # e.g. ampw_1234567890
 export E2E_PASSWORD_ADMIN_LOGIN_NAME=  # e.g. "admin"

--- a/testing/internal/e2e/boundary/account.go
+++ b/testing/internal/e2e/boundary/account.go
@@ -29,11 +29,6 @@ func CreateNewAccountApi(t testing.TB, ctx context.Context, client *api.Client, 
 
 	accountId = newAccountResult.Item.Id
 	t.Logf("Create Account: %s", accountId)
-	t.Cleanup(func() {
-		_, err := aClient.Delete(ctx, accountId)
-		require.NoError(t, err)
-	})
-
 	return
 }
 
@@ -64,15 +59,6 @@ func CreateNewAccountCli(t testing.TB, ctx context.Context, loginName string) (s
 	require.NoError(t, err)
 
 	newAccountId := newAccountResult.Item.Id
-	t.Cleanup(func() {
-		AuthenticateAdminCli(t, context.Background())
-		output := e2e.RunCommand(ctx, "boundary",
-			e2e.WithArgs("accounts", "delete", "-id", newAccountId),
-		)
-		require.NoError(t, output.Err, string(output.Stderr))
-	})
-
 	t.Logf("Created Account: %s", newAccountId)
-
 	return newAccountId, password
 }

--- a/testing/internal/e2e/boundary/credential.go
+++ b/testing/internal/e2e/boundary/credential.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/boundary/api"
+	"github.com/hashicorp/boundary/api/credentials"
 	"github.com/hashicorp/boundary/api/credentialstores"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/stretchr/testify/require"
 )
 
-// CreateNewCredentialStoreStaticApi creates a new static credential store using the Go api.
+// CreateNewCredentialStoreStaticApi uses the Go api to create a new static credential store.
 // Returns the id of the new credential store
 func CreateNewCredentialStoreStaticApi(t testing.TB, ctx context.Context, client *api.Client, projectId string) string {
 	csClient := credentialstores.NewClient(client)
@@ -23,7 +24,29 @@ func CreateNewCredentialStoreStaticApi(t testing.TB, ctx context.Context, client
 	return newCredentialStoreId
 }
 
-// CreateNewCredentialStoreStaticCli creates a new static credential store using the cli.
+// CreateNewCredentialStoreVaultCli uses the cli to create a Vault credential store
+// Returns the id of the new credential store
+func CreateNewCredentialStoreVaultCli(t testing.TB, ctx context.Context, projectId string, vaultAddr string, vaultToken string) string {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"credential-stores", "create", "vault",
+			"-scope-id", projectId,
+			"-vault-address", vaultAddr,
+			"-vault-token", vaultToken,
+			"-format", "json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var newCredentialStoreResult credentialstores.CredentialStoreCreateResult
+	err := json.Unmarshal(output.Stdout, &newCredentialStoreResult)
+	require.NoError(t, err)
+	newVaultCredentialStoreId := newCredentialStoreResult.Item.Id
+	t.Logf("Created Credential Store: %s", newVaultCredentialStoreId)
+
+	return newVaultCredentialStoreId
+}
+
+// CreateNewCredentialStoreStaticCli uses the cli to create a new static credential store.
 // Returns the id of the new credential store
 func CreateNewCredentialStoreStaticCli(t testing.TB, ctx context.Context, projectId string) string {
 	output := e2e.RunCommand(ctx, "boundary",
@@ -41,4 +64,73 @@ func CreateNewCredentialStoreStaticCli(t testing.TB, ctx context.Context, projec
 	t.Logf("Created Credential Store: %s", newCredentialStoreId)
 
 	return newCredentialStoreId
+}
+
+// CreateNewStaticCredentialPrivateKeyCli uses the cli to create a new private key credential in the
+// provided static credential store.
+// Returns the id of the new credential
+func CreateNewStaticCredentialPrivateKeyCli(t testing.TB, ctx context.Context, credentialStoreId string, user string, filePath string) string {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"credentials", "create", "ssh-private-key",
+			"-credential-store-id", credentialStoreId,
+			"-username", user,
+			"-private-key", "file://"+filePath,
+			"-format", "json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var newCredentialsResult credentials.CredentialCreateResult
+	err := json.Unmarshal(output.Stdout, &newCredentialsResult)
+	require.NoError(t, err)
+	newCredentialsId := newCredentialsResult.Item.Id
+	t.Logf("Created SSH Private Key Credentials: %s", newCredentialsId)
+
+	return newCredentialsId
+}
+
+// CreateNewStaticCredentialPasswordCli uses the cli to create a new password credential in the
+// provided static credential store.
+// Returns the id of the new credential
+func CreateNewStaticCredentialPasswordCli(t testing.TB, ctx context.Context, credentialStoreId string, user string, password string) string {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"credentials", "create", "username-password",
+			"-credential-store-id", credentialStoreId,
+			"-username", user,
+			"-password", "env://E2E_CREDENTIALS_PASSWORD",
+			"-format", "json",
+		),
+		e2e.WithEnv("E2E_CREDENTIALS_PASSWORD", password),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var newCredentialsResult credentials.CredentialCreateResult
+	err := json.Unmarshal(output.Stdout, &newCredentialsResult)
+	require.NoError(t, err)
+	newCredentialsId := newCredentialsResult.Item.Id
+	t.Logf("Created Username/Password Credentials: %s", newCredentialsId)
+
+	return newCredentialsId
+}
+
+// CreateNewStaticCredentialJsonCli uses the cli to create a new json credential in the provided
+// static credential store.
+// Returns the id of the new credential
+func CreateNewStaticCredentialJsonCli(t testing.TB, ctx context.Context, credentialStoreId string, jsonFilePath string) string {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"credentials", "create", "json",
+			"-credential-store-id", credentialStoreId,
+			"-object", "file://"+jsonFilePath,
+			"-format", "json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var newCredentialsResult credentials.CredentialCreateResult
+	err := json.Unmarshal(output.Stdout, &newCredentialsResult)
+	require.NoError(t, err)
+	newCredentialsId := newCredentialsResult.Item.Id
+	t.Logf("Created Username/Password Credentials: %s", newCredentialsId)
+
+	return newCredentialsId
 }

--- a/testing/internal/e2e/boundary/host.go
+++ b/testing/internal/e2e/boundary/host.go
@@ -3,8 +3,11 @@ package boundary
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/hostcatalogs"
 	"github.com/hashicorp/boundary/api/hosts"
@@ -13,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CreateNewHostCatalogApi creates a new host catalog in boundary using the Go api.
+// CreateNewHostCatalogApi uses the Go api to create a new host catalog.
 // Returns the id of the new host catalog.
 func CreateNewHostCatalogApi(t testing.TB, ctx context.Context, client *api.Client, projectId string) string {
 	hcClient := hostcatalogs.NewClient(client)
@@ -25,7 +28,7 @@ func CreateNewHostCatalogApi(t testing.TB, ctx context.Context, client *api.Clie
 	return newHostCatalogId
 }
 
-// CreateNewHostSetApi creates a new host set in boundary using the Go api.
+// CreateNewHostSetApi uses the Go api to create a new host set.
 // Returns the id of the new host set.
 func CreateNewHostSetApi(t testing.TB, ctx context.Context, client *api.Client, hostCatalogId string) string {
 	hsClient := hostsets.NewClient(client)
@@ -37,7 +40,7 @@ func CreateNewHostSetApi(t testing.TB, ctx context.Context, client *api.Client, 
 	return newHostSetId
 }
 
-// CreateNewHostApi creates a new host in boundary using the Go api
+// CreateNewHostApi uses the Go api to create a new host.
 // Returns the id of the new host.
 func CreateNewHostApi(t testing.TB, ctx context.Context, client *api.Client, hostCatalogId string, address string) string {
 	hClient := hosts.NewClient(client)
@@ -52,14 +55,14 @@ func CreateNewHostApi(t testing.TB, ctx context.Context, client *api.Client, hos
 	return newHostId
 }
 
-// AddHostToHostSetApi adds a host to a host set using the Go api
+// AddHostToHostSetApi uses the Go api to add a host to a host set
 func AddHostToHostSetApi(t testing.TB, ctx context.Context, client *api.Client, hostSetId string, hostId string) {
 	hsClient := hostsets.NewClient(client)
 	_, err := hsClient.AddHosts(ctx, hostSetId, 0, []string{hostId}, hostsets.WithAutomaticVersioning(true))
 	require.NoError(t, err)
 }
 
-// CreateNewHostCatalogCli creates a new host catalog in boundary using the cli.
+// CreateNewHostCatalogCli uses the cli to create a new host catalog.
 // Returns the id of the new host catalog.
 func CreateNewHostCatalogCli(t testing.TB, ctx context.Context, projectId string) string {
 	output := e2e.RunCommand(ctx, "boundary",
@@ -80,7 +83,7 @@ func CreateNewHostCatalogCli(t testing.TB, ctx context.Context, projectId string
 	return newHostCatalogId
 }
 
-// CreateNewHostSetCli creates a new host set in boundary using the cli.
+// CreateNewHostSetCli uses the cli to create a new host set.
 // Returns the id of the new host set.
 func CreateNewHostSetCli(t testing.TB, ctx context.Context, hostCatalogId string) string {
 	output := e2e.RunCommand(ctx, "boundary",
@@ -101,7 +104,7 @@ func CreateNewHostSetCli(t testing.TB, ctx context.Context, hostCatalogId string
 	return newHostSetId
 }
 
-// CreateNewHostCli creates a new host in boundary using the cli.
+// CreateNewHostCli uses the cli to create a new host.
 // Returns the id of the new host.
 func CreateNewHostCli(t testing.TB, ctx context.Context, hostCatalogId string, address string) string {
 	output := e2e.RunCommand(ctx, "boundary",
@@ -123,10 +126,100 @@ func CreateNewHostCli(t testing.TB, ctx context.Context, hostCatalogId string, a
 	return newHostId
 }
 
-// AddHostToHostSetCli adds a host to a host set using the cli
+// AddHostToHostSetCli uses the cli to add a host to a host set
 func AddHostToHostSetCli(t testing.TB, ctx context.Context, hostSetId string, hostId string) {
 	output := e2e.RunCommand(ctx, "boundary",
 		e2e.WithArgs("host-sets", "add-hosts", "-id", hostSetId, "-host", hostId),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
+}
+
+// CreateNewAwsHostCatalogCli uses the cli to create a new AWS dynamic host catalog.
+// Returns the id of the new host catalog.
+func CreateNewAwsHostCatalogCli(t testing.TB, ctx context.Context, projectId string, accessKeyId string, secretAccessKey string) string {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"host-catalogs", "create", "plugin",
+			"-scope-id", projectId,
+			"-plugin-name", "aws",
+			"-attr", "disable_credential_rotation=true",
+			"-attr", "region=us-east-1",
+			"-secret", "access_key_id=env://E2E_AWS_ACCESS_KEY_ID",
+			"-secret", "secret_access_key=env://E2E_AWS_SECRET_ACCESS_KEY",
+			"-format", "json",
+		),
+		e2e.WithEnv("E2E_AWS_ACCESS_KEY_ID", accessKeyId),
+		e2e.WithEnv("E2E_AWS_SECRET_ACCESS_KEY", secretAccessKey),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var newHostCatalogResult hostcatalogs.HostCatalogCreateResult
+	err := json.Unmarshal(output.Stdout, &newHostCatalogResult)
+	require.NoError(t, err)
+	newHostCatalogId := newHostCatalogResult.Item.Id
+	t.Logf("Created Host Catalog: %s", newHostCatalogId)
+
+	return newHostCatalogId
+}
+
+// CreateNewAwsHostSetCli uses the cli to create a new host set from an AWS dynamic host catalog.
+// Returns the id of the new host set.
+func CreateNewAwsHostSetCli(t testing.TB, ctx context.Context, hostCatalogId string, filter string) string {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"host-sets", "create", "plugin",
+			"-host-catalog-id", hostCatalogId,
+			"-attr", "filters="+filter,
+			"-format", "json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var newHostSetResult hostsets.HostSetCreateResult
+	err := json.Unmarshal(output.Stdout, &newHostSetResult)
+	require.NoError(t, err)
+
+	newHostSetId := newHostSetResult.Item.Id
+	t.Logf("Created Host Set: %s", newHostSetId)
+	return newHostSetId
+}
+
+// WaitForHostsInHostSetCli uses the cli to check if there are hosts in a host set. It will check a
+// few times before returning a result. The method will fail if there are 0 hosts found.
+func WaitForHostsInHostSetCli(t testing.TB, ctx context.Context, hostSetId string) int {
+	t.Logf("Looking for items in the host set...")
+	var actualHostSetCount int
+	err := backoff.RetryNotify(
+		func() error {
+			output := e2e.RunCommand(ctx, "boundary",
+				e2e.WithArgs(
+					"host-sets", "read",
+					"-id", hostSetId,
+					"-format", "json",
+				),
+			)
+			if output.Err != nil {
+				return backoff.Permanent(errors.New(string(output.Stderr)))
+			}
+
+			var hostSetsReadResult hostsets.HostSetReadResult
+			err := json.Unmarshal(output.Stdout, &hostSetsReadResult)
+			if err != nil {
+				return backoff.Permanent(err)
+			}
+
+			actualHostSetCount = len(hostSetsReadResult.Item.HostIds)
+			if actualHostSetCount == 0 {
+				return errors.New("No items are appearing in the host set")
+			}
+
+			t.Logf("Found %d hosts", actualHostSetCount)
+			return nil
+		},
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
+		func(err error, td time.Duration) {
+			t.Logf("%s. Retrying...", err.Error())
+		},
+	)
+	require.NoError(t, err)
+
+	return actualHostSetCount
 }

--- a/testing/internal/e2e/boundary/scope.go
+++ b/testing/internal/e2e/boundary/scope.go
@@ -19,11 +19,6 @@ func CreateNewOrgApi(t testing.TB, ctx context.Context, client *api.Client) stri
 	require.NoError(t, err)
 
 	newOrgId := newOrgResult.Item.Id
-	t.Cleanup(func() {
-		_, err := scopeClient.Delete(ctx, newOrgId)
-		require.NoError(t, err)
-	})
-
 	t.Logf("Created Org Id: %s", newOrgId)
 	return newOrgId
 }
@@ -59,14 +54,6 @@ func CreateNewOrgCli(t testing.TB, ctx context.Context) string {
 	require.NoError(t, err)
 
 	newOrgId := newOrgResult.Item.Id
-	t.Cleanup(func() {
-		AuthenticateAdminCli(t, context.Background())
-		output := e2e.RunCommand(ctx, "boundary",
-			e2e.WithArgs("scopes", "delete", "-id", newOrgId),
-		)
-		require.NoError(t, output.Err, string(output.Stderr))
-	})
-
 	t.Logf("Created Org Id: %s", newOrgId)
 	return newOrgId
 }

--- a/testing/internal/e2e/boundary/target.go
+++ b/testing/internal/e2e/boundary/target.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CreateNewTargetApi creates a new target in boundary using the Go api.
+// CreateNewTargetApi uses the Go api to create a new target in boundary
 // Returns the id of the new target.
 func CreateNewTargetApi(t testing.TB, ctx context.Context, client *api.Client, projectId string, defaultPort string) string {
 	tClient := targets.NewClient(client)
@@ -29,7 +29,7 @@ func CreateNewTargetApi(t testing.TB, ctx context.Context, client *api.Client, p
 	return newTargetId
 }
 
-// AddHostSourceToTargetApi adds a host source (host set or host) to a target using the Go api
+// AddHostSourceToTargetApi uses the Go api to add a host source (host set or host) to a target
 func AddHostSourceToTargetApi(t testing.TB, ctx context.Context, client *api.Client, targetId string, hostSourceId string) {
 	tClient := targets.NewClient(client)
 	_, err := tClient.AddHostSources(ctx, targetId, 0,
@@ -39,7 +39,7 @@ func AddHostSourceToTargetApi(t testing.TB, ctx context.Context, client *api.Cli
 	require.NoError(t, err)
 }
 
-// CreateNewTargetCli creates a new target in boundary using the cli
+// CreateNewTargetCli uses the cli to create a new target in boundary
 // Returns the id of the new target.
 func CreateNewTargetCli(t testing.TB, ctx context.Context, projectId string, defaultPort string) string {
 	output := e2e.RunCommand(ctx, "boundary",
@@ -61,10 +61,23 @@ func CreateNewTargetCli(t testing.TB, ctx context.Context, projectId string, def
 	return newTargetId
 }
 
-// AddHostSourceToTargetCli adds a host source (host set or host) to a target using the cli
+// AddHostSourceToTargetCli uses the cli to add a host source (host set or host) to a target
 func AddHostSourceToTargetCli(t testing.TB, ctx context.Context, targetId string, hostSourceId string) {
 	output := e2e.RunCommand(ctx, "boundary",
 		e2e.WithArgs("targets", "add-host-sources", "-id", targetId, "-host-source", hostSourceId),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+}
+
+// AddCredentialSourceToTargetCli uses the cli to add a credential source (credential library or
+// credential) to a target
+func AddCredentialSourceToTargetCli(t testing.TB, ctx context.Context, targetId string, credentialSourceId string) {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"targets", "add-credential-sources",
+			"-id", targetId,
+			"-brokered-credential-source", credentialSourceId,
+		),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
 }

--- a/testing/internal/e2e/boundary/user.go
+++ b/testing/internal/e2e/boundary/user.go
@@ -17,13 +17,9 @@ func CreateNewUserApi(t testing.TB, ctx context.Context, client *api.Client, sco
 	uClient := users.NewClient(client)
 	newUserResult, err := uClient.Create(ctx, scopeId)
 	require.NoError(t, err)
+
 	newUserId := newUserResult.Item.Id
 	t.Logf("Created User: %s", newUserId)
-	t.Cleanup(func() {
-		_, err := uClient.Delete(ctx, newUserId)
-		require.NoError(t, err)
-	})
-
 	return newUserId
 }
 
@@ -46,23 +42,7 @@ func CreateNewUserCli(t testing.TB, ctx context.Context, scopeId string) string 
 	require.NoError(t, err)
 
 	newUserId := newUserResult.Item.Id
-	t.Cleanup(func() {
-		AuthenticateAdminCli(t, context.Background())
-		output := e2e.RunCommand(ctx, "boundary",
-			e2e.WithArgs("users", "delete", "-id", newUserId, "-format", "json"),
-		)
-		// Only allow an error if it's due to a Resource Not Found (404)
-		// This was needed since there's a test that already deletes the user and would run into an
-		// error during cleanup
-		if output.Err != nil {
-			var response e2e.CliError
-			err := json.Unmarshal(output.Stderr, &response)
-			require.NoError(t, err)
-			require.Equal(t, 404, int(response.Status))
-		}
-	})
 	t.Logf("Created User: %s", newUserId)
-
 	return newUserId
 }
 

--- a/testing/internal/e2e/helpers.go
+++ b/testing/internal/e2e/helpers.go
@@ -48,7 +48,7 @@ func getOpts(opt ...Option) options {
 	return opts
 }
 
-const EnvToCheckSkip = "E2E_PASSWORD_AUTH_METHOD_ID"
+const EnvToCheckSkip = "E2E_TESTS"
 
 // RunCommand executes external commands on the system. Returns the results
 // of running the provided command.

--- a/testing/internal/e2e/tests/static/connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/static/connect_authz_token_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/boundary/api/credentials"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
@@ -40,36 +39,11 @@ func TestCliConnectTargetWithAuthzToken(t *testing.T) {
 	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 	newCredentialStoreId := boundary.CreateNewCredentialStoreStaticCli(t, ctx, newProjectId)
-
-	// Create credentials
-	output := e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"credentials", "create", "ssh-private-key",
-			"-credential-store-id", newCredentialStoreId,
-			"-username", c.TargetSshUser,
-			"-private-key", "file://"+c.TargetSshKeyPath,
-			"-format", "json",
-		),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	var newCredentialsResult credentials.CredentialCreateResult
-	err = json.Unmarshal(output.Stdout, &newCredentialsResult)
-	require.NoError(t, err)
-	newCredentialsId := newCredentialsResult.Item.Id
-	t.Logf("Created Credentials: %s", newCredentialsId)
-
-	// Add credentials to target
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"targets", "add-credential-sources",
-			"-id", newTargetId,
-			"-brokered-credential-source", newCredentialsId,
-		),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
+	newCredentialsId := boundary.CreateNewStaticCredentialPrivateKeyCli(t, ctx, newCredentialStoreId, c.TargetSshUser, c.TargetSshKeyPath)
+	boundary.AddCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialsId)
 
 	// Get credentials for target
-	output = e2e.RunCommand(ctx, "boundary",
+	output := e2e.RunCommand(ctx, "boundary",
 		e2e.WithArgs("targets", "authorize-session", "-id", newTargetId, "-format", "json"),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))

--- a/testing/internal/e2e/tests/static/connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/static/connect_authz_token_test.go
@@ -26,6 +26,12 @@ func TestCliConnectTargetWithAuthzToken(t *testing.T) {
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
 	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)

--- a/testing/internal/e2e/tests/static/connect_localhost_test.go
+++ b/testing/internal/e2e/tests/static/connect_localhost_test.go
@@ -24,6 +24,12 @@ func TestCliConnectTargetWithLocalhost(t *testing.T) {
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
 	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)

--- a/testing/internal/e2e/tests/static/connect_ssh_test.go
+++ b/testing/internal/e2e/tests/static/connect_ssh_test.go
@@ -26,6 +26,12 @@ func TestCliConnectTargetWithSsh(t *testing.T) {
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
 	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)

--- a/testing/internal/e2e/tests/static/connect_test.go
+++ b/testing/internal/e2e/tests/static/connect_test.go
@@ -21,6 +21,12 @@ func TestCliConnectTarget(t *testing.T) {
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
 	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)

--- a/testing/internal/e2e/tests/static/credential_store_test.go
+++ b/testing/internal/e2e/tests/static/credential_store_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/boundary/api/credentials"
+	"github.com/hashicorp/boundary/api/scopes"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
@@ -26,6 +27,12 @@ func TestCliStaticCredentialStore(t *testing.T) {
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
 	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)
@@ -152,6 +159,11 @@ func TestApiStaticCredentialStore(t *testing.T) {
 	ctx := context.Background()
 
 	newOrgId := boundary.CreateNewOrgApi(t, ctx, client)
+	t.Cleanup(func() {
+		scopeClient := scopes.NewClient(client)
+		_, err := scopeClient.Delete(ctx, newOrgId)
+		require.NoError(t, err)
+	})
 	newProjectId := boundary.CreateNewProjectApi(t, ctx, client, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogApi(t, ctx, client, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetApi(t, ctx, client, newHostCatalogId)

--- a/testing/internal/e2e/tests/static/session_cancel_admin_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_admin_test.go
@@ -22,6 +22,12 @@ func TestCliSessionCancelAdmin(t *testing.T) {
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
 	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)

--- a/testing/internal/e2e/tests/static/session_cancel_user_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_user_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/boundary/api/accounts"
 	"github.com/hashicorp/boundary/api/roles"
+	"github.com/hashicorp/boundary/api/scopes"
 	"github.com/hashicorp/boundary/api/sessions"
 	"github.com/hashicorp/boundary/api/users"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
@@ -26,6 +28,12 @@ func TestCliSessionCancelUser(t *testing.T) {
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
 	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)
@@ -35,7 +43,21 @@ func TestCliSessionCancelUser(t *testing.T) {
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 	acctName := "e2e-account"
 	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, acctName)
+	t.Cleanup(func() {
+		boundary.AuthenticateAdminCli(t, context.Background())
+		output := e2e.RunCommand(ctx, "boundary",
+			e2e.WithArgs("accounts", "delete", "-id", newAccountId),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	newUserId := boundary.CreateNewUserCli(t, ctx, "global")
+	t.Cleanup(func() {
+		boundary.AuthenticateAdminCli(t, context.Background())
+		output := e2e.RunCommand(ctx, "boundary",
+			e2e.WithArgs("users", "delete", "-id", newUserId),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	boundary.SetAccountToUserCli(t, ctx, newUserId, newAccountId)
 
 	// Try to connect to the target as a user without permissions
@@ -139,6 +161,11 @@ func TestApiCreateUser(t *testing.T) {
 	ctx := context.Background()
 
 	newOrgId := boundary.CreateNewOrgApi(t, ctx, client)
+	t.Cleanup(func() {
+		scopeClient := scopes.NewClient(client)
+		_, err := scopeClient.Delete(ctx, newOrgId)
+		require.NoError(t, err)
+	})
 	newProjectId := boundary.CreateNewProjectApi(t, ctx, client, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogApi(t, ctx, client, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetApi(t, ctx, client, newHostCatalogId)
@@ -149,7 +176,17 @@ func TestApiCreateUser(t *testing.T) {
 
 	acctName := "e2e-account"
 	newAcctId, _ := boundary.CreateNewAccountApi(t, ctx, client, acctName)
+	t.Cleanup(func() {
+		aClient := accounts.NewClient(client)
+		_, err := aClient.Delete(ctx, newAcctId)
+		require.NoError(t, err)
+	})
 	newUserId := boundary.CreateNewUserApi(t, ctx, client, "global")
+	t.Cleanup(func() {
+		uClient := users.NewClient(client)
+		_, err := uClient.Delete(ctx, newUserId)
+		require.NoError(t, err)
+	})
 	uClient := users.NewClient(client)
 	uClient.SetAccounts(ctx, newUserId, 0, []string{newAcctId})
 

--- a/testing/internal/e2e/tests/static/session_end_delete_user_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_user_test.go
@@ -24,6 +24,12 @@ func TestCliSessionEndWhenUserIsDeleted(t *testing.T) {
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
 	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)

--- a/testing/internal/e2e/tests/static_with_vault/connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_authz_token_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/boundary/api/credentiallibraries"
-	"github.com/hashicorp/boundary/api/credentialstores"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
@@ -88,28 +87,14 @@ func TestCliVaultConnectTargetWithAuthzToken(t *testing.T) {
 		),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
-	var tokenCreateResult createTokenResponse
+	var tokenCreateResult vault.CreateTokenResponse
 	err = json.Unmarshal(output.Stdout, &tokenCreateResult)
 	require.NoError(t, err)
 	credStoreToken := tokenCreateResult.Auth.Client_Token
 	t.Log("Created Vault Cred Store Token")
 
 	// Create a credential store
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"credential-stores", "create", "vault",
-			"-scope-id", newProjectId,
-			"-vault-address", vaultAddr,
-			"-vault-token", credStoreToken,
-			"-format", "json",
-		),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	var newCredentialStoreResult credentialstores.CredentialStoreCreateResult
-	err = json.Unmarshal(output.Stdout, &newCredentialStoreResult)
-	require.NoError(t, err)
-	newCredentialStoreId := newCredentialStoreResult.Item.Id
-	t.Logf("Created Credential Store: %s", newCredentialStoreId)
+	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, vaultAddr, credStoreToken)
 
 	// Create a credential library
 	output = e2e.RunCommand(ctx, "boundary",
@@ -129,15 +114,7 @@ func TestCliVaultConnectTargetWithAuthzToken(t *testing.T) {
 	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
 	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
 
-	// Add brokered credentials to target
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"targets", "add-credential-sources",
-			"-id", newTargetId,
-			"-brokered-credential-source", newCredentialLibraryId,
-		),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
+	boundary.AddCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialLibraryId)
 
 	// Get credentials for target
 	output = e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static_with_vault/connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_authz_token_test.go
@@ -29,6 +29,12 @@ func TestCliVaultConnectTargetWithAuthzToken(t *testing.T) {
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
 	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)
@@ -39,6 +45,13 @@ func TestCliVaultConnectTargetWithAuthzToken(t *testing.T) {
 
 	// Configure vault
 	vaultAddr, boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	t.Cleanup(func() {
+		output := e2e.RunCommand(ctx, "vault",
+			e2e.WithArgs("policy", "delete", boundaryPolicyName),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+
 	output := e2e.RunCommand(ctx, "vault",
 		e2e.WithArgs("secrets", "enable", "-path="+c.VaultSecretPath, "kv-v2"),
 	)
@@ -53,6 +66,12 @@ func TestCliVaultConnectTargetWithAuthzToken(t *testing.T) {
 	// Create credential in vault
 	privateKeySecretName := vault.CreateKvPrivateKeyCredential(t, c.VaultSecretPath, c.TargetSshUser, c.TargetSshKeyPath, kvPolicyFilePath)
 	kvPolicyName := vault.WritePolicy(t, ctx, kvPolicyFilePath)
+	t.Cleanup(func() {
+		output := e2e.RunCommand(ctx, "vault",
+			e2e.WithArgs("policy", "delete", kvPolicyName),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	t.Log("Created Vault Credential")
 
 	// Create vault token for boundary

--- a/testing/internal/e2e/tests/static_with_vault/connect_ssh_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_ssh_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/boundary/api/credentiallibraries"
-	"github.com/hashicorp/boundary/api/credentialstores"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
@@ -88,28 +87,14 @@ func TestCliVaultConnectTargetWithSsh(t *testing.T) {
 		),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
-	var tokenCreateResult createTokenResponse
+	var tokenCreateResult vault.CreateTokenResponse
 	err = json.Unmarshal(output.Stdout, &tokenCreateResult)
 	require.NoError(t, err)
 	credStoreToken := tokenCreateResult.Auth.Client_Token
 	t.Log("Created Vault Cred Store Token")
 
 	// Create a credential store
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"credential-stores", "create", "vault",
-			"-scope-id", newProjectId,
-			"-vault-address", vaultAddr,
-			"-vault-token", credStoreToken,
-			"-format", "json",
-		),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	var newCredentialStoreResult credentialstores.CredentialStoreCreateResult
-	err = json.Unmarshal(output.Stdout, &newCredentialStoreResult)
-	require.NoError(t, err)
-	newCredentialStoreId := newCredentialStoreResult.Item.Id
-	t.Logf("Created Credential Store: %s", newCredentialStoreId)
+	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, vaultAddr, credStoreToken)
 
 	// Create a credential library
 	output = e2e.RunCommand(ctx, "boundary",
@@ -130,14 +115,7 @@ func TestCliVaultConnectTargetWithSsh(t *testing.T) {
 	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
 
 	// Add brokered credentials to target
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"targets", "add-credential-sources",
-			"-id", newTargetId,
-			"-brokered-credential-source", newCredentialLibraryId,
-		),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
+	boundary.AddCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialLibraryId)
 
 	// Get credentials for target
 	output = e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static_with_vault/connect_ssh_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_ssh_test.go
@@ -29,6 +29,12 @@ func TestCliVaultConnectTargetWithSsh(t *testing.T) {
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
 	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
 	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
 	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)
@@ -39,6 +45,13 @@ func TestCliVaultConnectTargetWithSsh(t *testing.T) {
 
 	// Configure vault
 	vaultAddr, boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	t.Cleanup(func() {
+		output := e2e.RunCommand(ctx, "vault",
+			e2e.WithArgs("policy", "delete", boundaryPolicyName),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+
 	output := e2e.RunCommand(ctx, "vault",
 		e2e.WithArgs("secrets", "enable", "-path="+c.VaultSecretPath, "kv-v2"),
 	)
@@ -53,6 +66,12 @@ func TestCliVaultConnectTargetWithSsh(t *testing.T) {
 	// Create credential in vault
 	privateKeySecretName := vault.CreateKvPrivateKeyCredential(t, c.VaultSecretPath, c.TargetSshUser, c.TargetSshKeyPath, kvPolicyFilePath)
 	kvPolicyName := vault.WritePolicy(t, ctx, kvPolicyFilePath)
+	t.Cleanup(func() {
+		output := e2e.RunCommand(ctx, "vault",
+			e2e.WithArgs("policy", "delete", kvPolicyName),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 	t.Log("Created Vault Credential")
 
 	// Create vault token for boundary

--- a/testing/internal/e2e/tests/static_with_vault/connect_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/boundary/api/credentiallibraries"
-	"github.com/hashicorp/boundary/api/credentialstores"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
@@ -17,12 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type createTokenResponse struct {
-	Auth struct {
-		Client_Token string
-	}
-}
 
 // TestCliVaultConnectTarget uses the boundary and vault clis to add secrets management
 // for a target. The test sets up vault as a credential store, creates a set of credentials
@@ -95,28 +88,14 @@ func TestCliVaultConnectTarget(t *testing.T) {
 		),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
-	var tokenCreateResult createTokenResponse
+	var tokenCreateResult vault.CreateTokenResponse
 	err = json.Unmarshal(output.Stdout, &tokenCreateResult)
 	require.NoError(t, err)
 	credStoreToken := tokenCreateResult.Auth.Client_Token
 	t.Log("Created Vault Cred Store Token")
 
 	// Create a credential store
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"credential-stores", "create", "vault",
-			"-scope-id", newProjectId,
-			"-vault-address", vaultAddr,
-			"-vault-token", credStoreToken,
-			"-format", "json",
-		),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	var newCredentialStoreResult credentialstores.CredentialStoreCreateResult
-	err = json.Unmarshal(output.Stdout, &newCredentialStoreResult)
-	require.NoError(t, err)
-	newCredentialStoreId := newCredentialStoreResult.Item.Id
-	t.Logf("Created Credential Store: %s", newCredentialStoreId)
+	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, vaultAddr, credStoreToken)
 
 	// Create a credential library
 	output = e2e.RunCommand(ctx, "boundary",
@@ -137,14 +116,7 @@ func TestCliVaultConnectTarget(t *testing.T) {
 	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
 
 	// Add brokered credentials to target
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"targets", "add-credential-sources",
-			"-id", newTargetId,
-			"-brokered-credential-source", newCredentialLibraryId,
-		),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
+	boundary.AddCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialLibraryId)
 
 	// Get credentials for target
 	output = e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/vault/vault.go
+++ b/testing/internal/e2e/vault/vault.go
@@ -130,12 +130,6 @@ func WritePolicy(t testing.TB, ctx context.Context, policyFilePath string) strin
 		e2e.WithArgs("policy", "write", policyName, policyFilePath),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
-	t.Cleanup(func() {
-		output := e2e.RunCommand(ctx, "vault",
-			e2e.WithArgs("policy", "delete", policyName),
-		)
-		require.NoError(t, output.Err, string(output.Stderr))
-	})
 
 	return policyName
 }

--- a/testing/internal/e2e/vault/vault.go
+++ b/testing/internal/e2e/vault/vault.go
@@ -22,6 +22,12 @@ type config struct {
 	VaultToken string `envconfig:"VAULT_TOKEN" required:"true"`
 }
 
+type CreateTokenResponse struct {
+	Auth struct {
+		Client_Token string
+	}
+}
+
 func loadConfig() (*config, error) {
 	var c config
 	err := envconfig.Process("", &c)


### PR DESCRIPTION
This is the 1st of 2 PRs to support the new automated migration test (A draft PR containing all of the changes can be found here: https://github.com/hashicorp/boundary/pull/2627). The migration test intends to do the following
- Set up a boundary database using the latest released version of Boundary
- Populate the boundary database with a number of resources (org, project, host catalog, host set, target, static credentials, an AWS dynamic host catalog, and some vault credentials)
- Use the newest version of Boundary to migrate the database (i.e. `boundary database migrate`)

This PR does some refactoring to make creating the migration test easier. These changes were split off to simplify the review process. The changes include the following
- Cleanup calls were moved out of methods and into each test. This makes it clearer where cleanup steps are happening when you're reading a test (as opposed to it being hidden in a method call).
- Additional methods were created for commonly used actions to help reduce the amount of code in each test. These methods will be used in the migration test to help populate the database with entries
- Previously, we were checking the environment variable `E2E_PASSWORD_AUTH_METHOD_ID` was set in order to determine if the e2e tests should run. The migration test will not have this variable set because it doesn't need a boundary instance to be spun up beforehand, so we needed a different way to denote an e2e test.