### PR TITLE
Add 'auth-methods' command doc

### DIFF
--- a/website/content/docs/api-clients/commands/auth-methods/change-state.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/change-state.mdx
@@ -1,0 +1,134 @@
+---
+layout: docs
+page_title: auth-methods change-state - Command
+description: |-
+  The "auth-methods change-state" command allows Boundary admin to change-state of an auth method.
+---
+
+# auth-methods change-state
+
+Command: `boundary auth-methods change-state`
+
+The `auth-methods change-state` command changes the active and visibility state
+of an oidc-type auth method given its ID. 
+
+An OIDC auth method can be in one of several different states: Inactive, Active
+Private, and Active Public. The current state of an OIDC auth method
+affects how endpoints respond to requests and, in some cases, whether access to
+an endpoint requires authentication.
+
+- **MakeInactive** transitions an OIDC auth method from either the Active Private
+  or the Active Public state into the Inactive state.
+- **MakePrivate** transitions an OIDC auth method from either the Inactive or the
+  Active Public state into the Active Private state. If transitioning from the
+  Inactive state, the transition will only succeed if the configuration is
+  valid.
+- **MakePublic** transitions an OIDC auth method from either the Inactive or the
+  Active Private state into the Active Public state. If transitioning from the
+  Inactive state, the transition will only succeed if the configuration is
+  valid.
+
+Before changing the state of an auth-method, Boundary will retrieve the
+Provider’s discovery document for the auth method’s issuer and attempt to
+validate the auth-method’s configuration against this published information. If
+Boundary is unable to validate the configuration an error is returned and the
+state change is not made.
+
+
+## Examples
+
+Change the OIDC auth method's state to active-public
+
+```shell-session
+$ boundary auth-methods change-state oidc -id amoidc_oHt4HQFCrN \
+   -state active-public
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Auth Method information:
+  Created Time:         Fri, 09 Sep 2022 11:11:55 MDT
+  ID:                   amoidc_oHt4HQFCrN
+  Name:                 auth0
+  Type:                 oidc
+  Updated Time:         Fri, 09 Sep 2022 11:41:33 MDT
+  Version:              3
+
+  Scope:
+    ID:                 global
+    Name:               global
+    Type:               global
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    change-state
+    authenticate
+
+  Authorized Actions on Auth Method's Collections:
+    accounts:
+      create
+      list
+    managed-groups:
+      create
+      list
+
+  Attributes:
+    api_url_prefix:     https://e58fe114-7624-431c-994d-b6670e90b03J.boundary.hashicorp.cloud
+    callback_url:       https://e58fe114-7624-431c-994d-b6670e90b03J.boundary.hashicorp.cloud/v1/auth-methods/oidc:authenticate:callback
+    client_id:          zbaJLTZh3n14WqSV7qQ9onuIVRDaZdzx
+    client_secret_hmac: Qc3i8NdnTP6rl4JANIg-a2GXgRW5rEKTp2ReIK_BOng
+    issuer:             https://dev-1vdl8c0q.us.auth0.com/
+    max_age:            0
+    signing_algorithms: [RS256]
+    state:              active-public
+```
+
+</CodeBlockConfig>
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary auth-methods change-state oidc [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id` `(string: "")` - ID of the oidc-type auth method on which to operate.
+
+### OIDC auth method options
+
+- `-disable-discovered-config-validation` `(bool: false)` - Disable validating
+   the given auth method against configuration from the authorization server's
+   discovery URL. This must be specified every time an unvalidatable auth method
+   is updated or state changed; not specifying it is equivalent to setting it to
+   false. The default is false.
+
+- `-state` `(string: "")` - The desired operational state of the auth method.
+  Three different states exist for an authentication method:
+
+   - `inactive` users can not authenticate with inactive auth methods and the
+   inactive auth methods are not listed for unauthenticated users.
+   - `active-private` users can authenticate with active-private auth methods
+   and active-private auth methods are not listed for unauthenticated users.
+   - `active-public` users can authenticate active-public auth methods and
+   active-public auth methods are listed for unauthenticated users.
+
+If a change is made from `active-public` or `active-private` to `inactive`, all
+in-flight authentications will succeed unless the auth method’s configuration is
+modified while the request is in-flight.
+
+When changing an auth method's state using `boundary auth-methods change-state`
+the `-disable-discovered-config-validation` flag is used to disable validation
+against the provider’s published discovery document. This allows for the very
+rare occurrence when the Provider has published an invalid discovery document.

--- a/website/content/docs/api-clients/commands/auth-methods/create.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/create.mdx
@@ -1,0 +1,271 @@
+---
+layout: docs
+page_title: auth-methods create - Command
+description: |-
+  The "auth-methods create" command allows Boundary admin to create an auth method.
+---
+
+# auth-methods create
+
+Command: `boundary auth-methods create`
+
+The `auth-methods create` command allows create operations on Boundary auth
+method resources. The available auth method types are: LDAP, OIDC, and password.
+
+## Examples
+
+Create an OIDC auth method by passing the OIDC provider's domain (`-issuer`),
+client ID, and client secret.
+
+```shell-session
+$ boundary auth-methods create oidc \
+  -issuer "https://dev-1sdl8c0z.us.auth0.com" \
+  -client-id "zaxJLTZh3n14WqSQ7qQ9onuIVRDaZdzz;" \
+  -client-secret "t35c9NNw1aZ8haEKFJbJF0lauMOSp5UNPovUJXo8Ea2sPZAR1DszEowX-6-lg-Xr" \
+  -signing-algorithm RS256 \
+  -api-url-prefix "http://localhost:9200" \
+  -name "auth0"
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Auth Method information:
+  Created Time:         Thu, 06 May 2021 16:39:33 MDT
+  ID:                   amoidc_oHt4HQFCrN
+  Name:                 auth0
+  Type:                 oidc
+  Updated Time:         Thu, 06 May 2021 16:39:33 MDT
+  Version:              1
+
+  Scope:
+    ID:                 global
+    Name:               global
+    Type:               global
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    change-state
+    authenticate
+
+  Authorized Actions on Auth Method's Collections:
+    accounts:
+      create
+      list
+
+  Attributes:
+    api_url_prefix:     http://localhost:9200
+    callback_url:       http://localhost:9200/v1/auth-methods/oidc:authenticate:callback
+    client_id:          zbaJLTZh3n14WqSV7qQ9onuIVRDaZdzx
+    client_secret_hmac: ayJRYSCphzxcHiKJvBrnDVtz1yiR958ejQuRGdQJMeM
+    issuer:             https://dev-1vdl8c0q.us.auth0.com
+    signing_algorithms: [RS256]
+    state:              inactive
+```
+
+</CodeBlockConfig>
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary auth-methods create [type] [sub command] [options] [args]
+```
+
+</CodeBlockConfig>
+
+The available types are: `ldap`, `oidc`, and `password`.
+
+### Command options:
+
+- `-description` `(string: "")` - Description to set on the ldap-type auth
+  method.
+- `-name` `(string: "")` - Name to set on the ldap-type auth method.
+- `-scope-id` `(string: "")` - Scope in which to make the request. The default
+   is global. This can also be specified via the `BOUNDARY_SCOPE_ID`
+   environment variable.
+
+#### Usages by type
+
+<Tabs>
+<Tab heading="ldap">
+
+Create an auth method of `ldap` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary auth-methods create ldap [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+#### LDAP auth method option
+
+The following are LDAP specific options in addition to the command
+options.
+
+- `-anon-group-search` `(bool: false)` - Use anon bind when performing LDAP
+   group searches (optional). The default is false.
+
+- `-bind-dn` `(string: "")` - The distinguished name of entry to bind when
+   performing user and group searches (optional). 
+
+- `-bind-password` `(string: "")` - The password to use along with bind-dn
+  performing user and group searches (optional). 
+
+- `-certificate` `(string: "")` - PEM-encoded X.509 CA certificate in ASN.1 DER
+   form that can be used as a trust anchor when connecting to an LDAP
+   server(optional). This may be specified multiple times. 
+
+- `-client-certificate` `(string: "")` - PEM-encoded X.509 client certificate in
+   ASN.1 DER form that can be used to authenticate against an LDAP server
+   (optional).
+
+- `-client-certificate-key` `(string: "")` - PEM-encoded X.509 client
+   certificate key in PKCS #8, ASN.1 DER form used with the client certificate
+   (optional).
+
+- `-discover-dn` `(bool: false)` - Use anon bind to discover the bind DN of a
+   user (optional). The default is false.
+
+- `-enable-groups` `(bool: false)` - Find the authenticated user's groups during
+   authentication (optional). The default is false.
+
+- `-group-attr` `(string: "")` - The attribute that enumerates a user's group
+   membership from entries returned by a group search (optional).
+
+- `-group-dn` `(string: "")` - The base DN under which to perform group search.
+
+- `-group-filter` `(string: "")` - A go template used to construct a LDAP group
+   search filter (optional).
+
+- `-insecure-tls` `(bool: false)` - Skip the LDAP server SSL certificate
+   validation (optional) - insecure and use with caution. The default is false.
+
+- `-start-tls` `(bool: false)` - Issue StartTLS command after connecting
+   (optional). The default is false.
+
+- `-state` `(string: "")` - The desired operational state of the auth method.
+
+- `-upn-domain` `(string: "")` - The userPrincipalDomain used to construct the
+   UPN string for the authenticating user (optional).
+
+- `-urls` `(string: "")` - The LDAP URLs that specify LDAP servers to connect to
+   (required). May be specified multiple times.
+
+- `-use-token-groups` `(bool: false)` - Use the Active Directory tokenGroups
+   constructed attribute of the user to find the group memberships (optional).
+   The default is false.
+
+- `-user-attr` `(string: "")` - The attribute on user entry matching the
+   username passed when authenticating (optional).
+
+- `-user-dn` `(string: "")` - The base DN under which to perform user search
+(optional).
+
+- `-user-filter` `(string: "")` - A go template used to construct a LDAP user
+search filter (optional).
+
+#### Example
+
+```shell-session
+$ boundary auth-methods create ldap -name prodops \
+   -description "LDAP auth-method for ProdOps"
+```
+
+</Tab>
+<Tab heading="oidc">
+
+Create an auth method of `oidc` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary auth-methods create oidc [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### OIDC auth method options
+
+The following are OIDC auth-methods specific options in addition to the command
+options.
+
+- `-account-claim-maps` `(string: "")` - The optional account claim maps from
+   custom claims to the standard claims of sub, name and email. These maps are
+   represented as key=value where the key equals the Provider from-claim and the
+   value equals the Boundary to-claim. For example "oid=sub". May be specified
+   multiple times for different to-claims.
+
+- `-allowed-audience` `(string: "")` - The acceptable audience ("aud") claim.
+  May be specified multiple times.
+
+- `-api-url-prefix` `(string: "")` - The URL prefix used by the OIDC provider in
+  the authentication flow.
+
+- `-claims-scopes` `(tring: "")` - The optional claims scope requested. May be
+  specified multiple times. 
+
+- `-client-id` `(string: "")` - The OAuth 2.0 Client Identifier this auth method
+   should use with the provider.
+
+- `-client-secret` `(string: "")` - The corresponding client secret.
+
+- `-idp-ca-cert` `(string: "")` - Optional PEM-encoded X.509 CA certificate that
+   can be used as trust anchors when connecting to an OIDC provider. May be
+   specified multiple times.
+
+- `-issuer` `(string: "")` - The provider's Issuer URL.
+
+- `-max-age` `(string: "")` - The OIDC "max_age" parameter sent to the provider.
+
+- `-signing-algorithm` `(string: "")` - The allowed signing algorithm. May be
+   specified multiple times for multiple values.
+
+#### Example
+
+```shell-session
+$ boundary auth-methods create oidc -name prodops \
+   -description "Oidc auth-method for ProdOps"
+```
+
+</Tab>
+<Tab heading="password">
+
+Create an auth method of `password` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary accounts create password [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Password auth method options
+
+The following are password auth method specific options in addition to the
+command options.
+
+- `-min-login-name-length` `(string: "")` - The minimum length of login names
+
+- `-min-password-length` `(string: "")` - The minimum length of passwords
+
+#### Example
+
+```shell-session
+$ boundary auth-methods create password -name prodops \
+   -description "Password auth-method for ProdOps"
+```
+
+</Tab>
+</Tabs>

--- a/website/content/docs/api-clients/commands/auth-methods/delete.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/delete.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: auth-methods delete - Command
+description: |-
+  The "auth-methods delete" command allows Boundary admin to delete an auth method.
+---
+
+# auth-methods delete
+
+Command: `boundary auth-methods delete`
+
+The `auth-methods delete` command deletes an auth method given its ID.
+
+## Examples
+
+Delete an auth method with ID, "amoidc_oHt4HQFCrN".
+
+```shell-session
+$ boundary auth-methods delete -id amoidc_oHt4HQFCrN
+```
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary auth-methods delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-id` `(string: "")` - ID of the auth method to delete.

--- a/website/content/docs/api-clients/commands/auth-methods/index.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/index.mdx
@@ -1,0 +1,109 @@
+---
+layout: docs
+page_title: auth-methods - Command
+description: |-
+  The "auth-methods" command create and manage Boundary authentication method configuration.
+---
+
+# auth-methods
+
+Command: `boundary auth-methods`
+
+The `auth-methods` command manages the auth method resource in Boundary. An auth
+method is a resource that provides a mechanism for users to authenticate to
+Boundary. An auth method contains accounts which link an individual user to a
+set of credentials and managed groups which groups accounts that satisfy
+criteria and can be used as principals in roles. 
+
+## Examples
+
+The following command configures an OIDC auth method where Boundary cluster
+address is stored in the `BOUNDARY_ADDR`, the OIDC provider's client ID is
+stored in the `CLIENT_ID`, and the client secret is stored in the
+`CLIENT_SECRET` environment variables.
+
+```shell-session
+$ boundary auth-methods create oidc \
+   -issuer "https://dev-1sdl8c0z.us.auth0.com" \
+   -client-id "$CLIENT_ID" \
+   -client-secret "$CLIENT_SECRET" \
+   -signing-algorithm RS256 \
+   -api-url-prefix "$BOUNDARY_ADDR" \
+   -name "auth0"
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Auth Method information:
+  Created Time:         Fri, 09 Sep 2022 11:11:55 MDT
+  ID:                   amoidc_40fr5jkLpk
+  Name:                 auth0
+  Type:                 oidc
+  Updated Time:         Fri, 09 Sep 2022 11:11:55 MDT
+  Version:              1
+
+  Scope:
+    ID:                 global
+    Name:               global
+    Type:               global
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    change-state
+    authenticate
+
+  Authorized Actions on Auth Method's Collections:
+    accounts:
+      create
+      list
+    managed-groups:
+      create
+      list
+
+  Attributes:
+    api_url_prefix:     https://e58fe114-7624-431c-994d-b6670e90b03J.boundary.hashicorp.cloud
+    callback_url:       https://e58fe114-7624-431c-994d-b6670e90b03J.boundary.hashicorp.cloud/v1/auth-methods/oidc:authenticate:callback
+    client_id:          zaxJLTZh3n14WqSQ7qQ9onuIVRDaZdzz
+    client_secret_hmac: Qc3i8NdnTP6rl4JANIg-a2GXgRW5rEKTp2ReIK_BOng
+    issuer:             https://dev-1sdl8c0z.us.auth0.com
+    signing_algorithms: [RS256]
+    state:              inactive
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary auth-methods [sub command] [options] [args]
+
+  # ...
+
+Subcommands:
+    change-state
+    create          Create an auth method
+    delete          Delete an auth method
+    list            List an auth method
+    read            Read an auth method
+    update          Update an auth method
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [change-state](/boundary/docs/api-clients/commands/auth-methods/change-state)
+- [create](/boundary/docs/api-clients/commands/auth-methods/create)
+- [delete](/boundary/docs/api-clients/commands/auth-methods/delete)
+- [list](/boundary/docs/api-clients/commands/auth-methods/list)
+- [read](/boundary/docs/api-clients/commands/auth-methods/read)
+- [update](/boundary/docs/api-clients/commands/auth-methods/update)

--- a/website/content/docs/api-clients/commands/auth-methods/list.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/list.mdx
@@ -1,0 +1,97 @@
+---
+layout: docs
+page_title: auth-methods list - Command
+description: |-
+  The "auth-methods list" command allows Boundary admin to list available auth methods.
+---
+
+# auth-methods list
+
+Command: `boundary auth-methods list`
+
+The `auth-methods list` command lists auth methods within an enclosing scope or
+resource.
+
+
+## Examples
+
+List auth methods recursively into child scopes if applicable.
+
+```shell-session
+$ boundary auth-methods list -recursive
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Auth Method information:
+  ID:                     amoidc_1234567890
+    Scope ID:             global
+    Version:              1
+    Type:                 oidc
+    Name:                 Generated global scope initial oidc auth method
+    Description:          Provides initial administrative and unprivileged authentication into Boundary
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+      change-state
+      authenticate
+
+  ID:                     ampw_1234567890
+    Scope ID:             global
+    Version:              1
+    Type:                 password
+    Name:                 Generated global scope initial password auth method
+    Description:          Provides initial administrative and unprivileged authentication into Boundary
+    Is Primary For Scope: true
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+      authenticate
+
+  ID:                     ampw_ZbB6UXpW3B
+    Scope ID:             o_u54jrD6ydN
+    Version:              1
+    Type:                 password
+    Name:                 org_auth_method
+    Description:          Org auth method
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+      authenticate
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary auth-methods list [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-filter` `(string: "")` - If set, the list operation will be filtered before
+   being returned. The filter operates against each item in the list. Using
+   single quotes is recommended as filters contain double quotes. 
+
+- `-recursive` `(bool: false)` - If set, the list operation will be applied
+   recursively into child scopes, if supported by the type. The default is
+   false.
+
+- `-scope-id` `(string: "")` - Scope in which to make the request. The default
+   is global. This can also be specified via the BOUNDARY_SCOPE_ID environment
+   variable.

--- a/website/content/docs/api-clients/commands/auth-methods/read.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/read.mdx
@@ -1,0 +1,80 @@
+---
+layout: docs
+page_title: auth-methods read - Command
+description: |-
+  The "auth-methods read" command allows Boundary admin to read an auth method.
+---
+
+# auth-methods read
+
+Command: `boundary auth-methods read`
+
+The `auth-methods read` command reads an auth method given its ID.
+
+## Examples
+
+Read the auth method details where its ID is "amoidc_AliCbVihqv".
+
+```shell-session
+$ boundary auth-methods read -id amoidc_AliCbVihqv
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Auth Method information:
+  Created Time:         Thu, 13 May 2021 17:01:02 MDT
+  Description:          OIDC auth method for Auth0
+  ID:                   amoidc_AliCbVihqv
+  Name:                 Auth0
+  Type:                 oidc
+  Updated Time:         Thu, 13 May 2021 17:01:02 MDT
+  Version:              2
+
+  Scope:
+    ID:                 o_1234567890
+    Name:               Generated org scope
+    Parent Scope ID:    global
+    Type:               org
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    change-state
+    authenticate
+
+  Authorized Actions on Auth Method's Collections:
+    accounts:
+      create
+      list
+
+  Attributes:
+    api_url_prefix:     http://localhost:9200
+    callback_url:       http://localhost:9200/v1/auth-methods/oidc:authenticate:callback
+    client_id:          zbaJLTZh3n14WqSV7qQ9onuIVRDaZdzx
+    client_secret_hmac: AhyxTBqlZpnny78iA9M7QHKAKocI17bjwvS70B1ccg0
+    issuer:             https://dev-1vdl8c0q.us.auth0.com/
+    signing_algorithms: [RS256]
+    state:              active-public
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary auth-methods read [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id` `(string: "")` - ID of the auth method to delete.
+

--- a/website/content/docs/api-clients/commands/auth-methods/update.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/update.mdx
@@ -1,0 +1,287 @@
+---
+layout: docs
+page_title: auth-methods update - Command
+description: |-
+  The "auth-methods update" command allows Boundary admin to update an auth method.
+---
+
+# auth-methods update
+
+Command: `boundary auth-methods update`
+
+The `auth-methods update` command allows update operations on Boundary auth
+method resources.
+
+## Examples
+
+Update an auth method to set the `-max-age` option to `0`, which will force the
+user to re-authenticate if they are already logged in with the current browser
+session.
+
+```shell-session
+$ boundary auth-methods update oidc -id amoidc_oHt4HQFCrN \
+   -issuer "https://dev-1vdl8c0q.us.auth0.com/" \
+   -max-age 0
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Auth Method information:
+  Created Time:         Thu, 06 May 2021 16:39:33 MDT
+  ID:                   amoidc_oHt4HQFCrN
+  Name:                 auth0
+  Type:                 oidc
+  Updated Time:         Thu, 06 May 2021 16:58:21 MDT
+  Version:              2
+
+  Scope:
+    ID:                 global
+    Name:               global
+    Type:               global
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    change-state
+    authenticate
+
+  Authorized Actions on Auth Method's Collections:
+    accounts:
+      create
+      list
+
+  Attributes:
+    api_url_prefix:     https://e58fe114-7624-431c-994d-b6670e90b03J.boundary.hashicorp.cloud
+    callback_url:       https://e58fe114-7624-431c-994d-b6670e90b03J.boundary.hashicorp.cloud/v1/auth-methods/oidc:authenticate:callback
+    client_id:          zbaJLTZh3n14WqSV7qQ9onuIVRDaZdzx
+    client_secret_hmac: ayJRYSCphzxcHiKJvBrnDVtz1yiR958ejQuRGdQJMeM
+    issuer:             https://dev-1vdl8c0q.us.auth0.com/
+    max_age:            0
+    signing_algorithms: [RS256]
+    state:              inactive
+```
+
+</CodeBlockConfig>
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary auth-methods update [type] [sub command] [options] [args]
+```
+
+</CodeBlockConfig>
+
+The available types are: `ldap`, `oidc`, and `password`.
+
+### Command options:
+
+- `-description` `(string: "")` - Description to set on the ldap-type auth
+  method.
+- `-id` `(string: "")` - ID of the ldap-type auth method on which to operate.
+- `-name` `(string: "")` - Name to set on the ldap-type auth method.
+- `-version` `(int: 0)` - The version of the ldap-type auth method against which
+   to perform an update operation. If not specified, the command will perform
+   a check-and-set automatically.
+
+#### Usages by type
+
+<Tabs>
+<Tab heading="ldap">
+
+Update an auth method of `ldap` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary auth-methods update ldap [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+#### LDAP auth method option
+
+The following are LDAP specific options in addition to the command
+options.
+
+- `-anon-group-search` `(bool: false)` - Use anon bind when performing LDAP
+   group searches (optional). The default is false.
+
+- `-bind-dn` `(string: "")` - The distinguished name of entry to bind when
+   performing user and group searches (optional). 
+
+- `-bind-password` `(string: "")` - The password to use along with bind-dn
+  performing user and group searches (optional). 
+
+- `-certificate` `(string: "")` - PEM-encoded X.509 CA certificate in ASN.1 DER
+   form that can be used as a trust anchor when connecting to an LDAP
+   server(optional). This may be specified multiple times. 
+
+- `-client-certificate` `(string: "")` - PEM-encoded X.509 client certificate in
+   ASN.1 DER form that can be used to authenticate against an LDAP server
+   (optional).
+
+- `-client-certificate-key` `(string: "")` - PEM-encoded X.509 client
+   certificate key in PKCS #8, ASN.1 DER form used with the client certificate
+   (optional).
+
+- `-discover-dn` `(bool: false)` - Use anon bind to discover the bind DN of a
+   user (optional). The default is false.
+
+- `-enable-groups` `(bool: false)` - Find the authenticated user's groups during
+   authentication (optional). The default is false.
+
+- `-group-attr` `(string: "")` - The attribute that enumerates a user's group
+   membership from entries returned by a group search (optional).
+
+- `-group-dn` `(string: "")` - The base DN under which to perform group search.
+
+- `-group-filter` `(string: "")` - A go template used to construct a LDAP group
+   search filter (optional).
+
+- `-insecure-tls` `(bool: false)` - Skip the LDAP server SSL certificate
+   validation (optional) - insecure and use with caution. The default is false.
+
+- `-start-tls` `(bool: false)` - Issue StartTLS command after connecting
+   (optional). The default is false.
+
+- `-state` `(string: "")` - The desired operational state of the auth method.
+
+- `-upn-domain` `(string: "")` - The userPrincipalDomain used to construct the
+   UPN string for the authenticating user (optional).
+
+- `-urls` `(string: "")` - The LDAP URLs that specify LDAP servers to connect to
+   (required). May be specified multiple times.
+
+- `-use-token-groups` `(bool: false)` - Use the Active Directory tokenGroups
+   constructed attribute of the user to find the group memberships (optional).
+   The default is false.
+
+- `-user-attr` `(string: "")` - The attribute on user entry matching the
+   username passed when authenticating (optional).
+
+- `-user-dn` `(string: "")` - The base DN under which to perform user search
+   (optional).
+
+- `-user-filter` `(string: "")` - A go template used to construct a LDAP user
+   search filter (optional).
+
+#### Example
+
+```shell-session
+$ boundary auth-methods update ldap -id amldap_1234567890 \
+   -name "devops" \
+   -description "LDAP auth-method for DevOps"
+```
+
+</Tab>
+<Tab heading="oidc">
+
+Update an auth method of `oidc` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary auth-methods update oidc [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### OIDC auth method options
+
+The following are OIDC auth-methods specific options in addition to the command
+options.
+
+- `-account-claim-maps` `(string: "")` - The optional account claim maps from
+   custom claims to the standard claims of sub, name and email. These maps are
+   represented as key=value where the key equals the Provider from-claim and the
+   value equals the Boundary to-claim. For example "oid=sub". May be specified
+   multiple times for different to-claims.
+
+- `-allowed-audience` `(string: "")` - The acceptable audience ("aud") claim.
+  May be specified multiple times.
+
+- `-api-url-prefix` `(string: "")` - The URL prefix used by the OIDC provider in
+  the authentication flow.
+
+- `-claims-scopes` `(tring: "")` - The optional claims scope requested. May be
+  specified multiple times.
+
+- `-client-id` `(string: "")` - The OAuth 2.0 Client Identifier this auth method
+   should use with the provider.
+
+- `-client-secret` `(string: "")` - The corresponding client secret.
+
+- `-idp-ca-cert` `(string: "")` - Optional PEM-encoded X.509 CA certificate that
+   can be used as trust anchors when connecting to an OIDC provider. May be
+   specified multiple times.
+
+- `-disable-discovered-config-validation` `(bool: false)` - Disable validating
+   the given auth method against configuration from the authorization server's
+   discovery URL. This must be specified every time an unvalidatable auth method
+   is updated or state changed; not specifying it is equivalent to setting it to
+   false. The default is false.
+
+- `-dry-run` `(bool: false)` - Performs all completeness and validation checks
+   with any newly-provided values without persisting the changes. The default is
+   false.
+
+- `-idp-ca-cert` `(tring: "")` - Optional PEM-encoded X.509 CA certificate that
+   can be used as trust anchors when connecting to an OIDC provider. May be
+   specified multiple times.
+
+- `-issuer` `(string: "")` - The provider's Issuer URL.
+
+- `-max-age` `(string: "")` - The OIDC "max_age" parameter sent to the provider.
+
+- `-signing-algorithm` `(string: "")` - The allowed signing algorithm. May be
+   specified multiple times for multiple values.
+
+#### Example
+
+```shell-session
+$ boundary auth-methods update oidc -id amoidc_1234567890 \
+   -name "devops" \
+   -description "Oidc auth-method for DevOps"
+```
+
+</Tab>
+<Tab heading="password">
+
+Update an auth method of `password` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary auth-methods update password [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Password auth method options
+
+The following are password auth method specific options in addition to the
+command options.
+
+- `-min-login-name-length` `(string: "")` - The minimum length of login names
+
+- `-min-password-length` `(string: "")` - The minimum length of passwords
+
+#### Example
+
+```shell-session
+$ boundary auth-methods update password -id ampw_1234567890 \
+   -name "devops" \
+   -description "Password auth-method for DevOps"
+```
+
+</Tab>
+</Tabs>

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -548,6 +548,39 @@
             ]
           },
           {
+            "title": "auth-methods",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/auth-methods"
+              },
+              {
+                "title": "change-state",
+                "path": "api-clients/commands/auth-methods/change-state"
+              },
+              {
+                "title": "create",
+                "path": "api-clients/commands/auth-methods/create"
+              },
+              {
+                "title": "delete",
+                "path": "api-clients/commands/auth-methods/delete"
+              },
+              {
+                "title": "list",
+                "path": "api-clients/commands/auth-methods/list"
+              },
+              {
+                "title": "read",
+                "path": "api-clients/commands/auth-methods/read"
+              },
+              {
+                "title": "update",
+                "path": "api-clients/commands/auth-methods/update"
+              }
+            ]
+          },
+          {
             "title": "connect",
             "routes": [
               {


### PR DESCRIPTION
This PR adds the `boundary auth-methods` command docs to https://github.com/hashicorp/boundary/pull/3411

🔍 [Deploy preview](https://boundary-77knuc0c8-hashicorp.vercel.app/boundary/docs/api-clients/commands/auth-methods)