### PR TITLE
Worker docs cleanup for 0.13

### DIFF
--- a/website/content/docs/configuration/worker/index.mdx
+++ b/website/content/docs/configuration/worker/index.mdx
@@ -5,7 +5,7 @@ description: |-
   The worker stanza configures worker-specific parameters.
 ---
 
-# `worker` Stanza
+# Worker stanza
 The `worker` stanza configures Boundary worker-specific parameters.
 
 All workers within Boundary use certificates and encryption keys to identify
@@ -92,7 +92,7 @@ Any other updated values are ignored.
 The `SIGTERM` and `SIGINT` signals initiate a graceful shutdown on a worker. The worker waits for any sessions to drain
 before shutting down. Workers in a graceful shutdown state do not receive any new work, including session proxying, from the control plane.
 
-## Multi-hop worker capabilities <sup>HCP only</sup>
+## Multi-hop worker capabilities <sup>HCP/ENT</sup>
 Multi-hop capabilities, including multi-hop sessions and Vault private access,
 is when a session or Vault credential request goes through more than one worker.
 To enable this, two or more workers must be connected to each other in some
@@ -118,25 +118,25 @@ traffic to a [target][]. Ingress worker filters determine which workers you
 connect with to initiate a session, and egress worker filters determine which
 workers are used to access targets.
 
-### Multi-hop worker requirements
+## Multi-hop worker requirements
 
 When you configure multi-hop sessions, there is an "ingress" worker, an "egress"
 worker, and any number of intermediary workers. Ingress, egress, and
 intermediary workers have the following requirements.
 
-#### Ingress worker requirements
+### Ingress worker requirements
 
 To proxy target connections, ingress workers require outbound access to the
 Boundary control plane and inbound access from clients.
 
-#### Intermediary worker requirements
+### Intermediary worker requirements
 
 Intermediary workers require outbound access to an upstream worker. The upstream
 worker may be an ingress worker or another intermediary worker. Intermediary
 workers also require inbound access from a downstream worker. The downstream
 worker may be an egress worker or another intermediary worker.
 
-#### Egress worker requirements
+### Egress worker requirements
 
 To proxy target connections, egress workers require outbound access to an
 upstream worker and outbound access to the destination host or service.

--- a/website/content/docs/configuration/worker/kms-worker.mdx
+++ b/website/content/docs/configuration/worker/kms-worker.mdx
@@ -6,7 +6,7 @@ description: |-
 ---
 
 
-# KMS Worker Configuration
+# KMS worker configuration
 
 This page describes configuration for workers that authenticate to upstreams
 using a shared KMS. This mechanism auto-registers the worker in addition to
@@ -87,7 +87,7 @@ key; in production you'd want to use a KMS such as AWS KMS, GCP CKMS, Azure
 KeyVault, or HashiCorp Vault. For a complete guide to all available KMS types,
 see our [KMS documentation](/boundary/docs/configuration/kms).
 
-## Complete Configuration Example
+## Complete configuration example
 
 ```hcl
 listener "tcp" {

--- a/website/content/docs/configuration/worker/kms-worker.mdx
+++ b/website/content/docs/configuration/worker/kms-worker.mdx
@@ -6,7 +6,7 @@ description: |-
 ---
 
 
-## KMS Worker Configuration
+# KMS Worker Configuration
 
 This page describes configuration for workers that authenticate to upstreams
 using a shared KMS. This mechanism auto-registers the worker in addition to
@@ -87,7 +87,7 @@ key; in production you'd want to use a KMS such as AWS KMS, GCP CKMS, Azure
 KeyVault, or HashiCorp Vault. For a complete guide to all available KMS types,
 see our [KMS documentation](/boundary/docs/configuration/kms).
 
-# Complete Configuration Example
+## Complete Configuration Example
 
 ```hcl
 listener "tcp" {

--- a/website/content/docs/configuration/worker/pki-worker.mdx
+++ b/website/content/docs/configuration/worker/pki-worker.mdx
@@ -74,6 +74,6 @@ kms "aead" {
 ```
 
 ~> **Note:** `name` and `description` fields are not valid config fields for PKI
-workers. These fields are only valid for [KMS Workers][]. `name` and
+workers. These fields are only valid for [KMS Workers]](/boundary/docs/configuration/worker/kms-worker). `name` and
 `description` can only be set for PKI workers through the API.
 

--- a/website/content/docs/configuration/worker/pki-worker.mdx
+++ b/website/content/docs/configuration/worker/pki-worker.mdx
@@ -74,6 +74,6 @@ kms "aead" {
 ```
 
 ~> **Note:** `name` and `description` fields are not valid config fields for PKI
-workers. These fields are only valid for [KMS Workers](/boundary/docs/configuration/worker/kms-worker). `name` and
+workers. These fields are only valid for [KMS Workers][]. `name` and
 `description` can only be set for PKI workers through the API.
 

--- a/website/content/docs/configuration/worker/pki-worker.mdx
+++ b/website/content/docs/configuration/worker/pki-worker.mdx
@@ -74,6 +74,6 @@ kms "aead" {
 ```
 
 ~> **Note:** `name` and `description` fields are not valid config fields for PKI
-workers. These fields are only valid for [KMS Workers]](/boundary/docs/configuration/worker/kms-worker). `name` and
+workers. These fields are only valid for [KMS Workers](/boundary/docs/configuration/worker/kms-worker). `name` and
 `description` can only be set for PKI workers through the API.
 

--- a/website/content/docs/configuration/worker/pki-worker.mdx
+++ b/website/content/docs/configuration/worker/pki-worker.mdx
@@ -21,7 +21,7 @@ worker {
 ```
 
 ## Authorization methods
-There are two mechanisms that can be used to register a worker to the cluster.
+There are two mechanisms that can be used to register a PKI worker to the cluster.
 
 ### Controller-led authorization flow
 In this flow, the operator fetches an activation token from the controller's
@@ -74,6 +74,6 @@ kms "aead" {
 ```
 
 ~> **Note:** `name` and `description` fields are not valid config fields for PKI
-workers. These fields are only valid for [KMS Workers][]. `name` and
+workers. These fields are only valid for [KMS Workers](/boundary/docs/configuration/worker/kms-worker). `name` and
 `description` can only be set for PKI workers through the API.
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -281,12 +281,7 @@
           },
           {
             "title": "KMS Workers",
-            "path": "configuration/worker/kms-worker",
-            "badge": {
-              "text": "OSS Only",
-              "type": "outlined",
-              "color": "neutral"
-            }
+            "path": "configuration/worker/kms-worker"
           }
         ]
       },


### PR DESCRIPTION
Cleaning up some text and formatting for 0.13, in the future we will restructure the worker docs so that it is easier to understand and use, as well as accommodating for future changes.