### PR TITLE
fix: update recursive auth-method listing test

### DIFF
--- a/internal/tests/cluster/recursive_anon_listing_test.go
+++ b/internal/tests/cluster/recursive_anon_listing_test.go
@@ -32,18 +32,18 @@ func TestListAnonymousRecursing(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(am)
 
-	// We expect to see all three with the normal token
+	// We expect to see all four with the normal token
 	l, err := amClient.List(tc.Context(), scope.Global.String(), amapi.WithRecursive(true))
 	require.NoError(err)
 	require.NotNil(l)
 	require.Len(l.GetItems(), 4)
 
-	// Originally we also expect to see all three as anon user
+	// Originally we also expect to see all four as anon user
 	amClient.ApiClient().SetToken("")
 	l, err = amClient.List(tc.Context(), scope.Global.String(), amapi.WithRecursive(true))
 	require.NoError(err)
 	require.NotNil(l)
-	require.Len(l.GetItems(), 3)
+	require.Len(l.GetItems(), 4)
 
 	// Find the global roles and delete them
 	rl, err := rolesClient.List(tc.Context(), scope.Global.String())


### PR DESCRIPTION
Recently, we made the initial dev ldap auth-method active-public, so it now shows up in listings.  This simply fixes the tests to reflect that change.