### PR TITLE
Only create WithAutomaticVersioning if versioning is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   never result in permissions being granted, causing confusion. As a result,
   attempting to write such grants into roles may now result in an error; the
   error message gives hints for resolution.
+* `WithAutomaticVersioning` for auth tokens in Go SDK: this option was
+  incorrectly being generated for auth token resources, which do not support
+  versioning. This is technically a breaking change, but it was a no-op option
+  anyways that there was no reason to be using. It has now been removed.
 
 ### New and Improved
 

--- a/api/authtokens/option.gen.go
+++ b/api/authtokens/option.gen.go
@@ -55,16 +55,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	return opts, apiOpts
 }
 
-// If set, and if the version is zero during an update, the API will perform a
-// fetch to get the current version of the resource and populate it during the
-// update call. This is convenient but opens up the possibility for subtle
-// order-of-modification issues, so use carefully.
-func WithAutomaticVersioning(enable bool) Option {
-	return func(o *options) {
-		o.withAutomaticVersioning = enable
-	}
-}
-
 // WithSkipCurlOutput tells the API to not use the current call for cURL output.
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {

--- a/internal/api/genapi/input.go
+++ b/internal/api/genapi/input.go
@@ -757,6 +757,15 @@ var inputStructs = []*structInfo{
 		recursiveListing:    true,
 	},
 	{
+		inProto:        &hosts.StaticHostAttributes{},
+		outFile:        "hosts/static_host_attributes.gen.go",
+		subtypeName:    "StaticHost",
+		parentTypeName: "Host",
+		templates: []*template.Template{
+			mapstructureConversionTemplate,
+		},
+	},
+	{
 		inProto: &hosts.Host{},
 		outFile: "hosts/host.gen.go",
 		templates: []*template.Template{
@@ -771,15 +780,6 @@ var inputStructs = []*structInfo{
 		parentTypeName:      "host-catalog",
 		versionEnabled:      true,
 		createResponseTypes: []string{CreateResponseType, ReadResponseType, UpdateResponseType, DeleteResponseType, ListResponseType},
-	},
-	{
-		inProto:        &hosts.StaticHostAttributes{},
-		outFile:        "hosts/static_host_attributes.gen.go",
-		subtypeName:    "StaticHost",
-		parentTypeName: "Host",
-		templates: []*template.Template{
-			mapstructureConversionTemplate,
-		},
 	},
 	{
 		inProto: &hostsets.HostSet{},
@@ -964,6 +964,7 @@ var inputStructs = []*structInfo{
 		pluralResourceName:  "sessions",
 		createResponseTypes: []string{CreateResponseType, ReadResponseType, UpdateResponseType, DeleteResponseType, ListResponseType},
 		fieldFilter:         []string{"private_key"},
+		versionEnabled:      true,
 		recursiveListing:    true,
 	},
 	{

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -194,6 +194,7 @@ func fillTemplates() {
 			Package:          pkg,
 			Fields:           fields,
 			RecursiveListing: inputMap[pkg].recursiveListing,
+			VersionEnabled:   inputMap[pkg].versionEnabled,
 		}
 
 		if err := optionTemplate.Execute(outBuf, input); err != nil {
@@ -683,6 +684,9 @@ var optionTemplate = template.Must(template.New("").Funcs(
 		"removeDups": removeDups,
 	},
 ).Parse(`
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package {{ .Package }}
 
 import (
@@ -736,6 +740,7 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	return opts, apiOpts
 }
 
+{{ if .VersionEnabled }}
 // If set, and if the version is zero during an update, the API will perform a
 // fetch to get the current version of the resource and populate it during the
 // update call. This is convenient but opens up the possibility for subtle
@@ -745,6 +750,7 @@ func WithAutomaticVersioning(enable bool) Option {
 		o.withAutomaticVersioning = enable
 	}
 }
+{{ end }}
 
 // WithSkipCurlOutput tells the API to not use the current call for cURL output.
 // Useful for when we need to look up versions.


### PR DESCRIPTION
This option did not respect whether or not versioning was enabled when writing it out during generation.

This does mean that there is a breaking change for auth tokens, but as it was a no-op anyways it's easy to fix and not something I want to /v2 about.