### PR TITLE
docs: Remove links from headings -v0.8

### DIFF
--- a/website/content/docs/release-notes/v0_1_0.mdx
+++ b/website/content/docs/release-notes/v0_1_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.1.0
 ---
 
-# [Boundary v0.1.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.1.0
 
 v0.1.0 is the first release of Boundary. As a result there are no changes, improvements, or bugfixes from past versions. To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/docs/getting-started).
 

--- a/website/content/docs/release-notes/v0_2_0.mdx
+++ b/website/content/docs/release-notes/v0_2_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.2.0
 ---
 
-# [Boundary v0.2.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.2.0
 
 The release notes below contain information about Boundary v0.2.0 as well as new features since Boundary's 0.1.0 that became available in 0.1.x releases. To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/docs/getting-started).
 

--- a/website/content/docs/release-notes/v0_3_0.mdx
+++ b/website/content/docs/release-notes/v0_3_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.3.0
 ---
 
-# [Boundary v0.3.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.3.0
 
 The release notes below contain information about Boundary v0.3.0, Boundary Desktop v1.1.0, as well as new features since Boundary's 0.2.0 that became available in 0.2.x releases. To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/docs/getting-started).
 

--- a/website/content/docs/release-notes/v0_4_0.mdx
+++ b/website/content/docs/release-notes/v0_4_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.4.0
 ---
 
-# [Boundary v0.4.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.4.0
 
 The release notes below contain information about new functionality available in Boundary v0.4.0. To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/docs/getting-started).
 

--- a/website/content/docs/release-notes/v0_5_0.mdx
+++ b/website/content/docs/release-notes/v0_5_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.5.0
 ---
 
-# [Boundary v0.5.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.5.0
 
 The release notes below contain information about new functionality available in Boundary v0.5.0.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).

--- a/website/content/docs/release-notes/v0_6_0.mdx
+++ b/website/content/docs/release-notes/v0_6_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.6.0
 ---
 
-# [Boundary v0.6.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.6.0
 
 The release notes below contain information about new functionality available in Boundary v0.6.0 and the corresponding Boundary Desktop v1.3.0 and Boundary Terraform Provider v1.0.5 releases.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).

--- a/website/content/docs/release-notes/v0_7_0.mdx
+++ b/website/content/docs/release-notes/v0_7_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.7.0
 ---
 
-# [Boundary v0.7.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.7.0
 
 The release notes below contain information about new functionality available in Boundary v0.7.0 and the corresponding Boundary Desktop v1.4.0 release.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).
@@ -16,9 +16,9 @@ Lastly, for instructions on how to upgrade an existing Boundary deployment to v0
 ## Boundary v0.7.0 Highlights
 
 **Dynamic Host Catalogs:** Boundary introduces a new resource type, dynamic host catalogs, which automate the discovery of host resources from a catalog provider. The 0.7 release includes
-initial support for Azure and AWS host catalogs with more catalog providers to follow in future releases. Catalogs are implemented via Boundary's (currently internal) new go-plugin system. 
+initial support for Azure and AWS host catalogs with more catalog providers to follow in future releases. Catalogs are implemented via Boundary's (currently internal) new go-plugin system.
 
-**Managed group configuration in the admin console**: Managed groups are a special type of IAM group which populate users based on administrator-defined filters of external identity provider (IdP) metadata. 
+**Managed group configuration in the admin console**: Managed groups are a special type of IAM group which populate users based on administrator-defined filters of external identity provider (IdP) metadata.
 Configuration of managed groups is now available in the Boundary admin console.
 
 **UI Support for Resource Filtering:** Users may now filter auth method and session resources in the admin console and Boundary Desktop.
@@ -26,4 +26,3 @@ Configuration of managed groups is now available in the Boundary admin console.
 ## What's Changed
 
 For more detailed information of all changes since 0.6.0, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md)
-

--- a/website/content/docs/release-notes/v0_8_0.mdx
+++ b/website/content/docs/release-notes/v0_8_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.8.0
 ---
 
-# [Boundary v0.8.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.8.0
 
 The release notes below contain information about new functionality available in the Boundary v0.8.0 release.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).
@@ -15,11 +15,11 @@ Lastly, for instructions on how to upgrade an existing Boundary deployment to v0
 
 ## Boundary v0.8.0 Highlights
 
-**Metrics and Health Endpoint:** Boundary is adding [Prometheus metrics](https://www.boundaryproject.io/docs/operations/metrics) to monitor the operations of workers and controllers, 
-as well as a [health endpoint](https://www.boundaryproject.io/docs/operations/health) for controllers. 
+**Metrics and Health Endpoint:** Boundary is adding [Prometheus metrics](/docs/oss/operations/metrics) to monitor the operations of workers and controllers,
+as well as a [health endpoint](/docs/oss/operations/health) for controllers.
 
-**Audit Event Logs:** We are expanding the audit event logs by increasing the captured [audit events](https://www.boundaryproject.io/docs/configuration/events/overview), 
-with support for sanitizing sensitive information from audit events. All of the events are now classified and events contain more usable data, with sensitive information redacted by default. 
+**Audit Event Logs:** We are expanding the audit event logs by increasing the captured [audit events](/docs/configuration/events/overview),
+with support for sanitizing sensitive information from audit events. All of the events are now classified and events contain more usable data, with sensitive information redacted by default.
 
 **UI Support for Worker Tags:** Users can now set and edit [worker tag](https://www.boundaryproject.io/docs/concepts/filtering/worker-tags) filters in the Boundary admin console.
 
@@ -30,4 +30,3 @@ and improving response times listing sessions and targets. We plan to continue t
 ## What's Changed
 
 For more detailed information of all changes since 0.7.0, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md)
-

--- a/website/content/docs/release-notes/v0_8_0.mdx
+++ b/website/content/docs/release-notes/v0_8_0.mdx
@@ -21,7 +21,7 @@ as well as a [health endpoint](/docs/oss/operations/health) for controllers.
 **Audit Event Logs:** We are expanding the audit event logs by increasing the captured [audit events](/docs/configuration/events/overview),
 with support for sanitizing sensitive information from audit events. All of the events are now classified and events contain more usable data, with sensitive information redacted by default.
 
-**UI Support for Worker Tags:** Users can now set and edit [worker tag](https://www.boundaryproject.io/docs/concepts/filtering/worker-tags) filters in the Boundary admin console.
+**UI Support for Worker Tags:** Users can now set and edit [worker tag](/docs/concepts/filtering/worker-tags) filters in the Boundary admin console.
 
 **Performance Improvements:** We have implemented changes to improve performance on larger deployments; such as adding a refresh button in the admin console and desktop client,
 and improving response times listing sessions and targets. We plan to continue these efforts as Boundary users grow their deployments!


### PR DESCRIPTION
This PR removes the links from the H1 headings in the release notes in branch `0.8.x`. From the web team:

> We're trying to remove instances of links in heading elements, as it can cause difficulties for users who rely on screen readers and voice-based assistive tech, and it can lead to issues when we automatically generation anchor links.