### PR TITLE
docs: Fix display issue with bullets and code

### DIFF
--- a/website/content/docs/concepts/iam.mdx
+++ b/website/content/docs/concepts/iam.mdx
@@ -69,14 +69,14 @@ Projects.
 2. Each role needs to have the user/group added as a principal
 3. Each role needs to have the grants of
 
-   - &#32; `id=*;type=*;actions=*`
+   - `id=*;type=*;actions=*`
 
 ### Boundary Viewer
 1. **Each** of the 7 scopes requires a role (ex. “viewer”)
 2. Each role needs to have the user/group added as a principal
 3. Each role needs to have the grants of
 
-   - &#32; `id=*;type=*;actions=read,list`
+   - `id=*;type=*;actions=read,list`
 
 ### Org_A admin
 1. The following scopes **each** require a role (ex. “admin”)
@@ -86,22 +86,22 @@ Projects.
 2. Each role needs to have the user/group added as a principal
 3. Each role needs to have the grants of
 
-   - &#32; `id=*;type=*;actions=*`
+   - `id=*;type=*;actions=*`
 
 ### Project_1 admin
 1. Project_1 requires a role (ex. “admin”)
 2. The role needs to have the user/group added as a principal
 3. The role needs to have the grants of
 
-   - &#32; `id=*;type=*;actions=*`
+   - `id=*;type=*;actions=*`
 
 ### Project_1 target access
 1. Project_1 requires a role (ex. “target_access”)
 2. The role needs to have the user/group added as a principal
 3. The role needs to have the grants of
 
-   - &#32; `id=*;type=target;actions=list,read,authorize-session`
-   - &#32; `id=*;type=session;actions=read:self,cancel:self,list`
+   - `id=*;type=target;actions=list,read,authorize-session`
+   - `id=*;type=session;actions=read:self,cancel:self,list`
 
 <Tip>
 You can use the same roles across “Boundary Admin”, “Org_A Admin”, and “Project_1 Admin” since the scopes and grants are the same. The only difference is

--- a/website/content/docs/install-boundary/configure-controllers.mdx
+++ b/website/content/docs/install-boundary/configure-controllers.mdx
@@ -18,10 +18,10 @@ To use TLS, you must have two files on each Boundary controller node.
 You may have to create a new directory to store the certificate material at `/etc/boundary.d/tls`.
 Place the files in the following paths:
 
-- &#32; `/etc/boundary.d/tls/boundary-cert.pem`
+- `/etc/boundary.d/tls/boundary-cert.pem`
 
     In this path, place the Boundary TLS certificate with a Common Name (CN) and Subject Alternate Name (SAN) that matches your planned primary DNS record for accessing the Boundary controllers and any additional SANs as necessary.
-- &#32; `/etc/boundary.d/tls/boundary-key.pem`
+- `/etc/boundary.d/tls/boundary-key.pem`
 
     In this path, place the Boundary TLS certificate's private key.
 
@@ -80,17 +80,17 @@ You must complete the following controller configuration for each of the Boundar
 
 The core required values for a Boundary controller configuration include the following:
 
-- &#32; `listener` blocks for `api`, `cluster`, and `ops`
+- `listener` blocks for `api`, `cluster`, and `ops`
 - A `kms` block
-- &#32; `disable_mlock`
+- `disable_mlock`
 - A `controller` block
 
 When you install Boundary from the HashiCorp Linux Repository, it installs some example configuration files under `/etc/boundary.d/`.
 Run the following commands to rename the example configuration files:
 
-1. &#32; `sudo mv boundary.hcl boundary.hcl.old`
-1. &#32; `sudo mv controller.hcl controller.hcl.old`
-1. &#32; `sudo mv worker.hcl worker.hcl.old`
+1. `sudo mv boundary.hcl boundary.hcl.old`
+1. `sudo mv controller.hcl controller.hcl.old`
+1. `sudo mv worker.hcl worker.hcl.old`
 
 We recommend that you use either the `env://` or `file://` notation in the configuration files to securely provide secret configuration components to the Boundary controller binaries.
 In the following controller configuration example, we use `env://` to declare the PostgreSQL connection string, as well as secure the AWS KMS configuration items.
@@ -248,7 +248,7 @@ kms "awskms" {
 
 Refer to the list below for explanations of the parameters used in the example above:
 
-- &#32;`disable mlcok (bool: false)` - Disables the server from executing the `mlock` syscall, which prevents memory from being swapped to the disk.
+- `disable mlcok (bool: false)` - Disables the server from executing the `mlock` syscall, which prevents memory from being swapped to the disk.
 This is fine for local development and testing.
 However, it is not recommended for production unless the systems running Boundary use only encrypted swap or do not use swap at all.
 Boundary only supports memory locking on UNIX-like systems that support `mlock()` syscall like Linux and FreeBSD.
@@ -261,15 +261,15 @@ Boundary only supports memory locking on UNIX-like systems that support `mlock()
 
    `LimitMEMLOCK=infinity`
 
-- &#32; `listener` - Configures the listeners on which Boundary serves traffic (API cluster and proxy).
-- &#32; `controller` - Configures the controller.
+- `listener` - Configures the listeners on which Boundary serves traffic (API cluster and proxy).
+- `controller` - Configures the controller.
 If present, `boundary server` starts a controller subprocess.
-- &#32; `events` - Configures event-specific parameters.
+- `events` - Configures event-specific parameters.
 
    The example events configuration above is exhaustive and writes all events to both `stderr` and a file.
    This configuration may or may not work for your organization's logging solution.
 
-- &#32; `kms` - Configures KMS blocks for [various purposes](/boundary/docs/concepts/security/data-encryption).
+- `kms` - Configures KMS blocks for [various purposes](/boundary/docs/concepts/security/data-encryption).
 
    Refer to the links below for configuration information for the different cloud KMS blocks:
 
@@ -312,8 +312,8 @@ boundary database init -h
 When the configuration files are in place on each Boundary controller, you can proceed to enable and start the binary on each of the Boundary controller nodes using `systemd`.
 Run the following commands to start the service:
 
-1. &#32;`sudo systemctl enable boundary`
-1. &#32;`sudo systemctl start boundary`
+1. `sudo systemctl enable boundary`
+1. `sudo systemctl start boundary`
 
 ## Authenticate and manage resources
 

--- a/website/content/docs/install-boundary/configure-workers.mdx
+++ b/website/content/docs/install-boundary/configure-workers.mdx
@@ -271,7 +271,7 @@ kms "awskms" {
 
 Refer to the list below for explanations of the parameters used in the example above:
 
-- &#32;`disable mlcok (bool: false)` - Disables the server from executing the `mlock` syscall, which prevents memory from being swapped to the disk.
+- `disable mlcok (bool: false)` - Disables the server from executing the `mlock` syscall, which prevents memory from being swapped to the disk.
 This is fine for local development and testing.
 However, it is not recommended for production unless the systems running Boundary use only encrypted swap or do not use swap at all.
 Boundary only supports memory locking on UNIX-like systems that support `mlock()` syscall like Linux and FreeBSD.
@@ -284,15 +284,15 @@ Boundary only supports memory locking on UNIX-like systems that support `mlock()
 
    `LimitMEMLOCK=infinity`
 
-- &#32; `listener` - Configures the listeners on which Boundary serves traffic (API cluster and proxy).
-- &#32; `controller` - Configures the controller.
+- `listener` - Configures the listeners on which Boundary serves traffic (API cluster and proxy).
+- `controller` - Configures the controller.
 If present, `boundary server` starts a controller subprocess.
-- &#32; `events` - Configures event-specific parameters.
+- `events` - Configures event-specific parameters.
 
    The example events configuration above is exhaustive and writes all events to both `stderr` and a file.
    This configuration may or may not work for your organization's logging solution.
 
-- &#32; `kms` - Configures KMS blocks for [various purposes](/boundary/docs/concepts/security/data-encryption).
+- `kms` - Configures KMS blocks for [various purposes](/boundary/docs/concepts/security/data-encryption).
 
    Refer to the links below for configuration information for the different cloud KMS blocks:
 
@@ -310,8 +310,8 @@ Refer to the documentation for additional [top-level configuration options](/bou
 When the configuration files are in place on each Boundary controller, you can proceed to enable and start the binary on each of the Boundary worker nodes using `systemd`.
 Run the following commands to start the service:
 
-1. &#32;`sudo systemctl enable boundary`
-1. &#32;`sudo systemctl start boundary`
+1. `sudo systemctl enable boundary`
+1. `sudo systemctl start boundary`
 
 ## Adopt the PKI workers (optional)
 


### PR DESCRIPTION
When the text inside a bullet begins with code, our renderer changes the text to a link. The link doesn't go anywhere when you click it, creating a bad user experience:


<img width="665" alt="image" src="https://github.com/hashicorp/boundary/assets/76443935/854142aa-062e-4945-b58c-80a72f5615d1">

___________________________________


I discussed it with the DevDot team, and this is a limitation of our system; there is no fix for it at this time.

I thought I figured out a workaround by adding the HTML entity for a space (`&#32;`) before the text for the bullet. The extra space prevented the code from rendering as a link, and Markdown ignored it as a duplicate space. This worked great on my local machine and in Vercel previews:


<img width="683" alt="image" src="https://github.com/hashicorp/boundary/assets/76443935/93562a21-8a4c-4b03-873e-34aab132d460">

____________________________________


However, when these updates were published, they did not render the same way in our production environment. The extra space is turning those bullet points into code blocks:


<img width="749" alt="image" src="https://github.com/hashicorp/boundary/assets/76443935/d5c8a8ba-d66f-45f2-94db-02b398083e8f">

____________________________________


This user experience is worse than having links that don't go anywhere. So this PR gets rid of the extra spaces and puts everything back to our standard format.