### PR TITLE
test(e2e): Update env variables and target creation

### DIFF
--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -40,6 +40,10 @@ module "worker" {
   ssh_aws_keypair = var.aws_ssh_keypair_name
 }
 
+module "bucket" {
+  source = "./modules/bucket"
+}
+
 module "build_crt" {
   source = "./modules/build_crt"
 }

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -182,5 +182,4 @@ variable "go_test_timeout" {
 variable "aws_region" {
   description = "AWS region where the resources will be created"
   type        = string
-  default     = ""
 }

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -178,3 +178,9 @@ variable "go_test_timeout" {
   type        = string
   default     = "10m"
 }
+
+variable "aws_region" {
+  description = "AWS region where the resources will be created"
+  type        = string
+  default     = ""
+}

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -112,6 +112,16 @@ variable "aws_host_set_ips2" {
   type        = list(string)
   default     = [""]
 }
+variable "aws_region" {
+  description = "AWS region where the resources will be created"
+  type        = string
+  default     = ""
+}
+variable "aws_bucket_name" {
+  description = "AWS S3 bucket name"
+  type        = string
+  default     = ""
+}
 variable "worker_tags" {
   type    = list(string)
   default = [""]
@@ -149,11 +159,15 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_AWS_HOST_SET_FILTER       = var.aws_host_set_filter1,
     E2E_AWS_HOST_SET_IPS          = local.aws_host_set_ips1,
     E2E_AWS_HOST_SET_FILTER2      = var.aws_host_set_filter2,
-    E2E_AWS_HOST_SET_IPS2         = local.aws_host_set_ips2
+    E2E_AWS_HOST_SET_IPS2         = local.aws_host_set_ips2,
+    E2E_AWS_REGION                = var.aws_region,
+    E2E_AWS_BUCKET_NAME           = var.aws_bucket_name,
     E2E_WORKER_TAG                = jsonencode(var.worker_tags),
   }
 
-  inline = var.debug_no_run ? [""] : ["set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json -timeout ${var.test_timeout}| tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.log"]
+  inline = var.debug_no_run ? [""] : [
+    "set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json -timeout ${var.test_timeout}| tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.log"
+  ]
 }
 
 output "test_results" {

--- a/testing/internal/e2e/tests/aws/env_test.go
+++ b/testing/internal/e2e/tests/aws/env_test.go
@@ -7,11 +7,13 @@ import "github.com/kelseyhightower/envconfig"
 
 type config struct {
 	AwsAccessKeyId     string `envconfig:"E2E_AWS_ACCESS_KEY_ID" required:"true"`
+	AwsBucketName      string `envconfig:"E2E_AWS_BUCKET_NAME" required:"true"`
 	AwsSecretAccessKey string `envconfig:"E2E_AWS_SECRET_ACCESS_KEY" required:"true"`
 	AwsHostSetFilter1  string `envconfig:"E2E_AWS_HOST_SET_FILTER" required:"true"`  // e.g. "tag:testtag=true"
 	AwsHostSetIps1     string `envconfig:"E2E_AWS_HOST_SET_IPS" required:"true"`     // e.g. "[\"1.2.3.4\", \"2.3.4.5\"]"
 	AwsHostSetFilter2  string `envconfig:"E2E_AWS_HOST_SET_FILTER2" required:"true"` // e.g. "tag:testtagtwo=test"
 	AwsHostSetIps2     string `envconfig:"E2E_AWS_HOST_SET_IPS2" required:"true"`    // e.g. "[\"1.2.3.4\"]"
+	AwsRegion          string `envconfig:"E2E_AWS_REGION" required:"true"`           // e.g. "us-east-1"
 	TargetSshKeyPath   string `envconfig:"E2E_SSH_KEY_PATH" required:"true"`         // e.g. "/Users/username/key.pem"
 	TargetSshUser      string `envconfig:"E2E_SSH_USER" required:"true"`             // e.g. "ubuntu"
 	TargetPort         string `envconfig:"E2E_SSH_PORT" required:"true"`             // e.g. "22"

--- a/testing/internal/e2e/tests/aws/worker_test.go
+++ b/testing/internal/e2e/tests/aws/worker_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,7 @@ func TestCliWorker(t *testing.T) {
 		require.NoError(t, output.Err, string(output.Stderr))
 	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
-	newTargetId := boundary.CreateNewAddressTargetCli(t, ctx, newProjectId, c.TargetPort, c.TargetIp)
+	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort, target.WithAddress(c.TargetIp))
 
 	// Set incorrect worker filter, expect connection failure
 	t.Logf("Setting incorrect worker filter...")

--- a/testing/internal/e2e/tests/base/session_end_delete_project_test.go
+++ b/testing/internal/e2e/tests/base/session_end_delete_project_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/boundary/internal/session"
+	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +35,7 @@ func TestCliSessionEndWhenProjectIsDeleted(t *testing.T) {
 		require.NoError(t, output.Err, string(output.Stderr))
 	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
-	newTargetId := boundary.CreateNewAddressTargetCli(t, ctx, newProjectId, c.TargetPort, c.TargetIp)
+	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort, target.WithAddress(c.TargetIp))
 	acctName := "e2e-account"
 	newAccountId, acctPassword := boundary.CreateNewAccountCli(t, ctx, bc.AuthMethodId, acctName)
 	t.Cleanup(func() {

--- a/testing/internal/e2e/tests/base/target_address_test.go
+++ b/testing/internal/e2e/tests/base/target_address_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,7 @@ func TestCliCreateUpdateTargetAddress(t *testing.T) {
 		require.NoError(t, output.Err, string(output.Stderr))
 	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
-	newTargetId := boundary.CreateNewAddressTargetCli(t, ctx, newProjectId, c.TargetPort, c.TargetIp)
+	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort, target.WithAddress(c.TargetIp))
 
 	// Connect to target and print host's IP address
 	output := e2e.RunCommand(ctx, "boundary",
@@ -151,7 +152,7 @@ func TestCliTargetAddressToHostSource(t *testing.T) {
 	newHostSetId := boundary.CreateNewHostSetCli(t, ctx, newHostCatalogId)
 	newHostId := boundary.CreateNewHostCli(t, ctx, newHostCatalogId, c.TargetIp)
 	boundary.AddHostToHostSetCli(t, ctx, newHostSetId, newHostId)
-	newTargetId := boundary.CreateNewAddressTargetCli(t, ctx, newProjectId, c.TargetPort, c.TargetIp)
+	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort, target.WithAddress(c.TargetIp))
 
 	// Connect to target and print host's IP address
 	output := e2e.RunCommand(ctx, "boundary",


### PR DESCRIPTION
Ticket: [ICU-9194](https://hashicorp.atlassian.net/browse/ICU-9194)

This PR prepares OSS for session recording tests:
- Updates environment variables for aws e2e tests
- Refactors the `CreateNewTargetCli` method for targets creation via CLI to support additional options

[ICU-9194]: https://hashicorp.atlassian.net/browse/ICU-9194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ