### PR TITLE
docs: Add JSON credentials blob example

### DIFF
--- a/website/content/docs/concepts/domain-model/credentials.mdx
+++ b/website/content/docs/concepts/domain-model/credentials.mdx
@@ -46,8 +46,28 @@ The following credential types are supported in Boundary:
 ### JSON
 
 As of Boundary 0.11.0, you can provide credentials using a JSON blob.
-There is no required structure for the JSON blob, other than it must be a key value map.
 JSON credentials are only brokered to users that connect to machines.
+There is no required structure for the JSON blob, other than it must be a key value map.
+Refer to the example below:
+
+<CodeBlockConfig heading="JSON credentials blob example">
+
+```JSON
+{
+  "type": "service_account",
+  "project_id": "",
+  "private_key_id": "",
+  "private_key": "-----BEGIN PRIVATE KEY----------END PRIVATE KEY-----\n",
+  "client_email": "",
+  "client_id": "",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": ""
+}
+```
+
+</CodeBlockConfig>
 
 ## Referenced by
 


### PR DESCRIPTION
We merged an update to add JSON credentials to the credentials documentation in PR #2871 . In discussions afterwards, we decided it might be nice to add an example of the JSON blob. This pull request adds that example of the JSON blob structure to the JSON credentials documentation.

[View the update in the preview deployment here](https://boundary-bmvgh7hq3-hashicorp.vercel.app/boundary/docs/concepts/domain-model/credentials#json).