### PR TITLE
fix(handler): return targetId as hostId for cli edge case support

### DIFF
--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -40,6 +40,7 @@ import (
 	"github.com/hashicorp/boundary/internal/types/subtypes"
 	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/scopes"
 	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/targets"
+	fm "github.com/hashicorp/boundary/version"
 	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/mr-tron/base58"
@@ -982,6 +983,13 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 		if err != nil {
 			return nil, errors.Wrap(ctx, err, op)
 		}
+	}
+
+	// this is an edge case issue where the hostId cannot be empty when trying to execute an ssh connection
+	// on a tcp target type. By setting the hostId to the targetId value, this will enable support of previous
+	// boundary cli versions.
+	if fm.SupportsFeature(fm.Binary, fm.ShhIntoTcpTargetAddress) && t.GetAddress() != "" {
+		hostId = t.GetPublicId()
 	}
 
 	sad := &pb.SessionAuthorizationData{

--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -988,7 +988,7 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 	// this is an edge case issue where the hostId cannot be empty when trying to execute an ssh connection
 	// on a tcp target type. By setting the hostId to the targetId value, this will enable support of previous
 	// boundary cli versions.
-	if fm.SupportsFeature(fm.Binary, fm.SshIntoTcpTargetAddress) && t.GetAddress() != "" {
+	if fm.SupportsFeature(fm.Binary, fm.UseTargetIdForHostId) && t.GetAddress() != "" {
 		hostId = t.GetPublicId()
 	}
 

--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -988,7 +988,7 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 	// this is an edge case issue where the hostId cannot be empty when trying to execute an ssh connection
 	// on a tcp target type. By setting the hostId to the targetId value, this will enable support of previous
 	// boundary cli versions.
-	if fm.SupportsFeature(fm.Binary, fm.ShhIntoTcpTargetAddress) && t.GetAddress() != "" {
+	if fm.SupportsFeature(fm.Binary, fm.SshIntoTcpTargetAddress) && t.GetAddress() != "" {
 		hostId = t.GetPublicId()
 	}
 

--- a/version/feature_manager.go
+++ b/version/feature_manager.go
@@ -28,7 +28,7 @@ const (
 	MultiHopSessionFeature
 	IncludeStatusInCli
 	CredentialLibraryVaultSubtype
-	SshIntoTcpTargetAddress
+	UseTargetIdForHostId
 )
 
 var featureMap map[Feature]MetadataConstraint
@@ -67,13 +67,11 @@ func init() {
 		Constraints: mustNewConstraints("< 0.14.0"),
 	}
 
-	/*
-		To support old CLI clients that are unaware of host-sourceless targets,
-		this feature populates the target's public id into the AuthorizeSessionResponse
-		and the SessionAuthroizationData so the CLI can properly build the ssh command 
-		when calling boundary connect ssh...
-	*/
-	featureMap[SshIntoTcpTargetAddress] = MetadataConstraint{
+	// UseTargetIdForHostId supports old CLI clients that are unaware of host-sourceless targets,
+	// this feature populates the target's public id into the AuthorizeSessionResponse
+	// and the SessionAuthroizationData so the CLI can properly build the ssh command 
+	// when calling "boundary connect ssh..."
+	featureMap[UseTargetIdForHostId] = MetadataConstraint{
 		MetaInfo:    []Metadata{OSS, HCP},
 		Constraints: mustNewConstraints("< 0.14.0"),
 	}

--- a/version/feature_manager.go
+++ b/version/feature_manager.go
@@ -28,6 +28,7 @@ const (
 	MultiHopSessionFeature
 	IncludeStatusInCli
 	CredentialLibraryVaultSubtype
+	ShhIntoTcpTargetAddress
 )
 
 var featureMap map[Feature]MetadataConstraint
@@ -63,6 +64,10 @@ func init() {
 	}
 	featureMap[CredentialLibraryVaultSubtype] = MetadataConstraint{
 		MetaInfo:    []Metadata{OSS, HCP},
+		Constraints: mustNewConstraints("< 0.14.0"),
+	}
+	featureMap[ShhIntoTcpTargetAddress] = MetadataConstraint{
+		MetaInfo: []Metadata{OSS, HCP},
 		Constraints: mustNewConstraints("< 0.14.0"),
 	}
 }

--- a/version/feature_manager.go
+++ b/version/feature_manager.go
@@ -69,7 +69,7 @@ func init() {
 
 	// UseTargetIdForHostId supports old CLI clients that are unaware of host-sourceless targets,
 	// this feature populates the target's public id into the AuthorizeSessionResponse
-	// and the SessionAuthroizationData so the CLI can properly build the ssh command 
+	// and the SessionAuthroizationData so the CLI can properly build the ssh command
 	// when calling "boundary connect ssh..."
 	featureMap[UseTargetIdForHostId] = MetadataConstraint{
 		MetaInfo:    []Metadata{OSS, HCP},

--- a/version/feature_manager.go
+++ b/version/feature_manager.go
@@ -28,7 +28,7 @@ const (
 	MultiHopSessionFeature
 	IncludeStatusInCli
 	CredentialLibraryVaultSubtype
-	ShhIntoTcpTargetAddress
+	SshIntoTcpTargetAddress
 )
 
 var featureMap map[Feature]MetadataConstraint
@@ -66,7 +66,14 @@ func init() {
 		MetaInfo:    []Metadata{OSS, HCP},
 		Constraints: mustNewConstraints("< 0.14.0"),
 	}
-	featureMap[ShhIntoTcpTargetAddress] = MetadataConstraint{
+
+	/*
+		To support old CLI clients that are unaware of host-sourceless targets,
+		this feature populates the target's public id into the AuthorizeSessionResponse
+		and the SessionAuthroizationData so the CLI can properly build the ssh command 
+		when calling boundary connect ssh...
+	*/
+	featureMap[SshIntoTcpTargetAddress] = MetadataConstraint{
 		MetaInfo:    []Metadata{OSS, HCP},
 		Constraints: mustNewConstraints("< 0.14.0"),
 	}

--- a/version/feature_manager.go
+++ b/version/feature_manager.go
@@ -67,7 +67,7 @@ func init() {
 		Constraints: mustNewConstraints("< 0.14.0"),
 	}
 	featureMap[ShhIntoTcpTargetAddress] = MetadataConstraint{
-		MetaInfo: []Metadata{OSS, HCP},
+		MetaInfo:    []Metadata{OSS, HCP},
 		Constraints: mustNewConstraints("< 0.14.0"),
 	}
 }


### PR DESCRIPTION
### Summary:

The recent feature of supporting associating a network address directly to a Target has caused a backwards compatibility issue with the older boundary binary cli. When authorizing a boundary session for a target tcp type and utilizing the ssh helper, the hostId value becomes a require value because it is used for `HostKeyAlias`

### Fix:

When authorizing a session, check if the target has a direct network address association and mock the hostId value with the targetId value. Using the targetId value as the mock value for hostId will guarantee a consistent HostKeyAlias value, which will prevent the ssh error: `Warning: Remote host identification has changed`.
