### PR TITLE
docs: Remove links from headings -v0.11

### DIFF
--- a/website/content/docs/release-notes/v0_11_0.mdx
+++ b/website/content/docs/release-notes/v0_11_0.mdx
@@ -5,32 +5,32 @@ description: |-
   Boundary release notes for v0.11.0
 ---
 
-# [Boundary v0.11.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.11.0
 
-The release notes below contain information about new functionality available in the Boundary v0.11.0 release. To see a granular record of when each item was 
-merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary 
+The release notes below contain information about new functionality available in the Boundary v0.11.0 release. To see a granular record of when each item was
+merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary
 consists of, we highly recommend you start at the [Getting Started Page](/docs/getting-started).
 
-Lastly, for instructions on how to upgrade an existing Boundary deployment to v0.11.0, please review Boundary's 
+Lastly, for instructions on how to upgrade an existing Boundary deployment to v0.11.0, please review Boundary's
 [general upgrade guide](https://learn.hashicorp.com/tutorials/boundary/upgrade-version).
 
 ## Boundary v0.11.0 Highlights
 
-**HCP Boundary General Availability:** Boundary is now available on the HashiCorp Cloud Platform! HCP Boundary provides an easy way to securely access critical 
-systems with fine-grained authorizations based on trusted identities. Boundary on HashiCorp Cloud Platform provides a fully managed, single workflow to securely 
+**HCP Boundary General Availability:** Boundary is now available on the HashiCorp Cloud Platform! HCP Boundary provides an easy way to securely access critical
+systems with fine-grained authorizations based on trusted identities. Boundary on HashiCorp Cloud Platform provides a fully managed, single workflow to securely
 connect to hosts and critical systems across Kubernetes clusters, cloud service catalogs, and on-premises infrastructure
 
-**Private Vault Access:** HCP Boundary users are now able to integrate their on-premises instance of Vault without having to publicly expose Vault. This is 
-accomplished by deploying a Boundary worker binary within the same private network as the Vault instance and peering with the HCP Boundary control plane. 
+**Private Vault Access:** HCP Boundary users are now able to integrate their on-premises instance of Vault without having to publicly expose Vault. This is
+accomplished by deploying a Boundary worker binary within the same private network as the Vault instance and peering with the HCP Boundary control plane.
 [Learn more here](https://learn.hashicorp.com/tutorials/boundary/hcp-vault-cred-brokering-quickstart).
 
-**SSH Credential Injection:** SSH Targets can now be set up through the Admin UI, making the Credential Injection workflow more seamless and easy to use. 
+**SSH Credential Injection:** SSH Targets can now be set up through the Admin UI, making the Credential Injection workflow more seamless and easy to use.
 [Learn more here](https://learn.hashicorp.com/tutorials/boundary/hcp-ssh-cred-injection?in=boundary/hcp-administration).
 
-**Improved Worker Management:** Administrators are now able to register and manage Boundary workers through the Admin UI. Admin users can view session counts, 
+**Improved Worker Management:** Administrators are now able to register and manage Boundary workers through the Admin UI. Admin users can view session counts,
 IP addresses and release versions of all registered workers through the 'Workers' tab.
 
-**Support for Generic Credentials:** Boundary now supports brokering of 'generic credentials'. This will enable users to broker any kind of key/value pair type 
+**Support for Generic Credentials:** Boundary now supports brokering of 'generic credentials'. This will enable users to broker any kind of key/value pair type
 credentials when they are connecting to a remote host.
 
 


### PR DESCRIPTION
This PR removes the links from the H1 headings in the release notes.  From the web team:

> We're trying to remove instances of links in heading elements, as it can cause difficulties for users who rely on screen readers and voice-based assistive tech, and it can lead to issues when we automatically generation anchor links.