### PR TITLE
fix(all): make copywrite ignores stricter

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -13,6 +13,7 @@ project {
     "internal/ui/.tmp/**",
     "website/.eslintrc.js",
     "website/prettier.config.js",
-    "**/*_ent*",
+    "**/*_ent.*",
+    "**/*_ent_test.*",
   ]
 }


### PR DESCRIPTION
The previous ignore matched oplog_entry.go accidentally.