### PR TITLE
docs: Remove links from release note headings - 0.11

### DIFF
--- a/website/content/docs/release-notes/v0_10_0.mdx
+++ b/website/content/docs/release-notes/v0_10_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.10.0
 ---
 
-# [Boundary v0.10.0](/boundary/downloads)
+# Boundary v0.10.0
 
 The release notes below contain information about new functionality available in the Boundary v0.10.0 release.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).
@@ -18,13 +18,13 @@ Lastly, for instructions on how to upgrade an existing Boundary deployment to v0
 **Credential Management of SSH Keys:** Boundary 0.10 includes enhancements to credential management, including added support for management of SSH private keys.
 
 
-**SSH Brokering Helper Function:** We’ve expanded support for the SSH brokering helper function that allows users to seamlessly connect to machines remotely 
-without having to manually enter their brokered credentials. 
+**SSH Brokering Helper Function:** We’ve expanded support for the SSH brokering helper function that allows users to seamlessly connect to machines remotely
+without having to manually enter their brokered credentials.
 
-**Enhanced IAM Workflows in the Boundary Admin UI:** Boundary 0.10 introduces enhanced IAM associations to Boundary’s Admin UI, allowing users to expand IAM associations in a 
+**Enhanced IAM Workflows in the Boundary Admin UI:** Boundary 0.10 introduces enhanced IAM associations to Boundary’s Admin UI, allowing users to expand IAM associations in a
 project scope to resources such as group members and principals that reside in other scopes.
 
-**SSH Credential Injection via Password and Public Key Authentication:** HCP Boundary now supports SSH Credential Injection, an active method of injecting credentials into an 
+**SSH Credential Injection via Password and Public Key Authentication:** HCP Boundary now supports SSH Credential Injection, an active method of injecting credentials into an
 established connection, so that credentials are never exposed to users. [Learn more here](/boundary/tutorials/hcp-administration/hcp-ssh-cred-injection).
 
 

--- a/website/content/docs/release-notes/v0_11_0.mdx
+++ b/website/content/docs/release-notes/v0_11_0.mdx
@@ -5,32 +5,32 @@ description: |-
   Boundary release notes for v0.11.0
 ---
 
-# [Boundary v0.11.0](/boundary/downloads)
+# Boundary v0.11.0
 
-The release notes below contain information about new functionality available in the Boundary v0.11.0 release. To see a granular record of when each item was 
-merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary 
+The release notes below contain information about new functionality available in the Boundary v0.11.0 release. To see a granular record of when each item was
+merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary
 consists of, we highly recommend you start at the [Getting Started Page](/boundary/docs/getting-started).
 
-Lastly, for instructions on how to upgrade an existing Boundary deployment to v0.11.0, please review Boundary's 
+Lastly, for instructions on how to upgrade an existing Boundary deployment to v0.11.0, please review Boundary's
 [general upgrade guide](/boundary/tutorials/oss-configuration/upgrade-version).
 
 ## Boundary v0.11.0 Highlights
 
-**HCP Boundary General Availability:** Boundary is now available on the HashiCorp Cloud Platform! HCP Boundary provides an easy way to securely access critical 
-systems with fine-grained authorizations based on trusted identities. Boundary on HashiCorp Cloud Platform provides a fully managed, single workflow to securely 
+**HCP Boundary General Availability:** Boundary is now available on the HashiCorp Cloud Platform! HCP Boundary provides an easy way to securely access critical
+systems with fine-grained authorizations based on trusted identities. Boundary on HashiCorp Cloud Platform provides a fully managed, single workflow to securely
 connect to hosts and critical systems across Kubernetes clusters, cloud service catalogs, and on-premises infrastructure
 
-**Private Vault Access:** HCP Boundary users are now able to integrate their on-premises instance of Vault without having to publicly expose Vault. This is 
-accomplished by deploying a Boundary worker binary within the same private network as the Vault instance and peering with the HCP Boundary control plane. 
+**Private Vault Access:** HCP Boundary users are now able to integrate their on-premises instance of Vault without having to publicly expose Vault. This is
+accomplished by deploying a Boundary worker binary within the same private network as the Vault instance and peering with the HCP Boundary control plane.
 [Learn more here](/boundary/tutorials/access-management/hcp-vault-cred-brokering-quickstart).
 
-**SSH Credential Injection:** SSH Targets can now be set up through the Admin UI, making the Credential Injection workflow more seamless and easy to use. 
+**SSH Credential Injection:** SSH Targets can now be set up through the Admin UI, making the Credential Injection workflow more seamless and easy to use.
 [Learn more here](/boundary/tutorials/hcp-administration/hcp-ssh-cred-injection).
 
-**Improved Worker Management:** Administrators are now able to register and manage Boundary workers through the Admin UI. Admin users can view session counts, 
+**Improved Worker Management:** Administrators are now able to register and manage Boundary workers through the Admin UI. Admin users can view session counts,
 IP addresses and release versions of all registered workers through the 'Workers' tab.
 
-**Support for Generic Credentials:** Boundary now supports brokering of 'generic credentials'. This will enable users to broker any kind of key/value pair type 
+**Support for Generic Credentials:** Boundary now supports brokering of 'generic credentials'. This will enable users to broker any kind of key/value pair type
 credentials when they are connecting to a remote host.
 
 

--- a/website/content/docs/release-notes/v0_1_0.mdx
+++ b/website/content/docs/release-notes/v0_1_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.1.0
 ---
 
-# [Boundary v0.1.0](/boundary/downloads)
+# Boundary v0.1.0
 
 v0.1.0 is the first release of Boundary. As a result there are no changes, improvements, or bugfixes from past versions. To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/boundary/docs/getting-started).
 

--- a/website/content/docs/release-notes/v0_2_0.mdx
+++ b/website/content/docs/release-notes/v0_2_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.2.0
 ---
 
-# [Boundary v0.2.0](/boundary/downloads)
+# Boundary v0.2.0
 
 The release notes below contain information about Boundary v0.2.0 as well as new features since Boundary's 0.1.0 that became available in 0.1.x releases. To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/boundary/docs/getting-started).
 

--- a/website/content/docs/release-notes/v0_3_0.mdx
+++ b/website/content/docs/release-notes/v0_3_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.3.0
 ---
 
-# [Boundary v0.3.0](/boundary/downloads)
+# Boundary v0.3.0
 
 The release notes below contain information about Boundary v0.3.0, Boundary Desktop v1.1.0, as well as new features since Boundary's 0.2.0 that became available in 0.2.x releases. To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/boundary/docs/getting-started).
 

--- a/website/content/docs/release-notes/v0_4_0.mdx
+++ b/website/content/docs/release-notes/v0_4_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.4.0
 ---
 
-# [Boundary v0.4.0](/boundary/downloads)
+# Boundary v0.4.0
 
 The release notes below contain information about new functionality available in Boundary v0.4.0. To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md). To learn about what Boundary consists of, we highly recommend you start at the [Getting Started Page](/boundary/docs/getting-started).
 

--- a/website/content/docs/release-notes/v0_5_0.mdx
+++ b/website/content/docs/release-notes/v0_5_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.5.0
 ---
 
-# [Boundary v0.5.0](/boundary/downloads)
+# Boundary v0.5.0
 
 The release notes below contain information about new functionality available in Boundary v0.5.0.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).

--- a/website/content/docs/release-notes/v0_6_0.mdx
+++ b/website/content/docs/release-notes/v0_6_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.6.0
 ---
 
-# [Boundary v0.6.0](/boundary/downloads)
+# Boundary v0.6.0
 
 The release notes below contain information about new functionality available in Boundary v0.6.0 and the corresponding Boundary Desktop v1.3.0 and Boundary Terraform Provider v1.0.5 releases.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).

--- a/website/content/docs/release-notes/v0_7_0.mdx
+++ b/website/content/docs/release-notes/v0_7_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.7.0
 ---
 
-# [Boundary v0.7.0](/boundary/downloads)
+# Boundary v0.7.0
 
 The release notes below contain information about new functionality available in Boundary v0.7.0 and the corresponding Boundary Desktop v1.4.0 release.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).
@@ -16,9 +16,9 @@ Lastly, for instructions on how to upgrade an existing Boundary deployment to v0
 ## Boundary v0.7.0 Highlights
 
 **Dynamic Host Catalogs:** Boundary introduces a new resource type, dynamic host catalogs, which automate the discovery of host resources from a catalog provider. The 0.7 release includes
-initial support for Azure and AWS host catalogs with more catalog providers to follow in future releases. Catalogs are implemented via Boundary's (currently internal) new go-plugin system. 
+initial support for Azure and AWS host catalogs with more catalog providers to follow in future releases. Catalogs are implemented via Boundary's (currently internal) new go-plugin system.
 
-**Managed group configuration in the admin console**: Managed groups are a special type of IAM group which populate users based on administrator-defined filters of external identity provider (IdP) metadata. 
+**Managed group configuration in the admin console**: Managed groups are a special type of IAM group which populate users based on administrator-defined filters of external identity provider (IdP) metadata.
 Configuration of managed groups is now available in the Boundary admin console.
 
 **UI Support for Resource Filtering:** Users may now filter auth method and session resources in the admin console and Boundary Desktop.
@@ -26,4 +26,3 @@ Configuration of managed groups is now available in the Boundary admin console.
 ## What's Changed
 
 For more detailed information of all changes since 0.6.0, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md)
-

--- a/website/content/docs/release-notes/v0_8_0.mdx
+++ b/website/content/docs/release-notes/v0_8_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.8.0
 ---
 
-# [Boundary v0.8.0](/boundary/downloads)
+# Boundary v0.8.0
 
 The release notes below contain information about new functionality available in the Boundary v0.8.0 release.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).
@@ -15,11 +15,11 @@ Lastly, for instructions on how to upgrade an existing Boundary deployment to v0
 
 ## Boundary v0.8.0 Highlights
 
-**Metrics and Health Endpoint:** Boundary is adding [Prometheus metrics](/boundary/docs/oss/operations/metrics) to monitor the operations of workers and controllers, 
-as well as a [health endpoint](/boundary/docs/oss/operations/health) for controllers. 
+**Metrics and Health Endpoint:** Boundary is adding [Prometheus metrics](/boundary/docs/oss/operations/metrics) to monitor the operations of workers and controllers,
+as well as a [health endpoint](/boundary/docs/oss/operations/health) for controllers.
 
-**Audit Event Logs:** We are expanding the audit event logs by increasing the captured [audit events](/boundary/docs/configuration/events/overview), 
-with support for sanitizing sensitive information from audit events. All of the events are now classified and events contain more usable data, with sensitive information redacted by default. 
+**Audit Event Logs:** We are expanding the audit event logs by increasing the captured [audit events](/boundary/docs/configuration/events/overview),
+with support for sanitizing sensitive information from audit events. All of the events are now classified and events contain more usable data, with sensitive information redacted by default.
 
 **UI Support for Worker Tags:** Users can now set and edit [worker tag](/boundary/docs/concepts/filtering/worker-tags) filters in the Boundary admin console.
 
@@ -30,4 +30,3 @@ and improving response times listing sessions and targets. We plan to continue t
 ## What's Changed
 
 For more detailed information of all changes since 0.7.0, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md)
-

--- a/website/content/docs/release-notes/v0_9_0.mdx
+++ b/website/content/docs/release-notes/v0_9_0.mdx
@@ -5,7 +5,7 @@ description: |-
   Boundary release notes for v0.9.0
 ---
 
-# [Boundary v0.9.0](/boundary/downloads)
+# Boundary v0.9.0
 
 The release notes below contain information about new functionality available in the Boundary v0.9.0 release.
 To see a granular record of when each item was merged into the Boundary project, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md).
@@ -15,23 +15,23 @@ Lastly, for instructions on how to upgrade an existing Boundary deployment to v0
 
 ## Boundary v0.9.0 Highlights
 
-**HCP Boundary Public Beta:** Boundary is coming to the HashiCorp Cloud Platform! HCP Boundary provides an easy way to securely access 
-critical systems with fine-grained authorizations based on trusted identities. Boundary on HashiCorp Cloud Platform provides a fully managed, 
+**HCP Boundary Public Beta:** Boundary is coming to the HashiCorp Cloud Platform! HCP Boundary provides an easy way to securely access
+critical systems with fine-grained authorizations based on trusted identities. Boundary on HashiCorp Cloud Platform provides a fully managed,
 single workflow to securely connect to hosts and critical systems across Kubernetes clusters, cloud service catalogs, and on-premises infrastructure.
 You can now [try HCP Boundary](/boundary/tutorials/hcp-getting-started) for free during our [Public Beta](https://cloud.hashicorp.com/products/boundary).
 
-**Self-Managed Workers:** With HCP Boundary, administrators have the option of setting up private, self-managed workers for infrastructure access. This provides the 
+**Self-Managed Workers:** With HCP Boundary, administrators have the option of setting up private, self-managed workers for infrastructure access. This provides the
 security of having privately managed workers while providing the low overhead of a managed service. Learn more about setting up self-managed workers
 [here](/boundary/tutorials/hcp-administration/hcp-manage-workers).
 
-**Worker Registration Enhancements:** Administrators now have a second method of authenticating workers, and we call these PKI Workers (the original 
-authentication method is now called KMS Workers). PKI Workers authenticate to Boundary using a new certificate-based method, allowing for worker deployment 
+**Worker Registration Enhancements:** Administrators now have a second method of authenticating workers, and we call these PKI Workers (the original
+authentication method is now called KMS Workers). PKI Workers authenticate to Boundary using a new certificate-based method, allowing for worker deployment
 without using a shared KMS.
 
-**Static Credential Store:** In Boundary 0.9.0, we are introducing the static credential store, a basic 
+**Static Credential Store:** In Boundary 0.9.0, we are introducing the static credential store, a basic
 [credential store](/boundary/docs/concepts/domain-model/credential-stores) that is native to Boundary. These credentials
-are encrypted and stored directly in Boundary. For users interested in integrated secrets management to Boundary targets, the new basic 
-credential store removes the dependency on HashiCorp Vault. Currently, the static credential store only supports username/password type credentials. Note: If you 
+are encrypted and stored directly in Boundary. For users interested in integrated secrets management to Boundary targets, the new basic
+credential store removes the dependency on HashiCorp Vault. Currently, the static credential store only supports username/password type credentials. Note: If you
 wish to use the Desktop Client for credential brokering, version 1.4.4 and up is required.
 
 **Admin UI Quickstart:** Users can now access a quickstart tool on the Admin UI which sets up a target along with a host, project, and organization.
@@ -39,4 +39,3 @@ wish to use the Desktop Client for credential brokering, version 1.4.4 and up is
 ## What's Changed
 
 For more detailed information of all changes since 0.8.0, please refer to the [Changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md)
-


### PR DESCRIPTION
This PR removes the links from the H1 headings in the release notes.  From the web team:

> We're trying to remove instances of links in heading elements, as it can cause difficulties for users who rely on screen readers and voice-based assistive tech, and it can lead to issues when we automatically generation anchor links.