### PR TITLE
feat(bsr): support container validation

### DIFF
--- a/internal/bsr/container.go
+++ b/internal/bsr/container.go
@@ -40,14 +40,14 @@ type FileChecksumValidation struct {
 	Error    error
 }
 
-// ChecksumValidation is a map where the key is a file name
+// ContainerChecksumValidation is a map where the key is a file name
 // and the value contains a validation report on whether or
 // not the file matches its expected checksum
-type ChecksumValidation map[string]*FileChecksumValidation
+type ContainerChecksumValidation map[string]*FileChecksumValidation
 
 // GetFailedItems returns a filtered map of FileChecksumValidation that have failed
-func (cv ChecksumValidation) GetFailedItems() ChecksumValidation {
-	failedValidations := ChecksumValidation{}
+func (cv ContainerChecksumValidation) GetFailedItems() ContainerChecksumValidation {
+	failedValidations := ContainerChecksumValidation{}
 	for fileName, validation := range cv {
 		if validation.Passed {
 			continue
@@ -545,7 +545,7 @@ func (c *container) close(_ context.Context) error {
 // This function expects that the container's kms keys
 // are loaded into memory and the signature files are
 // verified.
-func (c *container) ValidateChecksums(ctx context.Context) (ChecksumValidation, error) {
+func (c *container) ValidateChecksums(ctx context.Context) (ContainerChecksumValidation, error) {
 	const op = "bsr.(container).Validate"
 	if len(c.shaSums) == 0 {
 		return nil, fmt.Errorf("%s: missing checksums", op)
@@ -553,7 +553,7 @@ func (c *container) ValidateChecksums(ctx context.Context) (ChecksumValidation, 
 	if c.keys == nil {
 		return nil, fmt.Errorf("%s: missing keys", op)
 	}
-	checksumValidation := make(ChecksumValidation, len(c.shaSums))
+	checksumValidation := make(ContainerChecksumValidation, len(c.shaSums))
 	for fileName, expectedChecksum := range c.shaSums {
 		report := &FileChecksumValidation{
 			Filename: fileName,

--- a/internal/bsr/container_test.go
+++ b/internal/bsr/container_test.go
@@ -73,27 +73,27 @@ func TestGetFailedItems(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name               string
-		checksumValidation ChecksumValidation
-		expectedChecksums  ChecksumValidation
+		checksumValidation ContainerChecksumValidation
+		expectedChecksums  ContainerChecksumValidation
 	}{
 		{
 			name:               "empty",
-			checksumValidation: ChecksumValidation{},
-			expectedChecksums:  ChecksumValidation{},
+			checksumValidation: ContainerChecksumValidation{},
+			expectedChecksums:  ContainerChecksumValidation{},
 		},
 		{
 			name: "no failed items",
-			checksumValidation: ChecksumValidation{
+			checksumValidation: ContainerChecksumValidation{
 				"test": &FileChecksumValidation{
 					Filename: "test",
 					Passed:   true,
 				},
 			},
-			expectedChecksums: ChecksumValidation{},
+			expectedChecksums: ContainerChecksumValidation{},
 		},
 		{
 			name: "failed item",
-			checksumValidation: ChecksumValidation{
+			checksumValidation: ContainerChecksumValidation{
 				"test": &FileChecksumValidation{
 					Filename: "test",
 					Passed:   true,
@@ -102,7 +102,7 @@ func TestGetFailedItems(t *testing.T) {
 					Filename: "capture",
 				},
 			},
-			expectedChecksums: ChecksumValidation{
+			expectedChecksums: ContainerChecksumValidation{
 				"capture": &FileChecksumValidation{
 					Filename: "capture",
 				},
@@ -134,7 +134,7 @@ func TestSessionValidateChecksums(t *testing.T) {
 	cases := []struct {
 		name              string
 		c                 *container
-		expectedChecksums ChecksumValidation
+		expectedChecksums ContainerChecksumValidation
 		expectedErr       string
 	}{
 		{
@@ -177,7 +177,7 @@ func TestSessionValidateChecksums(t *testing.T) {
 
 				return c
 			}(),
-			expectedChecksums: ChecksumValidation{
+			expectedChecksums: ContainerChecksumValidation{
 				"test": &FileChecksumValidation{
 					Filename: "test",
 					Passed:   false,
@@ -215,7 +215,7 @@ func TestSessionValidateChecksums(t *testing.T) {
 
 				return s.container
 			}(),
-			expectedChecksums: ChecksumValidation{
+			expectedChecksums: ContainerChecksumValidation{
 				bsrPubKeyFileName: &FileChecksumValidation{
 					Filename: bsrPubKeyFileName,
 					Passed:   true,
@@ -318,7 +318,7 @@ func TestSessionValidateChecksums(t *testing.T) {
 
 				return c.container
 			}(),
-			expectedChecksums: ChecksumValidation{
+			expectedChecksums: ContainerChecksumValidation{
 				"requests-inbound.data": &FileChecksumValidation{
 					Filename: "requests-inbound.data",
 					Passed:   true,
@@ -436,7 +436,7 @@ func TestSessionValidateChecksums(t *testing.T) {
 
 				return chr.container
 			}(),
-			expectedChecksums: ChecksumValidation{
+			expectedChecksums: ContainerChecksumValidation{
 				"requests-inbound.data": &FileChecksumValidation{
 					Filename: "requests-inbound.data",
 					Passed:   true,

--- a/internal/bsr/container_test.go
+++ b/internal/bsr/container_test.go
@@ -6,10 +6,14 @@ package bsr
 import (
 	"context"
 	"fmt"
+	"io"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/boundary/internal/bsr/internal/checksum"
 	"github.com/hashicorp/boundary/internal/bsr/internal/fstest"
 	"github.com/hashicorp/boundary/internal/bsr/kms"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,6 +65,422 @@ func TestSyncBsrKeys(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGetFailedItems(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name               string
+		checksumValidation ChecksumValidation
+		expectedChecksums  ChecksumValidation
+	}{
+		{
+			name:               "empty",
+			checksumValidation: ChecksumValidation{},
+			expectedChecksums:  ChecksumValidation{},
+		},
+		{
+			name: "no failed items",
+			checksumValidation: ChecksumValidation{
+				"test": &FileChecksumValidation{
+					Filename: "test",
+					Passed:   true,
+				},
+			},
+			expectedChecksums: ChecksumValidation{},
+		},
+		{
+			name: "failed item",
+			checksumValidation: ChecksumValidation{
+				"test": &FileChecksumValidation{
+					Filename: "test",
+					Passed:   true,
+				},
+				"capture": &FileChecksumValidation{
+					Filename: "capture",
+				},
+			},
+			expectedChecksums: ChecksumValidation{
+				"capture": &FileChecksumValidation{
+					Filename: "capture",
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedChecksums, tc.checksumValidation.GetFailedItems())
+		})
+	}
+}
+
+func TestSessionValidateChecksums(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	protocol := Protocol("TEST")
+	RegisterSummaryAllocFunc(protocol, SessionContainer, func(ctx context.Context) Summary {
+		return &BaseSessionSummary{Id: "s_123456789", ConnectionCount: 1}
+	})
+	RegisterSummaryAllocFunc(protocol, ConnectionContainer, func(ctx context.Context) Summary {
+		return &BaseConnectionSummary{Id: "cr_123456789", ChannelCount: 1}
+	})
+	RegisterSummaryAllocFunc(protocol, ChannelContainer, func(ctx context.Context) Summary {
+		return &BaseChannelSummary{Id: "chr_123456789", ConnectionRecordingId: "cr_123456789"}
+	})
+
+	cases := []struct {
+		name              string
+		c                 *container
+		expectedChecksums ChecksumValidation
+		expectedErr       string
+	}{
+		{
+			name:        "missing checksums",
+			c:           &container{},
+			expectedErr: "missing checksums",
+		},
+		{
+			name: "missing keys",
+			c: &container{
+				shaSums: checksum.Sha256Sums{
+					"test": []byte("test"),
+				},
+			},
+			expectedErr: "missing keys",
+		},
+		{
+			name: "failed checksum match",
+			c: func() *container {
+				sessionId := "session_123456789"
+				keys, err := kms.CreateKeys(ctx, kms.TestWrapper(t), sessionId)
+				require.NoError(t, err)
+
+				fs := &fstest.MemFS{}
+				sc, err := fs.New(ctx, fmt.Sprintf(bsrFileNameTemplate, sessionId))
+				require.NoError(t, err)
+
+				c, err := newContainer(ctx, SessionContainer, sc, keys)
+				require.NoError(t, err)
+
+				c.shaSums = checksum.Sha256Sums{
+					"test": []byte("test"),
+				}
+
+				f, err := c.create(ctx, "test")
+				require.NoError(t, err)
+				_, err = f.Write([]byte("hello world"))
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+
+				return c
+			}(),
+			expectedChecksums: ChecksumValidation{
+				"test": &FileChecksumValidation{
+					Filename: "test",
+					Passed:   false,
+					Error:    fmt.Errorf("checksum mismatch"),
+				},
+			},
+		},
+		{
+			name: "valid session container",
+			c: func() *container {
+				sessionId := "session_123456789"
+				fs := &fstest.MemFS{}
+				keys, err := kms.CreateKeys(ctx, kms.TestWrapper(t), sessionId)
+				require.NoError(t, err)
+				keyFn := func(w kms.WrappedKeys) (kms.UnwrappedKeys, error) {
+					u := kms.UnwrappedKeys{
+						BsrKey:  keys.BsrKey,
+						PrivKey: keys.PrivKey,
+					}
+					return u, nil
+				}
+
+				s, err := NewSession(ctx, TestSessionRecordingMeta(sessionId, protocol), TestSessionMeta(sessionId), fs, keys)
+				require.NoError(t, err)
+				require.NoError(t, s.EncodeSummary(ctx, &BaseSessionSummary{
+					Id:              sessionId,
+					ConnectionCount: 1,
+					StartTime:       time.Now(),
+					EndTime:         time.Now(),
+				}))
+				require.NoError(t, s.Close(ctx))
+
+				s, err = OpenSession(ctx, sessionId, fs, keyFn)
+				require.NoError(t, err)
+
+				return s.container
+			}(),
+			expectedChecksums: ChecksumValidation{
+				bsrPubKeyFileName: &FileChecksumValidation{
+					Filename: bsrPubKeyFileName,
+					Passed:   true,
+				},
+				pubKeyBsrSignatureFileName: &FileChecksumValidation{
+					Filename: pubKeyBsrSignatureFileName,
+					Passed:   true,
+				},
+				pubKeySelfSignatureFileName: &FileChecksumValidation{
+					Filename: pubKeySelfSignatureFileName,
+					Passed:   true,
+				},
+				wrappedBsrKeyFileName: &FileChecksumValidation{
+					Filename: wrappedBsrKeyFileName,
+					Passed:   true,
+				},
+				wrappedPrivKeyFileName: &FileChecksumValidation{
+					Filename: wrappedPrivKeyFileName,
+					Passed:   true,
+				},
+				sessionMetaFileName: &FileChecksumValidation{
+					Filename: sessionMetaFileName,
+					Passed:   true,
+				},
+				"session-recording.meta": &FileChecksumValidation{
+					Filename: "session-recording.meta",
+					Passed:   true,
+				},
+				"session-recording-summary.json": &FileChecksumValidation{
+					Filename: "session-recording-summary.json",
+					Passed:   true,
+				},
+			},
+		},
+		{
+			name: "valid connection container",
+			c: func() *container {
+				sessionId := "s_123456789"
+				connectionId := "cr_123456789"
+				fs := &fstest.MemFS{}
+				keys, err := kms.CreateKeys(ctx, kms.TestWrapper(t), sessionId)
+				require.NoError(t, err)
+				keyFn := func(w kms.WrappedKeys) (kms.UnwrappedKeys, error) {
+					u := kms.UnwrappedKeys{
+						BsrKey:  keys.BsrKey,
+						PrivKey: keys.PrivKey,
+					}
+					return u, nil
+				}
+
+				s, err := NewSession(ctx, TestSessionRecordingMeta(sessionId, protocol), TestSessionMeta(sessionId), fs, keys)
+				require.NoError(t, err)
+				require.NoError(t, s.EncodeSummary(ctx, &BaseSessionSummary{
+					Id:              sessionId,
+					ConnectionCount: 1,
+					StartTime:       time.Now(),
+					EndTime:         time.Now(),
+				}))
+
+				c, err := s.NewConnection(ctx, &ConnectionRecordingMeta{
+					Id: connectionId,
+					channels: map[string]bool{
+						"test": true,
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, c.EncodeSummary(ctx, &BaseConnectionSummary{
+					Id:           connectionId,
+					ChannelCount: 1,
+					StartTime:    time.Now(),
+					EndTime:      time.Now(),
+					BytesUp:      256,
+					BytesDown:    256,
+				}))
+
+				inbound, err := c.NewRequestsWriter(ctx, Inbound)
+				require.NoError(t, err)
+				n, err := inbound.Write([]byte("hello world"))
+				require.NoError(t, err)
+				require.Equal(t, len("hello world"), n)
+				closer := inbound.(io.Closer)
+				require.NoError(t, closer.Close())
+
+				outbound, err := c.NewRequestsWriter(ctx, Outbound)
+				require.NoError(t, err)
+				n, err = outbound.Write([]byte("hello world"))
+				require.NoError(t, err)
+				require.Equal(t, len("hello world"), n)
+				closer = outbound.(io.Closer)
+				require.NoError(t, closer.Close())
+
+				require.NoError(t, c.Close(ctx))
+				require.NoError(t, s.Close(ctx))
+
+				s, err = OpenSession(ctx, sessionId, fs, keyFn)
+				require.NoError(t, err)
+
+				c, err = s.OpenConnection(ctx, connectionId)
+				require.NoError(t, err)
+
+				return c.container
+			}(),
+			expectedChecksums: ChecksumValidation{
+				"requests-inbound.data": &FileChecksumValidation{
+					Filename: "requests-inbound.data",
+					Passed:   true,
+				},
+				"requests-outbound.data": &FileChecksumValidation{
+					Filename: "requests-outbound.data",
+					Passed:   true,
+				},
+				"connection-recording.meta": &FileChecksumValidation{
+					Filename: "connection-recording.meta",
+					Passed:   true,
+				},
+				"connection-recording-summary.json": &FileChecksumValidation{
+					Filename: "connection-recording-summary.json",
+					Passed:   true,
+				},
+			},
+		},
+		{
+			name: "valid channel container",
+			c: func() *container {
+				sessionId := "s_123456789"
+				connectionId := "cr_123456789"
+				channelId := "chr_123456789"
+				fs := &fstest.MemFS{}
+				keys, err := kms.CreateKeys(ctx, kms.TestWrapper(t), sessionId)
+				require.NoError(t, err)
+				keyFn := func(w kms.WrappedKeys) (kms.UnwrappedKeys, error) {
+					u := kms.UnwrappedKeys{
+						BsrKey:  keys.BsrKey,
+						PrivKey: keys.PrivKey,
+					}
+					return u, nil
+				}
+
+				s, err := NewSession(ctx, TestSessionRecordingMeta(sessionId, protocol), TestSessionMeta(sessionId), fs, keys, WithSupportsMultiplex(true))
+				require.NoError(t, err)
+				require.NoError(t, s.EncodeSummary(ctx, &BaseSessionSummary{
+					Id:              sessionId,
+					ConnectionCount: 1,
+					StartTime:       time.Now(),
+					EndTime:         time.Now(),
+				}))
+
+				c, err := s.NewConnection(ctx, &ConnectionRecordingMeta{
+					Id: connectionId,
+					channels: map[string]bool{
+						"test": true,
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, c.EncodeSummary(ctx, &BaseConnectionSummary{
+					Id:           connectionId,
+					ChannelCount: 1,
+					StartTime:    time.Now(),
+					EndTime:      time.Now(),
+					BytesUp:      256,
+					BytesDown:    256,
+				}))
+
+				chr, err := c.NewChannel(ctx, &ChannelRecordingMeta{
+					Id:   channelId,
+					Type: "chan",
+				})
+				require.NoError(t, err)
+				require.NoError(t, chr.EncodeSummary(ctx, &ChannelRecordingMeta{
+					Id:   channelId,
+					Type: "chan",
+				}))
+
+				inboundReq, err := chr.NewRequestsWriter(ctx, Inbound)
+				require.NoError(t, err)
+				n, err := inboundReq.Write([]byte("hello world"))
+				require.NoError(t, err)
+				require.Equal(t, len("hello world"), n)
+				closer := inboundReq.(io.Closer)
+				require.NoError(t, closer.Close())
+
+				outboundReq, err := chr.NewRequestsWriter(ctx, Outbound)
+				require.NoError(t, err)
+				n, err = outboundReq.Write([]byte("hello world"))
+				require.NoError(t, err)
+				require.Equal(t, len("hello world"), n)
+				closer = outboundReq.(io.Closer)
+				require.NoError(t, closer.Close())
+
+				inboundMsg, err := chr.NewMessagesWriter(ctx, Inbound)
+				require.NoError(t, err)
+				n, err = inboundMsg.Write([]byte("hello world"))
+				require.NoError(t, err)
+				require.Equal(t, len("hello world"), n)
+				closer = inboundMsg.(io.Closer)
+				require.NoError(t, closer.Close())
+
+				outboundMsg, err := chr.NewMessagesWriter(ctx, Outbound)
+				require.NoError(t, err)
+				n, err = outboundMsg.Write([]byte("hello world"))
+				require.NoError(t, err)
+				require.Equal(t, len("hello world"), n)
+				closer = outboundMsg.(io.Closer)
+				require.NoError(t, closer.Close())
+
+				require.NoError(t, chr.Close(ctx))
+				require.NoError(t, c.Close(ctx))
+				require.NoError(t, s.Close(ctx))
+
+				s, err = OpenSession(ctx, sessionId, fs, keyFn)
+				require.NoError(t, err)
+
+				c, err = s.OpenConnection(ctx, connectionId)
+				require.NoError(t, err)
+
+				chr, err = c.OpenChannel(ctx, channelId)
+				require.NoError(t, err)
+
+				return chr.container
+			}(),
+			expectedChecksums: ChecksumValidation{
+				"requests-inbound.data": &FileChecksumValidation{
+					Filename: "requests-inbound.data",
+					Passed:   true,
+				},
+				"requests-outbound.data": &FileChecksumValidation{
+					Filename: "requests-outbound.data",
+					Passed:   true,
+				},
+				"messages-inbound.data": &FileChecksumValidation{
+					Filename: "messages-inbound.data",
+					Passed:   true,
+				},
+				"messages-outbound.data": &FileChecksumValidation{
+					Filename: "messages-outbound.data",
+					Passed:   true,
+				},
+				"channel-recording.meta": &FileChecksumValidation{
+					Filename: "channel-recording.meta",
+					Passed:   true,
+				},
+				"channel-recording-summary.json": &FileChecksumValidation{
+					Filename: "channel-recording-summary.json",
+					Passed:   true,
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			validatedChecksums, err := tc.c.ValidateChecksums(ctx)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotEmpty(t, validatedChecksums)
+
+			require.Equal(t, len(tc.expectedChecksums), len(validatedChecksums))
+			for fileName, expectedStatus := range tc.expectedChecksums {
+				actualStatus, ok := validatedChecksums[fileName]
+				require.True(t, ok, fmt.Sprintf("missing %s", fileName))
+				assert.Equal(t, expectedStatus, actualStatus, fileName)
+			}
 		})
 	}
 }


### PR DESCRIPTION
# Summary:

This PR adds a new method for the bsr *container called `ValidateChecksums`. This method calculates the checksums of all files that are listed in the SHA256SUM file and compares the expected value. Here is an example output from a session container:

```
ChecksumValidation{
  "bsrKey.pub": &FileChecksumValidation{
	  Filename: "bsrKey.pub",
	  Passed:   false,
	  Error:  error("checksum mismatch"),
  },
  "pubKeyBsrSignature.sign": &FileChecksumValidation{
	  Filename: "pubKeyBsrSignature.sign",
	  Passed:   true,
  },
  "pubKeySelfSignature.sign": &FileChecksumValidation{
	  Filename: "pubKeySelfSignature.sign",
	  Passed:   true,
  },
  "wrappedBsrKey": &FileChecksumValidation{
	  Filename: "wrappedBsrKey",
	  Passed:   true,
  },
  "wrappedPrivKey": &FileChecksumValidation{
	  Filename: "wrappedPrivKey",
	  Passed:   true,
  },
  "session-meta.json": &FileChecksumValidation{
	  Filename: "session-meta.json",
	  Passed:   true,
  },
  "session-recording.meta": &FileChecksumValidation{
	  Filename: "session-recording.meta",
	  Passed:   true,
  },
  "session-recording-summary.json": &FileChecksumValidation{
	  Filename: "session-recording-summary.json",
	  Passed:   true,
  },
}
```