### PR TITLE
docs: Fix a capitalization error in the TOC

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -46,7 +46,7 @@
     ]
   },
   {
-    "title": "Get Started",
+    "title": "Get started",
     "routes": [
       {
         "title": "Overview",


### PR DESCRIPTION
In PR #3396 , I updated headings and the TOC to use sentence style capitalization. I missed one of the TOC entries. This pull request updates that entry.