### PR TITLE
chore(e2e): Update test attributes for new builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,6 +401,7 @@ jobs:
     with:
       artifact-name: "boundary_${{ needs.set-product-version.outputs.product-version }}_linux_amd64.zip"
       go-version: ${{ needs.product-metadata.outputs.go-version }}
+      edition: ${{ needs.product-metadata.outputs.product-edition }}
       docker-image-name: ${{ needs.build-docker.outputs.name }}
       docker-image-file: "boundary_default_linux_amd64_${{ needs.set-product-version.outputs.product-version }}_${{ github.sha }}.docker.dev.tar"
     secrets: inherit

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -9,6 +9,9 @@ on:
       artifact-name:
         required: true
         type: string
+      edition:
+        required: true
+        type: string
       go-version:
         required: true
         type: string
@@ -223,6 +226,7 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
+          ENOS_VAR_boundary_edition: ${{ inputs.edition }}
           ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
           ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |
@@ -243,6 +247,7 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
+          ENOS_VAR_boundary_edition: ${{ inputs.edition }}
           ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
           ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |
@@ -274,6 +279,7 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
+          ENOS_VAR_boundary_edition: ${{ inputs.edition }}
           ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
           ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -304,6 +304,7 @@ jobs:
           ENOS_VAR_crt_bundle_path: ./support/boundary.zip
           ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
           ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
+          ENOS_VAR_boundary_edition: ${{ inputs.edition }}
           ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
           ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -83,7 +83,19 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     env:
       GITHUB_TOKEN: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}
+      # Scenario variables
       ENOS_DEBUG_DATA_ROOT_DIR: ./enos/support/debug-data
+      ENOS_VAR_aws_region: us-east-1
+      ENOS_VAR_aws_ssh_keypair_name: ${{ github.event.repository.name }}-ci-ssh-key
+      ENOS_VAR_aws_ssh_private_key_path: ./support/private_key.pem
+      ENOS_VAR_local_boundary_dir: ./support/boundary
+      ENOS_VAR_local_boundary_ui_dir: ./support/boundary-ui
+      ENOS_VAR_crt_bundle_path: ./support/boundary.zip
+      ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
+      ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
+      ENOS_VAR_boundary_edition: ${{ inputs.edition }}
+      ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
+      ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -216,19 +228,6 @@ jobs:
         run: npx playwright install --with-deps
         working-directory: enos/support/boundary-ui
       - name: Output Terraform version info
-        # Use the same env vars from the following step
-        env:
-          ENOS_VAR_aws_region: us-east-1
-          ENOS_VAR_aws_ssh_keypair_name: ${{ github.event.repository.name }}-ci-ssh-key
-          ENOS_VAR_aws_ssh_private_key_path: ./support/private_key.pem
-          ENOS_VAR_local_boundary_dir: ./support/boundary
-          ENOS_VAR_local_boundary_ui_dir: ./support/boundary-ui
-          ENOS_VAR_crt_bundle_path: ./support/boundary.zip
-          ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
-          ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
-          ENOS_VAR_boundary_edition: ${{ inputs.edition }}
-          ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
-          ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |
           mkdir -p ./enos/terraform-plugin-cache
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
@@ -238,18 +237,6 @@ jobs:
         id: run
         # Continue once and retry
         continue-on-error: true
-        env:
-          ENOS_VAR_aws_region: us-east-1
-          ENOS_VAR_aws_ssh_keypair_name: ${{ github.event.repository.name }}-ci-ssh-key
-          ENOS_VAR_aws_ssh_private_key_path: ./support/private_key.pem
-          ENOS_VAR_local_boundary_dir: ./support/boundary
-          ENOS_VAR_local_boundary_ui_dir: ./support/boundary-ui
-          ENOS_VAR_crt_bundle_path: ./support/boundary.zip
-          ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
-          ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
-          ENOS_VAR_boundary_edition: ${{ inputs.edition }}
-          ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
-          ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |
           mkdir -p ./enos/terraform-plugin-cache
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
@@ -270,18 +257,6 @@ jobs:
       - name: Retry Enos scenario
         id: run_retry
         if: steps.run.outcome == 'failure'
-        env:
-          ENOS_VAR_aws_region: us-east-1
-          ENOS_VAR_aws_ssh_keypair_name: ${{ github.event.repository.name }}-ci-ssh-key
-          ENOS_VAR_aws_ssh_private_key_path: ./support/private_key.pem
-          ENOS_VAR_local_boundary_dir: ./support/boundary
-          ENOS_VAR_local_boundary_ui_dir: ./support/boundary-ui
-          ENOS_VAR_crt_bundle_path: ./support/boundary.zip
-          ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
-          ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
-          ENOS_VAR_boundary_edition: ${{ inputs.edition }}
-          ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
-          ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
@@ -295,18 +270,6 @@ jobs:
           retention-days: 30
       - name: Destroy Enos scenario
         if: ${{ always() && steps.run_retry.outcome == 'failure' }}
-        env:
-          ENOS_VAR_aws_region: us-east-1
-          ENOS_VAR_aws_ssh_keypair_name: ${{ github.event.repository.name }}-ci-ssh-key
-          ENOS_VAR_aws_ssh_private_key_path: ./support/private_key.pem
-          ENOS_VAR_local_boundary_dir: ./support/boundary
-          ENOS_VAR_local_boundary_ui_dir: ./support/boundary-ui
-          ENOS_VAR_crt_bundle_path: ./support/boundary.zip
-          ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
-          ENOS_VAR_test_email: ${{ secrets.SERVICE_USER_EMAIL }}
-          ENOS_VAR_boundary_edition: ${{ inputs.edition }}
-          ENOS_VAR_boundary_docker_image_name: ${{ inputs.docker-image-name }}
-          ENOS_VAR_boundary_docker_image_file: ./support/boundary_docker_image.tar
         run: |
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario destroy --timeout 60m0s --chdir ./enos ${{ matrix.filter }}

--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -11,7 +11,7 @@ module "bats_deps" {
 
 module "boundary" {
   source  = "app.terraform.io/hashicorp-qti/aws-boundary/enos"
-  version = ">= 0.5.0"
+  version = ">= 0.6.2"
 
   project_name = "qti-enos-boundary"
   environment  = var.environment
@@ -22,8 +22,9 @@ module "boundary" {
     "Environment" : var.environment
   }
 
-  ssh_aws_keypair       = var.aws_ssh_keypair_name
   alb_listener_api_port = var.alb_listener_api_port
+  boundary_binary_name  = var.boundary_binary_name
+  ssh_aws_keypair       = var.aws_ssh_keypair_name
 }
 
 module "worker" {
@@ -77,6 +78,10 @@ module "infra" {
     "Enos User" : var.enos_user,
     "Environment" : var.environment
   }
+}
+
+module "read_license" {
+  source = "./modules/read_license"
 }
 
 module "random_stringifier" {

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -18,6 +18,7 @@ scenario "e2e_aws" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
     local_boundary_dir       = abspath(var.local_boundary_dir)
+    license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
     build_path = {
       "local" = "/tmp",
       "crt"   = var.crt_bundle_path == null ? null : abspath(var.crt_bundle_path)
@@ -37,6 +38,15 @@ scenario "e2e_aws" {
         var.worker_instance_type,
         var.controller_instance_type
       ]
+    }
+  }
+
+  step "read_license" {
+    skip_step = var.boundary_edition == "oss"
+    module    = module.read_license
+
+    variables {
+      file_name = local.license_path
     }
   }
 
@@ -74,6 +84,7 @@ scenario "e2e_aws" {
 
     variables {
       boundary_install_dir     = local.boundary_install_dir
+      boundary_license         = var.boundary_edition != "oss" ? step.read_license.license : null
       common_tags              = local.tags
       controller_instance_type = var.controller_instance_type
       controller_count         = var.controller_count

--- a/enos/enos-scenario-e2e-static-with-vault.hcl
+++ b/enos/enos-scenario-e2e-static-with-vault.hcl
@@ -16,6 +16,7 @@ scenario "e2e_static_with_vault" {
   locals {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
+    boundary_license_path    = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
     local_boundary_dir       = abspath(var.local_boundary_dir)
     build_path = {
       "local" = "/tmp",
@@ -36,6 +37,15 @@ scenario "e2e_static_with_vault" {
         var.worker_instance_type,
         var.controller_instance_type
       ]
+    }
+  }
+
+  step "read_license" {
+    skip_step = var.boundary_edition == "oss"
+    module    = module.read_license
+
+    variables {
+      file_name = local.license_path
     }
   }
 
@@ -73,6 +83,7 @@ scenario "e2e_static_with_vault" {
 
     variables {
       boundary_install_dir     = local.boundary_install_dir
+      boundary_license         = var.boundary_edition != "oss" ? step.read_license.license : null
       common_tags              = local.tags
       controller_instance_type = var.controller_instance_type
       controller_count         = var.controller_count

--- a/enos/enos-scenario-e2e-static.hcl
+++ b/enos/enos-scenario-e2e-static.hcl
@@ -16,6 +16,7 @@ scenario "e2e_static" {
   locals {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
+    license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
     local_boundary_dir       = abspath(var.local_boundary_dir)
     build_path = {
       "local" = "/tmp",
@@ -36,6 +37,15 @@ scenario "e2e_static" {
         var.worker_instance_type,
         var.controller_instance_type
       ]
+    }
+  }
+
+  step "read_license" {
+    skip_step = var.boundary_edition == "oss"
+    module    = module.read_license
+
+    variables {
+      file_name = local.license_path
     }
   }
 
@@ -73,6 +83,7 @@ scenario "e2e_static" {
 
     variables {
       boundary_install_dir     = local.boundary_install_dir
+      boundary_license         = var.boundary_edition != "oss" ? step.read_license.license : null
       common_tags              = local.tags
       controller_instance_type = var.controller_instance_type
       controller_count         = var.controller_count

--- a/enos/enos-scenario-e2e-ui.hcl
+++ b/enos/enos-scenario-e2e-ui.hcl
@@ -16,6 +16,7 @@ scenario "e2e_ui" {
   locals {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
+    license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
     local_boundary_dir       = abspath(var.local_boundary_dir)
     local_boundary_ui_dir    = abspath(var.local_boundary_ui_dir)
     build_path = {
@@ -37,6 +38,15 @@ scenario "e2e_ui" {
         var.worker_instance_type,
         var.controller_instance_type
       ]
+    }
+  }
+
+  step "read_license" {
+    skip_step = var.boundary_edition == "oss"
+    module    = module.read_license
+
+    variables {
+      file_name = local.license_path
     }
   }
 
@@ -74,6 +84,7 @@ scenario "e2e_ui" {
 
     variables {
       boundary_install_dir     = local.boundary_install_dir
+      boundary_license         = var.boundary_edition != "oss" ? step.read_license.license : null
       common_tags              = local.tags
       controller_instance_type = var.controller_instance_type
       controller_count         = var.controller_count

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -154,3 +154,21 @@ variable "docker_mirror" {
   type        = string
   default     = "docker.mirror.hashicorp.services"
 }
+
+variable "boundary_binary_name" {
+  description = "Boundary binary name"
+  type        = string
+  default     = "boundary"
+}
+
+variable "boundary_edition" {
+  description = "Edition of boundary build"
+  type        = string
+  default     = "oss"
+}
+
+variable "boundary_license_path" {
+  description = "Boundary license path"
+  type        = string
+  default     = null
+}

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -32,6 +32,15 @@
 // The directory that contains the copy of boundary-ui you want to use for UI tests
 // local_boundary_ui_dir = "/Users/<user>/Developer/boundary-ui"
 
+// Path to a license file if required
+// boundary_license_path = "./support/boundary.hclic"
+
+// Built binary custom name, if not "boundary"
+// boundary_binary_name = "boundary"
+
+// Build edition from CRT
+// boundary_edition = "oss"
+
 // The path to the installation bundle for the target machines. The existing
 // scenarios all use linux/amd64 architecture so bundle ought to match that
 // architecture. This is only used for variants which use the `crt` builder

--- a/enos/modules/build_local/main.tf
+++ b/enos/modules/build_local/main.tf
@@ -17,6 +17,10 @@ variable "build_target" {
   default = "build-ui build"
 }
 
+variable "binary_name" {
+  default = "boundary"
+}
+
 variable "edition" {
   default = "oss"
 }
@@ -27,6 +31,7 @@ resource "enos_local_exec" "build" {
     "GOARCH"        = "amd64",
     "CGO_ENABLED"   = 0,
     "ARTIFACT_PATH" = var.path
+    "BINARY_NAME"   = var.binary_name
     "BUILD_TARGET"  = var.build_target
     "EDITION"       = var.edition
   }

--- a/enos/modules/build_local/templates/build.sh
+++ b/enos/modules/build_local/templates/build.sh
@@ -14,6 +14,6 @@ root_dir="$(git rev-parse --show-toplevel)"
 pushd "${root_dir}" > /dev/null
 
 make ${BUILD_TARGET}
-zip -j ${ARTIFACT_PATH}/boundary.zip bin/boundary
+zip -j ${ARTIFACT_PATH}/boundary.zip bin/${BINARY_NAME}
 
 popd > /dev/null

--- a/enos/modules/read_license/main.tf
+++ b/enos/modules/read_license/main.tf
@@ -1,0 +1,5 @@
+variable "file_name" {}
+
+output "license" {
+  value = file(var.file_name)
+}

--- a/enos/modules/read_license/main.tf
+++ b/enos/modules/read_license/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 variable "file_name" {}
 
 output "license" {

--- a/enos/modules/worker/main.tf
+++ b/enos/modules/worker/main.tf
@@ -78,7 +78,7 @@ resource "aws_security_group" "default" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["${data.enos_environment.current.public_ip_address}/32"]
+    cidr_blocks = flatten([formatlist("%s/32", data.enos_environment.current.public_ipv4_addresses)])
   }
 
   ingress {


### PR DESCRIPTION
This is mostly scenario support for future pipeline work and some housekeeping cleanup. All new attributes have safe defaults won't break current tests. Also, updates the worker module to use new provider attribute for ipv4 public addressing and simplifes variables in the workflow.