### PR TITLE
docs: Add frontmatter to ref architecture topic

### DIFF
--- a/website/content/docs/oss/installing/reference-architectures.mdx
+++ b/website/content/docs/oss/installing/reference-architectures.mdx
@@ -1,8 +1,8 @@
 ---
 layout: docs
-page_title: Reference Architecture
+page_title: Reference Architectures
 description: |-
-  Boundary reference architecture
+  Boundary reference architectures
 ---
 
 # Reference Architectures

--- a/website/content/docs/oss/installing/reference-architectures.mdx
+++ b/website/content/docs/oss/installing/reference-architectures.mdx
@@ -1,3 +1,10 @@
+---
+layout: docs
+page_title: Reference Architecture
+description: |-
+  Boundary reference architecture
+---
+
 # Reference Architectures
 A number of community-supported reference architectures for non-dev deployments can be found in Boundary's dedicated [reference architecture repo](https://github.com/hashicorp/boundary-reference-architecture).
 


### PR DESCRIPTION
The Reference Architecture topic was missing front matter. This PR adds the front matter to improve search relevancy and SEO.