### PR TITLE
chore: Update some e2e test scenarios to use docker-based infra

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -403,7 +403,6 @@ jobs:
     needs:
       - set-product-version
       - product-metadata
-      - build-linux
       - build-docker
     uses: ./.github/workflows/enos-run.yml
     with:

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -78,9 +78,8 @@ jobs:
         include:
           - filter: 'e2e_aws builder:crt'
           - filter: 'e2e_database'
-          - filter: 'e2e_base builder:crt'
-          - filter: 'e2e_base_with_vault builder:crt'
-          # - filter: 'e2e_ui builder:crt' # Don't run UI tests yet. takes too long.
+          - filter: 'e2e_docker_base builder:crt'
+          - filter: 'e2e_docker_base_with_vault builder:crt'
     runs-on: ${{ fromJSON(vars.RUNNER_LARGE) }}
     env:
       GITHUB_TOKEN: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}
@@ -182,14 +181,21 @@ jobs:
         run: |
           wget https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_linux_amd64.zip -O /tmp/test-deps/vault.zip
       - name: Install Vault CLI
-        if: matrix.filter == 'e2e_base_with_vault builder:crt' || matrix.filter == 'e2e_database' || matrix.filter == 'e2e_ui builder:crt' || matrix.filter == 'e2e_docker builder:crt'
+        if: matrix.filter == 'e2e_base_with_vault builder:crt' || matrix.filter == 'e2e_database' || matrix.filter == 'e2e_ui builder:crt' || matrix.filter == 'e2e_docker_base_with_vault builder:crt'
         run: |
           unzip /tmp/test-deps/vault.zip -d /usr/local/bin
       - name: Add hosts to /etc/hosts
         # This enables the use of `boundary connect` with docker containers
-        if: matrix.filter == 'e2e_docker builder:crt'
+        if: contains(matrix.filter, 'e2e_docker')
         run: |
           sudo echo "127.0.0.1 localhost boundary" | sudo tee -a /etc/hosts
+      - name: GH fix for localhost resolution
+        if: github.repository == 'hashicorp/boundary' && contains(matrix.filter, 'e2e_docker')
+        run: |
+          cat /etc/hosts && echo "-----------"
+          sudo sed -i 's/::1 *localhost ip6-localhost ip6-loopback/::1 ip6 -localhost ip6-loopback/g' /etc/hosts
+          cat /etc/hosts
+          ssh -V
       - name: Download Boundary Linux AMD64 bundle
         id: download
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
@@ -201,14 +207,14 @@ jobs:
           unzip ${{steps.download.outputs.download-path}}/*.zip -d enos/support/boundary
           mv ${{steps.download.outputs.download-path}}/*.zip enos/support/boundary.zip
       - name: Download Boundary Linux AMD64 docker image
-        if: matrix.filter == 'e2e_docker builder:crt'
+        if: contains(matrix.filter, 'e2e_docker')
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         id: download-docker
         with:
           name: ${{ inputs.docker-image-file }}
           path: ./enos/support/downloads
       - name: Rename docker image file
-        if: matrix.filter == 'e2e_docker builder:crt'
+        if: contains(matrix.filter, 'e2e_docker')
         run: |
           mv ${{ steps.download-docker.outputs.download-path }}/*.tar enos/support/boundary_docker_image.tar
       - name: Set up Node.js

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -81,7 +81,7 @@ jobs:
           - filter: 'e2e_base builder:crt'
           - filter: 'e2e_base_with_vault builder:crt'
           # - filter: 'e2e_ui builder:crt' # Don't run UI tests yet. takes too long.
-    runs-on: ${{ fromJSON(vars.RUNNER) }}
+    runs-on: ${{ fromJSON(vars.RUNNER_LARGE) }}
     env:
       GITHUB_TOKEN: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}
       # Scenario variables

--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-scenario "e2e_base_with_vault" {
+scenario "e2e_aws_base_with_vault" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [

--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-scenario "e2e_base" {
+scenario "e2e_aws_base" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [

--- a/enos/enos-scenario-e2e-docker-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-vault.hcl
@@ -4,11 +4,10 @@
 # For this scenario to work, add the following line to /etc/hosts
 # 127.0.0.1 localhost boundary
 
-scenario "e2e_docker" {
+scenario "e2e_docker_base_with_vault" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
-    provider.aws.default,
     provider.enos.default
   ]
 
@@ -22,10 +21,6 @@ scenario "e2e_docker" {
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
 
-    build_path = {
-      "local" = "/tmp",
-      "crt"   = var.crt_bundle_path == null ? null : abspath(var.crt_bundle_path)
-    }
     tags = merge({
       "Project Name" : var.project_name
       "Project" : "Enos",

--- a/enos/enos-scenario-e2e-docker-base.hcl
+++ b/enos/enos-scenario-e2e-docker-base.hcl
@@ -1,0 +1,116 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# For this scenario to work, add the following line to /etc/hosts
+# 127.0.0.1 localhost boundary
+
+scenario "e2e_docker_base" {
+  terraform_cli = terraform_cli.default
+  terraform     = terraform.default
+  providers = [
+    provider.enos.default
+  ]
+
+  matrix {
+    builder = ["local", "crt"]
+  }
+
+  locals {
+    aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
+    local_boundary_dir         = abspath(var.local_boundary_dir)
+    boundary_docker_image_file = abspath(var.boundary_docker_image_file)
+    license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+
+    tags = merge({
+      "Project Name" : var.project_name
+      "Project" : "Enos",
+      "Environment" : "ci"
+    }, var.tags)
+  }
+
+  step "build_boundary_docker_image" {
+    module = matrix.builder == "crt" ? module.build_boundary_docker_crt : module.build_boundary_docker_local
+
+    variables {
+      path = matrix.builder == "crt" ? local.boundary_docker_image_file : "/tmp/boundary_docker_image.tar"
+    }
+  }
+
+  step "create_docker_network" {
+    module = module.docker_network
+  }
+
+  step "create_boundary_database" {
+    depends_on = [
+      step.create_docker_network
+    ]
+    variables {
+      image_name   = "${var.docker_mirror}/library/postgres:latest"
+      network_name = step.create_docker_network.network_name
+    }
+    module = module.docker_postgres
+  }
+
+  step "read_license" {
+    skip_step = var.boundary_edition == "oss"
+    module    = module.read_license
+
+    variables {
+      file_name = local.license_path
+    }
+  }
+
+  step "create_boundary" {
+    module = module.docker_boundary
+    depends_on = [
+      step.create_docker_network,
+      step.create_boundary_database,
+      step.build_boundary_docker_image
+    ]
+    variables {
+      image_name       = matrix.builder == "crt" ? var.boundary_docker_image_name : step.build_boundary_docker_image.image_name
+      network_name     = step.create_docker_network.network_name
+      postgres_address = step.create_boundary_database.address
+      boundary_license = var.boundary_edition != "oss" ? step.read_license.license : ""
+    }
+  }
+
+  step "create_host" {
+    module = module.docker_openssh_server
+    depends_on = [
+      step.create_docker_network
+    ]
+    variables {
+      image_name            = "${var.docker_mirror}/linuxserver/openssh-server:latest"
+      network_name          = step.create_docker_network.network_name
+      private_key_file_path = local.aws_ssh_private_key_path
+    }
+  }
+
+  step "run_e2e_test" {
+    module = module.test_e2e
+    depends_on = [
+      step.create_boundary,
+      step.create_host,
+      step.create_boundary_database
+    ]
+
+    variables {
+      test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/base"
+      debug_no_run             = var.e2e_debug_no_run
+      alb_boundary_api_addr    = step.create_boundary.address
+      auth_method_id           = step.create_boundary.auth_method_id
+      auth_login_name          = step.create_boundary.login_name
+      auth_password            = step.create_boundary.password
+      local_boundary_dir       = local.local_boundary_dir
+      aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      target_ip                = step.create_host.address
+      target_port              = step.create_host.port
+      target_user              = "ubuntu"
+    }
+  }
+
+  output "test_results" {
+    value = step.run_e2e_test.test_results
+  }
+}

--- a/enos/modules/docker_boundary/init.sh
+++ b/enos/modules/docker_boundary/init.sh
@@ -15,6 +15,7 @@ docker run \
     --rm \
     --name $TEST_CONTAINER_NAME \
     -e "BOUNDARY_POSTGRES_URL=$TEST_DATABASE_ADDRESS" \
+    -e "BOUNDARY_LICENSE=$TEST_BOUNDARY_LICENSE" \
     -e "SKIP_CHOWN=true" \
     --cap-add IPC_LOCK \
     --mount type=bind,src=$SOURCE,dst=/boundary/ \

--- a/enos/modules/docker_boundary/main.tf
+++ b/enos/modules/docker_boundary/main.tf
@@ -36,6 +36,10 @@ variable "postgres_address" {
   description = "Address to postgres database"
   type        = string
 }
+variable "boundary_license" {
+  description = "License string"
+  type        = string
+}
 
 
 resource "docker_image" "boundary" {
@@ -48,6 +52,7 @@ resource "enos_local_exec" "init_database" {
     TEST_BOUNDARY_IMAGE   = var.image_name,
     TEST_DATABASE_ADDRESS = var.postgres_address,
     TEST_NETWORK_NAME     = var.network_name
+    TEST_BOUNDARY_LICENSE = var.boundary_license
   }
   inline = ["bash ./${path.module}/init.sh"]
 }
@@ -68,6 +73,7 @@ resource "docker_container" "boundary" {
   command = ["boundary", "server", "-config", "/boundary/boundary-config.hcl"]
   env = [
     "BOUNDARY_POSTGRES_URL=${var.postgres_address}",
+    "BOUNDARY_LICENSE=${var.boundary_license}",
     "HOSTNAME=boundary",
     "SKIP_CHOWN=true",
   ]


### PR DESCRIPTION
This PR updates some e2e test scenarios to use docker-based infra as opposed to AWS-based. This drastically improves run-time and reliability for the following scenarios.

Here's an example comparison
```
base: 24m 38s --> 9m 53s
base with vault: 13m 46s --> 2m 52s
```

This leaves the current run times for e2e tests
```
aws: 13m 37s
database: 4m 39s
docker_base: 9m 52s
docker_base_with_vault: 2m 54s
```
