### PR TITLE
fix(schema-diff): Include foreign key constraints in diff

### DIFF
--- a/.github/workflows/schema-diff.yml
+++ b/.github/workflows/schema-diff.yml
@@ -76,6 +76,9 @@ jobs:
 
           #### Constraints
           $(getdiff .schema-diff/constraints.diff)
+
+          #### Foreign Key Constraints
+          $(getdiff .schema-diff/fk_constraints.diff)
           EOF
 
           # Parse it through jq to build a valid json object.

--- a/.github/workflows/schema-diff.yml
+++ b/.github/workflows/schema-diff.yml
@@ -59,6 +59,9 @@ jobs:
           cat << EOF > github-comment.txt
           $gh_comment_prefix \`${GITHUB_BASE_REF}\` and \`${GITHUB_HEAD_REF}\` @ ${{ github.event.pull_request.head.sha }}
 
+          To understand how these diffs are generated and some limitations see the
+          [documentation](https://github.com/hashicorp/boundary/blob/main/scripts/schema-diff.sh) of the script.
+
           #### Functions
           $(getdiff .schema-diff/funcs.diff)
 


### PR DESCRIPTION
With the change to report changes to constraints instead of all of the 
post-data section, foreign key constraints where no longer captured in the
diff. This now extracts the foreign key constraints and generates a diff of
them between versions.

Also includes some additional documentation about this tool.