### PR TITLE
chore: Add write permission to milestone checker

### DIFF
--- a/.github/workflows/milestone-checker.yml
+++ b/.github/workflows/milestone-checker.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   # checks that a milestone entry is present for a PR

--- a/.github/workflows/milestone-checker.yml
+++ b/.github/workflows/milestone-checker.yml
@@ -19,7 +19,7 @@ jobs:
   # checks that a milestone entry is present for a PR
   milestone-check:
     # If there is a `pr/no-milestone` label we ignore this check
-    if: contains(github.event.pull_request.labels.*.name, 'pr/no-milestone') != 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'pr/no-milestone') != true
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     steps:
       - name: Checkout Actions


### PR DESCRIPTION
This PR adds another permission to the milestone-checker workflow. I noticed that the workflow was passing, but I didn't see the expected "Milestone not set" failure status on a PR. This was in the logs:
```
got check result {
  state: 'failure',
  sha: '3c340a2cfcc1dcc67b38f2f59756ecef1bbed322',
  title: 'Milestone Check',
  description: 'Milestone not set',
  targetURL: undefined
}
failed to dispatch RequestError [HttpError]: Resource not accessible by integration
    at /home/runner/work/boundary/boundary/actions/node_modules/@octokit/request/dist-node/index.js:86:21
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async OctoKitIssue.createStatus (/home/runner/work/boundary/boundary/actions/api/octokit.js:442:9)
    at async Dispatcher.dispatch (/home/runner/work/boundary/boundary/actions/pr-checks/Dispatcher.js:63:17)
    at async PRChecksAction.runAction (/home/runner/work/boundary/boundary/actions/pr-checks/index.js:28:9)
    at async PRChecksAction.run (/home/runner/work/boundary/boundary/actions/common/Action.js:58:13) {
  status: 403,
  response: {
    url: 'https://api.github.com/repos/hashicorp/boundary/statuses/3c340a2cfcc1dcc67b38f2f59756ecef1bbed322',
    status: 403,
    headers: {
      ...
    },
    data: {
      message: 'Resource not accessible by integration',
      documentation_url: 'https://docs.github.com/rest/commits/statuses#create-a-commit-status'
    }
  },
```

Based on the above, it seemed to point to some permission issues on the workflow's end. Now, the status is successfully set (see below in the status checks)