### PR TITLE
Remove cleanup calls for test controller/worker

### DIFF
--- a/internal/cmd/ops/server_test.go
+++ b/internal/cmd/ops/server_test.go
@@ -573,7 +573,6 @@ func TestHealthEndpointLifecycle(t *testing.T) {
 	// Start controller. This sets `cmd.controller`.
 	err = tc.Controller().Start()
 	require.NoError(t, err)
-	t.Cleanup(tc.Shutdown)
 
 	// Controller has started and is set onto our Command object, start ops.
 	opsServer, err := NewServer(hclog.Default(), tc.Controller(), nil, tc.Config().Listeners...)
@@ -767,14 +766,12 @@ func TestCreateOpsHandler(t *testing.T) {
 			var c *controller.Controller
 			if tt.setupController {
 				tc := controller.NewTestController(t, &controller.TestControllerOpts{})
-				t.Cleanup(tc.Shutdown)
 
 				c = tc.Controller()
 			}
 			var w *worker.Worker
 			if tt.setupWorker {
 				tc := worker.NewTestWorker(t, &worker.TestWorkerOpts{})
-				t.Cleanup(tc.Shutdown)
 				w = tc.Worker()
 			}
 

--- a/internal/daemon/controller/handlers/scopes/scope_service_test.go
+++ b/internal/daemon/controller/handlers/scopes/scope_service_test.go
@@ -1315,7 +1315,6 @@ func TestUpdate(t *testing.T) {
 
 func TestListKeys(t *testing.T) {
 	tc := controller.NewTestController(t, nil)
-	t.Cleanup(tc.Shutdown)
 
 	aToken := tc.Token()
 	uToken := tc.UnprivilegedToken()
@@ -1806,7 +1805,6 @@ func TestListKeys(t *testing.T) {
 
 func TestRotateKeys(t *testing.T) {
 	tc := controller.NewTestController(t, nil)
-	t.Cleanup(tc.Shutdown)
 
 	aToken := tc.Token()
 	uToken := tc.UnprivilegedToken()
@@ -1964,7 +1962,6 @@ func TestRotateKeys(t *testing.T) {
 
 func TestListKeyVersionDestructionJobs(t *testing.T) {
 	tc := controller.NewTestController(t, nil)
-	t.Cleanup(tc.Shutdown)
 
 	aToken := tc.Token()
 	uToken := tc.UnprivilegedToken()
@@ -2189,7 +2186,6 @@ func TestListKeyVersionDestructionJobs(t *testing.T) {
 
 func TestDestroyKeyVersion(t *testing.T) {
 	tc := controller.NewTestController(t, nil)
-	t.Cleanup(tc.Shutdown)
 
 	aToken := tc.Token()
 	uToken := tc.UnprivilegedToken()

--- a/internal/daemon/worker/auth_rotation_test.go
+++ b/internal/daemon/worker/auth_rotation_test.go
@@ -56,7 +56,6 @@ func TestRotationTicking(t *testing.T) {
 		Config:                     wConf,
 		WorkerAuthDebuggingEnabled: workerAuthDebugEnabled,
 	})
-	t.Cleanup(w.Shutdown)
 
 	// Get a server repo and worker auth repo
 	serversRepo, err := c.Controller().ServersRepoFn()

--- a/internal/daemon/worker/testing_test.go
+++ b/internal/daemon/worker/testing_test.go
@@ -140,7 +140,6 @@ func TestNewAuthorizedPkiTestWorker(t *testing.T) {
 		Config: conf,
 		Logger: logger.Named("controller"),
 	})
-	t.Cleanup(c.Shutdown)
 	tw, id := NewAuthorizedPkiTestWorker(t, c.ServersRepo(), "test", c.ClusterAddrs())
 	assert.NotNil(t, tw)
 	assert.NotEmpty(t, id)
@@ -163,7 +162,6 @@ func TestNewTestMultihopWorkers(t *testing.T) {
 		Config: conf,
 		Logger: logger.Named("controller"),
 	})
-	t.Cleanup(c.Shutdown)
 	pkiTags := map[string][]string{"connected": {"directly"}}
 	childPkiTags := map[string][]string{"connected": {"multihop"}}
 	childKmsTags := map[string][]string{"connected": {"multihop"}}

--- a/internal/daemon/worker/worker_test.go
+++ b/internal/daemon/worker/worker_test.go
@@ -158,7 +158,6 @@ func TestSetupWorkerAuthStorage(t *testing.T) {
 		WorkerAuthStoragePath: tmpDir,
 		DisableAutoStart:      true,
 	})
-	t.Cleanup(tw.Shutdown)
 	err = tw.Worker().Start()
 	require.NoError(t, err)
 
@@ -248,7 +247,6 @@ func TestSetupWorkerAuthStorage(t *testing.T) {
 				WorkerAuthStoragePath: tmpDir,
 				DisableAutoStart:      true,
 			})
-			t.Cleanup(tw.Shutdown)
 
 			// Always clear out storage that was there before, ignore errors
 			storage, err := nodeefile.New(tw.Context(), nodeefile.WithBaseDirectory(tmpDir))

--- a/internal/daemon/worker/workerdisconnect_test.go
+++ b/internal/daemon/worker/workerdisconnect_test.go
@@ -28,7 +28,6 @@ func TestDeleteConnectedWorkers(t *testing.T) {
 		Config: conf,
 		Logger: logger.Named("controller"),
 	})
-	t.Cleanup(c.Shutdown)
 	_, directPkiWorker, multiHoppedPkiWorker, multiHoppedKmsWorker := NewTestMultihopWorkers(t, logger, c.Context(), c.ClusterAddrs(),
 		c.Config().WorkerAuthKms, c.Controller().ServersRepoFn, nil, nil, nil, nil)
 

--- a/internal/tests/api/authmethods/authmethod_test.go
+++ b/internal/tests/api/authmethods/authmethod_test.go
@@ -41,7 +41,6 @@ func TestCrud(t *testing.T) {
 	tcConfig.Eventing = &eventConfig.EventerConfig
 
 	tc := controller.NewTestController(t, &controller.TestControllerOpts{Config: tcConfig})
-	t.Cleanup(tc.Shutdown)
 
 	client := tc.Client()
 	token := tc.Token()
@@ -192,7 +191,6 @@ func TestList(t *testing.T) {
 	require.NoError(err)
 
 	tc := controller.NewTestController(t, &controller.TestControllerOpts{Config: tcConfig})
-	t.Cleanup(tc.Shutdown)
 
 	client := tc.Client()
 	token := tc.Token()

--- a/internal/tests/api/credentials/credentials_test.go
+++ b/internal/tests/api/credentials/credentials_test.go
@@ -415,7 +415,6 @@ func TestUpdateAfterKeyRotation(t *testing.T) {
 
 	tc := controller.NewTestController(t, &controller.TestControllerOpts{SchedulerRunJobInterval: 100 * time.Millisecond})
 	ctx := tc.Context()
-	t.Cleanup(tc.Shutdown)
 	client := tc.Client()
 	token := tc.Token()
 	client.SetToken(token.Token)
@@ -448,13 +447,13 @@ func TestUpdateAfterKeyRotation(t *testing.T) {
 	_, err = tgClient.AddHostSources(ctx, targ.Item.Id, 1, []string{hs.Item.Id})
 	require.NoError(err)
 	_, err = tgClient.AddCredentialSources(ctx, targ.Item.Id, 2, targets.WithBrokeredCredentialSourceIds([]string{cred.Item.Id}))
+	require.NoError(err)
 	w := worker.NewTestWorker(t, &worker.TestWorkerOpts{
 		InitialUpstreams: tc.ClusterAddrs(),
 		Logger:           logger.Named("worker"),
 		WorkerAuthKms:    tc.Config().WorkerAuthKms,
 		Name:             "worker",
 	})
-	t.Cleanup(w.Shutdown)
 	require.NoError(w.Worker().WaitForNextSuccessfulStatusUpdate())
 
 	// Authorize session, requires decrypting json credential

--- a/internal/tests/api/scopes/scope_test.go
+++ b/internal/tests/api/scopes/scope_test.go
@@ -162,7 +162,6 @@ func TestErrors(t *testing.T) {
 func TestKeyDestruction(t *testing.T) {
 	ctx := context.Background()
 	tc := controller.NewTestController(t, &controller.TestControllerOpts{SchedulerRunJobInterval: time.Second})
-	t.Cleanup(tc.Shutdown)
 	c := tc.Client()
 	c.SetToken(tc.Token().Token)
 	sc := scopes.NewClient(c)

--- a/internal/tests/api/targets/target_test.go
+++ b/internal/tests/api/targets/target_test.go
@@ -386,7 +386,6 @@ func TestList(t *testing.T) {
 
 func TestTarget_AddressMutualExclusiveRelationship(t *testing.T) {
 	tc := controller.NewTestController(t, nil)
-	t.Cleanup(tc.Shutdown)
 
 	client := tc.Client()
 	at := tc.Token()
@@ -440,7 +439,6 @@ func TestTarget_AddressMutualExclusiveRelationship(t *testing.T) {
 
 func TestTarget_HostSourceMutualExclusiveRelationship(t *testing.T) {
 	tc := controller.NewTestController(t, nil)
-	t.Cleanup(tc.Shutdown)
 
 	client := tc.Client()
 	at := tc.Token()
@@ -500,7 +498,6 @@ func TestTarget_HostSourceMutualExclusiveRelationship(t *testing.T) {
 
 func TestCreateTarget_DirectlyAttachedAddress(t *testing.T) {
 	tc := controller.NewTestController(t, nil)
-	t.Cleanup(tc.Shutdown)
 
 	client := tc.Client()
 	at := tc.Token()
@@ -552,7 +549,6 @@ func TestCreateTarget_DirectlyAttachedAddress(t *testing.T) {
 
 func TestUpdateTarget_DeleteAddress(t *testing.T) {
 	tc := controller.NewTestController(t, nil)
-	t.Cleanup(tc.Shutdown)
 
 	client := tc.Client()
 	at := tc.Token()

--- a/internal/tests/cluster/worker_bytesupdown_test.go
+++ b/internal/tests/cluster/worker_bytesupdown_test.go
@@ -43,7 +43,6 @@ func TestWorkerBytesUpDown(t *testing.T) {
 		PublicClusterAddr:               pl.Addr().String(),
 		WorkerStatusGracePeriodDuration: helper.DefaultWorkerStatusGracePeriod,
 	})
-	t.Cleanup(c1.Shutdown)
 
 	expectWorkers(t, c1)
 
@@ -64,7 +63,6 @@ func TestWorkerBytesUpDown(t *testing.T) {
 		Logger:                              logger.Named("w1"),
 		SuccessfulStatusGracePeriodDuration: helper.DefaultSuccessfulStatusGracePeriod,
 	})
-	t.Cleanup(w1.Shutdown)
 
 	require.NoError(w1.Worker().WaitForNextSuccessfulStatusUpdate())
 	require.NoError(c1.WaitForNextWorkerStatusUpdate(w1.Name()))

--- a/internal/tests/cluster/x509_verification_test.go
+++ b/internal/tests/cluster/x509_verification_test.go
@@ -48,7 +48,6 @@ func TestCustomX509Verification_Client(t *testing.T) {
 		InitialResourcesSuffix: "1234567890",
 		Logger:                 logger.Named("c1"),
 	})
-	t.Cleanup(c1.Shutdown)
 
 	conf, err = config.DevWorker()
 	conf.Eventing = &ec.EventerConfig
@@ -58,7 +57,6 @@ func TestCustomX509Verification_Client(t *testing.T) {
 		InitialUpstreams: c1.ClusterAddrs(),
 		Logger:           logger.Named("w1"),
 	})
-	t.Cleanup(w1.Shutdown)
 
 	// Give time for it to connect
 	time.Sleep(10 * time.Second)
@@ -188,7 +186,6 @@ func testCustomX509Verification_Server(ec event.TestConfig, certPool *x509.CertP
 			Config:                 conf,
 			InitialResourcesSuffix: "1234567890",
 		})
-		t.Cleanup(c1.Shutdown)
 
 		conf, err = config.DevWorker()
 		conf.Eventing = &ec.EventerConfig
@@ -199,7 +196,6 @@ func testCustomX509Verification_Server(ec event.TestConfig, certPool *x509.CertP
 		})
 		w1.Worker().TestOverrideX509VerifyCertPool = certPool
 		w1.Worker().TestOverrideX509VerifyDnsName = dnsName
-		t.Cleanup(w1.Shutdown)
 
 		// Give time for it to connect
 		time.Sleep(10 * time.Second)


### PR DESCRIPTION
A previous commit added a call to t.Cleanup in the NewTestController/NewTestWorker commands; as a result these statements are no longer needed.