### PR TITLE
[main] Update version.go to remove additional oss metadata

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -32,6 +32,10 @@ func Get() *Info {
 	if GitDescribe == "" && rel == "" && VersionPrerelease != "" {
 		rel = "dev"
 	}
+	// Remove metadata string from version output for oss
+	if md == "oss" {
+		md = ""
+	}
 
 	return &Info{
 		CgoEnabled:        CgoEnabled,
@@ -53,7 +57,7 @@ func (c *Info) VersionNumber() string {
 		version = fmt.Sprintf("%s-%s", version, c.VersionPrerelease)
 	}
 
-	if c.VersionMetadata != "" {
+	if c.VersionMetadata != "" && c.VersionMetadata != "oss" {
 		version = fmt.Sprintf("%s+%s", version, c.VersionMetadata)
 	}
 
@@ -95,7 +99,7 @@ func FromVersionString(s string) *Info {
 		return nil
 	}
 
-	if md := v.Metadata(); len(md) > 0 {
+	if md := v.Metadata(); len(md) > 0 && md != "oss" {
 		i.VersionMetadata = md
 	}
 	if pr := v.Prerelease(); len(pr) > 0 {
@@ -118,7 +122,7 @@ func (c *Info) FullVersionNumber(rev bool) string {
 		fmt.Fprintf(&versionString, "-%s", c.VersionPrerelease)
 	}
 
-	if c.VersionMetadata != "" {
+	if c.VersionMetadata != "" && c.VersionMetadata != "oss" {
 		fmt.Fprintf(&versionString, "+%s", c.VersionMetadata)
 	}
 


### PR DESCRIPTION
Now that version metadata is being set to oss, it's appearing in the version string output:

```
Version information:
  Git Revision:        d6f04e6e0867932cb1f44ccd94bc584e6a6a842e
  Metadata:            oss
  Version Number:      0.12.0+oss
```

As a quick fix for the 0.12.x release, I merged in https://github.com/hashicorp/boundary/commit/034f27ec8528251ce23b5afbf3851c48b0c54bec, but I think we'd rather keep these fields set across all build.yml workflows in the boundary-* repos to reduce merge conflicts. This PR is meant to fix the underlying issue in version.go where having the metadata value set to oss was not expected/accounted for. This should be a safe change to merge across the boundary-* repos. 