### PR TITLE
Get accountid from configure-aws-credentials action for OSS

### DIFF
--- a/.github/workflows/test-ci-cleanup-oss.yml
+++ b/.github/workflows/test-ci-cleanup-oss.yml
@@ -9,8 +9,7 @@ jobs:
     if: ${{ github.event.repository.name == 'boundary' }}
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     outputs:
-      regions: ${{steps.setup.outputs.regions}}
-      account_id: ${{steps.setup.outputs.account_id}}
+      regions: ${{steps.regions.outputs.regions}}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -22,14 +21,12 @@ jobs:
           role-skip-session-tagging: true
           role-duration-seconds: 3600
       - name: Get all regions
-        id: setup
+        id: regions
         run: |
           echo "regions=$(aws ec2 describe-regions --region us-east-1 --output json --query 'Regions[].RegionName' | tr -d '\n ')" >> $GITHUB_OUTPUT
-          echo "account_id=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | awk -F'"' '/"accountId"/ { print $4 }')" >> $GITHUB_OUTPUT
 
   aws-nuke:
     if: ${{ github.event.repository.name == 'boundary' }}
-    needs: setup
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     container:
       image: rebuy/aws-nuke
@@ -43,6 +40,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Configure AWS credentials
+        id: aws-configure
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
@@ -51,11 +49,12 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_CI }}
           role-skip-session-tagging: true
           role-duration-seconds: 3600
+          mask-aws-account-id: false
       - uses: actions/checkout@v3
       - name: Configure
         run: |
           cp enos/ci/aws-nuke.yml .
-          sed -i "s/ACCOUNT_NUM/${{ needs.setup.outputs.account_id }}/g" aws-nuke.yml
+          sed -i "s/ACCOUNT_NUM/${{ steps.aws-configure.outputs.aws-account-id }}/g" aws-nuke.yml
           sed -i "s/TIME_LIMIT/${TIME_LIMIT}/g" aws-nuke.yml
       # We don't care if cleanup succeeds or fails, because dependencies be dependenceies,
       # we'll fail on actually actionable things in the quota steep afterwards.


### PR DESCRIPTION
We were previously using the logic/method for doormat-based repos, which doesn't work with the `configure-aws-credentials` action (it masks the accountid...and also just provides it as an output out of the box.)