### PR TITLE
test(e2e): Update grants to use new ids field

### DIFF
--- a/testing/internal/e2e/tests/base/session_cancel_group_test.go
+++ b/testing/internal/e2e/tests/base/session_cancel_group_test.go
@@ -99,7 +99,7 @@ func TestCliSessionCancelGroup(t *testing.T) {
 
 	// Create a role for a group
 	newRoleId := boundary.CreateNewRoleCli(t, ctx, newProjectId)
-	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "id=*;type=target;actions=authorize-session")
+	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "ids=*;type=target;actions=authorize-session")
 	boundary.AddPrincipalToRoleCli(t, ctx, newRoleId, newGroupId)
 
 	// Connect to target to create a session
@@ -207,7 +207,7 @@ func TestApiCreateGroup(t *testing.T) {
 	newRoleId := newRoleResult.Item.Id
 	t.Logf("Created Role: %s", newRoleId)
 
-	_, err = rClient.AddGrants(ctx, newRoleId, 0, []string{"id=*;type=target;actions=authorize-session"},
+	_, err = rClient.AddGrants(ctx, newRoleId, 0, []string{"ids=*;type=target;actions=authorize-session"},
 		roles.WithAutomaticVersioning(true),
 	)
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/base/session_cancel_user_test.go
+++ b/testing/internal/e2e/tests/base/session_cancel_user_test.go
@@ -94,7 +94,7 @@ func TestCliSessionCancelUser(t *testing.T) {
 	// Create a role for user
 	boundary.AuthenticateAdminCli(t, ctx)
 	newRoleId := boundary.CreateNewRoleCli(t, ctx, newProjectId)
-	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "id=*;type=target;actions=authorize-session")
+	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "ids=*;type=target;actions=authorize-session")
 	boundary.AddPrincipalToRoleCli(t, ctx, newRoleId, newUserId)
 
 	// Connect to target to create a session
@@ -193,7 +193,7 @@ func TestApiCreateUser(t *testing.T) {
 	newRoleId := newRoleResult.Item.Id
 	t.Logf("Created Role: %s", newRoleId)
 
-	_, err = rClient.AddGrants(ctx, newRoleId, 0, []string{"id=*;type=target;actions=authorize-session"},
+	_, err = rClient.AddGrants(ctx, newRoleId, 0, []string{"ids=*;type=target;actions=authorize-session"},
 		roles.WithAutomaticVersioning(true),
 	)
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/base/session_end_delete_host_set_test.go
+++ b/testing/internal/e2e/tests/base/session_end_delete_host_set_test.go
@@ -59,7 +59,7 @@ func TestCliSessionEndWhenHostSetIsDeleted(t *testing.T) {
 	})
 	boundary.SetAccountToUserCli(t, ctx, newUserId, newAccountId)
 	newRoleId := boundary.CreateNewRoleCli(t, ctx, newProjectId)
-	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "id=*;type=target;actions=authorize-session")
+	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "ids=*;type=target;actions=authorize-session")
 	boundary.AddPrincipalToRoleCli(t, ctx, newRoleId, newUserId)
 
 	// Connect to target to create a session

--- a/testing/internal/e2e/tests/base/session_end_delete_host_test.go
+++ b/testing/internal/e2e/tests/base/session_end_delete_host_test.go
@@ -59,7 +59,7 @@ func TestCliSessionEndWhenHostIsDeleted(t *testing.T) {
 	})
 	boundary.SetAccountToUserCli(t, ctx, newUserId, newAccountId)
 	newRoleId := boundary.CreateNewRoleCli(t, ctx, newProjectId)
-	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "id=*;type=target;actions=authorize-session")
+	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "ids=*;type=target;actions=authorize-session")
 	boundary.AddPrincipalToRoleCli(t, ctx, newRoleId, newUserId)
 
 	// Connect to target to create a session

--- a/testing/internal/e2e/tests/base/session_end_delete_project_test.go
+++ b/testing/internal/e2e/tests/base/session_end_delete_project_test.go
@@ -55,7 +55,7 @@ func TestCliSessionEndWhenProjectIsDeleted(t *testing.T) {
 	})
 	boundary.SetAccountToUserCli(t, ctx, newUserId, newAccountId)
 	newRoleId := boundary.CreateNewRoleCli(t, ctx, newProjectId)
-	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "id=*;type=target;actions=authorize-session")
+	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "ids=*;type=target;actions=authorize-session")
 	boundary.AddPrincipalToRoleCli(t, ctx, newRoleId, newUserId)
 
 	// Connect to target to create a session

--- a/testing/internal/e2e/tests/base/session_end_delete_target_test.go
+++ b/testing/internal/e2e/tests/base/session_end_delete_target_test.go
@@ -59,7 +59,7 @@ func TestCliSessionEndWhenTargetIsDeleted(t *testing.T) {
 	})
 	boundary.SetAccountToUserCli(t, ctx, newUserId, newAccountId)
 	newRoleId := boundary.CreateNewRoleCli(t, ctx, newProjectId)
-	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "id=*;type=target;actions=authorize-session")
+	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "ids=*;type=target;actions=authorize-session")
 	boundary.AddPrincipalToRoleCli(t, ctx, newRoleId, newUserId)
 
 	// Connect to target to create a session

--- a/testing/internal/e2e/tests/base/session_end_delete_user_test.go
+++ b/testing/internal/e2e/tests/base/session_end_delete_user_test.go
@@ -64,7 +64,7 @@ func TestCliSessionEndWhenUserIsDeleted(t *testing.T) {
 	})
 	boundary.SetAccountToUserCli(t, ctx, newUserId, newAccountId)
 	newRoleId := boundary.CreateNewRoleCli(t, ctx, newProjectId)
-	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "id=*;type=target;actions=authorize-session")
+	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "ids=*;type=target;actions=authorize-session")
 	boundary.AddPrincipalToRoleCli(t, ctx, newRoleId, newUserId)
 
 	// Connect to target to create a session

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -213,7 +213,7 @@ func populateBoundaryDatabase(t testing.TB, ctx context.Context, c *config, te T
 	newGroupId := boundary.CreateNewGroupCli(t, ctx, "global")
 	boundary.AddUserToGroup(t, ctx, newUserId, newGroupId)
 	newRoleId := boundary.CreateNewRoleCli(t, ctx, newProjectId)
-	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "id=*;type=target;actions=authorize-session")
+	boundary.AddGrantToRoleCli(t, ctx, newRoleId, "ids=*;type=target;actions=authorize-session")
 	boundary.AddPrincipalToRoleCli(t, ctx, newRoleId, newGroupId)
 
 	// Create static credentials


### PR DESCRIPTION
Ticket: [ICU-10291](https://hashicorp.atlassian.net/browse/ICU-10291)

This PR updates e2e tests to use the new `ids` field in permission grants, which was introduced in `0.13.1`. 

One thing to note: originally, the migration test was failing with this change (before `0.13.1` was released) because it would try to upgrade from `0.13.0 (latest release) -> latest changes`) and  `0.13.0` did not recognize the `ids` field. Once `0.13.1` was released, that became the latest released version, which does support this field. We may look to address this in future work if we decide to update the migration test to try to update from a variety of different versions (i.e. `0.12.X -> latest`, 0.11.X -> latest`).

[ICU-10291]: https://hashicorp.atlassian.net/browse/ICU-10291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ