### PR TITLE
[QT-444] Use repo isolated AWS account for enos CI tests

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -66,10 +66,10 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
           aws-region: us-east-1
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_CI }}
           role-skip-session-tagging: true
           role-duration-seconds: 3600
       - name: Set up Enos
@@ -79,7 +79,7 @@ jobs:
       - name: Set up AWS SSH private key
         run: |
           mkdir -p ./enos/support
-          echo "${{ secrets.ENOS_CI_SSH_KEY }}" > ./enos/support/private_key.pem
+          echo "${{ secrets.SSH_KEY_PRIVATE_CI }}" > ./enos/support/private_key.pem
           chmod 600 ./enos/support/private_key.pem
       - name: Set up dependency cache
         id: dep-cache
@@ -126,7 +126,7 @@ jobs:
         # Use the same env vars from the following step
         env:
           ENOS_VAR_aws_region: us-east-1
-          ENOS_VAR_aws_ssh_keypair_name: enos-ci-ssh-key
+          ENOS_VAR_aws_ssh_keypair_name: ${{ github.event.repository.name }}-ci-ssh-key
           ENOS_VAR_aws_ssh_private_key_path: ./support/private_key.pem
           ENOS_VAR_local_boundary_dir: ./support/
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
@@ -143,7 +143,7 @@ jobs:
         continue-on-error: true
         env:
           ENOS_VAR_aws_region: us-east-1
-          ENOS_VAR_aws_ssh_keypair_name: enos-ci-ssh-key
+          ENOS_VAR_aws_ssh_keypair_name: ${{ github.event.repository.name }}-ci-ssh-key
           ENOS_VAR_aws_ssh_private_key_path: ./support/private_key.pem
           ENOS_VAR_local_boundary_dir: ./support/
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
@@ -171,7 +171,7 @@ jobs:
         if: steps.run.outcome == 'failure'
         env:
           ENOS_VAR_aws_region: us-east-1
-          ENOS_VAR_aws_ssh_keypair_name: enos-ci-ssh-key
+          ENOS_VAR_aws_ssh_keypair_name: ${{ github.event.repository.name }}-ci-ssh-key
           ENOS_VAR_aws_ssh_private_key_path: ./support/private_key.pem
           ENOS_VAR_local_boundary_dir: ./support/
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
@@ -183,7 +183,7 @@ jobs:
       - name: Destroy Enos scenario
         env:
           ENOS_VAR_aws_region: us-east-1
-          ENOS_VAR_aws_ssh_keypair_name: enos-ci-ssh-key
+          ENOS_VAR_aws_ssh_keypair_name: ${{ github.event.repository.name }}-ci-ssh-key
           ENOS_VAR_aws_ssh_private_key_path: ./support/private_key.pem
           ENOS_VAR_local_boundary_dir: ./support/
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip

--- a/.github/workflows/test-ci-bootstrap-oss.yml
+++ b/.github/workflows/test-ci-bootstrap-oss.yml
@@ -1,4 +1,4 @@
-name: enos-ci-bootstrap-oss
+name: test-ci-bootstrap-oss
 
 on:
   pull_request:
@@ -6,13 +6,13 @@ on:
       - main
     paths:
       - enos/ci/**
-      - .github/workflows/enos-ci-bootstrap-oss.yml
+      - .github/workflows/test-ci-bootstrap-oss.yml
   push:
     branches:
       - main
     paths:
       - enos/ci/**
-      - .github/workflows/enos-ci-bootstrap-oss.yml
+      - .github/workflows/test-ci-bootstrap-oss.yml
 
 jobs:
   bootstrap-ci-oss:
@@ -28,12 +28,12 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::271311691044:role/github_actions-boundary_ci
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_CI }}
           role-skip-session-tagging: true
           role-duration-seconds: 3600
       - name: Init Terraform

--- a/.github/workflows/test-ci-cleanup-oss.yml
+++ b/.github/workflows/test-ci-cleanup-oss.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     outputs:
       regions: ${{steps.setup.outputs.regions}}
+      account_id: ${{steps.setup.outputs.account_id}}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -24,10 +25,6 @@ jobs:
         id: setup
         run: |
           echo "regions=$(aws ec2 describe-regions --region us-east-1 --output json --query 'Regions[].RegionName' | tr -d '\n ')" >> $GITHUB_OUTPUT
-          echo "account_id=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | awk -F'"' '/"accountId"/ { print $4 }')" >> $GITHUB_OUTPUT
-      - name: Get account ID
-        id: setup_aws
-        run: |
           echo "account_id=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | awk -F'"' '/"accountId"/ { print $4 }')" >> $GITHUB_OUTPUT
 
   aws-nuke:
@@ -58,8 +55,7 @@ jobs:
       - name: Configure
         run: |
           cp enos/ci/aws-nuke.yml .
-          echo "test: ${{ needs.setup.output.account_num }}"
-          sed -i "s/ACCOUNT_NUM/${{ needs.setup.output.account_num }}/g" aws-nuke.yml
+          sed -i "s/ACCOUNT_NUM/${{ needs.setup.outputs.account_id }}/g" aws-nuke.yml
           sed -i "s/TIME_LIMIT/${TIME_LIMIT}/g" aws-nuke.yml
       # We don't care if cleanup succeeds or fails, because dependencies be dependenceies,
       # we'll fail on actually actionable things in the quota steep afterwards.

--- a/enos/README.md
+++ b/enos/README.md
@@ -158,7 +158,7 @@ Here are the steps to configure the GitHub Actions service user:
 2. **Execute the Terraform module**
 ```shell
 > cd ./enos/ci/service-user-iam
-> export TF_WORKSPACE=<repo name>-ci-service-user-iam
+> export TF_WORKSPACE=<repo name>-ci-enos-service-user-iam
 > export TF_TOKEN_app_terraform_io=<Terraform Cloud Token>
 > export TF_VAR_repository=<repository name>
 > terraform init

--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -18,8 +18,14 @@ terraform {
 locals {
   enterprise_repositories = ["boundary-enterprise", "boundary-hcp"]
   is_ent                  = contains(local.enterprise_repositories, var.repository)
-  service_user            = "github_actions-boundary_ci" # convert to a data source to lookup the service user
+  service_user            = data.aws_iam_user.service_user.user_name
   oss_aws_account_id      = "271311691044"
+}
+
+
+data "aws_iam_user" "service_user" {
+  # This is the user created in the hashicorp/hc-service-users repo
+  user_name = "github_actions-boundary_ci"
 }
 
 resource "aws_iam_role" "role" {

--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -18,7 +18,7 @@ terraform {
 locals {
   enterprise_repositories = ["boundary-enterprise", "boundary-hcp"]
   is_ent                  = contains(local.enterprise_repositories, var.repository)
-  service_user            = "github_actions-boundary_ci"
+  service_user            = "github_actions-boundary_ci" # convert to a data source to lookup the service user
   oss_aws_account_id      = "271311691044"
 }
 
@@ -158,6 +158,7 @@ data "aws_iam_policy_document" "enos_policy_document" {
       "iam:CreatePolicy",
       "iam:CreateRole",
       "iam:CreateRole",
+      "iam:CreateServiceLinkedRole",
       "iam:CreateUser",
       "iam:CreateUserPolicy",
       "iam:CreateUserTag",

--- a/enos/modules/iam_setup/main.tf
+++ b/enos/modules/iam_setup/main.tf
@@ -12,9 +12,9 @@ locals {
 }
 
 resource "aws_iam_user" "boundary" {
-  name                 = "boundary-e2e-${var.test_id}"
-  tags                 = { boundary-demo = local.user_email }
-  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryDemoPermissionsBoundary"
+  name = "boundary-e2e-${var.test_id}"
+  #  tags                 = { boundary-demo = local.user_email }
+  #  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryDemoPermissionsBoundary"
 }
 
 resource "aws_iam_user_policy" "boundary" {

--- a/enos/modules/iam_setup/main.tf
+++ b/enos/modules/iam_setup/main.tf
@@ -13,6 +13,7 @@ locals {
 
 resource "aws_iam_user" "boundary" {
   name = "boundary-e2e-${var.test_id}"
+  # These are disabled currently, as we cannot lock down this user and still perform certain tests with the service user
   #  tags                 = { boundary-demo = local.user_email }
   #  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryDemoPermissionsBoundary"
 }


### PR DESCRIPTION
In order to use the AWS account `boundary_ci` the relevant GitHub workflows have been updated to use the newly created account.