### PR TITLE
test(e2e): Clean up user if test fails

### DIFF
--- a/testing/internal/e2e/tests/static/session_end_delete_user_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_user_test.go
@@ -18,7 +18,7 @@ import (
 // TestCliSessionEndWhenUserIsDeleted tests that an active session is canceled when the respective
 // user who started the session is deleted.
 func TestCliSessionEndWhenUserIsDeleted(t *testing.T) {
-	deleted := false
+	userIsDeleted := false
 
 	e2e.MaybeSkipTest(t)
 	c, err := loadConfig()
@@ -53,7 +53,7 @@ func TestCliSessionEndWhenUserIsDeleted(t *testing.T) {
 	})
 	newUserId := boundary.CreateNewUserCli(t, ctx, "global")
 	t.Cleanup(func() {
-		if !deleted {
+		if !userIsDeleted {
 			t.Log("Deleting user...")
 			boundary.AuthenticateAdminCli(t, context.Background())
 			output := e2e.RunCommand(ctx, "boundary",
@@ -101,7 +101,7 @@ func TestCliSessionEndWhenUserIsDeleted(t *testing.T) {
 	t.Log("Deleting user...")
 	output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("users", "delete", "-id", newUserId))
 	require.NoError(t, output.Err, string(output.Stderr))
-	deleted = true
+	userIsDeleted = true
 
 	// Check if session has terminated
 	t.Log("Waiting for session to be canceling/terminated...")


### PR DESCRIPTION
When investigating a separate issue, noticed some logs showing that some test data was not cleaned up. Turns out, if the test `TestCliSessionEndWhenUserIsDeleted` fails prior to it deleting the user, then subsequent tests will get impacted.

This PR updates that test to have an additional cleanup step if the test isn't able to get to it.