### PR TITLE
Add Heimdall summary

### DIFF
--- a/META.d/_summary.yaml
+++ b/META.d/_summary.yaml
@@ -1,0 +1,8 @@
+---
+schema: 1.1
+partition: secure
+category: product
+summary:
+  owner: team-boundary
+  description: The repository holding the Boundary OSS backend code and releases
+  visibility: external


### PR DESCRIPTION
Used by the CORE SRE team Heimdall product to give quick overview of all the HashiCorp repositories.
Initially this just adds some very basic information about this repository. Could be expanded if we
expand the use of Heimdall.

The schema for these files are defined here: https://github.com/hashicorp/cloud-catalog/blob/main/docs/SCHEMA.md