### PR TITLE
Fix worker auth rotation test

### DIFF
--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -132,6 +133,8 @@ type Server struct {
 	DevDatabaseCleanupFunc func() error
 
 	Database *db.DB
+
+	WorkerAuthDebuggingEnabled *atomic.Bool
 }
 
 // NewServer creates a new Server.

--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -461,6 +462,9 @@ type TestControllerOpts struct {
 
 	// The time to use for CA certificate lifetime for worker auth
 	WorkerAuthCaCertificateLifetime time.Duration
+
+	// Toggle worker auth debugging
+	WorkerAuthDebuggingEnabled *atomic.Bool
 }
 
 func NewTestController(t testing.TB, opts *TestControllerOpts) *TestController {
@@ -479,6 +483,7 @@ func NewTestController(t testing.TB, opts *TestControllerOpts) *TestController {
 		shutdownDoneCh: make(chan struct{}),
 		shutdownOnce:   new(sync.Once),
 	}
+	t.Cleanup(tc.Shutdown)
 
 	conf := TestControllerConfig(t, ctx, tc, opts)
 	var err error
@@ -531,6 +536,7 @@ func TestControllerConfig(t testing.TB, ctx context.Context, tc *TestController,
 		ContextCancel: cancel,
 		ShutdownCh:    make(chan struct{}),
 	})
+	tc.b.WorkerAuthDebuggingEnabled = opts.WorkerAuthDebuggingEnabled
 
 	// Get dev config, or use a provided one
 	var err error
@@ -789,6 +795,8 @@ func (tc *TestController) AddClusterControllerMember(t testing.TB, opts *TestCon
 		PublicClusterAddr:               opts.PublicClusterAddr,
 		WorkerStatusGracePeriodDuration: opts.WorkerStatusGracePeriodDuration,
 		LivenessTimeToStaleDuration:     opts.LivenessTimeToStaleDuration,
+		WorkerAuthCaCertificateLifetime: tc.c.conf.TestOverrideWorkerAuthCaCertificateLifetime,
+		WorkerAuthDebuggingEnabled:      tc.c.conf.WorkerAuthDebuggingEnabled,
 	}
 	if opts.Logger != nil {
 		nextOpts.Logger = opts.Logger

--- a/internal/daemon/worker/testing.go
+++ b/internal/daemon/worker/testing.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -212,6 +213,9 @@ type TestWorkerOpts struct {
 
 	// If set, override the normal auth rotation period
 	AuthRotationPeriod time.Duration
+
+	// Toggle worker auth debugging
+	WorkerAuthDebuggingEnabled *atomic.Bool
 }
 
 func NewTestWorker(t testing.TB, opts *TestWorkerOpts) *TestWorker {
@@ -225,6 +229,7 @@ func NewTestWorker(t testing.TB, opts *TestWorkerOpts) *TestWorker {
 		shutdownDoneCh: make(chan struct{}),
 		shutdownOnce:   new(sync.Once),
 	}
+	t.Cleanup(tw.Shutdown)
 
 	if opts == nil {
 		opts = new(TestWorkerOpts)

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -135,6 +135,10 @@ type Worker struct {
 	successfulStatusGracePeriod *atomic.Int64
 	statusCallTimeoutDuration   *atomic.Int64
 
+	// AuthRotationNextRotation is useful in tests to understand how long to
+	// sleep
+	AuthRotationNextRotation atomic.Pointer[time.Time]
+
 	// Test-specific options (and possibly hidden dev-mode flags)
 	TestOverrideX509VerifyDnsName  string
 	TestOverrideX509VerifyCertPool *x509.CertPool


### PR DESCRIPTION
Most of the changes here are changes or enhancements that are useful for tests. The crux of the issue was that I had pulled up one var to the package level so it could be read from tests, but that var was not being reset between tests. It's not even used in tests anymore, so I put it back to function-local.