### PR TITLE
chore: Modify go test retry settings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,9 +168,9 @@ jobs:
         env:
           TEST_PACKAGE: "./..."
           TESTARGS: -v
-          TEST_TIMEOUT: 120m
+          TEST_TIMEOUT: 40m
         with:
-          max_attempts: 3
+          max_attempts: 1
           timeout_minutes: 120
           retry_on: error
           command: make test


### PR DESCRIPTION
This PR modifies the `go test` workflow in CI. Actual values can still be up for debate (figured we can have that discussion in the PR).
- The `go test` timeout was reduced to 40m to differentiate it from the `nick-fields/retry` action timeout. 
  - We currently have a test that is hanging and causing jobs to run the whole 2 hours. Since the two timeout values have the same value, it seems like the `nick-fields/retry` action took precedence and prevented `go test` from printing any output for why it's hanging. Here is an example that shows output for why it has been hanging: https://github.com/hashicorp/boundary-enterprise/actions/runs/5743578382/attempts/1
  - In `boundary`, `go test` takes about ~10 minutes (there are a number of jobs that are more in the 15 minute range - this is due to some flaky tests and `nick-fields/retry` attempts a retry -- it seems like the primary culprit is [TestServer_ReloadInitialUpstreams](https://hashicorp.atlassian.net/browse/ICU-10499)
  - In `boundary-enterprise`, `go test` takes about ~30 minutes. We could, however, set different values for enterprise if we wanted.
- The max_attempts was set to 1 (i.e. don't retry). I'm still not sure about this one. Having retries on masks flaky tests, so we wouldn't be able to identify them without implementing some other notification.