### PR TITLE
fix(vault): Only persist revokable credentials

### DIFF
--- a/internal/credential/vault/private_library.go
+++ b/internal/credential/vault/private_library.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/boundary/internal/credential"
 	"github.com/hashicorp/boundary/internal/credential/vault/internal/sshprivatekey"
 	"github.com/hashicorp/boundary/internal/credential/vault/internal/usernamepassword"
+	"github.com/hashicorp/boundary/internal/db/sentinel"
 	"github.com/hashicorp/boundary/internal/db/timestamp"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/kms"
@@ -46,6 +47,7 @@ func (bc *baseCred) Library() credential.Library   { return bc.lib }
 func (bc *baseCred) Purpose() credential.Purpose   { return bc.lib.GetPurpose() }
 func (bc *baseCred) getExpiration() time.Duration  { return bc.expiration }
 func (bc *baseCred) getCredential() *Credential    { return bc.Credential }
+func (bc *baseCred) isRevokable() bool             { return bc.ExternalId != sentinel.ExternalIdNone }
 
 // convert converts bc to a specific credential type if bc is not
 // UnspecifiedType.
@@ -289,6 +291,7 @@ type dynamicCred interface {
 	credential.Dynamic
 	getExpiration() time.Duration
 	getCredential() *Credential
+	isRevokable() bool
 }
 
 // retrieveCredential retrieves a dynamic credential from Vault for the


### PR DESCRIPTION
When issuing credentials from vault credential libraries, only persist
to the `credential_vault_credential` table if it is revokable. A
credential that is revokable has a valid lease id that can be used to
revoke the lease in vault. If the credential is not revokable it is 
also not renewable since renewing also requires a lease id.

Note that previously we would persist to this table with a sentinel
value for the external id (aka the lease id), and a status of
"unknown". This meant that row was (correctly) ignored by the renewal
and revoke job.

See: https://developer.hashicorp.com/vault/docs/concepts/lease