### PR TITLE
chore: Add slack notifications when e2e or bats tests fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -499,3 +499,14 @@ jobs:
         if: success() || failure()
         run: |
           make -C internal/tests/cli test-vault-down
+      - name: Send Slack message
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+        with:
+          channel-id: ${{ secrets.SLACK_BOUNDARY_TEST_BOT_CHANNEL_ID }}
+          payload: |
+            {
+              "text": ":x: bats tests failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Branch:* ${{ github.event.ref }}\n*SHA:* <${{github.event.pull_request.html_url || github.event.head_commit.url }}|${{ github.event.after }}>"
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_TEST_BOT_TOKEN }}

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}
+    outputs:
+      status: ${{ steps.enos-status.outputs.status }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -135,8 +137,6 @@ jobs:
           enos scenario exec --chdir ./enos ${{ matrix.filter }} --cmd "version"
       - name: Run Enos scenario
         id: run
-        # Continue once and retry
-        continue-on-error: true
         env:
           ENOS_VAR_aws_region: us-east-1
           ENOS_VAR_aws_ssh_keypair_name: enos-ci-ssh-key
@@ -155,20 +155,10 @@ jobs:
           name: test-e2e-output.zip
           path: enos/test*.out
           retention-days: 5
-      - name: Retry Enos scenario
-        id: run_retry
-        if: steps.run.outcome == 'failure'
-        env:
-          ENOS_VAR_aws_region: us-east-1
-          ENOS_VAR_aws_ssh_keypair_name: enos-ci-ssh-key
-          ENOS_VAR_aws_ssh_private_key_path: ./support/private_key.pem
-          ENOS_VAR_local_boundary_dir: ./support/
-          ENOS_VAR_crt_bundle_path: ./support/boundary.zip
-          ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
-          ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
-        run: |
-          export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
-          enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
+      - name: Set Enos Job Status
+        id: enos-status
+        if: ${{ failure() }}
+        run: echo "status=${{ steps.run.outcome }}" >> $GITHUB_OUTPUT
       - name: Destroy Enos scenario
         env:
           ENOS_VAR_aws_region: us-east-1
@@ -186,3 +176,23 @@ jobs:
         run: |
           env
           find ./enos -name "scenario.tf" -exec cat {} \;
+  notify:
+    name: Notify
+    needs: enos
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checking status from enos run
+        run: |
+          echo "STATUS: ${{ needs.enos.outputs.status }}"
+      - name: Send Slack message
+        if: ${{ contains(needs.enos.outputs.status, 'failure') }}
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+        with:
+          channel-id: ${{ secrets.SLACK_BOUNDARY_TEST_BOT_CHANNEL_ID }}
+          payload: |
+            {
+              "text": ":x: e2e tests failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Branch:* ${{ github.event.ref }}\n*SHA:* <${{github.event.pull_request.html_url || github.event.head_commit.url }}|${{ github.event.after }}>"
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_TEST_BOT_TOKEN }}


### PR DESCRIPTION
This PR adds slack notifications when e2e or bats tests fail. This will be used for me to track failures and triage any issues. It is currently set to post in `#proj-boundary-tests`.

![Screenshot 2023-02-08 at 9 44 51 PM](https://user-images.githubusercontent.com/2474253/217852307-3f6929c8-08e5-47d5-90ec-3c22e2d5b0c6.png)

2 secrets were added to the repository to facilitate this. 
- `SLACK_BOUNDARY_TEST_BOT_CHANNEL_ID`
- `SLACK_BOUNDARY_TEST_BOT_TOKEN`

Here is an example run where tests failed and the slack jobs ran: https://github.com/hashicorp/boundary/actions/runs/4130485934