### PR TITLE
Add downstream worker auth KMS

### DIFF
--- a/globals/kms.go
+++ b/globals/kms.go
@@ -4,10 +4,11 @@
 package globals
 
 const (
-	KmsPurposeRoot              = "root"
-	KmsPurposePreviousRoot      = "previous-root"
-	KmsPurposeWorkerAuth        = "worker-auth"
-	KmsPurposeWorkerAuthStorage = "worker-auth-storage"
-	KmsPurposeRecovery          = "recovery"
-	KmsPurposeConfig            = "config"
+	KmsPurposeRoot                 = "root"
+	KmsPurposePreviousRoot         = "previous-root"
+	KmsPurposeWorkerAuth           = "worker-auth"
+	KmsPurposeWorkerAuthStorage    = "worker-auth-storage"
+	KmsPurposeRecovery             = "recovery"
+	KmsPurposeConfig               = "config"
+	KmsPurposeDownstreamWorkerAuth = "downstream-worker-auth"
 )

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -77,12 +77,16 @@ type Server struct {
 	StderrLock *sync.Mutex
 	Eventer    *event.Eventer
 
-	RootKms              wrapping.Wrapper
-	WorkerAuthKms        wrapping.Wrapper
-	WorkerAuthStorageKms wrapping.Wrapper
-	RecoveryKms          wrapping.Wrapper
-	Kms                  *kms.Kms
-	SecureRandomReader   io.Reader
+	// NOTE: Unlike the other wrappers below, if set, DownstreamWorkerAuthKms
+	// should always be a PooledWrapper, so that we can allow multiple KMSes to
+	// accept downstream connections. As such it's made explicit here.
+	DownstreamWorkerAuthKms *multi.PooledWrapper
+	RootKms                 wrapping.Wrapper
+	WorkerAuthKms           wrapping.Wrapper
+	WorkerAuthStorageKms    wrapping.Wrapper
+	RecoveryKms             wrapping.Wrapper
+	Kms                     *kms.Kms
+	SecureRandomReader      io.Reader
 
 	WorkerAuthDebuggingEnabled *atomic.Bool
 
@@ -546,25 +550,22 @@ func (b *Server) SetupListeners(ui cli.Ui, config *configutil.SharedConfig, allo
 // SetupKMSes takes in a parsed config, does some minor checking on purposes,
 // and sends each off to configutil to instantiate a wrapper.
 func (b *Server) SetupKMSes(ctx context.Context, ui cli.Ui, config *config.Config, opt ...Option) error {
-	opts := getOpts(opt...)
-
 	sharedConfig := config.SharedConfig
 	var pluginLogger hclog.Logger
 	var err error
 	var previousRootKms wrapping.Wrapper
+	purposeCount := map[string]uint{}
 	for _, kms := range sharedConfig.Seals {
 		for _, purpose := range kms.Purpose {
 			purpose = strings.ToLower(purpose)
+			purposeCount[purpose] = purposeCount[purpose] + 1
 			switch purpose {
 			case "":
 				return errors.New("KMS block missing 'purpose'")
-			case globals.KmsPurposeWorkerAuth:
-				if opts.withSkipWorkerAuthKmsInstantiation {
-					continue
-				}
 			case globals.KmsPurposeRoot,
 				globals.KmsPurposePreviousRoot,
 				globals.KmsPurposeConfig,
+				globals.KmsPurposeWorkerAuth,
 				globals.KmsPurposeWorkerAuthStorage:
 			case globals.KmsPurposeRecovery:
 				if config.Controller != nil && config.DevRecoveryKey != "" {
@@ -595,7 +596,7 @@ func (b *Server) SetupKMSes(ctx context.Context, ui cli.Ui, config *config.Confi
 					pluginutil.WithPluginsFilesystem(kms_plugin_assets.KmsPluginPrefix, kms_plugin_assets.FileSystem()),
 					pluginutil.WithPluginExecutionDirectory(config.Plugins.ExecutionDir),
 				),
-				configutil.WithLogger(pluginLogger.Named(kms.Type).With("purpose", purpose)),
+				configutil.WithLogger(pluginLogger.Named(kms.Type).With("purpose", fmt.Sprintf("%s-%d", purpose, purposeCount[purpose]))),
 			)
 			if wrapperConfigError != nil {
 				return fmt.Errorf(
@@ -641,6 +642,21 @@ func (b *Server) SetupKMSes(ctx context.Context, ui cli.Ui, config *config.Confi
 					return fmt.Errorf("Duplicate KMS block for purpose '%s'. You may need to remove all but the last KMS block for this purpose.", purpose)
 				}
 				b.WorkerAuthKms = wrapper
+			case globals.KmsPurposeDownstreamWorkerAuth:
+				if b.DownstreamWorkerAuthKms == nil {
+					b.DownstreamWorkerAuthKms, err = multi.NewPooledWrapper(ctx, wrapper)
+					if err != nil {
+						return fmt.Errorf("Error instantiating pooled wrapper for downstream worker auth: %w.", err)
+					}
+				} else {
+					added, err := b.DownstreamWorkerAuthKms.AddWrapper(ctx, wrapper)
+					if err != nil {
+						return fmt.Errorf("Error adding additional wrapper to downstream worker auth wrapper pool: %w.", err)
+					}
+					if !added {
+						return fmt.Errorf("Wrapper already added to downstream worker auth wrapper pool.")
+					}
+				}
 			case globals.KmsPurposeWorkerAuthStorage:
 				if b.WorkerAuthStorageKms != nil {
 					return fmt.Errorf("Duplicate KMS block for purpose '%s'. You may need to remove all but the last KMS block for this purpose.", purpose)

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -818,7 +818,9 @@ func Parse(d string) (*Config, error) {
 		}
 	}
 
-	sharedConfig, err := configutil.ParseConfig(d)
+	// Now that we can have multiple KMSes for downstream workers, allow an
+	// unlimited number of KMS blocks as we don't know how many might be defined
+	sharedConfig, err := configutil.ParseConfig(d, configutil.WithMaxKmsBlocks(-1))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/worker/testing_test.go
+++ b/internal/daemon/worker/testing_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"math/big"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -165,16 +166,19 @@ func TestNewTestMultihopWorkers(t *testing.T) {
 	t.Cleanup(c.Shutdown)
 	pkiTags := map[string][]string{"connected": {"directly"}}
 	childPkiTags := map[string][]string{"connected": {"multihop"}}
+	childKmsTags := map[string][]string{"connected": {"multihop"}}
 
-	kmsWorker, pkiWorker, childPkiWorker := NewTestMultihopWorkers(t, logger, c.Context(), c.ClusterAddrs(),
-		c.Config().WorkerAuthKms, c.Controller().ServersRepoFn, pkiTags, childPkiTags)
+	enableAuthDebugging := new(atomic.Bool)
+	enableAuthDebugging.Store(true)
+	kmsWorker, pkiWorker, childPkiWorker, childKmsWorker := NewTestMultihopWorkers(t, logger, c.Context(), c.ClusterAddrs(),
+		c.Config().WorkerAuthKms, c.Controller().ServersRepoFn, pkiTags, childPkiTags, childKmsTags, enableAuthDebugging)
 
 	srvRepo, err := c.Controller().ServersRepoFn()
 	require.NoError(t, err)
 	workers, err := srvRepo.ListWorkers(ctx, []string{"global"})
-	assert.Len(t, workers, 3)
+	assert.Len(t, workers, 4)
 	require.NoError(t, err)
-	var kmsW, pkiW, childPkiW *server.Worker
+	var kmsW, pkiW, childPkiW, childKmsW *server.Worker
 	for _, w := range workers {
 		switch w.GetAddress() {
 		case kmsWorker.ProxyAddrs()[0]:
@@ -183,18 +187,23 @@ func TestNewTestMultihopWorkers(t *testing.T) {
 			pkiW = w
 		case childPkiWorker.ProxyAddrs()[0]:
 			childPkiW = w
+		case childKmsWorker.ProxyAddrs()[0]:
+			childKmsW = w
 		}
 	}
 	require.NotNil(t, kmsW)
 	require.NotNil(t, pkiW)
 	require.NotNil(t, childPkiW)
+	require.NotNil(t, childKmsW)
 
 	assert.NotZero(t, kmsW.GetLastStatusTime())
 	assert.NotZero(t, pkiW.GetLastStatusTime())
 	assert.NotZero(t, childPkiW.GetLastStatusTime())
+	assert.NotZero(t, childKmsW.GetLastStatusTime())
 
 	assert.Equal(t, pkiTags, pkiW.GetConfigTags())
 	assert.Equal(t, childPkiTags, childPkiW.GetConfigTags())
+	assert.Equal(t, childKmsTags, childKmsW.GetConfigTags())
 }
 
 func createTestCert(t *testing.T) ([]byte, ed25519.PublicKey, ed25519.PrivateKey) {

--- a/sdk/wrapper/wrapper.go
+++ b/sdk/wrapper/wrapper.go
@@ -48,7 +48,7 @@ func GetWrapperFromPath(ctx context.Context, path, purpose string, opt ...config
 }
 
 func GetWrapperFromHcl(ctx context.Context, inHcl, purpose string, opt ...configutil.Option) (wrapping.Wrapper, func() error, error) {
-	kmses, err := configutil.ParseKMSes(inHcl)
+	kmses, err := configutil.ParseKMSes(inHcl, configutil.WithMaxKmsBlocks(-1))
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error parsing KMS HCL: %w", err)
 	}


### PR DESCRIPTION
This adds an alternate KMS that can be used to handle incoming downstream connections for PKI-KMS registration. This can be specified multiple times; because the upstream only needs to decrypt, we can simply use a PooledWrapper and add each given KMS to the pool.