### PR TITLE
Update references to deprecated controllers field

### DIFF
--- a/website/content/docs/configuration/controller.mdx
+++ b/website/content/docs/configuration/controller.mdx
@@ -74,7 +74,7 @@ description will be read.
 - `public_cluster_addr` - Specifies the public host or IP address (and
   optionally port) at which the controller can be reached _by workers_. This will
   be used by workers after initial connection to controllers via the worker's
-  `controllers` block. This defaults to the address of the listener marked for
+  `initial_upstreams` block. This defaults to the address of the listener marked for
   `cluster` purpose. This is especially useful for cloud environments that do not
   bind a publicly accessible IP to a NIC on the host directly, such as an Amazon
   EIP. This value can be a direct address string, can refer to a file on disk (file://)

--- a/website/content/docs/getting-started/installing/production.mdx
+++ b/website/content/docs/getting-started/installing/production.mdx
@@ -129,7 +129,7 @@ worker {
   # Name attr must be unique
 	name = "demo-worker-${count.index}"
 	description = "A default worker created demonstration"
-	controllers = [
+	initial_upstreams = [
     "${aws_instance.controller[0].private_ip}",
     "${aws_instance.controller[1].private_ip}",
     "${aws_instance.controller[2].private_ip}"


### PR DESCRIPTION
Change references to the deprecated `controllers` field to `initial_upstreams`