### PR TITLE
chore(e2e): Add tparse to summarize test output

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ inputs.go-version }}
+      - name: Install tools to get tparse
+        run: make tools
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
         with:

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -122,7 +122,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_AWS_HOST_SET_IPS2         = local.aws_host_set_ips2
   }
 
-  inline = ["PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1"]
+  inline = ["PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json | tparse -follow -format plain"]
 }
 
 output "test_results" {


### PR DESCRIPTION
This PR adds the tparse tool to include a table summary of test results at the end. This is the same tool used by unit tests.

Here's an example log: https://github.com/hashicorp/boundary/actions/runs/3699246273/jobs/6266548822

The standard format didn't look nice...
![Screen Shot 2022-12-14 at 5 57 15 PM](https://user-images.githubusercontent.com/2474253/207735239-9691f0dd-86c4-4abd-acd7-c978d6656d9f.png)

... so this PR is currently opting to use the plain format
![Screen Shot 2022-12-14 at 5 57 05 PM](https://user-images.githubusercontent.com/2474253/207735248-30cf9602-ed47-4bcd-8385-2f444a2f9cbb.png)
