### PR TITLE
fix(session): List performance with large number of session connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 * resource listing: API requests to list a resource (targets, sessions, users,
   etc) now properly return all resources the callers has appropriate permission
   to list ([PR](https://github.com/hashicorp/boundary/pull/3278))
+* sessions: Fix a bug that contributed to slow response times when listing
+  sessions that had a large number of connections
+  ([PR](https://github.com/hashicorp/boundary/pull/3280))
 
 ## 0.12.3 (2023/05/26)
 

--- a/internal/db/schema/migrations/oss/postgres/60/02_sessions.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/60/02_sessions.up.sql
@@ -176,7 +176,7 @@ begin;
     for each row execute procedure insert_session();
 
   -- Replaces view from 59/01_target_ingress_egress_worker_filters.up.sql
-  -- Replaced in 69/02_session_worker_protocol.up.sql
+  -- Replaced in 64/04_session_list.up.sql
   create view session_list as
   select
     s.public_id,

--- a/internal/db/schema/migrations/oss/postgres/64/04_session_list.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/64/04_session_list.up.sql
@@ -1,0 +1,38 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: MPL-2.0
+
+begin;
+
+  -- Replaces view from 60/02.02_sessions.up.sql
+  drop view session_list;
+  create view session_list as
+      select s.public_id,
+             s.user_id,
+             shsh.host_id,
+             s.target_id,
+             shsh.host_set_id,
+             s.auth_token_id,
+             s.project_id,
+             s.certificate,
+             s.certificate_private_key,
+             s.expiration_time,
+             s.connection_limit,
+             s.tofu_token,
+             s.key_id,
+             s.termination_reason,
+             s.version,
+             s.create_time,
+             s.update_time,
+             s.endpoint,
+             s.worker_filter,
+             s.egress_worker_filter,
+             s.ingress_worker_filter,
+             ss.state,
+             ss.previous_end_time,
+             ss.start_time,
+             ss.end_time
+        from session s
+        join session_state            ss on s.public_id = ss.session_id
+   left join session_host_set_host  shsh on s.public_id = shsh.session_id;
+
+commit;

--- a/internal/db/schema/migrations/oss/postgres/69/02_session_worker_protocol.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/69/02_session_worker_protocol.up.sql
@@ -17,7 +17,7 @@ begin;
   );
 
   drop view session_list;
-  -- Replaces view from 60/02_sessions.up.sql to add swp.worker_id
+  -- Replaces view from 64/04_session_list.up.sql to add swp.worker_id
   -- Replaced in 72/03_session_list_perf_fix.up.sql
   create view session_list as
   select

--- a/internal/db/schema/migrations/oss/postgres/69/02_session_worker_protocol.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/69/02_session_worker_protocol.up.sql
@@ -18,6 +18,7 @@ begin;
 
   drop view session_list;
   -- Replaces view from 60/02_sessions.up.sql to add swp.worker_id
+  -- Replaced in 72/03_session_list_perf_fix.up.sql
   create view session_list as
   select
     s.public_id,

--- a/internal/db/schema/migrations/oss/postgres/72/03_session_list_perf_fix.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/72/03_session_list_perf_fix.up.sql
@@ -1,0 +1,40 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: MPL-2.0
+
+begin;
+
+  -- Replaces the view created in 69/02_session_worker_protocol.up.sql
+  drop view session_list;
+  create view session_list as
+      select s.public_id,
+             s.user_id,
+             shsh.host_id,
+             s.target_id,
+             shsh.host_set_id,
+             s.auth_token_id,
+             s.project_id,
+             s.certificate,
+             s.certificate_private_key,
+             s.expiration_time,
+             s.connection_limit,
+             s.tofu_token,
+             s.key_id,
+             s.termination_reason,
+             s.version,
+             s.create_time,
+             s.update_time,
+             s.endpoint,
+             s.worker_filter,
+             s.egress_worker_filter,
+             s.ingress_worker_filter,
+             swp.worker_id,
+             ss.state,
+             ss.previous_end_time,
+             ss.start_time,
+             ss.end_time
+        from session s
+        join session_state            ss on s.public_id = ss.session_id
+   left join session_host_set_host  shsh on s.public_id = shsh.session_id
+   left join session_worker_protocol swp on s.public_id = swp.session_id;
+
+commit;


### PR DESCRIPTION
As part of the performance improvements for listing sessions for v0.9.0,
the view used to retrieve sessions for listing was updated to no longer
include a join on session_connection. However, a later migration that
was adding additional columns to this view inadvertently re-added the
join and session_connection columns. This resulted in requests to list
sessions performing this join, and returning additional rows for each
connection in a session. The application would ignore this additional
data, since it is no longer returned via the API. This would be
particularly impactful in cases where there are a large number of
connections per session, as this would greatly increase the amount of
data returned by the database.

This fix removes the session_connection join from this view, which
should restore the original performance improvements even in cases where
there is a large number of session connections per session.

See: https://github.com/hashicorp/boundary/pull/2160
Ref: 32070678dc712812a42a511bb68f668658bd327a
Fixes: 1e3c941be11086e4fa3cbba3e90cb160377103b3

This should also help with #3281.