### PR TITLE
docs: Remove SSH creds from 0.12 branch

### DIFF
--- a/website/content/docs/concepts/domain-model/credential-libraries.mdx
+++ b/website/content/docs/concepts/domain-model/credential-libraries.mdx
@@ -17,9 +17,9 @@ A credential library has the following configurable attributes:
 
 - `description` - (optional) A user-defined description of the credential library for identification purposes.
 
-### Vault generic credential library attributes
+### Vault credential library attributes
 
-The generic Vault credential library has the following additional attributes:
+The Vault credential library has the following additional attributes:
 
 - `path` - (required) The path in Vault to request credentials from.
 
@@ -29,52 +29,6 @@ The default value is `GET`.
 
 - `http_request_body` - (optional) The body of the HTTP request the library sends to Vault when requesting credentials.
 Only valid if `http_method` is set to `POST`.
-
-### Vault SSH certificate credential library attributes
-
-As of Boundary 0.12.0, you can configure SSH credential injection using [Vault's SSH secrets engine](/vault/docs/secrets/ssh) to create the SSH certificate credentials.
-SSH certificate-based authentication extends key-based authentication using digital signatures.
-Your users' authenticity is determined by a certificate signed by a trusted certificate authority (CA).
-You can configure Vault's SSH secrets engine to act as the CA.
-
-SSH certificates let you specify how long they are valid for, who can gain access to a target host, how users can log in, and what commands can be used on the target machine.
-Unlike SSH key pairs, SSH certificates are short-lived and self-destructive.
-
-A Vault SSH certificate credential library has the following additional attributes:
-
-<Note>
-
-The certificate is issued for the entire session, so if the `ttl` value is shorter than the target's `session_max_seconds` value, later connections may fail.
-To prevent failures, you should ensure that the `ttl` value is equal to or longer than the target's `session_max_seconds`.
-Alternatively, you could set the `session_connection_limit` to `1` for any targets that use the credential library.
-
-</Note>
-
-- `path` - (required) The path in Vault to request credentials from.
-
-- `username` - (required) The username to use with the SSH certificate.
-You can create a template for this value using [Vault credential library parameter templating](#vault-credential-library-parameter-templating).
-
-- `key_type` - (optional) The type of key to use for the generated SSH private key.
-The key type is either `ed25519`, `ecdsa`, or `rsa`.
-The default key type is `ed25519`.
-
-- `key_bits` - (optional) The number of bits used to generate the SSH private key.
-The number of bits depends on the `key_type` value you select:
-  - For an `ed25519` key type, you should not set the `key_bits` value.
-  - For an `ecdsa` key type, you can select either `256`, `384`, or `521`.
-  - For an `rsa` key type, you can select either `2048`, `3072`, or `4096`.
-
-- `ttl` - (optional) The SSH certificate's time-to-live (TTL).
-
-- `key_id` - (optional) The key ID for the created SSH certificate.
-
-- `critical_options` - (optional) Any critical options that the certificate should be signed for.
-For more information, refer to the [list of critical options](https://github.com/openssh/openssh-portable/blob/5f93c4836527d9fda05de8944a1c7b4a205080c7/PROTOCOL.certkeys#L221-L269) supported by OpenSSH.
-
-- `extensions` - (optional) Any extensions that the certificate should be signed for.
-For more information, refer to the [list of extensions](https://github.com/openssh/openssh-portable/blob/5f93c4836527d9fda05de8944a1c7b4a205080c7/PROTOCOL.certkeys#L270-L319) supported by OpenSSH.
-Note that the `permit-pty` value should be set for an interactive shell to function properly.
 
 ### Vault credential library parameter templating
 

--- a/website/content/docs/concepts/domain-model/credentials.mdx
+++ b/website/content/docs/concepts/domain-model/credentials.mdx
@@ -35,14 +35,6 @@ The following credential types are supported in Boundary:
 
 - `private_key` - The private key field associated with the credential.
 
-### SSH certificate
-
-`ssh_certificate` credentials contain the following fields:
-
-- `username` -  The username field associated with the credential.
-
-- `ssh_certificate` - The SSH certificate associated with the credential.
-
 ### JSON
 
 As of Boundary 0.11.0, you can provide credentials using a JSON blob.


### PR DESCRIPTION
The Boundary OSS binaries will be available to the public on Feb 8, but HCP features will not be available until the following week. I documented the HCP-only SSH credential update in the same PR (#2871) with the JSON credential update, and merged the pull request to `main` and `release/0.12.x` branches. The SSH credential injection information needs to be removed from the `release/0.12.x` branch, so that it does not go live on the 8th.

This PR removes the SSH credential injection docs from the `release/0.12.x` branch. We will have to create a new PR or revert this PR to add this content back to the `release/0.12.x` and `stable-website` branches, when the HCP 0.12.0 release goes live.