### PR TITLE
test(e2e): Add test for `boundary version`

### DIFF
--- a/testing/internal/e2e/tests/static/version_test.go
+++ b/testing/internal/e2e/tests/static/version_test.go
@@ -29,10 +29,10 @@ func TestCliVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	parts := strings.Split(versionResult.Version, ".")
-	assert.Equal(t, 3, len(parts), "Incorrect number of parts in version (%s). EXPECTED: 3, ACTUAL: %d", versionResult.Version, len(parts))
+	assert.Equal(t, 3, len(parts), "Incorrect number of parts in version %q. EXPECTED: 3, ACTUAL: %d", versionResult.Version, len(parts))
 
 	for _, v := range parts {
 		_, err := strconv.Atoi(v)
-		require.NoError(t, err, "Invalid value in version (%s). EXPECTED: Number, ACTUAL: %s", versionResult.Version, v)
+		assert.NoError(t, err, "Invalid value in version %q. EXPECTED: Number, ACTUAL: %s", versionResult.Version, v)
 	}
 }

--- a/testing/internal/e2e/tests/static/version_test.go
+++ b/testing/internal/e2e/tests/static/version_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package static_test
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCliVersion validates the output from `boundary version`
+func TestCliVersion(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+
+	ctx := context.Background()
+	output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("version", "-format", "json"))
+	require.NoError(t, output.Err, string(output.Stderr))
+
+	var versionResult version.Info
+	err := json.Unmarshal(output.Stdout, &versionResult)
+	require.NoError(t, err)
+
+	parts := strings.Split(versionResult.Version, ".")
+	assert.Equal(t, 3, len(parts), "Incorrect number of parts in version (%s). EXPECTED: 3, ACTUAL: %d", versionResult.Version, len(parts))
+
+	for _, v := range parts {
+		_, err := strconv.Atoi(v)
+		require.NoError(t, err, "Invalid value in version (%s). EXPECTED: Number, ACTUAL: %s", versionResult.Version, v)
+	}
+}


### PR DESCRIPTION
During 0.12.0 testing, there was an issue observed where some additional characters were added to the `boundary version` output. This PR adds an e2e test to validate that output.

Here are some examples where the test would fail.
```
❯ go test -v github.com/hashicorp/boundary/testing/internal/e2e/tests/static -count=1 -run TestCliVersion
=== RUN   TestCliVersion
    version_test.go:30: [0a 12 0+oss]
    version_test.go:35: 
                Error Trace:    /Users/mycow/Developer/boundary/testing/internal/e2e/tests/static/version_test.go:35
                Error:          Received unexpected error:
                                strconv.Atoi: parsing "0a": invalid syntax
                Test:           TestCliVersion
                Messages:       Invalid value in version (0a.12.0+oss). EXPECTED: Number, ACTUAL: 0a
--- FAIL: TestCliVersion (0.10s)
```

```
❯ go test -v github.com/hashicorp/boundary/testing/internal/e2e/tests/static -count=1 -run TestCliVersion
=== RUN   TestCliVersion
    version_test.go:30: [0 12 0+oss]
    version_test.go:35: 
                Error Trace:    /Users/mycow/Developer/boundary/testing/internal/e2e/tests/static/version_test.go:35
                Error:          Received unexpected error:
                                strconv.Atoi: parsing "0+oss": invalid syntax
                Test:           TestCliVersion
                Messages:       Invalid value in version (0.12.0+oss). EXPECTED: Number, ACTUAL: 0+oss
--- FAIL: TestCliVersion (0.10s)
```

```
❯ go test -v github.com/hashicorp/boundary/testing/internal/e2e/tests/static -count=1 -run TestCliVersion
=== RUN   TestCliVersion
    version_test.go:30: [0 12 0 1]
    version_test.go:31: 
                Error Trace:    /Users/mycow/Developer/boundary/testing/internal/e2e/tests/static/version_test.go:31
                Error:          Not equal: 
                                expected: 3
                                actual  : 4
                Test:           TestCliVersion
                Messages:       Incorrect number of parts in version (0.12.0.1). EXPECTED: 3, ACTUAL: 4
--- FAIL: TestCliVersion (0.11s)
```