### PR TITLE
Add SIGHUP ignoring to sdk/plugin

### DIFF
--- a/sdk/plugins/host/plugin.go
+++ b/sdk/plugins/host/plugin.go
@@ -3,7 +3,10 @@ package external_host_plugins
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"os/signal"
+	"syscall"
 
 	pb "github.com/hashicorp/boundary/sdk/pbs/plugin"
 	"github.com/hashicorp/go-plugin"
@@ -28,6 +31,15 @@ func ServeHostPlugin(svc pb.HostPluginServiceServer, opt ...Option) error {
 	if err != nil {
 		return err
 	}
+
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, syscall.SIGHUP)
+	go func() {
+		for {
+			<-signalCh
+		}
+	}()
+
 	hostServiceServer, err := NewHostPluginServiceServer(svc)
 	if err != nil {
 		return err


### PR DESCRIPTION
After this is merged I will have to point the aws/azure mains to a commit with this (I am assuming we save tags for `main`). I've verified via boundary-local-env that when referencing this sdk code it successfully ignores HUPs.