### PR TITLE
Create a solo worker module for testing

### DIFF
--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -11,7 +11,7 @@ module "bats_deps" {
 
 module "boundary" {
   source  = "app.terraform.io/hashicorp-qti/aws-boundary/enos"
-  version = ">= 0.2.6"
+  version = ">= 0.4.0"
 
   project_name = "qti-enos-boundary"
   environment  = var.environment
@@ -24,6 +24,21 @@ module "boundary" {
 
   ssh_aws_keypair       = var.aws_ssh_keypair_name
   alb_listener_api_port = var.alb_listener_api_port
+}
+
+module "solo_worker" {
+  source = "./modules/solo_worker"
+
+  project_name = "qti-enos-boundary"
+  environment  = var.environment
+  common_tags = {
+    "Project" : "Enos",
+    "Project Name" : "qti-enos-boundary",
+    "Enos User" : var.enos_user,
+    "Environment" : var.environment
+  }
+
+  ssh_aws_keypair = var.aws_ssh_keypair_name
 }
 
 module "build_crt" {

--- a/enos/modules/solo_worker/main.tf
+++ b/enos/modules/solo_worker/main.tf
@@ -1,0 +1,173 @@
+terraform {
+  required_providers {
+    enos = {
+      source = "app.terraform.io/hashicorp-qti/enos"
+    }
+  }
+}
+
+locals {
+  selected_az = data.aws_availability_zones.available.names[random_integer.az.result]
+}
+
+resource "random_string" "cluster_id" {
+  length  = 8
+  upper   = false
+  numeric = false
+  special = false
+}
+
+resource "random_pet" "worker" {
+  separator = "_"
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+  filter {
+    name   = "zone-name"
+    values = var.availability_zones
+  }
+}
+
+data "aws_availability_zone" "worker_az" {
+  name = local.selected_az
+}
+
+data "aws_kms_key" "kms_key" {
+  key_id = var.kms_key_arn
+}
+
+resource "random_integer" "az" {
+  min = 0
+  max = length(data.aws_availability_zones.available.names) - 1
+  keepers = {
+    # Generate a new integer each time the list of aws_availability_zones changes
+    # keepers have to be strings, sort the list in case order changes but zones don't
+    listener_arn = join("", sort(data.aws_availability_zones.available.names))
+  }
+}
+
+# Create a subnet so that the worker doesn't share one with a controller
+resource "aws_subnet" "default" {
+  vpc_id                  = var.vpc_name
+  cidr_block              = "10.13.9.0/24"
+  map_public_ip_on_launch = true
+  availability_zone       = local.selected_az
+  tags = merge(
+    var.common_tags,
+    {
+      "Name" = "${var.vpc_name}_solo_worker_subnet"
+    },
+  )
+}
+
+resource "aws_security_group" "default" {
+  vpc_id = var.vpc_name
+
+  ingress {
+    description = "allow traffic from all IPs"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.common_tags,
+    {
+      "Name" = "${var.vpc_name}_solo_worker_sg"
+    },
+  )
+}
+
+data "aws_route_table" "default" {
+  vpc_id = var.vpc_name
+
+  filter {
+    name   = "tag:Name"
+    values = ["enos-vpc_route"]
+  }
+}
+
+resource "aws_route_table_association" "solo_worker_rta" {
+  subnet_id      = aws_subnet.default.id
+  route_table_id = data.aws_route_table.default.id
+}
+
+resource "aws_instance" "worker" {
+  ami                    = var.ubuntu_ami_id
+  instance_type          = var.worker_instance_type
+  vpc_security_group_ids = [aws_security_group.default.id]
+  subnet_id              = aws_subnet.default.id
+  key_name               = var.ssh_aws_keypair
+  iam_instance_profile   = var.iam_instance_profile_name
+  monitoring             = var.worker_monitoring
+
+  root_block_device {
+    iops        = var.ebs_iops
+    volume_size = var.ebs_size
+    volume_type = var.ebs_type
+    throughput  = var.ebs_throughput
+    tags        = var.common_tags
+  }
+
+  tags = merge(
+    var.common_tags,
+    {
+      Name = "${var.name_prefix}-boundary-solo-worker",
+      Type = var.cluster_tag,
+    },
+  )
+}
+
+resource "enos_bundle_install" "worker" {
+  depends_on  = [aws_instance.worker, aws_route_table_association.solo_worker_rta]
+  destination = var.boundary_install_dir
+
+  artifactory = var.boundary_artifactory_release
+  path        = var.local_artifact_path
+  release     = var.boundary_release == null ? var.boundary_release : merge(var.boundary_release, { product = "boundary", edition = "oss" })
+
+  transport = {
+    ssh = {
+      host = aws_instance.worker.public_ip
+    }
+  }
+}
+
+resource "enos_file" "worker_config" {
+  depends_on  = [enos_bundle_install.worker]
+  destination = "/etc/boundary/boundary.hcl"
+  content = templatefile("${path.module}/templates/worker.hcl", {
+    id             = random_pet.worker.id
+    kms_key_id     = data.aws_kms_key.kms_key.id
+    controller_ips = jsonencode(var.controller_ips)
+    public_addr    = aws_instance.worker.public_ip
+    type           = jsonencode(var.worker_type_tags)
+    region         = data.aws_availability_zone.worker_az.region
+  })
+
+  transport = {
+    ssh = {
+      host = aws_instance.worker.public_ip
+    }
+  }
+}
+
+resource "enos_boundary_start" "worker_start" {
+  depends_on = [enos_file.worker_config]
+
+  bin_path    = "/opt/boundary/bin"
+  config_path = "/etc/boundary"
+  transport = {
+    ssh = {
+      host = aws_instance.worker.public_ip
+    }
+  }
+}

--- a/enos/modules/solo_worker/outputs.tf
+++ b/enos/modules/solo_worker/outputs.tf
@@ -1,0 +1,14 @@
+output "worker_ip" {
+  description = "The public IP of the Boundary worker"
+  value       = aws_instance.worker.public_ip
+}
+
+output "worker_tags" {
+  description = "The tags used in the worker's configuration"
+  value       = var.worker_type_tags
+}
+
+output "subnet_id" {
+  description = "The ID of the subnet this worker resides in"
+  value       = aws_subnet.default.id
+}

--- a/enos/modules/solo_worker/templates/worker.hcl
+++ b/enos/modules/solo_worker/templates/worker.hcl
@@ -1,0 +1,28 @@
+listener "tcp" {
+  purpose = "proxy"
+  tls_disable = true
+  address = "0.0.0.0"
+}
+
+worker {
+  # Name attr must be unique across workers
+  name = "worker-${id}"
+  description = "Enos Boundary worker ${id}"
+
+  # Workers must be able to reach controllers on :9201
+  initial_upstreams = ${controller_ips}
+
+  public_addr = "${public_addr}"
+
+  tags {
+    region = "["${region}"]"
+    type = ${type}
+  }
+}
+
+# must be same key as used on controller config
+kms "awskms" {
+  purpose    = "worker-auth"
+  region     = "${region}"
+  kms_key_id = "${kms_key_id}"
+}

--- a/enos/modules/solo_worker/variables.tf
+++ b/enos/modules/solo_worker/variables.tf
@@ -1,0 +1,133 @@
+variable "project_name" {
+  description = "Name of the project."
+  type        = string
+}
+
+variable "environment" {
+  description = "Name of the environment. (CI/Dev/Test/etc)"
+  type        = string
+}
+
+variable "vpc_name" {
+  description = "The name of the existing VPC to be used for this module"
+  type        = string
+}
+
+variable "availability_zones" {
+  description = "List of AWS availability zones to use (or * for all available)"
+  type        = list(string)
+  default     = ["*"]
+}
+
+variable "common_tags" {
+  description = "Tags to set for all resources"
+  type        = map(string)
+  default     = { "Project" : "Enos" }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of KMS key used for SSHing to this module's instance"
+  type        = string
+}
+
+variable "controller_ips" {
+  description = "A list of public IPs for this worker's Boundary controllers"
+  type        = list(string)
+}
+
+variable "ubuntu_ami_id" {
+  description = "Ubuntu LTS AMI from the VPC this module will use"
+  type        = string
+}
+
+variable "worker_instance_type" {
+  description = "The EC2 Instance type to be used for the worker's node"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "ssh_aws_keypair" {
+  description = "The name of the SSH keypair used to connect to EC2 instances"
+  type        = string
+}
+
+variable "worker_monitoring" {
+  description = "Enable detailed monitoring for workers"
+  type        = bool
+  default     = false
+}
+
+variable "ebs_iops" {
+  description = "EBS IOPS for the root volume"
+  type        = number
+  default     = null
+}
+
+variable "ebs_size" {
+  description = "EBS volume size"
+  type        = number
+  default     = 8
+}
+
+variable "ebs_type" {
+  description = "EBS volume type"
+  type        = string
+  default     = "gp2"
+}
+
+variable "ebs_throughput" {
+  description = "EBS data throughput (MiB/s) (only for gp2)"
+  default     = null
+}
+
+variable "boundary_artifactory_release" {
+  description = "Boundary release, version, and edition to install from artifactory.hashicorp.engineering"
+  type = object({
+    username = string
+    token    = string
+    url      = string
+    sha256   = string
+  })
+  default = null
+}
+
+variable "local_artifact_path" {
+  description = "The path to a local boundary.zip"
+  type        = string
+  default     = null
+}
+
+variable "boundary_release" {
+  description = "Boundary release, version, and edition to install from releases.hashicorp.com"
+  type = object({
+    version = string
+  })
+  default = null
+}
+
+variable "boundary_install_dir" {
+  description = "The remote directory where the Boundary binary will be installed"
+  type        = string
+  default     = "/opt/boundary/bin"
+}
+
+variable "iam_instance_profile_name" {
+  description = "The name of the AWS IAM instance profile from the Boundary cluster module"
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "The name_prefix from the Boundary cluster module"
+  type        = string
+}
+
+variable "cluster_tag" {
+  description = "The cluster_tag from the Boundary cluster module"
+  type        = string
+}
+
+variable "worker_type_tags" {
+  description = "A list of tags to add in the worker's configuration file"
+  type        = list(string)
+  default     = ["prod", "webservers"]
+}


### PR DESCRIPTION
This module adds support for provisioning a worker node separately from the Boundary cluster in Enos scenarios.

For the mean time, I have left the dummy scenario that I use to exercise the module. I will remove that before merging this pull request.

I'm wondering what outputs may be useful for a user of the module. I was thinking that the subnet and availability zone may be the details we want to provide as an output so that targets can be put in the same AZ and under the same subnet.