### PR TITLE
docs: Update FAQs with IAM role answer

### DIFF
--- a/website/content/docs/troubleshoot/faq.mdx
+++ b/website/content/docs/troubleshoot/faq.mdx
@@ -55,7 +55,7 @@ for HCP Boundary. Audit logs for both distributions can be exported to SIEM or B
 **Session Termination:** Supported. Session termination for Boundary administrators is a supported capability, as demonstrated in this
 [tutorial](/boundary/tutorials/getting-started/getting-started-connect#manage-sessions).
 
-#### Q: As an AWS user, can I use IAM role to configure Boundary's dynamic host catalog?
+#### Q: As an AWS user, can IAM roles be used to configure Boundary's dynamic host catalog?
 At this time, it is not possible to configure Boundary's dynamic host catalog using IAM role.
 You can configure the dynamic host catalog using IAM user, however.
 For more information, refer to the [Dynamic host catalogs on AWS](/boundary/tutorials/access-management/aws-host-catalogs) tutorial.

--- a/website/content/docs/troubleshoot/faq.mdx
+++ b/website/content/docs/troubleshoot/faq.mdx
@@ -56,7 +56,6 @@ for HCP Boundary. Audit logs for both distributions can be exported to SIEM or B
 [tutorial](/boundary/tutorials/getting-started/getting-started-connect#manage-sessions).
 
 #### Q: As an AWS user, can I use IAM role to configure Boundary's dynamic host catalog?
-An IAM role does not have any credentials, and cannot make direct requests to AWS services.
 At this time, it is not possible to configure Boundary's dynamic host catalog using IAM role.
 You can configure the dynamic host catalog using IAM user, however.
 For more information, refer to the [Dynamic host catalogs on AWS](/boundary/tutorials/access-management/aws-host-catalogs) tutorial.

--- a/website/content/docs/troubleshoot/faq.mdx
+++ b/website/content/docs/troubleshoot/faq.mdx
@@ -56,6 +56,6 @@ for HCP Boundary. Audit logs for both distributions can be exported to SIEM or B
 [tutorial](/boundary/tutorials/getting-started/getting-started-connect#manage-sessions).
 
 #### Q: As an AWS user, can IAM roles be used to configure Boundary's dynamic host catalog?
-At this time, it is not possible to configure Boundary's dynamic host catalog using IAM role.
-You can configure the dynamic host catalog using IAM user, however.
+At this time, it is not possible to configure Boundary's dynamic host catalog using IAM roles.
+You can configure the dynamic host catalog using an IAM user, however.
 For more information, refer to the [Dynamic host catalogs on AWS](/boundary/tutorials/access-management/aws-host-catalogs) tutorial.

--- a/website/content/docs/troubleshoot/faq.mdx
+++ b/website/content/docs/troubleshoot/faq.mdx
@@ -28,7 +28,7 @@ Boundary supports [OIDC authentication](/boundary/tutorials/access-management/oi
 like Okta, Azure AD, Auth0, etc. For non-OIDC authentication protocols (such as LDAP), users can also log in with an OIDC bridge identity provider
 such as [Vault's OIDC bridge](/vault/docs/concepts/oidc-provider) capabilities released in 1.9, [Dex](https://dexidp.io), or various others.
 
-#### Q: Does Boundary support Multi-factor Authentication (MFA)
+#### Q: Does Boundary support Multi-factor Authentication (MFA)?
 Boundary Open-ID Connect (OIDC)-based authentication supports MFA if the IdP being used enforces MFA. This allows users to authenticate with an identity
 provider supporting MFA, such as Azure AD, Okta, Auth0, etc.
 Boundary also supports syncing permission claims between an IDP-managed identity and Boundary. This can be very useful when you want to sync group memberships

--- a/website/content/docs/troubleshoot/faq.mdx
+++ b/website/content/docs/troubleshoot/faq.mdx
@@ -7,37 +7,37 @@ description: |-
 
 # Frequently Asked Questions
 #### Q: What are the networking requirements for Boundary? Do my workers need to be exposed to the public internet?
-Boundary workers require inbound access from clients. This does not necessarily require that workers be exposed to the public internet. 
-If the client is coming from a private network (eg a corporate network), the worker needs to allow connectivity from the private network. 
-If the client is coming from the public internet, the worker needs to allow connectivity from the public internet. For more information, 
+Boundary workers require inbound access from clients. This does not necessarily require that workers be exposed to the public internet.
+If the client is coming from a private network (eg a corporate network), the worker needs to allow connectivity from the private network.
+If the client is coming from the public internet, the worker needs to allow connectivity from the public internet. For more information,
 check out the [worker networking requirements](/hcp/docs/boundary/self-managed-workers).
 
 #### Q: Does Boundary require Vault? What is the integration story?
-While Vault isn't a *required* secrets backend for Boundary sessions, the potential for Boundary | Vault integration is a core part of Boundary's overall 
+While Vault isn't a *required* secrets backend for Boundary sessions, the potential for Boundary | Vault integration is a core part of Boundary's overall
 value proposition for identity-based access.There are three primary points of integration with Vault:
-1. Vault can be used as a secrets backend for Boundary, offering single signon to end target systems via credential brokering. This was covered in Boundary's 
-[0.4 announcement](https://www.hashicorp.com/blog/announcing-hashicorp-boundary-0-4) and there are ample 
-[tutorials](/boundary/tutorials/access-management/oss-vault-cred-brokering-quickstart) of this scenario. 
-2. Boundary can use Vault as an OIDC provider to enable sign-in with Vault's supported auth methods (even non-OIDC auth methods like Active Directory kerberos/LDAP). 
+1. Vault can be used as a secrets backend for Boundary, offering single signon to end target systems via credential brokering. This was covered in Boundary's
+[0.4 announcement](https://www.hashicorp.com/blog/announcing-hashicorp-boundary-0-4) and there are ample
+[tutorials](/boundary/tutorials/access-management/oss-vault-cred-brokering-quickstart) of this scenario.
+2. Boundary can use Vault as an OIDC provider to enable sign-in with Vault's supported auth methods (even non-OIDC auth methods like Active Directory kerberos/LDAP).
 This scenario is walked through in this [tutorial](/vault/tutorials/auth-methods/oidc-identity-provider).
-3. OSS Boundary can use Vault as the external KMS that serves as Boundary's root of trust. More information on this use case can be found 
+3. OSS Boundary can use Vault as the external KMS that serves as Boundary's root of trust. More information on this use case can be found
 [here](/boundary/docs/configuration/kms/transit).
 
 #### Q: What Identity Providers does Boundary Support?
-Boundary supports [OIDC authentication](/boundary/tutorials/access-management/oidc-auth), which allows support for many popular IdPs 
-like Okta, Azure AD, Auth0, etc. For non-OIDC authentication protocols (such as LDAP), users can also log in with an OIDC bridge identity provider 
+Boundary supports [OIDC authentication](/boundary/tutorials/access-management/oidc-auth), which allows support for many popular IdPs
+like Okta, Azure AD, Auth0, etc. For non-OIDC authentication protocols (such as LDAP), users can also log in with an OIDC bridge identity provider
 such as [Vault's OIDC bridge](/vault/docs/concepts/oidc-provider) capabilities released in 1.9, [Dex](https://dexidp.io), or various others.
 
 #### Q: Does Boundary support Multi-factor Authentication (MFA)
-Boundary Open-ID Connect (OIDC)-based authentication supports MFA if the IdP being used enforces MFA. This allows users to authenticate with an identity 
+Boundary Open-ID Connect (OIDC)-based authentication supports MFA if the IdP being used enforces MFA. This allows users to authenticate with an identity
 provider supporting MFA, such as Azure AD, Okta, Auth0, etc.
-Boundary also supports syncing permission claims between an IDP-managed identity and Boundary. This can be very useful when you want to sync group memberships 
+Boundary also supports syncing permission claims between an IDP-managed identity and Boundary. This can be very useful when you want to sync group memberships
 from an IDP to Boundary to assign role assignments dynamically. See Boundary's [managed groups capabilities](/boundary/tutorials/configuration/oidc-idp-groups).
 
 #### Q: Does Boundary automate the discovery and configuration of new targets (e.g. servers)? What happens if a host IP address changes?
 Yes, this is one of the core competencies of Boundary. Boundary can discover new targets in two primary ways
 1. Boundary's [Terraform provider](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs) supports discovery of targets provisioned by Terraform
-2. Boundary's [dynamic host catalog](/boundary/tutorials/oss-access-management/aws-host-catalogs) 
+2. Boundary's [dynamic host catalog](/boundary/tutorials/oss-access-management/aws-host-catalogs)
 agentlessly queries infrastructure providers to automate the onboarding and configuration of hosts
 
 All of these methods will automate the discovery and configuration of targets when their ip addresses change. Of course, static hosts can still be manually added via Boundary admin UI and CLI.
@@ -47,10 +47,16 @@ For more information on dynamic host catalogs, please see:
 - [Dynamic Host Catalogs on Azure](/boundary/tutorials/access-management/azure-host-catalogs)
 
 #### Q: Session management capabilities - Does Boundary support live session monitoring and termination?
-**Session Logging/Monitoring:** Supported. Boundary creates a session log of all sessions created between identities and targets that have been onboarded to 
-Boundary. You can learn how to monitor these sessions in this [tutorial](/boundary/tutorials/getting-started/getting-started-connect#manage-sessions). 
-Boundary supports audit logs for [Boundary OSS](/boundary/tutorials/oss-configuration/event-logging) and [audit log streaming](/hcp/docs/boundary/audit-logging) 
+**Session Logging/Monitoring:** Supported. Boundary creates a session log of all sessions created between identities and targets that have been onboarded to
+Boundary. You can learn how to monitor these sessions in this [tutorial](/boundary/tutorials/getting-started/getting-started-connect#manage-sessions).
+Boundary supports audit logs for [Boundary OSS](/boundary/tutorials/oss-configuration/event-logging) and [audit log streaming](/hcp/docs/boundary/audit-logging)
 for HCP Boundary. Audit logs for both distributions can be exported to SIEM or BI tools.
 
-**Session Termination:** Supported. Session termination for Boundary administrators is a supported capability, as demonstrated in this 
+**Session Termination:** Supported. Session termination for Boundary administrators is a supported capability, as demonstrated in this
 [tutorial](/boundary/tutorials/getting-started/getting-started-connect#manage-sessions).
+
+#### Q: As an AWS user, can I use IAM role to configure Boundary's dynamic host catalog?
+An IAM role does not have any credentials, and cannot make direct requests to AWS services.
+At this time, it is not possible to configure Boundary's dynamic host catalog using IAM role.
+You can configure the dynamic host catalog using IAM user, however.
+For more information, refer to the [Dynamic host catalogs on AWS](/boundary/tutorials/access-management/aws-host-catalogs) tutorial.


### PR DESCRIPTION
From a Slack conversation:

> We get variations of this question a fair bit — can we add an answer to it in the public-facing Boundary FAQ?  https://hashicorp.slack.com/archives/C01CHBHMYJ1/p1670475532772349
> @x980707x
> >[Dynamic Host Catalogs Credential Question [Boundary]](https://discuss.hashicorp.com/t/dynamic-host-catalogs-credential-question/47762/1)
> >Hi!,
> >I am using AWS and I am not using IAM User, I am using IAM Role. Can’t I use an IAM role rather than a credential to use Boundary’s Dynamic Host Catalog?
> >Thanks!

Cannot use IAM role at this time. Work with Joe on the text. Should be added here to the [FAQs](https://developer.hashicorp.com/boundary/docs/troubleshoot/faq) topic.

[View the change in the preview deployment.](https://boundary-diyoapx3l-hashicorp.vercel.app/boundary/docs/troubleshoot/faq)