### PR TITLE
chore: Remove extraneous fail-on-cache-miss attribute

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,6 @@ jobs:
           key: ${{ steps.go-cache-key.outputs.key }}
           restore-keys: |
             ${{ runner.os }}-go
-          fail-on-cache-miss: true
       - name: Install Tools
         run: |
           go mod download
@@ -183,7 +182,7 @@ jobs:
           which pg_isready || sudo apt-get update && sudo apt-get install -y postgresql-client
           make DOCKER_ARGS='-d' PG_OPTS='-c shared_buffers=256MB -c max_connections=200000' -C testing/dbtest/docker database-up
           until pg_isready -h 127.0.0.1; do docker container inspect boundary-sql-tests &> /dev/null || exit 255; sleep 1; done
-    
+
       - name: Test
         uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
         env:
@@ -191,7 +190,7 @@ jobs:
           GOMAXPROCS: ${{ vars.TEST_GOMAXPROCS }}
           TESTARGS: -v
           TEST_TIMEOUT: 120m
-        with: 
+        with:
           max_attempts: 3
           timeout_minutes: 120
           retry_on: error


### PR DESCRIPTION
This PR removes an extraneous `fail-on-cache-miss` attribute. This particular job is the setup step, so there should be no expectation that the cache is present. 