### PR TITLE
Don't attempt session teardown if the session is expired

### DIFF
--- a/internal/cmd/commands/connect/connect.go
+++ b/internal/cmd/commands/connect/connect.go
@@ -621,7 +621,10 @@ func (c *Command) Run(args []string) (retCode int) {
 		}
 	}
 
-	if sendSessionCancel {
+	// Only send it if we should, and also if we're not after expiration, with a
+	// bit of buffer in case clocks are not quite the same between worker and
+	// this machine.
+	if sendSessionCancel && time.Now().Before(c.expiration.Add(-5*time.Minute)) {
 		ctx, cancel := context.WithTimeout(context.Background(), sessionCancelTimeout)
 		wsConn, err := c.getWsConn(ctx, workerAddr, transport)
 		if err != nil {


### PR DESCRIPTION
This avoids a situation where teardown results in an error due to the worker not accepting the connection (since the credentials are invalid). Teardown is a best-effort way to avoid sessions that have long lifetimes ending up having to wait for expiration before cleanup, but if we're near expiration it doesn't really matter.

Fixes ICU-9633