### PR TITLE
chore(enos): Add debug variable

### DIFF
--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -176,7 +176,7 @@ scenario "e2e_aws" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/aws"
-      debug                    = var.e2e_debug_no_run
+      debug_no_run             = var.e2e_debug_no_run
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -176,6 +176,7 @@ scenario "e2e_aws" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/aws"
+      debug                    = var.e2e_debug
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -176,7 +176,7 @@ scenario "e2e_aws" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/aws"
-      debug                    = var.e2e_debug
+      debug                    = var.e2e_debug_no_run
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -100,7 +100,7 @@ scenario "e2e_database" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/database"
-      debug                    = var.e2e_debug
+      debug                    = var.e2e_debug_no_run
       local_boundary_dir       = local.local_boundary_dir
       target_user              = "ubuntu"
       aws_ssh_private_key_path = local.aws_ssh_private_key_path

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -100,6 +100,7 @@ scenario "e2e_database" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/database"
+      debug                    = var.e2e_debug
       local_boundary_dir       = local.local_boundary_dir
       target_user              = "ubuntu"
       aws_ssh_private_key_path = local.aws_ssh_private_key_path

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -100,7 +100,7 @@ scenario "e2e_database" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/database"
-      debug                    = var.e2e_debug_no_run
+      debug_no_run             = var.e2e_debug_no_run
       local_boundary_dir       = local.local_boundary_dir
       target_user              = "ubuntu"
       aws_ssh_private_key_path = local.aws_ssh_private_key_path

--- a/enos/enos-scenario-e2e-static-with-vault.hcl
+++ b/enos/enos-scenario-e2e-static-with-vault.hcl
@@ -132,7 +132,7 @@ scenario "e2e_static_with_vault" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/static_with_vault"
-      debug                    = var.e2e_debug
+      debug                    = var.e2e_debug_no_run
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name

--- a/enos/enos-scenario-e2e-static-with-vault.hcl
+++ b/enos/enos-scenario-e2e-static-with-vault.hcl
@@ -132,7 +132,7 @@ scenario "e2e_static_with_vault" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/static_with_vault"
-      debug                    = var.e2e_debug_no_run
+      debug_no_run             = var.e2e_debug_no_run
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name

--- a/enos/enos-scenario-e2e-static-with-vault.hcl
+++ b/enos/enos-scenario-e2e-static-with-vault.hcl
@@ -132,6 +132,7 @@ scenario "e2e_static_with_vault" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/static_with_vault"
+      debug                    = var.e2e_debug
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name

--- a/enos/enos-scenario-e2e-static.hcl
+++ b/enos/enos-scenario-e2e-static.hcl
@@ -109,7 +109,7 @@ scenario "e2e_static" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/static"
-      debug                    = var.e2e_debug_no_run
+      debug_no_run             = var.e2e_debug_no_run
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name

--- a/enos/enos-scenario-e2e-static.hcl
+++ b/enos/enos-scenario-e2e-static.hcl
@@ -109,7 +109,7 @@ scenario "e2e_static" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/static"
-      debug                    = var.e2e_debug
+      debug                    = var.e2e_debug_no_run
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name

--- a/enos/enos-scenario-e2e-static.hcl
+++ b/enos/enos-scenario-e2e-static.hcl
@@ -109,6 +109,7 @@ scenario "e2e_static" {
 
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/static"
+      debug                    = var.e2e_debug
       alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
       auth_method_id           = step.create_boundary_cluster.auth_method_id
       auth_login_name          = step.create_boundary_cluster.auth_login_name

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -125,7 +125,7 @@ variable "local_build_target" {
   default     = "build-ui build"
 }
 
-variable "e2e_debug" {
+variable "e2e_debug_no_run" {
   description = "If set, this will prevent test suites from running"
   type        = bool
   default     = false

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -124,3 +124,9 @@ variable "local_build_target" {
   type        = string
   default     = "build-ui build"
 }
+
+variable "e2e_debug" {
+  description = "If set, this will prevent test suites from running"
+  type        = bool
+  default     = false
+}

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -40,3 +40,8 @@
 // The port the ALB will listen on to proxy controller API requests. This defaults
 // to 9200
 // alb_listener_api_port = 9200
+
+// Generally, if there's failure in the test suite for any reason, enos/terraform will throw an error and you
+// would not be able to access the environment variables needed to test locally. Enabling this
+// will ensure that the enos scenario passes.
+// e2e_debug = true

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -44,4 +44,4 @@
 // Generally, if there's failure in the test suite for any reason, enos/terraform will throw an error and you
 // would not be able to access the environment variables needed to test locally. Enabling this
 // will ensure that the enos scenario passes.
-// e2e_debug = true
+// e2e_debug_no_run = true

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -9,7 +9,7 @@ terraform {
   }
 }
 
-variable "debug" {
+variable "debug_no_run" {
   description = "If set, this module will not execute the tests so that you can still access environment variables"
   type        = bool
   default     = false
@@ -144,7 +144,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_AWS_HOST_SET_IPS2         = local.aws_host_set_ips2
   }
 
-  inline = var.debug ? ["pwd"] : ["set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json | tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.out"]
+  inline = var.debug_no_run ? ["pwd"] : ["set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json | tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.out"]
 }
 
 output "test_results" {

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -144,7 +144,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_AWS_HOST_SET_IPS2         = local.aws_host_set_ips2
   }
 
-  inline = var.debug_no_run ? ["pwd"] : ["set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json | tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.out"]
+  inline = var.debug_no_run ? [""] : ["set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json | tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.out"]
 }
 
 output "test_results" {

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -9,6 +9,11 @@ terraform {
   }
 }
 
+variable "debug" {
+  description = "If set, this module will not execute the tests so that you can still access environment variables"
+  type        = bool
+  default     = false
+}
 variable "test_package" {
   description = "Name of Go test package to run"
   type        = string
@@ -139,7 +144,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_AWS_HOST_SET_IPS2         = local.aws_host_set_ips2
   }
 
-  inline = ["set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json | tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.out"]
+  inline = var.debug ? ["pwd"] : ["set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json | tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.out"]
 }
 
 output "test_results" {

--- a/enos/scripts/test_e2e_env.sh
+++ b/enos/scripts/test_e2e_env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+DIR=$(pwd)
+
+SCRIPTS_DIR=$( cd -- "$( dirname -- "$0" )" &> /dev/null && pwd )
+STATEDIR=$(ls -td $SCRIPTS_DIR/../.enos/*/ | head -1) # get latest directory
+
+cd $STATEDIR
+terraform show -json terraform.tfstate | jq -r '.values.root_module.child_modules[].resources[] | select(.address=="module.run_e2e_test.enos_local_exec.run_e2e_test") | .values.environment | to_entries[] | "export \(.key)=\(.value|@sh)"'
+
+cd $DIR

--- a/testing/internal/e2e/README.md
+++ b/testing/internal/e2e/README.md
@@ -110,11 +110,7 @@ Launch an enos scenario and print out the environment variables
 ```
 cd enos
 enos scenario launch e2e_{scenario} builder:local
-enos scenario output
-cd .enos
-ls -ltr
-cd <most_recent_directory> # bottom of list
-terraform show -json terraform.tfstate | jq -r '.values.root_module.child_modules[].resources[] | select(.address=="module.run_e2e_test.enos_local_exec.run_e2e_test") | .values.environment | to_entries[] | "export \(.key)=\(.value)"'
+bash scripts/test_e2e_env.sh
 ```
 
 Take the printed environment variable information and export them into another terminal session


### PR DESCRIPTION
If you're running an enos scenario and there's a failure in the test suite for any reason (bug, test issue), enos will throw an error and you would not be able to access the environment variables needed to test/reproduce it locally. Enabling this `e2e_debug` variable will ensure that the enos scenario passes so that you can extract the needed environment variables.

This PR does the following
- adds an enos variable `e2e_debug` to stop scenarios from running the test suite so that you can always get the environment variables of the generated infrastructure
- adds a script `test_e2e_env.sh` to more easily extract the environment variables 
