### PR TITLE
docs: Add bsr key to requirements

### DIFF
--- a/website/content/docs/concepts/security/data-encryption.mdx
+++ b/website/content/docs/concepts/security/data-encryption.mdx
@@ -105,6 +105,11 @@ $ boundary scopes list-key-version-destruction-jobs -scope-id p_A4jfDjZ9jf
 Once the job disappears from this list, the associated key version will have
 been destroyed and any existing data will have been re-encrypted.
 
+## The `bsr` KMS key <sup>HCP/ENT</sup>
+The `bsr` KMS key is required for [session recording](/boundary/docs/configuration/session-recording).
+If you do not add a `bsr` key to your controller configuration, you will receive an error when you attempt to enable session recording.
+The key is used for encrypting data and checking the integrity of recordings.
+
 ## The `previous-root` KMS key <sup>OSS Only</sup>
 
 The `previous-root` KMS key is used when migrating to a new `root` key. Adding

--- a/website/content/docs/configuration/session-recording/enable-session-recording.mdx
+++ b/website/content/docs/configuration/session-recording/enable-session-recording.mdx
@@ -15,7 +15,7 @@ You use the storage bucket's ID to associate a target with the storage bucket.
 
 - One or more storage buckets to store the recordings.
 - Session recording is only supported for SSH targets at this time.
-- A KMS key must be added to the controller configuration with the purpose `bsr`.
+- A KMS key with the purpose `bsr` must be added to the controller configuration.
 The key is used for encrypting data and checking the integrity of recordings.
 Refer to [Create the controller configuration](/boundary/docs/install-boundary/configure-controllers#create-the-controller-configuration) for more information about configuring a KMS block.
 - The targets must be configured with an ingress or egress worker filter that includes a worker with access to the storage bucket you created.

--- a/website/content/docs/configuration/session-recording/enable-session-recording.mdx
+++ b/website/content/docs/configuration/session-recording/enable-session-recording.mdx
@@ -13,8 +13,11 @@ You use the storage bucket's ID to associate a target with the storage bucket.
 
 **Requirements**:
 
-- One or more storage buckets to store the recordings
+- One or more storage buckets to store the recordings.
 - Session recording is only supported for SSH targets at this time.
+- A KMS key must be added to the controller configuration with the purpose `bsr`.
+The key is used for encrypting data and checking the integrity of recordings.
+Refer to [Create the controller configuration](/boundary/docs/install-boundary/configure-controllers#create-the-controller-configuration) for more information about configuring a KMS block.
 - The targets must be configured with an ingress or egress worker filter that includes a worker with access to the storage bucket you created.
 Refer to [SSH target attributes](/boundary/docs/concepts/docmain-model/targets#ssh-target-attributes-hcp-ent) for more information.
 - You must enable injected application credentials on any target that you want to use for session recording.


### PR DESCRIPTION
A bsr KMS key is required to enable session recording, but it currently is not documented. From a [Slack conversation](https://hashicorp.slack.com/archives/C01AQDJF3SA/p1686764521142459).

This PR adds the requirement to the pre-requisites for Enabling session recording. It also adds the `bsr` key to the list of KMS keys in the Data security topic.

View the topics in the preview deployment:

[Enabling session recording on a target](https://boundary-28e411yh8-hashicorp.vercel.app/boundary/docs/configuration/session-recording/enable-session-recording#:~:text=A%20KMS%20key%20with%20the%20purpose%20bsr%20must%20be%20added%20to%20the%20controller%20configuration.%20The%20key%20is%20used%20for%20encrypting%20data%20and%20checking%20the%20integrity%20of%20recordings.%20Refer%20to%20Create%20the%20controller%20configuration%20for%20more%20information%20about%20configuring%20a%20KMS%20block.)
[Data encryption](https://boundary-28e411yh8-hashicorp.vercel.app/boundary/docs/concepts/security/data-encryption#the-bsr-kms-key-hcp-ent)

