### PR TITLE
Do not allow PKI-KMS workers to have names updated via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   only recommended if compatibility with pre-0.13 workers using the KMS auth
   method is required. Requiring opting in removes some potentially confusing
   behavior for deciding when to use the old versus new mechanism. To opt in, add
-  `use_deprecated_kms_auth_method = true` to the `worker` config block.
+  `use_deprecated_kms_auth_method = true` to the `worker` config block. Note
+  that if a 0.13+ worker using KMS connects to a 0.13+ controller using KMS, the
+  transition to the new method will happen automatically. To go back to the old
+  method after that will require the worker to be deleted and re-added with the
+  `use_deprecated_kms_auth_method` config field specified.
 * When grants are added to roles additional validity checking is now performed.
   This extra validity checking is designed to reject grants that are not
   [documented grant

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ golangci-lint:
 	$(eval GOLINT_INSTALLED := $(shell which golangci-lint))
 
 	if [ "$(GOLINT_INSTALLED)" = "" ]; then \
-		sh scripts/install-golangci-lint.sh -b $(GO_PATH)/bin v1.51.2; \
+		sh scripts/install-golangci-lint.sh -b $(GO_PATH)/bin v1.52.2; \
 	fi;
 
 .PHONY: cleangen

--- a/internal/daemon/controller/handlers/workers/worker_service.go
+++ b/internal/daemon/controller/handlers/workers/worker_service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
 	"strings"
 
@@ -334,8 +335,21 @@ func (s Service) UpdateWorker(ctx context.Context, req *pbs.UpdateWorkerRequest)
 	if authResults.Error != nil {
 		return nil, authResults.Error
 	}
+
 	w, err := s.updateInRepo(ctx, authResults.Scope.GetId(), req.GetId(), req.GetUpdateMask().GetPaths(), req.GetItem())
-	if err != nil {
+	switch {
+	case err == nil:
+	case stderrors.Is(err, server.ErrCannotUpdateKmsWorkerName):
+		// Treat this like a "bad field" error on name even though we couldn't
+		// return it in validation without having to make an additional call and
+		// a lot of additional logic
+		return nil, handlers.ValidateUpdateRequest(req, req.GetItem(), func() map[string]string {
+			badFields := map[string]string{
+				globals.NameField: "KMS-registered workers cannot have their names updated via the API.",
+			}
+			return badFields
+		}, globals.WorkerPrefix)
+	default:
 		return nil, err
 	}
 

--- a/internal/daemon/controller/handlers/workers/worker_service_test.go
+++ b/internal/daemon/controller/handlers/workers/worker_service_test.go
@@ -508,9 +508,6 @@ func TestUpdate(t *testing.T) {
 		wkr, _, err := repo.UpdateWorker(context.Background(), pkiWkr, pkiVersion, []string{"Name", "Description"})
 		require.NoError(t, err, "Failed to reset pki worker.")
 		pkiVersion = wkr.Version
-		wkr, _, err = repo.UpdateWorker(context.Background(), pkiKmsWkr, pkiKmsVersion, []string{"Description"})
-		require.NoError(t, err, "Failed to reset pki-kms worker.")
-		pkiKmsVersion = wkr.Version
 	}
 
 	wCreated := pkiWkr.GetCreateTime().GetTimestamp().AsTime()
@@ -912,17 +909,17 @@ func TestUpdate(t *testing.T) {
 				}
 
 				// Search through update masks to see if we're updating name
-				var nameChange bool
+				var basicInfoChange bool
 				if tc.req != nil && tc.req.UpdateMask != nil {
 					for _, field := range tc.req.UpdateMask.Paths {
-						if strings.ToLower(field) == "name" {
-							nameChange = true
+						if strings.ToLower(field) == "name" || strings.ToLower(field) == "description" {
+							basicInfoChange = true
 						}
 						if strings.Contains(field, ",") {
 							splitStr := strings.Split(field, ",")
 							for _, field := range splitStr {
-								if strings.ToLower(field) == "name" {
-									nameChange = true
+								if strings.ToLower(field) == "name" || strings.ToLower(field) == "description" {
+									basicInfoChange = true
 								}
 							}
 						}
@@ -933,9 +930,9 @@ func TestUpdate(t *testing.T) {
 				// If it's a PKI-KMS worker and we wouldn't otherwise expect an
 				// error but we tried a name change, ensure we see the expected
 				// error here.
-				if wkr.PublicId == pkiKmsWkr.PublicId && nameChange && tc.err == nil {
+				if wkr.PublicId == pkiKmsWkr.PublicId && basicInfoChange && tc.err == nil {
 					require.Error(t, gErr)
-					assert.Contains(t, gErr.Error(), "KMS-registered workers cannot have their names updated via the API.")
+					assert.Contains(t, gErr.Error(), "KMS-registered workers cannot have their")
 					assert.True(t, errors.Is(gErr, handlers.ApiErrorWithCode(codes.InvalidArgument)))
 					return
 				}

--- a/internal/daemon/worker/testing.go
+++ b/internal/daemon/worker/testing.go
@@ -264,9 +264,7 @@ func NewTestWorker(t testing.TB, opts *TestWorkerOpts) *TestWorker {
 		}
 	}
 
-	if opts.UseDeprecatedKmsAuthMethod {
-		opts.Config.Worker.UseDeprecatedKmsAuthMethod = true
-	}
+	opts.Config.Worker.UseDeprecatedKmsAuthMethod = opts.UseDeprecatedKmsAuthMethod
 	if len(opts.InitialUpstreams) > 0 {
 		opts.Config.Worker.InitialUpstreams = opts.InitialUpstreams
 	}

--- a/internal/server/public_ids.go
+++ b/internal/server/public_ids.go
@@ -22,8 +22,8 @@ func newWorkerId(ctx context.Context) (string, error) {
 // newWorkerIdFromScopeAndName generates a predictable public id based on the
 // scope and the worker name.  This should only be used on kms workers at
 // upsert time.
-func newWorkerIdFromScopeAndName(ctx context.Context, scope, name string) (string, error) {
-	const op = "server.newWorkerIdFromScopeAndName"
+func NewWorkerIdFromScopeAndName(ctx context.Context, scope, name string) (string, error) {
+	const op = "server.NewWorkerIdFromScopeAndName"
 	id, err := db.NewPublicId(globals.WorkerPrefix, db.WithPrngValues([]string{scope, name}))
 	if err != nil {
 		return "", errors.Wrap(ctx, err, "server.newWorkerId")

--- a/internal/server/public_ids.go
+++ b/internal/server/public_ids.go
@@ -19,7 +19,7 @@ func newWorkerId(ctx context.Context) (string, error) {
 	return id, nil
 }
 
-// newWorkerIdFromScopeAndName generates a predictable public id based on the
+// NewWorkerIdFromScopeAndName generates a predictable public id based on the
 // scope and the worker name.  This should only be used on kms workers at
 // upsert time.
 func NewWorkerIdFromScopeAndName(ctx context.Context, scope, name string) (string, error) {

--- a/internal/server/repository_worker.go
+++ b/internal/server/repository_worker.go
@@ -423,11 +423,12 @@ func setWorkerTags(ctx context.Context, w db.Writer, id string, ts TagSource, ta
 
 // UpdateWorker will update a worker in the repository and return the resulting
 // worker. fieldMaskPaths provides field_mask.proto paths for fields that should
-// be updated.  Fields will be set to NULL if the field is a zero value and
+// be updated. Fields will be set to NULL if the field is a zero value and
 // included in fieldMask. Name, Description, and Address are the only updatable
 // fields, if no updatable fields are included in the fieldMaskPaths, then an
-// error is returned.  If any paths besides those listed above are included in
-// the path then an error is returned.
+// error is returned. If any paths besides those listed above are included in
+// the path then an error is returned. If the worker is a KMS worker (whether
+// via the old registration method or pki-kms) name updates will be disallowed.
 func (r *Repository) UpdateWorker(ctx context.Context, worker *Worker, version uint32, fieldMaskPaths []string, opt ...Option) (*Worker, int, error) {
 	const (
 		nameField = "name"

--- a/internal/server/repository_worker.go
+++ b/internal/server/repository_worker.go
@@ -484,8 +484,8 @@ func (r *Repository) UpdateWorker(ctx context.Context, worker *Worker, version u
 				}
 				// If it's a KMS-PKI worker we do not want to allow name updates via
 				// the API, it should only come in via the upsert mechanism via
-				// status updates. We key off whether or not the public ID is random
-				// or known to be generated in KMS fashion.
+				// status updates. If the public ID is predictably generated in the 
+				// KMS fashion, it's a KMS-PKI worker.
 				workerId, err := NewWorkerIdFromScopeAndName(ctx, wAgg.ScopeId, wAgg.Name)
 				if err != nil {
 					return errors.Wrap(ctx, err, op, errors.WithMsg("error generating worker id in kms-pki name check case"))

--- a/internal/server/repository_worker_test.go
+++ b/internal/server/repository_worker_test.go
@@ -1277,6 +1277,20 @@ func TestRepository_UpdateWorker(t *testing.T) {
 				assert.Greater(t, w.GetUpdateTime().AsTime(), w.GetCreateTime().AsTime())
 			},
 		},
+		{
+			name: "update description against kms-pki",
+			modifyWorker: func(t *testing.T, w *server.Worker) {
+				t.Helper()
+				w.Description = "foo"
+			},
+			newIdFunc: func(ctx context.Context, scopeId, name string) func(ctx context.Context) (string, error) {
+				return func(ctx context.Context) (string, error) {
+					return server.NewWorkerIdFromScopeAndName(ctx, scopeId, name)
+				}
+			},
+			path:    []string{"Description"},
+			wantErr: true,
+		},
 	}
 	for _, tt := range pkiCases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tests/cluster/multi_controller_worker_test.go
+++ b/internal/tests/cluster/multi_controller_worker_test.go
@@ -118,7 +118,8 @@ func TestWorkerAppendInitialUpstreams(t *testing.T) {
 	defer w1.Shutdown()
 
 	// Wait for worker to send status
-	cancelCtx, _ := context.WithTimeout(ctx, 10*time.Second)
+	cancelCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	t.Cleanup(cancel)
 	for {
 		select {
 		case <-time.After(500 * time.Millisecond):

--- a/internal/tests/cluster/switch_kms_method_test.go
+++ b/internal/tests/cluster/switch_kms_method_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cluster
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/internal/cmd/config"
+	"github.com/hashicorp/boundary/internal/daemon/controller"
+	"github.com/hashicorp/boundary/internal/daemon/worker"
+	"github.com/hashicorp/boundary/internal/observability/event"
+	"github.com/hashicorp/boundary/internal/types/scope"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkerUpgradeKmsAuthMethod(t *testing.T) {
+	ec := event.TestEventerConfig(t, "TestWorkerUpgradeKmsAuthMethod", event.TestWithObservationSink(t), event.TestWithSysSink(t))
+	testLock := &sync.Mutex{}
+	testLogger := hclog.New(&hclog.LoggerOptions{
+		Mutex: testLock,
+		Name:  "test",
+	})
+	require.NoError(t, event.InitSysEventer(testLogger, testLock, "use-TestWorkerUpgradeKmsAuthMethod", event.WithEventerConfig(&ec.EventerConfig)))
+
+	conf, err := config.DevController()
+	conf.Eventing = &ec.EventerConfig
+	require.NoError(t, err)
+	c1 := controller.NewTestController(t, &controller.TestControllerOpts{
+		Config: conf,
+	})
+	defer c1.Shutdown()
+	serversRepo := c1.ServersRepo()
+
+	conf, err = config.DevWorker()
+	conf.Eventing = &ec.EventerConfig
+	require.NoError(t, err)
+	w1 := worker.NewTestWorker(t, &worker.TestWorkerOpts{
+		Config:                     conf,
+		WorkerAuthKms:              c1.Config().WorkerAuthKms,
+		InitialUpstreams:           c1.ClusterAddrs(),
+		UseDeprecatedKmsAuthMethod: true,
+	})
+	defer w1.Shutdown()
+
+	// Give time for it to connect
+	time.Sleep(10 * time.Second)
+
+	// Verify it's KMS type
+	workers, err := serversRepo.ListWorkers(c1.Context(), []string{scope.Global.String()})
+	require.NoError(t, err)
+	require.Len(t, workers, 1)
+	assert.Equal(t, "kms", workers[0].Type)
+
+	// Assert that the worker has connected
+	logBuf, err := os.ReadFile(ec.AllEvents.Name())
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(string(logBuf), "worker successfully authed"))
+
+	require.NoError(t, w1.Worker().Shutdown())
+
+	// Now, start up again, using the new method
+	w1 = worker.NewTestWorker(t, &worker.TestWorkerOpts{
+		Config:           conf,
+		WorkerAuthKms:    c1.Config().WorkerAuthKms,
+		InitialUpstreams: c1.ClusterAddrs(),
+	})
+	defer w1.Shutdown()
+
+	// Give time for it to connect
+	time.Sleep(10 * time.Second)
+
+	// We should find only one nonce, and one successful worker authentication,
+	// both in the output and in the database
+	ec.AllEvents.Close()
+	logBuf, err = os.ReadFile(ec.AllEvents.Name())
+	require.NoError(t, err)
+	require.Equal(t, 2, strings.Count(string(logBuf), "worker has successfully authenticated"))
+
+	// Verify it's PKI type
+	workers, err = serversRepo.ListWorkers(c1.Context(), []string{scope.Global.String()})
+	require.NoError(t, err)
+	require.Len(t, workers, 1)
+	assert.Equal(t, "pki", workers[0].Type)
+}

--- a/internal/tests/cluster/switch_kms_method_test.go
+++ b/internal/tests/cluster/switch_kms_method_test.go
@@ -57,6 +57,7 @@ func TestWorkerUpgradeKmsAuthMethod(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, workers, 1)
 	assert.Equal(t, "kms", workers[0].Type)
+	oldId := workers[0].PublicId
 
 	// Assert that the worker has connected
 	logBuf, err := os.ReadFile(ec.AllEvents.Name())
@@ -88,4 +89,5 @@ func TestWorkerUpgradeKmsAuthMethod(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, workers, 1)
 	assert.Equal(t, "pki", workers[0].Type)
+	assert.Equal(t, oldId, workers[0].PublicId)
 }

--- a/internal/tests/cluster/unix_listener_test.go
+++ b/internal/tests/cluster/unix_listener_test.go
@@ -5,7 +5,6 @@ package cluster
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -29,7 +28,7 @@ func TestUnixListener(t *testing.T) {
 	conf, err := config.DevController()
 	require.NoError(err)
 
-	tempDir, err := ioutil.TempDir("", "boundary-unix-listener-test")
+	tempDir, err := os.MkdirTemp("", "boundary-unix-listener-test")
 	require.NoError(err)
 
 	defer func() {

--- a/internal/tests/cluster/worker_replay_test.go
+++ b/internal/tests/cluster/worker_replay_test.go
@@ -66,7 +66,7 @@ func TestWorkerReplay(t *testing.T) {
 	require.NoError(t, w1.Worker().Shutdown())
 
 	// Now, start up again with the same nonce
-	w1 = worker.NewTestWorker(t, &worker.TestWorkerOpts{
+	worker.NewTestWorker(t, &worker.TestWorkerOpts{
 		Config:           conf,
 		WorkerAuthKms:    c1.Config().WorkerAuthKms,
 		InitialUpstreams: c1.ClusterAddrs(),


### PR DESCRIPTION
This would cause their public IDs to change, which we do not want.

Note to reviewers: I recommend hiding whitespace.