### PR TITLE
chore(enos): Always destroy enos infrastructure

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -170,6 +170,7 @@ jobs:
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
       - name: Destroy Enos scenario
+        if: ${{ always() }}
         env:
           ENOS_VAR_aws_region: us-east-1
           ENOS_VAR_aws_ssh_keypair_name: ${{ github.event.repository.name }}-ci-ssh-key


### PR DESCRIPTION
This PR updates the enos GitHub action workflow to always run the `Destroy` command. 

Currently, we do the following
- `enos scenario run` (with `continue-on-error`)
- if failure, `enos scenario run` (retry)
- `enos scenario destroy`

If the Retry fails, it marks the workflow as failed (it does not have `continue-on-error`) and skips the destroy step. When testing locally, `enos scenario run` does not cleanup infrastructure if there is a failure. This leads to leaving some infrastructure hanging around.