### PR TITLE
chore: Add check for `go mod tidy`

### DIFF
--- a/.github/workflows/make-gen-delta.yml
+++ b/.github/workflows/make-gen-delta.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   make-gen-delta:
-    name: "Check for uncommited changes from make gen"
+    name: "Check for uncommitted changes from make gen"
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -26,6 +26,9 @@ jobs:
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: "${{ steps.get-go-version.outputs.go-version }}"
+      - name: Running go mod tidy
+        run: |
+          go mod tidy
       - name: Install Dependencies
         run: |
           make tools


### PR DESCRIPTION
This PR adds another check to the `make-gen-delta` workflow to ensure that `go mod tidy` changes have been committed to the branch. There was a recent case where `go.mod` and `go.sum` were out of sync with the code base. Adding this check would prevent that from happening.

An alternate implementation is to update `make gen` to run `go mod tidy`. Curious to hear if there are any opinions here.