### PR TITLE
chore(enos): Use docker mirror

### DIFF
--- a/testing/internal/e2e/infra/docker.go
+++ b/testing/internal/e2e/infra/docker.go
@@ -239,7 +239,7 @@ func StartOpenSshServer(t testing.TB, pool *dockertest.Pool, network *dockertest
 
 	networkAlias := "target"
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: "lscr.io/linuxserver/openssh-server",
+		Repository: "docker.mirror.hashicorp.services/linuxserver/openssh-server",
 		Env: []string{
 			"PUID=1000",
 			"PGID=1000",


### PR DESCRIPTION
This PR updates the enos GitHub Action workflow to use our internal docker mirror in order to insulate ourselves from issues with GitHub. We were experiencing test failures when trying to pull the `linuxserver/openssh-server` docker image due to an issue with GitHub Packages.

Note: There is an enos test reporting a failure in the status checks due to a bug in enos with the latest Terraform. That work is ongoing.