### PR TITLE
Honor default cert lifetime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/creack/pty v1.1.11
 	github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20221122211539-47c893099f13
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/nodeenrollment v0.1.19-0.20230519203148-c9c47e8a27a7
+	github.com/hashicorp/nodeenrollment v0.1.19-0.20230523043818-7c690b927b7f
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a
 	golang.org/x/exp v0.0.0-20220921164117-439092de6870

--- a/go.sum
+++ b/go.sum
@@ -748,8 +748,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/nodeenrollment v0.1.19-0.20230519203148-c9c47e8a27a7 h1:xz/gmYJoSxgiHTC5o2uitxeKTTe2CLg2l6L5xN/bM3A=
-github.com/hashicorp/nodeenrollment v0.1.19-0.20230519203148-c9c47e8a27a7/go.mod h1:N5gYsm8mWiDfIw/j+1IQ6NBO1cWCmhPpvQ9GB1QUnsU=
+github.com/hashicorp/nodeenrollment v0.1.19-0.20230523043818-7c690b927b7f h1:xvrvRvlqXexui9nfvdZ8Ay83l0RGvH6Z/1OtEP7KdKU=
+github.com/hashicorp/nodeenrollment v0.1.19-0.20230523043818-7c690b927b7f/go.mod h1:N5gYsm8mWiDfIw/j+1IQ6NBO1cWCmhPpvQ9GB1QUnsU=
 github.com/hashicorp/vault/api v1.3.1 h1:pkDkcgTh47PRjY1NEFeofqR4W/HkNUi9qIakESO2aRM=
 github.com/hashicorp/vault/api v1.3.1/go.mod h1:QeJoWxMFt+MsuWcYhmwRLwKEXrjwAFFywzhptMsTIUw=
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=


### PR DESCRIPTION
This updates the nodee lib with a change that causes 0 cert lifetime to instead use the default, which is what we want.