### PR TITLE
ci: Fix permissions in labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,7 +3,7 @@ on:
 - pull_request_target
 
 permissions:
-  content: read
+  contents: read
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   triage:


### PR DESCRIPTION
This PR is a follow-up to https://github.com/hashicorp/boundary/pull/3011.

It addresses an issue where the `labeler` workflow was failing to the following reason.

![Screenshot 2023-02-27 at 9 49 25 AM](https://user-images.githubusercontent.com/2474253/221595747-f8bb1fae-8264-4cee-897d-18ce742df461.png)
