### PR TITLE
internal/server: fix dropped testing error

### DIFF
--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -64,6 +64,7 @@ func TestRootCertificate(ctx context.Context, t *testing.T, conn *db.DB, kmsKey 
 
 	cert, err := newRootCertificate(ctx, mathRand.Uint64(), populateBytes(defaultLength), beforeTimestamp, afterTimestamp,
 		rootCertKeys, kmsKey, CurrentState)
+	require.NoError(t, err)
 	err = rw.Create(ctx, cert)
 	require.NoError(t, err)
 	return cert


### PR DESCRIPTION
This fixes a dropped error in `internal/server`. No changelog update is required.