### PR TITLE
test: use `t.TempDir` to create temporary test directory

### DIFF
--- a/internal/cmd/commands/server/controller_db_swap_test.go
+++ b/internal/cmd/commands/server/controller_db_swap_test.go
@@ -83,9 +83,7 @@ where
 `
 
 func TestReloadControllerDatabase(t *testing.T) {
-	td, err := os.MkdirTemp("", "boundary-test-")
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, os.RemoveAll(td)) })
+	td := t.TempDir()
 
 	// Set the close time to something small
 	db.CloseSwappedDbDuration = 5 * time.Second
@@ -223,9 +221,7 @@ func TestReloadControllerDatabase(t *testing.T) {
 }
 
 func TestReloadControllerDatabase_InvalidNewDatabaseState(t *testing.T) {
-	td, err := os.MkdirTemp("", "boundary-test-")
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, os.RemoveAll(td)) })
+	td := t.TempDir()
 
 	// Create and migrate database A and B.
 	controllerKey := config.DevKeyGeneration()

--- a/internal/cmd/commands/server/listener_reload_test.go
+++ b/internal/cmd/commands/server/listener_reload_test.go
@@ -90,9 +90,7 @@ func TestServer_ReloadListener(t *testing.T) {
 	wd, _ := os.Getwd()
 	wd += "/test-fixtures/reload/"
 
-	td, err := os.MkdirTemp("", "boundary-test-")
-	require.NoError(err)
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	controllerKey := config.DevKeyGeneration()
 	workerAuthKey := config.DevKeyGeneration()

--- a/internal/cmd/commands/server/worker_initial_upstreams_reload_test.go
+++ b/internal/cmd/commands/server/worker_initial_upstreams_reload_test.go
@@ -7,7 +7,6 @@ package server
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -64,9 +63,7 @@ func TestServer_ReloadInitialUpstreams(t *testing.T) {
 	defer testController2.Shutdown()
 	require.NotEqual(testController.Config().DatabaseUrl, testController2.Config().DatabaseUrl)
 
-	authStoragePath, err := os.MkdirTemp("", "")
-	require.NoError(err)
-	t.Cleanup(func() { os.RemoveAll(authStoragePath) })
+	authStoragePath := t.TempDir()
 
 	wg := &sync.WaitGroup{}
 

--- a/internal/cmd/commands/server/worker_tags_reload_test.go
+++ b/internal/cmd/commands/server/worker_tags_reload_test.go
@@ -17,7 +17,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -81,9 +80,7 @@ func TestServer_ReloadWorkerTags(t *testing.T) {
 	testController := controller.NewTestController(t, controller.WithWorkerAuthKms(workerAuthWrapper), controller.WithRootKms(rootWrapper), controller.WithRecoveryKms(recoveryWrapper))
 	defer testController.Shutdown()
 
-	authStoragePath, err := os.MkdirTemp("", "")
-	require.NoError(err)
-	t.Cleanup(func() { os.RemoveAll(authStoragePath) })
+	authStoragePath := t.TempDir()
 
 	wg := &sync.WaitGroup{}
 

--- a/internal/daemon/worker/worker_test.go
+++ b/internal/daemon/worker/worker_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"os"
 	"testing"
 	"time"
 
@@ -153,9 +152,7 @@ func TestSetupWorkerAuthStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	// First, just test the key ID is populated
-	tmpDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, os.RemoveAll(tmpDir)) })
+	tmpDir := t.TempDir()
 	tw := NewTestWorker(t, &TestWorkerOpts{
 		WorkerAuthStorageKms:  ts,
 		WorkerAuthStoragePath: tmpDir,
@@ -170,9 +167,7 @@ func TestSetupWorkerAuthStorage(t *testing.T) {
 	assert.Equal(t, keyId, wKeyId)
 
 	// Create a fresh persistent dir for the following tests
-	tmpDir, err = os.MkdirTemp("", "")
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, os.RemoveAll(tmpDir)) })
+	tmpDir = t.TempDir()
 
 	// Get an initial set of authorized node credentials
 	initStorage, err := nodeefile.New(ctx)


### PR DESCRIPTION
This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `t.TempDir` function from the `testing` package to create temporary directory. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	t.Cleanup(func() { require.NoError(t, os.RemoveAll(td)) })

	// now
	tmpDir := t.TempDir()
}
```