### PR TITLE
chore(enos): Modify destroy condition

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -170,7 +170,7 @@ jobs:
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
       - name: Destroy Enos scenario
-        if: ${{ always() }}
+        if: ${{ always() && steps.run_retry.outcome == 'failure' }}
         env:
           ENOS_VAR_aws_region: us-east-1
           ENOS_VAR_aws_ssh_keypair_name: ${{ github.event.repository.name }}-ci-ssh-key


### PR DESCRIPTION
This PR is a follow-up to https://github.com/hashicorp/boundary/pull/3000.

In that PR, we updated the workflow always run `enos destroy` to make sure we clear our infrastructure. However, on the merge to `main`, there was an interesting observation. The workflow failed in an earlier step (before `enos` was even installed). That caused the destroy step to fail because `enos` doesn't exist yet.

This change makes it such that the step only runs if the Retry step fails.