### PR TITLE
test(e2e): Add "update host set filter" check

### DIFF
--- a/testing/internal/e2e/boundary/host.go
+++ b/testing/internal/e2e/boundary/host.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -185,7 +186,7 @@ func CreateNewAwsHostSetCli(t testing.TB, ctx context.Context, hostCatalogId str
 	return newHostSetId
 }
 
-// WaitForHostsInHostSetCli uses the cli to check if there are hosts in a host set. It will check a
+// WaitForHostsInHostSetCli uses the cli to check if there are any hosts in a host set. It will check a
 // few times before returning a result. The method will fail if there are 0 hosts found.
 func WaitForHostsInHostSetCli(t testing.TB, ctx context.Context, hostSetId string) int {
 	t.Logf("Looking for items in the host set...")
@@ -214,7 +215,7 @@ func WaitForHostsInHostSetCli(t testing.TB, ctx context.Context, hostSetId strin
 				return errors.New("No items are appearing in the host set")
 			}
 
-			t.Logf("Found %d hosts", actualHostSetCount)
+			t.Logf("Found %d host(s)", actualHostSetCount)
 			return nil
 		},
 		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
@@ -225,4 +226,49 @@ func WaitForHostsInHostSetCli(t testing.TB, ctx context.Context, hostSetId strin
 	require.NoError(t, err)
 
 	return actualHostSetCount
+}
+
+// WaitForNumberOfHostsInHostSetCli uses the cli to check if the number of hosts
+// in a host set match the expected. The method will throw an error if it does
+// not match after some retries.
+func WaitForNumberOfHostsInHostSetCli(t testing.TB, ctx context.Context, hostSetId string, expectedHostCount int) {
+	t.Logf("Looking for items in the host set...")
+	var actualHostSetCount int
+	err := backoff.RetryNotify(
+		func() error {
+			output := e2e.RunCommand(ctx, "boundary",
+				e2e.WithArgs(
+					"host-sets", "read",
+					"-id", hostSetId,
+					"-format", "json",
+				),
+			)
+			if output.Err != nil {
+				return backoff.Permanent(errors.New(string(output.Stderr)))
+			}
+
+			var hostSetsReadResult hostsets.HostSetReadResult
+			err := json.Unmarshal(output.Stdout, &hostSetsReadResult)
+			if err != nil {
+				return backoff.Permanent(err)
+			}
+
+			actualHostSetCount = len(hostSetsReadResult.Item.HostIds)
+			if actualHostSetCount != expectedHostCount {
+				return errors.New(
+					fmt.Sprintf("Number of hosts in host set do not match expected. EXPECTED: %d, ACTUAL: %d",
+						expectedHostCount,
+						actualHostSetCount,
+					))
+			}
+
+			t.Logf("Found %d host(s)", actualHostSetCount)
+			return nil
+		},
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
+		func(err error, td time.Duration) {
+			t.Logf("%s. Retrying...", err.Error())
+		},
+	)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Coming from a test plan item in `0.13.1`, there was a check to update a host set from an AWS Dynamic Host Catalog. This PR ports that check over to the e2e test. 

Now, this test will update the filter on one of the host sets and confirm that the right number of hosts show up. 