### PR TITLE
test(e2e): Add helper method for `boundary connect`

### DIFF
--- a/testing/internal/e2e/boundary/boundary.go
+++ b/testing/internal/e2e/boundary/boundary.go
@@ -8,6 +8,12 @@ import (
 	"github.com/hashicorp/boundary/api/authmethods"
 )
 
+// ConnectCliOutput parses the json response from running `boundary connect`
+type ConnectCliOutput struct {
+	Port    int    `json:"port"`
+	Address string `json:"address"`
+}
+
 // AuthenticateCliOutput parses the json response from running `boundary authenticate`
 type AuthenticateCliOutput struct {
 	Item       *authmethods.AuthenticateResult

--- a/testing/internal/e2e/boundary/connect.go
+++ b/testing/internal/e2e/boundary/connect.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package boundary
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os/exec"
+	"testing"
+
+	"github.com/creack/pty"
+	"github.com/stretchr/testify/require"
+)
+
+// ConnectCli uses the boundary CLI to establish connection to the target.
+// It then parses proxy details from the command output and returns them.
+// The connection must be closed separately via the `boundary sessions cancel` command
+func ConnectCli(t testing.TB, ctx context.Context, targetId string) ConnectCliOutput {
+	cmd := exec.CommandContext(ctx,
+		"boundary", "connect",
+		"-target-id", targetId,
+		"-format", "json",
+	)
+	fileConnect, err := pty.Start(cmd)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := fileConnect.Close()
+		require.NoError(t, err)
+	})
+
+	scanner := bufio.NewScanner(fileConnect)
+	var connectCliOutputJson string
+	if scanner.Scan() {
+		connectCliOutputJson = scanner.Text()
+	}
+	require.NoError(t, scanner.Err())
+
+	var connectCliOutput ConnectCliOutput
+	err = json.Unmarshal([]byte(connectCliOutputJson), &connectCliOutput)
+	require.NoError(t, err)
+
+	return connectCliOutput
+}


### PR DESCRIPTION
This PR adds a helper method for the `boundary connect` command. It is to be used in the following enterprise tests:
- [Add recording several connections test](https://github.com/hashicorp/boundary-enterprise/pull/623)
- [Add SCP request test](https://github.com/hashicorp/boundary-enterprise/pull/625)

The method scans the first line of the `boundary connect` command's output to parse proxy details (i.e. port, address) and returns them.