### PR TITLE
docs: Add note regarding HCP workers

### DIFF
--- a/website/content/docs/configuration/worker/index.mdx
+++ b/website/content/docs/configuration/worker/index.mdx
@@ -74,6 +74,9 @@ worker {
   using env or file, their contents must formatted as a JSON array:
   `["127.0.0.1", "192.168.0.1", "10.0.0.1"]`
 
+  HCP Boundary workers require the `hcp_boundary_cluster_id` parameter instead of `initial upstreams`.
+  If you configure an HCP worker with `initial_upstreams`, the worker configuration fails.
+
 - `tags` - A map of key-value pairs where values are an array of strings. Most
   commonly used for [filtering](/boundary/docs/concepts/filtering) targets a
   worker can proxy via [worker

--- a/website/content/docs/configuration/worker/index.mdx
+++ b/website/content/docs/configuration/worker/index.mdx
@@ -74,7 +74,7 @@ worker {
   using env or file, their contents must formatted as a JSON array:
   `["127.0.0.1", "192.168.0.1", "10.0.0.1"]`
 
-  HCP Boundary workers require the `hcp_boundary_cluster_id` parameter instead of `initial upstreams`.
+  HCP Boundary workers require the [`hcp_boundary_cluster_id`](/boundary/docs/configuration/worker/#hcp_boundary_cluster_id) parameter instead of `initial upstreams`.
   If you configure an HCP worker with `initial_upstreams`, the worker configuration fails.
 
 - `tags` - A map of key-value pairs where values are an array of strings. Most

--- a/website/content/docs/configuration/worker/index.mdx
+++ b/website/content/docs/configuration/worker/index.mdx
@@ -77,17 +77,17 @@ worker {
   HCP Boundary workers require the [`hcp_boundary_cluster_id`](/boundary/docs/configuration/worker/#hcp_boundary_cluster_id) parameter instead of `initial upstreams`.
   If you configure an HCP worker with `initial_upstreams`, the worker configuration fails.
 
+- `hcp_boundary_cluster_id` - A string that you must use to configure PKI workers
+  to connect to your HCP Boundary cluster rather than specifying
+  `initial_upstreams`. This parameter is currently only valid for workers using the PKI
+  registration method and for workers directly connected to HCP Boundary.
+
 - `tags` - A map of key-value pairs where values are an array of strings. Most
   commonly used for [filtering](/boundary/docs/concepts/filtering) targets a
   worker can proxy via [worker
   tags](/boundary/docs/concepts/filtering/worker-tags). On `SIGHUP`, the tags
   set here will be re-parsed and new values used. It can also be a string
   referring to a file on disk (`file://`) or an env var (`env://`).
-
-- `hcp_boundary_cluster_id` - A string that can be used to configure PKI workers
-  to connect to your HCP Boundary cluster rather than specifying
-  `initial_upstreams`. This is currently only valid for workers using the PKI
-  registration method and for workers directly connected to HCP Boundary.
 
 ## Signals
 


### PR DESCRIPTION
The `initial_upstreams` parameter is not used for HCP workers, but this has caused some confusion with users. ([Via Slack](https://hashicorp.slack.com/archives/C01AQDJF3SA/p1690549357466249)) This PR adds clarification that HCP users should configure workers with `hcp_boundary_cluster_id` instead.

[See the update in the preview deployment.](https://boundary-chlj6cxfl-hashicorp.vercel.app/boundary/docs/configuration/worker#initial_upstreams)