### PR TITLE
chore: Remove automatic backport to latest release branch

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,26 +23,6 @@ jobs:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
           BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      - name: Backport changes to latest release branch
-        run: |
-          resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/labels?per_page=100")
-          ret="$?"
-          if [[ "$ret" -ne 0 ]]; then
-              echo "The GitHub API returned $ret"
-              exit $ret
-          fi
-
-          # get the latest backport label excluding any website labels, ex: `backport/0.3.x` and not `backport/website`
-          latest_backport_label=$(echo "$resp" | jq -r '.[] | select(.name | (startswith("backport/") and (contains("website") | not))) | .name' | sort -rV | head -n1)
-          echo "Latest backport label: $latest_backport_label"
-
-          # set BACKPORT_TARGET_TEMPLATE for backport-assistant
-          # trims backport/ from the beginning with parameter substitution
-          export BACKPORT_TARGET_TEMPLATE="release/${latest_backport_label#backport/}"
-          backport-assistant backport -automerge
-        env:
-          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
-          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to targeted release branch
         run: |
           backport-assistant backport -automerge


### PR DESCRIPTION
This PR updates the `Backport` workflow to remove the automatic backport to the latest release branch when the `backport/website` label is applied to a PR. This mitigates some unintended merges to other branches. If a change needs to be added to the latest release branch, the `backport/<version>` label can be added to the PR.

This comes from a request at Boundary Docs Days. When we first created `0.13.0`, there may have been some differences in procedures and the `release/0.13.x` branch wasn't created. As a result, lots of backport PRs were trying to merge to `release/0.12.x` (the latest release version) and throwing lots of errors and conflicts.

Currently...
- when you add the `backport/website` label, it will backport to `stable-website` and the latest release branch
- when you add the `backport/<version>` label, it will backport to the specified release branch

Proposal...
- when you add the `backport/website` label, it will backport to `stable-website`
- when you add the `backport/<version>` label, it will backport to the specified release branch

