### PR TITLE
fix: Close opened BSR files

### DIFF
--- a/internal/bsr/bsr.go
+++ b/internal/bsr/bsr.go
@@ -200,8 +200,11 @@ func OpenSession(ctx context.Context, sessionRecordingId string, f storage.FS, k
 	// Load and verify recording metadata
 	sha256Reader, err := crypto.NewSha256SumReader(ctx, cc.metaFile)
 	if err != nil {
+		cc.metaFile.Close()
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
+	defer sha256Reader.Close()
+
 	meta, err := decodeSessionRecordingMeta(ctx, sha256Reader)
 	if err != nil {
 		return nil, err
@@ -319,8 +322,11 @@ func (s *Session) OpenConnection(ctx context.Context, connId string) (*Connectio
 	// Load and verify connection metadata
 	sha256Reader, err := crypto.NewSha256SumReader(ctx, cc.metaFile)
 	if err != nil {
+		cc.metaFile.Close()
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
+	defer sha256Reader.Close()
+
 	sm, err := decodeConnectionRecordingMeta(ctx, sha256Reader)
 	if err != nil {
 		return nil, err
@@ -420,8 +426,11 @@ func (c *Connection) OpenChannel(ctx context.Context, chanId string) (*Channel, 
 	// Load and verify channel metadata
 	sha256Reader, err := crypto.NewSha256SumReader(ctx, cc.metaFile)
 	if err != nil {
+		cc.metaFile.Close()
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
+	defer sha256Reader.Close()
+
 	sm, err := decodeChannelRecordingMeta(ctx, sha256Reader)
 	if err != nil {
 		return nil, err

--- a/internal/bsr/bsr.go
+++ b/internal/bsr/bsr.go
@@ -173,7 +173,7 @@ func persistBsrSessionKeys(ctx context.Context, keys *kms.Keys, c *container) er
 // Signature and checksum files will then be verified.
 // Fields on the underlying container will be populated so that the returned Session can be used for BSR
 // playback and conversion to formats such as asciinema
-func OpenSession(ctx context.Context, sessionRecordingId string, f storage.FS, keyUnwrapFn kms.KeyUnwrapCallbackFunc) (*Session, error) {
+func OpenSession(ctx context.Context, sessionRecordingId string, f storage.FS, keyUnwrapFn kms.KeyUnwrapCallbackFunc) (s *Session, err error) {
 	const op = "bsr.OpenSession"
 	switch {
 	case sessionRecordingId == "":
@@ -203,7 +203,11 @@ func OpenSession(ctx context.Context, sessionRecordingId string, f storage.FS, k
 		cc.metaFile.Close()
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
-	defer sha256Reader.Close()
+	defer func() {
+		if closeErr := sha256Reader.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("%s: %w", op, closeErr))
+		}
+	}()
 
 	meta, err := decodeSessionRecordingMeta(ctx, sha256Reader)
 	if err != nil {
@@ -292,7 +296,7 @@ func (s *Session) NewConnection(ctx context.Context, meta *ConnectionRecordingMe
 }
 
 // OpenConnection will open and validate a BSR connection
-func (s *Session) OpenConnection(ctx context.Context, connId string) (*Connection, error) {
+func (s *Session) OpenConnection(ctx context.Context, connId string) (conn *Connection, err error) {
 	const op = "bsr.(Session).OpenConnection"
 	switch {
 	case connId == "":
@@ -325,7 +329,11 @@ func (s *Session) OpenConnection(ctx context.Context, connId string) (*Connectio
 		cc.metaFile.Close()
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
-	defer sha256Reader.Close()
+	defer func() {
+		if closeErr := sha256Reader.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("%s: %w", op, closeErr))
+		}
+	}()
 
 	sm, err := decodeConnectionRecordingMeta(ctx, sha256Reader)
 	if err != nil {
@@ -397,7 +405,7 @@ func (c *Connection) NewChannel(ctx context.Context, meta *ChannelRecordingMeta)
 }
 
 // OpenChannel will open and validate a BSR channel
-func (c *Connection) OpenChannel(ctx context.Context, chanId string) (*Channel, error) {
+func (c *Connection) OpenChannel(ctx context.Context, chanId string) (ch *Channel, err error) {
 	const op = "bsr.OpenChannel"
 	switch {
 	case chanId == "":
@@ -429,7 +437,11 @@ func (c *Connection) OpenChannel(ctx context.Context, chanId string) (*Channel, 
 		cc.metaFile.Close()
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
-	defer sha256Reader.Close()
+	defer func() {
+		if closeErr := sha256Reader.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("%s: %w", op, closeErr))
+		}
+	}()
 
 	sm, err := decodeChannelRecordingMeta(ctx, sha256Reader)
 	if err != nil {

--- a/internal/bsr/bsr_open_test.go
+++ b/internal/bsr/bsr_open_test.go
@@ -469,3 +469,131 @@ func TestOpenBSRMethods_WithoutSummaryAllocFunc(t *testing.T) {
 		})
 	}
 }
+
+func TestCloseBSRMethods(t *testing.T) {
+	ctx := context.Background()
+
+	protocol := Protocol("TEST_CLOSED_FILE")
+	sessionRecordingId := "sr_012344567890"
+	sessionId := "s_012344567890"
+	connectionId := "connection"
+	channelId := "channel"
+
+	keys, err := kms.CreateKeys(ctx, kms.TestWrapper(t), "session")
+	require.NoError(t, err)
+
+	err = RegisterSummaryAllocFunc(protocol, ChannelContainer, func(ctx context.Context) Summary {
+		return &BaseChannelSummary{Id: channelId, ConnectionRecordingId: connectionId}
+	})
+	require.NoError(t, err)
+
+	err = RegisterSummaryAllocFunc(protocol, SessionContainer, func(ctx context.Context) Summary {
+		return &BaseSessionSummary{Id: sessionId, ConnectionCount: 1}
+	})
+	require.NoError(t, err)
+
+	err = RegisterSummaryAllocFunc(protocol, ConnectionContainer, func(ctx context.Context) Summary {
+		return &BaseConnectionSummary{Id: connectionId, ChannelCount: 1}
+	})
+	require.NoError(t, err)
+
+	f := fstest.NewMemFS(fstest.WithOriginalFile())
+
+	srm := &SessionRecordingMeta{
+		Id:       sessionRecordingId,
+		Protocol: protocol,
+	}
+	sessionMeta := TestSessionMeta(sessionId)
+
+	sesh, err := NewSession(ctx, srm, sessionMeta, f, keys, WithSupportsMultiplex(true))
+	require.NoError(t, err)
+	require.NotNil(t, sesh)
+
+	sesh.EncodeSummary(ctx, &BaseChannelSummary{
+		Id:                    "TEST_CHANNEL_ID",
+		ConnectionRecordingId: "TEST_CONNECTION_RECORDING_ID",
+	})
+
+	connMeta := &ConnectionRecordingMeta{Id: connectionId}
+	conn, err := sesh.NewConnection(ctx, connMeta)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	conn.EncodeSummary(ctx, &BaseConnectionSummary{
+		Id:           "TEST_CONNECTION_ID",
+		ChannelCount: 1,
+	})
+
+	chanMeta := &ChannelRecordingMeta{
+		Id:   channelId,
+		Type: "chan",
+	}
+	ch, err := conn.NewChannel(ctx, chanMeta)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+
+	ch.EncodeSummary(ctx, &BaseSessionSummary{
+		Id:              "TEST_SESSION_ID",
+		ConnectionCount: 1,
+	})
+
+	ch.Close(ctx)
+	conn.Close(ctx)
+	sesh.Close(ctx)
+
+	keyFn := func(w kms.WrappedKeys) (kms.UnwrappedKeys, error) {
+		u := kms.UnwrappedKeys{
+			BsrKey:  keys.BsrKey,
+			PrivKey: keys.PrivKey,
+		}
+		return u, nil
+	}
+
+	opSesh, err := OpenSession(ctx, srm.Id, f, keyFn)
+	require.NoError(t, err)
+	require.NotNil(t, opSesh)
+
+	opConn, err := opSesh.OpenConnection(ctx, connectionId)
+	require.NoError(t, err)
+	require.NotNil(t, opConn)
+
+	opChan, err := opConn.OpenChannel(ctx, channelId)
+	require.NoError(t, err)
+	require.NotNil(t, opChan)
+
+	// Close all opened containers
+	require.NoError(t, opChan.Close(ctx))
+	require.NoError(t, opConn.Close(ctx))
+	require.NoError(t, opSesh.Close(ctx))
+
+	// Get session container
+	sessionContainer := f.Containers[fmt.Sprintf(bsrFileNameTemplate, sessionRecordingId)]
+	require.NotNil(t, sessionContainer)
+	assert.True(t, sessionContainer.Closed)
+
+	// Ensure all session files are closed
+	for _, file := range sessionContainer.Files {
+		assert.True(t, file.Closed)
+	}
+
+	// Get connection container
+	connectionContainer := sessionContainer.Sub[fmt.Sprintf(connectionFileNameTemplate, connectionId)]
+	require.NotNil(t, connectionContainer)
+	assert.True(t, connectionContainer.Closed)
+
+	// Ensure all connection files are closed
+	for _, file := range connectionContainer.Files {
+		assert.True(t, file.Closed)
+	}
+
+	// Get channel container
+	channelContainer := connectionContainer.Sub[fmt.Sprintf(channelFileNameTemplate, channelId)]
+	require.NotNil(t, channelContainer)
+	assert.True(t, channelContainer.Closed)
+
+	// Ensure all channel files are closed
+	for _, file := range channelContainer.Files {
+		assert.True(t, file.Closed, file)
+	}
+
+}

--- a/internal/bsr/bsr_open_test.go
+++ b/internal/bsr/bsr_open_test.go
@@ -593,7 +593,6 @@ func TestCloseBSRMethods(t *testing.T) {
 
 	// Ensure all channel files are closed
 	for _, file := range channelContainer.Files {
-		assert.True(t, file.Closed, file)
+		assert.True(t, file.Closed)
 	}
-
 }

--- a/internal/bsr/container.go
+++ b/internal/bsr/container.go
@@ -512,28 +512,40 @@ func (c *container) close(_ context.Context) error {
 
 	var closeError error
 
-	if err := c.meta.Close(); err != nil {
-		closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+	if !is.Nil(c.meta) {
+		if err := c.meta.Close(); err != nil {
+			closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+		}
 	}
 
-	if err := c.sum.Close(); err != nil {
-		closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+	if !is.Nil(c.sum) {
+		if err := c.sum.Close(); err != nil {
+			closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+		}
 	}
 
-	if err := c.checksums.Close(); err != nil {
-		closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+	if !is.Nil(c.checksums) {
+		if err := c.checksums.Close(); err != nil {
+			closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+		}
 	}
 
-	if err := c.sigs.Close(); err != nil {
-		closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+	if !is.Nil(c.sigs) {
+		if err := c.sigs.Close(); err != nil {
+			closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+		}
 	}
 
-	if err := c.journal.Close(); err != nil {
-		closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+	if !is.Nil(c.journal) {
+		if err := c.journal.Close(); err != nil {
+			closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+		}
 	}
 
-	if err := c.container.Close(); err != nil {
-		closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+	if !is.Nil(c.container) {
+		if err := c.container.Close(); err != nil {
+			closeError = errors.Join(closeError, fmt.Errorf("%s: %w", op, err))
+		}
 	}
 
 	return closeError

--- a/internal/bsr/internal/fstest/options.go
+++ b/internal/bsr/internal/fstest/options.go
@@ -41,6 +41,7 @@ type options struct {
 	withStatFunc       StatFunc
 	withReadOnly       bool
 	withStorageOptions []storage.Option
+	withOriginalFile   bool
 }
 
 func getDefaultOptions() options {
@@ -50,6 +51,7 @@ func getDefaultOptions() options {
 		withStatFunc:       nil,
 		withReadOnly:       false,
 		withStorageOptions: nil,
+		withOriginalFile:   false,
 	}
 }
 
@@ -85,5 +87,14 @@ func WithReadOnly(b bool) Option {
 func WithStorageOptions(opts []storage.Option) Option {
 	return func(o *options) {
 		o.withStorageOptions = opts
+	}
+}
+
+// WithOriginalFile is used to decide if the original of a file
+// should be returned instead of a copy of the file during
+// opening a file.
+func WithOriginalFile() Option {
+	return func(o *options) {
+		o.withOriginalFile = true
 	}
 }


### PR DESCRIPTION
- Add checks to close opened files in a container if not nil
- Close files opened during reads for `OpenSession`, `OpenConnection` & `OpenChannel`
- Close opened scanner readers

### Considerations
Update `fs.MemFS` to support returning the original files instead of copies when the `withOriginalOption` is passed. Had to do this to get the current `Closed` state of each file. Because all changes were just editing a copy, `fs.MemFS` was not getting updated with the true closed state of the fil