### PR TITLE
docs: Update HCP only references

### DIFF
--- a/website/content/docs/concepts/credential-management.mdx
+++ b/website/content/docs/concepts/credential-management.mdx
@@ -65,7 +65,7 @@ Learn more about [credential brokering](/boundary/tutorials/hcp-getting-started/
 
 Learn more about the [Vault dynamic secrets engine](/vault/docs/secrets).
 
-## Credential injection <sup>HCP only</sup>
+## Credential injection <sup>HCP/ENT</sup>
 
 Credential injection is the process by which a credential is fetched from a credential store and then passed on to a worker for authentication to a remote machine.
 With credential injection, the user never sees the credential required to authenticate to the target.

--- a/website/content/docs/concepts/domain-model/credential-libraries.mdx
+++ b/website/content/docs/concepts/domain-model/credential-libraries.mdx
@@ -30,7 +30,7 @@ The default value is `GET`.
 - `http_request_body` - (optional) The body of the HTTP request the library sends to Vault when requesting credentials.
 Only valid if `http_method` is set to `POST`.
 
-### Vault SSH certificate credential library attributes <sup>HCP only</sup>
+### Vault SSH certificate credential library attributes <sup>HCP/ENT</sup>
 
 As of Boundary 0.12.0, you can configure SSH credential injection using [Vault's SSH secrets engine](/vault/docs/secrets/ssh) to create the SSH certificate credentials.
 SSH certificate-based authentication extends key-based authentication using digital signatures.

--- a/website/content/docs/concepts/domain-model/credential-stores.mdx
+++ b/website/content/docs/concepts/domain-model/credential-stores.mdx
@@ -58,7 +58,7 @@ A Vault credential store has the following additional attributes:
 - `namespace` - (optional)
   A Vault [namespace][]. Requires Vault Enterprise.
 
-- `worker_filter` <sup>HCP Only</sup> - (optional)
+- `worker_filter` <sup>HCP/ENT</sup> - (optional)
   A [filter] used to control which [PKI workers] can handle Vault requests.
   This allows the use of private Vault instances with Boundary. PKI workers
   deployed in the same network as a private Vault instance can access and relay

--- a/website/content/docs/concepts/filtering/worker-tags.mdx
+++ b/website/content/docs/concepts/filtering/worker-tags.mdx
@@ -144,11 +144,11 @@ when you configure [targets](/boundary/docs/concepts/domain-model/targets).
 The `egress_worker_filter` attribute controls which workers are used for egress to a target. This is the worker
 that accesses the target.
 
-The `ingress_worker_filter`<sup>HCP Only</sup> attribute controls which workers are used for ingress to a target.
+The `ingress_worker_filter`<sup>HCP/ENT</sup> attribute controls which workers are used for ingress to a target.
 This is the worker a client connects to when initiating a connection to a target.
 
 
-# Vault worker filtering <sup>HCP only</sup>
+# Vault worker filtering <sup>HCP/ENT</sup>
 Tags are used to control which [PKI workers] can manage Vault requests by specifying
 a `worker_filter`attribute when configuring [credential stores].
 


### PR DESCRIPTION
The **HCP only** tag should be updated to **HCP/ENT** in places where a feature is supported by both versions. This PR fixes some topics that I missed in the 0.13 release.