### PR TITLE
chore(enos): Define explicit dependencies between steps

### DIFF
--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -54,6 +54,9 @@ scenario "e2e_aws" {
 
   step "create_base_infra" {
     module = module.infra
+    depends_on = [
+      step.find_azs,
+    ]
 
     variables {
       availability_zones = step.find_azs.availability_zones
@@ -65,6 +68,7 @@ scenario "e2e_aws" {
     module = module.boundary
     depends_on = [
       step.create_base_infra,
+      step.create_db_password,
       step.build_boundary
     ]
 

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -32,6 +32,9 @@ scenario "e2e_database" {
 
   step "create_base_infra" {
     module = module.infra
+    depends_on = [
+      step.find_azs,
+    ]
 
     variables {
       availability_zones = step.find_azs.availability_zones

--- a/enos/enos-scenario-e2e-static-with-vault.hcl
+++ b/enos/enos-scenario-e2e-static-with-vault.hcl
@@ -53,6 +53,9 @@ scenario "e2e_static_with_vault" {
 
   step "create_base_infra" {
     module = module.infra
+    depends_on = [
+      step.find_azs,
+    ]
 
     variables {
       availability_zones = step.find_azs.availability_zones
@@ -64,6 +67,7 @@ scenario "e2e_static_with_vault" {
     module = module.boundary
     depends_on = [
       step.create_base_infra,
+      step.create_db_password,
       step.build_boundary
     ]
 

--- a/enos/enos-scenario-e2e-static.hcl
+++ b/enos/enos-scenario-e2e-static.hcl
@@ -53,6 +53,9 @@ scenario "e2e_static" {
 
   step "create_base_infra" {
     module = module.infra
+    depends_on = [
+      step.find_azs,
+    ]
 
     variables {
       availability_zones = step.find_azs.availability_zones
@@ -64,6 +67,7 @@ scenario "e2e_static" {
     module = module.boundary
     depends_on = [
       step.create_base_infra,
+      step.create_db_password,
       step.build_boundary
     ]
 


### PR DESCRIPTION
This PR explicitly defines all dependencies between steps to ensure that steps run in order. While this doesn't address an immediate issue, it may help to ensure that there's no potential race condition that could occur here.