### PR TITLE
Telemetry: worker.proto

### DIFF
--- a/internal/gen/controller/api/services/worker_service.pb.go
+++ b/internal/gen/controller/api/services/worker_service.pb.go
@@ -33,7 +33,7 @@ type GetWorkerRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *GetWorkerRequest) Reset() {
@@ -127,7 +127,7 @@ type ListWorkersRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public"`          // @gotags: `class:"public"`
 	Filter    string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty" class:"sensitive"`                 // @gotags: `class:"sensitive"`
 }
@@ -284,7 +284,7 @@ type CreateWorkerLedResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Uri  string          `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public"` // @gotags: `class:"public"`
+	Uri  string          `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Item *workers.Worker `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 }
 
@@ -386,7 +386,7 @@ type CreateControllerLedResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Uri  string          `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public"` // @gotags: `class:"public"`
+	Uri  string          `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Item *workers.Worker `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 }
 
@@ -636,7 +636,7 @@ type AddWorkerTagsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version uint32                         `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`                                                                                          // @gotags: `class:"public"`
@@ -748,7 +748,7 @@ type SetWorkerTagsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version uint32                         `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`                                                                                          // @gotags: `class:"public"`
@@ -860,7 +860,7 @@ type RemoveWorkerTagsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version uint32                         `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`                                                                                          // @gotags: `class:"public"`

--- a/internal/proto/controller/api/resources/workers/v1/worker.proto
+++ b/internal/proto/controller/api/resources/workers/v1/worker.proto
@@ -16,10 +16,10 @@ option go_package = "github.com/hashicorp/boundary/sdk/pbs/controller/api/resour
 // Worker contains all fields related to a Worker resource
 message Worker {
   // Output only. The ID of the User.
-  string id = 10; // @gotags: `class:"public"`
+  string id = 10; // @gotags: `class:"public" eventstream:"observation"`
 
   // The ID of the Scope this resource is in.
-  string scope_id = 20 [json_name = "scope_id"]; // @gotags: `class:"public"`
+  string scope_id = 20 [json_name = "scope_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. Scope information for this resource.
   resources.scopes.v1.ScopeInfo scope = 30;
@@ -45,10 +45,10 @@ message Worker {
   ]; // @gotags: `class:"sensitive"`
 
   // Output only. The time this resource was created.
-  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The time this resource was last updated.
-  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
@@ -67,7 +67,7 @@ message Worker {
   map<string, google.protobuf.ListValue> config_tags = 130 [json_name = "config_tags"]; // @gotags: `class:"public"`
 
   // Output only. The time this worker daemon last reported its status.
-  google.protobuf.Timestamp last_status_time = 140 [json_name = "last_status_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp last_status_time = 140 [json_name = "last_status_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // worker_generated_auth_token is input only. Supports the worker led node
   // enrollment flow where this credentials token is produced by a worker. This
@@ -80,7 +80,7 @@ message Worker {
   google.protobuf.StringValue controller_generated_activation_token = 151 [json_name = "controller_generated_activation_token"]; // @gotags: `class:"secret"`
 
   // Output only. The number of connections that this worker is currently handling.
-  google.protobuf.UInt32Value active_connection_count = 160 [json_name = "active_connection_count"]; // @gotags: `class:"public"`
+  google.protobuf.UInt32Value active_connection_count = 160 [json_name = "active_connection_count"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The type of the worker, denoted by how it authenticates: `pki`
   // or `kms`.
@@ -90,10 +90,10 @@ message Worker {
   map<string, google.protobuf.ListValue> api_tags = 180 [json_name = "api_tags"]; // @gotags: `class:"public"`
 
   // Output only. The version of the Boundary binary the worker is running.
-  string release_version = 190 [json_name = "release_version"]; // @gotags: `class:"public"`
+  string release_version = 190 [json_name = "release_version"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The ids of the workers directly connected to this worker.
-  repeated string directly_connected_downstream_workers = 200 [json_name = "directly_connected_downstream_workers"]; // @gotags: `class:"public"`
+  repeated string directly_connected_downstream_workers = 200 [json_name = "directly_connected_downstream_workers"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The available actions on this resource for the requester.
   repeated string authorized_actions = 300 [json_name = "authorized_actions"]; // @gotags: `class:"public"`

--- a/internal/proto/controller/api/services/v1/worker_service.proto
+++ b/internal/proto/controller/api/services/v1/worker_service.proto
@@ -143,7 +143,7 @@ service WorkerService {
 }
 
 message GetWorkerRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message GetWorkerResponse {
@@ -151,7 +151,7 @@ message GetWorkerResponse {
 }
 
 message ListWorkersRequest {
-  string scope_id = 1; // @gotags: `class:"public"`
+  string scope_id = 1; // @gotags: `class:"public" eventstream:"observation"`
   bool recursive = 20 [json_name = "recursive"]; // @gotags: `class:"public"`
   string filter = 30 [json_name = "filter"]; // @gotags: `class:"sensitive"`
 }
@@ -165,7 +165,7 @@ message CreateWorkerLedRequest {
 }
 
 message CreateWorkerLedResponse {
-  string uri = 1; // @gotags: `class:"public"`
+  string uri = 1; // @gotags: `class:"public" eventstream:"observation"`
   resources.workers.v1.Worker item = 2;
 }
 
@@ -174,7 +174,7 @@ message CreateControllerLedRequest {
 }
 
 message CreateControllerLedResponse {
-  string uri = 1; // @gotags: `class:"public"`
+  string uri = 1; // @gotags: `class:"public" eventstream:"observation"`
   resources.workers.v1.Worker item = 2;
 }
 
@@ -195,7 +195,7 @@ message DeleteWorkerRequest {
 message DeleteWorkerResponse {}
 
 message AddWorkerTagsRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 2; // @gotags: `class:"public"`
@@ -207,7 +207,7 @@ message AddWorkerTagsResponse {
 }
 
 message SetWorkerTagsRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 2; // @gotags: `class:"public"`
@@ -219,7 +219,7 @@ message SetWorkerTagsResponse {
 }
 
 message RemoveWorkerTagsRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 2; // @gotags: `class:"public"`

--- a/sdk/pbs/controller/api/resources/workers/worker.pb.go
+++ b/sdk/pbs/controller/api/resources/workers/worker.pb.go
@@ -35,9 +35,9 @@ type Worker struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the User.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// The ID of the Scope this resource is in.
-	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. Scope information for this resource.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,30,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Optional name for identification purposes. Can only be set through the API
@@ -47,9 +47,9 @@ type Worker struct {
 	// through the API for `pki`-type workers; read-only for `kms`-type workers.
 	Description *wrapperspb.StringValue `protobuf:"bytes,50,opt,name=description,proto3" json:"description,omitempty" class:"sensitive"` // @gotags: `class:"sensitive"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The time this resource was last updated.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
@@ -63,7 +63,7 @@ type Worker struct {
 	// Output only. The tags set in the worker's configuration file.
 	ConfigTags map[string]*structpb.ListValue `protobuf:"bytes,130,rep,name=config_tags,proto3" json:"config_tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this worker daemon last reported its status.
-	LastStatusTime *timestamppb.Timestamp `protobuf:"bytes,140,opt,name=last_status_time,proto3" json:"last_status_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	LastStatusTime *timestamppb.Timestamp `protobuf:"bytes,140,opt,name=last_status_time,proto3" json:"last_status_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// worker_generated_auth_token is input only. Supports the worker led node
 	// enrollment flow where this credentials token is produced by a worker. This
 	// token is a base58 encoded types.FetchNodeCredentialsRequest from
@@ -73,16 +73,16 @@ type Worker struct {
 	// it to the created resource.
 	ControllerGeneratedActivationToken *wrapperspb.StringValue `protobuf:"bytes,151,opt,name=controller_generated_activation_token,proto3" json:"controller_generated_activation_token,omitempty" class:"secret"` // @gotags: `class:"secret"`
 	// Output only. The number of connections that this worker is currently handling.
-	ActiveConnectionCount *wrapperspb.UInt32Value `protobuf:"bytes,160,opt,name=active_connection_count,proto3" json:"active_connection_count,omitempty" class:"public"` // @gotags: `class:"public"`
+	ActiveConnectionCount *wrapperspb.UInt32Value `protobuf:"bytes,160,opt,name=active_connection_count,proto3" json:"active_connection_count,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The type of the worker, denoted by how it authenticates: `pki`
 	// or `kms`.
 	Type string `protobuf:"bytes,170,opt,name=type,proto3" json:"type,omitempty"`
 	// Output only. The api tags set for the worker.
 	ApiTags map[string]*structpb.ListValue `protobuf:"bytes,180,rep,name=api_tags,proto3" json:"api_tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3" class:"public"` // @gotags: `class:"public"`
 	// Output only. The version of the Boundary binary the worker is running.
-	ReleaseVersion string `protobuf:"bytes,190,opt,name=release_version,proto3" json:"release_version,omitempty" class:"public"` // @gotags: `class:"public"`
+	ReleaseVersion string `protobuf:"bytes,190,opt,name=release_version,proto3" json:"release_version,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The ids of the workers directly connected to this worker.
-	DirectlyConnectedDownstreamWorkers []string `protobuf:"bytes,200,rep,name=directly_connected_downstream_workers,proto3" json:"directly_connected_downstream_workers,omitempty" class:"public"` // @gotags: `class:"public"`
+	DirectlyConnectedDownstreamWorkers []string `protobuf:"bytes,200,rep,name=directly_connected_downstream_workers,proto3" json:"directly_connected_downstream_workers,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The available actions on this resource for the requester.
 	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public"` // @gotags: `class:"public"`
 }


### PR DESCRIPTION
This PR adds observation gotags into `worker.proto` and `worker_service.proto` for telemetry purposes.
cc: @jimlambrt @ajayreshc 