### PR TITLE
docs: Update enable session recording on a target

### DIFF
--- a/website/content/docs/configuration/session-recording/enable-session-recording.mdx
+++ b/website/content/docs/configuration/session-recording/enable-session-recording.mdx
@@ -68,9 +68,6 @@ Complete the following steps to enable session recording on a target.
 The following settings are required for session recording:
 
    - Select **SSH** for the **Type**.
-   - On the **Injected Application Credentials** tab, select the inject application credential sources you want to use for this target.
-
-      ![Add injected application credentials](/img/inject-creds.png)
 
 1. Select **Save**.
 1. Select **Enable recording**.

--- a/website/content/docs/configuration/session-recording/enable-session-recording.mdx
+++ b/website/content/docs/configuration/session-recording/enable-session-recording.mdx
@@ -65,7 +65,7 @@ Complete the following steps to enable session recording on a target.
    - To create a new target, select **New Target**.
    - To edit an existing target, select the target, and then select **Edit Form**.
 1. Configure the target with any relevant [attributes](/boundary/docs/concepts/domain-model/targets).
-The following settings are required for session recording:
+The following setting is required for session recording:
 
    - Select **SSH** for the **Type**.
 


### PR DESCRIPTION
We don't need to inject an application credential source to enable session recording on a target. We only need an injected application credential source before making a target connection.