### PR TITLE
Update SSH target attributes url typo

### DIFF
--- a/website/content/docs/configuration/session-recording/enable-session-recording.mdx
+++ b/website/content/docs/configuration/session-recording/enable-session-recording.mdx
@@ -19,7 +19,7 @@ You use the storage bucket's ID to associate a target with the storage bucket.
 The key is used for encrypting data and checking the integrity of recordings.
 Refer to [Create the controller configuration](/boundary/docs/install-boundary/configure-controllers#create-the-controller-configuration) for more information about configuring a KMS block.
 - The targets must be configured with an ingress or egress worker filter that includes a worker with access to the storage bucket you created.
-Refer to [SSH target attributes](/boundary/docs/concepts/docmain-model/targets#ssh-target-attributes-hcp-ent) for more information.
+Refer to [SSH target attributes](/boundary/docs/concepts/domain-model/targets#ssh-target-attributes-hcp-ent) for more information.
 - You must enable injected application credentials on any target that you want to use for session recording.
 
 Complete the following steps to enable session recording on a target.


### PR DESCRIPTION
https://developer.hashicorp.com/boundary/docs/concepts/docmain-model/targets#ssh-target-attributes-hcp-ent should be https://developer.hashicorp.com/boundary/docs/concepts/domain-model/targets#ssh-target-attributes-hcp-ent

(domain not docmain)