### PR TITLE
[check-legacy-links-format] Upgrading to latest workflow

### DIFF
--- a/.github/workflows/check-legacy-links-format.yml
+++ b/.github/workflows/check-legacy-links-format.yml
@@ -1,10 +1,13 @@
 name: Legacy Link Format Checker
 
-on: [deployment_status]
+on:
+  push:
+    paths:
+      - "website/content/**/*.mdx"
+      - "website/data/*-nav-data.json"
 
 jobs:
   check-links:
-    if: github.event.deployment_status.state == 'success'
     uses: hashicorp/dev-portal/.github/workflows/docs-content-check-legacy-links-format.yml@475289345d312552b745224b46895f51cc5fc490
     with:
       repo-owner: "hashicorp"

--- a/.github/workflows/check-legacy-links-format.yml
+++ b/.github/workflows/check-legacy-links-format.yml
@@ -5,7 +5,7 @@ on: [deployment_status]
 jobs:
   check-links:
     if: github.event.deployment_status.state == 'success'
-    uses: hashicorp/dev-portal/.github/workflows/docs-content-check-legacy-links-format.yml@d3c23a582bc0e02a62545644f1fb0a3922cc4b17
+    uses: hashicorp/dev-portal/.github/workflows/docs-content-check-legacy-links-format.yml@475289345d312552b745224b46895f51cc5fc490
     with:
       repo-owner: "hashicorp"
       repo-name: "boundary"

--- a/.github/workflows/check-legacy-links-format.yml
+++ b/.github/workflows/check-legacy-links-format.yml
@@ -1,14 +1,11 @@
 name: Legacy Link Format Checker
 
-on:
-  push:
-    paths:
-      - "website/content/**/*.mdx"
-      - "website/data/*-nav-data.json"
+on: [deployment_status]
 
 jobs:
   check-links:
-    uses: hashicorp/dev-portal/.github/workflows/docs-content-check-legacy-links-format.yml@d7c2fceac2dc41e3f857f1ce7c344141fd6a13dd
+    if: github.event.deployment_status.state == 'success'
+    uses: hashicorp/dev-portal/.github/workflows/docs-content-check-legacy-links-format.yml@d3c23a582bc0e02a62545644f1fb0a3922cc4b17
     with:
       repo-owner: "hashicorp"
       repo-name: "boundary"


### PR DESCRIPTION
## What

- Upgrades the `check-legacy-links-format` workflow to reference the latest hash of the workflow it calls. See [`hashicorp/dev-portal#1558`](https://github.com/hashicorp/dev-portal/pull/1558) for information on what changed and why.
