### PR TITLE
chore(enos): Upload e2e test output

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -173,6 +173,11 @@ jobs:
           mkdir -p ./enos/terraform-plugin-cache
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
+      - name: Upload e2e tests output
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-e2e-output.zip
+          path: enos/test*.out
       - name: Retry Enos scenario
         id: run_retry
         if: steps.run.outcome == 'failure'

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -178,6 +178,7 @@ jobs:
         with:
           name: test-e2e-output.zip
           path: enos/test*.out
+          retention-days: 5
       - name: Retry Enos scenario
         id: run_retry
         if: steps.run.outcome == 'failure'

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -100,6 +100,7 @@ locals {
   vault_addr               = var.vault_addr != "" ? "http://${var.vault_addr}:8200" : ""
   aws_host_set_ips1        = jsonencode(var.aws_host_set_ips1)
   aws_host_set_ips2        = jsonencode(var.aws_host_set_ips2)
+  package_name             = reverse(split("/", var.test_package))[0]
 }
 
 resource "enos_local_exec" "run_e2e_test" {
@@ -122,7 +123,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_AWS_HOST_SET_IPS2         = local.aws_host_set_ips2
   }
 
-  inline = ["PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json | tparse -follow -format plain"]
+  inline = ["PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json | tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.out"]
 }
 
 output "test_results" {


### PR DESCRIPTION
This PR updates the e2e test suite to upload its `go test` log as a GitHub action artifact. This helps ensure that tests ran successfully (enos does not print out the `go test` output on a success). It also serves to more easily grab all of the output when tests fail. 

![Screen Shot 2023-01-31 at 12 17 56 PM](https://user-images.githubusercontent.com/2474253/215834998-944cf19c-41c0-416b-90d4-8e59309d3ab4.png)

The zip file contains a text file for each enos scenario
```
❯ ls -al
total 72
drwx------@  6 mycow  staff    192 Jan 31 11:12 .
drwx------@ 34 mycow  staff   1088 Jan 31 11:53 ..
-rw-rw-r--@  1 mycow  staff   2901 Jan 31  2023 test-e2e-aws.out
-rw-rw-r--@  1 mycow  staff   8041 Jan 31  2023 test-e2e-database.out
-rw-rw-r--@  1 mycow  staff  15858 Jan 31  2023 test-e2e-static.out
-rw-rw-r--@  1 mycow  staff   4522 Jan 31  2023 test-e2e-static_with_vault.out
```

```
❯ more test-e2e-static.out
=== RUN   TestCliBytesUpDownEmpty
    scope.go:57: Created Org Id: o_8LYFz8V6Sa
    scope.go:80: Created Project Id: p_bECZf6c0PP
    host.go:82: Created Host Catalog: hcst_a9s3yGeove
    host.go:102: Created Host Set: hsst_IKdA2NNJN9
    host.go:124: Created Host: hst_NpQdjaHkBg
    target.go:59: Created Target: ttcp_1GVeFQ6wpk
    session.go:20: Waiting for session to appear...
    bytes_up_down_empty_test.go:44: Starting session...
    session.go:43: Found 1 session(s)
    bytes_up_down_empty_test.go:71: Waiting for bytes_up/bytes_down to be greater than 0...
    bytes_up_down_empty_test.go:82: bytes_up: 0, bytes_down: 0
    bytes_up_down_empty_test.go:82: bytes_up: 2721, bytes_down: 3589
    ...
```