### PR TITLE
chore(enos): Remove unused skip_failing_bats_tests variable

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -149,7 +149,6 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
-          ENOS_VAR_skip_failing_bats_tests: "true"
         run: |
           mkdir -p ./enos/terraform-plugin-cache
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
@@ -167,8 +166,6 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
-          # Skip a few known failing bats tests
-          ENOS_VAR_skip_failing_bats_tests: "true"
         run: |
           mkdir -p ./enos/terraform-plugin-cache
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
@@ -184,8 +181,6 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
-          # Skip a few known failing bats tests
-          ENOS_VAR_skip_failing_bats_tests: "true"
         run: |
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
@@ -198,8 +193,6 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
-          # Skip a few known failing bats tests
-          ENOS_VAR_skip_failing_bats_tests: "true"
         run: |
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario destroy --timeout 60m0s --chdir ./enos ${{ matrix.filter }}

--- a/enos/enos-scenario-integration.hcl
+++ b/enos/enos-scenario-integration.hcl
@@ -104,7 +104,6 @@ scenario "integration" {
       local_boundary_dir    = local.local_boundary_dir
       project_scope_id      = step.create_boundary_cluster.project_scope_id
       org_scope_id          = step.create_boundary_cluster.org_scope_id
-      skip_failing_tests    = var.skip_failing_bats_tests
       target_id             = step.create_boundary_cluster.target_id
     }
   }

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -98,12 +98,6 @@ variable "tfc_api_token" {
   type        = string
 }
 
-variable "skip_failing_bats_tests" {
-  description = "Skip known Bats test failures"
-  type        = string
-  default     = "false"
-}
-
 variable "vault_instance_type" {
   description = "Instance type for test target nodes"
   type        = string

--- a/enos/modules/test_cli_ui/tests.tf
+++ b/enos/modules/test_cli_ui/tests.tf
@@ -19,9 +19,6 @@ variable "host_set_id" {}
 variable "local_boundary_dir" {}
 variable "org_scope_id" {}
 variable "project_scope_id" {}
-variable "skip_failing_tests" {
-  default = "false"
-}
 variable "target_id" {}
 
 resource "enos_local_exec" "local_boundary_version" {
@@ -119,7 +116,6 @@ resource "enos_local_exec" "run_bats" {
     DEFAULT_AMPW               = var.auth_method_id
     DEFAULT_USER               = var.auth_user_id
     DEFAULT_UNPRIVILEGED_USER  = local.user_id
-    SKIP_FAILING_TESTS_IN_CI   = var.skip_failing_tests
   }
   // TERM isn't set automatically in CI so we need to make sure it's always there.
   inline = ["TERM=\"$${TERM:=dumb}\" PATH=\"${var.local_boundary_dir}:$PATH\" bats -p ../../../internal/tests/cli/boundary"]


### PR DESCRIPTION
This PR updates some enos files to remove the `skip_failing_bats_tests` variable. This is additional cleanup from https://github.com/hashicorp/boundary/pull/2468, which removed `SKIP_FAILING_TESTS_IN_CI` from the bats tests. 