### PR TITLE
Fix string regression in attribute parsing

### DIFF
--- a/internal/cmd/base/flags.go
+++ b/internal/cmd/base/flags.go
@@ -1020,9 +1020,8 @@ func (c *combinedSliceValue) Set(val string) error {
 		if err != nil && !errors.Is(err, parseutil.ErrNotAUrl) {
 			return fmt.Errorf("error checking if value is a path: %w", err)
 		}
-		if pathParsedValue != "" {
-			ret.Value = wrapperspb.String(pathParsedValue)
-		}
+		// This will either be the round-tripped value or the substituted value
+		ret.Value = wrapperspb.String(pathParsedValue)
 	}
 
 	*c.target = append(*c.target, ret)

--- a/internal/cmd/common/flags.go
+++ b/internal/cmd/common/flags.go
@@ -288,7 +288,7 @@ func HandleAttributeFlags(c *base.Command, suffix, fullField string, sepFields [
 			if field.Value == nil {
 				return fmt.Errorf("string-%s flag requires a value", suffix)
 			}
-			val = strings.Trim(field.Value.GetValue(), `"`)
+			val = field.Value.GetValue()
 
 		case "bool-" + suffix:
 			if field.Value == nil {

--- a/internal/cmd/common/flags.go
+++ b/internal/cmd/common/flags.go
@@ -318,9 +318,6 @@ func HandleAttributeFlags(c *base.Command, suffix, fullField string, sepFields [
 			case field.Value.GetValue() == "false": // bool false
 				val = false
 
-			case strings.HasPrefix(field.Value.GetValue(), `"`): // explicitly quoted string
-				val = strings.Trim(field.Value.GetValue(), `"`)
-
 			case jsonNumberRegex.MatchString(strings.Trim(field.Value.GetValue(), `"`)): // number
 				// Same logic as above
 				if strings.Contains(field.Value.GetValue(), ".") {
@@ -355,7 +352,7 @@ func HandleAttributeFlags(c *base.Command, suffix, fullField string, sepFields [
 
 			default:
 				// Default is to treat as a string value
-				val = field.Value
+				val = strings.Trim(field.Value.GetValue(), `"`)
 			}
 
 		default:

--- a/internal/cmd/common/flags.go
+++ b/internal/cmd/common/flags.go
@@ -352,7 +352,7 @@ func HandleAttributeFlags(c *base.Command, suffix, fullField string, sepFields [
 
 			default:
 				// Default is to treat as a string value
-				val = strings.Trim(field.Value.GetValue(), `"`)
+				val = field.Value.GetValue()
 			}
 
 		default:

--- a/internal/cmd/common/flags_test.go
+++ b/internal/cmd/common/flags_test.go
@@ -236,7 +236,7 @@ func TestHandleAttributeFlags(t *testing.T) {
 			},
 			expectedMap: map[string]any{
 				"foo": "bar",
-				"bar": "baz",
+				"bar": "\"baz\"",
 			},
 		},
 		{

--- a/internal/cmd/common/flags_test.go
+++ b/internal/cmd/common/flags_test.go
@@ -98,7 +98,7 @@ func TestPopulateAttrFlags(t *testing.T) {
 		},
 		{
 			name: "mixed",
-			args: []string{"-num-attr", "foo=9820", "-string-attr", "bar=9820", "-attr", "baz=9820", "-attr", "zoom=\"flubber\""},
+			args: []string{"-num-attr", "foo=9820", "-string-attr", "bar=9820", "-attr", "baz=9820", "-attr", `zoom="flubber"`},
 			expected: []base.CombinedSliceFlagValue{
 				{
 					Name:  "num-attr",
@@ -118,7 +118,7 @@ func TestPopulateAttrFlags(t *testing.T) {
 				{
 					Name:  "attr",
 					Keys:  []string{"zoom"},
-					Value: wrapperspb.String(`"flubber"`),
+					Value: wrapperspb.String("\"flubber\""),
 				},
 			},
 		},
@@ -373,7 +373,7 @@ func TestHandleAttributeFlags(t *testing.T) {
 				{
 					Name:  "%s",
 					Keys:  []string{"s2"},
-					Value: wrapperspb.String(`"woop"`),
+					Value: wrapperspb.String("\"woo\"p"),
 				},
 				{
 					Name:  "%s",
@@ -405,7 +405,7 @@ func TestHandleAttributeFlags(t *testing.T) {
 				"b1": true,
 				"b2": false,
 				"s1": "scoopde",
-				"s2": "woop",
+				"s2": "\"woo\"p",
 				"n1": float64(-1.2),
 				"n2": int64(5),
 				"a": []any{

--- a/internal/cmd/common/flags_test.go
+++ b/internal/cmd/common/flags_test.go
@@ -98,7 +98,7 @@ func TestPopulateAttrFlags(t *testing.T) {
 		},
 		{
 			name: "mixed",
-			args: []string{"-num-attr", "foo=9820", "-string-attr", "bar=9820", "-attr", "baz=9820"},
+			args: []string{"-num-attr", "foo=9820", "-string-attr", "bar=9820", "-attr", "baz=9820", "-attr", "zoom=\"flubber\""},
 			expected: []base.CombinedSliceFlagValue{
 				{
 					Name:  "num-attr",
@@ -114,6 +114,11 @@ func TestPopulateAttrFlags(t *testing.T) {
 					Name:  "attr",
 					Keys:  []string{"baz"},
 					Value: wrapperspb.String("9820"),
+				},
+				{
+					Name:  "attr",
+					Keys:  []string{"zoom"},
+					Value: wrapperspb.String(`"flubber"`),
 				},
 			},
 		},
@@ -399,7 +404,7 @@ func TestHandleAttributeFlags(t *testing.T) {
 			expectedMap: map[string]any{
 				"b1": true,
 				"b2": false,
-				"s1": wrapperspb.String("scoopde"),
+				"s1": "scoopde",
 				"s2": "woop",
 				"n1": float64(-1.2),
 				"n2": int64(5),
@@ -462,7 +467,7 @@ func TestHandleAttributeFlags(t *testing.T) {
 			expectedMap: map[string]any{
 				"bools": []any{true, false},
 				"strings": map[string]any{
-					"s1": wrapperspb.String("scoopde"),
+					"s1": "scoopde",
 					"s2": nil,
 				},
 				"numbers": map[string]any{


### PR DESCRIPTION
In #2721, the ability for key-only values was added via using a wrapperspb.StringValue that could be null. This introduced a bug because originally the default case for `-attr` was to get the string value but instead it used the incoming value as-is to allow for nulls; the null check was moved up later but the original behavior was not restored. As a result, non-explicitly-quoted strings carried through the wrapperspb.StringValue, resulting in a map for the value in JSON instead of a string.

This also fixes explicitly quoted string handling.