### PR TITLE
bug(sessions): Fix authorizeSession race conditions in handleProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   plugin to exit ([PR](https://github.com/hashicorp/boundary/pull/2677))
 * data warehouse: Fix bug that caused credential dimensions to not get
     associated with session facts ([PR](https://github.com/hashicorp/boundary/pull/2787)).
+* sessions: Fix two authorizeSession race conditions in handleProxy. ([PR](https://github.com/hashicorp/boundary/pull/2795))
 
 ## 0.11.2 (2022/12/09)
 

--- a/internal/daemon/worker/handler.go
+++ b/internal/daemon/worker/handler.go
@@ -182,19 +182,13 @@ func (w *Worker) handleProxy(listenerCfg *listenerutil.ListenerConfig, sessionMa
 			if handshake.Command == proxy.HANDSHAKECOMMAND_HANDSHAKECOMMAND_UNSPECIFIED {
 				err = sess.RequestActivate(ctx, handshake.GetTofuToken())
 				if err != nil {
-					// If this is a duplicate session activation, ignore it
-					if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
-						event.WriteSysEvent(ctx, op, fmt.Sprintf("Ignoring duplicate session activation attempt for session %v", sess.GetId()))
-					} else {
-						event.WriteError(ctx, op, err, event.WithInfoMsg("unable to validate session"))
-						if err = conn.Close(websocket.StatusInternalError, "unable to activate session"); err != nil {
-							event.WriteError(ctx, op, err, event.WithInfoMsg("error closing client connection"))
-						}
-						return
+					event.WriteError(ctx, op, err, event.WithInfoMsg("unable to validate session"))
+					if err = conn.Close(websocket.StatusInternalError, "unable to activate session"); err != nil {
+						event.WriteError(ctx, op, err, event.WithInfoMsg("error closing client connection"))
 					}
-				} else {
-					event.WriteSysEvent(ctx, op, "session successfully activated", "session_id", sessionId)
+					return
 				}
+				event.WriteSysEvent(ctx, op, "session successfully activated", "session_id", sessionId)
 			}
 		}
 

--- a/internal/daemon/worker/session/session.go
+++ b/internal/daemon/worker/session/session.go
@@ -295,15 +295,12 @@ func (s *sess) RequestCancel(ctx context.Context) error {
 }
 
 func (s *sess) RequestActivate(ctx context.Context, tofu string) error {
-	if s.GetStatus() == pbs.SESSIONSTATUS_SESSIONSTATUS_ACTIVE {
-		return nil
-	}
 	st, err := activate(ctx, s.client, s.GetId(), tofu, s.resp.GetVersion())
 	if err != nil {
 		return err
 	}
-	s.ApplyLocalStatus(st)
 	s.ApplyLocalTofuToken(tofu)
+	s.ApplyLocalStatus(st)
 	return nil
 }
 

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -470,6 +470,7 @@ func (r *Repository) sessionAuthzSummary(ctx context.Context, sessionId string) 
 	return info, nil
 }
 
+// Lookup an activated session. Must run in a transaction.
 func (r *Repository) lookupActivatedSessionTx(ctx context.Context, reader db.Reader, writer db.Writer, sessionId string,
 	tofuToken []byte, activatedSession *Session,
 ) error {
@@ -488,6 +489,7 @@ func (r *Repository) lookupActivatedSessionTx(ctx context.Context, reader db.Rea
 	return nil
 }
 
+// Return states for an activated session. Must run in a transaction.
 func (r *Repository) fetchActivatedSessionStatesTx(ctx context.Context, reader db.Reader, sessionId string) ([]*State, error) {
 	const op = "session.(Repository).fetchActivatedSessionStatesTx"
 	var txErr error

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -600,7 +600,7 @@ func (r *Repository) ActivateSession(ctx context.Context, sessionId string, sess
 	if err != nil {
 		// If this was a duplicate activation attempt, return existing session if the tofu token matches
 		if errors.IsUniqueError(err) {
-			event.WriteSysEvent(ctx, op, fmt.Sprintf("Ignoring duplicate session activation attempt for session %v", sessionId))
+			event.WriteSysEvent(ctx, op, fmt.Sprintf("ignoring duplicate session activation attempt for session %v", sessionId))
 			return r.getActivatedSession(ctx, sessionId, tofuToken)
 		}
 		return nil, nil, errors.Wrap(ctx, err, op)

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -471,7 +471,8 @@ func (r *Repository) sessionAuthzSummary(ctx context.Context, sessionId string) 
 }
 
 func (r *Repository) lookupActivatedSessionTx(ctx context.Context, reader db.Reader, writer db.Writer, sessionId string,
-	tofuToken []byte, activatedSession *Session) error {
+	tofuToken []byte, activatedSession *Session,
+) error {
 	const op = "session.(Repository).lookupActivatedSessionTx"
 	var txErr error
 	if txErr = reader.LookupById(ctx, activatedSession); txErr != nil {

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -470,6 +470,35 @@ func (r *Repository) sessionAuthzSummary(ctx context.Context, sessionId string) 
 	return info, nil
 }
 
+func (r *Repository) lookupActivatedSessionTx(ctx context.Context, reader db.Reader, writer db.Writer, sessionId string,
+	tofuToken []byte, activatedSession *Session) error {
+	const op = "session.(Repository).lookupActivatedSessionTx"
+	var txErr error
+	if txErr = reader.LookupById(ctx, activatedSession); txErr != nil {
+		return errors.Wrap(ctx, txErr, op, errors.WithMsg(fmt.Sprintf("failed for %s", sessionId)))
+	}
+	if txErr = decryptAndMaybeUpdateSession(ctx, r.kms, activatedSession, writer); txErr != nil {
+		return errors.Wrap(ctx, txErr, op)
+	}
+	if len(activatedSession.TofuToken) > 0 && subtle.ConstantTimeCompare(activatedSession.TofuToken, tofuToken) != 1 {
+		return errors.New(ctx, errors.TokenMismatch, op, "tofu token mismatch")
+	}
+
+	return nil
+}
+
+func (r *Repository) fetchActivatedSessionStatesTx(ctx context.Context, reader db.Reader, sessionId string) ([]*State, error) {
+	const op = "session.(Repository).fetchActivatedSessionStatesTx"
+	var txErr error
+
+	var returnedStates []*State
+	returnedStates, txErr = fetchStates(ctx, reader, sessionId, db.WithOrder("start_time desc"))
+	if txErr != nil {
+		return nil, errors.Wrap(ctx, txErr, op)
+	}
+	return returnedStates, nil
+}
+
 // getActivatedSession is called if there was a duplicate attempt to activate a session
 // It validates the tofu token matches and returns the session
 func (r *Repository) getActivatedSession(ctx context.Context, sessionId string, tofuToken []byte) (*Session, []*State, error) {
@@ -483,20 +512,13 @@ func (r *Repository) getActivatedSession(ctx context.Context, sessionId string, 
 		db.StdRetryCnt,
 		db.ExpBackoff{},
 		func(reader db.Reader, w db.Writer) error {
-			var txErr error
-			if txErr = reader.LookupById(ctx, &activatedSession); txErr != nil {
-				return errors.Wrap(ctx, txErr, op, errors.WithMsg(fmt.Sprintf("failed for %s", sessionId)))
+			err := r.lookupActivatedSessionTx(ctx, reader, w, sessionId, tofuToken, &activatedSession)
+			if err != nil {
+				return errors.Wrap(ctx, err, op)
 			}
-			if txErr = decryptAndMaybeUpdateSession(ctx, r.kms, &activatedSession, w); txErr != nil {
-				return errors.Wrap(ctx, txErr, op)
-			}
-			if len(activatedSession.TofuToken) > 0 && subtle.ConstantTimeCompare(activatedSession.TofuToken, tofuToken) != 1 {
-				return errors.New(ctx, errors.TokenMismatch, op, "tofu token mismatch")
-			}
-
-			returnedStates, txErr = fetchStates(ctx, reader, sessionId, db.WithOrder("start_time desc"))
-			if txErr != nil {
-				return errors.Wrap(ctx, txErr, op)
+			returnedStates, err = r.fetchActivatedSessionStatesTx(ctx, reader, sessionId)
+			if err != nil {
+				return errors.Wrap(ctx, err, op)
 			}
 			return nil
 		},
@@ -546,14 +568,9 @@ func (r *Repository) ActivateSession(ctx context.Context, sessionId string, sess
 			}
 			foundSession := AllocSession()
 			foundSession.PublicId = sessionId
-			if err := reader.LookupById(ctx, &foundSession); err != nil {
-				return errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("failed for %s", sessionId)))
-			}
-			if err := decryptAndMaybeUpdateSession(ctx, r.kms, &foundSession, w); err != nil {
+			err = r.lookupActivatedSessionTx(ctx, reader, w, sessionId, tofuToken, &foundSession)
+			if err != nil {
 				return errors.Wrap(ctx, err, op)
-			}
-			if len(foundSession.TofuToken) > 0 && subtle.ConstantTimeCompare(foundSession.TofuToken, tofuToken) != 1 {
-				return errors.New(ctx, errors.TokenMismatch, op, "tofu token mismatch")
 			}
 
 			updatedSession.TofuToken = tofuToken
@@ -573,7 +590,7 @@ func (r *Repository) ActivateSession(ctx context.Context, sessionId string, sess
 				return errors.New(ctx, errors.MultipleRecords, op, "more than 1 resource would have been updated")
 			}
 
-			returnedStates, err = fetchStates(ctx, reader, sessionId, db.WithOrder("start_time desc"))
+			returnedStates, err = r.fetchActivatedSessionStatesTx(ctx, reader, sessionId)
 			if err != nil {
 				return errors.Wrap(ctx, err, op)
 			}
@@ -582,7 +599,7 @@ func (r *Repository) ActivateSession(ctx context.Context, sessionId string, sess
 	)
 	if err != nil {
 		// If this was a duplicate activation attempt, return existing session if the tofu token matches
-		if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
+		if errors.IsUniqueError(err) {
 			event.WriteSysEvent(ctx, op, fmt.Sprintf("Ignoring duplicate session activation attempt for session %v", sessionId))
 			return r.getActivatedSession(ctx, sessionId, tofuToken)
 		}

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -5,7 +5,6 @@ import (
 	"crypto/subtle"
 	"database/sql"
 	"fmt"
-	"github.com/hashicorp/boundary/internal/observability/event"
 	"strings"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/boundary/internal/db/timestamp"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/observability/event"
 	"github.com/hashicorp/boundary/internal/util"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 )

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"database/sql"
 	"fmt"
+	"github.com/hashicorp/boundary/internal/observability/event"
 	"strings"
 	"time"
 
@@ -469,11 +470,50 @@ func (r *Repository) sessionAuthzSummary(ctx context.Context, sessionId string) 
 	return info, nil
 }
 
+// getActivatedSession is called if there was a duplicate attempt to activate a session
+// It validates the tofu token matches and returns the session
+func (r *Repository) getActivatedSession(ctx context.Context, sessionId string, tofuToken []byte) (*Session, []*State, error) {
+	const op = "session.(Repository).getActivatedSession"
+
+	activatedSession := AllocSession()
+	activatedSession.PublicId = sessionId
+	var returnedStates []*State
+	_, err := r.writer.DoTx(
+		ctx,
+		db.StdRetryCnt,
+		db.ExpBackoff{},
+		func(reader db.Reader, w db.Writer) error {
+			var txErr error
+			if txErr = reader.LookupById(ctx, &activatedSession); txErr != nil {
+				return errors.Wrap(ctx, txErr, op, errors.WithMsg(fmt.Sprintf("failed for %s", sessionId)))
+			}
+			if txErr = decryptAndMaybeUpdateSession(ctx, r.kms, &activatedSession, w); txErr != nil {
+				return errors.Wrap(ctx, txErr, op)
+			}
+			if len(activatedSession.TofuToken) > 0 && subtle.ConstantTimeCompare(activatedSession.TofuToken, tofuToken) != 1 {
+				return errors.New(ctx, errors.TokenMismatch, op, "tofu token mismatch")
+			}
+
+			returnedStates, txErr = fetchStates(ctx, reader, sessionId, db.WithOrder("start_time desc"))
+			if txErr != nil {
+				return errors.Wrap(ctx, txErr, op)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, nil, errors.Wrap(ctx, err, op)
+	}
+	return &activatedSession, returnedStates, nil
+}
+
 // ActivateSession will activate the session and is called by a worker after
 // authenticating the session. The session must be in a "pending" state to be
 // activated. States are ordered by start time descending. Returns an
 // InvalidSessionState error code if a connection cannot be made because the session
 // was canceled or terminated.
+// If ActivateSession receives duplicate requests for the same session, it will return the
+// already active session if the tofu token is correct
 func (r *Repository) ActivateSession(ctx context.Context, sessionId string, sessionVersion uint32, tofuToken []byte) (*Session, []*State, error) {
 	const op = "session.(Repository).ActivateSession"
 	if sessionId == "" {
@@ -541,6 +581,11 @@ func (r *Repository) ActivateSession(ctx context.Context, sessionId string, sess
 		},
 	)
 	if err != nil {
+		// If this was a duplicate activation attempt, return existing session if the tofu token matches
+		if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
+			event.WriteSysEvent(ctx, op, fmt.Sprintf("Ignoring duplicate session activation attempt for session %v", sessionId))
+			return r.getActivatedSession(ctx, sessionId, tofuToken)
+		}
 		return nil, nil, errors.Wrap(ctx, err, op)
 	}
 	return &updatedSession, returnedStates, nil


### PR DESCRIPTION
Fixes for two race conditions when authorizing sessions.
1. Two calls could reach ActivateSession and execute activateStateCte. The first would succeed and the second would fail with a duplicate key value error
2. Two calls could hit handleProxy; one activates and update the session state to Active; the second would come in before the first call updated the tofu token, resulting in the err `no tofu token but not in correct session state`

Fixes #2741
