### PR TITLE
docs: Fix typo in Use Cases topic

### DIFF
--- a/website/content/docs/overview/use-cases.mdx
+++ b/website/content/docs/overview/use-cases.mdx
@@ -13,7 +13,7 @@ Before understanding use cases, it's useful to know [what Boundary is](/docs/ove
 
 Boundary’s access-on-demand workflow securely connects trusted identities to infrastructure services based on granular, admin-defined permission grants. Boundary removes the need to create or store credentials when accessing services. In this way, Boundary can be used to extend or replace many traditional access solutions like VPNs.
 
-Traditional access solutions do not employ the the Zero-Trust philosophy - meaning they fail to authenticate and authorize users’ access and actions continuously, and often lack granular access controls.
+Traditional access solutions do not employ the Zero-Trust philosophy - meaning they fail to authenticate and authorize users’ access and actions continuously, and often lack granular access controls.
 
 ## Multi-Cloud Access
 


### PR DESCRIPTION
Via feedback on Slack, the Use Cases topic contains a typo in the Zero Trust section:

> Traditional access solutions do not employ **the** the Zero-Trust philosophy.

This PR deletes the extra word.