### PR TITLE
test(e2e): Build UI when running docker scenarios locally

### DIFF
--- a/enos/modules/build_boundary_docker_local/build.sh
+++ b/enos/modules/build_boundary_docker_local/build.sh
@@ -9,6 +9,6 @@ root_dir="$(git rev-parse --show-toplevel)"
 pushd "${root_dir}" > /dev/null
 
 export IMAGE_TAG_DEV="${IMAGE_NAME}"
-make docker-build-dev
+make build-ui docker-build-dev
 
 popd > /dev/null

--- a/testing/internal/e2e/boundary/session.go
+++ b/testing/internal/e2e/boundary/session.go
@@ -49,6 +49,7 @@ func WaitForSessionCli(t testing.TB, ctx context.Context, projectId string) *ses
 			}
 
 			session = sessionListResult.Items[0]
+			t.Logf("Created Session: %s", session.Id)
 			return nil
 		},
 		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),


### PR DESCRIPTION
This PR updates the e2e test suite to ensure we re-build the boundary UI when running a docker scenario locally. This ensures we have updated UI changes. 