### PR TITLE
chore(enos): Fix `iam_setup` when running locally 

### DIFF
--- a/enos/modules/iam_setup/main.tf
+++ b/enos/modules/iam_setup/main.tf
@@ -12,10 +12,9 @@ locals {
 }
 
 resource "aws_iam_user" "boundary" {
-  name = "boundary-e2e-${var.test_id}"
-  # These are disabled currently, as we cannot lock down this user and still perform certain tests with the service user
-  #  tags                 = { boundary-demo = local.user_email }
-  #  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryDemoPermissionsBoundary"
+  name                 = "boundary-e2e-${var.test_id}"
+  tags                 = { boundary-demo = local.user_email }
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryDemoPermissionsBoundary"
 }
 
 resource "aws_iam_user_policy" "boundary" {


### PR DESCRIPTION
This PR addresses an issue when running the `e2e_aws` enos scenario locally. It would run into the following error
```
not authorized to perform: iam:CreateUser on resource: 
```

There have been some underlying enos infrastructure changes recently, and this was the recommended approach by the QTI team. The deleted comment was referring to an older way things were handled behind the scenes. Verified with the QTI team that this is all set.