### PR TITLE
test(e2e): Improve reliability of enos docker scenario

### DIFF
--- a/enos/enos-scenario-e2e-docker.hcl
+++ b/enos/enos-scenario-e2e-docker.hcl
@@ -48,7 +48,7 @@ scenario "e2e_docker" {
       step.create_docker_network
     ]
     variables {
-      image_name   = "docker.mirror.hashicorp.services/library/postgres:latest"
+      image_name   = "${var.docker_mirror}/library/postgres:latest"
       network_name = step.create_docker_network.network_name
     }
     module = module.docker_postgres
@@ -74,7 +74,7 @@ scenario "e2e_docker" {
       step.create_docker_network
     ]
     variables {
-      image_name   = "docker.mirror.hashicorp.services/hashicorp/vault:${var.vault_version}"
+      image_name   = "${var.docker_mirror}/hashicorp/vault:${var.vault_version}"
       network_name = step.create_docker_network.network_name
     }
   }
@@ -85,7 +85,7 @@ scenario "e2e_docker" {
       step.create_docker_network
     ]
     variables {
-      image_name            = "docker.mirror.hashicorp.services/linuxserver/openssh-server"
+      image_name            = "${var.docker_mirror}/linuxserver/openssh-server:latest"
       network_name          = step.create_docker_network.network_name
       private_key_file_path = local.aws_ssh_private_key_path
     }

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -148,3 +148,9 @@ variable "e2e_debug_no_run" {
   type        = bool
   default     = false
 }
+
+variable "docker_mirror" {
+  description = ""
+  type        = string
+  default     = "docker.mirror.hashicorp.services"
+}

--- a/enos/modules/docker_boundary/init.sh
+++ b/enos/modules/docker_boundary/init.sh
@@ -8,8 +8,6 @@
 # This script must only output the JSON that comes from `boundary database init` as the output is
 # consumed by other scripts.
 
-TEST_BOUNDARY_IMAGE=$1
-TEST_DATABASE_ADDRESS=$2
 TEST_CONTAINER_NAME=boundary-init
 SOURCE=$(realpath $(dirname ${BASH_SOURCE[0]})) # get directory of this script
 
@@ -20,6 +18,6 @@ docker run \
     -e "SKIP_CHOWN=true" \
     --cap-add IPC_LOCK \
     --mount type=bind,src=$SOURCE,dst=/boundary/ \
-    --network e2e_network \
+    --network $TEST_NETWORK_NAME \
     $TEST_BOUNDARY_IMAGE \
     boundary database init -config /boundary/boundary-config.hcl -format json

--- a/enos/modules/docker_postgres/main.tf
+++ b/enos/modules/docker_postgres/main.tf
@@ -7,6 +7,10 @@ terraform {
       source  = "kreuzwerker/docker"
       version = "3.0.1"
     }
+
+    enos = {
+      source = "app.terraform.io/hashicorp-qti/enos"
+    }
   }
 }
 
@@ -73,6 +77,14 @@ resource "docker_container" "postgres" {
   networks_advanced {
     name = var.network_name
   }
+}
+
+resource "enos_local_exec" "wait" {
+  depends_on = [
+    docker_container.postgres
+  ]
+
+  inline = ["timeout 10s bash -c 'until docker exec ${var.container_name} pg_isready; do sleep 2; done'"]
 }
 
 output "address" {

--- a/enos/modules/docker_vault/main.tf
+++ b/enos/modules/docker_vault/main.tf
@@ -61,9 +61,17 @@ resource "docker_container" "vault" {
   }
 }
 
-resource "enos_local_exec" "wait" {
+resource "enos_local_exec" "check_address" {
   depends_on = [
     docker_container.vault
+  ]
+
+  inline = ["timeout 10s bash -c 'until curl http://0.0.0.0:8200; do sleep 2; done'"]
+}
+
+resource "enos_local_exec" "check_health" {
+  depends_on = [
+    enos_local_exec.check_address
   ]
 
   environment = {


### PR DESCRIPTION
This PR updates the enos docker scenario to include some additional waits in order to ensure that the docker resources are ready to handle requests. This was done to mitigate flaky behavior where tests would experience some failures because some containers did not finish loading. 