### PR TITLE
chore(e2e): Add support for variable binary names for end-to-end tests

### DIFF
--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -11,7 +11,7 @@ module "bats_deps" {
 
 module "boundary" {
   source  = "app.terraform.io/hashicorp-qti/aws-boundary/enos"
-  version = ">= 0.5.0"
+  version = ">= 0.6.1"
 
   project_name = "qti-enos-boundary"
   environment  = var.environment
@@ -22,8 +22,10 @@ module "boundary" {
     "Environment" : var.environment
   }
 
-  ssh_aws_keypair       = var.aws_ssh_keypair_name
   alb_listener_api_port = var.alb_listener_api_port
+  boundary_license      = var.boundary_license
+  boundary_binary_name  = var.boundary_binary_name
+  ssh_aws_keypair       = var.aws_ssh_keypair_name
 }
 
 module "worker" {

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -154,3 +154,15 @@ variable "docker_mirror" {
   type        = string
   default     = "docker.mirror.hashicorp.services"
 }
+
+variable "boundary_license" {
+  description = "Boundary enterprise license"
+  type        = string
+  default     = null
+}
+
+variable "boundary_binary_name" {
+  description = "Boundary binary name"
+  type        = string
+  default     = "boundary"
+}

--- a/enos/modules/build_local/main.tf
+++ b/enos/modules/build_local/main.tf
@@ -17,6 +17,10 @@ variable "build_target" {
   default = "build-ui build"
 }
 
+variable "binary_name" {
+  default = "boundary"
+}
+
 variable "edition" {
   default = "oss"
 }
@@ -27,9 +31,11 @@ resource "enos_local_exec" "build" {
     "GOARCH"        = "amd64",
     "CGO_ENABLED"   = 0,
     "ARTIFACT_PATH" = var.path
+    "BINARY_NAME"   = var.binary_name
     "BUILD_TARGET"  = var.build_target
     "EDITION"       = var.edition
   }
+
   scripts = ["${path.module}/templates/build.sh"]
 }
 

--- a/enos/modules/build_local/templates/build.sh
+++ b/enos/modules/build_local/templates/build.sh
@@ -14,6 +14,6 @@ root_dir="$(git rev-parse --show-toplevel)"
 pushd "${root_dir}" > /dev/null
 
 make ${BUILD_TARGET}
-zip -j ${ARTIFACT_PATH}/boundary.zip bin/boundary
+zip -j ${ARTIFACT_PATH}/boundary.zip bin/${BINARY_NAME}
 
 popd > /dev/null


### PR DESCRIPTION
This PR updates enos workflows to add support for variable binary names in order to test various Boundary builds. 