### PR TITLE
cmd: fix session recording download flag help

### DIFF
--- a/internal/cmd/commands/sessionrecordingscmd/download.go
+++ b/internal/cmd/commands/sessionrecordingscmd/download.go
@@ -54,18 +54,18 @@ func (c *DownloadCommand) Flags() *base.FlagSets {
 	f.StringVar(&base.StringVar{
 		Name:   "id",
 		Target: &c.FlagId,
-		Usage:  "The id of the session recording resource to download",
+		Usage:  "The id of the session recording resource to download.",
 	})
 	f.StringVar(&base.StringVar{
 		Name:    "output",
 		Target:  &c.FlagOutputFile,
-		Usage:   "An optional output file for the download. If not provided the recording id will be used with a \".cast\" extension. Use \"-\" for stdout",
+		Usage:   "An optional output file for the download. If not provided the recording id will be used with a \".cast\" extension. Use \"-\" for stdout.",
 		Aliases: []string{"o"},
 	})
 	f.BoolVar(&base.BoolVar{
 		Name:    "no-clobber",
 		Target:  &c.FlagNoClobber,
-		Usage:   "An option to stop downloads that would overwrite existing files",
+		Usage:   "An option to stop downloads that would overwrite existing files.",
 		Aliases: []string{"nc"},
 	})
 	return set


### PR DESCRIPTION
When using an alias, we automatically add a little blurb to the end of the flag help. When not terminating the flag help with a full stop, this looks a bit odd. Add full stops to all the download flags for consistency.

Old help:
```
Command Options:

  -id=<string>
      The id of the session recording resource to download

  -no-clobber
      An option to stop downloads that would overwrite existing files This is
      aliased as "-nc". The default is false.

  -output=<string>
      An optional output file for the download. If not provided the recording
      id will be used with a ".cast" extension. Use "-" for stdout This is
      aliased as "-o".
```

New help:
```
Command Options:

  -id=<string>
      The id of the session recording resource to download.

  -no-clobber
      An option to stop downloads that would overwrite existing files. This is
      aliased as "-nc". The default is false.

  -output=<string>
      An optional output file for the download. If not provided the recording
      id will be used with a ".cast" extension. Use "-" for stdout. This is
      aliased as "-o".
```