### PR TITLE
fix(handlers): return error when updating json cred w/ empty obj

### DIFF
--- a/internal/daemon/controller/handlers/credentials/credential_service.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service.go
@@ -849,11 +849,14 @@ func validateUpdateRequest(req *pbs.UpdateCredentialRequest) error {
 				if err != nil {
 					badFields[objectField] = "Unable to parse given json value"
 				}
-				if !handlers.MaskContainsSubString(req.GetUpdateMask().GetPaths(), objectField) || len(object.AsMap()) <= 0 {
+				if !handlers.MaskContainsPrefix(req.GetUpdateMask().GetPaths(), objectField) {
+					badFields[objectField] = "This is a required field and cannot be set to empty."
+				}
+				if len(object.AsMap()) == 0 {
 					badFields[objectField] = "This is a required field and cannot be set to empty."
 				}
 			}
-			if handlers.MaskContainsSubString(req.GetUpdateMask().GetPaths(), objectField) && object == nil {
+			if handlers.MaskContainsPrefix(req.GetUpdateMask().GetPaths(), objectField) && object == nil {
 				badFields[objectField] = "This is a required field and cannot be set to empty."
 			}
 

--- a/internal/daemon/controller/handlers/credentials/credential_service.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service.go
@@ -845,15 +845,15 @@ func validateUpdateRequest(req *pbs.UpdateCredentialRequest) error {
 		case credential.JsonSubtype:
 			object := req.GetItem().GetJsonAttributes().GetObject()
 			if object != nil {
-				objectBytes, err := json.Marshal(object.AsMap())
+				_, err := json.Marshal(object.AsMap())
 				if err != nil {
 					badFields[objectField] = "Unable to parse given json value"
 				}
-				if handlers.MaskContains(req.GetUpdateMask().GetPaths(), objectField) && len(objectBytes) <= 0 {
+				if !handlers.MaskContainsSubString(req.GetUpdateMask().GetPaths(), objectField) || len(object.AsMap()) <= 0 {
 					badFields[objectField] = "This is a required field and cannot be set to empty."
 				}
 			}
-			if handlers.MaskContains(req.GetUpdateMask().GetPaths(), objectField) && object == nil {
+			if handlers.MaskContainsSubString(req.GetUpdateMask().GetPaths(), objectField) && object == nil {
 				badFields[objectField] = "This is a required field and cannot be set to empty."
 			}
 

--- a/internal/daemon/controller/handlers/credentials/credential_service_test.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service_test.go
@@ -1148,6 +1148,48 @@ func TestUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "update-empty-json",
+			req: &pbs.UpdateCredentialRequest{
+				UpdateMask: fieldmask(),
+				Item: &pb.Credential{
+					Attrs: &pb.Credential_JsonAttributes{
+						JsonAttributes: &pb.JsonAttributes{
+							Object: &structpb.Struct{},
+						},
+					},
+				},
+			},
+			expErrorContains: "This is a required field and cannot be set to empty",
+		},
+		{
+			name: "update-empty-object-json",
+			req: &pbs.UpdateCredentialRequest{
+				UpdateMask: fieldmask("attributes.object.password"),
+				Item: &pb.Credential{
+					Attrs: &pb.Credential_JsonAttributes{
+						JsonAttributes: &pb.JsonAttributes{
+							Object: &structpb.Struct{},
+						},
+					},
+				},
+			},
+			expErrorContains: "This is a required field and cannot be set to empty",
+		},
+		{
+			name: "update-empty-mask-json",
+			req: &pbs.UpdateCredentialRequest{
+				UpdateMask: fieldmask(),
+				Item: &pb.Credential{
+					Attrs: &pb.Credential_JsonAttributes{
+						JsonAttributes: &pb.JsonAttributes{
+							Object: secondSecret,
+						},
+					},
+				},
+			},
+			expErrorContains: "This is a required field and cannot be set to empty",
+		},
+		{
 			name: "update-spk-with-bad-passphrase",
 			req: &pbs.UpdateCredentialRequest{
 				UpdateMask: fieldmask("attributes.private_key", "attributes.private_key_passphrase"),

--- a/internal/daemon/controller/handlers/mask_manager.go
+++ b/internal/daemon/controller/handlers/mask_manager.go
@@ -118,7 +118,7 @@ func MaskContains(paths []string, s string) bool {
 	return false
 }
 
-func MaskContainsSubString(paths []string, s string) bool {
+func MaskContainsPrefix(paths []string, s string) bool {
 	for _, p := range paths {
 		if strings.Contains(p, s) {
 			return true

--- a/internal/daemon/controller/handlers/mask_manager.go
+++ b/internal/daemon/controller/handlers/mask_manager.go
@@ -117,3 +117,12 @@ func MaskContains(paths []string, s string) bool {
 	}
 	return false
 }
+
+func MaskContainsSubString(paths []string, s string) bool {
+	for _, p := range paths {
+		if strings.Contains(p, s) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
### Summary:

The API was returning a 200 when updating a json credential with an empty object secret. No changes were applied to the credential. The expected behavior is to return an error to the user that the object field cannot be empty. This bug only appears in the API, not the CLI.

### Steps to Reproduce Bug:

1. Launch `boundary dev`
2. Authenticate
```
curl \
  --header "Content-Type: application/json" \
  --request POST \
  --data '{"attributes":{"login_name": "admin","password": "password"},"type": "token"}' \
  http://localhost:9200/v1/auth-methods/ampw_1234567890:authenticate | export TOKEN=$(jq -r '.attributes.token')
```
3. Create a Static Credential Store
```
curl \
  --header "Content-Type: application/json" \
  --header "Authorization: Bearer $TOKEN" \
  --request POST \
  --data '{"scope_id":"p_1234567890","type": "static"}' \
  http://localhost:9200/v1/credential-stores | export STORE_ID=$(jq -r '.id')
```
4. Create a JSON Credential. Save the output of the resource id.
```
curl \
  --header "Content-Type: application/json" \
  --header "Authorization: Bearer $TOKEN" \
  --request POST \
  --data "{\"credential_store_id\":\"$STORE_ID\",\"type\":\"json\",\"attributes\":{\"object\":{\"test\":\"value\"}}}" \
  http://localhost:9200/v1/credentials | jq
```
5. Update JSON Credential w/ Empty Object
```
curl \
  --header "Content-Type: application/json" \
  --header "Authorization: Bearer $TOKEN" \
  --request PATCH \
  --data '{"credential_store_id":"csst_CNSHyoQx8u","version":1,"description":"test update","type":"json","attributes":{"object":{}}}' \
  http://localhost:9200/v1/credentials/credjson_tq7j9hiaYz
```

### Fix:

Expected return response in step 5:
```
{
  "kind": "InvalidArgument",
  "message": "Error in provided request.",
  "details": {
    "request_fields": [
      {
        "name": "attributes.object",
        "description": "This is a required field and cannot be set to empty."
      }
    ]
  }
}
```