### PR TITLE
chore: Ignore tags in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,13 @@
 name: build
 
 on:
-  - workflow_dispatch
-  - push
-  - workflow_call
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+  workflow_call:
+  workflow_dispatch:
 
 env:
   PKG_NAME: "boundary"


### PR DESCRIPTION
This PR updates the `build` workflow to ignore running on tags. This was done to prevent extra workflows from triggering that aren't necessary.