### PR TITLE
api: remove create from auth-tokens help

### DIFF
--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -44,7 +44,6 @@ func (n AuthTokenReadResult) GetResponse() *api.Response {
 	return n.response
 }
 
-type AuthTokenCreateResult = AuthTokenReadResult
 type AuthTokenUpdateResult = AuthTokenReadResult
 
 type AuthTokenDeleteResult struct {

--- a/internal/api/genapi/input.go
+++ b/internal/api/genapi/input.go
@@ -486,7 +486,7 @@ var inputStructs = []*structInfo{
 			listTemplate,
 		},
 		pluralResourceName:  "auth-tokens",
-		createResponseTypes: []string{CreateResponseType, ReadResponseType, UpdateResponseType, DeleteResponseType, ListResponseType},
+		createResponseTypes: []string{ReadResponseType, UpdateResponseType, DeleteResponseType, ListResponseType},
 		recursiveListing:    true,
 	},
 	// Credentials

--- a/internal/cmd/commands/authtokenscmd/authtokens.gen.go
+++ b/internal/cmd/commands/authtokenscmd/authtokens.gen.go
@@ -79,7 +79,7 @@ func (c *Command) Help() string {
 
 	default:
 
-		helpStr = helpMap["base"]()
+		helpStr = c.extraHelpFunc(helpMap)
 
 	}
 

--- a/internal/cmd/commands/authtokenscmd/authtokens.go
+++ b/internal/cmd/commands/authtokenscmd/authtokens.go
@@ -1,0 +1,29 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package authtokenscmd
+
+import "github.com/hashicorp/boundary/internal/cmd/base"
+
+func (c *Command) extraHelpFunc(helpMap map[string]func() string) string {
+	var helpStr string
+	switch c.Func {
+	case "":
+		return base.WrapForHelpText([]string{
+			"Usage: boundary auth-tokens [sub command] [options] [args]",
+			"",
+			"  This command allows operations on Boundary auth token resources. Example:",
+			"",
+			"    List all auth tokens:",
+			"",
+			`      $ boundary auth-tokens list -recursive `,
+			"",
+			"  Please see the auth-tokens subcommand help for detailed usage information.",
+			"  Note: To create an auth token, see the authenticate subcommand.",
+		})
+
+	default:
+		helpStr = helpMap["base"]()
+	}
+	return helpStr
+}

--- a/internal/cmd/gencli/input.go
+++ b/internal/cmd/gencli/input.go
@@ -204,10 +204,11 @@ var inputStructs = map[string][]*cmdInfo{
 	},
 	"authtokens": {
 		{
-			ResourceType: resource.AuthToken.String(),
-			Pkg:          "authtokens",
-			StdActions:   []string{"read", "delete", "list"},
-			Container:    "Scope",
+			ResourceType:     resource.AuthToken.String(),
+			Pkg:              "authtokens",
+			StdActions:       []string{"read", "delete", "list"},
+			HasExtraHelpFunc: true,
+			Container:        "Scope",
 		},
 	},
 	"credentialstores": {


### PR DESCRIPTION
The auth-tokens help command included a reference to a non-existent auth-tokens create command. Replace the default help and also add a helpful pointer to the authenticate command.

Before:
```
$ boundary auth-tokens -h
Usage: boundary auth-tokens [sub command] [options] [args]

  This command allows operations on Boundary auth token resources. Example:

    Create an auth token:

      $ boundary auth-tokens create -name prodops -description "For ProdOps usage"

  Please see the auth-tokens subcommand help for detailed usage information.

Subcommands:
    delete    Delete an auth token
    list      List an auth token
    read      Read an auth token
```

After:
```
$ boundary auth-tokens -h
Usage: boundary auth-tokens [sub command] [options] [args]

  This command allows operations on Boundary auth token resources. Example:

    List all auth tokens:

      $ boundary auth-tokens list -recursive

  Please see the auth-tokens subcommand help for detailed usage information.
  Note: To create an auth token, see the authenticate subcommand.

Subcommands:
    delete    Delete an auth token
    list      List an auth token
    read      Read an auth token
```