### PR TITLE
Draft connection option documentation for kube, http, and rdp

### DIFF
--- a/website/content/docs/api-clients/commands/connect/http.mdx
+++ b/website/content/docs/api-clients/commands/connect/http.mdx
@@ -6,3 +6,67 @@ description: |-
 ---
 
 # connect http
+
+Command: `boundary connect http`
+
+The `connect http` command will authorize a session against a target and invoke an
+http client to connect, filling in the local address and port.
+
+You also have access to some templated values that are substituted into the
+command arguments, and these values are additionally injected as environment
+variables in the executed command:
+
+- `{{boundary.ip}}` (`BOUNDARY_PROXIED_IP`): The IP address of the listening
+  socket that `boundary connect` has opened.
+- `{{boundary.port}}` (`BOUNDARY_PROXIED_PORT`): The port of the listening
+  socket that `boundary connect` has opened.
+- `{{boundary.addr}}` (`BOUNDARY_PROXIED_ADDR`): The host:port format of the
+  address. This is essentially equivalent to `{{boundary.ip}}:{{boundary.port}}`.
+
+## Examples
+
+Authorize a session to target id named "ttcp_1234567890" and invoke default http client `curl`
+
+```shell-session
+$ boundary connect http \
+   -target-id ttcp_1234567890
+```
+
+## Usage
+
+```shell-session
+$ boundary connect http [options] [args]
+```
+
+This command performs a target authorization (or consumes an
+existing authorization token) and launches a proxied http connection.
+
+### HTTP Options:
+
+- `-host=<string>`
+  Specifies the host value to use, overriding the endpoint address from
+  the session information. The specified hostname will be passed through
+  to the client (if supported) for use in the Host header and TLS SNI
+  value. This can also be specified via the BOUNDARY_CONNECT_HTTP_HOST
+  environment variable.
+
+- `-method=<string>`
+  Specifies the method to use. If not set, will use the client's default.
+  This can also be specified via the BOUNDARY_CONNECT_HTTP_METHOD
+  environment variable.
+
+- `-path=<string>`
+  Specifies a path that will be appended to the generated URL. This
+  can also be specified via the BOUNDARY_CONNECT_HTTP_PATH environment
+  variable.
+
+- `-scheme=<string>`
+  Specifies the scheme to use. The default is https. This can also be
+  specified via the BOUNDARY_CONNECT_HTTP_SCHEME environment variable.
+
+- `-style=<string>`
+  Specifies how the CLI will attempt to invoke an HTTP client. This will
+  also set a suitable default for -exec if a value was not specified.
+  Currently-understood values are "curl". The default is curl. This
+  can also be specified via the BOUNDARY_CONNECT_HTTP_STYLE environment
+  variable.

--- a/website/content/docs/api-clients/commands/connect/kube.mdx
+++ b/website/content/docs/api-clients/commands/connect/kube.mdx
@@ -6,3 +6,57 @@ description: |-
 ---
 
 # connect kube
+
+Command: `boundary connect kube`
+
+The `connect kube` command will authorize a session against a target and invoke an
+Kubernetes client to connect, filling in the local address and port.
+
+You also have access to some templated values that are substituted into the
+command arguments, and these values are additionally injected as environment
+variables in the executed command:
+
+- `{{boundary.ip}}` (`BOUNDARY_PROXIED_IP`): The IP address of the listening
+  socket that `boundary connect` has opened.
+- `{{boundary.port}}` (`BOUNDARY_PROXIED_PORT`): The port of the listening
+  socket that `boundary connect` has opened.
+- `{{boundary.addr}}` (`BOUNDARY_PROXIED_ADDR`): The host:port format of the
+  address. This is essentially equivalent to `{{boundary.ip}}:{{boundary.port}}`.
+
+## Examples
+
+Authorize a session to target id named "ttcp_1234567890" and run `get nodes` command using default `kubectl` client
+
+```shell-session
+$ boundary connect kube \
+   -target-id ttcp_t12345 \
+   -- get nodes
+```
+
+## Usage
+
+```shell-session
+$ boundary connect kube [options] [args]
+```
+
+This command performs a target authorization (or consumes an
+existing authorization token) and launches a proxied kube connection.
+
+### Kubernetes Options:
+
+- `-host=<string>`
+  Specifies the host value to use, overriding the endpoint address from
+  the session information. The specified hostname will be passed through
+  to the client (if supported) for use in the TLS SNI value. This can also
+  be specified via the BOUNDARY_CONNECT_KUBE_HOST environment variable.
+
+- `-scheme=<string>`
+  Specifies the scheme to use. The default is https. This can also be
+  specified via the BOUNDARY_CONNECT_KUBE_SCHEME environment variable.
+
+- `-style=<string>`
+  Specifies how the CLI will attempt to invoke a Kubernetes client. This
+  will also set a suitable default for -exec if a value was not specified.
+  Currently-understood values are "kubectl". The default is kubectl. This
+  can also be specified via the BOUNDARY_CONNECT_KUBE_STYLE environment
+  variable.

--- a/website/content/docs/api-clients/commands/connect/rdp.mdx
+++ b/website/content/docs/api-clients/commands/connect/rdp.mdx
@@ -6,3 +6,56 @@ description: |-
 ---
 
 # connect rdp
+
+Command: `boundary connect rdp`
+
+The `connect rdp` command will authorize a session against a target and invoke an
+RDP client to connect, filling in the local address and port.
+
+You also have access to some templated values that are substituted into the
+command arguments, and these values are additionally injected as environment
+variables in the executed command:
+
+- `{{boundary.ip}}` (`BOUNDARY_PROXIED_IP`): The IP address of the listening
+  socket that `boundary connect` has opened.
+- `{{boundary.port}}` (`BOUNDARY_PROXIED_PORT`): The port of the listening
+  socket that `boundary connect` has opened.
+- `{{boundary.addr}}` (`BOUNDARY_PROXIED_ADDR`): The host:port format of the
+  address. This is essentially equivalent to `{{boundary.ip}}:{{boundary.port}}`.
+
+## Examples
+
+Authorize a session to target id named "ttcp_1234567890" and invoke an RDP session with built-in Windows RDP client (`mstsc`)
+
+```shell-session
+$ boundary connect rdp \
+   -target-id ttcp_1234567890
+```
+
+Authorize a session to a target id named "ttcp_123457890" and invoke a custom command for RDP (macOS) client
+
+```shell-session
+$ boundary connect rdp \
+   -target-id ttcp_1234567890
+   -exec bash \
+   -- -c "open rdp://full%20address=s={{boundary.addr}} && sleep 600"
+```
+
+## Usage
+
+```shell-session
+$ boundary connect rdp [options] [args]
+```
+
+This command performs a target authorization (or consumes an
+existing authorization token) and launches a proxied rdp connection.
+
+### RDP Options:
+
+- `-style=<string>`
+  Specifies how the CLI will attempt to invoke an RDP client. This will
+  also set a suitable default for -exec if a value was not specified.
+  urrently-understood values are "mstsc", which is the default on Windows
+  and launches the Windows client, and "open", which is the default on
+  Mac and launches via an rdp:// URL. This can also be specified via the
+  BOUNDARY_CONNECT_RDP_STYLE environment variable.


### PR DESCRIPTION
Connect helper documentation for 'http', 'kube', and 'rdp'