### PR TITLE
chore: Bump version of security scanner

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -38,7 +38,7 @@ jobs:
         repository: hashicorp/security-scanner
         token: ${{ secrets.HASHIBOT_PRODSEC_GITHUB_TOKEN }}
         path: security-scanner
-        ref: 2526c196a28bb367b1ac6c997ff48e9ebf06834f
+        ref: 5a491479f4131d343afe0a4f18f6fcd36639f3fa
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
This PR bumps the version of the security scanner used in order to mitigate the GitHub deprecation of set-output and node 12. It addresses this issue: https://github.com/hashicorp/boundary/issues/3227.