### PR TITLE
initial commit

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/59/01_target_ingress_egress_worker_filters.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/59/01_target_ingress_egress_worker_filters.up.sql
@@ -67,8 +67,9 @@ create trigger insert_tcp_target_filter_validate before insert on target_tcp
 -- Update views
 
 -- Replaces target_all_subtypes defined in 44/03_targets.up.sql
-drop view target_all_subtypes;
-create view target_all_subtypes as
+-- Using create or replace instead of delete/create, as views whx_credential_dimension_source and
+-- whx_host_dimension_source depend on this view and are unaffected by the worker_filter changes
+create or replace view target_all_subtypes as
 select public_id,
    project_id,
    name,


### PR DESCRIPTION
HCP migration failed with 
```
cannot drop view target_all_subtypes because other objects depend on it

"Detail":"view whx_credential_dimension_source depends on view target_all_subtypes\nview whx_host_dimension_source depends on view target_all_subtypes","Hint":"Use DROP ... CASCADE to drop the dependent objects too."
```

This copies the logic from https://github.com/hashicorp/boundary-enterprise/blob/main/internal/db/schema/migrations/enterprise/postgres/59/01_target_ingress_egress_worker_filters_ent.up.sql#L18-L23 to use create or replace instead of drop