### PR TITLE
feat(cmd): Create target using address on boundary dev / database init

### DIFF
--- a/internal/cmd/base/dev.go
+++ b/internal/cmd/base/dev.go
@@ -160,7 +160,10 @@ func (b *Server) CreateDevDatabase(ctx context.Context, opt ...Option) error {
 		return nil
 	}
 
-	if _, err := b.CreateInitialTarget(ctx); err != nil {
+	if _, err := b.CreateInitialTargetWithAddress(ctx); err != nil {
+		return err
+	}
+	if _, err := b.CreateInitialTargetWithHostSources(ctx); err != nil {
 		return err
 	}
 

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -106,8 +106,10 @@ type Server struct {
 	DevHostCatalogId                 string
 	DevHostSetId                     string
 	DevHostId                        string
-	DevTargetId                      string
-	DevHostAddress                   string
+	DevTargetId                      string // Target using address.
+	DevSecondaryTargetId             string // Target using host sources.
+	DevHostAddress                   string // Host address for target using host sources.
+	DevTargetAddress                 string // Network address for target with address.
 	DevTargetDefaultPort             int
 	DevTargetSessionMaxSeconds       int
 	DevTargetSessionConnectionLimit  int

--- a/internal/cmd/commands/server/listener_reload_test.go
+++ b/internal/cmd/commands/server/listener_reload_test.go
@@ -99,7 +99,7 @@ func TestServer_ReloadListener(t *testing.T) {
 		CreateDevDatabase: true,
 		ControllerKey:     controllerKey,
 		UseDevAuthMethod:  true,
-		UseDevTarget:      true,
+		UseDevTargets:     true,
 	})
 	// Unset auto-created KMSes that are overwritten by config on startup
 	cmd.RootKms = nil

--- a/internal/cmd/commands/server/server_test.go
+++ b/internal/cmd/commands/server/server_test.go
@@ -14,15 +14,18 @@ import (
 // We try to pull these from TestController, but targets et al are
 // computed off of a suffix instead of having constants. Just define
 // for now here, this can be tweaked later if need be.
-const defaultTestTargetId = "ttcp_1234567890"
+const (
+	defaultTestTargetId          = "ttcp_1234567890"
+	defaultSecondaryTestTargetId = "ttcp_0987654321"
 
-const rootKmsConfig = `
+	rootKmsConfig = `
 kms "aead" {
 	purpose = "root"
 	aead_type = "aes-gcm"
 	key = "%s"
 	key_id = "global_root"
 }`
+)
 
 type testServerCommandOpts struct {
 	// Whether or not to create the dev database
@@ -34,8 +37,8 @@ type testServerCommandOpts struct {
 	// Use the well-known dev mode auth method id (1234567890)
 	UseDevAuthMethod bool
 
-	// Use the well-known dev mode target method id (1234567890)
-	UseDevTarget bool
+	// Use the well-known dev mode target method ids (1234567890 and 0987654321)
+	UseDevTargets bool
 
 	// Whether or not to enable metric collection. If enable metrics will use
 	// prometheus' default registerer.
@@ -71,8 +74,9 @@ func testServerCommand(t *testing.T, opts testServerCommandOpts) *Command {
 			cmd.Server.DevPassword = controller.DefaultTestPassword
 		}
 
-		if opts.UseDevTarget {
+		if opts.UseDevTargets {
 			cmd.Server.DevTargetId = defaultTestTargetId
+			cmd.Server.DevSecondaryTargetId = defaultSecondaryTestTargetId
 		}
 
 		err = cmd.CreateDevDatabase(cmd.Context, base.WithDatabaseTemplate("boundary_template"), base.WithSkipOidcAuthMethodCreation())

--- a/internal/cmd/commands/server/worker_shutdown_reload_test.go
+++ b/internal/cmd/commands/server/worker_shutdown_reload_test.go
@@ -78,9 +78,10 @@ func TestServer_ShutdownWorker(t *testing.T) {
 	tcl := targets.NewClient(client)
 	tgtL, err := tcl.List(ctx, scope.Global.String(), targets.WithRecursive(true))
 	require.NoError(err)
-	require.Len(tgtL.Items, 1)
+	require.Len(tgtL.Items, 2)
 	tgt := tgtL.Items[0]
 	require.NotNil(tgt)
+	require.NotNil(tgtL.GetItems()[1])
 
 	// Create test server, update default port on target
 	ts := helper.NewTestTcpServer(t)

--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -709,7 +709,7 @@ func TestControllerConfig(t testing.TB, ctx context.Context, tc *TestController,
 								t.Fatal(err)
 							}
 							if !opts.DisableTargetCreation {
-								if _, err := tc.b.CreateInitialTarget(ctx); err != nil {
+								if _, err := tc.b.CreateInitialTargetWithHostSources(ctx); err != nil {
 									t.Fatal(err)
 								}
 							}


### PR DESCRIPTION
Creates a target using an address for boundary dev and when first init-ing boundary (boundary database init).

It also makes this newly created target the default one (ttcp_1234567890). The target using host sources is now a secondary target (ttcp_0987654321).