### PR TITLE
fix(cmd): pass in PublicClusterAddr from the config

### DIFF
--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -302,7 +302,7 @@ func (c *Command) Run(args []string) int {
 			c.UI.Error(`Config activates controller but no listener with "cluster" purpose found`)
 			return base.CommandUserError
 		}
-		if err := c.Config.SetupControllerPublicClusterAddress(""); err != nil {
+		if err := c.Config.SetupControllerPublicClusterAddress(c.Config.Controller.PublicClusterAddr); err != nil {
 			c.UI.Error(err.Error())
 			return base.CommandUserError
 		}
@@ -821,7 +821,7 @@ func (c *Command) Reload(newConf *config.Config) error {
 	if newConf != nil && c.worker != nil {
 		workerReloadErr := func() error {
 			if newConf.Controller != nil {
-				if err := newConf.SetupControllerPublicClusterAddress(""); err != nil {
+				if err := newConf.SetupControllerPublicClusterAddress(newConf.Controller.PublicClusterAddr); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
## Summary:

Users should be able to include a public_cluster_addr field in the controller stanza of their config file.  The value entered there should be used when reporting down to workers which addresses they should use when attempting to connect to the set of controller.  This no longer works.

### Fix:

Pass in the public_cluster_addr from the config into the `SetupControllerPublicClusterAddress` function. When public_cluster_addr is not set by the user, it should fall back to the cluster listener value.