### PR TITLE
[QT-400] Fix doormat hc-service-uri for ci bootstrap ci doormat role

### DIFF
--- a/enos/ci/service-user-iam/outputs.tf
+++ b/enos/ci/service-user-iam/outputs.tf
@@ -1,22 +1,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-output "ci_role" {
-  value = local.is_ent ? {
-    name = aws_iam_role.github_actions_doormat_role[0].name
-    arn  = aws_iam_role.github_actions_doormat_role[0].arn
-    } : {
-    name = aws_iam_role.role[0].name
-    arn  = aws_iam_role.role[0].arn
-  }
-}
-
-output "ci_role_policy" {
-  value = local.is_ent ? {
-    name   = local.github_actions_doormat_assume_policy_name
-    policy = data.aws_iam_policy_document.github_actions_doormat_assume[0].json
-    } : {
-    name   = aws_iam_role_policy.role_policy[0].name
+output "ci_roles" {
+  value = local.is_ent ? [for role in aws_iam_role.github_actions_doormat_role : {
+    name = role.name
+    arn  = role.arn
+    policy = [for policy in role.inline_policy : {
+      name   = policy.name
+      policy = jsondecode(policy.policy)
+    }][0]
+    }] : [{
+    name   = aws_iam_role.role[0].name
+    arn    = aws_iam_role.role[0].arn
     policy = aws_iam_role_policy.role_policy[0].policy
-  }
+  }]
 }


### PR DESCRIPTION
When using the doormat GHA it is required to set a tag named `hc-service-uri` on the role the doormat user is to assume. When the `ci-test-cleanup` scheduled workflow was added, we needed to update the tag to include the new event type. Unfortunately there is a 256 character limit on the size of an AWS tag, therefore we needed to create a new role to support the new workflow. With this PR, I modify the doormat role and policy to extract a second role and policy that is tailored to be used with the scheduled cleanup workflow.