### PR TITLE
chore: update security-scanner workflow runner

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   scan:
-    runs-on: ${{ fromJSON(vars.RUNNER) }}
+    runs-on: ${{ fromJSON(vars.RUNNER_LARGE) }}
     if: ${{ github.actor != 'dependabot[bot]' || github.actor != 'hc-github-team-secure-boundary' }}
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2


### PR DESCRIPTION
Some runs of the security-scanner workflow have resulted in the following error:

![image](https://github.com/hashicorp/boundary/assets/106274486/e17030dc-685a-488e-b7fe-e554b77653f2)

This may be due to resource [constraints](https://github.com/actions/runner-images/issues/6709#issuecomment-1341048989) within the GitHub Actions runner itself. 

Hopefully bumping it to a larger runner does the trick.