### PR TITLE
refactor(bsr): optimize ChunkEncoder.Encode()

### DIFF
--- a/internal/bsr/encode.go
+++ b/internal/bsr/encode.go
@@ -9,9 +9,36 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"hash"
 	"hash/crc32"
 	"io"
+	"sync"
 )
+
+type encodeCache struct {
+	crced    [crcDataSize]byte
+	compress *bytes.Buffer
+	crc      hash.Hash32
+}
+
+// Reset clears all existing values in the cache item, preventing dirty reads.
+// This function should be called when retrieving items from the encodeCachePool.
+func (e *encodeCache) Reset() {
+	e.compress.Reset()
+	e.crc.Reset()
+}
+
+// encodeCachePool is to cache allocated but unused items for later reuse, relieving pressure on the garbage collector.
+// encodeCachePool is safe for use by multiple goroutines simultaneously.
+// encodeCachePool must not be copied after first use.
+var encodeCachePool = &sync.Pool{
+	New: func() interface{} {
+		return &encodeCache{
+			compress: bytes.NewBuffer(make([]byte, 0, 1024)),
+			crc:      crc32.NewIEEE(),
+		}
+	},
+}
 
 // ChunkEncoder will encode a chunk and write it to the writer.
 // It will compress the chunk data based on the compression.
@@ -46,12 +73,15 @@ func NewChunkEncoder(ctx context.Context, w io.Writer, c Compression, e Encrypti
 
 // Encode serializes a Chunk and writes it with the encoder's writer.
 func (e ChunkEncoder) Encode(ctx context.Context, c Chunk) (int, error) {
+	encode := encodeCachePool.Get().(*encodeCache)
+	encode.Reset()
+	defer encodeCachePool.Put(encode)
+
 	data, err := c.MarshalData(ctx)
 	if err != nil {
 		return 0, err
 	}
 
-	var buf bytes.Buffer
 	var compressor io.WriteCloser
 	switch c.GetType() {
 	// Header should not be compressed since we need to read it prior to knowing
@@ -59,13 +89,13 @@ func (e ChunkEncoder) Encode(ctx context.Context, c Chunk) (int, error) {
 	// End should not be compressed since it has no data and compressing an empty
 	// byte slice just adds data in the form of the compression magic strings.
 	case ChunkHeader, ChunkEnd:
-		compressor = newNullCompressionWriter(&buf)
+		compressor = newNullCompressionWriter(encode.compress)
 	default:
 		switch e.compression {
 		case GzipCompression:
-			compressor = gzip.NewWriter(&buf)
+			compressor = gzip.NewWriter(encode.compress)
 		default:
-			compressor = newNullCompressionWriter(&buf)
+			compressor = newNullCompressionWriter(encode.compress)
 		}
 	}
 
@@ -76,30 +106,28 @@ func (e ChunkEncoder) Encode(ctx context.Context, c Chunk) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	length := buf.Len()
+	length := encode.compress.Len()
 
-	t := c.GetTimestamp().marshal()
+	copy(encode.crced[0:], []byte(c.GetProtocol()))
+	copy(encode.crced[protocolSize:], []byte(c.GetType()))
+	encode.crced[protocolSize+chunkTypeSize] = byte(c.GetDirection())
+	copy(encode.crced[protocolSize+chunkTypeSize+directionSize:], c.GetTimestamp().marshal())
 
-	// calculate CRC for protocol+type+dir+timestamp+data
-	crced := make([]byte, 0, chunkBaseSize+length)
-	crced = append(crced, c.GetProtocol()...)
-	crced = append(crced, c.GetType()...)
-	crced = append(crced, byte(c.GetDirection()))
-	crced = append(crced, t...)
-	crced = append(crced, buf.Bytes()...)
-
-	crc := crc32.NewIEEE()
-	_, err = crc.Write(crced)
-	if err != nil {
+	if _, err := encode.crc.Write(encode.crced[0:]); err != nil {
 		return 0, err
 	}
+	if _, err := encode.crc.Write(encode.compress.Bytes()); err != nil {
+		return 0, err
+	}
+	sum := encode.crc.Sum32()
 
-	d := make([]byte, 0, chunkBaseSize+length+crcSize)
-	d = binary.BigEndian.AppendUint32(d, uint32(length))
-	d = append(d, crced...)
-	d = binary.BigEndian.AppendUint32(d, crc.Sum32())
+	encodedChunk := make([]byte, chunkBaseSize+length+crcSize)
+	binary.BigEndian.PutUint32(encodedChunk[0:], uint32(length))
+	copy(encodedChunk[lengthSize:], encode.crced[0:])
+	copy(encodedChunk[chunkBaseSize:], encode.compress.Bytes())
+	binary.BigEndian.PutUint32(encodedChunk[chunkBaseSize+length:], sum)
 
-	return e.w.Write(d)
+	return e.w.Write(encodedChunk)
 }
 
 // Close closes the encoder.

--- a/internal/bsr/encode_bench_test.go
+++ b/internal/bsr/encode_bench_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package bsr
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+type testChunk struct {
+	*BaseChunk
+	Data []byte
+}
+
+// MarshalData serializes the data portion of a chunk.
+func (t *testChunk) MarshalData(_ context.Context) ([]byte, error) {
+	return t.Data, nil
+}
+
+func newTestChunk(d int) *testChunk {
+	data := make([]byte, d)
+	ts := time.Date(2023, time.March, 16, 10, 47, 3, 14, time.UTC)
+	return &testChunk{
+		BaseChunk: &BaseChunk{
+			Protocol:  "TEST",
+			Direction: Inbound,
+			Timestamp: NewTimestamp(ts),
+			Type:      "TEST",
+		},
+		Data: data,
+	}
+}
+
+func BenchmarkEncodeParallel(b *testing.B) {
+	b.ReportAllocs()
+	cases := []int{16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536}
+	for _, chunkSize := range cases {
+		b.StopTimer()
+		ctx := context.Background()
+		chunks := make([]Chunk, 250)
+		for i := range chunks {
+			chunks[i] = newTestChunk(chunkSize)
+		}
+		b.StartTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				var buf bytes.Buffer
+				enc, _ := NewChunkEncoder(ctx, &buf, NoCompression, NoEncryption)
+				for _, c := range chunks {
+					if _, err := enc.Encode(ctx, c); err != nil {
+						b.Fatal("Encode:", err)
+					}
+				}
+				b.SetBytes(int64(len(buf.Bytes())))
+			}
+		})
+	}
+}
+
+func BenchmarkEncodeSequential(b *testing.B) {
+	cases := []int{16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536}
+	for _, chunkSize := range cases {
+		b.Run(fmt.Sprintf("%d", chunkSize), func(b *testing.B) {
+			b.ReportAllocs()
+			b.StopTimer()
+			ctx := context.Background()
+			chunks := make([]Chunk, 250)
+			for i := range chunks {
+				chunks[i] = newTestChunk(chunkSize)
+			}
+			b.StartTimer()
+
+			for i := 0; i < b.N; i++ {
+				var buf bytes.Buffer
+				enc, _ := NewChunkEncoder(ctx, &buf, NoCompression, NoEncryption)
+				for _, c := range chunks {
+					if _, err := enc.Encode(ctx, c); err != nil {
+						b.Fatal("Encode:", err)
+					}
+				}
+				b.SetBytes(int64(len(buf.Bytes())))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR optimizes the Encode function for the ChunkEncoder in the bsr package.

### Benchmarks

- sec/op: 
	- average amount of time each iteration took to complete, expressed in seconds per operation
	- we want this number to be as low as possible
	- 34.86% faster than the original implementation.
```
              28.49µ ±  0%  -35.57% (p=0.000 n=20)
              29.22µ ±  0%  -35.66% (p=0.000 n=20)
              33.72µ ±  2%  -34.07% (p=0.000 n=20)
              44.54µ ±  2%  -35.13% (p=0.000 n=20)
              60.50µ ±  3%  -32.86% (p=0.000 n=20)
              102.61µ ± 21%  -31.96% (p=0.000 n=20)
              175.3µ ±  5%  -33.10% (p=0.000 n=20)
              295.3µ ±  2%  -33.12% (p=0.000 n=20)
              519.0µ ±  3%  -33.25% (p=0.000 n=20)
              796.8µ ±  0%  -43.17% (p=0.000 n=20)
              105.2µ        -34.86%
```

- B/s:
	- average amount of bytes each iteration processed, expressed in bytes per second
	- we want this number to be as high as possible
	- 53.53% more bytes processed per second than the original implementation.
```
              376.6Mi ±  0%  +55.21% (p=0.000 n=20)
              497.7Mi ±  0%  +55.42% (p=0.000 n=20)
              657.5Mi ±  2%  +51.68% (p=0.000 n=20)
              840.5Mi ±  2%  +54.15% (p=0.000 n=20)
              1123.1Mi ±  3%  +48.94% (p=0.000 n=20)
              1257.1Mi ± 18%  +46.97% (p=0.000 n=20)
              1432.5Mi ±  5%  +49.48% (p=0.000 n=20)
              1.637Gi ±  2%  +49.53% (p=0.000 n=20)
              1.850Gi ±  3%  +49.80% (p=0.000 n=20)
              2.402Gi ±  0%  +75.97% (p=0.000 n=20)
              1.026Gi        +53.53%
```
	
- B/op:
	- average amount of bytes each iteration allocated, expressed in bytes per operation
	- we want this number to be as low as possible
	- 39.87% less bytes allocated per operation than the original implementation
```
              49.61Ki ± 0%  -46.40% (p=0.000 n=20)
              53.52Ki ± 0%  -46.68% (p=0.000 n=20)
              77.31Ki ± 0%  -41.41% (p=0.000 n=20)
              135.2Ki ± 0%  -38.85% (p=0.000 n=20)
              234.9Ki ± 0%  -38.71% (p=0.000 n=20)
              465.0Ki ± 0%  -37.67% (p=0.000 n=20)
              925.3Ki ± 0%  -37.13% (p=0.000 n=20)
              1.803Mi ± 0%  -36.85% (p=0.000 n=20)
              3.661Mi ± 0%  -37.00% (p=0.000 n=20)
              7.254Mi ± 0%  -36.81% (p=0.000 n=20)
              412.9Ki       -39.87%
```

- allocs/op:
	- average amount of distinct memory allocations each iteration, expressed in allocations per operation
	- we want this number to be as low as possible
	- 56.76% less number of distinct memory allocations per operation than the original implementation
```
              761.0 ± 0%  -56.79% (p=0.000 n=20)
              761.0 ± 0%  -56.79% (p=0.000 n=20)
              761.0 ± 0%  -56.79% (p=0.000 n=20)
              761.0 ± 0%  -56.79% (p=0.000 n=20)
              761.0 ± 0%  -56.79% (p=0.000 n=20)
              761.0 ± 0%  -56.79% (p=0.000 n=20)
              761.0 ± 0%  -56.79% (p=0.000 n=20)
              762.0 ± 0%  -56.73% (p=0.000 n=20)
              763.0 ± 0%  -56.67% (p=0.000 n=20)
              763.0 ± 0%  -56.67% (p=0.000 n=20)
              761.5       -56.76%
```