### PR TITLE
chore(e2e): Change port used by vault docker container

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -181,7 +181,7 @@ jobs:
         run: |
           wget https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_linux_amd64.zip -O /tmp/test-deps/vault.zip
       - name: Install Vault CLI
-        if: matrix.filter == 'e2e_base_with_vault builder:crt' || matrix.filter == 'e2e_database' || matrix.filter == 'e2e_ui builder:crt' || matrix.filter == 'e2e_docker_base_with_vault builder:crt'
+        if: matrix.filter == 'e2e_aws_base_with_vault builder:crt' || matrix.filter == 'e2e_database' || matrix.filter == 'e2e_ui builder:crt' || matrix.filter == 'e2e_docker_base_with_vault builder:crt'
         run: |
           unzip /tmp/test-deps/vault.zip -d /usr/local/bin
       - name: Add hosts to /etc/hosts

--- a/enos/enos-scenario-e2e-docker-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-vault.hcl
@@ -122,6 +122,7 @@ scenario "e2e_docker_base_with_vault" {
       vault_addr               = step.create_vault.address
       vault_addr_internal      = step.create_vault.address_internal
       vault_root_token         = step.create_vault.token
+      vault_port               = step.create_vault.port
     }
   }
 

--- a/enos/modules/docker_vault/main.tf
+++ b/enos/modules/docker_vault/main.tf
@@ -37,6 +37,11 @@ variable "vault_token" {
   type        = string
   default     = "boundarytok"
 }
+variable "vault_port" {
+  description = "External Port to use"
+  type        = string
+  default     = "8300"
+}
 
 resource "docker_image" "vault" {
   name         = var.image_name
@@ -51,7 +56,7 @@ resource "docker_container" "vault" {
   ]
   ports {
     internal = 8200
-    external = 8200
+    external = var.vault_port
   }
   capabilities {
     add = ["IPC_LOCK"]
@@ -66,7 +71,7 @@ resource "enos_local_exec" "check_address" {
     docker_container.vault
   ]
 
-  inline = ["timeout 10s bash -c 'until curl http://0.0.0.0:8200; do sleep 2; done'"]
+  inline = ["timeout 10s bash -c 'until curl http://0.0.0.0:${var.vault_port}; do sleep 2; done'"]
 }
 
 resource "enos_local_exec" "check_health" {
@@ -75,7 +80,7 @@ resource "enos_local_exec" "check_health" {
   ]
 
   environment = {
-    VAULT_ADDR  = "http://0.0.0.0:8200"
+    VAULT_ADDR  = "http://0.0.0.0:${var.vault_port}"
     VAULT_TOKEN = var.vault_token
   }
 
@@ -92,4 +97,8 @@ output "address_internal" {
 
 output "token" {
   value = var.vault_token
+}
+
+output "port" {
+  value = var.vault_port
 }

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -77,6 +77,11 @@ variable "vault_root_token" {
   type        = string
   default     = ""
 }
+variable "vault_port" {
+  description = "External Port that vault instance is attached to (outside of docker network)"
+  type        = string
+  default     = "8200"
+}
 variable "aws_access_key_id" {
   description = "Access Key Id for AWS IAM user used in dynamic host catalogs"
   type        = string
@@ -133,7 +138,7 @@ variable "test_timeout" {
 
 locals {
   aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
-  vault_addr               = var.vault_addr != "" ? "http://${var.vault_addr}:8200" : ""
+  vault_addr               = var.vault_addr != "" ? "http://${var.vault_addr}:${var.vault_port}" : ""
   vault_addr_internal      = var.vault_addr_internal != "" ? "http://${var.vault_addr_internal}:8200" : local.vault_addr
   aws_host_set_ips1        = jsonencode(var.aws_host_set_ips1)
   aws_host_set_ips2        = jsonencode(var.aws_host_set_ips2)

--- a/enos/modules/test_e2e_ui/main.tf
+++ b/enos/modules/test_e2e_ui/main.tf
@@ -77,6 +77,11 @@ variable "vault_root_token" {
   type        = string
   default     = ""
 }
+variable "vault_port" {
+  description = "External Port that vault instance is attached to (outside of docker network)"
+  type        = string
+  default     = "8200"
+}
 variable "aws_access_key_id" {
   description = "Access Key Id for AWS IAM user used in dynamic host catalogs"
   type        = string
@@ -115,7 +120,7 @@ variable "aws_host_set_ips2" {
 
 locals {
   aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
-  vault_addr               = var.vault_addr != "" ? "http://${var.vault_addr}:8200" : ""
+  vault_addr               = var.vault_addr != "" ? "http://${var.vault_addr}:${var.vault_port}" : ""
   vault_addr_internal      = var.vault_addr_internal != "" ? "http://${var.vault_addr_internal}:8200" : local.vault_addr
   aws_host_set_ips1        = jsonencode(var.aws_host_set_ips1)
   aws_host_set_ips2        = jsonencode(var.aws_host_set_ips2)


### PR DESCRIPTION
This PR updates the vault docker container used in e2e tests to attach to port 8300 instead of 8200 to prevent conflicts to other Vault instances that may be used in CI workflows. 