### PR TITLE
[docs] Fixing link syntax

### DIFF
--- a/website/content/docs/overview/what-is-boundary.mdx
+++ b/website/content/docs/overview/what-is-boundary.mdx
@@ -85,8 +85,7 @@ supported for the specific inputs and examples with those inputs.
 
 ## What is HCP Boundary?
 
-Boundary offers two types of deployment options. A first option is an *OSS self-managed* deployment solution as discussed above. A self-managed approach enables organizations to proxy all session data through their own network while still providing the convenience of a managed service. A second option is an *HCP-managed* deployment solution where both the control plan and worker nodes are managed by HashiCorp. With this managed solution, an option of private workers is offered. **HCP Boundary** is a fully-managed, cloud-based workflow that enables secure connections to remote hosts and critical systems across cloud and on-premise environments. Refer to the [HCP Boundary](https://cloud.hashicorp.com/docs/boundary
-) documentation to learn more.
+Boundary offers two types of deployment options. A first option is an *OSS self-managed* deployment solution as discussed above. A self-managed approach enables organizations to proxy all session data through their own network while still providing the convenience of a managed service. A second option is an *HCP-managed* deployment solution where both the control plan and worker nodes are managed by HashiCorp. With this managed solution, an option of private workers is offered. **HCP Boundary** is a fully-managed, cloud-based workflow that enables secure connections to remote hosts and critical systems across cloud and on-premise environments. Refer to the [HCP Boundary](https://cloud.hashicorp.com/docs/boundary) documentation to learn more.
 
 -> **Hands On:** Try the [Create a Boundary Instance on HCP](https://learn.hashicorp.com/tutorials/boundary/hcp-getting-started-create?in=boundary/hcp-getting-started) tutorial to deploy an HCP Boundary instance.
 


### PR DESCRIPTION
## What

Fixes a link in `website/content/docs/overview/what-is-boundary.mdx` that had its closing parenthesis (`)`) broken onto a separate line.

## Testing

Just a quick manual review of the change is needed. 😊
