### PR TITLE
chore(enos): Pin Terraform to 1.3.9 to mitigate bug

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -98,6 +98,9 @@ jobs:
           # the terraform wrapper will break Terraform execution in enos because
           # it changes the output to text when we expect it to be JSON.
           terraform_wrapper: false
+          # Terraform 1.4.x introduced an issue that prevents some resources from
+          # planning. Pin to 1.3.x until it is resolved.
+          terraform_version: 1.3.9
       - name: Import GPG key for Boundary pass keystore
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549  # TSCCR: could not find tsccr entry for crazy-max/ghaction-import-gpg


### PR DESCRIPTION
This PR pins the version of Terraform used in the enos GitHub Action workflows to 1.3.9 in order to mitigate a bug in enos with the introduction of Terraform 1.4.x. This will be reverted once the bug is resolved. 