### PR TITLE
chore: Add missing ** in paths-ignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     tags-ignore:
       - '**'
     paths-ignore:
-      - 'website/'
+      - 'website/**'
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/hashicorp/boundary/pull/3426/files, which attempts to prevent certain workflows from running when there are only changes in the `website/` directory. This PR fixes one of the paths to make sure it's appropriately set.