### PR TITLE
Refactor Target Repository

### DIFF
--- a/internal/cmd/base/initial_resources.go
+++ b/internal/cmd/base/initial_resources.go
@@ -461,7 +461,7 @@ func (b *Server) CreateInitialTargetWithAddress(ctx context.Context) (target.Tar
 	if err != nil {
 		return nil, fmt.Errorf("failed to create target object: %w", err)
 	}
-	tt, _, _, err := targetRepo.CreateTarget(ctx, t, opts...)
+	tt, err := targetRepo.CreateTarget(ctx, t, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to save target to the db: %w", err)
 	}
@@ -525,11 +525,11 @@ func (b *Server) CreateInitialTargetWithHostSources(ctx context.Context) (target
 	if err != nil {
 		return nil, fmt.Errorf("failed to create target object: %w", err)
 	}
-	tt, _, _, err := targetRepo.CreateTarget(ctx, t, opts...)
+	tt, err := targetRepo.CreateTarget(ctx, t, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to save target to the db: %w", err)
 	}
-	tt, _, _, err = targetRepo.AddTargetHostSources(ctx, tt.GetPublicId(), tt.GetVersion(), []string{b.DevHostSetId})
+	tt, err = targetRepo.AddTargetHostSources(ctx, tt.GetPublicId(), tt.GetVersion(), []string{b.DevHostSetId})
 	if err != nil {
 		return nil, fmt.Errorf("failed to add host source %q to target: %w", b.DevHostSetId, err)
 	}

--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -245,7 +245,7 @@ func (s Service) ListTargets(ctx context.Context, req *pbs.ListTargetsRequest) (
 			outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authorizedActions))
 		}
 
-		item, err := toProto(ctx, item, nil, nil, outputOpts...)
+		item, err := toProto(ctx, item, outputOpts...)
 		if err != nil {
 			return nil, err
 		}
@@ -291,8 +291,10 @@ func (s Service) GetTarget(ctx context.Context, req *pbs.GetTargetRequest) (*pbs
 	if outputFields.Has(globals.AuthorizedActionsField) {
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, t.GetPublicId(), IdActions).Strings()))
 	}
+	t.SetHostSources(ts)
+	t.SetCredentialSources(cl)
 
-	item, err := toProto(ctx, t, ts, cl, outputOpts...)
+	item, err := toProto(ctx, t, outputOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -329,8 +331,10 @@ func (s Service) CreateTarget(ctx context.Context, req *pbs.CreateTargetRequest)
 	if outputFields.Has(globals.AuthorizedActionsField) {
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, t.GetPublicId(), IdActions).Strings()))
 	}
+	t.SetHostSources(ts)
+	t.SetCredentialSources(cl)
 
-	item, err := toProto(ctx, t, ts, cl, outputOpts...)
+	item, err := toProto(ctx, t, outputOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -367,8 +371,10 @@ func (s Service) UpdateTarget(ctx context.Context, req *pbs.UpdateTargetRequest)
 	if outputFields.Has(globals.AuthorizedActionsField) {
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, t.GetPublicId(), IdActions).Strings()))
 	}
+	t.SetHostSources(ts)
+	t.SetCredentialSources(cl)
 
-	item, err := toProto(ctx, t, ts, cl, outputOpts...)
+	item, err := toProto(ctx, t, outputOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -403,10 +409,12 @@ func (s Service) AddTargetHostSources(ctx context.Context, req *pbs.AddTargetHos
 	if authResults.Error != nil {
 		return nil, authResults.Error
 	}
-	t, ts, cl, err := s.addHostSourcesInRepo(ctx, req.GetId(), req.GetHostSourceIds(), req.GetVersion())
+	t, err := s.addHostSourcesInRepo(ctx, req.GetId(), req.GetHostSourceIds(), req.GetVersion())
 	if err != nil {
 		return nil, err
 	}
+	ts := t.GetHostSources()
+	cl := t.GetCredentialSources()
 
 	outputFields, ok := requests.OutputFields(ctx)
 	if !ok {
@@ -421,8 +429,10 @@ func (s Service) AddTargetHostSources(ctx context.Context, req *pbs.AddTargetHos
 	if outputFields.Has(globals.AuthorizedActionsField) {
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, t.GetPublicId(), IdActions).Strings()))
 	}
+	t.SetHostSources(ts)
+	t.SetCredentialSources(cl)
 
-	item, err := toProto(ctx, t, ts, cl, outputOpts...)
+	item, err := toProto(ctx, t, outputOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -459,8 +469,10 @@ func (s Service) SetTargetHostSources(ctx context.Context, req *pbs.SetTargetHos
 	if outputFields.Has(globals.AuthorizedActionsField) {
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, t.GetPublicId(), IdActions).Strings()))
 	}
+	t.SetHostSources(ts)
+	t.SetCredentialSources(cl)
 
-	item, err := toProto(ctx, t, ts, cl, outputOpts...)
+	item, err := toProto(ctx, t, outputOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -497,8 +509,10 @@ func (s Service) RemoveTargetHostSources(ctx context.Context, req *pbs.RemoveTar
 	if outputFields.Has(globals.AuthorizedActionsField) {
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, t.GetPublicId(), IdActions).Strings()))
 	}
+	t.SetHostSources(ts)
+	t.SetCredentialSources(cl)
 
-	item, err := toProto(ctx, t, ts, cl, outputOpts...)
+	item, err := toProto(ctx, t, outputOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -537,8 +551,10 @@ func (s Service) AddTargetCredentialSources(ctx context.Context, req *pbs.AddTar
 	if outputFields.Has(globals.AuthorizedActionsField) {
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, t.GetPublicId(), IdActions).Strings()))
 	}
+	t.SetHostSources(ts)
+	t.SetCredentialSources(cl)
 
-	item, err := toProto(ctx, t, ts, cl, outputOpts...)
+	item, err := toProto(ctx, t, outputOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -577,8 +593,10 @@ func (s Service) SetTargetCredentialSources(ctx context.Context, req *pbs.SetTar
 	if outputFields.Has(globals.AuthorizedActionsField) {
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, t.GetPublicId(), IdActions).Strings()))
 	}
+	t.SetHostSources(ts)
+	t.SetCredentialSources(cl)
 
-	item, err := toProto(ctx, t, ts, cl, outputOpts...)
+	item, err := toProto(ctx, t, outputOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -617,8 +635,10 @@ func (s Service) RemoveTargetCredentialSources(ctx context.Context, req *pbs.Rem
 	if outputFields.Has(globals.AuthorizedActionsField) {
 		outputOpts = append(outputOpts, handlers.WithAuthorizedActions(authResults.FetchActionSetForId(ctx, t.GetPublicId(), IdActions).Strings()))
 	}
+	t.SetHostSources(ts)
+	t.SetCredentialSources(cl)
 
-	item, err := toProto(ctx, t, ts, cl, outputOpts...)
+	item, err := toProto(ctx, t, outputOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -711,7 +731,10 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 	if err != nil {
 		return nil, err
 	}
-	t, hostSources, credSources, err := repo.LookupTarget(ctx, t.GetPublicId())
+	t, err = repo.LookupTarget(ctx, t.GetPublicId())
+	hostSources := t.GetHostSources()
+	credSources := t.GetCredentialSources()
+
 	if err != nil {
 		if errors.IsNotFoundError(err) {
 			return nil, handlers.NotFoundErrorf("Target %q not found.", t.GetPublicId())
@@ -1032,13 +1055,16 @@ func (s Service) getFromRepo(ctx context.Context, id string) (target.Target, []t
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	u, hs, cl, err := repo.LookupTarget(ctx, id)
+	u, err := repo.LookupTarget(ctx, id)
 	if err != nil {
 		if errors.IsNotFoundError(err) {
 			return nil, nil, nil, handlers.NotFoundErrorf("Target %q doesn't exist.", id)
 		}
 		return nil, nil, nil, err
 	}
+	hs := u.GetHostSources()
+	cl := u.GetCredentialSources()
+
 	if u == nil {
 		return nil, nil, nil, handlers.NotFoundErrorf("Target %q doesn't exist.", id)
 	}
@@ -1081,10 +1107,13 @@ func (s Service) createInRepo(ctx context.Context, item *pb.Target) (target.Targ
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	out, hs, cl, err := repo.CreateTarget(ctx, u)
+	out, err := repo.CreateTarget(ctx, u)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to create target"))
 	}
+	hs := out.GetHostSources()
+	cl := out.GetCredentialSources()
+
 	if out == nil {
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to create target but no error returned from repository.")
 	}
@@ -1152,10 +1181,13 @@ func (s Service) updateInRepo(ctx context.Context, scopeId, id string, mask []st
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	out, hs, cl, rowsUpdated, err := repo.UpdateTarget(ctx, u, version, dbMask, opts...)
+	out, rowsUpdated, err := repo.UpdateTarget(ctx, u, version, dbMask, opts...)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to update target"))
 	}
+	hs := out.GetHostSources()
+	cl := out.GetCredentialSources()
+
 	if rowsUpdated == 0 {
 		return nil, nil, nil, handlers.NotFoundErrorf("Target %q not found or incorrect version provided.", id)
 	}
@@ -1190,26 +1222,26 @@ func (s Service) listFromRepo(ctx context.Context, perms []perms.Permission) ([]
 	return ul, nil
 }
 
-func (s Service) addHostSourcesInRepo(ctx context.Context, targetId string, hostSourceIds []string, version uint32) (target.Target, []target.HostSource, []target.CredentialSource, error) {
+func (s Service) addHostSourcesInRepo(ctx context.Context, targetId string, hostSourceIds []string, version uint32) (target.Target, error) {
 	repo, err := s.repoFn()
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
-	out, hs, cl, err := repo.AddTargetHostSources(ctx, targetId, version, strutil.RemoveDuplicates(hostSourceIds, false))
+	out, err := repo.AddTargetHostSources(ctx, targetId, version, strutil.RemoveDuplicates(hostSourceIds, false))
 	if err != nil {
 		var internalErr *errors.Err
 		if stderrors.As(err, &internalErr) && internalErr.Code == errors.Conflict {
 			// The conflict error is surfaced directly as it's correctly
 			// converted all the way down to the HTTP status.
-			return nil, nil, nil, err
+			return nil, err
 		}
 		// TODO: Figure out a way to surface more helpful error info beyond the Internal error.
-		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Failed to add target host sources")
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Failed to add target host sources")
 	}
 	if out == nil {
-		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to lookup target after adding host sources to it.")
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to lookup target after adding host sources to it.")
 	}
-	return out, hs, cl, nil
+	return out, nil
 }
 
 func (s Service) setHostSourcesInRepo(ctx context.Context, targetId string, hostSourceIds []string, version uint32) (target.Target, []target.HostSource, []target.CredentialSource, error) {
@@ -1230,10 +1262,13 @@ func (s Service) setHostSourcesInRepo(ctx context.Context, targetId string, host
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Failed to set target host sources")
 	}
 
-	out, hs, cl, err := repo.LookupTarget(ctx, targetId)
+	out, err := repo.LookupTarget(ctx, targetId)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to look up target after setting host sources"))
 	}
+	hs := out.GetHostSources()
+	cl := out.GetCredentialSources()
+
 	if out == nil {
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to lookup target after setting host sources for it.")
 	}
@@ -1251,10 +1286,13 @@ func (s Service) removeHostSourcesInRepo(ctx context.Context, targetId string, h
 		// TODO: Figure out a way to surface more helpful error info beyond the Internal error.
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to remove host sources from target: %v.", err)
 	}
-	out, hs, cl, err := repo.LookupTarget(ctx, targetId)
+	out, err := repo.LookupTarget(ctx, targetId)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to look up target after removing host sources"))
 	}
+	hs := out.GetHostSources()
+	cl := out.GetCredentialSources()
+
 	if out == nil {
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to lookup target after removing host sources from it.")
 	}
@@ -1275,11 +1313,14 @@ func (s Service) addCredentialSourcesInRepo(ctx context.Context, targetId string
 		creds.InjectedApplicationCredentialIds = strutil.RemoveDuplicates(injectedAppIds, false)
 	}
 
-	out, hs, credSources, err := repo.AddTargetCredentialSources(ctx, targetId, version, creds)
+	out, err := repo.AddTargetCredentialSources(ctx, targetId, version, creds)
 	if err != nil {
 		// TODO: Figure out a way to surface more helpful error info beyond the Internal error.
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to add credential sources to target: %v.", err)
 	}
+	hs := out.GetHostSources()
+	credSources := out.GetCredentialSources()
+
 	if out == nil {
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to lookup target after adding credential sources to it.")
 	}
@@ -1307,10 +1348,13 @@ func (s Service) setCredentialSourcesInRepo(ctx context.Context, targetId string
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to set credential sources in target: %v.", err)
 	}
 
-	out, hs, credSources, err := repo.LookupTarget(ctx, targetId)
+	out, err := repo.LookupTarget(ctx, targetId)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to look up target after setting credential sources"))
 	}
+	hs := out.GetHostSources()
+	credSources := out.GetCredentialSources()
+
 	if out == nil {
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to lookup target after setting credential sources for it.")
 	}
@@ -1336,10 +1380,13 @@ func (s Service) removeCredentialSourcesInRepo(ctx context.Context, targetId str
 		// TODO: Figure out a way to surface more helpful error info beyond the Internal error.
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to remove credential sources from target: %v.", err)
 	}
-	out, hs, credSources, err := repo.LookupTarget(ctx, targetId)
+	out, err := repo.LookupTarget(ctx, targetId)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to look up target after removing credential sources"))
 	}
+	hs := out.GetHostSources()
+	credSources := out.GetCredentialSources()
+
 	if out == nil {
 		return nil, nil, nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Unable to lookup target after removing credential sources from it.")
 	}
@@ -1375,7 +1422,7 @@ func (s Service) authResult(ctx context.Context, id string, a action.Type, looku
 			res.Error = err
 			return res
 		}
-		t, _, _, err = repo.LookupTarget(ctx, id, lookupOpt...)
+		t, err = repo.LookupTarget(ctx, id, lookupOpt...)
 		if err != nil {
 			// TODO: Fix this with new/better error handling
 			if strings.Contains(err.Error(), "more than one row returned by a subquery") {
@@ -1399,13 +1446,15 @@ func (s Service) authResult(ctx context.Context, id string, a action.Type, looku
 	return ret
 }
 
-func toProto(ctx context.Context, in target.Target, hostSources []target.HostSource, credSources []target.CredentialSource, opt ...handlers.Option) (*pb.Target, error) {
+func toProto(ctx context.Context, in target.Target, opt ...handlers.Option) (*pb.Target, error) {
 	const op = "target_service.toProto"
 	opts := handlers.GetOpts(opt...)
 	if opts.WithOutputFields == nil {
 		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "output fields not found when building target proto")
 	}
 	outputFields := *opts.WithOutputFields
+	hostSources := in.GetHostSources()
+	credSources := in.GetCredentialSources()
 
 	out := pb.Target{}
 	if outputFields.Has(globals.IdField) {

--- a/internal/daemon/controller/handlers/targets/tcp/target_service_test.go
+++ b/internal/daemon/controller/handlers/targets/tcp/target_service_test.go
@@ -818,16 +818,16 @@ func TestUpdate(t *testing.T) {
 		target.WithSessionConnectionLimit(1),
 		target.WithDefaultPort(2))
 	require.NoError(t, err)
-	tar, _, _, err := repo.CreateTarget(context.Background(), ttar)
+	tar, err := repo.CreateTarget(context.Background(), ttar)
 	require.NoError(t, err)
-	tar, _, _, err = repo.AddTargetHostSources(context.Background(), tar.GetPublicId(), tar.GetVersion(), []string{hs[0].GetPublicId(), hs[1].GetPublicId()})
+	tar, err = repo.AddTargetHostSources(context.Background(), tar.GetPublicId(), tar.GetVersion(), []string{hs[0].GetPublicId(), hs[1].GetPublicId()})
 	require.NoError(t, err)
 
 	resetTarget := func() {
-		itar, _, _, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
+		itar, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
 		require.NoError(t, err)
 
-		tar, _, _, _, err = repo.UpdateTarget(context.Background(), tar, itar.GetVersion(),
+		tar, _, err = repo.UpdateTarget(context.Background(), tar, itar.GetVersion(),
 			[]string{"Name", "Description", "SessionMaxSeconds", "SessionConnectionLimit", "DefaultPort"})
 		require.NoError(t, err, "Failed to reset target.")
 	}
@@ -1296,7 +1296,7 @@ func TestUpdate_BadVersion(t *testing.T) {
 	tar := ttar.(*tcp.Target)
 	tar.DefaultPort = 2
 	require.NoError(t, err)
-	gtar, _, _, err := repo.CreateTarget(context.Background(), tar)
+	gtar, err := repo.CreateTarget(context.Background(), tar)
 	require.NoError(t, err)
 
 	tested, err := testService(t, context.Background(), conn, kms, wrapper)

--- a/internal/session/repository_session_test.go
+++ b/internal/session/repository_session_test.go
@@ -999,7 +999,7 @@ func TestRepository_CancelSession(t *testing.T) {
 
 				targetRepo, err := target.NewRepository(ctx, rw, rw, testKms)
 				require.NoError(t, err)
-				_, _, _, err = targetRepo.AddTargetHostSources(ctx, tcpTarget.GetPublicId(), tcpTarget.GetVersion(), []string{sets[0].PublicId})
+				_, err = targetRepo.AddTargetHostSources(ctx, tcpTarget.GetPublicId(), tcpTarget.GetVersion(), []string{sets[0].PublicId})
 				require.NoError(t, err)
 
 				authMethod := password.TestAuthMethods(t, conn, org.PublicId, 1)[0]
@@ -1527,7 +1527,7 @@ func testSessionCredentialParams(t *testing.T, conn *db.DB, wrapper wrapping.Wra
 	kms := kms.TestKms(t, conn, wrapper)
 	targetRepo, err := target.NewRepository(ctx, rw, rw, kms)
 	require.NoError(err)
-	tar, _, _, err := targetRepo.LookupTarget(ctx, params.TargetId)
+	tar, err := targetRepo.LookupTarget(ctx, params.TargetId)
 	require.NoError(err)
 	require.NotNil(tar)
 
@@ -1540,7 +1540,7 @@ func testSessionCredentialParams(t *testing.T, conn *db.DB, wrapper wrapping.Wra
 	ids := target.CredentialSources{
 		BrokeredCredentialIds: []string{libIds[0].GetPublicId(), libIds[1].GetPublicId(), upCreds[0].GetPublicId(), upCreds[1].GetPublicId()},
 	}
-	_, _, _, err = targetRepo.AddTargetCredentialSources(ctx, tar.GetPublicId(), tar.GetVersion(), ids)
+	_, err = targetRepo.AddTargetCredentialSources(ctx, tar.GetPublicId(), tar.GetVersion(), ids)
 	require.NoError(err)
 	dynamicCreds := []*DynamicCredential{
 		NewDynamicCredential(libIds[0].GetPublicId(), cred.BrokeredPurpose),

--- a/internal/session/service_authorize_connection_test.go
+++ b/internal/session/service_authorize_connection_test.go
@@ -95,7 +95,7 @@ func TestService_AuthorizeConnection(t *testing.T) {
 
 				targetRepo, err := target.NewRepository(ctx, rw, rw, testKms)
 				require.NoError(t, err)
-				_, _, _, err = targetRepo.AddTargetHostSources(ctx, tcpTarget.GetPublicId(), tcpTarget.GetVersion(), []string{sets[0].PublicId})
+				_, err = targetRepo.AddTargetHostSources(ctx, tcpTarget.GetPublicId(), tcpTarget.GetVersion(), []string{sets[0].PublicId})
 				require.NoError(t, err)
 
 				authMethod := password.TestAuthMethods(t, conn, org.PublicId, 1)[0]

--- a/internal/session/service_close_connections_test.go
+++ b/internal/session/service_close_connections_test.go
@@ -56,7 +56,7 @@ func TestServiceCloseConnections(t *testing.T) {
 
 		targetRepo, err := target.NewRepository(ctx, rw, rw, testKms)
 		require.NoError(t, err)
-		_, _, _, err = targetRepo.AddTargetHostSources(ctx, tcpTarget.GetPublicId(), tcpTarget.GetVersion(), []string{sets[0].PublicId})
+		_, err = targetRepo.AddTargetHostSources(ctx, tcpTarget.GetPublicId(), tcpTarget.GetVersion(), []string{sets[0].PublicId})
 		require.NoError(t, err)
 
 		authMethod := password.TestAuthMethods(t, conn, org.PublicId, 1)[0]

--- a/internal/session/testing.go
+++ b/internal/session/testing.go
@@ -222,7 +222,7 @@ func TestSessionParams(t testing.TB, conn *db.DB, wrapper wrapping.Wrapper, iamR
 	kms := kms.TestKms(t, conn, wrapper)
 	targetRepo, err := target.NewRepository(ctx, rw, rw, kms)
 	require.NoError(err)
-	_, _, _, err = targetRepo.AddTargetHostSources(ctx, tcpTarget.GetPublicId(), tcpTarget.GetVersion(), []string{sets[0].PublicId})
+	_, err = targetRepo.AddTargetHostSources(ctx, tcpTarget.GetPublicId(), tcpTarget.GetVersion(), []string{sets[0].PublicId})
 	require.NoError(err)
 
 	authMethod := password.TestAuthMethods(t, conn, org.PublicId, 1)[0]

--- a/internal/target/repository_credential_source_test.go
+++ b/internal/target/repository_credential_source_test.go
@@ -78,10 +78,13 @@ func TestRepository_SetTargetCredentialSources(t *testing.T) {
 			ids.BrokeredCredentialIds = append(ids.BrokeredCredentialIds, cred.GetPublicId())
 		}
 
-		_, _, created, err := repo.AddTargetCredentialSources(context.Background(), tar.GetPublicId(), 1, ids)
+		target, err := repo.AddTargetCredentialSources(context.Background(), tar.GetPublicId(), 1, ids)
 		require.NoError(t, err)
-		require.Equal(t, 10, len(created))
-		return created, ids
+
+		credentialSources := target.GetCredentialSources()
+
+		require.Equal(t, 10, len(credentialSources))
+		return credentialSources, ids
 	}
 	type args struct {
 		targetVersion    uint32
@@ -266,9 +269,10 @@ func TestRepository_SetTargetCredentialSources(t *testing.T) {
 				}
 			}
 
-			origTarget, _, lookupCredSources, err := repo.LookupTarget(ctx, tar.GetPublicId())
+			origTarget, err := repo.LookupTarget(ctx, tar.GetPublicId())
 			require.NoError(err)
-			assert.Equal(origCredSources, lookupCredSources)
+
+			assert.Equal(origCredSources, origTarget.GetCredentialSources())
 
 			_, gotSources, affectedRows, err := repo.SetTargetCredentialSources(ctx, tar.GetPublicId(), tt.args.targetVersion, tt.args.ids)
 			if tt.wantErr {
@@ -288,7 +292,7 @@ func TestRepository_SetTargetCredentialSources(t *testing.T) {
 				assert.Equal(w.CredentialPurpose(), cs.CredentialPurpose())
 			}
 
-			foundTarget, _, _, err := repo.LookupTarget(ctx, tar.GetPublicId())
+			foundTarget, err := repo.LookupTarget(ctx, tar.GetPublicId())
 			require.NoError(err)
 			if tt.name != "no-change" {
 				assert.Equalf(tt.args.targetVersion+1, foundTarget.GetVersion(), "%s unexpected version: %d/%d", tt.name, tt.args.targetVersion+1, foundTarget.GetVersion())

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -33,6 +33,8 @@ type Target interface {
 	GetEgressWorkerFilter() string
 	GetIngressWorkerFilter() string
 	GetAddress() string
+	GetHostSources() []HostSource
+	GetCredentialSources() []CredentialSource
 	Clone() Target
 	SetPublicId(context.Context, string) error
 	SetProjectId(string)
@@ -48,6 +50,8 @@ type Target interface {
 	SetEgressWorkerFilter(string)
 	SetIngressWorkerFilter(string)
 	SetAddress(string)
+	SetHostSources([]HostSource)
+	SetCredentialSources([]CredentialSource)
 	Oplog(op oplog.OpType) oplog.Metadata
 }
 
@@ -66,8 +70,10 @@ var (
 type targetView struct {
 	*store.TargetView
 	// Network address assigned to the Target.
-	Address   string `json:"address,omitempty" gorm:"-"`
-	tableName string `gorm:"-"`
+	Address           string             `json:"address,omitempty" gorm:"-"`
+	tableName         string             `gorm:"-"`
+	HostSource        []HostSource       `gorm:"-"`
+	CredentialSources []CredentialSource `gorm:"-"`
 }
 
 // allocTargetView will allocate a target view
@@ -96,6 +102,14 @@ func (t *targetView) SetTableName(n string) {
 	}
 }
 
+func (t *targetView) SetHostSources(hs []HostSource) {
+	t.HostSource = hs
+}
+
+func (t *targetView) SetCredentialSources(cs []CredentialSource) {
+	t.CredentialSources = cs
+}
+
 // GetPublicId satisfies boundary.AuthzProtectedEntity
 func (t targetView) GetPublicId() string {
 	return t.PublicId
@@ -104,6 +118,14 @@ func (t targetView) GetPublicId() string {
 // GetProjectId satisfies boundary.AuthzProtectedEntity
 func (t targetView) GetProjectId() string {
 	return t.ProjectId
+}
+
+func (t targetView) GetHostSources() []HostSource {
+	return t.HostSource
+}
+
+func (t targetView) GetCredentialSources() []CredentialSource {
+	return t.CredentialSources
 }
 
 // GetUserId satisfies boundary.AuthzProtectedEntity; targets are not associated
@@ -147,5 +169,7 @@ func (t *targetView) targetSubtype(ctx context.Context, address string) (Target,
 	tt.SetEgressWorkerFilter(t.EgressWorkerFilter)
 	tt.SetIngressWorkerFilter(t.IngressWorkerFilter)
 	tt.SetAddress(address)
+	tt.SetHostSources(t.HostSource)
+	tt.SetCredentialSources(t.CredentialSources)
 	return tt, nil
 }

--- a/internal/target/targettest/target.go
+++ b/internal/target/targettest/target.go
@@ -30,8 +30,10 @@ const (
 // Target is a target.Target used for tests.
 type Target struct {
 	*store.Target
-	Address   string `gorm:"-"`
-	tableName string `gorm:"-"`
+	Address           string                    `gorm:"-"`
+	tableName         string                    `gorm:"-"`
+	HostSource        []target.HostSource       `gorm:"-"`
+	CredentialSources []target.CredentialSource `gorm:"-"`
 }
 
 var (
@@ -133,11 +135,21 @@ func (t *Target) GetAddress() string {
 	return t.Address
 }
 
+func (t *Target) GetHostSources() []target.HostSource {
+	return t.HostSource
+}
+
+func (t *Target) GetCredentialSources() []target.CredentialSource {
+	return t.CredentialSources
+}
+
 func (t *Target) Clone() target.Target {
 	cp := proto.Clone(t.Target)
 	return &Target{
-		Address: t.Address,
-		Target:  cp.(*store.Target),
+		Address:           t.Address,
+		Target:            cp.(*store.Target),
+		HostSource:        t.HostSource,
+		CredentialSources: t.CredentialSources,
 	}
 }
 
@@ -196,6 +208,14 @@ func (t *Target) SetIngressWorkerFilter(filter string) {
 
 func (t *Target) SetAddress(a string) {
 	t.Address = a
+}
+
+func (t *Target) SetHostSources(sources []target.HostSource) {
+	t.HostSource = sources
+}
+
+func (t *Target) SetCredentialSources(sources []target.CredentialSource) {
+	t.CredentialSources = sources
 }
 
 func (t *Target) Oplog(op oplog.OpType) oplog.Metadata {

--- a/internal/target/tcp/immutable_fields_test.go
+++ b/internal/target/tcp/immutable_fields_test.go
@@ -178,7 +178,8 @@ func TestTargetHostSet_ImmutableFields(t *testing.T) {
 	updateTarget := tcp.TestTarget(ctx, t, conn, proj.PublicId, tcp.TestId(t))
 	updateHset := hsets[1]
 
-	_, gotHostSources, _, err := repo.AddTargetHostSources(ctx, projTarget.GetPublicId(), 1, []string{hsets[0].PublicId})
+	gotTarget, err := repo.AddTargetHostSources(ctx, projTarget.GetPublicId(), 1, []string{hsets[0].PublicId})
+	gotHostSources := gotTarget.GetHostSources()
 	require.NoError(t, err)
 	require.Equal(t, 1, len(gotHostSources))
 	new, err := target.NewTargetHostSet(projTarget.GetPublicId(), gotHostSources[0].Id())

--- a/internal/target/tcp/repository_tcp_target_test.go
+++ b/internal/target/tcp/repository_tcp_target_test.go
@@ -210,7 +210,7 @@ func TestRepository_CreateTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
-			tar, hostSources, credSources, err := repo.CreateTarget(context.Background(), tt.args.target, tt.args.opt...)
+			tar, err := repo.CreateTarget(context.Background(), tt.args.target, tt.args.opt...)
 			if tt.wantErr {
 				assert.Error(err)
 				assert.Nil(tar)
@@ -220,7 +220,13 @@ func TestRepository_CreateTarget(t *testing.T) {
 			require.NoError(err)
 			assert.NotNil(tar.GetPublicId())
 
-			foundTarget, foundHostSources, foundCredLibs, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
+			hostSources := tar.GetHostSources()
+			credSources := tar.GetCredentialSources()
+
+			foundTarget, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
+			foundHostSources := foundTarget.GetHostSources()
+			foundCredLibs := foundTarget.GetCredentialSources()
+
 			assert.NoError(err)
 			if len(tt.wantAddress) != 0 {
 				assert.Equal(tt.wantAddress, tar.GetAddress())
@@ -576,7 +582,7 @@ func TestRepository_UpdateTcpTarget(t *testing.T) {
 				ut.PublicId = *tt.args.PublicId
 			}
 
-			targetAfterUpdate, hostSources, credSources, updatedRows, err := repo.UpdateTarget(ctx, updateTarget, tar.GetVersion(), tt.args.fieldMaskPaths, tt.args.opt...)
+			targetAfterUpdate, updatedRows, err := repo.UpdateTarget(ctx, updateTarget, tar.GetVersion(), tt.args.fieldMaskPaths, tt.args.opt...)
 			if tt.wantErr {
 				assert.Error(err)
 				assert.True(errors.Match(errors.T(tt.wantIsError), err))
@@ -592,6 +598,9 @@ func TestRepository_UpdateTcpTarget(t *testing.T) {
 			require.NoError(err)
 			require.NotNil(targetAfterUpdate)
 			assert.Equal(tt.wantRowsUpdate, updatedRows)
+
+			hostSources := targetAfterUpdate.GetHostSources()
+			credSources := targetAfterUpdate.GetCredentialSources()
 			afterUpdateIds := make([]string, 0, len(hostSources))
 			for _, hs := range hostSources {
 				afterUpdateIds = append(afterUpdateIds, hs.Id())
@@ -615,7 +624,7 @@ func TestRepository_UpdateTcpTarget(t *testing.T) {
 			default:
 				assert.NotEqual(tar.GetUpdateTime(), targetAfterUpdate.GetUpdateTime())
 			}
-			foundTarget, _, _, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
+			foundTarget, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
 			assert.NoError(err)
 			assert.True(proto.Equal(targetAfterUpdate.((*tcp.Target)), foundTarget.((*tcp.Target))))
 			assert.Equal(targetAfterUpdate.GetAddress(), foundTarget.GetAddress())

--- a/internal/target/tcp/repository_test.go
+++ b/internal/target/tcp/repository_test.go
@@ -129,7 +129,7 @@ func TestRepository_LookupTarget(t *testing.T) {
 			if tt.projectName != "" {
 				opts = append(opts, target.WithProjectName(tt.projectName))
 			}
-			got, _, _, err := repo.LookupTarget(ctx, id, opts...)
+			got, err := repo.LookupTarget(ctx, id, opts...)
 			if tt.wantErr {
 				require.Error(err)
 				return
@@ -261,7 +261,7 @@ func TestRepository_DeleteTarget(t *testing.T) {
 			}
 			assert.NoError(err)
 			assert.Equal(tt.wantRowsDeleted, deletedRows)
-			foundGroup, _, _, err := repo.LookupTarget(ctx, tt.args.target.GetPublicId())
+			foundGroup, err := repo.LookupTarget(ctx, tt.args.target.GetPublicId())
 			assert.NoError(err)
 			assert.Nil(foundGroup)
 

--- a/internal/target/tcp/target.go
+++ b/internal/target/tcp/target.go
@@ -31,8 +31,10 @@ const (
 type Target struct {
 	*store.Target
 	// Network address assigned to the Target.
-	Address   string `json:"address,omitempty" gorm:"-"`
-	tableName string `gorm:"-"`
+	Address           string                    `json:"address,omitempty" gorm:"-"`
+	tableName         string                    `gorm:"-"`
+	HostSource        []target.HostSource       `gorm:"-"`
+	CredentialSources []target.CredentialSource `gorm:"-"`
 }
 
 // Ensure Target implements interfaces
@@ -78,8 +80,10 @@ func (h targetHooks) AllocTarget() target.Target {
 func (t *Target) Clone() target.Target {
 	cp := proto.Clone(t.Target)
 	return &Target{
-		Target:  cp.(*store.Target),
-		Address: t.Address,
+		Target:            cp.(*store.Target),
+		Address:           t.Address,
+		HostSource:        t.HostSource,
+		CredentialSources: t.CredentialSources,
 	}
 }
 
@@ -133,6 +137,14 @@ func (t *Target) GetType() subtypes.Subtype {
 
 func (t *Target) GetAddress() string {
 	return t.Address
+}
+
+func (t *Target) GetHostSources() []target.HostSource {
+	return t.HostSource
+}
+
+func (t *Target) GetCredentialSources() []target.CredentialSource {
+	return t.CredentialSources
 }
 
 func (t *Target) SetPublicId(ctx context.Context, publicId string) error {
@@ -195,4 +207,12 @@ func (t *Target) SetIngressWorkerFilter(filter string) {
 
 func (t *Target) SetAddress(address string) {
 	t.Address = address
+}
+
+func (t *Target) SetHostSources(sources []target.HostSource) {
+	t.HostSource = sources
+}
+
+func (t *Target) SetCredentialSources(sources []target.CredentialSource) {
+	t.CredentialSources = sources
 }

--- a/internal/target/tcp/testing_test.go
+++ b/internal/target/tcp/testing_test.go
@@ -43,7 +43,9 @@ func Test_TestTcpTarget(t *testing.T) {
 	require.NotEmpty(tar.GetPublicId())
 	require.Equal(name, tar.GetName())
 
-	_, foundSources, _, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
+	foundTarget, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
+	foundSources := foundTarget.GetHostSources()
+
 	require.NoError(err)
 	foundIds := make([]string, 0, len(foundSources))
 	for _, s := range foundSources {
@@ -79,7 +81,9 @@ func Test_TestCredentialLibrary(t *testing.T) {
 
 	assert.Len(libs, 2)
 
-	_, _, foundSources, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
+	foundTarget, err := repo.LookupTarget(context.Background(), tar.GetPublicId())
+	foundSources := foundTarget.GetCredentialSources()
+
 	require.NoError(err)
 	foundIds := make([]string, 0, len(foundSources))
 	for _, s := range foundSources {


### PR DESCRIPTION
## Change
Refactor the Target domain repository functions so that they no longer return 4 different types.

`Target` struct now contains `HostSource` & `CredentialSources` with Getters & Setters

## Rationale
Extending `Target` to contain `HostSource` & `CredentialSources` enables `funcs` to just return `Target` instead of multiple return types. This also allows easy future refactors and extensions of `Target`

## Breaking changes
There should not be any breaking changes from this change