### PR TITLE
docs: update view session recordings in ui steps

### DIFF
--- a/website/content/docs/operations/manage-recorded-sessions.mdx
+++ b/website/content/docs/operations/manage-recorded-sessions.mdx
@@ -21,7 +21,10 @@ You can view any sessions that Boundary recorded in your storage provider or via
 
 You can view a list of all recorded sessions, or if you know the ID of a specific recorded session, you can find any channels associated with that recording.
 
-### Find all recorded sessions
+<Tabs>
+<Tab heading="CLI">
+
+## Find all recorded sessions
 
 Complete the following steps to find all recorded sessions using the CLI.
 
@@ -34,29 +37,13 @@ Complete the following steps to find all recorded sessions using the CLI.
 
    Boundary displays a list of all recorded sessions by scope.
 
-### Find a specific recorded session by ID
+## Find a specific recorded session by ID
 
 If you have the ID of a recorded session, you can use the following command to list the connections and channels associated with a session recording.
 
 ```bash
 boundary session-recordings read -id <id>
 ```
-
-## View recorded sessions
-
-You can view recorded sessions in the UI, if you have the proper permissions.
-
-1. Log in to Boundary.
-1. Select **Orgs** in the navigation pane.
-1. Select the org that contains the target from the recorded session you want to view.
-1. Select **Session Recordings** in the navigation pane.
-
-   The **Session Recordings** page displays the time, user, target, and duration of the recording.
-1. Select **View** next to the recording you want to view.
-1. Select **Play** next to the channel recording you want to view.
-
-   The recorded session appears in the media plyaer.
-   You can click the **Play** button to watch the recording.
 
 ## Download recorded session channels
 
@@ -78,3 +65,23 @@ Substitute the ID of the channel for **chr_1234567890**:
    ```bash
    boundary session-recordings download -id chr_1234567890
    ```
+
+</Tab>
+<Tab heading="Admin Console">
+
+## View recorded sessions
+
+You can view all recorded sessions in the UI from the global scope.
+
+1. Log in to Boundary.
+1. Select **Session Recordings** in the navigation pane.
+
+   The **Session Recordings** page displays the created time, user, project, target, and duration of the recording.
+1. Select **View** next to the session recording you want to view.
+1. Select **Play** next to the channel recording you want to view.
+
+   The recorded session appears in the media player.
+   You can click the **Play** button to watch the recording.
+
+</Tab>
+</Tabs>

--- a/website/content/docs/operations/manage-recorded-sessions.mdx
+++ b/website/content/docs/operations/manage-recorded-sessions.mdx
@@ -77,24 +77,24 @@ You can find all recorded sessions in the UI from the global scope.
    The **Session Recordings** page displays the created time, user, project,
    target, and duration of the recording.
 
-## View Session Recording details
+## View session recording details
 
 1. Select **View** next to the session recording you want to view.
 
    The details page has information related to the session recording and
    links to related inforation like user, target, and storage bucket.
 
-## Playback Channel Recording
+## Play back channel recording
 
 1. Select **Play** next to the channel recording you want to view.
 
    The recorded session appears in the media player.
-   You can click the **Play** button located at the bottom of the media player
+   Click the **Play** button located at the bottom of the media player
    to watch the recording.
 
-   If a recorded session channel does not support playback a **View** button
-   will be shown. The playback page will display a message stating playback
-   is not supported but still show details specific to that channel.
+   If a recorded session channel does not support playback, a **View** button
+   is shown. The playback page displays a message stating that playback
+   is not supported, but still shows details specific to that channel.
 
 </Tab>
 </Tabs>

--- a/website/content/docs/operations/manage-recorded-sessions.mdx
+++ b/website/content/docs/operations/manage-recorded-sessions.mdx
@@ -13,8 +13,6 @@ The session begins when an authorized user requests access to a target, and it e
 When you enable session recording on a target, any user session that connects to the target is automatically recorded.
 An administrator can later view the recordings to investigate security issues, review system activity, or perform regular assessments of security policies and procedures.
 
-## Find recorded sessions
-
 Recorded sessions are stored in an external storage bucket that you create.
 Storing session recordings in a system external to Boundary means those recordings can be accessed, modified, deleted, and even restored independently of Boundary.
 You can view any sessions that Boundary recorded in your storage provider or via the CLI.
@@ -69,19 +67,34 @@ Substitute the ID of the channel for **chr_1234567890**:
 </Tab>
 <Tab heading="Admin Console">
 
-## View recorded sessions
+## Find all recorded sessions
 
-You can view all recorded sessions in the UI from the global scope.
+You can find all recorded sessions in the UI from the global scope.
 
 1. Log in to Boundary.
 1. Select **Session Recordings** in the navigation pane.
 
-   The **Session Recordings** page displays the created time, user, project, target, and duration of the recording.
+   The **Session Recordings** page displays the created time, user, project,
+   target, and duration of the recording.
+
+## View Session Recording details
+
 1. Select **View** next to the session recording you want to view.
+
+   The details page has information related to the session recording and
+   links to related inforation like user, target, and storage bucket.
+
+## Playback Channel Recording
+
 1. Select **Play** next to the channel recording you want to view.
 
    The recorded session appears in the media player.
-   You can click the **Play** button to watch the recording.
+   You can click the **Play** button located at the bottom of the media player
+   to watch the recording.
+
+   If a recorded session channel does not support playback a **View** button
+   will be shown. The playback page will display a message stating playback
+   is not supported but still show details specific to that channel.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
Since we had steps for viewing session recordings and playback related to the UI already, I split the current steps into a `CLI` tab and `Admin Console` tab. The Admin Console tab is fairly sparse and I wonder if this is an exception for a screenshot or gif showing the player in the UI. Let me know your thoughts on that.

I also wanted to ask if we should include a note for channels that cannot be played back. Right now, they are buttons that show as `View` instead of `Play` and have no player shown and just details related to that specific channel recording.

Example with a screenshot of the player:
<img width="1011" alt="Screen Shot 2023-07-12 at 5 31 08 PM" src="https://github.com/hashicorp/boundary/assets/29386339/dfae389b-3ade-40fa-a7d4-0b5f0db3595d">
