### PR TITLE
feat: update session domain to support using address directly associated to a target

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -66,12 +66,8 @@ type Session struct {
 	PublicId string `json:"public_id,omitempty" gorm:"primary_key"`
 	// UserId for the session
 	UserId string `json:"user_id,omitempty" gorm:"default:null"`
-	// HostId of the session
-	HostId string `json:"host_id,omitempty" gorm:"default:null"`
 	// TargetId for the session
 	TargetId string `json:"target_id,omitempty" gorm:"default:null"`
-	// HostSetId for the session
-	HostSetId string `json:"host_set_id,omitempty" gorm:"default:null"`
 	// AuthTokenId for the session
 	AuthTokenId string `json:"auth_token_id,omitempty" gorm:"default:null"`
 	// ProjectId for the session
@@ -118,6 +114,12 @@ type Session struct {
 
 	// StaticCredentials for the session.
 	StaticCredentials []*StaticCredential `gorm:"-"`
+
+	// HostSetId for the session
+	HostSetId string `gorm:"-"`
+
+	// HostId of the session
+	HostId string `gorm:"-"`
 
 	// Connections for the session are for read only and are ignored during write operations
 	Connections []*Connection `gorm:"-"`
@@ -334,14 +336,8 @@ func (s *Session) validateNewSession() error {
 	if s.UserId == "" {
 		return errors.NewDeprecated(errors.InvalidParameter, op, "missing user id")
 	}
-	if s.HostId == "" {
-		return errors.NewDeprecated(errors.InvalidParameter, op, "missing host id")
-	}
 	if s.TargetId == "" {
 		return errors.NewDeprecated(errors.InvalidParameter, op, "missing target id")
-	}
-	if s.HostSetId == "" {
-		return errors.NewDeprecated(errors.InvalidParameter, op, "missing host set id")
 	}
 	if s.AuthTokenId == "" {
 		return errors.NewDeprecated(errors.InvalidParameter, op, "missing auth token id")

--- a/internal/session/session_host_set_host.go
+++ b/internal/session/session_host_set_host.go
@@ -1,0 +1,68 @@
+package session
+
+import "github.com/hashicorp/boundary/internal/errors"
+
+const (
+	defaultSessionHostSetHostTableName = "session_host_set_host"
+)
+
+// SessionHostSetHost contains information about a user's session with a target that has a host source association.
+type SessionHostSetHost struct {
+	// SessionId of the session
+	SessionId string `json:"session_id,omitempty" gorm:"primary_key"`
+	// HostSetId of the session
+	HostSetId string `json:"host_set_id,omitempty" gorm:"default:null"`
+	// HostId of the session
+	HostId string `json:"host_id,omitempty" gorm:"default:null"`
+
+	tableName string `gorm:"-"`
+}
+
+func NewSessionHostSetHost(sessionId, hostSetId, hostId string) (*SessionHostSetHost, error) {
+	const op = "session.NewSessionHostSetHost"
+	if sessionId == "" {
+		return nil, errors.NewDeprecated(errors.InvalidParameter, op, "missing session id")
+	}
+	if hostSetId == "" {
+		return nil, errors.NewDeprecated(errors.InvalidParameter, op, "missing host set id")
+	}
+	if hostId == "" {
+		return nil, errors.NewDeprecated(errors.InvalidParameter, op, "missing host id")
+	}
+	shs := &SessionHostSetHost{
+		SessionId: sessionId,
+		HostSetId: hostSetId,
+		HostId:    hostId,
+	}
+	return shs, nil
+}
+
+// TableName returns the tablename to override the default gorm table name
+func (s *SessionHostSetHost) TableName() string {
+	if s.tableName != "" {
+		return s.tableName
+	}
+	return defaultSessionHostSetHostTableName
+}
+
+// SetTableName sets the tablename and satisfies the ReplayableMessage
+// interface. If the caller attempts to set the name to "" the name will be
+// reset to the default name.
+func (s *SessionHostSetHost) SetTableName(n string) {
+	s.tableName = n
+}
+
+// AllocSessionHostSet will allocate a SessionHostSetHost
+func AllocSessionHostSetHost() *SessionHostSetHost {
+	return &SessionHostSetHost{}
+}
+
+// Clone creates a clone of the SessionHostSetHost
+func (s *SessionHostSetHost) Clone() any {
+	clone := &SessionHostSetHost{
+		SessionId: s.SessionId,
+		HostSetId: s.HostSetId,
+		HostId:    s.HostId,
+	}
+	return clone
+}

--- a/internal/session/session_target_address.go
+++ b/internal/session/session_target_address.go
@@ -1,0 +1,62 @@
+package session
+
+import "github.com/hashicorp/boundary/internal/errors"
+
+const (
+	defaultSessionTargetAddressTableName = "session_target_address"
+)
+
+// SessionTargetAddress contains information about a user's session with a target that has a direct network address association.
+type SessionTargetAddress struct {
+	// SessionId of the session
+	SessionId string `json:"session_id,omitempty" gorm:"primary_key"`
+	// TargetId of the session
+	TargetId string `json:"target_id,omitempty" gorm:"default:null"`
+
+	tableName string `gorm:"-"`
+}
+
+// NewSessionTargetAddress creates a new in memory session target address.
+func NewSessionTargetAddress(sessionId, targetId string) (*SessionTargetAddress, error) {
+	const op = "sesssion.NewSessionTargetAddress"
+	if sessionId == "" {
+		return nil, errors.NewDeprecated(errors.InvalidParameter, op, "missing session id")
+	}
+	if targetId == "" {
+		return nil, errors.NewDeprecated(errors.InvalidParameter, op, "missing target id")
+	}
+	sta := &SessionTargetAddress{
+		SessionId: sessionId,
+		TargetId:  targetId,
+	}
+	return sta, nil
+}
+
+// TableName returns the tablename to override the default gorm table name
+func (s *SessionTargetAddress) TableName() string {
+	if s.tableName != "" {
+		return s.tableName
+	}
+	return defaultSessionTargetAddressTableName
+}
+
+// SetTableName sets the tablename and satisfies the ReplayableMessage
+// interface. If the caller attempts to set the name to "" the name will be
+// reset to the default name.
+func (s *SessionTargetAddress) SetTableName(n string) {
+	s.tableName = n
+}
+
+// AllocSessionTargetAddress will allocate a SessionTargetAddress
+func AllocSessionTargetAddress() *SessionTargetAddress {
+	return &SessionTargetAddress{}
+}
+
+// Clone creates a clone of the SessionTargetAddress
+func (s *SessionTargetAddress) Clone() any {
+	clone := &SessionTargetAddress{
+		SessionId: s.SessionId,
+		TargetId:  s.TargetId,
+	}
+	return clone
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -45,7 +45,7 @@ func TestSession_Create(t *testing.T) {
 		wantCreateErr bool
 	}{
 		{
-			name: "valid",
+			name: "valid-hostset-host",
 			args: args{
 				composedOf: composedOf,
 				opt:        []Option{WithExpirationTime(exp)},
@@ -67,6 +67,48 @@ func TestSession_Create(t *testing.T) {
 			create: true,
 		},
 		{
+			name: "valid-target-address",
+			args: args{
+				composedOf: func() ComposedOf {
+					c := composedOf
+					c.HostSetId = ""
+					c.HostId = ""
+					return c
+				}(),
+				opt:       []Option{WithExpirationTime(exp)},
+				addresses: defaultAddresses,
+			},
+			want: &Session{
+				UserId:             composedOf.UserId,
+				HostId:             "",
+				HostSetId:          "",
+				TargetId:           composedOf.TargetId,
+				AuthTokenId:        composedOf.AuthTokenId,
+				ProjectId:          composedOf.ProjectId,
+				Endpoint:           "tcp://127.0.0.1:22",
+				ExpirationTime:     composedOf.ExpirationTime,
+				ConnectionLimit:    composedOf.ConnectionLimit,
+				DynamicCredentials: composedOf.DynamicCredentials,
+				StaticCredentials:  composedOf.StaticCredentials,
+			},
+			create: true,
+		},
+		{
+			name: "invalid-missing-target-address-host-source",
+			args: args{
+				composedOf: func() ComposedOf {
+					c := composedOf
+					c.HostSetId = ""
+					c.HostId = ""
+					c.Endpoint = ""
+					return c
+				}(),
+				addresses: defaultAddresses,
+			},
+			wantErr:   true,
+			wantIsErr: errors.InvalidParameter,
+		},
+		{
 			name: "empty-userId",
 			args: args{
 				composedOf: func() ComposedOf {
@@ -80,37 +122,11 @@ func TestSession_Create(t *testing.T) {
 			wantIsErr: errors.InvalidParameter,
 		},
 		{
-			name: "empty-hostId",
-			args: args{
-				composedOf: func() ComposedOf {
-					c := composedOf
-					c.HostId = ""
-					return c
-				}(),
-				addresses: defaultAddresses,
-			},
-			wantErr:   true,
-			wantIsErr: errors.InvalidParameter,
-		},
-		{
 			name: "empty-targetId",
 			args: args{
 				composedOf: func() ComposedOf {
 					c := composedOf
 					c.TargetId = ""
-					return c
-				}(),
-				addresses: defaultAddresses,
-			},
-			wantErr:   true,
-			wantIsErr: errors.InvalidParameter,
-		},
-		{
-			name: "empty-hostSetId",
-			args: args{
-				composedOf: func() ComposedOf {
-					c := composedOf
-					c.HostSetId = ""
 					return c
 				}(),
 				addresses: defaultAddresses,


### PR DESCRIPTION
Summary:

A host_id and host_set_id are no longer required arguments when authorizing a session. The session endpoint is now derived from either a host or a direct network address association to a Target resource. If a network address association is deleted from a Target, then all sessions using the same Target will be canceled. The behavior of canceling a session when a resource is deleted follows the existing pattern for host and host set. A session will not be canceled if the network address value is changed.