### PR TITLE
chore(enos): Default to use OSS edition

### DIFF
--- a/enos/modules/build_local/main.tf
+++ b/enos/modules/build_local/main.tf
@@ -17,6 +17,10 @@ variable "build_target" {
   default = "build-ui build"
 }
 
+variable "edition" {
+  default = "oss"
+}
+
 resource "enos_local_exec" "build" {
   environment = {
     "GOOS"          = "linux",
@@ -24,6 +28,7 @@ resource "enos_local_exec" "build" {
     "CGO_ENABLED"   = 0,
     "ARTIFACT_PATH" = var.path
     "BUILD_TARGET"  = var.build_target
+    "EDITION"       = var.edition
   }
   scripts = ["${path.module}/templates/build.sh"]
 }


### PR DESCRIPTION
There was an update to the Boundary build scripts to detect what edition of boundary is being built so that it knows which version of the UI to grab. However, this affected instances when building boundary on an architecture that is not the same as the host (in this case, building a linux/amd64 version on a mac). When the scripts try to use the built CLI to get the edition, it threw an `exec format error`.

This PR updates the enos scripts to default to `oss` so that the build scripts do not have to use the CLI to determine the edition, bypassing the CLI command.