### PR TITLE
doc: Add boundary logo back to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Boundary
+![](boundary.png)
 
 ----
 


### PR DESCRIPTION
In https://github.com/hashicorp/boundary/pull/3065, I think we unintentionally removed the boundary logo from the README file. This PR adds the logo back.