### PR TITLE
chore(enos): Use node16 version of action

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -60,7 +60,7 @@ jobs:
           echo "trusted-key ${{ secrets.ENOS_GPG_UID }}" >> ~/.gnupg/gpg.conf
           cat ~/.gnupg/gpg.conf
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838  # TSCCR: could not find tsccr entry for aws-actions/configure-aws-credentials
+        uses: aws-actions/configure-aws-credentials@023daa7fe5f7f817faa31fc0fc4a8d0fb6224ed0  # TSCCR: could not find tsccr entry for aws-actions/configure-aws-credentials
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}

--- a/.github/workflows/test-ci-bootstrap-oss.yml
+++ b/.github/workflows/test-ci-bootstrap-oss.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # TSCCR: could not find tsccr entry for hashicorp/setup-terraform
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838  # TSCCR: could not find tsccr entry for aws-actions/configure-aws-credentials
+        uses: aws-actions/configure-aws-credentials@023daa7fe5f7f817faa31fc0fc4a8d0fb6224ed0  # TSCCR: could not find tsccr entry for aws-actions/configure-aws-credentials
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}

--- a/.github/workflows/test-ci-cleanup-oss.yml
+++ b/.github/workflows/test-ci-cleanup-oss.yml
@@ -15,7 +15,7 @@ jobs:
       regions: ${{steps.regions.outputs.regions}}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838  # TSCCR: could not find tsccr entry for aws-actions/configure-aws-credentials
+        uses: aws-actions/configure-aws-credentials@023daa7fe5f7f817faa31fc0fc4a8d0fb6224ed0  # TSCCR: could not find tsccr entry for aws-actions/configure-aws-credentials
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Configure AWS credentials
         id: aws-configure
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838  # TSCCR: could not find tsccr entry for aws-actions/configure-aws-credentials
+        uses: aws-actions/configure-aws-credentials@023daa7fe5f7f817faa31fc0fc4a8d0fb6224ed0  # TSCCR: could not find tsccr entry for aws-actions/configure-aws-credentials
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
@@ -80,7 +80,7 @@ jobs:
         region: ${{ fromJSON(needs.setup.outputs.regions) }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838  # TSCCR: could not find tsccr entry for aws-actions/configure-aws-credentials
+        uses: aws-actions/configure-aws-credentials@023daa7fe5f7f817faa31fc0fc4a8d0fb6224ed0  # TSCCR: could not find tsccr entry for aws-actions/configure-aws-credentials
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}


### PR DESCRIPTION
This PR updates the version of the `aws-actions/configure-aws-credentials` GitHub action to use the node16 version. This is to mitigate some deprecation warnings shown below:

Example: https://github.com/hashicorp/boundary/actions/runs/4316959009
![Screenshot 2023-03-02 at 2 46 07 PM](https://user-images.githubusercontent.com/2474253/222536028-5fdf68d0-e2f4-45e4-8572-cd211d676558.png)

The run for this branch reduces the number of warnings: https://github.com/hashicorp/boundary/actions/runs/4317537965