### PR TITLE
docs: Remove "Overview" titles

### DIFF
--- a/website/content/docs/concepts/domain-model/index.mdx
+++ b/website/content/docs/concepts/domain-model/index.mdx
@@ -5,7 +5,7 @@ description: |-
   Reference documentation for Boundary's domain model.
 ---
 
-# Overview
+# Boundary's Domain Model
 
 [HashiCorp Boundary](https://www.boundaryproject.io/) has an extensible domain model that allows administrators to organize IAM (Identity and Access Management) and target resources in a way that best compliments how their organization manages its computing infrastructure. This concept page is a high-level look at scopes, how they work, and their role in the domain model. We will also explore how Boundary approaches IAM and granting access to Targets. For more information about Boundary’s resource types, see the subpages of the Domain Model section.
 

--- a/website/content/docs/concepts/index.mdx
+++ b/website/content/docs/concepts/index.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # Concepts
 
-This section covers some concepts that are imporant to understand Boundary usage and operation. Every page in this section is recommended reading for anyone consuming or operating
+This section covers some concepts that are important to understand Boundary usage and operation. Every page in this section is recommended reading for anyone consuming or operating
 Boundary. For a glossary of terms, refer to the [domain model](/docs/concepts/domain-model) section.
 
 Please use the navigation to the left to learn more about a topic.

--- a/website/content/docs/concepts/security/permissions/index.mdx
+++ b/website/content/docs/concepts/security/permissions/index.mdx
@@ -7,8 +7,6 @@ description: |-
 
 # Permissions in Boundary
 
-## Overview
-
 Boundary's permissions model is a composable, RBAC, allow-only model that
 attempts to marry flexibility with usability. This page discusses the permission
 model's fundamental concepts, provides examples of the specific forms of allowed
@@ -31,7 +29,7 @@ relatively simple and predictable.
 At a very high level, permissions within Boundary are declared via grant strings
 and mapped to users via roles.
 
-### Grant Strings
+## Grant Strings
 
 A grant string has a form similar to:
 
@@ -61,7 +59,7 @@ Additionally, there are two types of assigned permissions:
 
 Grant strings can be supplied via a human-friendly string syntax or via JSON.
 
-### Roles
+## Roles
 
 Roles map grant strings to _principals_, currently users and groups. Every role
 assigns grants within a specific scope: either the scope in which the role

--- a/website/content/docs/concepts/service-discovery.mdx
+++ b/website/content/docs/concepts/service-discovery.mdx
@@ -7,53 +7,52 @@ description: |-
 
 # Service Discovery
 
-## Overview
-Traditionally, connecting to remote hosts and services requires knowledge of 
-the endpoint’s connection info (e.g. the IP address and port of the service). 
+Traditionally, connecting to remote hosts and services requires knowledge of
+the endpoint’s connection info (e.g. the IP address and port of the service).
 This creates complexity when managing the onboarding of new resources at scale
 or dealing with dynamic services whose connection info frequently changes.
 
-**Service discovery** focuses on automating the process of onboarding new or 
-changed infrastructure resources – and their connection info – to Boundary 
+**Service discovery** focuses on automating the process of onboarding new or
+changed infrastructure resources – and their connection info – to Boundary
 as hosts.
 
-# Automating Service Discovery in Boundary
+## Automating Service Discovery in Boundary
 
-Boundary supports target/service discovery in three primary workflows: 
+Boundary supports target/service discovery in three primary workflows:
 
-**[Manual configuration](https://learn.hashicorp.com/tutorials/boundary/oss-manage-targets)**: 
-Boundary administrators can manually configure static 
-hosts and targets via the administrator UI and CLI. Manual configuration of 
-targets with static hosts requires knowledge of the IP address or endpoint used 
+**[Manual configuration](https://learn.hashicorp.com/tutorials/boundary/oss-manage-targets)**:
+Boundary administrators can manually configure static
+hosts and targets via the administrator UI and CLI. Manual configuration of
+targets with static hosts requires knowledge of the IP address or endpoint used
 to connect to a host.
 
-**[Service discovery via configuration as code with Terraform](https://learn.hashicorp.com/tutorials/boundary/oss-getting-started-config)**: 
-Boundary is fully programmatically instrumented and the discovery and configuration of new 
-infrastructure targets can be automated with 
-[Boundary’s Terraform provider](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs). 
-This allows for dynamic configuration of a host and target without the need 
-for prior knowledge of the target’s connection info. 
+**[Service discovery via configuration as code with Terraform](https://learn.hashicorp.com/tutorials/boundary/oss-getting-started-config)**:
+Boundary is fully programmatically instrumented and the discovery and configuration of new
+infrastructure targets can be automated with
+[Boundary’s Terraform provider](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs).
+This allows for dynamic configuration of a host and target without the need
+for prior knowledge of the target’s connection info.
 
-**[Runtime service discovery via dynamic host catalogs](https://learn.hashicorp.com/tutorials/boundary/azure-host-catalogs)**: 
-Boundary dynamic host catalogs automate the ingestion of resources from 
-infrastructure providers into Boundary. Boundary hosts are automatically 
-created, updated and added to host sets in order to reflect the connection 
-information maintained in these providers. This removes the need to know 
-host connection info or reapply infrastructure as code templates to 
-configure new or changed resources.This removes the need to know host connection 
+**[Runtime service discovery via dynamic host catalogs](https://learn.hashicorp.com/tutorials/boundary/azure-host-catalogs)**:
+Boundary dynamic host catalogs automate the ingestion of resources from
+infrastructure providers into Boundary. Boundary hosts are automatically
+created, updated and added to host sets in order to reflect the connection
+information maintained in these providers. This removes the need to know
+host connection info or reapply infrastructure as code templates to
+configure new or changed resources.This removes the need to know host connection
 info or reapply infrastructure as code templates to configure new or changed resources.
 
-# Dynamic Host Catalogs
-Dynamic host catalogs are an agentless workflow for Boundary to 
-securely query infrastructure providers at runtime to discover and configure 
-new services. Boundary dynamic host catalogs are written in go-plugin and run 
-as separate processes. Boundary administrators can define rules for which 
-external resources should be ingested into the catalog by 
+## Dynamic Host Catalogs
+Dynamic host catalogs are an agentless workflow for Boundary to
+securely query infrastructure providers at runtime to discover and configure
+new services. Boundary dynamic host catalogs are written in go-plugin and run
+as separate processes. Boundary administrators can define rules for which
+external resources should be ingested into the catalog by
 [creating dynamic host](https://www.boundaryproject.io/docs/concepts/domain-model/host-sets)
- sets with an attributes filter. Attributes specify the fields which the plugin 
+ sets with an attributes filter. Attributes specify the fields which the plugin
  should use to lookup which hosts should be members of this host set.
 
-Currently, Boundary supports dynamic host catalog implementations for AWS and 
-Azure and we will continue to grow this ecosystem to support additional providers. 
+Currently, Boundary supports dynamic host catalog implementations for AWS and
+Azure and we will continue to grow this ecosystem to support additional providers.
 
 You can get started with dynamic host catalogs [here](https://learn.hashicorp.com/tutorials/boundary/azure-host-catalogs).

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -14,7 +14,7 @@
         "title": "Boundary vs. Other Software",
         "routes": [
           {
-            "title": "Overview",
+            "title": "Compare Boundary",
             "path": "overview/vs/other-software"
           },
           {
@@ -49,7 +49,7 @@
     "title": "Getting Started",
     "routes": [
       {
-        "title": "Overview",
+        "title": "Boundary Offerings",
         "path": "getting-started"
       },
       {
@@ -80,14 +80,14 @@
     "title": "Configuration",
     "routes": [
       {
-        "title": "Overview/Top-Level Parameters",
+        "title": "Top-Level Parameters",
         "path": "configuration"
       },
       {
         "title": "worker",
         "routes": [
           {
-            "title": "Overview",
+            "title": "Stanza",
             "path": "configuration/worker"
           },
           {
@@ -109,7 +109,7 @@
         "title": "listener",
         "routes": [
           {
-            "title": "Overview",
+            "title": "Stanza",
             "path": "configuration/listener"
           },
           {
@@ -126,7 +126,7 @@
         "title": "KMS",
         "routes": [
           {
-            "title": "Overview",
+            "title": "Stanza",
             "path": "configuration/kms"
           },
           {
@@ -163,7 +163,7 @@
         "title": "events",
         "routes": [
           {
-            "title": "Overview",
+            "title": "Stanza",
             "path": "configuration/events"
           },
           {
@@ -204,7 +204,7 @@
     "title": "Concepts",
     "routes": [
       {
-        "title": "Overview",
+        "title": "Understand Boundary",
         "path": "concepts"
       },
       {
@@ -215,14 +215,14 @@
         "title": "Security",
         "routes": [
           {
-            "title": "Overview",
+            "title": "Security Model",
             "path": "concepts/security"
           },
           {
             "title": "Permissions",
             "routes": [
               {
-                "title": "Overview",
+                "title": "Permissions in Boundary",
                 "path": "concepts/security/permissions"
               },
               {
@@ -253,7 +253,7 @@
         "title": "Domain Model",
         "routes": [
           {
-            "title": "Overview",
+            "title": "Boundary's Domain Model",
             "path": "concepts/domain-model"
           },
           {
@@ -326,7 +326,7 @@
         "title": "Filtering",
         "routes": [
           {
-            "title": "Overview",
+            "title": "Filter Expressions",
             "path": "concepts/filtering"
           },
           {
@@ -404,7 +404,7 @@
     "title": "API/Clients",
     "routes": [
       {
-        "title": "Overview",
+        "title": "Clients",
         "path": "api-clients"
       },
       {
@@ -437,14 +437,14 @@
     "title": "Boundary OSS",
     "routes": [
       {
-        "title": "Overview",
+        "title": "OSS Distribution",
         "path": "oss"
       },
       {
         "title": "Installation",
         "routes": [
           {
-            "title": "Overview",
+            "title": "Install Boundary",
             "path": "oss/installing"
           },
           {
@@ -485,7 +485,7 @@
         "title": "Operations",
         "routes": [
           {
-            "title": "Overview",
+            "title": "Operate Boundary",
             "path": "oss/operations"
           },
           {
@@ -499,18 +499,18 @@
         ]
       },
       {
-        "title": "Developing Boundary",
+        "title": "Development",
         "routes": [
           {
-            "title": "Overview",
+            "title": "Develop Boundary",
             "path": "oss/developing"
           },
           {
-            "title": "Building",
+            "title": "Build Boundary",
             "path": "oss/developing/building"
           },
           {
-            "title": "Developing the UI",
+            "title": "Develop the UI",
             "path": "oss/developing/ui"
           }
         ]

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1,9 +1,9 @@
 [
   {
-    "title": "Introduction",
+    "title": "What is Boundary?",
     "routes": [
       {
-        "title": "What is Boundary?",
+        "title": "Introduction",
         "path": "overview/what-is-boundary"
       },
       {
@@ -14,7 +14,7 @@
         "title": "Boundary vs. Other Software",
         "routes": [
           {
-            "title": "Compare Boundary",
+            "title": "Introduction",
             "path": "overview/vs/other-software"
           },
           {
@@ -46,10 +46,10 @@
     ]
   },
   {
-    "title": "Getting Started",
+    "title": "Get Started",
     "routes": [
       {
-        "title": "Boundary Offerings",
+        "title": "Deployment Options",
         "path": "getting-started"
       },
       {
@@ -201,10 +201,10 @@
     ]
   },
   {
-    "title": "Concepts",
+    "title": "Core Concepts",
     "routes": [
       {
-        "title": "Understand Boundary",
+        "title": "Introduction",
         "path": "concepts"
       },
       {
@@ -215,14 +215,14 @@
         "title": "Security",
         "routes": [
           {
-            "title": "Security Model",
+            "title": "Introduction",
             "path": "concepts/security"
           },
           {
             "title": "Permissions",
             "routes": [
               {
-                "title": "Permissions in Boundary",
+                "title": "Permissions Model",
                 "path": "concepts/security/permissions"
               },
               {
@@ -253,7 +253,7 @@
         "title": "Domain Model",
         "routes": [
           {
-            "title": "Boundary's Domain Model",
+            "title": "Introduction",
             "path": "concepts/domain-model"
           },
           {
@@ -326,7 +326,7 @@
         "title": "Filtering",
         "routes": [
           {
-            "title": "Filter Expressions",
+            "title": "Expressions",
             "path": "concepts/filtering"
           },
           {
@@ -404,7 +404,7 @@
     "title": "API/Clients",
     "routes": [
       {
-        "title": "Clients",
+        "title": "Introduction",
         "path": "api-clients"
       },
       {
@@ -437,7 +437,7 @@
     "title": "Boundary OSS",
     "routes": [
       {
-        "title": "OSS Distribution",
+        "title": "Introduction",
         "path": "oss"
       },
       {
@@ -482,10 +482,10 @@
         ]
       },
       {
-        "title": "Operations",
+        "title": "Maintain and Operate Boundary",
         "routes": [
           {
-            "title": "Operate Boundary",
+            "title": "Introduction",
             "path": "oss/operations"
           },
           {
@@ -502,7 +502,7 @@
         "title": "Development",
         "routes": [
           {
-            "title": "Develop Boundary",
+            "title": "Contribute to Boundary",
             "path": "oss/developing"
           },
           {


### PR DESCRIPTION
There are several topics titled "Overview" in the Boundary navigation. This is a somewhat unhelpful title for users. This PR attempts to provide more meaningful topic titles.