### PR TITLE
fix paths-ignore on security-scan workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - 'main'
     paths-ignore:
-      - 'website/'
+      - 'website/**'
       
 jobs:
   scan:


### PR DESCRIPTION
adding `**` per https://github.com/hashicorp/boundary/pull/3418#discussion_r1262902487