### PR TITLE
Update README.md

### DIFF
--- a/.release/docker/README.md
+++ b/.release/docker/README.md
@@ -49,7 +49,7 @@ If you're starting with a new, unused postgres instance, initialize the database
 docker run \
   --network host \
   -e 'BOUNDARY_POSTGRES_URL=postgresql://postgres:postgres@0.0.0.0:5432/postgres?sslmode=disable' \
-  boundary database init -config /boundary/config.hcl
+  hashicorp/boundary database init -config /boundary/config.hcl
 ```
 
 If you want to run this with your own config.hcl (assuming config.hcl is located at `$(pwd)/config.hcl`):
@@ -59,7 +59,7 @@ docker run \
   --network host \
   -e 'BOUNDARY_POSTGRES_URL=postgresql://postgres:postgres@0.0.0.0:5432/postgres?sslmode=disable' \
   -v "$(pwd)":/boundary/ \
-  boundary database init -config /boundary/config.hcl
+  hashicorp/boundary database init -config /boundary/config.hcl
 ```
 
 ### Server
@@ -72,7 +72,7 @@ docker run \
   -p 9201:9201 \
   -p 9202:9202 \
   -e 'BOUNDARY_POSTGRES_URL=postgresql://postgres:postgres@0.0.0.0:5432/postgres?sslmode=disable' \
-  boundary
+  hashicorp/boundary
 ```
 
 Start a Boundary server using your own `config.hcl`, assuming it's located at `$(pwd)/config.hcl`:
@@ -85,5 +85,5 @@ docker run \
   -p 9202:9202 \
   -v "$(pwd)":/boundary/ \
   -e 'BOUNDARY_POSTGRES_URL=postgresql://postgres:postgres@0.0.0.0:5432/postgres?sslmode=disable' \
-  boundary
+  hashicorp/boundary
 ```


### PR DESCRIPTION
Fix image names in Docker run commands to include `hashicorp/` prefix.  Without this we see the following errors:

```sh
$ docker run \
  --network host \
  -e 'BOUNDARY_POSTGRES_URL=postgresql://postgres:postgres@0.0.0.0:5432/postgres?sslmode=disable' \
  boundary database init -config /boundary/config.hcl

Unable to find image 'boundary:latest' locally
docker: Error response from daemon: pull access denied for boundary, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```