### PR TITLE
Bats Tests: Target Host Sources

### DIFF
--- a/internal/tests/cli/boundary/_target_host_sources.bash
+++ b/internal/tests/cli/boundary/_target_host_sources.bash
@@ -28,7 +28,6 @@ function set_target_host_sources_sources() {
 }
 
 function validate_host_sources() {
-    echo $3
     targetData=$(boundary targets read -id $1 -format $3)
     if [[ "$3" == "json" ]]; then
         for i in "${@:2}"; do

--- a/internal/tests/cli/boundary/_target_host_sources.bash
+++ b/internal/tests/cli/boundary/_target_host_sources.bash
@@ -1,0 +1,51 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+load _authorized_actions
+
+function add_target_host_sources_sources() {
+    for i in "${@:2}"; do
+        hostSource+="-host-source $i "
+    done
+
+    boundary targets add-host-sources -id $1 $hostSource
+}
+
+function remove_target_host_sources_sources() {
+    for i in "${@:2}"; do
+        hostSource+="-host-source $i "
+    done
+
+    boundary targets remove-host-sources -id $1 $hostSource
+}
+
+function set_target_host_sources_sources() {
+    for i in "${@:2}"; do
+        hostSource+="-host-source $i "
+    done
+
+    boundary targets set-host-sources -id $1 $hostSource
+}
+
+function validate_host_sources() {
+    echo $3
+    targetData=$(boundary targets read -id $1 -format $3)
+    if [[ "$3" == "json" ]]; then
+        for i in "${@:2}"; do
+            if ! echo "$targetData" | jq ".item.host_sources[]"; then
+                echo "Host source id '$i' not found on target"
+                echo "$targetData"
+                exit 1
+            fi
+        done
+    elif [[ "$3" == "table" ]]; then
+        for i in "${@:2}"; do
+            pattern="Host Sources:.*ID:.*$2*"
+            OUTPUT=$(echo $targetData)
+            if ! [[ $OUTPUT =~ $pattern ]]; then
+                echo "Host source id '$i' not found on target"
+                exit 1
+            fi
+        done
+    fi
+}

--- a/internal/tests/cli/boundary/_target_host_sources.bash
+++ b/internal/tests/cli/boundary/_target_host_sources.bash
@@ -52,7 +52,7 @@ function target_has_host_source_id() {
     elif [[ "$format" == "table" ]]; then
         for i in "${hostSources}"; do
             pattern="Host Sources:.*ID:.*$i*"
-            OUTPUT=$(boundary targets read -id $1 -format table)
+            OUTPUT=$(boundary targets read -id $tid -format table)
             if ! [[ $OUTPUT =~ $pattern ]]; then
                 echo "Host source id '$i' not found on target"
                 return 1

--- a/internal/tests/cli/boundary/_target_host_sources.bash
+++ b/internal/tests/cli/boundary/_target_host_sources.bash
@@ -4,35 +4,43 @@
 load _authorized_actions
 
 function set_target_host_sources() {
-    for i in "${@:2}"; do
+    local tid=$1
+    local hostSources=${@:2}
+    for i in "${hostSources}"; do
         hostSource+="-host-source $i "
     done
 
-    boundary targets set-host-sources -id $1 $hostSource
+    boundary targets set-host-sources -id $tid $hostSource
 }
 
 function add_target_host_sources() {
-    for i in "${@:2}"; do
+    local tid=$1
+    local hostSources=${@:2}
+    for i in "${hostSources}"; do
         hostSource+="-host-source $i "
     done
 
-    boundary targets add-host-sources -id $1 $hostSource
+    boundary targets add-host-sources -id $tid $hostSource
 }
 
 function remove_target_host_sources() {
-    for i in "${@:2}"; do
+    local tid=$1
+    local hostSources=${@:2}
+    for i in "${hostSources}"; do
         hostSource+="-host-source $i "
     done
 
-    boundary targets remove-host-sources -id $1 $hostSource
+    boundary targets remove-host-sources -id $tid $hostSource
 }
 
 function target_has_host_source_id() {
     local tid=$1
-    ids=$(boundary targets read -id $tid -format json | jq '.item.host_sources[].id')
+    local format=$2
+    local hostSources=${@:3}
 
-    if [[ "$2" == "json" ]]; then
-        for i in "${@:3}"; do
+    if [[ "$format" == "json" ]]; then
+        ids=$(boundary targets read -id $tid -format json | jq '.item.host_sources[].id')
+        for i in "${hostSources}"; do
             local hsid=$i
             for id in $ids; do
                 if [ $(strip "$id") == "$hsid" ]; then
@@ -41,14 +49,16 @@ function target_has_host_source_id() {
             done
         done
         return 1
-    elif [[ "$2" == "table" ]]; then
-        for i in "${@:3}"; do
+    elif [[ "$format" == "table" ]]; then
+        for i in "${hostSources}"; do
             pattern="Host Sources:.*ID:.*$i*"
             OUTPUT=$(boundary targets read -id $1 -format table)
             if ! [[ $OUTPUT =~ $pattern ]]; then
                 echo "Host source id '$i' not found on target"
-                exit 1
+                return 1
             fi
         done
+        return 0
     fi
+    return 1
 }

--- a/internal/tests/cli/boundary/_targets.bash
+++ b/internal/tests/cli/boundary/_targets.bash
@@ -48,40 +48,10 @@ function update_address() {
   boundary targets update tcp -id $id -address $2
 }
 
-function assoc_host_sources() {
-  local id=$1
-  local hst=$2
-  boundary targets add-host-sources -id $id -host-source $hst
-}
-
-function remove_host_sources() {
-  local id=$1
-  local hst=$2
-  boundary targets remove-host-sources -id $id -host-source $hst
-}
-
 function target_id_from_name() {
   local sid=$1
   local name=$2
   strip $(list_targets $sid | jq -c ".items[] | select(.name | contains(\"$name\")) | .[\"id\"]")
-}
-
-function target_host_source_ids() {
-  local tid=$1
-  boundary targets read -id $tid -format json | jq '.item.host_sources[].id'
-}
-
-function target_has_host_source_id() {
-  local tid=$1
-  local hsid=$2
-
-  ids=$(target_host_source_ids $tid)
-  for id in $ids; do
-    if [ $(strip "$id") == "$hsid" ]; then
-      return 0
-    fi
-  done
-  return 1
 }
 
 function has_default_target_actions() {

--- a/internal/tests/cli/boundary/target.bats
+++ b/internal/tests/cli/boundary/target.bats
@@ -4,6 +4,7 @@ load _auth
 load _connect
 load _targets
 load _helpers
+load _target_host_sources
 
 
 @test "boundary/login: can login as admin user" {
@@ -69,7 +70,7 @@ load _helpers
 
 @test "boundary/target: admin user can add default host set to created target" {
   local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-  run assoc_host_sources $id $DEFAULT_HOST_SET
+  run add_target_host_sources $id $DEFAULT_HOST_SET
   echo "$output"
   [ "$status" -eq 0 ]
 }
@@ -108,7 +109,7 @@ load _helpers
 
 @test "boundary/target: cannot assign an host source to a target with an address" {
   local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME_WITH_ADDR)
-  run assoc_host_sources $id $DEFAULT_HOST_SET
+  run add_target_host_sources $id $DEFAULT_HOST_SET
   [ "$status" -eq 1 ]
 }
 
@@ -116,7 +117,7 @@ load _helpers
   local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME_WITH_ADDR)
   run update_address $id "null"
   [ "$status" -eq 0 ]
-  run assoc_host_sources $id $DEFAULT_HOST_SET
+  run add_target_host_sources $id $DEFAULT_HOST_SET
   [ "$status" -eq 0 ]
 }
 
@@ -128,7 +129,7 @@ load _helpers
 
 @test "boundary/target: can assign an an address to a target after deleting host source" {
   local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME_WITH_ADDR)
-  run remove_host_sources $id $DEFAULT_HOST_SET
+  run remove_target_host_sources $id $DEFAULT_HOST_SET
   [ "$status" -eq 0 ]
   run update_address $id "localhost"
   [ "$status" -eq 0 ]

--- a/internal/tests/cli/boundary/target.bats
+++ b/internal/tests/cli/boundary/target.bats
@@ -78,7 +78,7 @@ load _target_host_sources
 @test "boundary/target: created target has default host set" {
   local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
   local format="json"
-  run target_has_host_source_id $id $DEFAULT_HOST_SET $format
+  run target_has_host_source_id $id $format $DEFAULT_HOST_SET
   echo "$output"
   [ "$status" -eq 0 ]
 }

--- a/internal/tests/cli/boundary/target.bats
+++ b/internal/tests/cli/boundary/target.bats
@@ -77,7 +77,8 @@ load _target_host_sources
 
 @test "boundary/target: created target has default host set" {
   local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-  run target_has_host_source_id $id $DEFAULT_HOST_SET
+  local format="json"
+  run target_has_host_source_id $id $DEFAULT_HOST_SET $format
   echo "$output"
   [ "$status" -eq 0 ]
 }

--- a/internal/tests/cli/boundary/target_host_sources.bats
+++ b/internal/tests/cli/boundary/target_host_sources.bats
@@ -8,9 +8,11 @@ load _targets
 load _host_catalogs
 load _host_sets
 
-export NEW_HOST='test-for-add-host-source'
+export NEW_HOST1='test-for-add-host-source-1'
+export NEW_HOST2='test-for-add-host-source-2'
 export NEW_HOST_CATALOG='test-host-catalog'
-export NEW_HOST_SET='test-host-set'
+export NEW_HOST_SET1='test-host-set-1'
+export NEW_HOST_SET2='test-host-set-2'
 export TGT_NAME='test-target'
 export TGT_DEFAULT_PORT='22'
 
@@ -31,95 +33,166 @@ export TGT_DEFAULT_PORT='22'
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/hosts: can create $NEW_HOST host in created host catalog" {
+@test "boundary/hosts: can multiple hosts in created host catalog" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
-    run create_host $NEW_HOST $hcid
+    run create_host $NEW_HOST1 $hcid
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    run create_host $NEW_HOST2 $hcid
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/host-sets: can add $NEW_HOST_SET host set to created host catalog" {
+@test "boundary/host-sets: can add multiple hosts to a created host catalog" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
-    run create_host_set $hcid $NEW_HOST_SET
+    run create_host_set $hcid $NEW_HOST_SET1
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    run create_host_set $hcid $NEW_HOST_SET2
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/host-set/add-host: can associate $NEW_HOST_SET host set with created host" {
+@test "boundary/host-set/add-host: can associate multiple host sets with created hosts" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
-    local hid=$(host_id $NEW_HOST $hcid)
-    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
-    run assoc_host_set_host $hid $hsid
+    local hid1=$(host_id $NEW_HOST1 $hcid)
+    local hid2=$(host_id $NEW_HOST2 $hcid)
+
+    local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
+    run assoc_host_set_host $hid1 $hsid1
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
+    run assoc_host_set_host $hid2 $hsid2
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/host-set/add-host: $NEW_HOST_SET host set contains created host" {
+@test "boundary/host-set/add-host: verify all host sets contain created hosts" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
-    local hid=$(host_id $NEW_HOST $hcid)
-    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
-    run host_set_has_host_id $hid $hsid
+    local hid1=$(host_id $NEW_HOST1 $hcid)
+    local hid2=$(host_id $NEW_HOST2 $hcid)
+
+    local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
+    run host_set_has_host_id $hid1 $hsid1
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
+    run host_set_has_host_id $hid2 $hsid2
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
 @test "boundary/target: can add created host set to created target" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
-    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run assoc_host_sources $tid $hsid
+    run assoc_host_sources $tid $hsid1
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/target: validate only $NEW_HOST host source present - JSON" {
+@test "boundary/target: validate only $NEW_HOST1 host source present - JSON" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
-    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    local hsid=$(host_set_id $NEW_HOST_SET1 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
     run validate_host_sources $tid $hsid "json"
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/target: validate only $NEW_HOST host source present - Table" {
+@test "boundary/target: validate only $NEW_HOST1 host source present - Table" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
-    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    local hsid=$(host_set_id $NEW_HOST_SET1 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
     run validate_host_sources $tid $hsid "table"
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/target: can remove $NEW_HOST_SET host set from created target" {
+@test "boundary/target: can add another host set to created target" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
-    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run remove_host_sources $tid $hsid
+    run assoc_host_sources $tid $hsid2
+    echo "$output"
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/target: validate $NEW_HOST host source is not present on target" {
+@test "boundary/target: validate only $NEW_HOST2 host source present - Table" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
-    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run validate_host_sources $tid $hsid "table"
+    run validate_host_sources $tid $hsid2 "table"
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: can remove $NEW_HOST_SET1 host set from created target" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
+    local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run remove_host_sources $tid $hsid1
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate $NEW_HOST1 host source is not present on target" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
+    local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run validate_host_sources $tid $hsid1 "table"
     echo "$output"
     [ "$status" -eq 1 ]
 }
 
-@test "boundary/host: can delete $NEW_HOST host" {
+@test "boundary/target: can remove $NEW_HOST_SET2 host set from created target" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
-    local hid=$(host_id $NEW_HOST $hcid)
-    run delete_host $hid
+    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
+    local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run remove_host_sources $tid $hsid2
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate $NEW_HOST2 host source is not present on target" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
+    local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run validate_host_sources $tid $hsid2 "json"
+    echo "$output"
+    [ "$status" -eq 1 ]
+}
+
+@test "boundary/host: can delete all created hosts" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hid1=$(host_id $NEW_HOST1 $hcid)
+    local hid2=$(host_id $NEW_HOST2 $hcid)
+
+    run delete_host $hid1
+    echo "$output"
+    run has_status_code "$output" "204"
+    [ "$status" -eq 0 ]
+
+    run delete_host $hid2
     echo "$output"
     run has_status_code "$output" "204"
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/host-set: can delete $NEW_HOST_SET host set" {
+@test "boundary/host-set: can delete all created host sets" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
-    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
-    run delete_host_set $hsid
+
+    local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
+    run delete_host_set $hsid1
+    echo "$output"
+    run has_status_code "$output" "204"
+    [ "$status" -eq 0 ]
+
+    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
+    run delete_host_set $hsid2
     echo "$output"
     run has_status_code "$output" "204"
     [ "$status" -eq 0 ]

--- a/internal/tests/cli/boundary/target_host_sources.bats
+++ b/internal/tests/cli/boundary/target_host_sources.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+
+load _auth
+load _hosts
+load _helpers
+load _target_host_sources
+load _targets
+load _host_catalogs
+load _host_sets
+
+export NEW_HOST='test-for-add-host-source'
+export NEW_HOST_CATALOG='test-host-catalog'
+export NEW_HOST_SET='test-host-set'
+export TGT_NAME='test-target'
+export TGT_DEFAULT_PORT='22'
+
+@test "boundary/login: can login as admin user" {
+    run login $DEFAULT_LOGIN
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: admin user can create target" {
+    run create_tcp_target $DEFAULT_P_ID $TGT_DEFAULT_PORT $TGT_NAME
+    echo $output
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/host-catalogs: can create $NEW_HOST_CATALOG host catalog in default project scope" {
+    run create_host_catalog $NEW_HOST_CATALOG $DEFAULT_P_ID
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/hosts: can create $NEW_HOST host in created host catalog" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    run create_host $NEW_HOST $hcid
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/host-sets: can add $NEW_HOST_SET host set to created host catalog" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    run create_host_set $hcid $NEW_HOST_SET
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/host-set/add-host: can associate $NEW_HOST_SET host set with created host" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hid=$(host_id $NEW_HOST $hcid)
+    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    run assoc_host_set_host $hid $hsid
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/host-set/add-host: $NEW_HOST_SET host set contains created host" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hid=$(host_id $NEW_HOST $hcid)
+    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    run host_set_has_host_id $hid $hsid
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: can add created host set to created target" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run assoc_host_sources $tid $hsid
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate only $NEW_HOST host source present - JSON" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run validate_host_sources $tid $hsid "json"
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate only $NEW_HOST host source present - Table" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run validate_host_sources $tid $hsid "table"
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: can remove $NEW_HOST_SET host set from created target" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run remove_host_sources $tid $hsid
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: validate $NEW_HOST host source is not present on target" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run validate_host_sources $tid $hsid "table"
+    echo "$output"
+    [ "$status" -eq 1 ]
+}
+
+@test "boundary/host: can delete $NEW_HOST host" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hid=$(host_id $NEW_HOST $hcid)
+    run delete_host $hid
+    echo "$output"
+    run has_status_code "$output" "204"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/host-set: can delete $NEW_HOST_SET host set" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hsid=$(host_set_id $NEW_HOST_SET $hcid)
+    run delete_host_set $hsid
+    echo "$output"
+    run has_status_code "$output" "204"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/host-catalogs: can delete $NEW_HOST_CATALOG host catalog in default project scope" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    run delete_host_catalog $hcid
+    echo "$output"
+    run has_status_code "$output" "204"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: can delete target" {
+    local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run delete_target $id
+    run has_status_code "$output" "204"
+    [ "$status" -eq 0 ]
+}

--- a/internal/tests/cli/boundary/target_host_sources.bats
+++ b/internal/tests/cli/boundary/target_host_sources.bats
@@ -33,7 +33,7 @@ export TGT_DEFAULT_PORT='22'
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/hosts: can multiple hosts in created host catalog" {
+@test "boundary/hosts: can create multiple hosts in created host catalog" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     run create_host $NEW_HOST1 $hcid
     echo "$output"
@@ -44,7 +44,7 @@ export TGT_DEFAULT_PORT='22'
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/host-sets: can add multiple hosts to a created host catalog" {
+@test "boundary/host-sets: can create add multiple host sets to a created host catalog" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     run create_host_set $hcid $NEW_HOST_SET1
     echo "$output"
@@ -59,13 +59,13 @@ export TGT_DEFAULT_PORT='22'
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     local hid1=$(host_id $NEW_HOST1 $hcid)
     local hid2=$(host_id $NEW_HOST2 $hcid)
-
     local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
+    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
+
     run assoc_host_set_host $hid1 $hsid1
     echo "$output"
     [ "$status" -eq 0 ]
 
-    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
     run assoc_host_set_host $hid2 $hsid2
     echo "$output"
     [ "$status" -eq 0 ]
@@ -75,14 +75,34 @@ export TGT_DEFAULT_PORT='22'
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     local hid1=$(host_id $NEW_HOST1 $hcid)
     local hid2=$(host_id $NEW_HOST2 $hcid)
-
     local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
+    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
+
     run host_set_has_host_id $hid1 $hsid1
     echo "$output"
     [ "$status" -eq 0 ]
 
-    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
     run host_set_has_host_id $hid2 $hsid2
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: can set host sources on a created target" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
+    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
+    local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run set_target_host_sources $tid $hsid1 $hsid2
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/target: can remove host sources on a created target" {
+    local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
+    local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
+    local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
+    local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run remove_target_host_sources $tid $hsid1 $hsid2
     echo "$output"
     [ "$status" -eq 0 ]
 }
@@ -91,25 +111,27 @@ export TGT_DEFAULT_PORT='22'
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run assoc_host_sources $tid $hsid1
+    run add_target_host_sources $tid $hsid1
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/target: validate only $NEW_HOST1 host source present - JSON" {
+@test "boundary/target: validate $NEW_HOST1 host source present - JSON" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     local hsid=$(host_set_id $NEW_HOST_SET1 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run validate_host_sources $tid $hsid "json"
+    local format="json"
+    run target_has_host_source_id $tid $format $hsid
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/target: validate only $NEW_HOST1 host source present - Table" {
+@test "boundary/target: validate $NEW_HOST1 host source present - Table" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     local hsid=$(host_set_id $NEW_HOST_SET1 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run validate_host_sources $tid $hsid "table"
+    local format="table"
+    run target_has_host_source_id $tid $format $hsid
     echo "$output"
     [ "$status" -eq 0 ]
 }
@@ -118,16 +140,17 @@ export TGT_DEFAULT_PORT='22'
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run assoc_host_sources $tid $hsid2
+    run add_target_host_sources $tid $hsid2
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/target: validate only $NEW_HOST2 host source present - Table" {
+@test "boundary/target: validate $NEW_HOST2 host source present - Table" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run validate_host_sources $tid $hsid2 "table"
+    local format="table"
+    run target_has_host_source_id $tid $format $hsid2
     echo "$output"
     [ "$status" -eq 0 ]
 }
@@ -136,7 +159,7 @@ export TGT_DEFAULT_PORT='22'
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run remove_host_sources $tid $hsid1
+    run remove_target_host_sources $tid $hsid1
     [ "$status" -eq 0 ]
 }
 
@@ -144,7 +167,8 @@ export TGT_DEFAULT_PORT='22'
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     local hsid1=$(host_set_id $NEW_HOST_SET1 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run validate_host_sources $tid $hsid1 "table"
+    local format="table"
+    run target_has_host_source_id $tid $format $hsid1
     echo "$output"
     [ "$status" -eq 1 ]
 }
@@ -153,7 +177,7 @@ export TGT_DEFAULT_PORT='22'
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run remove_host_sources $tid $hsid2
+    run remove_target_host_sources $tid $hsid2
     [ "$status" -eq 0 ]
 }
 
@@ -161,7 +185,8 @@ export TGT_DEFAULT_PORT='22'
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     local hsid2=$(host_set_id $NEW_HOST_SET2 $hcid)
     local tid=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run validate_host_sources $tid $hsid2 "json"
+    local format="json"
+    run target_has_host_source_id $tid $format $hsid2
     echo "$output"
     [ "$status" -eq 1 ]
 }

--- a/internal/tests/cli/boundary/target_host_sources.bats
+++ b/internal/tests/cli/boundary/target_host_sources.bats
@@ -44,7 +44,7 @@ export TGT_DEFAULT_PORT='22'
     [ "$status" -eq 0 ]
 }
 
-@test "boundary/host-sets: can create add multiple host sets to a created host catalog" {
+@test "boundary/host-sets: can create multiple host sets in a host catalog" {
     local hcid=$(host_catalog_id $NEW_HOST_CATALOG $DEFAULT_P_ID)
     run create_host_set $hcid $NEW_HOST_SET1
     echo "$output"


### PR DESCRIPTION
- Add bats test coverage for adding a Host Source to a Target
- Create `target_host_sources.bash` file with helper functions for bats test file

## Testing Scenarios

1. Add a newly created `host-set` as a `host-source` to a target
   i. Verify the newly created `host-source` is present in both JSON & Table format
1. Verify a target can have more than 1 `host-source` by adding an additional `host-source`
1. Verify `host-source` can be disassociated from a target 

## Considerations
Created new resources like a target & host catalog instead of using already created resources because the changes could affect existing tests and it made it easy to change the newly created resources