### PR TITLE
chore(enos): Use docker image generated from code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -357,6 +357,8 @@ jobs:
     strategy:
       matrix:
         arch: ["arm", "arm64", "386", "amd64"]
+    outputs:
+      tag: docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}
     env:
       repo: ${{ github.event.repository.name }}
       version: ${{ needs.set-product-version.outputs.product-version }}
@@ -394,6 +396,8 @@ jobs:
     with:
       artifact-name: "boundary_${{ needs.set-product-version.outputs.product-version }}_linux_amd64.zip"
       go-version: ${{ needs.product-metadata.outputs.go-version }}
+      docker-image-name: ${{ needs.build-docker.outputs.tag }}
+      docker-image-file: "boundary_default_linux_amd64_${{ needs.set-product-version.outputs.product-version }}_${{ github.sha }}.docker.dev.tar"
     secrets: inherit
 
   bats:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,7 +358,7 @@ jobs:
       matrix:
         arch: ["arm", "arm64", "386", "amd64"]
     outputs:
-      tag: docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}
+      name: docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}
     env:
       repo: ${{ github.event.repository.name }}
       version: ${{ needs.set-product-version.outputs.product-version }}
@@ -396,7 +396,7 @@ jobs:
     with:
       artifact-name: "boundary_${{ needs.set-product-version.outputs.product-version }}_linux_amd64.zip"
       go-version: ${{ needs.product-metadata.outputs.go-version }}
-      docker-image-name: ${{ needs.build-docker.outputs.tag }}
+      docker-image-name: ${{ needs.build-docker.outputs.name }}
       docker-image-file: "boundary_default_linux_amd64_${{ needs.set-product-version.outputs.product-version }}_${{ github.sha }}.docker.dev.tar"
     secrets: inherit
 

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -13,10 +13,10 @@ on:
         required: true
         type: string
       docker-image-name:
-        required: true
+        required: false
         type: string
       docker-image-file:
-        required: true
+        required: false
         type: string
 
 env:

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -12,6 +12,12 @@ on:
       go-version:
         required: true
         type: string
+      docker-image-name:
+        required: true
+        type: string
+      docker-image-file:
+        required: true
+        type: string
 
 env:
   PKG_NAME: boundary
@@ -177,6 +183,17 @@ jobs:
         run: |
           unzip ${{steps.download.outputs.download-path}}/*.zip -d enos/support/boundary
           mv ${{steps.download.outputs.download-path}}/*.zip enos/support/boundary.zip
+      - name: Download Boundary Linux AMD64 docker image
+        if: matrix.filter == 'e2e_docker builder:crt'
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        id: download-docker
+        with:
+          name: ${{ inputs.docker-image-file }}
+          path: ./enos/support/downloads
+      - name: Rename docker image file
+        if: matrix.filter == 'e2e_docker builder:crt'
+        run: |
+          mv ${{ steps.download-docker.outputs.download-path }}/*.tar enos/support/boundary_docker_image.tar
       - name: Set up Node.js
         uses: actions/setup-node@v3
         if: matrix.filter == 'e2e_ui builder:crt'
@@ -206,6 +223,8 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
+          ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
+          ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |
           mkdir -p ./enos/terraform-plugin-cache
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
@@ -224,6 +243,8 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
+          ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
+          ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |
           mkdir -p ./enos/terraform-plugin-cache
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
@@ -253,6 +274,8 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
+          ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
+          ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
@@ -267,6 +290,8 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
+          ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
+          ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario destroy --timeout 60m0s --chdir ./enos ${{ matrix.filter }}

--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ REGISTRY_NAME?=docker.io/hashicorp
 IMAGE_NAME=boundary
 VERSION?=0.7.4
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
-IMAGE_TAG_DEV=$(REGISTRY_NAME)/$(IMAGE_NAME):latest-$(shell git rev-parse --short HEAD)
+IMAGE_TAG_DEV?=$(REGISTRY_NAME)/$(IMAGE_NAME):latest-$(shell git rev-parse --short HEAD)
 
 .PHONY: docker
 docker: docker-build

--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -117,3 +117,7 @@ module "docker_openssh_server" {
 module "docker_network" {
   source = "./modules/docker_network"
 }
+
+module "load_docker_image" {
+  source = "./modules/load_docker_image"
+}

--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -36,6 +36,14 @@ module "build_local" {
   build_target = var.local_build_target
 }
 
+module "build_boundary_docker_crt" {
+  source = "./modules/build_boundary_docker_crt"
+}
+
+module "build_boundary_docker_local" {
+  source = "./modules/build_boundary_docker_local"
+}
+
 module "generate_aws_host_tag_vars" {
   source = "./modules/generate_aws_host_tag_vars"
 }
@@ -116,8 +124,4 @@ module "docker_openssh_server" {
 
 module "docker_network" {
   source = "./modules/docker_network"
-}
-
-module "load_docker_image" {
-  source = "./modules/load_docker_image"
 }

--- a/enos/enos-scenario-e2e-docker.hcl
+++ b/enos/enos-scenario-e2e-docker.hcl
@@ -20,11 +20,23 @@ scenario "e2e_docker" {
     aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
     local_boundary_dir         = abspath(var.local_boundary_dir)
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
+    build_path = {
+      "local" = "/tmp",
+      "crt"   = var.crt_bundle_path == null ? null : abspath(var.crt_bundle_path)
+    }
     tags = merge({
       "Project Name" : var.project_name
       "Project" : "Enos",
       "Environment" : "ci"
     }, var.tags)
+  }
+
+  step "build_boundary_docker_image" {
+    module = matrix.builder == "crt" ? module.build_boundary_docker_crt : module.build_boundary_docker_local
+
+    variables {
+      path = matrix.builder == "crt" ? local.boundary_docker_image_file : "/tmp/boundary_docker_image.tar"
+    }
   }
 
   step "create_docker_network" {
@@ -36,21 +48,10 @@ scenario "e2e_docker" {
       step.create_docker_network
     ]
     variables {
+      image_name   = "docker.mirror.hashicorp.services/library/postgres:latest"
       network_name = step.create_docker_network.network_name
     }
     module = module.docker_postgres
-  }
-
-  // step "build_boundary_docker_image" {
-
-  // }
-
-  step "load_boundary_docker_image" {
-    module = module.load_docker_image
-
-    variables {
-      path = local.boundary_docker_image_file
-    }
   }
 
   step "create_boundary" {
@@ -58,10 +59,10 @@ scenario "e2e_docker" {
     depends_on = [
       step.create_docker_network,
       step.create_boundary_database,
-      step.load_boundary_docker_image
+      step.build_boundary_docker_image
     ]
     variables {
-      image_name       = var.boundary_docker_image_name
+      image_name       = matrix.builder == "crt" ? var.boundary_docker_image_name : step.build_boundary_docker_image.image_name
       network_name     = step.create_docker_network.network_name
       postgres_address = step.create_boundary_database.address
     }
@@ -73,7 +74,7 @@ scenario "e2e_docker" {
       step.create_docker_network
     ]
     variables {
-      image_name   = "docker.io/hashicorp/vault:${var.vault_version}"
+      image_name   = "docker.mirror.hashicorp.services/hashicorp/vault:${var.vault_version}"
       network_name = step.create_docker_network.network_name
     }
   }
@@ -84,6 +85,7 @@ scenario "e2e_docker" {
       step.create_docker_network
     ]
     variables {
+      image_name            = "docker.mirror.hashicorp.services/linuxserver/openssh-server"
       network_name          = step.create_docker_network.network_name
       private_key_file_path = local.aws_ssh_private_key_path
     }

--- a/enos/enos-scenario-e2e-docker.hcl
+++ b/enos/enos-scenario-e2e-docker.hcl
@@ -12,9 +12,14 @@ scenario "e2e_docker" {
     provider.enos.default
   ]
 
+  matrix {
+    builder = ["local", "crt"]
+  }
+
   locals {
-    aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
-    local_boundary_dir       = abspath(var.local_boundary_dir)
+    aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
+    local_boundary_dir         = abspath(var.local_boundary_dir)
+    boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     tags = merge({
       "Project Name" : var.project_name
       "Project" : "Enos",
@@ -36,14 +41,27 @@ scenario "e2e_docker" {
     module = module.docker_postgres
   }
 
+  // step "build_boundary_docker_image" {
+
+  // }
+
+  step "load_boundary_docker_image" {
+    module = module.load_docker_image
+
+    variables {
+      path = local.boundary_docker_image_file
+    }
+  }
+
   step "create_boundary" {
     module = module.docker_boundary
     depends_on = [
       step.create_docker_network,
-      step.create_boundary_database
+      step.create_boundary_database,
+      step.load_boundary_docker_image
     ]
     variables {
-      image_name       = var.boundary_docker_image
+      image_name       = var.boundary_docker_image_name
       network_name     = step.create_docker_network.network_name
       postgres_address = step.create_boundary_database.address
     }

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -25,10 +25,16 @@ variable "enos_user" {
 }
 
 # Test configs
-variable "boundary_docker_image" {
-  description = "Name of Docker Image to use"
+variable "boundary_docker_image_name" {
+  description = "Name of Docker image to use"
   type        = string
   default     = "docker.io/hashicorp/boundary:latest"
+}
+
+variable "boundary_docker_image_file" {
+  description = "Path to Boundary Docker image"
+  type        = string
+  default     = ""
 }
 
 variable "worker_instance_type" {

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -26,7 +26,7 @@ variable "enos_user" {
 
 # Test configs
 variable "boundary_docker_image_name" {
-  description = "Name of Docker image to use"
+  description = "Name:Tag of Docker image to use"
   type        = string
   default     = "docker.io/hashicorp/boundary:latest"
 }

--- a/enos/modules/build_boundary_docker_crt/main.tf
+++ b/enos/modules/build_boundary_docker_crt/main.tf
@@ -10,10 +10,10 @@ terraform {
 }
 
 variable "path" {
-  description = "Path to Docker image file"
+  description = "Path of boundary docker image file to load"
   type        = string
 }
 
-resource "enos_local_exec" "load" {
+resource "enos_local_exec" "load_docker_image" {
   inline = ["docker load -i ${var.path}"]
 }

--- a/enos/modules/build_boundary_docker_local/build.sh
+++ b/enos/modules/build_boundary_docker_local/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+set -eux -o pipefail
+
+# Go to the root of the boundary repo
+root_dir="$(git rev-parse --show-toplevel)"
+pushd "${root_dir}" > /dev/null
+
+export IMAGE_TAG_DEV="${IMAGE_NAME}"
+make docker-build-dev
+
+popd > /dev/null

--- a/enos/modules/build_boundary_docker_local/main.tf
+++ b/enos/modules/build_boundary_docker_local/main.tf
@@ -1,0 +1,39 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_providers {
+    enos = {
+      source = "app.terraform.io/hashicorp-qti/enos"
+    }
+  }
+}
+
+variable "path" {
+  description = "File Path of boundary docker image that will be created"
+  type        = string
+  default     = "/tmp/boundary_docker_image.tar"
+}
+
+resource "enos_local_exec" "get_git_sha" {
+  inline = ["git rev-parse --short HEAD"]
+}
+
+locals {
+  image_name = trimspace("docker.io/hashicorp/boundary-dev:latest-${enos_local_exec.get_git_sha.stdout}")
+}
+
+resource "enos_local_exec" "build_docker_image" {
+  environment = {
+    "IMAGE_NAME" = local.image_name
+  }
+  scripts = ["${path.module}/build.sh"]
+}
+
+output "artifact_path" {
+  value = var.path
+}
+
+output "image_name" {
+  value = local.image_name
+}

--- a/enos/modules/docker_openssh_server/main.tf
+++ b/enos/modules/docker_openssh_server/main.tf
@@ -15,6 +15,11 @@ terraform {
   }
 }
 
+variable "image_name" {
+  description = "Name of Docker Image"
+  type        = string
+  default     = "docker.mirror.hashicorp.services/linuxserver/openssh-server"
+}
 variable "network_name" {
   description = "Name of Docker Network"
   type        = string
@@ -43,7 +48,7 @@ locals {
 }
 
 resource "docker_image" "openssh_server" {
-  name         = "lscr.io/linuxserver/openssh-server"
+  name         = var.image_name
   keep_locally = true
 }
 

--- a/enos/modules/docker_postgres/main.tf
+++ b/enos/modules/docker_postgres/main.tf
@@ -10,6 +10,11 @@ terraform {
   }
 }
 
+variable "image_name" {
+  description = "Name of Docker Image"
+  type        = string
+  default     = "docker.mirror.hashicorp.services/library/postgres:latest"
+}
 variable "network_name" {
   description = "Name of Docker Network"
   type        = string
@@ -36,7 +41,7 @@ variable "database_name" {
 }
 
 resource "docker_image" "postgres" {
-  name         = "postgres:latest"
+  name         = var.image_name
   keep_locally = true
 }
 

--- a/enos/modules/load_docker_image/main.tf
+++ b/enos/modules/load_docker_image/main.tf
@@ -1,0 +1,19 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_providers {
+    enos = {
+      source = "app.terraform.io/hashicorp-qti/enos"
+    }
+  }
+}
+
+variable "path" {
+  description = "Path to Docker image file"
+  type        = string
+}
+
+resource "enos_local_exec" "load" {
+  inline = ["docker load -i ${var.path}"]
+}


### PR DESCRIPTION
This PR continues to extend on the docker work for e2e tests introduced here: https://github.com/hashicorp/boundary/pull/3073. It adds support for the following...
- when run in CI, it will use the docker image built in the Actions workflow 
- when run locally, it will build a boundary docker image using your local checkout and use that to start a docker container

Next step would be to refactor the existing enos scenarios to make use of the docker containers.