### PR TITLE
server: allow release version to be set in test

### DIFF
--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -114,10 +114,12 @@ func TestKmsWorker(t *testing.T, conn *db.DB, wrapper wrapping.Wrapper, opt ...O
 		address := "127.0.0.1"
 		opt = append(opt, WithAddress(address))
 	}
-	versionInfo := version.Get()
-	relVer := versionInfo.FullVersionNumber(false)
-
-	opt = append(opt, WithReleaseVersion(relVer))
+	if opts.withReleaseVersion == "" {
+		// Only set the release version if it isn't already set
+		versionInfo := version.Get()
+		relVer := versionInfo.FullVersionNumber(false)
+		opt = append(opt, WithReleaseVersion(relVer))
+	}
 
 	wrk := NewWorker(scope.Global.String(), opt...)
 	wrk, err = serversRepo.UpsertWorkerStatus(ctx, wrk)


### PR DESCRIPTION
The old logic made it impossible for the caller to set the release version with WithReleaseVersion. Only
set the release version when it's not explicitly set already.