### PR TITLE
fix(e2e): Fix path to echo in connect_test & update scenarios for local builds

### DIFF
--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -47,6 +47,7 @@ module "build_crt" {
 module "build_local" {
   source = "./modules/build_local"
 
+  binary_name  = var.boundary_binary_name
   build_target = var.local_build_target
 }
 

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -83,6 +83,7 @@ scenario "e2e_aws" {
     ]
 
     variables {
+      boundary_binary_name     = var.boundary_binary_name
       boundary_install_dir     = local.boundary_install_dir
       boundary_license         = var.boundary_edition != "oss" ? step.read_license.license : null
       common_tags              = local.tags

--- a/enos/enos-scenario-e2e-static-with-vault.hcl
+++ b/enos/enos-scenario-e2e-static-with-vault.hcl
@@ -82,6 +82,7 @@ scenario "e2e_static_with_vault" {
     ]
 
     variables {
+      boundary_binary_name     = var.boundary_binary_name
       boundary_install_dir     = local.boundary_install_dir
       boundary_license         = var.boundary_edition != "oss" ? step.read_license.license : null
       common_tags              = local.tags

--- a/enos/enos-scenario-e2e-static.hcl
+++ b/enos/enos-scenario-e2e-static.hcl
@@ -82,6 +82,7 @@ scenario "e2e_static" {
     ]
 
     variables {
+      boundary_binary_name     = var.boundary_binary_name
       boundary_install_dir     = local.boundary_install_dir
       boundary_license         = var.boundary_edition != "oss" ? step.read_license.license : null
       common_tags              = local.tags

--- a/enos/enos-scenario-e2e-ui.hcl
+++ b/enos/enos-scenario-e2e-ui.hcl
@@ -83,6 +83,7 @@ scenario "e2e_ui" {
     ]
 
     variables {
+      boundary_binary_name     = var.boundary_binary_name
       boundary_install_dir     = local.boundary_install_dir
       boundary_license         = var.boundary_edition != "oss" ? step.read_license.license : null
       common_tags              = local.tags

--- a/testing/internal/e2e/tests/static/connect_test.go
+++ b/testing/internal/e2e/tests/static/connect_test.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
-	"github.com/stretchr/testify/require"
 )
 
 // TestCliConnectTargetBasic uses the boundary cli to create a number of
@@ -94,7 +95,7 @@ func TestCliConnectTargetWithTargetClientPort(t *testing.T) {
 		e2e.WithArgs(
 			"connect",
 			"-target-id", newTargetId,
-			"-exec", "/usr/bin/echo", "--",
+			"-exec", "/bin/echo", "--",
 			"{{boundary.port}}",
 		),
 	)


### PR DESCRIPTION
This change updates the path to `echo` to work across various workers, as well as providing `binary_name` to the local build & boundary modules