### PR TITLE
chore(enos): Reset slack notification status on job retry

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -35,6 +35,8 @@ jobs:
     outputs:
       status: ${{ steps.enos-status.outputs.status }}
     steps:
+      - name: Reset status output
+        run: echo "status=none" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Go


### PR DESCRIPTION
This PR attempts to address an issue with the Slack notifications on e2e test failures.

If an enos job fails and a user reruns those failing jobs, the GitHub action workflow will still send a slack notification even if the rerun runs successfully (without any enos retries). Here are some examples:
- https://github.com/hashicorp/boundary/actions/runs/4147983229
- https://github.com/hashicorp/boundary/actions/runs/4166088499

The slack notification step is gated on the following condition...
```
if: ${{ always() && needs.enos.outputs.status == 'failure' }}
```

The theory is that on a retry, it appears that `needs.enos.outputs.status` is still somehow set to `failure`. To mitigate this, the idea is to 