### PR TITLE
chore: Update milestone-checker to use newer version of node

### DIFF
--- a/.github/workflows/milestone-checker.yml
+++ b/.github/workflows/milestone-checker.yml
@@ -27,6 +27,10 @@ jobs:
           repository: "grafana/grafana-github-actions"
           path: ./actions
           ref: be89ad434792280ebaa4d982ac72ba548b6f7095
+      - name: Set up Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: '16.x'
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run PR Checks


### PR DESCRIPTION
This PR updates the `milestone-checker` workflow to fix an error that appears in boundary-enterprise. On the enterprise repo, this job fails due to this error: https://github.com/hashicorp/boundary-enterprise/actions/runs/4639652070/jobs/8210746838. 

Updating the version of node resolved the issue: https://github.com/hashicorp/boundary-enterprise/actions/runs/4640154276/jobs/8211784046?pr=355. 

Not sure if this is the right approach. Using this PR as a discussion starter.