### PR TITLE
Handle Invalid Vault Paths in SSH Signed Certs retrieveCredential

### DIFF
--- a/internal/credential/vault/private_library_test.go
+++ b/internal/credential/vault/private_library_test.go
@@ -1333,15 +1333,6 @@ func TestRepository_sshCertIssuingCredentialLibrary_retrieveCredential(t *testin
 			vaulthPath: "ssh/issue/boundary",
 			opts:       []Option{WithKeyType(KeyTypeEcdsa), WithKeyBits(384), WithExtensions("{ \"permit-port-forwarding\": \"\" }")},
 		},
-		{
-			name:     "invalid vault path returns correct error",
-			username: "username-11-palindrome",
-			expected: map[string]string{
-				"error": "vault path was not in an expected format. expected path containing \"sign\" or \"issue\"",
-			},
-			vaulthPath: "ssh/biscuit/boundary",
-			opts:       []Option{WithKeyType(KeyTypeEd25519)},
-		},
 	}
 
 	for _, tt := range tests {

--- a/internal/credential/vault/private_library_test.go
+++ b/internal/credential/vault/private_library_test.go
@@ -1333,6 +1333,15 @@ func TestRepository_sshCertIssuingCredentialLibrary_retrieveCredential(t *testin
 			vaulthPath: "ssh/issue/boundary",
 			opts:       []Option{WithKeyType(KeyTypeEcdsa), WithKeyBits(384), WithExtensions("{ \"permit-port-forwarding\": \"\" }")},
 		},
+		{
+			name:     "invalid vault path returns correct error",
+			username: "username-11-palindrome",
+			expected: map[string]string{
+				"error": "vault path was not in an expected format. expected path containing \"sign\" or \"issue\"",
+			},
+			vaulthPath: "ssh/biscuit/boundary",
+			opts:       []Option{WithKeyType(KeyTypeEd25519)},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
fixes issue where an invalid vault path (one not in the format of `.../.../(sign|issue)/username`) would cause a panic rather than handle the error correctly