### PR TITLE
docs: Remove links from headings -v0.7

### DIFF
--- a/website/content/docs/releases/release-notes/v0_1_0.mdx
+++ b/website/content/docs/releases/release-notes/v0_1_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.1.0
 ---
 
-# [Boundary v0.1.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.1.0
 
 v0.1.0 is the first release of Boundary. As a result there are no changes, improvements, or bugfixes from past versions. To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/docs/getting-started).
 

--- a/website/content/docs/releases/release-notes/v0_2_0.mdx
+++ b/website/content/docs/releases/release-notes/v0_2_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.2.0
 ---
 
-# [Boundary v0.2.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.2.0
 
 The release notes below contain information about Boundary v0.2.0 as well as new features since Boundary's 0.1.0 that became available in 0.1.x releases. To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/docs/getting-started).
 

--- a/website/content/docs/releases/release-notes/v0_3_0.mdx
+++ b/website/content/docs/releases/release-notes/v0_3_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.3.0
 ---
 
-# [Boundary v0.3.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.3.0
 
 The release notes below contain information about Boundary v0.3.0, Boundary Desktop v1.1.0, as well as new features since Boundary's 0.2.0 that became available in 0.2.x releases. To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/docs/getting-started).
 

--- a/website/content/docs/releases/release-notes/v0_4_0.mdx
+++ b/website/content/docs/releases/release-notes/v0_4_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.4.0
 ---
 
-# [Boundary v0.4.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.4.0
 
 The release notes below contain information about new functionality available in Boundary v0.4.0. To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/docs/getting-started).
 

--- a/website/content/docs/releases/release-notes/v0_5_0.mdx
+++ b/website/content/docs/releases/release-notes/v0_5_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.5.0
 ---
 
-# [Boundary v0.5.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.5.0
 
 The release notes below contain information about new functionality available in Boundary v0.5.0.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).

--- a/website/content/docs/releases/release-notes/v0_6_0.mdx
+++ b/website/content/docs/releases/release-notes/v0_6_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.6.0
 ---
 
-# [Boundary v0.6.0](https://www.boundaryproject.io/downloads)
+# Boundary v0.6.0
 
 The release notes below contain information about new functionality available in Boundary v0.6.0 and the corresponding Boundary Desktop v1.3.0 and Boundary Terraform Provider v1.0.5 releases.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).


### PR DESCRIPTION
This PR removes the links from the H1 headings in the release notes in branch `0.7.x`. From the web team:

> We're trying to remove instances of links in heading elements, as it can cause difficulties for users who rely on screen readers and voice-based assistive tech, and it can lead to issues when we automatically generation anchor links.