### PR TITLE
Telemetry: session proto

### DIFF
--- a/internal/gen/controller/api/services/session_service.pb.go
+++ b/internal/gen/controller/api/services/session_service.pb.go
@@ -31,7 +31,7 @@ type GetSessionRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *GetSessionRequest) Reset() {
@@ -125,12 +125,12 @@ type ListSessionsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
-	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public"`          // @gotags: `class:"public"`
+	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
+	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public" eventstream:"observation"`          // @gotags: `class:"public" eventstream:"observation"`
 	Filter    string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty" class:"public"`                 // @gotags: `class:"public"`
 	// Experimental. By default only non-terminated (i.e. pending, active, canceling) are returned.
 	// Set this option to include terminated sessions as well.
-	IncludeTerminated bool `protobuf:"varint,40,opt,name=include_terminated,proto3" json:"include_terminated,omitempty" class:"public"` // @gotags: `class:"public"`
+	IncludeTerminated bool `protobuf:"varint,40,opt,name=include_terminated,proto3" json:"include_terminated,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *ListSessionsRequest) Reset() {
@@ -245,7 +245,7 @@ type CancelSessionRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id      string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"`            // @gotags: `class:"public"`
+	Id      string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"`            // @gotags: `class:"public" eventstream:"observation"`
 	Version uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
 }
 

--- a/internal/proto/controller/api/resources/sessions/v1/session.proto
+++ b/internal/proto/controller/api/resources/sessions/v1/session.proto
@@ -12,13 +12,13 @@ option go_package = "github.com/hashicorp/boundary/sdk/pbs/controller/api/resour
 
 message SessionState {
   // The status of the Session, e.g. "pending", "active", "canceling", "terminated".
-  string status = 10; // @gotags: `class:"public"`
+  string status = 10; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The time the Session entered this state.
-  google.protobuf.Timestamp start_time = 20 [json_name = "start_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp start_time = 20 [json_name = "start_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The time the Session stopped being in this state.
-  google.protobuf.Timestamp end_time = 30 [json_name = "end_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp end_time = 30 [json_name = "end_time"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 // Connection contains information about a specific connection in a session
@@ -55,43 +55,43 @@ message Session {
   reserved "worker_info";
 
   // Output only. The ID of the Session.
-  string id = 10; // @gotags: `class:"public"`
+  string id = 10; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The ID of the Target that created this Session.
-  string target_id = 20 [json_name = "target_id"]; // @gotags: `class:"public"`
+  string target_id = 20 [json_name = "target_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. Scope information for this resource.
   resources.scopes.v1.ScopeInfo scope = 30;
 
   // Output only. The time this resource was created.
-  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The time this resource was last updated.
-  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Version is used when canceling this Session to ensure that the operation is acting on a known session state.
   uint32 version = 80; // @gotags: `class:"public"`
 
   // Output only. Type of the Session (e.g. tcp).
-  string type = 90; // @gotags: `class:"public"`
+  string type = 90; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. After this time the connection will be expired, e.g. forcefully terminated.
-  google.protobuf.Timestamp expiration_time = 100 [json_name = "expiration_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp expiration_time = 100 [json_name = "expiration_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The ID of the Auth Token used to authenticate.
   string auth_token_id = 110 [json_name = "auth_token_id"]; // @gotags: `class:"public"`
 
   // Output only. The ID of the User that requested the Session.
-  string user_id = 120 [json_name = "user_id"]; // @gotags: `class:"public"`
+  string user_id = 120 [json_name = "user_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The Host Set sourcing the Host for this Session.
-  string host_set_id = 130 [json_name = "host_set_id"]; // @gotags: `class:"public"`
+  string host_set_id = 130 [json_name = "host_set_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The Host used by the Session.
-  string host_id = 140 [json_name = "host_id"]; // @gotags: `class:"public"`
+  string host_id = 140 [json_name = "host_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The Scope of the Session.
-  string scope_id = 150 [json_name = "scope_id"]; // @gotags: `class:"public"`
+  string scope_id = 150 [json_name = "scope_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The endpoint of the Session; that is, the address to which the worker is proxying data.
   string endpoint = 160; // @gotags: `class:"public"`
@@ -100,13 +100,13 @@ message Session {
   repeated SessionState states = 170;
 
   // Output only. The current status of this Session.
-  string status = 180; // @gotags: `class:"public"`
+  string status = 180; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The certificate generated for the session. Raw DER bytes.
   bytes certificate = 200; // @gotags: `class:"public"`
 
   // Output only. If the session is terminated, this provides a short description as to why.
-  string termination_reason = 210 [json_name = "termination_reason"]; // @gotags: `class:"public"`
+  string termination_reason = 210 [json_name = "termination_reason"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The available actions on this resource for this user.
   repeated string authorized_actions = 300 [json_name = "authorized_actions"]; // @gotags: `class:"public"`

--- a/internal/proto/controller/api/services/v1/session_service.proto
+++ b/internal/proto/controller/api/services/v1/session_service.proto
@@ -47,7 +47,7 @@ service SessionService {
 }
 
 message GetSessionRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message GetSessionResponse {
@@ -55,12 +55,12 @@ message GetSessionResponse {
 }
 
 message ListSessionsRequest {
-  string scope_id = 1; // @gotags: `class:"public"`
-  bool recursive = 20 [json_name = "recursive"]; // @gotags: `class:"public"`
+  string scope_id = 1; // @gotags: `class:"public" eventstream:"observation"`
+  bool recursive = 20 [json_name = "recursive"]; // @gotags: `class:"public" eventstream:"observation"`
   string filter = 30 [json_name = "filter"]; // @gotags: `class:"public"`
   // Experimental. By default only non-terminated (i.e. pending, active, canceling) are returned.
   // Set this option to include terminated sessions as well.
-  bool include_terminated = 40 [json_name = "include_terminated"]; // @gotags: `class:"public"`
+  bool include_terminated = 40 [json_name = "include_terminated"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message ListSessionsResponse {
@@ -68,7 +68,7 @@ message ListSessionsResponse {
 }
 
 message CancelSessionRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   uint32 version = 2; // @gotags: `class:"public"`
 }
 

--- a/sdk/pbs/controller/api/resources/sessions/session.pb.go
+++ b/sdk/pbs/controller/api/resources/sessions/session.pb.go
@@ -31,11 +31,11 @@ type SessionState struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The status of the Session, e.g. "pending", "active", "canceling", "terminated".
-	Status string `protobuf:"bytes,10,opt,name=status,proto3" json:"status,omitempty" class:"public"` // @gotags: `class:"public"`
+	Status string `protobuf:"bytes,10,opt,name=status,proto3" json:"status,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The time the Session entered this state.
-	StartTime *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=start_time,proto3" json:"start_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	StartTime *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=start_time,proto3" json:"start_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The time the Session stopped being in this state.
-	EndTime *timestamppb.Timestamp `protobuf:"bytes,30,opt,name=end_time,proto3" json:"end_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	EndTime *timestamppb.Timestamp `protobuf:"bytes,30,opt,name=end_time,proto3" json:"end_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *SessionState) Reset() {
@@ -201,41 +201,41 @@ type Session struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the Session.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The ID of the Target that created this Session.
-	TargetId string `protobuf:"bytes,20,opt,name=target_id,proto3" json:"target_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	TargetId string `protobuf:"bytes,20,opt,name=target_id,proto3" json:"target_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. Scope information for this resource.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,30,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The time this resource was last updated.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used when canceling this Session to ensure that the operation is acting on a known session state.
 	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. Type of the Session (e.g. tcp).
-	Type string `protobuf:"bytes,90,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
+	Type string `protobuf:"bytes,90,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. After this time the connection will be expired, e.g. forcefully terminated.
-	ExpirationTime *timestamppb.Timestamp `protobuf:"bytes,100,opt,name=expiration_time,proto3" json:"expiration_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	ExpirationTime *timestamppb.Timestamp `protobuf:"bytes,100,opt,name=expiration_time,proto3" json:"expiration_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The ID of the Auth Token used to authenticate.
 	AuthTokenId string `protobuf:"bytes,110,opt,name=auth_token_id,proto3" json:"auth_token_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The ID of the User that requested the Session.
-	UserId string `protobuf:"bytes,120,opt,name=user_id,proto3" json:"user_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	UserId string `protobuf:"bytes,120,opt,name=user_id,proto3" json:"user_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The Host Set sourcing the Host for this Session.
-	HostSetId string `protobuf:"bytes,130,opt,name=host_set_id,proto3" json:"host_set_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	HostSetId string `protobuf:"bytes,130,opt,name=host_set_id,proto3" json:"host_set_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The Host used by the Session.
-	HostId string `protobuf:"bytes,140,opt,name=host_id,proto3" json:"host_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	HostId string `protobuf:"bytes,140,opt,name=host_id,proto3" json:"host_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The Scope of the Session.
-	ScopeId string `protobuf:"bytes,150,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	ScopeId string `protobuf:"bytes,150,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The endpoint of the Session; that is, the address to which the worker is proxying data.
 	Endpoint string `protobuf:"bytes,160,opt,name=endpoint,proto3" json:"endpoint,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The states of this Session in descending order from the current state to the first.
 	States []*SessionState `protobuf:"bytes,170,rep,name=states,proto3" json:"states,omitempty"`
 	// Output only. The current status of this Session.
-	Status string `protobuf:"bytes,180,opt,name=status,proto3" json:"status,omitempty" class:"public"` // @gotags: `class:"public"`
+	Status string `protobuf:"bytes,180,opt,name=status,proto3" json:"status,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The certificate generated for the session. Raw DER bytes.
 	Certificate []byte `protobuf:"bytes,200,opt,name=certificate,proto3" json:"certificate,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. If the session is terminated, this provides a short description as to why.
-	TerminationReason string `protobuf:"bytes,210,opt,name=termination_reason,proto3" json:"termination_reason,omitempty" class:"public"` // @gotags: `class:"public"`
+	TerminationReason string `protobuf:"bytes,210,opt,name=termination_reason,proto3" json:"termination_reason,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The available actions on this resource for this user.
 	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The associated connections with this session.


### PR DESCRIPTION
This PR adds observation gotags into `session.proto` and `session_service.proto` for telemetry purposes
** please review all the fields as this proto has more fields

cc: @jimlambrt @ajayreshc 