### PR TITLE
style(cli): boundary connect output returns pasteable X.509 certificates

### DIFF
--- a/internal/cmd/commands/connect/funcs.go
+++ b/internal/cmd/commands/connect/funcs.go
@@ -120,7 +120,7 @@ func fmtSecretForTable(indent int, sc *targets.SessionCredential) []string {
 			certs := make(map[string]any, len(iface))
 			for kk, vv := range iface {
 				if p, _ := pem.Decode([]byte(fmt.Sprintf("%v", vv))); p != nil {
-					// iface is a certificate. Print without indents.
+					// If the value is PEM formatted, add it to a map to be formatted without indents.
 					certs[kk] = vv
 				}
 			}


### PR DESCRIPTION
When a target accesses a session credential from a credential library with a vault path pointing to a .crt certificate, this credential is treated as an unspecified credential (which isn't username-password, ssh-private-key, or json type). Instead of being unmarshalled into a struct, the raw secret is decoded into a []byte by `base64.StdEncoding.DecodeString`, and then sent to a `bytes.Buffer` by `json.Indent` before being converted back into a string. This results in the certificate being returned in the CLI output as a json value containing `\n` characters like so (and in my environment there's some `\r`s as well):

![image](https://github.com/hashicorp/boundary/assets/23140824/7f29533e-5c4b-4240-a1a1-f85f91363d08)

I had thought that the newline characters were a [valid format](https://serverfault.com/questions/466683/can-an-ssl-certificate-be-on-a-single-line-in-a-file-no-line-breaks) for a crt file , but I was told by the reporter that this format rendered the certificate useless for their [kubernetes workflow](https://www.hashicorp.com/blog/how-to-connect-to-kubernetes-clusters-using-boundary). Furthermore, the newline between "BEGIN" and "CERTIFICATE" and the tabs before each "CERTIFICATE" makes the output bad to copy/paste.

I understand that setting -format=json fixes the latter issue. 

This PR attempts to unmarshal and print all unspecified credential values without indentation when `-format=table`, so the certificates can be displayed like so in a nice-looking block.

![image](https://github.com/hashicorp/boundary/assets/23140824/6ce03b01-dc60-4a0a-86d1-920013bd3ba4)


