### PR TITLE
chore: Change summary errors field type

### DIFF
--- a/internal/bsr/types.go
+++ b/internal/bsr/types.go
@@ -8,6 +8,14 @@ import (
 	"time"
 )
 
+type SummaryError struct {
+	Message string
+}
+
+func (e *SummaryError) Error() string {
+	return e.Message
+}
+
 // BaseSummary contains the common fields of all summary types.
 type BaseSummary struct {
 	Id        string
@@ -48,7 +56,7 @@ type BaseSessionSummary struct {
 	ConnectionCount uint64
 	StartTime       time.Time
 	EndTime         time.Time
-	Errors          error
+	Errors          SummaryError
 }
 
 // SessionSummary contains statistics for a session container
@@ -88,12 +96,12 @@ func (b *BaseSessionSummary) GetConnectionCount() uint64 {
 
 // GetErrors returns errors.
 func (b *BaseSessionSummary) GetErrors() error {
-	return b.Errors
+	return &b.Errors
 }
 
 // SetErrors sets errors.
 func (b *BaseSessionSummary) SetErrors(e error) {
-	b.Errors = e
+	b.Errors = SummaryError{Message: e.Error()}
 }
 
 // BaseChannelSummary encapsulates data for a channel, including its id, channel type,
@@ -169,7 +177,7 @@ type BaseConnectionSummary struct {
 	EndTime      time.Time
 	BytesUp      uint64
 	BytesDown    uint64
-	Errors       error
+	Errors       SummaryError
 }
 
 // ConnectionSummary contains statistics for a connection container
@@ -223,10 +231,10 @@ func (b *BaseConnectionSummary) GetBytesDown() uint64 {
 
 // GetErrors returns errors.
 func (b *BaseConnectionSummary) GetErrors() error {
-	return b.Errors
+	return &b.Errors
 }
 
 // SetErrors sets errors.
 func (b *BaseConnectionSummary) SetErrors(e error) {
-	b.Errors = e
+	b.Errors = SummaryError{Message: e.Error()}
 }

--- a/internal/bsr/types.go
+++ b/internal/bsr/types.go
@@ -5,16 +5,9 @@ package bsr
 
 import (
 	"context"
+	"errors"
 	"time"
 )
-
-type SummaryError struct {
-	Message string
-}
-
-func (e *SummaryError) Error() string {
-	return e.Message
-}
 
 // BaseSummary contains the common fields of all summary types.
 type BaseSummary struct {
@@ -56,7 +49,7 @@ type BaseSessionSummary struct {
 	ConnectionCount uint64
 	StartTime       time.Time
 	EndTime         time.Time
-	Errors          SummaryError
+	Errors          string
 }
 
 // SessionSummary contains statistics for a session container
@@ -96,12 +89,12 @@ func (b *BaseSessionSummary) GetConnectionCount() uint64 {
 
 // GetErrors returns errors.
 func (b *BaseSessionSummary) GetErrors() error {
-	return &b.Errors
+	return errors.New(b.Errors)
 }
 
 // SetErrors sets errors.
 func (b *BaseSessionSummary) SetErrors(e error) {
-	b.Errors = SummaryError{Message: e.Error()}
+	b.Errors = e.Error()
 }
 
 // BaseChannelSummary encapsulates data for a channel, including its id, channel type,
@@ -177,7 +170,7 @@ type BaseConnectionSummary struct {
 	EndTime      time.Time
 	BytesUp      uint64
 	BytesDown    uint64
-	Errors       SummaryError
+	Errors       string
 }
 
 // ConnectionSummary contains statistics for a connection container
@@ -231,10 +224,10 @@ func (b *BaseConnectionSummary) GetBytesDown() uint64 {
 
 // GetErrors returns errors.
 func (b *BaseConnectionSummary) GetErrors() error {
-	return &b.Errors
+	return errors.New(b.Errors)
 }
 
 // SetErrors sets errors.
 func (b *BaseConnectionSummary) SetErrors(e error) {
-	b.Errors = SummaryError{Message: e.Error()}
+	b.Errors = e.Error()
 }


### PR DESCRIPTION
decoding summary `Errors` field currently fails with type `error`.  Using a string type to handle `Errors` field

**Previous commit approach**
Using a custom `SummaryError` type that implements the `error` interface to fix this issue. This caused the `Errors` field to be nested. eg. `Errors: { Message: "err"}` which failed other tests