### PR TITLE
refactor (kms): add GetWrapperer for RewrapFn parameter

### DIFF
--- a/internal/auth/oidc/rewrapping.go
+++ b/internal/auth/oidc/rewrapping.go
@@ -13,7 +13,7 @@ func init() {
 	kms.RegisterTableRewrapFn(defaultAuthMethodTableName, authMethodRewrapFn)
 }
 
-func authMethodRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func authMethodRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "oidc.authMethodRewrapFn"
 	if dataKeyVersionId == "" {
 		return errors.New(ctx, errors.InvalidParameter, op, "missing data key version id")

--- a/internal/auth/password/rewrapping.go
+++ b/internal/auth/password/rewrapping.go
@@ -13,7 +13,7 @@ func init() {
 	kms.RegisterTableRewrapFn("auth_password_argon2_cred", argon2ConfigRewrapFn)
 }
 
-func argon2ConfigRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func argon2ConfigRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "password.argon2ConfigRewrapFn"
 	if dataKeyVersionId == "" {
 		return errors.New(ctx, errors.InvalidParameter, op, "missing data key version id")

--- a/internal/authtoken/rewrapping.go
+++ b/internal/authtoken/rewrapping.go
@@ -13,7 +13,7 @@ func init() {
 	kms.RegisterTableRewrapFn(defaultAuthTokenTableName, authTokenRewrapFn)
 }
 
-func authTokenRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func authTokenRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "authtoken.authTokenRewrapFn"
 	if dataKeyVersionId == "" {
 		return errors.New(ctx, errors.InvalidParameter, op, "missing data key version id")

--- a/internal/credential/static/rewrapping.go
+++ b/internal/credential/static/rewrapping.go
@@ -15,7 +15,7 @@ func init() {
 	kms.RegisterTableRewrapFn("credential_static_json_credential", credStaticJsonRewrapFn)
 }
 
-func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) string {
+func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) string {
 	if dataKeyVersionId == "" {
 		return "missing data key version id"
 	}
@@ -34,7 +34,7 @@ func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId
 	return ""
 }
 
-func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "static.credStaticUsernamePasswordRewrapFn"
 	if errStr := rewrapParameterChecks(ctx, dataKeyVersionId, scopeId, reader, writer, kmsRepo); errStr != "" {
 		return errors.New(ctx, errors.InvalidParameter, op, errStr)
@@ -79,7 +79,7 @@ func credStaticUsernamePasswordRewrapFn(ctx context.Context, dataKeyVersionId, s
 	return nil
 }
 
-func credStaticSshPrivKeyRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func credStaticSshPrivKeyRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "static.credStaticSshPrivKeyRewrapFn"
 	if errStr := rewrapParameterChecks(ctx, dataKeyVersionId, scopeId, reader, writer, kmsRepo); errStr != "" {
 		return errors.New(ctx, errors.InvalidParameter, op, errStr)
@@ -125,7 +125,7 @@ func credStaticSshPrivKeyRewrapFn(ctx context.Context, dataKeyVersionId, scopeId
 	return nil
 }
 
-func credStaticJsonRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func credStaticJsonRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "static.credStaticJsonRewrapFn"
 	if errStr := rewrapParameterChecks(ctx, dataKeyVersionId, scopeId, reader, writer, kmsRepo); errStr != "" {
 		return errors.New(ctx, errors.InvalidParameter, op, errStr)

--- a/internal/credential/vault/rewrapping.go
+++ b/internal/credential/vault/rewrapping.go
@@ -14,7 +14,7 @@ func init() {
 	kms.RegisterTableRewrapFn("credential_vault_token", credVaultTokenRewrapFn)
 }
 
-func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) string {
+func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) string {
 	if dataKeyVersionId == "" {
 		return "missing data key version id"
 	}
@@ -33,7 +33,7 @@ func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId
 	return ""
 }
 
-func credVaultClientCertificateRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func credVaultClientCertificateRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "vault.credVaultClientCertificateRewrapFn"
 	if errStr := rewrapParameterChecks(ctx, dataKeyVersionId, scopeId, reader, writer, kmsRepo); errStr != "" {
 		return errors.New(ctx, errors.InvalidParameter, op, errStr)
@@ -62,7 +62,7 @@ func credVaultClientCertificateRewrapFn(ctx context.Context, dataKeyVersionId, s
 	return nil
 }
 
-func credVaultTokenRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func credVaultTokenRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "vault.credVaultTokenRewrapFn"
 	if errStr := rewrapParameterChecks(ctx, dataKeyVersionId, scopeId, reader, writer, kmsRepo); errStr != "" {
 		return errors.New(ctx, errors.InvalidParameter, op, errStr)

--- a/internal/host/plugin/rewrapping.go
+++ b/internal/host/plugin/rewrapping.go
@@ -13,7 +13,7 @@ func init() {
 	kms.RegisterTableRewrapFn("host_plugin_catalog_secret", hostCatalogSecretRewrapFn)
 }
 
-func hostCatalogSecretRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func hostCatalogSecretRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "plugin.hostCatalogSecretRewrapFn"
 	if dataKeyVersionId == "" {
 		return errors.New(ctx, errors.InvalidParameter, op, "missing data key version id")

--- a/internal/kms/kms_test.go
+++ b/internal/kms/kms_test.go
@@ -439,7 +439,7 @@ func TestMonitorTableRewrappingRuns(t *testing.T) {
 
 	t.Run("does-nothing-when-no-run-available", func(t *testing.T) {
 		callbackCalled := false
-		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms *Kms) error {
+		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms GetWrapperer) error {
 			callbackCalled = true
 			return nil
 		}
@@ -476,7 +476,7 @@ func TestMonitorTableRewrappingRuns(t *testing.T) {
 			require.NoError(t, err)
 		})
 		callbackCalled := false
-		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms *Kms) error {
+		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms GetWrapperer) error {
 			callbackCalled = true
 			return nil
 		}
@@ -501,7 +501,7 @@ func TestMonitorTableRewrappingRuns(t *testing.T) {
 		})
 		callbackCalled := make(chan struct{})
 		returnFromCallback := make(chan struct{})
-		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms *Kms) error {
+		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms GetWrapperer) error {
 			close(callbackCalled)
 			assert.Equal(t, "global", scopeId)
 			// Block here until we want it to return
@@ -568,7 +568,7 @@ func TestMonitorTableRewrappingRuns(t *testing.T) {
 			require.NoError(t, err)
 		})
 		rewrappedKeyVersion := ""
-		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms *Kms) error {
+		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms GetWrapperer) error {
 			rewrappedKeyVersion = dataKeyVersionId
 			return nil
 		}
@@ -600,7 +600,7 @@ func TestMonitorTableRewrappingRuns(t *testing.T) {
 			require.NoError(t, err)
 		})
 		rewrappedKeyVersion := ""
-		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms *Kms) error {
+		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms GetWrapperer) error {
 			rewrappedKeyVersion = dataKeyVersionId
 			return nil
 		}
@@ -624,7 +624,7 @@ func TestMonitorTableRewrappingRuns(t *testing.T) {
 			require.NoError(t, err)
 		})
 		callbackCalled := make(chan struct{})
-		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms *Kms) error {
+		tableNameToRewrapFn["auth_token"] = func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms GetWrapperer) error {
 			close(callbackCalled)
 			// Block here until we want it to return
 			<-ctx.Done()
@@ -909,7 +909,7 @@ func TestDestroyKeyVersion(t *testing.T) {
 }
 
 func Test_RegisterTableRewrapFn(t *testing.T) {
-	rewrapFn := func(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kms *Kms) error {
+	rewrapFn := func(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kms GetWrapperer) error {
 		return nil
 	}
 	RegisterTableRewrapFn("a_table", rewrapFn)
@@ -923,7 +923,7 @@ func Test_RegisterTableRewrapFn(t *testing.T) {
 
 func Test_ListTablesSupportingRewrap(t *testing.T) {
 	assert.Empty(t, ListTablesSupportingRewrap())
-	rewrapFn := func(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kms *Kms) error {
+	rewrapFn := func(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kms GetWrapperer) error {
 		return nil
 	}
 	RegisterTableRewrapFn("a_table", rewrapFn)

--- a/internal/kms/rewrapping.go
+++ b/internal/kms/rewrapping.go
@@ -5,10 +5,18 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/boundary/internal/db"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"golang.org/x/exp/maps"
 )
 
-type RewrapFn func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms *Kms) error
+// GetWrapperer defines (and constrains) the kms features required by the
+// RewrapFn
+type GetWrapperer interface {
+	// GetWrapper returns a wrapper for the given scope and purpose.
+	GetWrapper(ctx context.Context, scopeId string, purpose KeyPurpose, opt ...Option) (wrapping.Wrapper, error)
+}
+
+type RewrapFn func(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kms GetWrapperer) error
 
 var tableNameToRewrapFn = map[string]RewrapFn{}
 

--- a/internal/server/rewrapping.go
+++ b/internal/server/rewrapping.go
@@ -15,7 +15,7 @@ func init() {
 	kms.RegisterTableRewrapFn("worker_auth_server_led_activation_token", workerAuthServerLedActivationTokenRewrapFn)
 }
 
-func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) string {
+func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) string {
 	if dataKeyVersionId == "" {
 		return "missing data key version id"
 	}
@@ -34,7 +34,7 @@ func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId
 	return ""
 }
 
-func workerAuthCertRewrapFn(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func workerAuthCertRewrapFn(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "server.workerAuthCertRewrapFn"
 	if errStr := rewrapParameterChecks(ctx, dataKeyVersionId, scopeId, reader, writer, kmsRepo); errStr != "" {
 		return errors.New(ctx, errors.InvalidParameter, op, errStr)
@@ -63,7 +63,7 @@ func workerAuthCertRewrapFn(ctx context.Context, dataKeyVersionId string, scopeI
 	return nil
 }
 
-func workerAuthRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func workerAuthRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "server.workerAuthRewrapFn"
 	if errStr := rewrapParameterChecks(ctx, dataKeyVersionId, scopeId, reader, writer, kmsRepo); errStr != "" {
 		return errors.New(ctx, errors.InvalidParameter, op, errStr)
@@ -108,7 +108,7 @@ func workerAuthRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, r
 	return nil
 }
 
-func workerAuthServerLedActivationTokenRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func workerAuthServerLedActivationTokenRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "server.workerAuthServerLedActivationTokenRewrapFn"
 	if errStr := rewrapParameterChecks(ctx, dataKeyVersionId, scopeId, reader, writer, kmsRepo); errStr != "" {
 		return errors.New(ctx, errors.InvalidParameter, op, errStr)

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -686,9 +686,9 @@ func fetchConnections(ctx context.Context, r db.Reader, sessionId string, opt ..
 // the session uses a legacy private key or not. It also updates the encrypted session
 // in the database (if necessary). Eventually we should be able to remove this function
 // and use the session key unconditionally.
-func decryptAndMaybeUpdateSession(ctx context.Context, kmsRepo *kms.Kms, session *Session, writer db.Writer) error {
+func decryptAndMaybeUpdateSession(ctx context.Context, kmsRepo kms.GetWrapperer, session *Session, writer db.Writer) error {
 	const op = "session.decryptAndMaybeUpdateSession"
-	if kmsRepo == nil {
+	if util.IsNil(kmsRepo) {
 		return errors.New(ctx, errors.InvalidParameter, op, "missing kms repo")
 	}
 	if session == nil {

--- a/internal/session/rewrapping.go
+++ b/internal/session/rewrapping.go
@@ -14,7 +14,7 @@ func init() {
 	kms.RegisterTableRewrapFn("session_credential", sessionCredentialRewrapFn)
 }
 
-func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) string {
+func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) string {
 	if dataKeyVersionId == "" {
 		return "missing data key version id"
 	}
@@ -33,7 +33,7 @@ func rewrapParameterChecks(ctx context.Context, dataKeyVersionId string, scopeId
 	return ""
 }
 
-func sessionCredentialRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func sessionCredentialRewrapFn(ctx context.Context, dataKeyVersionId, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "session.sessionCredentialRewrapFn"
 	if errStr := rewrapParameterChecks(ctx, dataKeyVersionId, scopeId, reader, writer, kmsRepo); errStr != "" {
 		return errors.New(ctx, errors.InvalidParameter, op, errStr)
@@ -84,7 +84,7 @@ func sessionCredentialRewrapFn(ctx context.Context, dataKeyVersionId, scopeId st
 	return nil
 }
 
-func sessionRewrapFn(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo *kms.Kms) error {
+func sessionRewrapFn(ctx context.Context, dataKeyVersionId string, scopeId string, reader db.Reader, writer db.Writer, kmsRepo kms.GetWrapperer) error {
 	const op = "session.sessionRewrapFn"
 	if errStr := rewrapParameterChecks(ctx, dataKeyVersionId, scopeId, reader, writer, kmsRepo); errStr != "" {
 		return errors.New(ctx, errors.InvalidParameter, op, errStr)


### PR DESCRIPTION
This refactor adds the `GetWrapperer` interface which defines (and constrains) the kms features required by `kms.RewrapFn(...)`