### PR TITLE
add changelog update for vendor label for linux packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   more details. ([PR](https://github.com/hashicorp/boundary/pull/2887))
 * database: Add job that automatically cleans up completed runs in the `job_run` table.
   ([PR](https://github.com/hashicorp/boundary/pull/2866))
+* core: Linux packages now have vendor label and set the default label to HashiCorp.
+  This fix is implemented for any future releases, but will not be updated for historical releases.
 
 ## 0.11.2 (2022/12/09)
 


### PR DESCRIPTION
This PR is just an update to the changelog to reflect a bug that was fixed in our [actions-packaging-linux](https://github.com/hashicorp/actions-packaging-linux) action. We received a report from a user stating that vendor labels were missing when downloading linux packages (for products that were released via CRT) We fixed this in [this PR](https://github.com/hashicorp/actions-packaging-linux/pull/14) and we added a vendor label and set the default to `HashiCorp` This will only affect future releases that go through our linux promotion pipeline -- historical releases will not have this vendor label. 