### PR TITLE
.github: fix test matrix script

### DIFF
--- a/.github/scripts/set-test-package-matrix.sh
+++ b/.github/scripts/set-test-package-matrix.sh
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 # set matrix var to list of unique packages containing tests
-matrix="$(go list -json="ImportPath,TestGoFiles" ./... | jq --compact-output '. | select(.TestGoFiles != null) | .ImportPath' | jq --slurp --compact-output '.')"
+matrix="$(go list -json="ImportPath,TestGoFiles,XTestGoFiles" ./... | jq --compact-output '. | select(.TestGoFiles != null or .XTestGoFiles != null) | .ImportPath' | jq --slurp --compact-output '.')"
 
 echo "matrix=${matrix}" | tee -a "${GITHUB_OUTPUT}"

--- a/internal/tests/api/authmethods/authmethod_test.go
+++ b/internal/tests/api/authmethods/authmethod_test.go
@@ -201,9 +201,10 @@ func TestList(t *testing.T) {
 
 	result, err := amClient.List(tc.Context(), global)
 	require.NoError(err)
-	require.Len(result.Items, 2)
+	require.Len(result.Items, 3)
 	genOIDCAM := result.Items[0]
 	genPWAM := result.Items[1]
+	genLDAPAM := result.Items[2]
 
 	pwAM, err := amClient.Create(tc.Context(), "password", global,
 		authmethods.WithName("bar"),
@@ -217,11 +218,11 @@ func TestList(t *testing.T) {
 
 	result, err = amClient.List(tc.Context(), global)
 	require.NoError(err)
-	require.Len(result.Items, 3)
+	require.Len(result.Items, 4)
 	assert.Empty(
 		cmp.Diff(
 			result.Items,
-			[]*authmethods.AuthMethod{genOIDCAM, genPWAM, pwAM.Item},
+			[]*authmethods.AuthMethod{genOIDCAM, genPWAM, genLDAPAM, pwAM.Item},
 			cmpopts.IgnoreUnexported(authmethods.AuthMethod{}),
 			cmpopts.SortSlices(func(a, b *authmethods.AuthMethod) bool {
 				return a.Name < b.Name
@@ -243,11 +244,11 @@ func TestList(t *testing.T) {
 
 	result, err = amClient.List(tc.Context(), global)
 	require.NoError(err)
-	require.Len(result.Items, 4)
+	require.Len(result.Items, 5)
 	assert.Empty(
 		cmp.Diff(
 			result.Items,
-			[]*authmethods.AuthMethod{genOIDCAM, genPWAM, pwAM.Item, oidcAM.Item},
+			[]*authmethods.AuthMethod{genOIDCAM, genPWAM, genLDAPAM, pwAM.Item, oidcAM.Item},
 			cmpopts.IgnoreUnexported(authmethods.AuthMethod{}),
 			cmpopts.SortSlices(func(a, b *authmethods.AuthMethod) bool {
 				return a.Name < b.Name
@@ -266,11 +267,11 @@ func TestList(t *testing.T) {
 
 	result, err = amClient.List(tc.Context(), global)
 	require.NoError(err)
-	require.Len(result.Items, 5)
+	require.Len(result.Items, 6)
 	assert.Empty(
 		cmp.Diff(
 			result.Items,
-			[]*authmethods.AuthMethod{genOIDCAM, genPWAM, pwAM.Item, oidcAM.Item, ldapAm.Item},
+			[]*authmethods.AuthMethod{genOIDCAM, genPWAM, genLDAPAM, pwAM.Item, oidcAM.Item, ldapAm.Item},
 			cmpopts.IgnoreUnexported(authmethods.AuthMethod{}),
 			cmpopts.SortSlices(func(a, b *authmethods.AuthMethod) bool {
 				return a.Name < b.Name


### PR DESCRIPTION
The test matrix script was excluding directories that only contained external package tests (i.e. tests packages with _test suffix). The following tests were not being run:

```
./internal/daemon/controller/common/scopeids
./internal/daemon/controller/handlers/authtokens
./internal/daemon/controller/handlers/groups
./internal/daemon/controller/handlers/host_catalogs
./internal/daemon/controller/handlers/host_sets
./internal/daemon/controller/handlers/hosts
./internal/daemon/controller/handlers/roles
./internal/daemon/controller/handlers/scopes
./internal/daemon/controller/handlers/sessions
./internal/daemon/controller/handlers/targets/tcp
./internal/daemon/controller/handlers/users
./internal/db/schema/internal/edition
./internal/db/schema/internal/provider
./internal/db/schema/migrations/oss
./internal/scheduler/cleaner
./internal/tests/api/accounts
./internal/tests/api/authmethods
./internal/tests/api/authtokens
./internal/tests/api/credentiallibraries
./internal/tests/api/credentials
./internal/tests/api/credentialstores
./internal/tests/api/groups
./internal/tests/api/hostcatalogs
./internal/tests/api/hosts
./internal/tests/api/hostsets
./internal/tests/api/managedgroups
./internal/tests/api/roles
./internal/tests/api/scopes
./internal/tests/api/sessions
./internal/tests/api/targets
./internal/tests/api/users
./internal/tests/api/workers
./internal/util
./testing/dbtest
./testing/internal/e2e/tests/aws
./testing/internal/e2e/tests/database
./testing/internal/e2e/tests/static
./testing/internal/e2e/tests/static_with_vault
```
