### PR TITLE
test(e2e): Add tests for bytes_up/bytes_down

### DIFF
--- a/testing/internal/e2e/boundary/authenticate.go
+++ b/testing/internal/e2e/boundary/authenticate.go
@@ -1,0 +1,94 @@
+package boundary
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/boundary/api"
+	"github.com/hashicorp/boundary/api/authmethods"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+// NewApiClient creates a new Api client for the specified Boundary instance and
+// attempts to authenticate it. Returns the client.
+func NewApiClient() (*api.Client, error) {
+	c, err := loadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := api.NewClient(&api.Config{Addr: c.Address})
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	authmethodsClient := authmethods.NewClient(client)
+	authenticationResult, err := authmethodsClient.Authenticate(ctx, c.AuthMethodId, "login",
+		map[string]any{
+			"login_name": c.AdminLoginName,
+			"password":   c.AdminLoginPassword,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	client.SetToken(fmt.Sprint(authenticationResult.Attributes["token"]))
+	return client, err
+}
+
+// AuthenticateAdminCli uses the cli to authenticate the specified Boundary instance as an admin
+func AuthenticateAdminCli(t testing.TB, ctx context.Context) {
+	c, err := loadConfig()
+	require.NoError(t, err)
+
+	AuthenticateCli(t, ctx, c.AdminLoginName, c.AdminLoginPassword)
+}
+
+// AuthenticateCli uses the cli to authenticate the specified Boundary instance
+func AuthenticateCli(t testing.TB, ctx context.Context, loginName string, password string) {
+	c, err := loadConfig()
+	require.NoError(t, err)
+
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"authenticate", "password",
+			"-addr", c.Address,
+			"-auth-method-id", c.AuthMethodId,
+			"-login-name", loginName,
+			"-password", "env://E2E_TEST_BOUNDARY_PASSWORD",
+		),
+		e2e.WithEnv("E2E_TEST_BOUNDARY_PASSWORD", password),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+}
+
+// GetAuthenticationTokenCli uses the cli to get an auth token that can be used in subsequent
+// commands
+func GetAuthenticationTokenCli(t testing.TB, ctx context.Context, loginName string, password string) string {
+	c, err := loadConfig()
+	require.NoError(t, err)
+
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"authenticate", "password",
+			"-addr", c.Address,
+			"-auth-method-id", c.AuthMethodId,
+			"-login-name", loginName,
+			"-password", "env://E2E_TEST_BOUNDARY_PASSWORD",
+			"-format", "json",
+		),
+		e2e.WithEnv("E2E_TEST_BOUNDARY_PASSWORD", password),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+
+	var authenticationResult AuthenticateCliOutput
+	err = json.Unmarshal(output.Stdout, &authenticationResult)
+	require.NoError(t, err)
+
+	return fmt.Sprint(authenticationResult.Item.Attributes["token"])
+}

--- a/testing/internal/e2e/boundary/boundary.go
+++ b/testing/internal/e2e/boundary/boundary.go
@@ -2,24 +2,9 @@
 package boundary
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"testing"
-
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/authmethods"
-	"github.com/hashicorp/boundary/testing/internal/e2e"
-	"github.com/kelseyhightower/envconfig"
-	"github.com/stretchr/testify/require"
 )
-
-type config struct {
-	Address            string `envconfig:"BOUNDARY_ADDR" required:"true"`               // e.g. http://127.0.0.1:9200
-	AuthMethodId       string `envconfig:"E2E_PASSWORD_AUTH_METHOD_ID" required:"true"` // e.g. ampw_1234567890
-	AdminLoginName     string `envconfig:"E2E_PASSWORD_ADMIN_LOGIN_NAME" default:"admin"`
-	AdminLoginPassword string `envconfig:"E2E_PASSWORD_ADMIN_PASSWORD" required:"true"`
-}
 
 // AuthenticateCliOutput parses the json response from running `boundary authenticate`
 type AuthenticateCliOutput struct {
@@ -42,95 +27,4 @@ type DbInitInfo struct {
 // CliError parses the Stderr from running a boundary command
 type CliError struct {
 	Status int `json:"status"`
-}
-
-func loadConfig() (*config, error) {
-	var c config
-	err := envconfig.Process("", &c)
-	if err != nil {
-		return nil, err
-	}
-
-	return &c, nil
-}
-
-// NewApiClient creates a new Api client for the specified Boundary instance and
-// attempts to authenticate it. Returns the client.
-func NewApiClient() (*api.Client, error) {
-	c, err := loadConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := api.NewClient(&api.Config{Addr: c.Address})
-	if err != nil {
-		return nil, err
-	}
-
-	ctx := context.Background()
-	authmethodsClient := authmethods.NewClient(client)
-	authenticationResult, err := authmethodsClient.Authenticate(ctx, c.AuthMethodId, "login",
-		map[string]any{
-			"login_name": c.AdminLoginName,
-			"password":   c.AdminLoginPassword,
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	client.SetToken(fmt.Sprint(authenticationResult.Attributes["token"]))
-	return client, err
-}
-
-// AuthenticateAdminCli uses the cli to authenticate the specified Boundary instance as an admin
-func AuthenticateAdminCli(t testing.TB, ctx context.Context) {
-	c, err := loadConfig()
-	require.NoError(t, err)
-
-	AuthenticateCli(t, ctx, c.AdminLoginName, c.AdminLoginPassword)
-}
-
-// AuthenticateCli uses the cli to authenticate the specified Boundary instance
-func AuthenticateCli(t testing.TB, ctx context.Context, loginName string, password string) {
-	c, err := loadConfig()
-	require.NoError(t, err)
-
-	output := e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"authenticate", "password",
-			"-addr", c.Address,
-			"-auth-method-id", c.AuthMethodId,
-			"-login-name", loginName,
-			"-password", "env://E2E_TEST_BOUNDARY_PASSWORD",
-		),
-		e2e.WithEnv("E2E_TEST_BOUNDARY_PASSWORD", password),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
-}
-
-// GetAuthenticationTokenCli uses the cli to get an auth token that can be used in subsequent
-// commands
-func GetAuthenticationTokenCli(t testing.TB, ctx context.Context, loginName string, password string) string {
-	c, err := loadConfig()
-	require.NoError(t, err)
-
-	output := e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"authenticate", "password",
-			"-addr", c.Address,
-			"-auth-method-id", c.AuthMethodId,
-			"-login-name", loginName,
-			"-password", "env://E2E_TEST_BOUNDARY_PASSWORD",
-			"-format", "json",
-		),
-		e2e.WithEnv("E2E_TEST_BOUNDARY_PASSWORD", password),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
-
-	var authenticationResult AuthenticateCliOutput
-	err = json.Unmarshal(output.Stdout, &authenticationResult)
-	require.NoError(t, err)
-
-	return fmt.Sprint(authenticationResult.Item.Attributes["token"])
 }

--- a/testing/internal/e2e/boundary/env.go
+++ b/testing/internal/e2e/boundary/env.go
@@ -1,0 +1,20 @@
+package boundary
+
+import "github.com/kelseyhightower/envconfig"
+
+type config struct {
+	Address            string `envconfig:"BOUNDARY_ADDR" required:"true"`               // e.g. http://127.0.0.1:9200
+	AuthMethodId       string `envconfig:"E2E_PASSWORD_AUTH_METHOD_ID" required:"true"` // e.g. ampw_1234567890
+	AdminLoginName     string `envconfig:"E2E_PASSWORD_ADMIN_LOGIN_NAME" default:"admin"`
+	AdminLoginPassword string `envconfig:"E2E_PASSWORD_ADMIN_PASSWORD" required:"true"`
+}
+
+func loadConfig() (*config, error) {
+	var c config
+	err := envconfig.Process("", &c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}

--- a/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_empty_test.go
+++ b/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_empty_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -58,7 +59,7 @@ func TestCliCreateAwsDynamicHostCatalogWithEmptyHostSet(t *testing.T) {
 		require.NoError(t, err)
 
 		actualHostSetCount = len(hostSetsReadResult.Item.HostIds)
-		require.Equal(t, actualHostSetCount, 0,
+		require.Equal(t, 0, actualHostSetCount,
 			fmt.Sprintf("Detected incorrect number of hosts. Expected: 0, Actual: %d", actualHostSetCount),
 		)
 	}
@@ -81,7 +82,7 @@ func TestCliCreateAwsDynamicHostCatalogWithEmptyHostSet(t *testing.T) {
 		require.NoError(t, err)
 
 		actualHostCatalogCount = len(hostCatalogListResult.Items)
-		require.Equal(t, actualHostCatalogCount, 0,
+		require.Equal(t, 0, actualHostCatalogCount,
 			fmt.Sprintf("Detected incorrect number of hosts. Expected: 0, Actual: %d", actualHostCatalogCount),
 		)
 	}
@@ -111,6 +112,6 @@ func TestCliCreateAwsDynamicHostCatalogWithEmptyHostSet(t *testing.T) {
 	var response boundary.CliError
 	err = json.Unmarshal(output.Stderr, &response)
 	require.NoError(t, err)
-	require.Equal(t, response.Status, 404, "Expected to error when connecting to a target with zero hosts")
+	require.Equal(t, http.StatusNotFound, response.Status, "Expected to error when connecting to a target with zero hosts")
 	t.Log("Successfully failed to connect to target")
 }

--- a/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_empty_test.go
+++ b/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_empty_test.go
@@ -41,8 +41,8 @@ func TestCliCreateAwsDynamicHostCatalogWithEmptyHostSet(t *testing.T) {
 	// Check that there are no hosts in the host set
 	t.Logf("Looking for items in the host set...")
 	var actualHostSetCount int
-	for i := 1; i <= 3; i++ {
-		if i != 1 {
+	for i := 0; i < 3; i++ {
+		if i != 0 {
 			time.Sleep(3 * time.Second)
 		}
 
@@ -68,8 +68,8 @@ func TestCliCreateAwsDynamicHostCatalogWithEmptyHostSet(t *testing.T) {
 	// Check that there are no hosts in the host catalog
 	t.Logf("Looking for items in the host catalog...")
 	var actualHostCatalogCount int
-	for i := 1; i <= 3; i++ {
-		if i != 1 {
+	for i := 0; i < 3; i++ {
+		if i != 0 {
 			time.Sleep(3 * time.Second)
 		}
 

--- a/testing/internal/e2e/tests/static/bytes_up_down_empty_test.go
+++ b/testing/internal/e2e/tests/static/bytes_up_down_empty_test.go
@@ -67,8 +67,8 @@ func TestCliBytesUpDownEmpty(t *testing.T) {
 	bytesUp := 0
 	bytesDown := 0
 	t.Log("Reading bytes_up/bytes_down values...")
-	for i := 1; i <= 3; i++ {
-		if i != 1 {
+	for i := 0; i < 3; i++ {
+		if i != 0 {
 			time.Sleep(2 * time.Second)
 		}
 

--- a/testing/internal/e2e/tests/static/bytes_up_down_empty_test.go
+++ b/testing/internal/e2e/tests/static/bytes_up_down_empty_test.go
@@ -83,8 +83,8 @@ func TestCliBytesUpDownEmpty(t *testing.T) {
 		bytesDown = int(newSessionReadResult.Item.Connections[0].BytesDown)
 
 		if i != 1 {
-			require.Equal(t, int(newSessionReadResult.Item.Connections[0].BytesUp), bytesUp)
-			require.Equal(t, int(newSessionReadResult.Item.Connections[0].BytesDown), bytesDown)
+			require.Equal(t, bytesUp, int(newSessionReadResult.Item.Connections[0].BytesUp))
+			require.Equal(t, bytesDown, int(newSessionReadResult.Item.Connections[0].BytesDown))
 		}
 
 		t.Logf("bytes_up: %d, bytes_down: %d", bytesUp, bytesDown)

--- a/testing/internal/e2e/tests/static/bytes_up_down_empty_test.go
+++ b/testing/internal/e2e/tests/static/bytes_up_down_empty_test.go
@@ -1,0 +1,92 @@
+package static_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/api/sessions"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCliBytesUpDownEmpty uses the cli to verify that the bytes_up/bytes_down fields of a
+// session correctly increase when data is transmitting during a session.
+func TestCliBytesUpDownEmpty(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+	c, err := loadConfig()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	boundary.AuthenticateAdminCli(t, ctx)
+	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
+	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
+	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)
+	newHostId := boundary.CreateNewHostCli(t, ctx, newHostCatalogId, c.TargetIp)
+	boundary.AddHostToHostSetCli(t, ctx, newHostSetId, newHostId)
+	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
+	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
+
+	// Create a session where no additional commands are run
+	ctxCancel, cancel := context.WithCancel(context.Background())
+	errChan := make(chan *e2e.CommandResult)
+	go func() {
+		t.Log("Starting session...")
+		errChan <- e2e.RunCommand(ctxCancel, "boundary",
+			e2e.WithArgs(
+				"connect",
+				"-target-id", newTargetId,
+				"-exec", "/usr/bin/ssh", "--",
+				"-l", c.TargetSshUser,
+				"-i", c.TargetSshKeyPath,
+				"-o", "UserKnownHostsFile=/dev/null",
+				"-o", "StrictHostKeyChecking=no",
+				"-o", "IdentitiesOnly=yes", // forces the use of the provided key
+				"-p", "{{boundary.port}}", // this is provided by boundary
+				"{{boundary.ip}}",
+			),
+		)
+	}()
+	t.Cleanup(cancel)
+
+	session := boundary.WaitForSessionCli(t, ctx, newProjectId)
+	assert.Equal(t, newTargetId, session.TargetId)
+	assert.Equal(t, newHostId, session.HostId)
+
+	// Confirm that bytesUp and bytesDown do not change
+	bytesUp := 0
+	bytesDown := 0
+	t.Log("Reading bytes_up/bytes_down values...")
+	for i := 1; i <= 3; i++ {
+		if i != 1 {
+			time.Sleep(2 * time.Second)
+		}
+
+		output := e2e.RunCommand(ctx, "boundary",
+			e2e.WithArgs("sessions", "read", "-id", session.Id, "-format", "json"),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+		var newSessionReadResult sessions.SessionReadResult
+		err = json.Unmarshal(output.Stdout, &newSessionReadResult)
+		require.NoError(t, err)
+		bytesUp = int(newSessionReadResult.Item.Connections[0].BytesUp)
+		bytesDown = int(newSessionReadResult.Item.Connections[0].BytesDown)
+
+		if i != 1 {
+			require.Equal(t, int(newSessionReadResult.Item.Connections[0].BytesUp), bytesUp)
+			require.Equal(t, int(newSessionReadResult.Item.Connections[0].BytesDown), bytesDown)
+		}
+
+		t.Logf("bytes_up: %d, bytes_down: %d", bytesUp, bytesDown)
+	}
+}

--- a/testing/internal/e2e/tests/static/bytes_up_down_test.go
+++ b/testing/internal/e2e/tests/static/bytes_up_down_test.go
@@ -70,8 +70,8 @@ func TestCliBytesUpDownTransferData(t *testing.T) {
 	bytesUp := 0
 	bytesDown := 0
 	t.Log("Reading bytes_up/bytes_down values...")
-	for i := 1; i <= 3; i++ {
-		if i != 1 {
+	for i := 0; i < 3; i++ {
+		if i != 0 {
 			time.Sleep(2 * time.Second)
 		}
 

--- a/testing/internal/e2e/tests/static/bytes_up_down_test.go
+++ b/testing/internal/e2e/tests/static/bytes_up_down_test.go
@@ -1,0 +1,92 @@
+package static_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/api/sessions"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCliBytesUpDownTransferData uses the cli to verify that the bytes_up/bytes_down fields of a
+// session correctly increase when data is transmitting during a session.
+func TestCliBytesUpDownTransferData(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+	c, err := loadConfig()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	boundary.AuthenticateAdminCli(t, ctx)
+	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
+	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
+	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)
+	newHostId := boundary.CreateNewHostCli(t, ctx, newHostCatalogId, c.TargetIp)
+	boundary.AddHostToHostSetCli(t, ctx, newHostSetId, newHostId)
+	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
+	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
+
+	// Create a session where no additional commands are run
+	ctxCancel, cancel := context.WithCancel(context.Background())
+	errChan := make(chan *e2e.CommandResult)
+
+	// Run commands on the target to send data through connection
+	go func() {
+		t.Log("Starting session...")
+		errChan <- e2e.RunCommand(ctxCancel, "boundary",
+			e2e.WithArgs(
+				"connect",
+				"-target-id", newTargetId,
+				"-exec", "/usr/bin/ssh", "--",
+				"-l", c.TargetSshUser,
+				"-i", c.TargetSshKeyPath,
+				"-o", "UserKnownHostsFile=/dev/null",
+				"-o", "StrictHostKeyChecking=no",
+				"-o", "IdentitiesOnly=yes", // forces the use of the provided key
+				"-p", "{{boundary.port}}", // this is provided by boundary
+				"{{boundary.ip}}",
+				"for i in {1..10}; do pwd; sleep 1s; done",
+			),
+		)
+	}()
+	t.Cleanup(cancel)
+
+	session := boundary.WaitForSessionToBeActiveCli(t, ctx, newProjectId)
+	assert.Equal(t, newTargetId, session.TargetId)
+	assert.Equal(t, newHostId, session.HostId)
+
+	// Confirm that bytesDown is increasing
+	bytesUp := 0
+	bytesDown := 0
+	t.Log("Reading bytes_up/bytes_down values...")
+	for i := 1; i <= 3; i++ {
+		if i != 1 {
+			time.Sleep(2 * time.Second)
+		}
+
+		output := e2e.RunCommand(ctx, "boundary",
+			e2e.WithArgs("sessions", "read", "-id", session.Id, "-format", "json"),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+		var newSessionReadResult sessions.SessionReadResult
+		err = json.Unmarshal(output.Stdout, &newSessionReadResult)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, int(newSessionReadResult.Item.Connections[0].BytesUp), bytesUp)
+		bytesUp = int(newSessionReadResult.Item.Connections[0].BytesUp)
+		require.Greater(t, int(newSessionReadResult.Item.Connections[0].BytesDown), bytesDown)
+		bytesDown = int(newSessionReadResult.Item.Connections[0].BytesDown)
+
+		t.Logf("bytes_up: %d, bytes_down: %d", bytesUp, bytesDown)
+	}
+}

--- a/testing/internal/e2e/tests/static/session_cancel_admin_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_admin_test.go
@@ -84,7 +84,7 @@ func TestCliSessionCancelAdmin(t *testing.T) {
 	select {
 	case output := <-errChan:
 		// `boundary connect` returns a 255 when cancelled
-		require.Equal(t, output.ExitCode, 255, string(output.Stdout), string(output.Stderr))
+		require.Equal(t, 255, output.ExitCode, string(output.Stdout), string(output.Stderr))
 	case <-time.After(time.Second * 5):
 		t.Fatal("Timed out waiting for session command to exit")
 	}

--- a/testing/internal/e2e/tests/static/session_cancel_group_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_group_test.go
@@ -3,6 +3,7 @@ package static_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -83,7 +84,7 @@ func TestCliSessionCancelGroup(t *testing.T) {
 	var response boundary.CliError
 	err = json.Unmarshal(output.Stderr, &response)
 	require.NoError(t, err)
-	require.Equal(t, 403, int(response.Status))
+	require.Equal(t, http.StatusForbidden, int(response.Status))
 	t.Log("Successfully received an error when connecting to target as a user without permissions")
 
 	// Create a group
@@ -168,7 +169,7 @@ func TestCliSessionCancelGroup(t *testing.T) {
 	select {
 	case output := <-errChan:
 		// `boundary connect` returns a 255 when cancelled
-		require.Equal(t, output.ExitCode, 255, string(output.Stdout), string(output.Stderr))
+		require.Equal(t, 255, output.ExitCode, string(output.Stdout), string(output.Stderr))
 	case <-time.After(time.Second * 5):
 		t.Fatal("Timed out waiting for session command to exit")
 	}

--- a/testing/internal/e2e/tests/static/session_cancel_user_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_user_test.go
@@ -3,6 +3,7 @@ package static_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -82,7 +83,7 @@ func TestCliSessionCancelUser(t *testing.T) {
 	var response boundary.CliError
 	err = json.Unmarshal(output.Stderr, &response)
 	require.NoError(t, err)
-	require.Equal(t, 403, int(response.Status))
+	require.Equal(t, http.StatusForbidden, int(response.Status))
 	t.Log("Successfully received an error when connecting to target as a user without permissions")
 
 	// Create a role for user
@@ -142,7 +143,7 @@ func TestCliSessionCancelUser(t *testing.T) {
 	select {
 	case output := <-errChan:
 		// `boundary connect` returns a 255 when cancelled
-		require.Equal(t, output.ExitCode, 255, string(output.Stdout), string(output.Stderr))
+		require.Equal(t, 255, output.ExitCode, string(output.Stdout), string(output.Stderr))
 	case <-time.After(time.Second * 5):
 		t.Fatal("Timed out waiting for session command to exit")
 	}

--- a/testing/internal/e2e/tests/static/session_end_delete_host_set_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_host_set_test.go
@@ -100,7 +100,7 @@ func TestCliSessionEndWhenHostSetIsDeleted(t *testing.T) {
 	select {
 	case output := <-errChan:
 		// `boundary connect` returns a 255 when cancelled
-		require.Equal(t, output.ExitCode, 255, string(output.Stdout), string(output.Stderr))
+		require.Equal(t, 255, output.ExitCode, string(output.Stdout), string(output.Stderr))
 	case <-time.After(time.Second * 5):
 		t.Fatal("Timed out waiting for session command to exit")
 	}

--- a/testing/internal/e2e/tests/static/session_end_delete_host_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_host_test.go
@@ -100,7 +100,7 @@ func TestCliSessionEndWhenHostIsDeleted(t *testing.T) {
 	select {
 	case output := <-errChan:
 		// `boundary connect` returns a 255 when cancelled
-		require.Equal(t, output.ExitCode, 255, string(output.Stdout), string(output.Stderr))
+		require.Equal(t, 255, output.ExitCode, string(output.Stdout), string(output.Stderr))
 	case <-time.After(time.Second * 5):
 		t.Fatal("Timed out waiting for session command to exit")
 	}

--- a/testing/internal/e2e/tests/static/session_end_delete_target_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_target_test.go
@@ -100,7 +100,7 @@ func TestCliSessionEndWhenTargetIsDeleted(t *testing.T) {
 	select {
 	case output := <-errChan:
 		// `boundary connect` returns a 255 when cancelled
-		require.Equal(t, output.ExitCode, 255, string(output.Stdout), string(output.Stderr))
+		require.Equal(t, 255, output.ExitCode, string(output.Stdout), string(output.Stderr))
 	case <-time.After(time.Second * 5):
 		t.Fatal("Timed out waiting for session command to exit")
 	}

--- a/testing/internal/e2e/tests/static/session_end_delete_user_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_user_test.go
@@ -93,7 +93,7 @@ func TestCliSessionEndWhenUserIsDeleted(t *testing.T) {
 	select {
 	case output := <-errChan:
 		// `boundary connect` returns a 255 when cancelled
-		require.Equal(t, output.ExitCode, 255, string(output.Stdout), string(output.Stderr))
+		require.Equal(t, 255, output.ExitCode, string(output.Stdout), string(output.Stderr))
 	case <-time.After(time.Second * 5):
 		t.Fatal("Timed out waiting for session command to exit")
 	}

--- a/testing/internal/e2e/vault/env.go
+++ b/testing/internal/e2e/vault/env.go
@@ -1,0 +1,18 @@
+package vault
+
+import "github.com/kelseyhightower/envconfig"
+
+type config struct {
+	VaultAddr  string `envconfig:"VAULT_ADDR" required:"true"` // e.g. "http://127.0.0.1:8200"
+	VaultToken string `envconfig:"VAULT_TOKEN" required:"true"`
+}
+
+func loadConfig() (*config, error) {
+	var c config
+	err := envconfig.Process("", &c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}

--- a/testing/internal/e2e/vault/vault.go
+++ b/testing/internal/e2e/vault/vault.go
@@ -10,30 +10,14 @@ import (
 
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/go-secure-stdlib/base62"
-	"github.com/kelseyhightower/envconfig"
 	"github.com/stretchr/testify/require"
 )
-
-type config struct {
-	VaultAddr  string `envconfig:"VAULT_ADDR" required:"true"` // e.g. "http://127.0.0.1:8200"
-	VaultToken string `envconfig:"VAULT_TOKEN" required:"true"`
-}
 
 // CreateTokenResponse parses the json response from running `vault token create`
 type CreateTokenResponse struct {
 	Auth struct {
 		Client_Token string
 	}
-}
-
-func loadConfig() (*config, error) {
-	var c config
-	err := envconfig.Process("", &c)
-	if err != nil {
-		return nil, err
-	}
-
-	return &c, nil
 }
 
 // Setup verifies if appropriate credentials are set and adds the boundary controller


### PR DESCRIPTION
This PR adds some tests around bytes up/down. There are two tests here.
- The first test starts a session and runs a series of commands on the host to send data across the connection. The test verifies that the bytes_down value is increasing as commands are run
- The second test starts and immediately ends a session. The test verifies that the bytes_up and bytes_down values don't change

Additionally, this PR updates a few things
- Refactors some common methods to be more consistent (i.e. moving environment variables to an env.go file)
- Fixes arguments in require.Equal statements to be in the right order

```
❯ go test -v github.com/hashicorp/boundary/testing/internal/e2e/tests/static -count=1 -run TestCliBytesUpDown
=== RUN   TestCliBytesUpDownEmpty
    scope.go:57: Created Org Id: o_SvMgUEFRMh
    scope.go:80: Created Project Id: p_IZ6QqzqUTv
    host.go:82: Created Host Catalog: hcst_h4FVIZOreN
    host.go:102: Created Host Set: hsst_Q41JJV32EY
    host.go:124: Created Host: hst_Vqvz3LJZdg
    target.go:59: Created Target: ttcp_ILTZHsfTnW
    bytes_up_down_empty_test.go:44: Starting session...
    session.go:20: Waiting for session to appear...
    session.go:53: No items are appearing in the session list. Retrying...
    session.go:43: Found 1 session(s)
    bytes_up_down_empty_test.go:69: Reading bytes_up/bytes_down values...
    bytes_up_down_empty_test.go:90: bytes_up: 2573, bytes_down: 3689
    bytes_up_down_empty_test.go:90: bytes_up: 2573, bytes_down: 3689
    bytes_up_down_empty_test.go:90: bytes_up: 2573, bytes_down: 3689
--- PASS: TestCliBytesUpDownEmpty (11.13s)
=== RUN   TestCliBytesUpDownTransferData
    scope.go:57: Created Org Id: o_HcExXhLRiC
    scope.go:80: Created Project Id: p_Hev3KvXqmu
    host.go:82: Created Host Catalog: hcst_6iZxyeuXZu
    host.go:102: Created Host Set: hsst_fcWEXFBc3P
    host.go:124: Created Host: hst_V85ohEaNQ4
    target.go:59: Created Target: ttcp_Ut3dSNV3P0
    session.go:64: Waiting for session to be active...
    bytes_up_down_test.go:46: Starting session...
    session.go:117: No items are appearing in the session list. Retrying...
    session.go:86: Found 1 session(s)
    bytes_up_down_test.go:72: Reading bytes_up/bytes_down values...
    bytes_up_down_test.go:90: bytes_up: 2517, bytes_down: 2937
    bytes_up_down_test.go:90: bytes_up: 2517, bytes_down: 3041
    bytes_up_down_test.go:90: bytes_up: 2517, bytes_down: 3145
--- PASS: TestCliBytesUpDownTransferData (11.13s)
PASS
ok  	github.com/hashicorp/boundary/testing/internal/e2e/tests/static	22.653s
```