### PR TITLE
Revert "chore(enos): Pin terraform to 1.3.9 to mitigate bug (#3087)"

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -98,9 +98,6 @@ jobs:
           # the terraform wrapper will break Terraform execution in enos because
           # it changes the output to text when we expect it to be JSON.
           terraform_wrapper: false
-          # Terraform 1.4.x introduced an issue that prevents some resources from
-          # planning. Pin to 1.3.x until it is resolved.
-          terraform_version: 1.3.9
       - name: Import GPG key for Boundary pass keystore
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549  # TSCCR: could not find tsccr entry for crazy-max/ghaction-import-gpg


### PR DESCRIPTION
This PR reverts commit 4e697d4dd56b5bfc2e0ef417583c1b6b7f05d449, which pinned the version of Terraform used in enos to `Terraform 1.3.9`. This was due to a bug in `Terraform 1.4.1` resulting in some enos operations to fail. `Terraform 1.4.2` was just released and addresses the bug. 