### PR TITLE
chore: Ignore website directory for build and test workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
       - '**'
     tags-ignore:
       - '**'
+    paths-ignore:
+      - 'website/'
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,9 @@
 name: "golangci-lint"
-on: ["pull_request"]
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'website/**'
 
 permissions:
   contents: read

--- a/.github/workflows/test-sql.yml
+++ b/.github/workflows/test-sql.yml
@@ -1,9 +1,11 @@
 name: test-sql
 
 on:
-  - workflow_dispatch
-  - push
-  - workflow_call
+  push:
+    paths-ignore:
+      - 'website/**'
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,11 @@
 name: test
 
 on:
-  - workflow_dispatch
-  - push
-  - workflow_call
+  push:
+    paths-ignore:
+      - 'website/**'
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR prevents the build and test GitHub Actions workflows from running if the only changes in a PR are in the website/ directory. This allows docs changes to more rapidly make changes without having to wait for the longer workflows, especially since docs changes should have no impact on the application.