### PR TITLE
test(e2e): Fix assertion statement in worker test

### DIFF
--- a/testing/internal/e2e/tests/aws/worker_test.go
+++ b/testing/internal/e2e/tests/aws/worker_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,7 +61,7 @@ func TestCliWorker(t *testing.T) {
 		),
 	)
 	require.Error(t, output.Err, string(output.Stderr))
-	require.Equal(t, output.ExitCode, 255)
+	assert.Equal(t, 255, output.ExitCode)
 	require.Contains(t, string(output.Stderr), "timed out")
 	t.Logf("Successfully detected connection failure")
 


### PR DESCRIPTION
In https://github.com/hashicorp/boundary/pull/3177, we added a new e2e test that uses a worker. We observed one flake in this test due to the following...
```
    worker_test.go:63: 
        	Error Trace:	/home/runner/work/boundary/boundary/testing/internal/e2e/tests/aws/worker_test.go:63
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 255
        	Test:       	TestCliWorker
```

This PR does the following:
- updates the exit code assertion to correct the `expected` and `actual` values
- modifies the `require` to be an `assert`. I wasn't able to reproduce this locally, so I want to see what the error message if this happens again in CI. 