### PR TITLE
feat(ui): serve controller metadata from ui handler

### DIFF
--- a/internal/daemon/controller/handler_ui.go
+++ b/internal/daemon/controller/handler_ui.go
@@ -17,6 +17,11 @@ func init() {
 	handleUi = handleUiWithAssets
 }
 
+// serveMetadata provides controller metadata to the UI for licensed versions of Boundary.
+var serveMetadata = noopServeMetadata
+
+func noopServeMetadata(w http.ResponseWriter) {}
+
 func handleUiWithAssets(c *Controller) http.Handler {
 	var nextHandler http.Handler
 	if c.conf.RawConfig.DevUiPassthroughDir != "" {
@@ -40,7 +45,9 @@ func handleUiWithAssets(c *Controller) http.Handler {
 		default:
 			switch r.URL.Path {
 			case "/", "/favicon.png", "/assets/styles.css":
-
+			case "/controller-metadata.json":
+				serveMetadata(w)
+				return
 			default:
 				for i := dotIndex + 1; i < len(r.URL.Path); i++ {
 					intVal := r.URL.Path[i]

--- a/internal/daemon/controller/handler_ui.go
+++ b/internal/daemon/controller/handler_ui.go
@@ -7,6 +7,7 @@
 package controller
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -18,7 +19,7 @@ func init() {
 }
 
 // serveMetadata provides controller metadata to the UI for licensed versions of Boundary.
-var serveMetadata = func(w http.ResponseWriter) {}
+var serveMetadata = func(ctx context.Context, w http.ResponseWriter) {}
 
 func handleUiWithAssets(c *Controller) http.Handler {
 	var nextHandler http.Handler

--- a/internal/daemon/controller/handler_ui.go
+++ b/internal/daemon/controller/handler_ui.go
@@ -44,7 +44,7 @@ func handleUiWithAssets(c *Controller) http.Handler {
 		default:
 			switch r.URL.Path {
 			case "/", "/favicon.png", "/assets/styles.css":
-			case "/controller-metadata.json":
+			case "/metadata.json":
 				serveMetadata(c.baseContext, w)
 				return
 			default:

--- a/internal/daemon/controller/handler_ui.go
+++ b/internal/daemon/controller/handler_ui.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build ui
-// +build ui
 
 package controller
 

--- a/internal/daemon/controller/handler_ui.go
+++ b/internal/daemon/controller/handler_ui.go
@@ -18,9 +18,7 @@ func init() {
 }
 
 // serveMetadata provides controller metadata to the UI for licensed versions of Boundary.
-var serveMetadata = noopServeMetadata
-
-func noopServeMetadata(w http.ResponseWriter) {}
+var serveMetadata = func(w http.ResponseWriter) {}
 
 func handleUiWithAssets(c *Controller) http.Handler {
 	var nextHandler http.Handler

--- a/internal/daemon/controller/handler_ui.go
+++ b/internal/daemon/controller/handler_ui.go
@@ -45,7 +45,7 @@ func handleUiWithAssets(c *Controller) http.Handler {
 			switch r.URL.Path {
 			case "/", "/favicon.png", "/assets/styles.css":
 			case "/controller-metadata.json":
-				serveMetadata(w)
+				serveMetadata(c.baseContext, w)
 				return
 			default:
 				for i := dotIndex + 1; i < len(r.URL.Path); i++ {

--- a/internal/daemon/controller/handler_ui_test.go
+++ b/internal/daemon/controller/handler_ui_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build ui
-// +build ui
 
 package controller
 

--- a/internal/db/sqltest/Makefile
+++ b/internal/db/sqltest/Makefile
@@ -3,7 +3,7 @@ all: test
 CWD := $(shell pwd)
 
 # Version of postgres docker image for test database
-PG_DOCKER_TAG ?= 11-bullseye
+PG_DOCKER_TAG ?= 13-alpine
 # Version of pg_tap docker image
 PG_TAP_DOCKER_TAG ?= 13
 SQL_TEST_DB_PORT ?=

--- a/internal/db/sqltest/Makefile
+++ b/internal/db/sqltest/Makefile
@@ -3,7 +3,7 @@ all: test
 CWD := $(shell pwd)
 
 # Version of postgres docker image for test database
-PG_DOCKER_TAG ?= 13-alpine
+PG_DOCKER_TAG ?= 11-bullseye
 # Version of pg_tap docker image
 PG_TAP_DOCKER_TAG ?= 13
 SQL_TEST_DB_PORT ?=


### PR DESCRIPTION
this PR adds a noop function to the UI handler to allow controller metadata to be served for licensed Boundary editions