### PR TITLE
Releng 483/test failure frequency

### DIFF
--- a/.github/workflows/trigger-test-cron.yml
+++ b/.github/workflows/trigger-test-cron.yml
@@ -1,0 +1,18 @@
+name: trigger-test-cron
+
+# This workflow will run every two hours to determine the frequency of test failures
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 */2 * * *'
+
+jobs:
+  trigger-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Trigger test workflow
+        run: gh workflow run test.yml
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
[Jira Ticket RELENG-483](https://hashicorp.atlassian.net/browse/RELENG-483)

To identify the frequency of boundary OSS failures, we have added a new workflow [trigger-test-cron]  that will trigger on a 2-hour schedule and run the test workflow. 