### PR TITLE
telemetry: accounts proto

### DIFF
--- a/internal/gen/controller.swagger.json
+++ b/internal/gen/controller.swagger.json
@@ -4356,7 +4356,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Output only. The ID of the Account.",
+          "description": "Output only. The ID of the Account.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`",
           "readOnly": true
         },
         "scope": {
@@ -4375,27 +4375,27 @@
         "created_time": {
           "type": "string",
           "format": "date-time",
-          "description": "Output only. The time this resource was created.",
+          "description": "Output only. The time this resource was created.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`",
           "readOnly": true
         },
         "updated_time": {
           "type": "string",
           "format": "date-time",
-          "description": "Output only. The time this resource was last updated.",
+          "description": "Output only. The time this resource was last updated.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`",
           "readOnly": true
         },
         "version": {
           "type": "integer",
           "format": "int64",
-          "description": "Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.\nThe mutation will fail if the version does not match the latest known good version."
+          "description": "Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.\nThe mutation will fail if the version does not match the latest known good version.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`"
         },
         "type": {
           "type": "string",
-          "description": "The type of this Account."
+          "description": "The type of this Account.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`"
         },
         "auth_method_id": {
           "type": "string",
-          "description": "The ID of the Auth Method that is associated with this Account."
+          "description": "The ID of the Auth Method that is associated with this Account.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`"
         },
         "attributes": {
           "type": "object",
@@ -4406,7 +4406,7 @@
           "items": {
             "type": "string"
           },
-          "description": "",
+          "description": "@gotags: `class:\"public\" eventstream:\"observation\"`",
           "title": "Output only. managed_group_ids indicates IDs of the managed groups that currently contain this account",
           "readOnly": true
         },
@@ -4415,7 +4415,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Output only. The available actions on this resource for this user.",
+          "description": "Output only. The available actions on this resource for this user.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`",
           "readOnly": true
         }
       },

--- a/internal/gen/controller.swagger.json
+++ b/internal/gen/controller.swagger.json
@@ -4356,7 +4356,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Output only. The ID of the Account.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`",
+          "description": "Output only. The ID of the Account.",
           "readOnly": true
         },
         "scope": {
@@ -4375,27 +4375,27 @@
         "created_time": {
           "type": "string",
           "format": "date-time",
-          "description": "Output only. The time this resource was created.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`",
+          "description": "Output only. The time this resource was created.",
           "readOnly": true
         },
         "updated_time": {
           "type": "string",
           "format": "date-time",
-          "description": "Output only. The time this resource was last updated.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`",
+          "description": "Output only. The time this resource was last updated.",
           "readOnly": true
         },
         "version": {
           "type": "integer",
           "format": "int64",
-          "description": "Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.\nThe mutation will fail if the version does not match the latest known good version.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`"
+          "description": "Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.\nThe mutation will fail if the version does not match the latest known good version."
         },
         "type": {
           "type": "string",
-          "description": "The type of this Account.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`"
+          "description": "The type of this Account."
         },
         "auth_method_id": {
           "type": "string",
-          "description": "The ID of the Auth Method that is associated with this Account.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`"
+          "description": "The ID of the Auth Method that is associated with this Account."
         },
         "attributes": {
           "type": "object",
@@ -4406,7 +4406,7 @@
           "items": {
             "type": "string"
           },
-          "description": "@gotags: `class:\"public\" eventstream:\"observation\"`",
+          "description": "",
           "title": "Output only. managed_group_ids indicates IDs of the managed groups that currently contain this account",
           "readOnly": true
         },
@@ -4415,7 +4415,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Output only. The available actions on this resource for this user.\n\n@gotags: `class:\"public\" eventstream:\"observation\"`",
+          "description": "Output only. The available actions on this resource for this user.",
           "readOnly": true
         }
       },

--- a/internal/gen/controller/api/services/account_service.pb.go
+++ b/internal/gen/controller/api/services/account_service.pb.go
@@ -33,7 +33,7 @@ type GetAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *GetAccountRequest) Reset() {
@@ -127,7 +127,7 @@ type ListAccountsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	AuthMethodId string `protobuf:"bytes,1,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	AuthMethodId string `protobuf:"bytes,1,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Filter       string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty" class:"sensitive"`                // @gotags: `class:"sensitive"`
 }
 
@@ -276,7 +276,7 @@ type CreateAccountResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Uri  string            `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public"` // @gotags: `class:"public"`
+	Uri  string            `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Item *accounts.Account `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 }
 
@@ -331,7 +331,7 @@ type UpdateAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Item       *accounts.Account      `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 	UpdateMask *fieldmaskpb.FieldMask `protobuf:"bytes,3,opt,name=update_mask,proto3" json:"update_mask,omitempty"`
 }
@@ -441,7 +441,7 @@ type DeleteAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *DeleteAccountRequest) Reset() {
@@ -526,10 +526,10 @@ type SetPasswordRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version  uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`  // @gotags: `class:"public"`
+	Version  uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public" eventstream:"observation"`  // @gotags: `class:"public" eventstream:"observation"`
 	Password string `protobuf:"bytes,3,opt,name=password,proto3" json:"password,omitempty" class:"secret"` // @gotags: `class:"secret"`
 }
 
@@ -638,10 +638,10 @@ type ChangePasswordRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version         uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`                  // @gotags: `class:"public"`
+	Version         uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public" eventstream:"observation"`                  // @gotags: `class:"public" eventstream:"observation"`
 	CurrentPassword string `protobuf:"bytes,3,opt,name=current_password,proto3" json:"current_password,omitempty" class:"secret"` // @gotags: `class:"secret"`
 	NewPassword     string `protobuf:"bytes,4,opt,name=new_password,proto3" json:"new_password,omitempty" class:"secret"`         // @gotags: `class:"secret"`
 }

--- a/internal/proto/controller/api/resources/accounts/v1/account.proto
+++ b/internal/proto/controller/api/resources/accounts/v1/account.proto
@@ -17,7 +17,7 @@ option go_package = "github.com/hashicorp/boundary/sdk/pbs/controller/api/resour
 // Account contains all fields related to an Account resource
 message Account {
   // Output only. The ID of the Account.
-  string id = 10; // @gotags: `class:"public"`
+  string id = 10; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. Scope information for the Account.
   resources.scopes.v1.ScopeInfo scope = 20;
@@ -41,23 +41,23 @@ message Account {
   ]; // @gotags: `class:"public"`
 
   // Output only. The time this resource was created.
-  google.protobuf.Timestamp created_time = 50 [json_name = "created_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp created_time = 50 [json_name = "created_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The time this resource was last updated.
-  google.protobuf.Timestamp updated_time = 60 [json_name = "updated_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp updated_time = 60 [json_name = "updated_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 70; // @gotags: `class:"public"`
+  uint32 version = 70; // @gotags: `class:"public" eventstream:"observation"`
 
   // The type of this Account.
-  string type = 80; // @gotags: `class:"public"`
+  string type = 80; // @gotags: `class:"public" eventstream:"observation"`
 
   // The ID of the Auth Method that is associated with this Account.
   string auth_method_id = 90 [
     json_name = "auth_method_id",
     (custom_options.v1.subtype_source_id) = true
-  ]; // @gotags: `class:"public"`
+  ]; // @gotags: `class:"public" eventstream:"observation"`
 
   oneof attrs {
     // The attributes that are applicable for the specific Account type.
@@ -83,10 +83,10 @@ message Account {
   }
 
   // Output only. managed_group_ids indicates IDs of the managed groups that currently contain this account
-  repeated string managed_group_ids = 110 [json_name = "managed_group_ids"]; // @gotags: `class:"public"`
+  repeated string managed_group_ids = 110 [json_name = "managed_group_ids"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The available actions on this resource for this user.
-  repeated string authorized_actions = 300 [json_name = "authorized_actions"]; // @gotags: `class:"public"`
+  repeated string authorized_actions = 300 [json_name = "authorized_actions"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 // Attributes associated only with Accounts with type "password".

--- a/internal/proto/controller/api/services/v1/account_service.proto
+++ b/internal/proto/controller/api/services/v1/account_service.proto
@@ -100,7 +100,7 @@ service AccountService {
 }
 
 message GetAccountRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message GetAccountResponse {
@@ -108,7 +108,7 @@ message GetAccountResponse {
 }
 
 message ListAccountsRequest {
-  string auth_method_id = 1 [json_name = "auth_method_id"]; // @gotags: `class:"public"`
+  string auth_method_id = 1 [json_name = "auth_method_id"]; // @gotags: `class:"public" eventstream:"observation"`
   string filter = 30 [json_name = "filter"]; // @gotags: `class:"sensitive"`
 }
 
@@ -121,12 +121,12 @@ message CreateAccountRequest {
 }
 
 message CreateAccountResponse {
-  string uri = 1; // @gotags: `class:"public"`
+  string uri = 1; // @gotags: `class:"public" eventstream:"observation"`
   resources.accounts.v1.Account item = 2;
 }
 
 message UpdateAccountRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   resources.accounts.v1.Account item = 2;
   google.protobuf.FieldMask update_mask = 3 [json_name = "update_mask"];
 }
@@ -136,16 +136,16 @@ message UpdateAccountResponse {
 }
 
 message DeleteAccountRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message DeleteAccountResponse {}
 
 message SetPasswordRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 2; // @gotags: `class:"public"`
+  uint32 version = 2; // @gotags: `class:"public" eventstream:"observation"`
   string password = 3; // @gotags: `class:"secret"`
 }
 
@@ -154,10 +154,10 @@ message SetPasswordResponse {
 }
 
 message ChangePasswordRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
-  uint32 version = 2; // @gotags: `class:"public"`
+  uint32 version = 2; // @gotags: `class:"public" eventstream:"observation"`
   string current_password = 3 [json_name = "current_password"]; // @gotags: `class:"secret"`
   string new_password = 4 [json_name = "new_password"]; // @gotags: `class:"secret"`
 }

--- a/scripts/remove-gotags-comments/main.go
+++ b/scripts/remove-gotags-comments/main.go
@@ -39,6 +39,10 @@ func run(swaggerPath string) error {
 			//   - When gotags appears on its own.
 			//   - When gotags appears at the end of another comment (preceded by \n\n).
 			for _, prefix := range []string{"\\n\\n", ""} {
+				// The two cases we're replacing gotags with empty message:
+				//   - When class gotags is set with eventstream gotags.
+				//   - When class gotags is set by itself.
+				swaggerBytes = bytes.ReplaceAll(swaggerBytes, []byte(fmt.Sprintf("%s@gotags: %sclass:\\\"%s\\\" eventstream:\\\"observation\\\"%s", prefix, wrapper, classification, wrapper)), nil)
 				swaggerBytes = bytes.ReplaceAll(swaggerBytes, []byte(fmt.Sprintf("%s@gotags: %sclass:\\\"%s\\\"%s", prefix, wrapper, classification, wrapper)), nil)
 			}
 		}

--- a/sdk/pbs/controller/api/resources/accounts/account.pb.go
+++ b/sdk/pbs/controller/api/resources/accounts/account.pb.go
@@ -36,7 +36,7 @@ type Account struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the Account.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. Scope information for the Account.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,20,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Optional name for identification purposes.
@@ -44,16 +44,16 @@ type Account struct {
 	// Optional user-set description for identification purposes.
 	Description *wrapperspb.StringValue `protobuf:"bytes,40,opt,name=description,proto3" json:"description,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,50,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,50,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The time this resource was last updated.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
-	Version uint32 `protobuf:"varint,70,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
+	Version uint32 `protobuf:"varint,70,opt,name=version,proto3" json:"version,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// The type of this Account.
-	Type string `protobuf:"bytes,80,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
+	Type string `protobuf:"bytes,80,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// The ID of the Auth Method that is associated with this Account.
-	AuthMethodId string `protobuf:"bytes,90,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	AuthMethodId string `protobuf:"bytes,90,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Types that are assignable to Attrs:
 	//
 	//	*Account_Attributes
@@ -62,9 +62,9 @@ type Account struct {
 	//	*Account_LdapAccountAttributes
 	Attrs isAccount_Attrs `protobuf_oneof:"attrs"`
 	// Output only. managed_group_ids indicates IDs of the managed groups that currently contain this account
-	ManagedGroupIds []string `protobuf:"bytes,110,rep,name=managed_group_ids,proto3" json:"managed_group_ids,omitempty" class:"public"` // @gotags: `class:"public"`
+	ManagedGroupIds []string `protobuf:"bytes,110,rep,name=managed_group_ids,proto3" json:"managed_group_ids,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The available actions on this resource for this user.
-	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public"` // @gotags: `class:"public"`
+	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *Account) Reset() {


### PR DESCRIPTION
This PR adds observation gotags to proper fields for telemetry purposes and modifies remove-gotags-comment to remove observation gotags from comments 
cc: @jimlambrt @ajayreshc 