### PR TITLE
feat(bsr/convert): Remove asciicast minimum window size

### DIFF
--- a/internal/bsr/convert/convert.go
+++ b/internal/bsr/convert/convert.go
@@ -16,8 +16,11 @@ import (
 
 // ToAsciicast accepts a bsr.Session and will convert the underlying BSR connection or channel file to an asciinema file.
 // The tempFs will be used to write the asciinema file to disk
-// It returns an io.Reader to the converted asciinema file
-// Supports WithChannelId() to indicate this conversion should occur on a channel on a multiplexed session
+// It returns an io.Reader to the converted asciinema file.
+// This supports the following options:
+//   - WithChannelId to indicate this conversion should occur on a channel on a multiplexed session
+//   - WithMinWidth to set a minimum width for the asciicast
+//   - WithMinHeigh to set a minimum height for the asciicast
 func ToAsciicast(ctx context.Context, session *bsr.Session, tmp storage.TempFile, connectionId string, options ...Option) (io.ReadCloser, error) {
 	const op = "convert.ToAsciicast"
 
@@ -65,7 +68,7 @@ func ToAsciicast(ctx context.Context, session *bsr.Session, tmp storage.TempFile
 			return nil, fmt.Errorf("%s: %w", op, err)
 		}
 
-		return sshChannelToAsciicast(ctx, reqScanner, msgScanner, tmp)
+		return sshChannelToAsciicast(ctx, reqScanner, msgScanner, tmp, options...)
 	default:
 		return nil, fmt.Errorf("%s: %w", op, ErrUnsupportedProtocol)
 	}

--- a/internal/bsr/convert/internal/asciicast/asciicast.go
+++ b/internal/bsr/convert/internal/asciicast/asciicast.go
@@ -23,8 +23,8 @@ const (
 // This is only the initial terminal size, so it does not seem to have any
 // real impact on playback.
 const (
-	MinWidth  uint32 = 80
-	MinHeight uint32 = 120
+	DefaultWidth  uint32 = 80
+	DefaultHeight uint32 = 24
 )
 
 // Sane defaults for the Env section of the Header.
@@ -71,8 +71,8 @@ type Header struct {
 func NewHeader() *Header {
 	return &Header{
 		Version: Version,
-		Width:   MinWidth,
-		Height:  MinHeight,
+		Width:   DefaultWidth,
+		Height:  DefaultHeight,
 		Env: HeaderEnv{
 			Shell: DefaultShell,
 			Term:  DefaultTerm,

--- a/internal/bsr/convert/internal/asciicast/asciicast_test.go
+++ b/internal/bsr/convert/internal/asciicast/asciicast_test.go
@@ -59,7 +59,7 @@ func TestHeaderMarshal(t *testing.T) {
 		{
 			"default",
 			asciicast.NewHeader(),
-			[]byte(`{"version":2,"width":80,"height":120,"timestamp":-62135596800,"env":{"SHELL":"/bin/bash","TERM":"xterm"}}`),
+			[]byte(`{"version":2,"width":80,"height":24,"timestamp":-62135596800,"env":{"SHELL":"/bin/bash","TERM":"xterm"}}`),
 			nil,
 		},
 		{

--- a/internal/bsr/convert/options.go
+++ b/internal/bsr/convert/options.go
@@ -18,6 +18,8 @@ type Option func(*options)
 // options = how options are represented
 type options struct {
 	withChannelId string
+	withMinWidth  uint32
+	withMinHeight uint32
 }
 
 func getDefaultOptions() options {
@@ -28,5 +30,19 @@ func getDefaultOptions() options {
 func WithChannelId(id string) Option {
 	return func(o *options) {
 		o.withChannelId = id
+	}
+}
+
+// WithMinWidth can be used to set a minimum width for playback.
+func WithMinWidth(w uint32) Option {
+	return func(o *options) {
+		o.withMinWidth = w
+	}
+}
+
+// WithMinHeight can be used to set a minimum height for playback.
+func WithMinHeight(h uint32) Option {
+	return func(o *options) {
+		o.withMinHeight = h
 	}
 }

--- a/internal/bsr/convert/options_test.go
+++ b/internal/bsr/convert/options_test.go
@@ -20,4 +20,20 @@ func Test_GetOpts(t *testing.T) {
 		testOpts.withChannelId = channelId
 		assert.Equal(opts, testOpts)
 	})
+	t.Run("WithMinWidth", func(t *testing.T) {
+		assert := assert.New(t)
+		width := uint32(23)
+		opts := getOpts(WithMinWidth(width))
+		testOpts := getDefaultOptions()
+		testOpts.withMinWidth = width
+		assert.Equal(opts, testOpts)
+	})
+	t.Run("WithMinHeight", func(t *testing.T) {
+		assert := assert.New(t)
+		height := uint32(64)
+		opts := getOpts(WithMinHeight(height))
+		testOpts := getDefaultOptions()
+		testOpts.withMinHeight = height
+		assert.Equal(opts, testOpts)
+	})
 }


### PR DESCRIPTION
This removes the minimum on width and height, instead it will just used
the largest width, height seen as the initial size for the asciicast.
This also provides the ability to still set a minimum via options to
convert.ToAsciicast if the caller has a known minimum size. Also note
that in cases where there is no size information, ie if there was no pty
request, this will still pick a default size of 80x24.