### PR TITLE
chore(e2e): Update to use Vault 1.12.2

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Download Vault AMD64 binary for integration testing
         if: steps.dep-cache.outputs.cache-hit != 'true'
         run: |
-          wget https://releases.hashicorp.com/vault/1.12.0/vault_1.12.0_linux_amd64.zip -O /tmp/test-deps/vault.zip
+          wget https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_linux_amd64.zip -O /tmp/test-deps/vault.zip
       - name: Install Vault for integration testing
         if: matrix.filter == 'e2e_static_with_vault builder:crt' || matrix.filter == 'e2e_database'
         run: |

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -99,7 +99,7 @@ scenario "e2e_database" {
       storage_backend = "raft"
       unseal_method   = "awskms"
       vault_release = {
-        version = "1.12.2"
+        version = var.vault_version
         edition = "oss"
       }
       vpc_id = step.create_base_infra.vpc_id

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -99,7 +99,7 @@ scenario "e2e_database" {
       storage_backend = "raft"
       unseal_method   = "awskms"
       vault_release = {
-        version = "1.12.0"
+        version = "1.12.2"
         edition = "oss"
       }
       vpc_id = step.create_base_infra.vpc_id

--- a/enos/enos-scenario-e2e-static-with-vault.hcl
+++ b/enos/enos-scenario-e2e-static-with-vault.hcl
@@ -94,7 +94,7 @@ scenario "e2e_static_with_vault" {
       sg_additional_ips = step.create_boundary_cluster.controller_ips
       unseal_method     = "awskms"
       vault_release = {
-        version = "1.12.0"
+        version = "1.12.2"
         edition = "oss"
       }
       vpc_id = step.create_base_infra.vpc_id

--- a/enos/enos-scenario-e2e-static-with-vault.hcl
+++ b/enos/enos-scenario-e2e-static-with-vault.hcl
@@ -94,7 +94,7 @@ scenario "e2e_static_with_vault" {
       sg_additional_ips = step.create_boundary_cluster.controller_ips
       unseal_method     = "awskms"
       vault_release = {
-        version = "1.12.2"
+        version = var.vault_version
         edition = "oss"
       }
       vpc_id = step.create_base_infra.vpc_id

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -110,6 +110,12 @@ variable "vault_instance_type" {
   default     = "t3a.small"
 }
 
+variable "vault_version" {
+  description = "Version of Vault to use"
+  type        = string
+  default     = "1.12.2"
+}
+
 variable "test_email" {
   description = "Email address for setting up AWS IAM user (module: iam_setup)"
   type        = string


### PR DESCRIPTION
This PR updates the e2e test suite to use the latest version of Vault (version 1.12.2).
