### PR TITLE
Update ui build scripts to check edition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ UI_TARGETS := update-ui-version build-ui build-ui-ifne clean-ui
 $(UI_TARGETS): export UI_CLONE_DIR      := internal/ui/.tmp/boundary-ui
 $(UI_TARGETS): export UI_VERSION_FILE   := internal/ui/VERSION
 $(UI_TARGETS): export UI_DEFAULT_BRANCH := main
-$(UI_TARGETS): export UI_CURRENT_COMMIT := $(shell head -n1 < "$(UI_VERSION_FILE)" | cut -d' ' -f1)
 $(UI_TARGETS): export UI_COMMITISH ?=
 
 .PHONY: update-ui-version
@@ -110,12 +109,6 @@ update-ui-version:
 
 .PHONY: build-ui
 build-ui:
-	@if [ -z "$(UI_COMMITISH)" ]; then \
-		echo "==> Building default UI version from $(UI_VERSION_FILE): $(UI_CURRENT_COMMIT)"; \
-		export UI_COMMITISH="$(UI_CURRENT_COMMIT)"; \
-	else \
-		echo "==> Building custom UI version $(UI_COMMITISH)"; \
-	fi; \
 	./scripts/build-ui.sh
 
 .PHONY: build-plugins

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -5,30 +5,45 @@
 
 set -e
 
-if [ -z "$UI_COMMITISH" ]; then
-	echo "Must set UI_COMMITISH"; exit 1
-fi
-
 if [ -z "$UI_CLONE_DIR" ]; then
 	echo "Must set UI_CLONE_DIR"; exit 1
 fi
 
 if [ -z "$UI_VERSION_FILE" ]; then
-	echo "Must set UI_CLONE_DIR"; exit 1
+	echo "Must set UI_VERSION_FILE"; exit 1
 fi
+
+UI_EDITION=$(make --no-print-directory edition)
+
+if [ "$UI_EDITION" == "oss" ]; then
+  UI_REPO=https://github.com/hashicorp/boundary-ui
+  REPO_NAME=boundary-ui
+else
+  UI_VERSION_FILE="${UI_VERSION_FILE}_ent"
+  UI_REPO=https://github.com/hashicorp/boundary-ui-enterprise
+  REPO_NAME=boundary-ui-enterprise
+fi
+
+UI_CURRENT_COMMIT=$(head -n1 < "${UI_VERSION_FILE}" | cut -d' ' -f1)
+
+if [ -z "$UI_COMMITISH" ]; then
+  echo "==> Building default UI version from $UI_VERSION_FILE: $UI_CURRENT_COMMIT"
+  export UI_COMMITISH="$UI_CURRENT_COMMIT"
+else
+  echo "==> Building custom UI version $UI_COMMITISH"
+fi;
 
 if which gh &> /dev/null;  then
     echo "Found gh cli, attempting to download ui assets"
 
-    UI_EDITION=$(make --no-print-directory edition)
-    artifact_id=$(gh api repos/hashicorp/boundary-ui/actions/artifacts | \
+    artifact_id=$(gh api "repos/hashicorp/${REPO_NAME}/actions/artifacts" --paginate | \
         jq ".artifacts[] | select(.workflow_run.head_sha == \"${UI_COMMITISH}\" and .name == \"admin-ui-${UI_EDITION}\")" | \
         jq -r '.id')
 
     if [[ ${artifact_id} ]]; then
         echo "Downloading artifact: ${artifact_id} for admin-ui-${UI_EDITION} ${UI_COMMITISH}"
         tmp_dir=$(mktemp -d)
-        gh api "repos/hashicorp/boundary-ui/actions/artifacts/${artifact_id}/zip" > "${tmp_dir}/boundary-ui.zip"
+        gh api "repos/hashicorp/${REPO_NAME}/actions/artifacts/${artifact_id}/zip" > "${tmp_dir}/boundary-ui.zip"
         trap 'rm -rf ${tmp_dir}' EXIT
 
         # remove any previous artifact download or git clone
@@ -55,7 +70,7 @@ echo "*" > "${tempdir}/.gitignore"
 if ! [ -d "${UI_CLONE_DIR}/.git" ]; then
     # clear out dir, incase it was previously an artifact download
     rm -rf "${UI_CLONE_DIR}"
-	git clone https://github.com/hashicorp/boundary-ui "${UI_CLONE_DIR}"
+	git clone "${UI_REPO}" "${UI_CLONE_DIR}"
 fi
 
 pushd "${UI_CLONE_DIR}"
@@ -66,5 +81,5 @@ git pull --ff-only origin "${UI_COMMITISH}"
 git reset --hard "${UI_COMMITISH}"
 
 yarn install
-yarn build
+EDITION=${UI_EDITION} yarn build
 popd

--- a/scripts/uiupdate.sh
+++ b/scripts/uiupdate.sh
@@ -8,12 +8,22 @@ set -e
 if [ -z "$UI_VERSION_FILE" ]; then
 	echo "Must set UI_VERSION_FILE"; exit 1
 fi
+
 if [ -z "$UI_COMMITISH" ]; then
 	echo "Must set UI_COMMITISH"; exit 1
 fi
 
+UI_EDITION=$(make --no-print-directory edition)
+
+if [ "$UI_EDITION" == "oss" ]; then
+  UI_REPO=https://github.com/hashicorp/boundary-ui
+else
+  UI_VERSION_FILE="${UI_VERSION_FILE}_ent"
+  UI_REPO=https://github.com/hashicorp/boundary-ui-enterprise
+fi
+
 shafileabs="$(pwd)/${UI_VERSION_FILE}"
-V="$(git ls-remote https://github.com/hashicorp/boundary-ui ${UI_COMMITISH})"
+V="$(git ls-remote ${UI_REPO} ${UI_COMMITISH})"
 
 if [ -z "$V" ]; then
 	V=$UI_COMMITISH;


### PR DESCRIPTION
Updated the UI build scripts to check the edition to know which boundary-ui repo to pull artifacts from. OSS will pull from `boundary-ui` while hcp and ent will pull from `boundary-ui-enterprise`.

I'll followup with a PR in the enterprise repo to actually commit the new `VERSION_ent` file.