### PR TITLE
test(e2e): Set worker config to a variable

### DIFF
--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -195,6 +195,7 @@ scenario "e2e_aws" {
       controller_addresses      = step.create_boundary_cluster.public_controller_addresses
       controller_sg_id          = step.create_boundary_cluster.controller_aux_sg_id
       worker_type_tags          = ["worker_e2e_test"]
+      config_file_path          = "templates/worker.hcl"
     }
   }
 

--- a/enos/modules/worker/main.tf
+++ b/enos/modules/worker/main.tf
@@ -173,7 +173,7 @@ resource "enos_file" "worker_config" {
   depends_on = [enos_bundle_install.worker]
 
   destination = "/etc/boundary/boundary.hcl"
-  content = templatefile("${path.module}/templates/worker.hcl", {
+  content = templatefile("${path.module}/${var.config_file_path}", {
     id                   = random_pet.worker.id
     kms_key_id           = data.aws_kms_key.kms_key.id
     public_addr          = aws_instance.worker.public_ip

--- a/enos/modules/worker/variables.tf
+++ b/enos/modules/worker/variables.tf
@@ -129,3 +129,8 @@ variable "controller_sg_id" {
   description = "The controllers' security group ID for adding rules allowing this worker to communicate with them"
   type        = string
 }
+
+variable "config_file_path" {
+  description = "Path to a config file (relative to module directory)"
+  type        = string
+}


### PR DESCRIPTION
This PR updates the enos worker module to allow for specifying different worker configs as a variable. This enables the ability for an enos scenario to use a different worker config to test different functionality.