### PR TITLE
Update resource-table.mdx

### DIFF
--- a/internal/website/permstable/permstable.go
+++ b/internal/website/permstable/permstable.go
@@ -866,7 +866,7 @@ var worker = &Resource{
 		{
 			Path: "/workers",
 			Params: map[string]string{
-				"Type": "workers",
+				"Type": "worker",
 			},
 			Actions: append(
 				lActions("a worker"),
@@ -892,7 +892,7 @@ var worker = &Resource{
 			Path: "/workers/<id>",
 			Params: map[string]string{
 				"ID":   "<id>",
-				"Type": "workers",
+				"Type": "worker",
 			},
 			Actions: append(
 				rudActions("a worker", false),

--- a/website/content/docs/concepts/security/permissions/resource-table.mdx
+++ b/website/content/docs/concepts/security/permissions/resource-table.mdx
@@ -1481,7 +1481,7 @@ documentation](/boundary/api-docs) for guidance.
           <li>Type</li>
           <ul>
             <li>
-              <code>workers</code>
+              <code>worker</code>
             </li>
           </ul>
         </ul>
@@ -1536,7 +1536,7 @@ documentation](/boundary/api-docs) for guidance.
           <li>Type</li>
           <ul>
             <li>
-              <code>workers</code>
+              <code>worker</code>
             </li>
           </ul>
         </ul>


### PR DESCRIPTION
Typo on table, "worker" does not have "s" in the grant string format.