### PR TITLE
ci(test): Remove matrix for running tests per package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,42 +112,10 @@ jobs:
         run: |
           make test-${{ matrix.module }}
 
-  set-test-package-matrix:
-    runs-on: ${{ fromJSON(vars.RUNNER) }}
-    needs:
-      - setup
-    outputs:
-      package-matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: Set up go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version: "${{ needs.setup.outputs.go-version }}"
-          cache: false
-      - name: Set up Go modules cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        with:
-          path: |
-            ${{ needs.setup.outputs.cache-go-build }}
-            ${{ needs.setup.outputs.cache-go-mod }}
-            ${{ needs.setup.outputs.cache-go-bin }}
-          key: ${{ needs.setup.outputs.go-cache-key }}
-          restore-keys: |
-            ${{ runner.os }}-go
-          fail-on-cache-miss: true
-      - id: set-matrix
-        run: ./.github/scripts/set-test-package-matrix.sh
-
   test:
     needs:
       - setup
-      - set-test-package-matrix
-    runs-on: ${{ fromJSON(vars.RUNNER) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        package: ${{ fromJson(needs.set-test-package-matrix.outputs.package-matrix) }}
+    runs-on: ${{ fromJSON(vars.RUNNER_LARGE) }}
     steps:
       - name: ulimit
         run: |
@@ -181,6 +149,12 @@ jobs:
           key: ${{ needs.setup.outputs.plugin-cache-key }}
           restore-keys: |
             ${{ runner.os }}-plugin
+      - name: GH fix for localhost resolution
+        if: github.repository == 'hashicorp/boundary'
+        run: |
+          cat /etc/hosts && echo "-----------"
+          sudo sed -i 's/::1 *localhost ip6-localhost ip6-loopback/::1 ip6 -localhost ip6-loopback/g' /etc/hosts
+          cat /etc/hosts
       - name: Initialize Test Database
         run: |
           which pg_isready || sudo apt-get update && sudo apt-get install -y postgresql-client
@@ -190,8 +164,7 @@ jobs:
       - name: Test
         uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd   # TSCCR: no entry for repository "nick-fields/retry"
         env:
-          TEST_PACKAGE: "${{ matrix.package }}"
-          GOMAXPROCS: ${{ vars.TEST_GOMAXPROCS }}
+          TEST_PACKAGE: "./..."
           TESTARGS: -v
           TEST_TIMEOUT: 120m
         with:


### PR DESCRIPTION
The original motivation for the matrix was to mitigate an issue some
tests failing that used a vault docker container. When the tests ran in
a single step, these tests would almost always fail. By splitting the
tests per package, the failure rate of these tests was around 20%.

GitHub was able to identify the cause. There was an issue with localhost
resolution that causes requests to the vault containers to sometimes
fail, resulting in the kinds of failures that were seen. Note that the
same issue was not seen when accessing the test postgres database that
was running in a container, since the test code connects via 127.0.0.1,
while the vault container used localhost. This commit includes the
recommended fix so that localhost name resolution works as expected on
the GitHub hosted runners.

It also removes the test matrix since it is no longer needed as a work
around. In addition it seems advisable to remove the matrix given the
recent discovery that some tests were not running with the matrix. While
this was fixed, removing the matrix reduces the risk of any future
mistakes from the test splitting.

This also seems to result in a faster pipeline execution time. The
overhead to determine the matrix values, wait for a runner to be
available, and restore from the cache seems to add up to a longer
overall execution time.

Eliminating the matrix can also help with another type of failure seen.
Sometimes restoring from the cache fails. By eliminating the test
matrix, it will greatly reduce the number of cache restoring done by the
workflow, which will reduce the chances of an issue restoring from
cache.

The only remaining benefit from the matrix, was that if there was a
transient test failure, a re-run of only the failed jobs would be
relatively quick (depending on which package had the failure), while
without the matrix the entire test suite will need to be re-run.

See: https://github.com/hashicorp/boundary/pull/3199
Refs:
    86214a85e1c5553618b8f83592b3548e6b0aeb1f
    e04438b7f87f9811bc43038a3f31c3ab4c76f854