### PR TITLE
Update census to run less frequently

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,13 @@
 name: build
 
 on:
-  - workflow_dispatch
-  - push
-  - workflow_call
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+  workflow_call:
+  workflow_dispatch:
 
 env:
   PKG_NAME: "boundary"

--- a/internal/census/census_job.go
+++ b/internal/census/census_job.go
@@ -51,7 +51,6 @@ func (c *censusJob) Status() scheduler.JobStatus {
 // Run performs the required work depending on the implementation.
 // The context is used to notify the job that it should exit early.
 func (c *censusJob) Run(ctx context.Context) error {
-	const op = "census.(censusJob).Run"
 	err := RunFn(ctx, c)
 	return err
 }
@@ -61,10 +60,9 @@ func runInternal(ctx context.Context, c *censusJob) error {
 }
 
 // NextRunIn returns the duration until the next job run should be scheduled.
-// We report as ready immediately after a successful run. This doesn't mean that
-// this job will run immediately, only about as often as the configured scheduler interval.
+// Census will run every hour to ensure any interrupted jobs will be re-attempted
 func (c *censusJob) NextRunIn(_ context.Context) (time.Duration, error) {
-	return 0, nil
+	return 3600, nil
 }
 
 // Name is the unique name of the job.

--- a/internal/census/census_job.go
+++ b/internal/census/census_job.go
@@ -62,7 +62,7 @@ func runInternal(ctx context.Context, c *censusJob) error {
 // NextRunIn returns the duration until the next job run should be scheduled.
 // Census will run every hour to ensure any interrupted jobs will be re-attempted
 func (c *censusJob) NextRunIn(_ context.Context) (time.Duration, error) {
-	return 3600, nil
+	return time.Hour, nil
 }
 
 // Name is the unique name of the job.

--- a/internal/db/schema/migrations/oss/postgres/73/01_census_logging.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/73/01_census_logging.up.sql
@@ -1,0 +1,20 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: MPL-2.0
+
+begin;
+
+  create table census_last_logged (
+    last_logged_at wt_timestamp primary key
+  );
+  comment on table census_last_logged is
+    'census_last_logged is a table with 1 row which contains the timestamp '
+    'of the last time the census status and snapshots were logged.';
+
+  -- This index ensures that there will only ever be one row in the table.
+  -- See: https://www.postgresql.org/docs/current/indexes-expressional.html
+  create unique index census_last_logged_one_row
+    on census_last_logged((last_logged_at is not null));
+
+  insert into census_last_logged(last_logged_at) values('-infinity');
+
+commit;

--- a/internal/db/sqltest/tests/census/last_logged.sql
+++ b/internal/db/sqltest/tests/census/last_logged.sql
@@ -1,0 +1,31 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: MPL-2.0
+
+begin;
+
+  select plan(6);
+
+  select has_table('census_last_logged');
+  select is(count(*), 1::bigint, 'census_last_logged should have only 1 row') from census_last_logged;
+  select ok(not isfinite(last_logged_at)) from census_last_logged;
+
+  prepare insert_row as
+   insert into census_last_logged
+    (last_logged_at)
+   values
+    (now());
+
+  select throws_ok('insert_row', '23505',
+    'duplicate key value violates unique constraint "census_last_logged_one_row"',
+    'insert into census_last_logged should fail');
+
+  prepare update_census_last_logged as
+   update census_last_logged
+      set last_logged_at = now();
+
+  select lives_ok('update_census_last_logged');
+  select ok(isfinite(last_logged_at)) from census_last_logged;
+
+  select * from finish();
+
+rollback;


### PR DESCRIPTION
Census is currently running about once a minute, this will reduce that run-time to once per hour. Also includes a table to track the most recent log time.