### PR TITLE
fix: add plugin normalization for onCreate methods

### DIFF
--- a/internal/host/plugin/repository_host_catalog.go
+++ b/internal/host/plugin/repository_host_catalog.go
@@ -130,6 +130,9 @@ func (r *Repository) CreateCatalog(ctx context.Context, c *HostCatalog, _ ...Opt
 		if err := normalizeCatalogAttributes(ctx, plgClient, plgHc); err != nil {
 			return nil, nil, errors.Wrap(ctx, err, op)
 		}
+		if c.Attributes, err = proto.Marshal(plgHc.GetAttributes()); err != nil {
+			return nil, nil, errors.Wrap(ctx, err, op)
+		}
 	}
 
 	oplogWrapper, err := r.kms.GetWrapper(ctx, c.ProjectId, kms.KeyPurposeOplog)

--- a/internal/host/plugin/repository_host_catalog_test.go
+++ b/internal/host/plugin/repository_host_catalog_test.go
@@ -205,9 +205,15 @@ func TestRepository_CreateCatalog(t *testing.T) {
 					ProjectId: prj.GetPublicId(),
 					PluginId:  plg.GetPublicId(),
 					Attributes: func() []byte {
-						st, err := structpb.NewStruct(map[string]any{"k1": "foo"})
-						require.NoError(t, err)
-						b, err := proto.Marshal(st)
+						b, err := proto.Marshal(&structpb.Struct{Fields: map[string]*structpb.Value{
+							"k1": structpb.NewStringValue("foo"),
+							normalizeToSliceKey: structpb.NewListValue(
+								&structpb.ListValue{
+									Values: []*structpb.Value{
+										structpb.NewStringValue("normalizeme"),
+									},
+								}),
+						}})
 						require.NoError(t, err)
 						return b
 					}(),
@@ -323,6 +329,7 @@ func TestRepository_CreateCatalog(t *testing.T) {
 			assert.Equal(tt.want.Name, got.Name)
 			assert.Equal(tt.want.Description, got.Description)
 			assert.Equal(got.CreateTime, got.UpdateTime)
+			assert.Equal(tt.want.Attributes, got.Attributes)
 
 			if origPluginAttrs != nil {
 				if normalizeVal := origPluginAttrs.Fields[normalizeToSliceKey]; normalizeVal != nil {

--- a/internal/host/plugin/repository_host_set.go
+++ b/internal/host/plugin/repository_host_set.go
@@ -132,6 +132,9 @@ func (r *Repository) CreateSet(ctx context.Context, projectId string, s *HostSet
 		if err := normalizeSetAttributes(ctx, plgClient, plgHs); err != nil {
 			return nil, nil, errors.Wrap(ctx, err, op)
 		}
+		if s.Attributes, err = proto.Marshal(plgHs.GetAttributes()); err != nil {
+			return nil, nil, errors.Wrap(ctx, err, op)
+		}
 	}
 
 	var preferredEndpoints []any

--- a/internal/host/plugin/repository_host_set_test.go
+++ b/internal/host/plugin/repository_host_set_test.go
@@ -259,7 +259,15 @@ func TestRepository_CreateSet(t *testing.T) {
 					CatalogId:   catalog.PublicId,
 					Description: ("test-description-repo"),
 					Attributes: func() []byte {
-						b, err := proto.Marshal(&structpb.Struct{Fields: map[string]*structpb.Value{"k1": structpb.NewStringValue("foo")}})
+						b, err := proto.Marshal(&structpb.Struct{Fields: map[string]*structpb.Value{
+							"k1": structpb.NewStringValue("foo"),
+							normalizeToSliceKey: structpb.NewListValue(
+								&structpb.ListValue{
+									Values: []*structpb.Value{
+										structpb.NewStringValue("normalizeme"),
+									},
+								}),
+						}})
 						require.NoError(t, err)
 						return b
 					}(),
@@ -328,6 +336,7 @@ func TestRepository_CreateSet(t *testing.T) {
 			assert.Equal(tt.want.Name, got.GetName())
 			assert.Equal(tt.want.Description, got.GetDescription())
 			assert.Equal(got.GetCreateTime(), got.GetUpdateTime())
+			assert.Equal(string(tt.want.GetAttributes()), string(got.GetAttributes()))
 
 			if origPluginAttrs != nil {
 				if normalizeVal := origPluginAttrs.Fields[normalizeToSliceKey]; normalizeVal != nil {


### PR DESCRIPTION
onUpdate for host catalog & host set make a plugin call to normalize attributes passed in. This behavior was introduced in [PR-2376](https://github.com/hashicorp/boundary/pull/2376) but was only applied to onUpdate calls. This created different data structures for onCreate calls and onUpdate calls.