### PR TITLE
test(vault): Increase threshold for period assertion

### DIFF
--- a/internal/credential/vault/testing_test.go
+++ b/internal/credential/vault/testing_test.go
@@ -134,7 +134,7 @@ func TestTestVaultServer_CreateToken(t *testing.T) {
 				gotPeriod, err := parseutil.ParseDurationSecond(period)
 				require.NoError(t, err)
 				if assert.True(t, ok, op) {
-					delta := 1 * time.Minute
+					delta := 5 * time.Minute
 					assert.InDelta(t, want.Seconds(), gotPeriod.Seconds(), delta.Seconds())
 				}
 			}


### PR DESCRIPTION
This allows for a greater delta between the period returned by vault and
they expected value to account for some delay due to load on the test
runners.