### PR TITLE
Merge duplicated attr/secret/kv flag handling into one function

### DIFF
--- a/internal/cmd/commands/credentialscmd/json_credentials.gen.go
+++ b/internal/cmd/commands/credentialscmd/json_credentials.gen.go
@@ -94,7 +94,15 @@ func (c *JsonCommand) Flags() *base.FlagSets {
 	common.PopulateCommonFlags(c.Command, f, "json-type credential", flagsJsonMap, c.Func)
 
 	f = set.NewFlagSet("Object Options")
-	common.PopulateObjectFlags(c.Command, f, flagsJsonMap, c.Func)
+	objsInput := common.CombinedSliceFlagValuePopulationInput{
+		FlagSet:                          f,
+		FlagNames:                        flagsJsonMap[c.Func],
+		FullPopulationFlag:               &c.FlagObject,
+		FullPopulationInputName:          "object",
+		PiecewisePopulationFlag:          &c.FlagKv,
+		PiecewisePopulationInputBaseName: "kv",
+	}
+	common.PopulateCombinedSliceFlagValue(objsInput)
 
 	extraJsonFlagsFunc(c, set, f)
 

--- a/internal/cmd/commands/hostcatalogscmd/plugin_hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/plugin_hostcatalogs.gen.go
@@ -94,10 +94,26 @@ func (c *PluginCommand) Flags() *base.FlagSets {
 	common.PopulateCommonFlags(c.Command, f, "plugin-type host catalog", flagsPluginMap, c.Func)
 
 	f = set.NewFlagSet("Attribute Options")
-	common.PopulateAttributeFlags(c.Command, f, flagsPluginMap, c.Func)
+	attrsInput := common.CombinedSliceFlagValuePopulationInput{
+		FlagSet:                          f,
+		FlagNames:                        flagsPluginMap[c.Func],
+		FullPopulationFlag:               &c.FlagAttributes,
+		FullPopulationInputName:          "attributes",
+		PiecewisePopulationFlag:          &c.FlagAttrs,
+		PiecewisePopulationInputBaseName: "attr",
+	}
+	common.PopulateCombinedSliceFlagValue(attrsInput)
 
 	f = set.NewFlagSet("Secrets Options")
-	common.PopulateSecretFlags(c.Command, f, flagsPluginMap, c.Func)
+	scrtsInput := common.CombinedSliceFlagValuePopulationInput{
+		FlagSet:                          f,
+		FlagNames:                        flagsPluginMap[c.Func],
+		FullPopulationFlag:               &c.FlagSecrets,
+		FullPopulationInputName:          "secrets",
+		PiecewisePopulationFlag:          &c.FlagScrts,
+		PiecewisePopulationInputBaseName: "secret",
+	}
+	common.PopulateCombinedSliceFlagValue(scrtsInput)
 
 	extraPluginFlagsFunc(c, set, f)
 

--- a/internal/cmd/commands/hostsetscmd/plugin_hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/plugin_hostsets.gen.go
@@ -96,7 +96,15 @@ func (c *PluginCommand) Flags() *base.FlagSets {
 	common.PopulateCommonFlags(c.Command, f, "plugin-type host set", flagsPluginMap, c.Func)
 
 	f = set.NewFlagSet("Attribute Options")
-	common.PopulateAttributeFlags(c.Command, f, flagsPluginMap, c.Func)
+	attrsInput := common.CombinedSliceFlagValuePopulationInput{
+		FlagSet:                          f,
+		FlagNames:                        flagsPluginMap[c.Func],
+		FullPopulationFlag:               &c.FlagAttributes,
+		FullPopulationInputName:          "attributes",
+		PiecewisePopulationFlag:          &c.FlagAttrs,
+		PiecewisePopulationInputBaseName: "attr",
+	}
+	common.PopulateCombinedSliceFlagValue(attrsInput)
 
 	extraPluginFlagsFunc(c, set, f)
 

--- a/internal/cmd/common/flags_test.go
+++ b/internal/cmd/common/flags_test.go
@@ -145,6 +145,7 @@ func TestPopulateAttrFlags(t *testing.T) {
 			flagSet := c.FlagSet(base.FlagSetNone)
 			f := flagSet.NewFlagSet("Attribute Options")
 			cmd := "create"
+
 			flagNames := map[string][]string{
 				cmd: {
 					"attributes",
@@ -155,7 +156,16 @@ func TestPopulateAttrFlags(t *testing.T) {
 				},
 			}
 
-			PopulateAttributeFlags(c, f, flagNames, cmd)
+			attrsInput := CombinedSliceFlagValuePopulationInput{
+				FlagSet:                          f,
+				FlagNames:                        flagNames[cmd],
+				FullPopulationFlag:               &c.FlagAttributes,
+				FullPopulationInputName:          "attributes",
+				PiecewisePopulationFlag:          &c.FlagAttrs,
+				PiecewisePopulationInputBaseName: "attr",
+			}
+			PopulateCombinedSliceFlagValue(attrsInput)
+
 			err := flagSet.Parse(tt.args)
 			if tt.expectedErr != "" {
 				require.Error(err)

--- a/internal/cmd/gencli/templates.go
+++ b/internal/cmd/gencli/templates.go
@@ -205,17 +205,41 @@ func (c *{{ camelCase .SubActionPrefix }}Command) Flags() *base.FlagSets {
 
 	{{ if .HasGenericAttributes }}
 	f = set.NewFlagSet("Attribute Options")
-	common.PopulateAttributeFlags(c.Command, f, flags{{ camelCase .SubActionPrefix }}Map, c.Func)
+		attrsInput := common.CombinedSliceFlagValuePopulationInput{
+		FlagSet: f,
+		FlagNames: flags{{ camelCase .SubActionPrefix }}Map[c.Func],
+		FullPopulationFlag: &c.FlagAttributes,
+		FullPopulationInputName: "attributes",
+		PiecewisePopulationFlag: &c.FlagAttrs,
+		PiecewisePopulationInputBaseName: "attr",
+	}
+	common.PopulateCombinedSliceFlagValue(attrsInput)
 	{{ end }}
 
 	{{ if .HasGenericSecrets }}
 	f = set.NewFlagSet("Secrets Options")
-	common.PopulateSecretFlags(c.Command, f, flags{{ camelCase .SubActionPrefix }}Map, c.Func)
+	scrtsInput := common.CombinedSliceFlagValuePopulationInput{
+		FlagSet: f,
+		FlagNames: flags{{ camelCase .SubActionPrefix }}Map[c.Func],
+		FullPopulationFlag: &c.FlagSecrets,
+		FullPopulationInputName: "secrets",
+		PiecewisePopulationFlag: &c.FlagScrts,
+		PiecewisePopulationInputBaseName: "secret",
+	}
+	common.PopulateCombinedSliceFlagValue(scrtsInput)
 	{{ end }}
 
 	{{ if .HasJsonObject }}
 	f = set.NewFlagSet("Object Options")
-	common.PopulateObjectFlags(c.Command, f, flags{{ camelCase .SubActionPrefix }}Map, c.Func)
+		objsInput := common.CombinedSliceFlagValuePopulationInput{
+		FlagSet: f,
+		FlagNames: flags{{ camelCase .SubActionPrefix }}Map[c.Func],
+		FullPopulationFlag: &c.FlagObject,
+		FullPopulationInputName: "object",
+		PiecewisePopulationFlag: &c.FlagKv,
+		PiecewisePopulationInputBaseName: "kv",
+	}
+	common.PopulateCombinedSliceFlagValue(objsInput)
 	{{ end }}
 
 	extra{{ camelCase .SubActionPrefix }}FlagsFunc(c, set, f)


### PR DESCRIPTION
This removes a bunch of copypasta. Diffs below:

```diff
--- hostcatalogs-before 2022-12-15 10:29:16.391945146 -0500
+++ hostcatalogs-after  2022-12-15 10:54:28.405221449 -0500
@@ -103,11 +103,11 @@
 Attribute Options:
 
   -attr
-      A key=value attribute to add to the request's attributes map. The type
-      is automatically inferred. Use -string-attr, -bool-attr, or -num-attr
+      A key=value pair to add to the request's attributes map. The type is
+      automatically inferred. Use -string-attr, -bool-attr, or -num-attr
       if the type needs to be overridden. Can be specified multiple times.
       Supports sourcing values from files via "file://" and env vars via
-      "env://"
+      "env://".
 
   -attributes=<string>
       A JSON map value to use as the entirety of the request's attributes
@@ -115,38 +115,38 @@
       exclusive with the other attr flags.
 
   -bool-attr
-      A key=value bool attribute to add to the request's attributes map. Can
+      A key=value bool value to add to the request's attributes map. Can
       be specified multiple times. Supports sourcing values from files via
-      "file://" and env vars via "env://"
+      "file://" and env vars via "env://"`.
 
   -num-attr
-      A key=value numeric attribute to add to the request's attributes map.
-      Can be specified multiple times. Supports sourcing values from files via
-      "file://" and env vars via "env://"
+      A key=value numeric value to add to the request's attributes map. Can
+      be specified multiple times. Supports sourcing values from files via
+      "file://" and env vars via "env://"`.
 
   -string-attr
-      A key=value string attribute to add to the request's attributes map.
-      Can be specified multiple times. Supports sourcing values from files via
-      "file://" and env vars via "env://"
+      A key=value string value to add to the request's attributes map. Can
+      be specified multiple times. Supports sourcing values from files via
+      "file://" and env vars via "env://"`.
 
 Secrets Options:
 
   -bool-secret
-      A key=value bool secret to add to the request's secrets map. Can be
+      A key=value bool value to add to the request's secrets map. Can be
       specified multiple times. Supports sourcing values from files via
-      "file://" and env vars via "env://"
+      "file://" and env vars via "env://"`.
 
   -num-secret
-      A key=value numeric secret to add to the request's secrets map. Can
+      A key=value numeric value to add to the request's secrets map. Can
       be specified multiple times. Supports sourcing values from files via
-      "file://" and env vars via "env://"
+      "file://" and env vars via "env://"`.
 
   -secret
-      A key=value secret to add to the request's secrets map. The type is
+      A key=value pair to add to the request's secrets map. The type is
       automatically inferred. Use -string-secret, -bool-secret, or -num-secret
       if the type needs to be overridden. Can be specified multiple times.
       Supports sourcing values from files via "file://" and env vars via
-      "env://"
+      "env://".
 
   -secrets=<string>
       A JSON map value to use as the entirety of the request's secrets map.
@@ -154,6 +154,6 @@
       exclusive with the other secret flags.
 
   -string-secret
-      A key=value string secret to add to the request's secrets map. Can
+      A key=value string value to add to the request's secrets map. Can
       be specified multiple times. Supports sourcing values from files via
-      "file://" and env vars via "env://"
+      "file://" and env vars via "env://"`.
```

```diff
--- credentials-before  2022-12-15 11:33:04.798467426 -0500
+++ credentials-after   2022-12-15 11:32:53.821801174 -0500
@@ -99,18 +99,18 @@
   -bool-kv
       A key=value bool value to add to the request's object map. Can be
       specified multiple times. Supports sourcing values from files via
-      "file://" and env vars via "env://"
+      "file://" and env vars via "env://"`.
 
   -kv
       A key=value pair to add to the request's object map. The type is
       automatically inferred. Use -string-kv, -bool-kv, or -num-kv if the
       type needs to be overridden. Can be specified multiple times. Supports
-      sourcing values from files via "file://" and env vars via "env://"
+      sourcing values from files via "file://" and env vars via "env://".
 
   -num-kv
       A key=value numeric value to add to the request's object map. Can
       be specified multiple times. Supports sourcing values from files via
-      "file://" and env vars via "env://"
+      "file://" and env vars via "env://"`.
 
   -object=<string>
       A JSON map value to use as the entirety of the request's object map.
@@ -120,4 +120,4 @@
   -string-kv
       A key=value string value to add to the request's object map. Can be
       specified multiple times. Supports sourcing values from files via
-      "file://" and env vars via "env://"
+      "file://" and env vars via "env://"`.
```