### PR TITLE
internal/daemon/controller/handlers/sessions: fix dropped error

### DIFF
--- a/internal/daemon/controller/handlers/sessions/session_service.go
+++ b/internal/daemon/controller/handlers/sessions/session_service.go
@@ -149,6 +149,9 @@ func (s Service) ListSessions(ctx context.Context, req *pbs.ListSessionsRequest)
 		scopeIds = map[string]*scopes.ScopeInfo{authResults.Scope.Id: authResults.Scope}
 	} else {
 		scopeIds, err = authResults.ScopesAuthorizedForList(ctx, req.GetScopeId(), resource.Session)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	listPerms := authResults.ACL().ListPermissions(scopeIds, resource.Session, IdActions, authResults.UserId)


### PR DESCRIPTION
This fixes a dropped `err` variable in `internal/daemon/controller/handlers/sessions`.