### PR TITLE
fix(cliui): Use correct git sha reference for artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -404,3 +404,12 @@ jobs:
       docker-image-name: ${{ needs.build-docker.outputs.name }}
       docker-image-file: "boundary_default_linux_amd64_${{ needs.set-product-version.outputs.product-version }}_${{ github.sha }}.docker.dev.tar"
     secrets: inherit
+  bats:
+    uses: ./.github/workflows/test-cli-ui.yml
+    if: "! github.event.pull_request.head.repo.fork"
+    needs:
+      - set-product-version
+      - build-linux
+    with:
+      product-version: ${{ needs.set-product-version.outputs.product-version }}
+    secrets: inherit

--- a/.github/workflows/test-cli-ui.yml
+++ b/.github/workflows/test-cli-ui.yml
@@ -1,35 +1,20 @@
 name: test-cli-ui
 
 on:
-  workflow_dispatch:
-  workflow_run:
-    workflows: [ build ]
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      product-version:
+        type: string
+        required: true
 
 permissions:
   contents: read
   actions: read
 
 jobs:
-  set-product-version:
-    runs-on: ${{ fromJSON(vars.RUNNER) }}
-    outputs:
-      product-version: ${{ steps.set-product-version.outputs.product-version }}
-      base-product-version: $${{ steps.set-product-version.outputs.base-product-version }}
-      prerelease-product-version: ${{ steps.set-product-version.outputs.prerelease-product-version }}
-    steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: Set Product version
-        id: set-product-version
-        uses: hashicorp/actions-set-product-version@v1  # TSCCR: loading action configs: failed to query HEAD reference: failed to get advertised references: authorization failed
-
   bats:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     name: CLI tests
-    if: "! github.event.pull_request.head.repo.fork"
-    needs:
-      - set-product-version
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Import GPG key for Boundary pass keystore
@@ -91,13 +76,13 @@ jobs:
         uses: dawidd6/action-download-artifact@5e780fc7bbd0cac69fc73271ed86edf5dcb72d67 # v2.26.0
         with:
           workflow: build.yml
-          commit: ${{ github.sha }}
-          name: boundary_${{ needs.set-product-version.outputs.product-version }}_linux_amd64.zip
+          commit: ${{ github.event.workflow_run.head_sha }}
+          name: boundary_${{ inputs.product-version }}_linux_amd64.zip
           path: /tmp
       - name: Unpack boundary bundle
         run: |
-          unzip /tmp/boundary_${{ needs.set-product-version.outputs.product-version }}_linux_amd64.zip -d /usr/local/bin
-          rm /tmp/boundary_${{ needs.set-product-version.outputs.product-version }}_linux_amd64.zip
+          unzip /tmp/boundary_${{ inputs.product-version }}_linux_amd64.zip -d /usr/local/bin
+          rm /tmp/boundary_${{ inputs.product-version }}_linux_amd64.zip
       - name: Versions
         run: |
           echo "go version:"


### PR DESCRIPTION
The git reference in github.sha is the latest commit on the default
branch (ie `main`). This instead used the commit hash for the workflow
that ran and triggered this workflow.

Blame: e76b3b95114ad696a89fe36f6b1bced4b090b9cf