### PR TITLE
chore: Prevent build and test workflows on docs-only changes

### DIFF
--- a/.github/scripts/verify_changes.sh
+++ b/.github/scripts/verify_changes.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#  This script validates if the git diff contains only docs changes
+
+event_type=$1 # GH event type (pull_request)
+ref_name=$2 # branch reference that triggered the workflow
+base_ref=$3 # PR branch base ref
+
+contains() {
+    target=$1; shift
+    for i; do
+        if [[ "$i" == "$target" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+if [[ "$event_type" == "pull_request" ]]; then
+  git fetch --no-tags --prune origin $base_ref
+  head_commit="HEAD"
+  base_commit="origin/$base_ref"
+else
+  git fetch --no-tags --prune origin $ref_name
+  head_commit=$(git log origin/$ref_name --oneline | head -1 | awk '{print $1}')
+  base_commit=$(git log origin/$ref_name --oneline | head -2 | awk 'NR==2 {print $1}')
+fi
+
+# git diff with ... shows the differences between base_commit and head_commit starting at the last common commit
+changed_dir=$(git diff $base_commit...$head_commit --name-only | awk -F"/" '{ print $1}' | uniq)
+change_count=$(git diff $base_commit...$head_commit --name-only | awk -F"/" '{ print $1}' | uniq | wc -l)
+
+# If the only change is in the website directory, mark as a docs change
+if [[ $change_count -eq 1 && "$changed_dir" == "website" ]]; then
+  echo "is_docs_change=true" >> "$GITHUB_OUTPUT"
+else
+  echo "is_docs_change=false" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,13 @@ permissions:
   actions: write
 
 jobs:
+  # verify-changes determines if the changes are only for docs (website)
+  verify-changes:
+    uses: ./.github/workflows/verify_changes.yml
+
   set-product-version:
+    needs: verify-changes
+    if: ${{ needs.verify-changes.outputs.is_docs_change == 'false' }}
     runs-on: ${{ fromJSON(vars.BUILDER_LINUX) }}
     outputs:
       product-version: ${{ steps.set-product-version.outputs.product-version }}
@@ -412,6 +418,7 @@ jobs:
       docker-image-name: ${{ needs.build-docker.outputs.name }}
       docker-image-file: "boundary_default_linux_amd64_${{ needs.set-product-version.outputs.product-version }}_${{ github.sha }}.docker.dev.tar"
     secrets: inherit
+
   bats:
     uses: ./.github/workflows/test-cli-ui_oss.yml
     if: github.event.pull_request.head.repo.fork != 'true'

--- a/.github/workflows/test-sql.yml
+++ b/.github/workflows/test-sql.yml
@@ -9,7 +9,13 @@ permissions:
   contents: read
 
 jobs:
+  # verify-changes determines if the changes are only for docs (website)
+  verify-changes:
+    uses: ./.github/workflows/verify_changes.yml
+
   test-sql:
+    needs: verify-changes
+    if: ${{ needs.verify-changes.outputs.is_docs_change == 'false' }}
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,13 @@ env:
   DOCKER_MIRROR: docker.mirror.hashicorp.services
 
 jobs:
+  # verify-changes determines if the changes are only for docs (website)
+  verify-changes:
+    uses: ./.github/workflows/verify_changes.yml
+
   setup:
+    needs: verify-changes
+    if: ${{ needs.verify-changes.outputs.is_docs_change == 'false' }}
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
       cache-go-build: ${{ steps.go-cache-paths.outputs.go-build }}

--- a/.github/workflows/verify_changes.yml
+++ b/.github/workflows/verify_changes.yml
@@ -1,0 +1,28 @@
+name: verify_changes
+
+on:
+  workflow_call:
+    outputs:
+      is_docs_change:
+        description: "determines if the changes contains docs"
+        value: ${{ jobs.verify-doc-changes.outputs.is_docs_change }}
+
+jobs:
+  # verify-doc-changes determines if the changes are only for docs (website)
+  verify-doc-changes:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    outputs:
+      is_docs_change: ${{ steps.get-changeddir.outputs.is_docs_change }}
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # Use fetch depth 0 for comparing changes to base branch
+      - name: Get changed directories
+        id: get-changeddir
+        env:
+          TYPE: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          BASE: ${{ github.base_ref }}
+        run: ./.github/scripts/verify_changes.sh ${{ env.TYPE }} ${{ env.REF_NAME }} ${{ env.BASE }}


### PR DESCRIPTION
This PR prevents the `build` and `test` GitHub Actions workflows from running if the only changes are in the `website/` directory. This allows the docs changes to more rapidly make changes without having to wait for the longer workflows, especially since docs changes should have no impact on the application.

The script and implementation was heavily borrowed from Vault: https://github.com/hashicorp/vault/blob/main/.github/scripts/verify_changes.sh

This was tested by this test commit: https://github.com/hashicorp/boundary/commit/47b2dd898d34128817f25d49e4d53e122e4114ac. I forced `is_docs_change=true` to validate that it will prevent `build` and `test` workflows from executing. I also confirmed that making a change in the `website/` directory will get detected by the script.