### PR TITLE
test(e2e/migration): Add additional resources to database before migrating

### DIFF
--- a/testing/internal/e2e/boundary/account.go
+++ b/testing/internal/e2e/boundary/account.go
@@ -37,16 +37,13 @@ func CreateNewAccountApi(t testing.TB, ctx context.Context, client *api.Client, 
 
 // CreateNewAccountCli creates a new account using the cli.
 // Returns the id of the new account as well as the password that was generated
-func CreateNewAccountCli(t testing.TB, ctx context.Context, loginName string) (string, string) {
-	c, err := LoadConfig()
-	require.NoError(t, err)
-
+func CreateNewAccountCli(t testing.TB, ctx context.Context, authMethodId string, loginName string) (string, string) {
 	password, err := base62.Random(16)
 	require.NoError(t, err)
 	output := e2e.RunCommand(ctx, "boundary",
 		e2e.WithArgs(
 			"accounts", "create", "password",
-			"-auth-method-id", c.AuthMethodId,
+			"-auth-method-id", authMethodId,
 			"-login-name", loginName,
 			"-password", "env://E2E_TEST_ACCOUNT_PASSWORD",
 			"-name", "e2e Account "+loginName,

--- a/testing/internal/e2e/boundary/group.go
+++ b/testing/internal/e2e/boundary/group.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package boundary
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/boundary/api/groups"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+// CreateNewGroupCli uses the cli to create a new group.
+// Returns the id of the new group.
+func CreateNewGroupCli(t testing.TB, ctx context.Context, scopeId string) string {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"groups", "create",
+			"-scope-id", "global",
+			"-format", "json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	var newGroupResult groups.GroupCreateResult
+	err := json.Unmarshal(output.Stdout, &newGroupResult)
+	require.NoError(t, err)
+
+	newGroupId := newGroupResult.Item.Id
+	t.Logf("Created Group: %s", newGroupId)
+	return newGroupId
+}
+
+// AddUserToGroup uses the cli to add a user to a group
+func AddUserToGroup(t testing.TB, ctx context.Context, userId string, groupId string) {
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"groups", "add-members",
+			"-id", groupId,
+			"-member", userId,
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+}

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -207,7 +207,7 @@ func populateBoundaryDatabase(t testing.TB, ctx context.Context, c *config, te T
 	boundary.WaitForHostsInHostSetCli(t, ctx, newAwsHostSetId)
 
 	// Create a user/group and add role to group
-	newAccountId, _ := boundary.CreateNewAccountCli(t, ctx, "test-account")
+	newAccountId, _ := boundary.CreateNewAccountCli(t, ctx, te.DbInitInfo.AuthMethod.AuthMethodId, "test-account")
 	newUserId := boundary.CreateNewUserCli(t, ctx, "global")
 	boundary.SetAccountToUserCli(t, ctx, newUserId, newAccountId)
 	newGroupId := boundary.CreateNewGroupCli(t, ctx, "global")

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -206,6 +206,16 @@ func populateBoundaryDatabase(t testing.TB, ctx context.Context, c *config, te T
 	newAwsHostSetId := boundary.CreateNewAwsHostSetCli(t, ctx, newAwsHostCatalogId, c.AwsHostSetFilter)
 	boundary.WaitForHostsInHostSetCli(t, ctx, newAwsHostSetId)
 
+	// Create a user/group and add role to group
+	newAccountId, _ := boundary.CreateNewAccountCli(t, ctx, "test-account")
+	newUserId := boundary.CreateNewUserCli(t, ctx, "global")
+	boundary.SetAccountToUserCli(t, ctx, newUserId, newAccountId)
+	newGroupId := boundary.CreateNewGroupCli(t, ctx, "global")
+	boundary.AddUserToGroup(t, ctx, newUserId, newGroupId)
+	newRoleId := boundary.CreateNewRoleCli(t, ctx, newProjectId)
+	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "id=*;type=target;actions=authorize-session")
+	boundary.AddPrincipalToRoleCli(t, ctx, newRoleId, newGroupId)
+
 	// Create static credentials
 	newCredentialStoreId := boundary.CreateNewCredentialStoreStaticCli(t, ctx, newProjectId)
 	boundary.CreateNewStaticCredentialPasswordCli(t, ctx, newCredentialStoreId, c.TargetSshUser, "password")
@@ -221,6 +231,7 @@ func populateBoundaryDatabase(t testing.TB, ctx context.Context, c *config, te T
 	require.NoError(t, output.Err, string(output.Stderr))
 
 	privateKeySecretName := vault.CreateKvPrivateKeyCredential(t, c.VaultSecretPath, c.TargetSshUser, c.TargetSshKeyPath, kvPolicyFilePath)
+	passwordSecretName, _ := vault.CreateKvPasswordCredential(t, c.VaultSecretPath, c.TargetSshUser, kvPolicyFilePath)
 	kvPolicyName := vault.WritePolicy(t, ctx, kvPolicyFilePath)
 	t.Log("Created Vault Credential")
 	output = e2e.RunCommand(ctx, "vault",
@@ -241,7 +252,11 @@ func populateBoundaryDatabase(t testing.TB, ctx context.Context, c *config, te T
 	require.NoError(t, err)
 	credStoreToken := tokenCreateResult.Auth.Client_Token
 	t.Log("Created Vault Cred Store Token")
+
+	// Create a credential store for vault
 	newVaultCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, te.Vault.UriNetwork, credStoreToken)
+
+	// Create a credential library for the private key in vault
 	output = e2e.RunCommand(ctx, "boundary",
 		e2e.WithArgs(
 			"credential-libraries", "create", "vault",
@@ -258,6 +273,23 @@ func populateBoundaryDatabase(t testing.TB, ctx context.Context, c *config, te T
 	require.NoError(t, err)
 	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
 	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
+
+	// Create a credential library for the password in vault
+	output = e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"credential-libraries", "create", "vault",
+			"-credential-store-id", newVaultCredentialStoreId,
+			"-vault-path", c.VaultSecretPath+"/data/"+passwordSecretName,
+			"-name", "e2e Automated Test Vault Credential Library - Password",
+			"-credential-type", "username_password",
+			"-format", "json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	err = json.Unmarshal(output.Stdout, &newCredentialLibraryResult)
+	require.NoError(t, err)
+	newPasswordCredentialLibraryId := newCredentialLibraryResult.Item.Id
+	t.Logf("Created Credential Library: %s", newPasswordCredentialLibraryId)
 
 	// Create a session. Uses Boundary in a docker container to do the connect in order to avoid
 	// modifying the runner's /etc/hosts file. Otherwise, you would need to add a `127.0.0.1

--- a/testing/internal/e2e/tests/static/session_cancel_group_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_group_test.go
@@ -49,7 +49,7 @@ func TestCliSessionCancelGroup(t *testing.T) {
 	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 	acctName := "e2e-account"
-	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, acctName)
+	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, bc.AuthMethodId, acctName)
 	t.Cleanup(func() {
 		boundary.AuthenticateAdminCli(t, context.Background())
 		output := e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static/session_cancel_group_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_group_test.go
@@ -94,29 +94,8 @@ func TestCliSessionCancelGroup(t *testing.T) {
 
 	// Create a group
 	boundary.AuthenticateAdminCli(t, ctx)
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"groups", "create",
-			"-scope-id", "global",
-			"-format", "json",
-		),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	var newGroupResult groups.GroupCreateResult
-	err = json.Unmarshal(output.Stdout, &newGroupResult)
-	require.NoError(t, err)
-	newGroupId := newGroupResult.Item.Id
-	t.Logf("Created Group: %s", newGroupId)
-
-	// Add user to group
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"groups", "add-members",
-			"-id", newGroupId,
-			"-member", newUserId,
-		),
-	)
-	require.NoError(t, output.Err, string(output.Stderr))
+	newGroupId := boundary.CreateNewGroupCli(t, ctx, "global")
+	boundary.AddUserToGroup(t, ctx, newUserId, newGroupId)
 
 	// Create a role for a group
 	newRoleId := boundary.CreateNewRoleCli(t, ctx, newProjectId)

--- a/testing/internal/e2e/tests/static/session_cancel_user_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_user_test.go
@@ -48,7 +48,7 @@ func TestCliSessionCancelUser(t *testing.T) {
 	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 	acctName := "e2e-account"
-	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, acctName)
+	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, bc.AuthMethodId, acctName)
 	t.Cleanup(func() {
 		boundary.AuthenticateAdminCli(t, context.Background())
 		output := e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static/session_end_delete_host_set_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_host_set_test.go
@@ -25,6 +25,8 @@ func TestCliSessionEndWhenHostSetIsDeleted(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)
+	bc, err := boundary.LoadConfig()
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
@@ -43,7 +45,7 @@ func TestCliSessionEndWhenHostSetIsDeleted(t *testing.T) {
 	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 	acctName := "e2e-account"
-	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, acctName)
+	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, bc.AuthMethodId, acctName)
 	t.Cleanup(func() {
 		boundary.AuthenticateAdminCli(t, context.Background())
 		output := e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static/session_end_delete_host_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_host_test.go
@@ -25,6 +25,8 @@ func TestCliSessionEndWhenHostIsDeleted(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)
+	bc, err := boundary.LoadConfig()
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
@@ -43,7 +45,7 @@ func TestCliSessionEndWhenHostIsDeleted(t *testing.T) {
 	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 	acctName := "e2e-account"
-	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, acctName)
+	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, bc.AuthMethodId, acctName)
 	t.Cleanup(func() {
 		boundary.AuthenticateAdminCli(t, context.Background())
 		output := e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static/session_end_delete_target_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_target_test.go
@@ -25,6 +25,8 @@ func TestCliSessionEndWhenTargetIsDeleted(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)
+	bc, err := boundary.LoadConfig()
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
@@ -43,7 +45,7 @@ func TestCliSessionEndWhenTargetIsDeleted(t *testing.T) {
 	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 	acctName := "e2e-account"
-	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, acctName)
+	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, bc.AuthMethodId, acctName)
 	t.Cleanup(func() {
 		boundary.AuthenticateAdminCli(t, context.Background())
 		output := e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static/session_end_delete_user_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_user_test.go
@@ -25,6 +25,8 @@ func TestCliSessionEndWhenUserIsDeleted(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
 	require.NoError(t, err)
+	bc, err := boundary.LoadConfig()
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	boundary.AuthenticateAdminCli(t, ctx)
@@ -43,7 +45,7 @@ func TestCliSessionEndWhenUserIsDeleted(t *testing.T) {
 	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 	acctName := "e2e-account"
-	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, acctName)
+	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, bc.AuthMethodId, acctName)
 	t.Cleanup(func() {
 		boundary.AuthenticateAdminCli(t, context.Background())
 		output := e2e.RunCommand(ctx, "boundary",


### PR DESCRIPTION
This PR updates the e2e migration test to add some new resources to the database before performing the migration.
- Vault credential (type: username/password)
- User/Role/Group
