### PR TITLE
refactor vault.(issueCredentialLibrary).retrieveCredential to no longer require sessionId

### DIFF
--- a/internal/credential/vault/credential_test.go
+++ b/internal/credential/vault/credential_test.go
@@ -57,17 +57,6 @@ func TestCredential_New(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "missing-session-id",
-			args: args{
-				libraryId:  lib.GetPublicId(),
-				externalId: "some/vault/credential",
-				tokenHmac:  token.GetTokenHmac(),
-				expiration: 5 * time.Minute,
-			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
 			name: "missing-tokenHmac",
 			args: args{
 				libraryId:  lib.GetPublicId(),
@@ -144,7 +133,7 @@ func TestCredential_New(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
-			got, err := newCredential(tt.args.libraryId, tt.args.sessionId,
+			got, err := newCredential(tt.args.libraryId,
 				tt.args.externalId, tt.args.tokenHmac, tt.args.expiration)
 			if tt.wantErr {
 				assert.Error(err)
@@ -162,7 +151,8 @@ func TestCredential_New(t *testing.T) {
 			tt.want.PublicId = id
 			got.PublicId = id
 
-			query, queryValues := got.insertQuery()
+			query, queryValues := insertQuery(got, tt.args.sessionId)
+			require.NoError(err)
 
 			rows, err2 := rw.Exec(ctx, query, queryValues)
 			assert.Equal(1, rows)

--- a/internal/credential/vault/private_library.go
+++ b/internal/credential/vault/private_library.go
@@ -284,15 +284,13 @@ func (pl *issueCredentialLibrary) client(ctx context.Context) (vaultClient, erro
 type dynamicCred interface {
 	credential.Dynamic
 	getExpiration() time.Duration
-	insertQuery() (query string, queryValues []any)
-	updateSessionQuery(purpose credential.Purpose) (query string, queryValues []any)
 }
 
 // retrieveCredential retrieves a dynamic credential from Vault for the
 // given sessionId.
 //
 // Supported options: credential.WithTemplateData
-func (pl *issueCredentialLibrary) retrieveCredential(ctx context.Context, op errors.Op, sessionId string, opt ...credential.Option) (dynamicCred, error) {
+func (pl *issueCredentialLibrary) retrieveCredential(ctx context.Context, op errors.Op, opt ...credential.Option) (dynamicCred, error) {
 	opts, err := credential.GetOpts(opt...)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
@@ -358,7 +356,7 @@ func (pl *issueCredentialLibrary) retrieveCredential(ctx context.Context, op err
 	}
 
 	leaseDuration := time.Duration(secret.LeaseDuration) * time.Second
-	cred, err := newCredential(pl.GetPublicId(), sessionId, secret.LeaseID, pl.TokenHmac, leaseDuration)
+	cred, err := newCredential(pl.GetPublicId(), secret.LeaseID, pl.TokenHmac, leaseDuration)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}

--- a/internal/credential/vault/repository_credentials.go
+++ b/internal/credential/vault/repository_credentials.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -12,6 +13,38 @@ import (
 )
 
 var _ credential.Issuer = (*Repository)(nil)
+
+func insertQuery(c *Credential, sessionId string) (query string, queryValues []any) {
+	queryValues = []any{
+		sql.Named("public_id", c.PublicId),
+		sql.Named("library_id", c.LibraryId),
+		sql.Named("session_id", sessionId),
+		sql.Named("token_hmac", c.TokenHmac),
+		sql.Named("external_id", c.ExternalId),
+		sql.Named("is_renewable", c.IsRenewable),
+		sql.Named("status", c.Status),
+		sql.Named("last_renewal_time", "now()"),
+	}
+	switch {
+	case c.expiration == 0:
+		query = insertCredentialWithInfiniteExpirationQuery
+	default:
+		query = insertCredentialWithExpirationQuery
+		queryValues = append(queryValues, sql.Named("expiration_time", int(c.expiration.Round(time.Second).Seconds())))
+	}
+	return
+}
+
+func updateSessionQuery(c *Credential, sessionId string, purpose credential.Purpose) (query string, queryValues []any) {
+	queryValues = []any{
+		sql.Named("public_id", c.PublicId),
+		sql.Named("library_id", c.LibraryId),
+		sql.Named("session_id", sessionId),
+		sql.Named("purpose", string(purpose)),
+	}
+	query = updateSessionCredentialQuery
+	return
+}
 
 // Issue issues and returns dynamic credentials from Vault for all of the
 // requests and assigns them to sessionId.
@@ -37,7 +70,7 @@ func (r *Repository) Issue(ctx context.Context, sessionId string, requests []cre
 	var minLease time.Duration
 	runJobsInterval := r.scheduler.GetRunJobsInterval()
 	for _, lib := range libs {
-		cred, err := lib.retrieveCredential(ctx, op, sessionId, opt...)
+		cred, err := lib.retrieveCredential(ctx, op, opt...)
 		if err != nil {
 			return nil, err
 		}
@@ -54,8 +87,28 @@ func (r *Repository) Issue(ctx context.Context, sessionId string, requests []cre
 		if minLease > cred.getExpiration() {
 			minLease = cred.getExpiration()
 		}
-		insertQuery, insertQueryValues := cred.insertQuery()
-		updateQuery, updateQueryValues := cred.updateSessionQuery(lib.Purpose)
+
+		var underlyingCred *Credential
+		switch c := cred.(type) {
+		case *usrPassCred:
+			underlyingCred = c.Credential
+		case *sshPrivateKeyCred:
+			underlyingCred = c.Credential
+		case *baseCred:
+			underlyingCred = c.Credential
+		default:
+			return nil, errors.New(ctx, errors.InvalidDynamicCredential, op, fmt.Sprintf("vault dynamicCred (typeof %T) could not be mapped back to vault.Credential", c))
+		}
+
+		insertQuery, insertQueryValues := insertQuery(underlyingCred, sessionId)
+		if err != nil {
+			return nil, err
+		}
+		updateQuery, updateQueryValues := updateSessionQuery(underlyingCred, sessionId, lib.Purpose)
+		if err != nil {
+			return nil, err
+		}
+
 		if _, err := r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{},
 			func(_ db.Reader, w db.Writer) error {
 				rowsInserted, err := w.Exec(ctx, insertQuery, insertQueryValues)

--- a/internal/credential/vault/testing.go
+++ b/internal/credential/vault/testing.go
@@ -168,7 +168,7 @@ func TestCredentials(t testing.TB, conn *db.DB, wrapper wrapping.Wrapper, librar
 
 	var credentials []*Credential
 	for i := 0; i < count; i++ {
-		credential, err := newCredential(lib.GetPublicId(), sessionId, fmt.Sprintf("vault/credential/%d", i), token.GetTokenHmac(), 5*time.Minute)
+		credential, err := newCredential(lib.GetPublicId(), fmt.Sprintf("vault/credential/%d", i), token.GetTokenHmac(), 5*time.Minute)
 		assert.NoError(err)
 		require.NotNil(credential)
 
@@ -177,7 +177,7 @@ func TestCredentials(t testing.TB, conn *db.DB, wrapper wrapping.Wrapper, librar
 		require.NotNil(id)
 		credential.PublicId = id
 
-		query, queryValues := credential.insertQuery()
+		query, queryValues := insertQuery(credential, sessionId)
 		rows, err2 := rw.Exec(ctx, query, queryValues)
 		assert.Equal(1, rows)
 		assert.NoError(err2)


### PR DESCRIPTION
- refactor vault.(issueCredentialLibrary).retrieveCredential to no longer use session id
- remove `dynamicCred`'s `insertQuery` and `updateSessionQuery` functions
- update `TestRepository_IssueCredentials` to perform db lookup for issued credentials