### PR TITLE
feat(e2e): Add configurable timeout for go test execution within scenarios

### DIFF
--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -118,7 +118,8 @@ module "vault" {
 }
 
 module "test_e2e" {
-  source = "./modules/test_e2e"
+  source       = "./modules/test_e2e"
+  test_timeout = var.test_timeout
 }
 
 module "test_e2e_ui" {

--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -119,7 +119,7 @@ module "vault" {
 
 module "test_e2e" {
   source       = "./modules/test_e2e"
-  test_timeout = var.test_timeout
+  test_timeout = var.go_test_timeout
 }
 
 module "test_e2e_ui" {

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -172,3 +172,9 @@ variable "boundary_license_path" {
   type        = string
   default     = null
 }
+
+variable "test_timeout" {
+  description = "Timeout for go test used in e2e tests"
+  type        = string
+  default     = "10m"
+}

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -173,7 +173,7 @@ variable "boundary_license_path" {
   default     = null
 }
 
-variable "test_timeout" {
+variable "go_test_timeout" {
   description = "Timeout for go test used in e2e tests"
   type        = string
   default     = "10m"

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -57,3 +57,6 @@
 // would not be able to access the environment variables needed to test locally. Enabling this
 // will ensure that the enos scenario passes.
 // e2e_debug_no_run = true
+
+// Timeout for `go test` execution in the e2e tests, 10m default
+// test_timeout = "10m"

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -59,4 +59,4 @@
 // e2e_debug_no_run = true
 
 // Timeout for `go test` execution in the e2e tests, 10m default
-// test_timeout = "10m"
+// go_test_timeout = "10m"

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -116,6 +116,10 @@ variable "worker_tags" {
   type    = list(string)
   default = [""]
 }
+variable "test_timeout" {
+  type    = string
+  default = "10m"
+}
 
 locals {
   aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
@@ -149,7 +153,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_WORKER_TAG                = jsonencode(var.worker_tags),
   }
 
-  inline = var.debug_no_run ? [""] : ["set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json | tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.log"]
+  inline = var.debug_no_run ? [""] : ["set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json -timeout ${var.test_timeout}| tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.log"]
 }
 
 output "test_results" {


### PR DESCRIPTION
The default `go test` timeout is 10 minutes, and we're coming awfully close to that limit in some test runs. This adds a tunable for that timeout we can customize per-execution if needed.