### PR TITLE
refact(e2e): Set up variables to prepare for docker implementation

### DIFF
--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -179,6 +179,7 @@ scenario "e2e_aws" {
       local_boundary_dir       = local.local_boundary_dir
       aws_ssh_private_key_path = local.aws_ssh_private_key_path
       target_user              = "ubuntu"
+      target_port              = "22"
       aws_access_key_id        = step.iam_setup.access_key_id
       aws_secret_access_key    = step.iam_setup.secret_access_key
       aws_host_set_filter1     = step.create_tag1_inputs.tag_string

--- a/enos/enos-scenario-e2e-static-with-vault.hcl
+++ b/enos/enos-scenario-e2e-static-with-vault.hcl
@@ -136,6 +136,7 @@ scenario "e2e_static_with_vault" {
       aws_ssh_private_key_path = local.aws_ssh_private_key_path
       target_ip                = step.create_target.target_ips[0]
       target_user              = "ubuntu"
+      target_port              = "22"
       vault_addr               = step.create_vault_cluster.instance_public_ips[0]
       vault_root_token         = step.create_vault_cluster.vault_root_token
     }

--- a/enos/enos-scenario-e2e-static.hcl
+++ b/enos/enos-scenario-e2e-static.hcl
@@ -113,6 +113,7 @@ scenario "e2e_static" {
       aws_ssh_private_key_path = local.aws_ssh_private_key_path
       target_ip                = step.create_target.target_ips[0]
       target_user              = "ubuntu"
+      target_port              = "22"
     }
   }
 

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -58,7 +58,12 @@ variable "target_port" {
   default     = ""
 }
 variable "vault_addr" {
-  description = "URL of Vault instance"
+  description = "External network address of Vault. Will be converted to a URL below"
+  type        = string
+  default     = ""
+}
+variable "vault_addr_internal" {
+  description = "Internal network address of Vault (i.e. within a docker network). Will be converted to a URL below"
   type        = string
   default     = ""
 }
@@ -106,6 +111,7 @@ variable "aws_host_set_ips2" {
 locals {
   aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
   vault_addr               = var.vault_addr != "" ? "http://${var.vault_addr}:8200" : ""
+  vault_addr_internal      = var.vault_addr_internal != "" ? "http://${var.vault_addr_internal}:8200" : local.vault_addr
   aws_host_set_ips1        = jsonencode(var.aws_host_set_ips1)
   aws_host_set_ips2        = jsonencode(var.aws_host_set_ips2)
   package_name             = reverse(split("/", var.test_package))[0]
@@ -124,6 +130,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_SSH_KEY_PATH              = local.aws_ssh_private_key_path,
     VAULT_ADDR                    = local.vault_addr,
     VAULT_TOKEN                   = var.vault_root_token,
+    E2E_VAULT_ADDR                = local.vault_addr_internal,
     E2E_AWS_ACCESS_KEY_ID         = var.aws_access_key_id,
     E2E_AWS_SECRET_ACCESS_KEY     = var.aws_secret_access_key,
     E2E_AWS_HOST_SET_FILTER       = var.aws_host_set_filter1,

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -52,6 +52,11 @@ variable "target_ip" {
   type        = string
   default     = ""
 }
+variable "target_port" {
+  description = "Port of target"
+  type        = string
+  default     = ""
+}
 variable "vault_addr" {
   description = "URL of Vault instance"
   type        = string
@@ -115,6 +120,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_PASSWORD_ADMIN_PASSWORD   = var.auth_password,
     E2E_TARGET_IP                 = var.target_ip,
     E2E_SSH_USER                  = var.target_user,
+    E2E_SSH_PORT                  = var.target_port,
     E2E_SSH_KEY_PATH              = local.aws_ssh_private_key_path,
     VAULT_ADDR                    = local.vault_addr,
     VAULT_TOKEN                   = var.vault_root_token,

--- a/testing/internal/e2e/tests/aws/env_test.go
+++ b/testing/internal/e2e/tests/aws/env_test.go
@@ -14,7 +14,7 @@ type config struct {
 	AwsHostSetIps2     string `envconfig:"E2E_AWS_HOST_SET_IPS2" required:"true"`    // e.g. "[\"1.2.3.4\"]"
 	TargetSshKeyPath   string `envconfig:"E2E_SSH_KEY_PATH" required:"true"`         // e.g. "/Users/username/key.pem"
 	TargetSshUser      string `envconfig:"E2E_SSH_USER" required:"true"`             // e.g. "ubuntu"
-	TargetPort         string `envconfig:"E2E_SSH_PORT" default:"22"`
+	TargetPort         string `envconfig:"E2E_SSH_PORT" required:"true"`
 }
 
 func loadConfig() (*config, error) {

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -224,7 +224,7 @@ func populateBoundaryDatabase(t testing.TB, ctx context.Context, c *config, te T
 	boundary.AddCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialsId)
 
 	// Create vault credentials
-	_, boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
 	output := e2e.RunCommand(ctx, "vault",
 		e2e.WithArgs("secrets", "enable", "-path="+c.VaultSecretPath, "kv-v2"),
 	)

--- a/testing/internal/e2e/tests/static/env_test.go
+++ b/testing/internal/e2e/tests/static/env_test.go
@@ -9,7 +9,7 @@ type config struct {
 	TargetIp         string `envconfig:"E2E_TARGET_IP" required:"true"`    // e.g. 192.168.0.1
 	TargetSshKeyPath string `envconfig:"E2E_SSH_KEY_PATH" required:"true"` // e.g. /Users/username/key.pem
 	TargetSshUser    string `envconfig:"E2E_SSH_USER" required:"true"`     // e.g. ubuntu
-	TargetPort       string `envconfig:"E2E_SSH_PORT" default:"22"`
+	TargetPort       string `envconfig:"E2E_SSH_PORT" required:"true"`
 }
 
 func loadConfig() (*config, error) {

--- a/testing/internal/e2e/tests/static_with_vault/connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_authz_token_test.go
@@ -46,7 +46,7 @@ func TestCliVaultConnectTargetWithAuthzToken(t *testing.T) {
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 
 	// Configure vault
-	vaultAddr, boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
 	t.Cleanup(func() {
 		output := e2e.RunCommand(ctx, "vault",
 			e2e.WithArgs("policy", "delete", boundaryPolicyName),
@@ -97,7 +97,7 @@ func TestCliVaultConnectTargetWithAuthzToken(t *testing.T) {
 	t.Log("Created Vault Cred Store Token")
 
 	// Create a credential store
-	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, vaultAddr, credStoreToken)
+	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, c.VaultAddr, credStoreToken)
 
 	// Create a credential library
 	output = e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static_with_vault/connect_ssh_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_ssh_test.go
@@ -45,7 +45,7 @@ func TestCliVaultConnectTargetWithSsh(t *testing.T) {
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 
 	// Configure vault
-	vaultAddr, boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
 	t.Cleanup(func() {
 		output := e2e.RunCommand(ctx, "vault",
 			e2e.WithArgs("policy", "delete", boundaryPolicyName),
@@ -96,7 +96,7 @@ func TestCliVaultConnectTargetWithSsh(t *testing.T) {
 	t.Log("Created Vault Cred Store Token")
 
 	// Create a credential store
-	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, vaultAddr, credStoreToken)
+	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, c.VaultAddr, credStoreToken)
 
 	// Create a credential library
 	output = e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static_with_vault/connect_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_test.go
@@ -47,7 +47,7 @@ func TestCliVaultConnectTarget(t *testing.T) {
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 
 	// Configure vault
-	vaultAddr, boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
 	t.Cleanup(func() {
 		output := e2e.RunCommand(ctx, "vault",
 			e2e.WithArgs("policy", "delete", boundaryPolicyName),
@@ -98,7 +98,7 @@ func TestCliVaultConnectTarget(t *testing.T) {
 	t.Log("Created Vault Cred Store Token")
 
 	// Create a credential store
-	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, vaultAddr, credStoreToken)
+	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, c.VaultAddr, credStoreToken)
 
 	// Create a credential library
 	output = e2e.RunCommand(ctx, "boundary",

--- a/testing/internal/e2e/tests/static_with_vault/credential_store_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/credential_store_test.go
@@ -45,7 +45,7 @@ func TestCliVaultCredentialStore(t *testing.T) {
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 
 	// Configure vault
-	vaultAddr, boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
 	t.Cleanup(func() {
 		output := e2e.RunCommand(ctx, "vault",
 			e2e.WithArgs("policy", "delete", boundaryPolicyName),
@@ -97,7 +97,7 @@ func TestCliVaultCredentialStore(t *testing.T) {
 	t.Log("Created Vault Cred Store Token")
 
 	// Create a credential store
-	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, vaultAddr, credStoreToken)
+	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, c.VaultAddr, credStoreToken)
 
 	// Create a credential library for the private key
 	output = e2e.RunCommand(ctx, "boundary",
@@ -209,7 +209,7 @@ func TestApiVaultCredentialStore(t *testing.T) {
 	boundary.AddHostSourceToTargetApi(t, ctx, client, newTargetId, newHostSetId)
 
 	// Configure vault
-	vaultAddr, boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
 	output := e2e.RunCommand(ctx, "vault",
 		e2e.WithArgs("secrets", "enable", "-path="+c.VaultSecretPath, "kv-v2"),
 	)
@@ -250,7 +250,7 @@ func TestApiVaultCredentialStore(t *testing.T) {
 	// Create a credential store
 	csClient := credentialstores.NewClient(client)
 	newCredentialStoreResult, err := csClient.Create(ctx, "vault", newProjectId,
-		credentialstores.WithVaultCredentialStoreAddress(vaultAddr),
+		credentialstores.WithVaultCredentialStoreAddress(c.VaultAddr),
 		credentialstores.WithVaultCredentialStoreToken(credStoreToken),
 	)
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/static_with_vault/env_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/env_test.go
@@ -5,14 +5,14 @@ package static_with_vault_test
 
 import "github.com/kelseyhightower/envconfig"
 
-// `VaultAddr` is the address that the Boundary server uses to interact with the running Vault instance
 type config struct {
 	TargetIp         string `envconfig:"E2E_TARGET_IP" required:"true"`    // e.g. 192.168.0.1
 	TargetSshUser    string `envconfig:"E2E_SSH_USER" required:"true"`     // e.g. ubuntu
 	TargetSshKeyPath string `envconfig:"E2E_SSH_KEY_PATH" required:"true"` // e.g. /Users/username/key.pem
 	TargetPort       string `envconfig:"E2E_SSH_PORT" required:"true"`
-	VaultAddr        string `envconfig:"E2E_VAULT_ADDR" required:"true"` // e.g. "http://127.0.0.1:8200"
-	VaultSecretPath  string `envconfig:"E2E_VAULT_SECRET_PATH" default:"e2e_secrets"`
+	// VaultAddr is the address that the Boundary server uses to interact with the running Vault instance
+	VaultAddr       string `envconfig:"E2E_VAULT_ADDR" required:"true"` // e.g. "http://127.0.0.1:8200"
+	VaultSecretPath string `envconfig:"E2E_VAULT_SECRET_PATH" default:"e2e_secrets"`
 }
 
 func loadConfig() (*config, error) {

--- a/testing/internal/e2e/tests/static_with_vault/env_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/env_test.go
@@ -5,11 +5,13 @@ package static_with_vault_test
 
 import "github.com/kelseyhightower/envconfig"
 
+// `VaultAddr` is the address that the Boundary server uses to interact with the running Vault instance
 type config struct {
 	TargetIp         string `envconfig:"E2E_TARGET_IP" required:"true"`    // e.g. 192.168.0.1
 	TargetSshUser    string `envconfig:"E2E_SSH_USER" required:"true"`     // e.g. ubuntu
 	TargetSshKeyPath string `envconfig:"E2E_SSH_KEY_PATH" required:"true"` // e.g. /Users/username/key.pem
 	TargetPort       string `envconfig:"E2E_SSH_PORT" required:"true"`
+	VaultAddr        string `envconfig:"E2E_VAULT_ADDR" required:"true"` // e.g. "http://127.0.0.1:8200"
 	VaultSecretPath  string `envconfig:"E2E_VAULT_SECRET_PATH" default:"e2e_secrets"`
 }
 

--- a/testing/internal/e2e/tests/static_with_vault/env_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/env_test.go
@@ -9,7 +9,7 @@ type config struct {
 	TargetIp         string `envconfig:"E2E_TARGET_IP" required:"true"`    // e.g. 192.168.0.1
 	TargetSshUser    string `envconfig:"E2E_SSH_USER" required:"true"`     // e.g. ubuntu
 	TargetSshKeyPath string `envconfig:"E2E_SSH_KEY_PATH" required:"true"` // e.g. /Users/username/key.pem
-	TargetPort       string `envconfig:"E2E_SSH_PORT" default:"22"`
+	TargetPort       string `envconfig:"E2E_SSH_PORT" required:"true"`
 	VaultSecretPath  string `envconfig:"E2E_VAULT_SECRET_PATH" default:"e2e_secrets"`
 }
 

--- a/testing/internal/e2e/vault/env.go
+++ b/testing/internal/e2e/vault/env.go
@@ -5,8 +5,8 @@ package vault
 
 import "github.com/kelseyhightower/envconfig"
 
-// `VaultAddr` is the address that the Vault CLI uses to interact with the running Vault instance
 type config struct {
+	// VaultAddr is the address that the Vault CLI uses to interact with the running Vault instance
 	VaultAddr  string `envconfig:"VAULT_ADDR" required:"true"` // e.g. "http://127.0.0.1:8200"
 	VaultToken string `envconfig:"VAULT_TOKEN" required:"true"`
 }

--- a/testing/internal/e2e/vault/env.go
+++ b/testing/internal/e2e/vault/env.go
@@ -5,6 +5,7 @@ package vault
 
 import "github.com/kelseyhightower/envconfig"
 
+// `VaultAddr` is the address that the Vault CLI uses to interact with the running Vault instance
 type config struct {
 	VaultAddr  string `envconfig:"VAULT_ADDR" required:"true"` // e.g. "http://127.0.0.1:8200"
 	VaultToken string `envconfig:"VAULT_TOKEN" required:"true"`

--- a/testing/internal/e2e/vault/vault.go
+++ b/testing/internal/e2e/vault/vault.go
@@ -25,11 +25,7 @@ type CreateTokenResponse struct {
 
 // Setup verifies if appropriate credentials are set and adds the boundary controller
 // policy to vault. Returns the vault address.
-func Setup(t testing.TB) (vaultAddr string, boundaryPolicyName string, kvPolicyFilePath string) {
-	c, err := loadConfig()
-	require.NoError(t, err)
-	vaultAddr = c.VaultAddr
-
+func Setup(t testing.TB) (boundaryPolicyName string, kvPolicyFilePath string) {
 	// Set up boundary policy
 	boundaryPolicyFilePath, err := filepath.Abs("testdata/boundary-controller-policy.hcl")
 	require.NoError(t, err)


### PR DESCRIPTION
This PR modifies some of the e2e test suite variables in order to set it up for using docker as an infrastructure platform. These changes also make some things more explicit. Specifically...
- To maintain consistency for how we define ports, we are changing it to be explicitly defined in the enos scenario as opposed to relying on a "default" value. This change is in support of work that attempts to spin up test infrastructure using docker. The openssh-server docker image (that we use as an example host) uses Port 2222, which needs to be passed to the test suite.
- There are some instances where we need to have two different Vault addresses, one used by the Vault CLI and one by the Boundary server instance. In the case when using a Docker container, the Boundary server
needs the Vault address "internal" to the Docker network, whereas the Vault CLI running outside of the
network needs a different address.