### PR TITLE
fix(handler): return human readable error for json cred w/ empty object

### DIFF
--- a/internal/daemon/controller/handlers/credentials/credential_service.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service.go
@@ -783,13 +783,9 @@ func validateCreateRequest(req *pbs.CreateCredentialRequest) error {
 		case credential.JsonSubtype.String():
 			object := req.GetItem().GetJsonAttributes().GetObject()
 			if object == nil || len(object.AsMap()) <= 0 {
-				badFields[objectField] = "Field required for creating a json credential."
-			}
-			objectBytes, err := json.Marshal(object)
-			if err != nil {
+				badFields[objectField] = "This is a required field and cannot be set to empty."
+			} else if _, err := json.Marshal(object); err != nil {
 				badFields[objectField] = "Unable to parse given json value"
-			} else if len(objectBytes) <= 0 {
-				badFields[objectField] = "Field required for creating a json credential."
 			}
 
 		default:

--- a/internal/daemon/controller/handlers/credentials/credential_service.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service.go
@@ -782,7 +782,7 @@ func validateCreateRequest(req *pbs.CreateCredentialRequest) error {
 
 		case credential.JsonSubtype.String():
 			object := req.GetItem().GetJsonAttributes().GetObject()
-			if object == nil && len(object.AsMap()) <= 0 {
+			if object == nil || len(object.AsMap()) <= 0 {
 				badFields[objectField] = "Field required for creating a json credential."
 			}
 			objectBytes, err := json.Marshal(object)

--- a/internal/daemon/controller/handlers/credentials/credential_service.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service.go
@@ -842,21 +842,13 @@ func validateUpdateRequest(req *pbs.UpdateCredentialRequest) error {
 			}
 
 		case credential.JsonSubtype:
-			object := req.GetItem().GetJsonAttributes().GetObject()
-			if object != nil {
-				_, err := json.Marshal(object.AsMap())
-				if err != nil {
+			if handlers.MaskContainsPrefix(req.GetUpdateMask().GetPaths(), objectField) {
+				object := req.GetItem().GetJsonAttributes().GetObject()
+				if object == nil || len(object.AsMap()) <= 0 {
+					badFields[objectField] = "This is a required field and cannot be set to empty"
+				} else if _, err := json.Marshal(object); err != nil {
 					badFields[objectField] = "Unable to parse given json value"
 				}
-				if !handlers.MaskContainsPrefix(req.GetUpdateMask().GetPaths(), objectField) {
-					badFields[objectField] = "This is a required field and cannot be set to empty."
-				}
-				if len(object.AsMap()) == 0 {
-					badFields[objectField] = "This is a required field and cannot be set to empty."
-				}
-			}
-			if handlers.MaskContainsPrefix(req.GetUpdateMask().GetPaths(), objectField) && object == nil {
-				badFields[objectField] = "This is a required field and cannot be set to empty."
 			}
 
 		default:

--- a/internal/daemon/controller/handlers/credentials/credential_service_test.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service_test.go
@@ -1151,20 +1151,6 @@ func TestUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "update-empty-json",
-			req: &pbs.UpdateCredentialRequest{
-				UpdateMask: fieldmask(),
-				Item: &pb.Credential{
-					Attrs: &pb.Credential_JsonAttributes{
-						JsonAttributes: &pb.JsonAttributes{
-							Object: &structpb.Struct{},
-						},
-					},
-				},
-			},
-			expErrorContains: "This is a required field and cannot be set to empty",
-		},
-		{
 			name: "update-empty-object-json",
 			req: &pbs.UpdateCredentialRequest{
 				UpdateMask: fieldmask("attributes.object.password"),
@@ -1179,14 +1165,12 @@ func TestUpdate(t *testing.T) {
 			expErrorContains: "This is a required field and cannot be set to empty",
 		},
 		{
-			name: "update-empty-mask-json",
+			name: "update-nil-object-json",
 			req: &pbs.UpdateCredentialRequest{
-				UpdateMask: fieldmask(),
+				UpdateMask: fieldmask("attributes.object.password"),
 				Item: &pb.Credential{
 					Attrs: &pb.Credential_JsonAttributes{
-						JsonAttributes: &pb.JsonAttributes{
-							Object: secondSecret,
-						},
+						JsonAttributes: &pb.JsonAttributes{},
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

When creating a JSON credential with an empty object, the return error is not a human readable message. 

Request:
```
cred, err := credClient.Create(tc.Context(), credential.JsonSubtype.String(), cs.Item.Id, credentials.WithName("foo"), credentials.WithJsonCredentialObject(map[string]any{}))
```

### Current Error Message:
```
{
  "kind":"Internal",
  "message":"credentials.(Service).createInRepo: unable to create credential: static.(Repository).CreateJsonCredential: missing object: parameter violation: error #100"
}
```

### Fixed Error Message:
```
{
  "kind":"InvalidArgument",
  "message":"Error in provided request.",
  "details":  {
      "request_fields":[{
        "name":"attributes.object",
        "description":"This is a required field and cannot be set to empty."
      }]
  }
}
```