### PR TITLE
refact(docs): Fix permissions headers

### DIFF
--- a/website/content/docs/concepts/security/permissions/assignable-permissions.mdx
+++ b/website/content/docs/concepts/security/permissions/assignable-permissions.mdx
@@ -5,7 +5,7 @@ description: |-
   Assignable Permissions
 ---
 
-## Assignable Permissions
+# Assignable Permissions
 
 Resources identified by the ID/Type selectors have permissions granted to the
 user in the form of actions and visibility (via `output_fields`). Each of these

--- a/website/content/docs/concepts/security/permissions/permission-grant-formats.mdx
+++ b/website/content/docs/concepts/security/permissions/permission-grant-formats.mdx
@@ -5,7 +5,7 @@ description: |-
   Permission Grant Formats
 ---
 
-## Permission Grant Formats
+# Permission Grant Formats
 
 Because of the aforementioned properties of the permissions model, grants are
 relatively simple. All grants take one of four forms. These examples use the

--- a/website/content/docs/concepts/security/permissions/resource-table.mdx
+++ b/website/content/docs/concepts/security/permissions/resource-table.mdx
@@ -5,7 +5,7 @@ description: |-
   Resource Table
 ---
 
-## Resource Table
+# Resource Table
 
 The following table works as a quick cheat-sheet to help you manage your
 permissions. Note that it's not exhaustive; for brevity it does _not_ show


### PR DESCRIPTION
Headers on permissions sub pages were titled with the .mdx filename:
<img width="825" alt="Screenshot 2023-06-05 at 10 17 27 AM" src="https://github.com/hashicorp/boundary/assets/3497566/9107a434-879b-443a-95ce-c2ed26459c81">

These changes fix headers to display as below:
<img width="825" alt="Screenshot 2023-06-05 at 10 17 22 AM" src="https://github.com/hashicorp/boundary/assets/3497566/6215cc61-77ab-4778-bf09-ffa41660bc54">