### PR TITLE
Telemetry: auth_methods proto

### DIFF
--- a/internal/gen/controller/api/services/auth_method_service.pb.go
+++ b/internal/gen/controller/api/services/auth_method_service.pb.go
@@ -36,7 +36,7 @@ type GetAuthMethodRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *GetAuthMethodRequest) Reset() {
@@ -130,7 +130,7 @@ type ListAuthMethodsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"`     // @gotags: `class:"public"`
+	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"`     // @gotags: `class:"public" eventstream:"observation"`
 	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public"` // @gotags: `class:"public"`
 	Filter    string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty" class:"public"`        // @gotags: `class:"public"`
 }
@@ -287,7 +287,7 @@ type CreateAuthMethodResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Uri  string                  `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public"` // @gotags: `class:"public"`
+	Uri  string                  `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Item *authmethods.AuthMethod `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 }
 
@@ -342,7 +342,7 @@ type UpdateAuthMethodRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string                  `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id         string                  `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Item       *authmethods.AuthMethod `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 	UpdateMask *fieldmaskpb.FieldMask  `protobuf:"bytes,3,opt,name=update_mask,proto3" json:"update_mask,omitempty"`
 }
@@ -452,7 +452,7 @@ type DeleteAuthMethodRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *DeleteAuthMethodRequest) Reset() {
@@ -919,7 +919,7 @@ type AuthenticateRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the Auth Method in the system that should be used for authentication.
-	AuthMethodId string `protobuf:"bytes,1,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	AuthMethodId string `protobuf:"bytes,1,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// This can be "cookie" or "token". If not provided, "token" will be used. "cookie" activates a split-cookie method where the token is split partially between http-only and regular cookies in order
 	// to keep it safe from rogue JS in the browser. Deprecated, use "type" instead.
 	//
@@ -927,7 +927,7 @@ type AuthenticateRequest struct {
 	TokenType string `protobuf:"bytes,2,opt,name=token_type,proto3" json:"token_type,omitempty" class:"public"` // @gotags: `class:"public"`
 	// This can be "cookie" or "token". If not provided, "token" will be used. "cookie" activates a split-cookie method where the token is split partially between http-only and regular cookies in order
 	// to keep it safe from rogue JS in the browser.
-	Type string `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
+	Type string `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Types that are assignable to Attrs:
 	//
 	//	*AuthenticateRequest_Attributes
@@ -1100,7 +1100,7 @@ type AuthenticateResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The type of the token returned. Either "cookie" or "token".
-	Type string `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
+	Type string `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Types that are assignable to Attrs:
 	//
 	//	*AuthenticateResponse_Attributes

--- a/internal/proto/controller/api/resources/authmethods/v1/auth_method.proto
+++ b/internal/proto/controller/api/resources/authmethods/v1/auth_method.proto
@@ -18,10 +18,10 @@ option (custom_options.v1.domain) = "auth";
 // AuthMethod contains all fields related to an Auth Method resource
 message AuthMethod {
   // Output only. The ID of the Auth Method.
-  string id = 10; // @gotags: `class:"public"`
+  string id = 10; // @gotags: `class:"public" eventstream:"observation"`
 
   // The ID of the Scope of which this Auth Method is a part.
-  string scope_id = 20 [json_name = "scope_id"]; // @gotags: `class:"public"`
+  string scope_id = 20 [json_name = "scope_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. Scope information for this Auth method.
   resources.scopes.v1.ScopeInfo scope = 30;
@@ -45,17 +45,17 @@ message AuthMethod {
   ]; // @gotags: `class:"public"`
 
   // Output only. The time this resource was created.
-  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The time this resource was last updated.
-  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 80; // @gotags: `class:"public"`
 
   // The Auth Method type.
-  string type = 90; // @gotags: `class:"public"`
+  string type = 90; // @gotags: `class:"public" eventstream:"observation"`
 
   oneof attrs {
     // The attributes that are applicable for the specific Auth Method type.
@@ -82,10 +82,10 @@ message AuthMethod {
 
   // Output only. Whether this auth method is the primary auth method for it's scope.
   // To change this value update the primary_auth_method_id field on the scope.
-  bool is_primary = 110 [json_name = "is_primary"]; // @gotags: `class:"public"`
+  bool is_primary = 110 [json_name = "is_primary"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The available actions on this resource for this user.
-  repeated string authorized_actions = 300 [json_name = "authorized_actions"]; // @gotags: `class:"public"`
+  repeated string authorized_actions = 300 [json_name = "authorized_actions"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The authorized actions for the scope's collections.
   map<string, google.protobuf.ListValue> authorized_collection_actions = 310 [json_name = "authorized_collection_actions"]; // classified as public via taggable implementation

--- a/internal/proto/controller/api/services/v1/auth_method_service.proto
+++ b/internal/proto/controller/api/services/v1/auth_method_service.proto
@@ -96,7 +96,7 @@ service AuthMethodService {
 }
 
 message GetAuthMethodRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message GetAuthMethodResponse {
@@ -104,7 +104,7 @@ message GetAuthMethodResponse {
 }
 
 message ListAuthMethodsRequest {
-  string scope_id = 1 [json_name = "scope_id"]; // @gotags: `class:"public"`
+  string scope_id = 1 [json_name = "scope_id"]; // @gotags: `class:"public" eventstream:"observation"`
   bool recursive = 20 [json_name = "recursive"]; // @gotags: `class:"public"`
   string filter = 30 [json_name = "filter"]; // @gotags: `class:"public"`
 }
@@ -118,12 +118,12 @@ message CreateAuthMethodRequest {
 }
 
 message CreateAuthMethodResponse {
-  string uri = 1; // @gotags: `class:"public"`
+  string uri = 1; // @gotags: `class:"public" eventstream:"observation"`
   resources.authmethods.v1.AuthMethod item = 2;
 }
 
 message UpdateAuthMethodRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   resources.authmethods.v1.AuthMethod item = 2;
   google.protobuf.FieldMask update_mask = 3 [json_name = "update_mask"];
 }
@@ -133,7 +133,7 @@ message UpdateAuthMethodResponse {
 }
 
 message DeleteAuthMethodRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message DeleteAuthMethodResponse {}
@@ -194,7 +194,7 @@ message LdapLoginAttributes {
 
 message AuthenticateRequest {
   // The ID of the Auth Method in the system that should be used for authentication.
-  string auth_method_id = 1 [json_name = "auth_method_id"]; // @gotags: `class:"public"`
+  string auth_method_id = 1 [json_name = "auth_method_id"]; // @gotags: `class:"public" eventstream:"observation"`
   // This can be "cookie" or "token". If not provided, "token" will be used. "cookie" activates a split-cookie method where the token is split partially between http-only and regular cookies in order
   // to keep it safe from rogue JS in the browser. Deprecated, use "type" instead.
   string token_type = 2 [
@@ -203,7 +203,7 @@ message AuthenticateRequest {
   ]; // @gotags: `class:"public"`
   // This can be "cookie" or "token". If not provided, "token" will be used. "cookie" activates a split-cookie method where the token is split partially between http-only and regular cookies in order
   // to keep it safe from rogue JS in the browser.
-  string type = 6 [json_name = "type"]; // @gotags: `class:"public"`
+  string type = 6 [json_name = "type"]; // @gotags: `class:"public" eventstream:"observation"`
   oneof attrs {
     // Attributes are passed to the Auth Method; the valid keys and values depend on the type of Auth Method as well as the command.
     google.protobuf.Struct attributes = 4;
@@ -227,7 +227,7 @@ message AuthenticateResponse {
   reserved 1, 2; // Old item and token_type
   reserved "item", "token_type";
   // The type of the token returned. Either "cookie" or "token".
-  string type = 3; // @gotags: `class:"public"`
+  string type = 3; // @gotags: `class:"public" eventstream:"observation"`
   oneof attrs {
     // Valid keys and values depend on the type of Auth Method as well as the command.
     google.protobuf.Struct attributes = 4 [json_name = "attributes"];

--- a/sdk/pbs/controller/api/resources/authmethods/auth_method.pb.go
+++ b/sdk/pbs/controller/api/resources/authmethods/auth_method.pb.go
@@ -36,9 +36,9 @@ type AuthMethod struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the Auth Method.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// The ID of the Scope of which this Auth Method is a part.
-	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. Scope information for this Auth method.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,30,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Optional name for identification purposes.
@@ -46,14 +46,14 @@ type AuthMethod struct {
 	// Optional user-set description for identification purposes.
 	Description *wrapperspb.StringValue `protobuf:"bytes,50,opt,name=description,proto3" json:"description,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The time this resource was last updated.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The Auth Method type.
-	Type string `protobuf:"bytes,90,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
+	Type string `protobuf:"bytes,90,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Types that are assignable to Attrs:
 	//
 	//	*AuthMethod_Attributes
@@ -63,9 +63,9 @@ type AuthMethod struct {
 	Attrs isAuthMethod_Attrs `protobuf_oneof:"attrs"`
 	// Output only. Whether this auth method is the primary auth method for it's scope.
 	// To change this value update the primary_auth_method_id field on the scope.
-	IsPrimary bool `protobuf:"varint,110,opt,name=is_primary,proto3" json:"is_primary,omitempty" class:"public"` // @gotags: `class:"public"`
+	IsPrimary bool `protobuf:"varint,110,opt,name=is_primary,proto3" json:"is_primary,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The available actions on this resource for this user.
-	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public"` // @gotags: `class:"public"`
+	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The authorized actions for the scope's collections.
 	AuthorizedCollectionActions map[string]*structpb.ListValue `protobuf:"bytes,310,rep,name=authorized_collection_actions,proto3" json:"authorized_collection_actions,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"` // classified as public via taggable implementation
 }


### PR DESCRIPTION
This PR adds observation gotags to auth_methods for telemetry purposes
cc: @jimlambrt @ajayreshc 