### PR TITLE
test(e2e): Verify different credentials are brokered to target

### DIFF
--- a/testing/internal/e2e/tests/static/credential_store_test.go
+++ b/testing/internal/e2e/tests/static/credential_store_test.go
@@ -21,7 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testCredentialsFile = "testdata/credential.json"
+const (
+	testCredentialsFile = "testdata/credential.json"
+	testPassword        = "password"
+)
 
 // TestCliStaticCredentialStore validates various credential-store operations using the cli
 func TestCliStaticCredentialStore(t *testing.T) {
@@ -49,7 +52,7 @@ func TestCliStaticCredentialStore(t *testing.T) {
 	// Create static credentials
 	newCredentialStoreId := boundary.CreateNewCredentialStoreStaticCli(t, ctx, newProjectId)
 	boundary.CreateNewStaticCredentialPrivateKeyCli(t, ctx, newCredentialStoreId, c.TargetSshUser, c.TargetSshKeyPath)
-	pwCredentialsId := boundary.CreateNewStaticCredentialPasswordCli(t, ctx, newCredentialStoreId, c.TargetSshUser, "password")
+	pwCredentialsId := boundary.CreateNewStaticCredentialPasswordCli(t, ctx, newCredentialStoreId, c.TargetSshUser, testPassword)
 	jsonCredentialsId := boundary.CreateNewStaticCredentialJsonCli(t, ctx, newCredentialStoreId, testCredentialsFile)
 
 	// Get credentials for target (expect empty)
@@ -86,7 +89,7 @@ func TestCliStaticCredentialStore(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedCredentials := []map[string]any{
-		{"username": c.TargetSshUser, "password": "password"},
+		{"username": c.TargetSshUser, "password": testPassword},
 		expectedJsonCredentials,
 	}
 

--- a/testing/internal/e2e/tests/static/credential_store_test.go
+++ b/testing/internal/e2e/tests/static/credential_store_test.go
@@ -156,10 +156,7 @@ func createPrivateKeyPemFile(fileName string) error {
 	if err != nil {
 		return err
 	}
-	return savePrivateKeyToFile(fileName, key)
-}
 
-func savePrivateKeyToFile(fileName string, key *rsa.PrivateKey) error {
 	pemFile, err := os.Create(fileName)
 	if err != nil {
 		return err

--- a/testing/internal/e2e/tests/static/credential_store_test.go
+++ b/testing/internal/e2e/tests/static/credential_store_test.go
@@ -105,7 +105,7 @@ func TestCliStaticCredentialStore(t *testing.T) {
 
 	sshPrivateKeyFileContent, err := os.ReadFile(testPemFile)
 	require.NoError(t, err)
-	sshPrivateKey := strings.TrimSuffix(string(sshPrivateKeyFileContent), "\n")
+	sshPrivateKey := strings.TrimSpace(string(sshPrivateKeyFileContent))
 
 	expectedCredentials := []map[string]any{
 		{"username": c.TargetSshUser, "password": testPassword},

--- a/testing/internal/e2e/tests/static/credential_store_test.go
+++ b/testing/internal/e2e/tests/static/credential_store_test.go
@@ -79,9 +79,15 @@ func TestCliStaticCredentialStore(t *testing.T) {
 		brokeredCredentials = append(brokeredCredentials, credential.Credential)
 	}
 
+	testCredentialsJson, err := os.ReadFile(testCredentialsFile)
+	require.NoError(t, err)
+	var expectedJsonCredentials map[string]any
+	err = json.Unmarshal(testCredentialsJson, &expectedJsonCredentials)
+	require.NoError(t, err)
+
 	expectedCredentials := []map[string]any{
 		{"username": c.TargetSshUser, "password": "password"},
-		{"username": "name-json", "password": "password-json"},
+		expectedJsonCredentials,
 	}
 
 	assert.ElementsMatch(t, expectedCredentials, brokeredCredentials)

--- a/testing/internal/e2e/tests/static/credential_store_test.go
+++ b/testing/internal/e2e/tests/static/credential_store_test.go
@@ -79,7 +79,7 @@ func TestCliStaticCredentialStore(t *testing.T) {
 		brokeredCredentials = append(brokeredCredentials, credential.Credential)
 	}
 
-	expectedCredentials := []map[string]interface{}{
+	expectedCredentials := []map[string]any{
 		{"username": c.TargetSshUser, "password": "password"},
 		{"username": "name-json", "password": "password-json"},
 	}

--- a/testing/internal/e2e/tests/static/testdata/credential.json
+++ b/testing/internal/e2e/tests/static/testdata/credential.json
@@ -1,0 +1,4 @@
+{
+    "username": "name-json",
+    "password": "password-json"
+}


### PR DESCRIPTION
[ICU-8561](https://hashicorp.atlassian.net/browse/ICU-8561)

This PR updates the e2e test `TestCliStaticCredentialStore` to do the following:

- Verify JSON-credentials are brokered to target correctly
- Verify private-key credentials are brokered to target correctly
- Use files and constants to store test data instead of hardcoding it


[ICU-8561]: https://hashicorp.atlassian.net/browse/ICU-8561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ