### PR TITLE
chore: update copyright_year in copywrite config

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -2,7 +2,7 @@ schema_version = 1
 
 project {
   license        = "MPL-2.0"
-  copyright_year = 2023
+  copyright_year = 2020
 
   header_ignore = [
     ".github/**",


### PR DESCRIPTION
Updating the `copyright_year` to 2020 after reviewing copywrite [README](https://github.com/hashicorp/copywrite#config-structure) that suggests using the year the project started.