### PR TITLE
docs: Fix redirect syntax

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -19,7 +19,7 @@ module.exports = [
   },
   {
     source: '/boundary/docs/roadmap',
-    destination: 'boundary/docs/overview/what-is-boundary',
+    destination: '/boundary/docs/overview/what-is-boundary',
     permanent: true,
   },
 ]


### PR DESCRIPTION
A recently merged redirect is not working and I believe it is because I left a slash out. This PR adds the slash.