### PR TITLE
fix(targets): Support authorize session request with target name

### DIFF
--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -970,7 +970,7 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 		}
 	}()
 
-	subtype := target.SubtypeFromId(req.GetId())
+	subtype := target.SubtypeFromId(t.GetPublicId())
 	subtypeEntry, err := subtypeRegistry.get(subtype)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)


### PR DESCRIPTION
For requests to the target authorize session endpoint we support passing
a target name instead of an id. This means that `req.GetId()` might not
be the target's public id. Since the first thing authorize session does
includes retrieving the target as part of the authorization checks, this
subtype check can leverage the public id of the target instead of using
the request.

Fixes: 6178dd516e81e84c732cb700a2c7ecc6ccc167af