### PR TITLE
test(e2e): Add test that checks that session ends after deleting project

### DIFF
--- a/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_empty_test.go
+++ b/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_empty_test.go
@@ -23,7 +23,7 @@ import (
 // one of the host sets, and attempts to connect to the target.
 func TestCliCreateAwsDynamicHostCatalogWithEmptyHostSet(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_test.go
+++ b/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_test.go
@@ -28,7 +28,7 @@ import (
 // one of the host sets, and attempts to connect to the target.
 func TestCliCreateAwsDynamicHostCatalogWithHostSet(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -138,7 +138,7 @@ func TestCliCreateAwsDynamicHostCatalogWithHostSet(t *testing.T) {
 // host set.
 func TestApiCreateAwsDynamicHostCatalog(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	client, err := boundary.NewApiClient()

--- a/testing/internal/e2e/tests/aws/env_test.go
+++ b/testing/internal/e2e/tests/aws/env_test.go
@@ -19,7 +19,7 @@ type config struct {
 	WorkerTags         string `envconfig:"E2E_WORKER_TAG" required:"true"`           // e.g. "[\"tag1\", \"tag2\"]"
 }
 
-func loadConfig() (*config, error) {
+func loadTestConfig() (*config, error) {
 	var c config
 	err := envconfig.Process("", &c)
 	if err != nil {

--- a/testing/internal/e2e/tests/aws/worker_test.go
+++ b/testing/internal/e2e/tests/aws/worker_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestCliWorker(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/database/env_test.go
+++ b/testing/internal/e2e/tests/database/env_test.go
@@ -15,7 +15,7 @@ type config struct {
 	AwsHostSetFilter   string `envconfig:"E2E_AWS_HOST_SET_FILTER" required:"true"` // e.g. "tag:testtag=true"
 }
 
-func loadConfig() (*config, error) {
+func loadTestConfig() (*config, error) {
 	var c config
 	err := envconfig.Process("", &c)
 	if err != nil {

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -41,7 +41,7 @@ type TestEnvironment struct {
 // and uses the Boundary version under test to migrate the database.
 func TestDatabaseMigration(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static/bytes_up_down_empty_test.go
+++ b/testing/internal/e2e/tests/static/bytes_up_down_empty_test.go
@@ -20,7 +20,7 @@ import (
 // session correctly increase when data is transmitting during a session.
 func TestCliBytesUpDownEmpty(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static/bytes_up_down_test.go
+++ b/testing/internal/e2e/tests/static/bytes_up_down_test.go
@@ -21,7 +21,7 @@ import (
 // session correctly increase when data is transmitting during a session.
 func TestCliBytesUpDownTransferData(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static/connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/static/connect_authz_token_test.go
@@ -22,7 +22,7 @@ import (
 // `authz_token` option
 func TestCliConnectTargetWithAuthzToken(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static/connect_localhost_test.go
+++ b/testing/internal/e2e/tests/static/connect_localhost_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCliConnectTargetWithLocalhost(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static/connect_ssh_test.go
+++ b/testing/internal/e2e/tests/static/connect_ssh_test.go
@@ -21,7 +21,7 @@ import (
 // to that target using those credentials.
 func TestCliConnectTargetWithSsh(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static/connect_test.go
+++ b/testing/internal/e2e/tests/static/connect_test.go
@@ -21,7 +21,7 @@ import (
 // that target and verifies that the connection was successful.
 func TestCliConnectTargetBasic(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -67,7 +67,7 @@ func TestCliConnectTargetBasic(t *testing.T) {
 
 func TestCliConnectTargetWithTargetClientPort(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static/credential_store_test.go
+++ b/testing/internal/e2e/tests/static/credential_store_test.go
@@ -35,7 +35,7 @@ const (
 // TestCliStaticCredentialStore validates various credential-store operations using the cli
 func TestCliStaticCredentialStore(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -175,7 +175,7 @@ func createPrivateKeyPemFile(fileName string) error {
 // boundary's built-in credential store. The test then attaches that credential to a target.
 func TestApiStaticCredentialStore(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	client, err := boundary.NewApiClient()

--- a/testing/internal/e2e/tests/static/env_test.go
+++ b/testing/internal/e2e/tests/static/env_test.go
@@ -12,7 +12,7 @@ type config struct {
 	TargetPort       string `envconfig:"E2E_SSH_PORT" required:"true"`
 }
 
-func loadConfig() (*config, error) {
+func loadTestConfig() (*config, error) {
 	var c config
 	err := envconfig.Process("", &c)
 	if err != nil {

--- a/testing/internal/e2e/tests/static/session_cancel_admin_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_admin_test.go
@@ -18,7 +18,7 @@ import (
 // TestCliSessionCancelAdmin uses the boundary cli to start and then cancel a session
 func TestCliSessionCancelAdmin(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static/session_cancel_group_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_group_test.go
@@ -27,7 +27,7 @@ import (
 // cancel the user's session.
 func TestCliSessionCancelGroup(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 	bc, err := boundary.LoadConfig()
 	require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestCliSessionCancelGroup(t *testing.T) {
 // TestApiCreateGroup uses the Go api to create a new group and add some grants to the group
 func TestApiCreateGroup(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	client, err := boundary.NewApiClient()

--- a/testing/internal/e2e/tests/static/session_cancel_user_test.go
+++ b/testing/internal/e2e/tests/static/session_cancel_user_test.go
@@ -26,7 +26,7 @@ import (
 // user's session.
 func TestCliSessionCancelUser(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 	bc, err := boundary.LoadConfig()
 	require.NoError(t, err)
@@ -150,7 +150,7 @@ func TestCliSessionCancelUser(t *testing.T) {
 // TestApiCreateUser uses the Go api to create a new user and add some grants to the user
 func TestApiCreateUser(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	client, err := boundary.NewApiClient()

--- a/testing/internal/e2e/tests/static/session_end_delete_host_set_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_host_set_test.go
@@ -19,7 +19,7 @@ import (
 // host set for the session is deleted.
 func TestCliSessionEndWhenHostSetIsDeleted(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 	bc, err := boundary.LoadConfig()
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/static/session_end_delete_host_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_host_test.go
@@ -19,7 +19,7 @@ import (
 // host set for the session is deleted.
 func TestCliSessionEndWhenHostIsDeleted(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 	bc, err := boundary.LoadConfig()
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/static/session_end_delete_project_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_project_test.go
@@ -19,7 +19,7 @@ import (
 // project for the session is deleted.
 func TestCliSessionEndWhenProjectIsDeleted(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 	bc, err := boundary.LoadConfig()
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/static/session_end_delete_project_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_project_test.go
@@ -34,12 +34,7 @@ func TestCliSessionEndWhenProjectIsDeleted(t *testing.T) {
 		require.NoError(t, output.Err, string(output.Stderr))
 	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
-	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
-	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)
-	newHostId := boundary.CreateNewHostCli(t, ctx, newHostCatalogId, c.TargetIp)
-	boundary.AddHostToHostSetCli(t, ctx, newHostSetId, newHostId)
-	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
-	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
+	newTargetId := boundary.CreateNewAddressTargetCli(t, ctx, newProjectId, c.TargetPort, c.TargetIp)
 	acctName := "e2e-account"
 	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, bc.AuthMethodId, acctName)
 	t.Cleanup(func() {
@@ -90,7 +85,6 @@ func TestCliSessionEndWhenProjectIsDeleted(t *testing.T) {
 	s := boundary.WaitForSessionCli(t, ctx, newProjectId)
 	boundary.WaitForSessionStatusCli(t, ctx, s.Id, session.StatusActive.String())
 	assert.Equal(t, newTargetId, s.TargetId)
-	assert.Equal(t, newHostId, s.HostId)
 
 	// Delete Project
 	t.Log("Deleting project...")

--- a/testing/internal/e2e/tests/static/session_end_delete_project_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_project_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package static_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/internal/session"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCliSessionEndWhenProjectIsDeleted tests that an active session is canceled when the respective
+// project for the session is deleted.
+func TestCliSessionEndWhenProjectIsDeleted(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+	c, err := loadConfig()
+	require.NoError(t, err)
+	bc, err := boundary.LoadConfig()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	boundary.AuthenticateAdminCli(t, ctx)
+	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
+	newHostCatalogId := boundary.CreateNewHostCatalogCli(t, ctx, newProjectId)
+	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)
+	newHostId := boundary.CreateNewHostCli(t, ctx, newHostCatalogId, c.TargetIp)
+	boundary.AddHostToHostSetCli(t, ctx, newHostSetId, newHostId)
+	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort)
+	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
+	acctName := "e2e-account"
+	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, bc.AuthMethodId, acctName)
+	t.Cleanup(func() {
+		boundary.AuthenticateAdminCli(t, context.Background())
+		output := e2e.RunCommand(ctx, "boundary",
+			e2e.WithArgs("accounts", "delete", "-id", newAccountId),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+	newUserId := boundary.CreateNewUserCli(t, ctx, "global")
+	t.Cleanup(func() {
+		boundary.AuthenticateAdminCli(t, context.Background())
+		output := e2e.RunCommand(ctx, "boundary",
+			e2e.WithArgs("users", "delete", "-id", newUserId),
+		)
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+	boundary.SetAccountToUserCli(t, ctx, newUserId, newAccountId)
+	newRoleId := boundary.CreateNewRoleCli(t, ctx, newProjectId)
+	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "id=*;type=target;actions=authorize-session")
+	boundary.AddPrincipalToRoleCli(t, ctx, newRoleId, newUserId)
+
+	// Connect to target to create a session
+	ctxCancel, cancel := context.WithCancel(context.Background())
+	errChan := make(chan *e2e.CommandResult)
+	go func() {
+		token := boundary.GetAuthenticationTokenCli(t, ctx, acctName, acctPassword)
+		t.Log("Starting session as user...")
+		errChan <- e2e.RunCommand(ctxCancel, "boundary",
+			e2e.WithArgs(
+				"connect",
+				"-token", "env://E2E_AUTH_TOKEN",
+				"-target-id", newTargetId,
+				"-exec", "/usr/bin/ssh", "--",
+				"-l", c.TargetSshUser,
+				"-i", c.TargetSshKeyPath,
+				"-o", "UserKnownHostsFile=/dev/null",
+				"-o", "StrictHostKeyChecking=no",
+				"-o", "IdentitiesOnly=yes", // forces the use of the provided key
+				"-p", "{{boundary.port}}", // this is provided by boundary
+				"{{boundary.ip}}",
+				"hostname -i; sleep 60",
+			),
+			e2e.WithEnv("E2E_AUTH_TOKEN", token),
+		)
+	}()
+	t.Cleanup(cancel)
+	s := boundary.WaitForSessionCli(t, ctx, newProjectId)
+	boundary.WaitForSessionStatusCli(t, ctx, s.Id, session.StatusActive.String())
+	assert.Equal(t, newTargetId, s.TargetId)
+	assert.Equal(t, newHostId, s.HostId)
+
+	// Delete Project
+	t.Log("Deleting project...")
+	output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newProjectId))
+	require.NoError(t, output.Err, string(output.Stderr))
+
+	// Check if session has terminated
+	t.Log("Waiting for session to be canceling/terminated...")
+	select {
+	case output := <-errChan:
+		// `boundary connect` returns a 255 when cancelled
+		require.Equal(t, 255, output.ExitCode, string(output.Stdout), string(output.Stderr))
+	case <-time.After(time.Second * 5):
+		t.Fatal("Timed out waiting for session command to exit")
+	}
+
+	t.Log("Session successfully ended after project was deleted")
+}

--- a/testing/internal/e2e/tests/static/session_end_delete_target_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_target_test.go
@@ -19,7 +19,7 @@ import (
 // target for the session is deleted.
 func TestCliSessionEndWhenTargetIsDeleted(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 	bc, err := boundary.LoadConfig()
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/static/session_end_delete_user_test.go
+++ b/testing/internal/e2e/tests/static/session_end_delete_user_test.go
@@ -21,7 +21,7 @@ func TestCliSessionEndWhenUserIsDeleted(t *testing.T) {
 	userIsDeleted := false
 
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 	bc, err := boundary.LoadConfig()
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/static/target_address_test.go
+++ b/testing/internal/e2e/tests/static/target_address_test.go
@@ -19,7 +19,7 @@ import (
 // using a valid address is successful.
 func TestCliCreateUpdateTargetAddress(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -134,7 +134,7 @@ func TestCliCreateUpdateTargetAddress(t *testing.T) {
 // commutative operation (they use different codepaths).
 func TestCliTargetAddressToHostSource(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -251,7 +251,7 @@ func TestCliTargetAddressToHostSource(t *testing.T) {
 // commutative operation (they use different codepaths).
 func TestCliTargetHostSourceToAddress(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static_with_vault/connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_authz_token_test.go
@@ -25,7 +25,7 @@ import (
 // authz-token option) using those credentials.
 func TestCliVaultConnectTargetWithAuthzToken(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static_with_vault/connect_ssh_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_ssh_test.go
@@ -24,7 +24,7 @@ import (
 // credentials.
 func TestCliVaultConnectTargetWithSsh(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static_with_vault/connect_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/connect_test.go
@@ -26,7 +26,7 @@ import (
 // credentials.
 func TestCliVaultConnectTarget(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/testing/internal/e2e/tests/static_with_vault/credential_store_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/credential_store_test.go
@@ -24,7 +24,7 @@ import (
 // vault
 func TestCliVaultCredentialStore(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -187,7 +187,7 @@ func TestCliVaultCredentialStore(t *testing.T) {
 // with vault
 func TestApiVaultCredentialStore(t *testing.T) {
 	e2e.MaybeSkipTest(t)
-	c, err := loadConfig()
+	c, err := loadTestConfig()
 	require.NoError(t, err)
 
 	client, err := boundary.NewApiClient()

--- a/testing/internal/e2e/tests/static_with_vault/env_test.go
+++ b/testing/internal/e2e/tests/static_with_vault/env_test.go
@@ -15,7 +15,7 @@ type config struct {
 	VaultSecretPath string `envconfig:"E2E_VAULT_SECRET_PATH" default:"e2e_secrets"`
 }
 
-func loadConfig() (*config, error) {
+func loadTestConfig() (*config, error) {
 	var c config
 	err := envconfig.Process("", &c)
 	if err != nil {


### PR DESCRIPTION
This PR adds an e2e test that checks that a session is cancelled after deleting the corresponding project it belongs on. This continues the series of tests that test a session ends after other kinds of resources are deleted.

This particular test is slightly different in that it does not read the session id to check that the session status itself is cancelled and solely relying on the goroutine that initiates a user's session to end. This is due to how the data is structured (details here: https://hashicorp.atlassian.net/browse/ICU-7296)