### PR TITLE
chore: prefer gosec for semgrep rule and turn on codeql

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,7 +6,9 @@ on:
   pull_request:
     branches:
       - 'main'
-
+    paths-ignore:
+      - 'website/'
+      
 jobs:
   scan:
     runs-on: ${{ fromJSON(vars.RUNNER_LARGE) }}

--- a/scan.hcl
+++ b/scan.hcl
@@ -14,7 +14,7 @@ repository {
   
   plugin "semgrep" {
     use_git_ignore = true
-    exclude = ["^.*_test\.go$", "website/*", "testing/*"]
+    exclude = ["*_test.go", "website/*", "testing/*"]
     config = ["p/gosec"]
   }
   

--- a/scan.hcl
+++ b/scan.hcl
@@ -14,9 +14,8 @@ repository {
   
   plugin "semgrep" {
     use_git_ignore = true
-    exclude = ["testing", "website"]
+    exclude = ["^.*_test\.go$", "website/*", "testing/*"]
     config = ["p/gosec"]
-    # exclude_rule = ["generic.html-templates.security.unquoted-attribute-var.unquoted-attribute-var"]
   }
   
   plugin "codeql" {

--- a/scan.hcl
+++ b/scan.hcl
@@ -15,11 +15,11 @@ repository {
   plugin "semgrep" {
     use_git_ignore = true
     exclude = ["testing", "website"]
-    config = ["p/r2c-security-audit"]
-    exclude_rule = ["generic.html-templates.security.unquoted-attribute-var.unquoted-attribute-var"]
+    config = ["p/gosec"]
+    # exclude_rule = ["generic.html-templates.security.unquoted-attribute-var.unquoted-attribute-var"]
   }
   
-  # plugin "codeql" {
-  #  languages = ["go"]
-  # }
+  plugin "codeql" {
+    languages = ["go"]
+   }
 }


### PR DESCRIPTION
Enabling CodeQL scanning since we can use beefier runners. Also moving to [gosec](https://github.com/securego/gosec) Semgrep rules for a more targeted ruleset.