### PR TITLE
chore: Update deprecated set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         # version, because "goenv" can react to it automatically.
         run: |
           echo "Building with Go $(cat .go-version)"
-          echo "::set-output name=go-version::$(cat .go-version)"
+          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
@@ -44,8 +44,8 @@ jobs:
       - name: Determine Go cache paths
         id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Set up Go modules cache
         uses: actions/cache@v3
         with:
@@ -60,16 +60,16 @@ jobs:
         # Run make edition twice to ensure that extra go output isn't included
         run: |
           make edition
-          echo "::set-output name=product-edition::$(make edition)"
+          echo "product-edition=$(make edition)" >> $GITHUB_OUTPUT
       - name: Determine minor product version
         id: get-product-minor-version
         run: |
           VERSION=${{ needs.set-product-version.outputs.product-version }}
           MINOR_VERSION=$(echo $VERSION | cut -d. -f-2)
-          echo "::set-output name=product-minor-version::$MINOR_VERSION"
+          echo "product-minor-version=$MINOR_VERSION" >> $GITHUB_OUTPUT
 
   verify-product-metadata:
-    needs: 
+    needs:
     - set-product-version
     - product-metadata
     runs-on: ubuntu-latest
@@ -134,8 +134,8 @@ jobs:
       - name: Determine Go cache paths
         id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Set up Go modules cache
         uses: actions/cache@v3
         with:
@@ -149,7 +149,7 @@ jobs:
         run: git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com".insteadOf "https://github.com"
       - name: Determine SHA
         id: set-sha
-        run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
+        run: echo "sha=$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
       - name: Download UI artifact
         uses: dawidd6/action-download-artifact@v2
         with:
@@ -207,8 +207,8 @@ jobs:
       - name: Determine Go cache paths
         id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Set up Go modules cache
         uses: actions/cache@v3
         with:
@@ -220,7 +220,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Determine SHA
         id: set-sha
-        run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
+        run: echo "sha=$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
       - name: Download UI artifact
         uses: dawidd6/action-download-artifact@v2
         with:
@@ -305,8 +305,8 @@ jobs:
       - name: Determine Go cache paths
         id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Set up Go modules cache
         uses: actions/cache@v3
         with:
@@ -318,7 +318,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Determine SHA
         id: set-sha
-        run: echo "::set-output name=sha::$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)"
+        run: echo "sha=$(head -n1 internal/ui/VERSION | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
       - name: Download UI artifact
         uses: dawidd6/action-download-artifact@v2
         with:

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -61,7 +61,7 @@ jobs:
           echo "trusted-key ${{ secrets.ENOS_GPG_UID }}" >> ~/.gnupg/gpg.conf
           cat ~/.gnupg/gpg.conf
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -25,7 +25,7 @@ jobs:
         else
           echo "Actor ${{ github.actor }} is not a ${TEAM} team member"
         fi
-        echo "::set-output name=role::${ROLE}"
+        echo "role=${ROLE}" >> $GITHUB_OUTPUT
       env:
         GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
 
@@ -41,9 +41,9 @@ jobs:
       id: set-ticket-type
       run: |
         if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-          echo "::set-output name=type::PR"
+          echo "type=PR" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=type::ISS"
+          echo "type=ISS" >> $GITHUB_OUTPUT
         fi
 
     - name: Create ticket

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,7 +15,7 @@ jobs:
         # version, because "goenv" can react to it automatically.
         run: |
           echo "Building with Go $(cat .go-version)"
-          echo "::set-output name=go-version::$(cat .go-version)"
+          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Set up Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
This PR updates some GitHub action workflows because of an upcoming deprecation of the `set-output` command. We were seeing warnings here: https://github.com/hashicorp/boundary/actions/runs/4060061351
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

A number of warnings have been addressed, going from 89 to 9. The remaining warnings will require some updates to `hashicorp/actions-docker-build` ~and `hashicorp/action-setup-enos`~.