### PR TITLE
[QT-400] Update ci boundary-enterprise hc-service-uri to include the schedule workflow trigger

### DIFF
--- a/enos/ci/service-user-iam/github-actions-doormat.tf
+++ b/enos/ci/service-user-iam/github-actions-doormat.tf
@@ -6,8 +6,8 @@ locals {
   // "Github Actions Doormat repositories and qualifiers"
   // see: https://docs.prod.secops.hashicorp.services/doormat/gha/
   github_actions_doormat_rwqs = {
-    boundary-enterprise = "github.com/hashicorp/boundary-enterprise@event_name=workflow_dispatch+push:ref=refs/heads/main+refs/heads/release/0.8.x+refs/heads/release/0.10.x+refs/heads/release/0.11.x///event_name=pull_request:base_ref=main+release/0.8.x+release/0.10.x+release/0.11.x",
-    boundary-hcp        = "github.com/hashicorp/boundary-hcp@event_name=workflow_dispatch+push:ref=refs/heads/main+refs/heads/release/0.8.x+refs/heads/release/0.10.x+refs/heads/release/0.11.x///event_name=pull_request:base_ref=main+release/0.8.x+release/0.10.x+release/0.11.x",
+    boundary-enterprise = "github.com/hashicorp/boundary-enterprise@event_name=schedule///event_name=workflow_dispatch+push:ref=refs/heads/main+refs/heads/release/0.8.x+refs/heads/release/0.10.x+refs/heads/release/0.11.x///event_name=pull_request:base_ref=main+release/0.8.x+release/0.10.x+release/0.11.x",
+    boundary-hcp        = "github.com/hashicorp/boundary-hcp@event_name=schedule///event_name=workflow_dispatch+push:ref=refs/heads/main+refs/heads/release/0.8.x+refs/heads/release/0.10.x+refs/heads/release/0.11.x///event_name=pull_request:base_ref=main+release/0.8.x+release/0.10.x+release/0.11.x",
   }
   github_actions_doormat_assume_policy_name = "AssumeServiceUserPolicy"
   boundary_gha_iam_role_name                = "${var.repository}-GHA-ci"


### PR DESCRIPTION
Since the `test_ci_cleanup` workflow will be running on a nightly basis via a schedule workflow trigger, the `hc-service-uri` needs to be updated to add the `event_type` `schedule` in order to ensure the service user is permitted to assume the Doormat role for scheduled workflow runs.