### PR TITLE
fix(targets): Readd WorkerFilterDeprecationMessage (#2982)

### DIFF
--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -94,6 +94,7 @@ var (
 
 	ValidateIngressWorkerFilterFn  = IngressWorkerFilterUnsupported
 	AuthorizeSessionWorkerFilterFn = AuthorizeSessionWithWorkerFilter
+	WorkerFilterDeprecationMessage = fmt.Sprintf("This field is deprecated. Use %s instead.", globals.EgressWorkerFilterField)
 )
 
 func IngressWorkerFilterUnsupported(string) error {
@@ -1553,7 +1554,7 @@ func validateCreateRequest(req *pbs.CreateTargetRequest) error {
 			badFields[globals.TypeField] = "Unknown type provided."
 		}
 		if workerFilter := req.GetItem().GetWorkerFilter(); workerFilter != nil {
-			badFields[globals.WorkerFilterField] = fmt.Sprintf("This field is deprecated. Use %s instead.", globals.EgressWorkerFilterField)
+			badFields[globals.WorkerFilterField] = WorkerFilterDeprecationMessage
 		}
 		if egressFilter := req.GetItem().GetEgressWorkerFilter(); egressFilter != nil {
 			if _, err := bexpr.CreateEvaluator(egressFilter.GetValue()); err != nil {


### PR DESCRIPTION
This variable is updated in the enterprise repo and needs to stay. This is a backport from `main`.