### PR TITLE
Fix ListPermissions when separate id/type grants are used

### DIFF
--- a/internal/perms/acl.go
+++ b/internal/perms/acl.go
@@ -163,7 +163,7 @@ func (a ACL) Allowed(r Resource, aType action.Type, userId string, opt ...Option
 		case grant.id == r.Id &&
 			grant.id != "" &&
 			grant.id != "*" &&
-			grant.typ == resource.Unknown &&
+			(grant.typ == resource.Unknown || grant.typ == globals.ResourceTypeFromPrefix(grant.id)) &&
 			!action.List.IsActionOrParent(aType) &&
 			!action.Create.IsActionOrParent(aType):
 
@@ -262,7 +262,7 @@ func (a ACL) ListPermissions(requestedScopes map[string]*scopes.ScopeInfo,
 		grants := a.scopeMap[scopeId]
 		for _, grant := range grants {
 			// This grant doesn't match what we're looking for, ignore.
-			if grant.typ != requestedType && grant.typ != resource.All {
+			if grant.typ != requestedType && grant.typ != resource.All && globals.ResourceTypeFromPrefix(grant.id) != requestedType {
 				continue
 			}
 

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -483,7 +483,7 @@ func Parse(scopeId, grantString string, opt ...Option) (Grant, error) {
 				}
 			}
 			if !allowed {
-				return Grant{}, errors.NewDeprecated(errors.InvalidParameter, op, "parsed grant string would not result in any action being authorized")
+				return Grant{}, errors.NewDeprecated(errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q would not result in any action being authorized", grant.CanonicalString()))
 			}
 		}
 	}


### PR DESCRIPTION
This makes two changes:

1. ListPermissions assumed every grant string had a type field, which does not match all grant formats. It now infers type from ID for formats which do not specify type.

2. Allow ID-only grant strings to be valid so long as the type specified matches the type of the specified ID.