### PR TITLE
docs: Add HCP link to navigation

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -521,7 +521,7 @@
     "divider": true
   },
   {
-    "title": "Boundary HCP",
+    "title": "HCP Boundary",
     "href": "https://cloud.hashicorp.com/docs/boundary/"
   },
   {

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -521,6 +521,13 @@
     "divider": true
   },
   {
+    "title": "HCP",
+    "href": "https://developer.hashicorp.com/hcp/docs/boundary"
+  },
+  {
+    "divider": true
+  },
+  {
     "title": "Release Notes",
     "routes": [
       {

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -522,7 +522,7 @@
   },
   {
     "title": "HCP",
-    "href": "https://developer.hashicorp.com/hcp/docs/boundary/"
+    "href": "hcp/docs/boundary"
   },
   {
     "divider": true

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -522,7 +522,7 @@
   },
   {
     "title": "HCP",
-    "href": "https://developer.hashicorp.com/hcp/docs/boundary"
+    "href": "https://developer.hashicorp.com/hcp/docs/boundary/"
   },
   {
     "divider": true

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -521,8 +521,8 @@
     "divider": true
   },
   {
-    "title": "HCP",
-    "href": "hcp/docs/boundary"
+    "title": "Boundary HCP",
+    "href": "https://developer.hashicorp.com/hcp/docs/boundary/"
   },
   {
     "divider": true

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -522,7 +522,7 @@
   },
   {
     "title": "Boundary HCP",
-    "href": "https://developer.hashicorp.com/hcp/docs/boundary/"
+    "href": "https://cloud.hashicorp.com/docs/boundary/"
   },
   {
     "divider": true


### PR DESCRIPTION
This PR adds a link to the HCP Boundary docs on the Boundary general documentation page.

<img width="315" alt="image" src="https://user-images.githubusercontent.com/76443935/207987600-543b4d7f-cc3b-4b07-a5b5-3aa66fe75544.png">

[View the preview here.](https://boundary-l5siv8hl6-hashicorp.vercel.app/boundary/docs)