### PR TITLE
Do not emit error on auth not found

### DIFF
--- a/internal/server/repository_workerauth.go
+++ b/internal/server/repository_workerauth.go
@@ -876,7 +876,7 @@ func (r *WorkerAuthRepositoryStorage) validateWorkerAuths(ctx context.Context, w
 	workerAuthsFound := len(workerAuths)
 	switch {
 	case workerAuthsFound == 0:
-		return nil, errors.New(ctx, errors.RecordNotFound, op, "did not find worker auth records for worker")
+		return nil, errors.New(ctx, errors.RecordNotFound, op, "did not find worker auth records for worker", errors.WithoutEvent())
 	case workerAuthsFound == 1:
 		if workerAuths[0].State != currentWorkerAuthState {
 			return nil, errors.New(ctx, errors.NotSpecificIntegrity, op,


### PR DESCRIPTION
Initial worker dials were emitting an error when a record was not found, which was not intended. 