### PR TITLE
Add s3 bucket module for Enos scenarios

### DIFF
--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -216,7 +216,10 @@ data "aws_iam_policy_document" "enos_policy_document" {
       "rds:ListTagsForResource",
       "rds:ModifyDBInstance",
       "rds:ModifyDBSubnetGroup",
-      "rds:RemoveTagsFromResource"
+      "rds:RemoveTagsFromResource",
+      "s3:ListAllMyBuckets",
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
     ]
     resources = ["*"]
   }
@@ -243,7 +246,9 @@ data "aws_iam_policy_document" "aws_nuke_policy_document" {
       "iam:ListUserTags",
       "iam:ListUsers",
       "iam:UntagUser",
-      "servicequotas:ListServiceQuotas"
+      "servicequotas:ListServiceQuotas",
+      "s3:ListAllMyBuckets",
+      "s3:DeleteBucket",
     ]
     resources = ["*"]
   }

--- a/enos/modules/bucket/locals.tf
+++ b/enos/modules/bucket/locals.tf
@@ -1,0 +1,13 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+locals {
+  common_tags = merge(
+    var.common_tags,
+    {
+      Type     = var.cluster_tag
+      Module   = "bucket"
+      BucketID = random_pet.default.id
+    },
+  )
+}

--- a/enos/modules/bucket/main.tf
+++ b/enos/modules/bucket/main.tf
@@ -1,0 +1,33 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resource "random_pet" "default" {}
+
+resource "aws_s3_bucket" "default" {
+  bucket_prefix = "enos-${random_pet.default.id}-"
+  force_destroy = true
+  tags          = local.common_tags
+}
+
+data "aws_iam_policy_document" "default" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:GetObjectAttributes",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.default.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_user_policy" "default" {
+  name   = "${aws_s3_bucket.default.id}_${var.user}_access"
+  user   = var.user
+  policy = data.aws_iam_policy_document.default.json
+}

--- a/enos/modules/bucket/outputs.tf
+++ b/enos/modules/bucket/outputs.tf
@@ -1,0 +1,7 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+output "bucket_name" {
+  value       = aws_s3_bucket.default.id
+  description = "The name of the S3 bucket created by this module."
+}

--- a/enos/modules/bucket/variables.tf
+++ b/enos/modules/bucket/variables.tf
@@ -1,0 +1,18 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "common_tags" {
+  description = "A map of tags to set for the S3 bucket."
+  type        = map(string)
+  default     = { "Project" : "Enos" }
+}
+
+variable "cluster_tag" {
+  description = "The cluster_tag from the Boundary cluster module."
+  type        = string
+}
+
+variable "user" {
+  description = "A username that will be allowed access to this module's bucket."
+  type        = string
+}

--- a/enos/modules/iam_setup/main.tf
+++ b/enos/modules/iam_setup/main.tf
@@ -46,3 +46,8 @@ output "secret_access_key" {
   value     = aws_iam_access_key.boundary.secret
   sensitive = true
 }
+
+output "user_name" {
+  description = "The name of the user created by this module."
+  value       = aws_iam_user.boundary.name
+}


### PR DESCRIPTION
This Terraform module can be used with Enos to supply a bucket in S3 along with a policy that allows a given user to write and delete objects in said bucket. I've done some simple testing to confirm that the above behavior is possible. A simple way to test this for yourself is to use a scenario like the one below, grab the outputs from the scenario to know the bucket name and AWS user ID (in order to assume this user's access). You'll need to get the key for this user from the state file itself as it's a sensitive value that can't be shown in Terraform output.

```
module "bucket" {
  source = "./modules/bucket"
}

scenario "bucket_test" {
  terraform_cli = terraform_cli.default
  terraform     = terraform.default
  providers     = [provider.aws.default]

  step "create_iam_user" {
    module = module.iam_setup

    variables {
      test_id    = "<TODO PUT AN ID FOR YOURSELF HERE>"
      test_email = "<TODO PUT AN EMAIL FOR YOURSELF HERE>"
    }
  }

  step "create_bucket" {
    module = module.bucket

    variables {
      cluster_tag = "TODO MAKE AN ARBITRARY CLUSTER TAG HERE"
      user        = step.create_iam_user.user_name
    }
  }

  output "bucket_name" {
    value = step.create_bucket.bucket_name
  }

  output "access_key_id" {
    value = step.create_iam_user.access_key_id
  }
}
```

If you've pulled down the branch to help me with testing, please note that I've force pushed after rebasing the module to bring the base up to date with main.