### PR TITLE
docs: add code blocks to LDAP auth method docs

### DIFF
--- a/website/content/docs/concepts/domain-model/auth-methods.mdx
+++ b/website/content/docs/concepts/domain-model/auth-methods.mdx
@@ -35,33 +35,33 @@ The password auth method has the following additional attributes:
 
 The ldap auth method has the following additional attributes:
 
-- `state` - The state of the auth method; either inactive, active-private, or
-  active-public.
+- `state` - The state of the auth method; either `inactive`, `active-private`, or
+  `active-public`.
 
-- `start_tls` - (optional) If true, issues a StartTLS command after establishing
-  an unencrypted connection. Defaults to false.
+- `start_tls` - (optional) If `true`, issues a StartTLS command after establishing
+  an unencrypted connection. Defaults to `false`.
 
-- `insecure_tls` - (optional) If true, skips LDAP server SSL certificate
+- `insecure_tls` - (optional) If `true`, skips LDAP server SSL certificate
   validation, which is insecure and should be used with caution. Defaults to
-  false.
+  `false`.
 
-- `discover_dn` - (optional) If true, use anon bind to discover the bind DN
-  (Distinguished Name) of a user. Defaults to false.
+- `discover_dn` - (optional) If `true`, use anon bind to discover the bind DN
+  (Distinguished Name) of a user. Defaults to `false`.
 
-- `anon_group_search` - (optional) If true, use anon bind when performing LDAP
-  group searches. Defaults to false.
+- `anon_group_search` - (optional) If `true`, use anon bind when performing LDAP
+  group searches. Defaults to `false`.
 
-- `upn_domain` - (optional) If set, the userPrincipalDomain is used to construct
+- `upn_domain` - (optional) If set, the `userPrincipalDomain` is used to construct
   the UPN string for the authenticating user. The constructed UPN appears as
-  [username]@UPNDomain  Example: example.com, which causes Boundary to
-  bind as username@example.com when it authenticates the user.
+  `[username]@UPNDomain`. Example: `example.com`, which causes Boundary to
+  bind as `username@example.com` when it authenticates the user.
 
 - `urls` - (required) The LDAP URLS that specify LDAP servers to connect to.
   There must be at least one URL for each LDAP auth method. When attempting to
   connect, the URLs are tried in the order specified.
 
 - `user_dn` - (optional) If set, the base DN under which to perform user
-  search. Example: ou=Users,dc=example,dc=com
+  search. Example: `ou=Users,dc=example,dc=com`.
 
 - `user_attr` - (optional) If set, defines the attribute on a user's entry
   matching the login-name passed when the user authenticates.  Examples: cn, uid
@@ -72,24 +72,24 @@ The ldap auth method has the following additional attributes:
   or (userPrincipalName={{.Username}}@UPNDomain) if the upn-domain parameter is
   set.
 
-- `enable_groups` - (optional) If true, an authenticated user's groups are
-  found during authentication. Defaults to false.
+- `enable_groups` - (optional) If `true`, an authenticated user's groups are
+  found during authentication. Defaults to `false`.
 
 - `group_dn` - (optional) If set, the base DN under which to perform a group
-  search. Example: ou=Groups,dc=example,dc=com
+  search. Example: `ou=Groups,dc=example,dc=com`.
 
   Note: There is no default, so no base DN is used for group searches, if
   it's not specified.
 
 - `group_attr` - (optional) If set, the LDAP attribute to follow on objects
-  returned by group_filter in order to enumerate user group membership.
-  Examples: for group_filter queries returning group objects, use: cn. For
-  queries returning user objects, use: memberOf. The default is cn.
+  returned by `group_filter` in order to enumerate user group membership.
+  Examples: for `group_filter` queries returning group objects, use: `cn`. For
+  queries returning user objects, use: `memberOf`. The default is `cn`.
 
 - `group_filter` - (optional) If set, the Go template used when constructing the
   group membership query. The template can access the following context
-  variables: [UserDN, Username]. The default is
-  (|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}})),
+  variables: `UserDN`, `Username`. The default is
+  `(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))`,
   which is compatible with several common directory schemas.
 
 - `certificates` - (optional) If set, PEM encoded x509 certificates in ASN.1
@@ -106,20 +106,20 @@ The ldap auth method has the following additional attributes:
 
 - `bind_dn` - (optional) If set, the distinguished name of entry to bind when
   performing user and group searches. Example:
-  cn=vault,ou=Users,dc=example,dc=com
+  `cn=vault,ou=Users,dc=example,dc=com`.
 
-- `bind_password` - (optional) If set, the password to use along with bind_dn
+- `bind_password` - (optional) If set, the password to use along with `bind_dn`
   when performing user search. It must be set, if you specify the optional
-  bind_dn.
+  `bind_dn`.
 
-- `use_token_groups` - (optional) If true, use the Active Directory tokenGroups
+- `use_token_groups` - (optional) If `true`, use the Active Directory `tokenGroups`
   constructed attribute of the user to find the group memberships. This
   finds all security groups, including nested ones.
 
 - `account_attribute_maps` - (optional) If set, the attribute maps from custom
   attributes to the standard fullname and email account attributes. These
-  maps are represented as key=value where the key equals the from_attribute, and
-  the value equals the to_attribute.  For example, "preferredName=fullName".  All
+  maps are represented as `key=value` where the key equals the `from_attribute`, and
+  the value equals the `to_attribute`.  For example, `preferredName=fullName`.  All
   attribute names are case insensitive.
 
 

--- a/website/content/docs/concepts/domain-model/auth-methods.mdx
+++ b/website/content/docs/concepts/domain-model/auth-methods.mdx
@@ -68,8 +68,9 @@ The ldap auth method has the following additional attributes:
 
 - `user_filter` - (optional) If set, the Go template used to construct an LDAP
   user search filter. The template can access the following context variables:
-  [UserAttr, Username]. The default user_filter is ({{.UserAttr}}={{.Username}})
-  or (userPrincipalName={{.Username}}@UPNDomain) if the upn-domain parameter is
+  [UserAttr, Username]. The default `user_filter` is
+  `({{.UserAttr}}={{.Username}})` or
+  `(userPrincipalName={{.Username}}@UPNDomain)` if the `upn-domain` parameter is
   set.
 
 - `enable_groups` - (optional) If `true`, an authenticated user's groups are


### PR DESCRIPTION
The code blocks make it much clearer what is and isn't an example.