### PR TITLE
refactor(metric): adds exclude and include maps to metric init function 

### DIFF
--- a/internal/daemon/metric/initialize_metrics.go
+++ b/internal/daemon/metric/initialize_metrics.go
@@ -34,7 +34,8 @@ var (
 /* The following methods are used to initialize Prometheus histogram vectors for gRPC connections. */
 
 // rangeProtoFiles returns true while there are services with associated methods in the proto package.
-// Fields in the "exclude" parameter are not added to the map.
+// It relies on RangeFilesByPackage to range through the package, and it adds them into map m.
+// Services and methods for which filter() returns true are not added into the map.
 func rangeProtoFiles(m map[string][]string, fd protoreflect.FileDescriptor, filter func(string, string) bool) bool {
 	if fd.Services().Len() == 0 {
 		return true
@@ -75,6 +76,8 @@ func appendServicesAndMethods(m map[string][]string, pkg protoreflect.FileDescri
 // InitializeGrpcCollectorsFromPackage registers and zeroes a Prometheus
 // histogram, populating all service and method labels by ranging through
 // the package containing the provided FileDescriptor.
+// The filter function takes in a service name and method name and skips adding them as labels
+// upon returning true.
 // Note: inputting a protoreflect.FileDescriptor will populate all services and methods
 // found in its package, not just methods associated with that specific FileDescriptor.
 func InitializeGrpcCollectorsFromPackage(r prometheus.Registerer, v prometheus.ObserverVec,

--- a/internal/daemon/metric/initialize_metrics_test.go
+++ b/internal/daemon/metric/initialize_metrics_test.go
@@ -26,7 +26,7 @@ func Test_AppendServicesAndMethods(t *testing.T) {
 	}
 	for _, tc := range cases {
 		m := make(map[string][]string, 0)
-		appendServicesAndMethods(m, tc.pkg)
+		appendServicesAndMethods(m, tc.pkg, nil)
 		assert.Equal(t, tc.expected, m)
 	}
 }

--- a/internal/daemon/metric/initialize_metrics_test.go
+++ b/internal/daemon/metric/initialize_metrics_test.go
@@ -16,17 +16,35 @@ func Test_AppendServicesAndMethods(t *testing.T) {
 	cases := []struct {
 		name     string
 		pkg      protoreflect.FileDescriptor
+		filter   func(string, string) bool
 		expected map[string][]string
 	}{
 		{
 			name:     "basic",
 			pkg:      protooptions.File_testing_options_v1_service_proto,
+			filter:   func(string, string) bool { return false },
+			expected: map[string][]string{"testing.options.v1.TestService": {"TestMethod"}},
+		},
+		{
+			name: "filter-out",
+			pkg:  protooptions.File_testing_options_v1_service_proto,
+			filter: func(_ string, m string) bool {
+				return m == "TestMethod"
+			},
+			expected: map[string][]string{},
+		},
+		{
+			name: "filter-allow",
+			pkg:  protooptions.File_testing_options_v1_service_proto,
+			filter: func(_ string, m string) bool {
+				return m != "TestMethod"
+			},
 			expected: map[string][]string{"testing.options.v1.TestService": {"TestMethod"}},
 		},
 	}
 	for _, tc := range cases {
 		m := make(map[string][]string, 0)
-		appendServicesAndMethods(m, tc.pkg, nil)
+		appendServicesAndMethods(m, tc.pkg, tc.filter)
 		assert.Equal(t, tc.expected, m)
 	}
 }

--- a/internal/daemon/worker/internal/metric/cluster_client.go
+++ b/internal/daemon/worker/internal/metric/cluster_client.go
@@ -17,7 +17,9 @@ const (
 	clusterClientSubsystem = "cluster_client"
 )
 
-var filterFunc = noopFilter
+// grpcCollectorFilter is currently used to filter the services and methods of the
+// controller.servers.services package upon running InitializeClusterClientCollectors.
+var grpcCollectorFilter = noopFilter
 
 func noopFilter(serviceName string, methodName string) bool {
 	return false
@@ -44,8 +46,7 @@ type requestRecorder struct {
 	start time.Time
 }
 
-// NewRequestRecorder creates a requestRecorder struct which is used to measure gRPC client request latencies.
-// For testing purposes, this method is exported.
+// newRequestRecorder creates a requestRecorder struct which is used to measure gRPC client request latencies.
 func newRequestRecorder(fullMethodName string, reqLatency prometheus.ObserverVec) requestRecorder {
 	service, method := metric.SplitMethodName(fullMethodName)
 	r := requestRecorder{
@@ -92,5 +93,5 @@ func InitializeClusterClientCollectors(r prometheus.Registerer) {
 	metric.InitializeGrpcCollectorsFromPackage(r, grpcRequestLatency,
 		[]protoreflect.FileDescriptor{
 			cservices.File_controller_servers_services_v1_session_service_proto,
-		}, expectedGrpcClientCodes, filterFunc)
+		}, expectedGrpcClientCodes, grpcCollectorFilter)
 }

--- a/internal/daemon/worker/internal/metric/cluster_client.go
+++ b/internal/daemon/worker/internal/metric/cluster_client.go
@@ -82,5 +82,7 @@ func InstrumentClusterClient() grpc.UnaryClientInterceptor {
 // prometheus register and initializes them to 0 for all possible label
 // combinations.
 func InitializeClusterClientCollectors(r prometheus.Registerer) {
-	metric.InitializeGrpcCollectorsFromPackage(r, grpcRequestLatency, services.File_controller_servers_services_v1_session_service_proto, expectedGrpcClientCodes)
+	excludeField := map[string][]string{"controller.servers.services.v1.CommandService": {"SendCommand"}}
+	metric.InitializeGrpcCollectorsFromPackage(r, grpcRequestLatency,
+		services.File_controller_servers_services_v1_session_service_proto, expectedGrpcClientCodes, excludeField, nil)
 }


### PR DESCRIPTION
* adds exclude and include filters to initialize grpc metric function
* ensures that the same metrics belong to the same subsystems after proto file revert in commit 0f89b1