### PR TITLE
docs: remove recovery crash scenario from 0.13.0 release notes

### DIFF
--- a/website/content/docs/release-notes/v0_13_0.mdx
+++ b/website/content/docs/release-notes/v0_13_0.mdx
@@ -128,4 +128,3 @@ There are a number of currently unsupported failure cases, including when the wo
 - Crashes and restarts while closing a session recorder, before all files are synced to remote storage
 - Crashes and never restarts or is seen again while closing a channel/connection recorer/session recorder
 - Loses its connection to the controller and cancels sessions, it must resend the information when communication resumes
-- Crashes during recovery


### PR DESCRIPTION
Remove reference to crash during recovery- we don't have a recovery flow, so the worker can't crash during it