### PR TITLE
fix(cli): correctly print secrets in authorize-session for current vault credential source subtypes

### DIFF
--- a/internal/cmd/commands/targetscmd/funcs.go
+++ b/internal/cmd/commands/targetscmd/funcs.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/cmd/base"
 	"github.com/hashicorp/boundary/internal/credential"
+	"github.com/hashicorp/boundary/internal/credential/static"
+	"github.com/hashicorp/boundary/internal/credential/vault"
 	"github.com/hashicorp/boundary/internal/types/scope"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/mitchellh/go-wordwrap"
@@ -731,7 +733,8 @@ func printCustomActionOutputImpl(c *Command) (bool, error) {
 
 					var secretStr []string
 					switch cred.CredentialSource.Type {
-					case "vault", "static":
+					case vault.Subtype.String(), vault.GenericLibrarySubtype.String(),
+						vault.SSHCertificateLibrarySubtype.String(), static.Subtype.String():
 						switch {
 						case cred.Credential != nil:
 							maxLength := 0

--- a/internal/cmd/commands/targetscmd/funcs.go
+++ b/internal/cmd/commands/targetscmd/funcs.go
@@ -733,8 +733,7 @@ func printCustomActionOutputImpl(c *Command) (bool, error) {
 
 					var secretStr []string
 					switch cred.CredentialSource.Type {
-					case vault.Subtype.String(), vault.GenericLibrarySubtype.String(),
-						vault.SSHCertificateLibrarySubtype.String(), static.Subtype.String():
+					case vault.Subtype.String(), vault.GenericLibrarySubtype.String(), static.Subtype.String():
 						switch {
 						case cred.Credential != nil:
 							maxLength := 0


### PR DESCRIPTION
The current `authorize-session` print function has a case statement which checks whether the session credential type matches "vault" or "static" before accessing and printing the credential's SessionSecret field. The current credential libraries are generated with types "vault-generic" or "vault-ssh-certificate".

In my understanding, this case statement should be updated so we also print read and print credential secrets for all current vault credential source types.