### PR TITLE
chore: Add "fail-on-cache-miss" setting to more jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
           key: ${{ steps.go-cache-key.outputs.key }}
           restore-keys: |
             ${{ runner.os }}-go
+          fail-on-cache-miss: true
       - name: Install Tools
         run: |
           go mod download
@@ -132,6 +133,7 @@ jobs:
           key: ${{ needs.setup.outputs.go-cache-key }}
           restore-keys: |
             ${{ runner.os }}-go
+          fail-on-cache-miss: true
       - id: set-matrix
         run: ./.github/scripts/set-test-package-matrix.sh
 
@@ -166,6 +168,7 @@ jobs:
           key: ${{ needs.setup.outputs.go-cache-key }}
           restore-keys: |
             ${{ runner.os }}-go
+          fail-on-cache-miss: true
       - name: Set up plugin cache
         id: plugin-cache
         uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4


### PR DESCRIPTION
This PR adds the `fail-on-cache-miss: true` setting to more jobs in the test workflow. We have observed some instances where the cache fails to restore due to a timeout (it gets stuck at 99.6%)

```
Received 16777216 of 965520185 (1.7%), 16.0 MBs/sec
Received 180355072 of 965520185 (18.7%), 85.8 MBs/sec
Received 356515840 of 965520185 (36.9%), 113.2 MBs/sec
Received 520093696 of 965520185 (53.9%), 123.8 MBs/sec
Received 679477248 of 965520185 (70.4%), 129.4 MBs/sec
Received 813694976 of 965520185 (84.3%), 129.1 MBs/sec
Received 961325881 of 965520185 (99.6%), 130.7 MBs/sec
Received 961325881 of 965520185 (99.6%), 114.4 MBs/sec
Received 961325881 of 965520185 (99.6%), 101.7 MBs/sec
Received 961325881 of 965520185 (99.6%), 91.5 MBs/sec
Received 961325881 of 965520185 (99.6%), 83.2 MBs/sec
Received 961325881 of 965520185 (99.6%), 76.3 MBs/sec
Received 961325881 of 965520185 (99.6%), 70.4 MBs/sec
Received 961325881 of 965520185 (99.6%), 65.4 MBs/sec
Received 961325881 of 965520185 (99.6%), 61.0 MBs/sec
Received 961325881 of 965520185 (99.6%), 57.2 MBs/sec
Received 961325881 of 965520185 (99.6%), 53.9 MBs/sec
Received 961325881 of 965520185 (99.6%), 50.9 MBs/sec
...
Warning: Failed to restore: Aborting cache download as the download time exceeded the timeout.
Cache not found for input keys: Linux-go-c1a759caff8d8283364572bf05425217ee48ff696401f8763676d2162aeb374a, Linux-go
```
Example: https://github.com/hashicorp/boundary/actions/runs/4385934376/jobs/7679355445

Currently, the workflow will continue to try to run tests without the cache, eventually resulting in a failure. We should just fail once it fails to restore to save some time.