### PR TITLE
docs: Update session recording configuration

### DIFF
--- a/website/content/docs/configuration/kms/awskms.mdx
+++ b/website/content/docs/configuration/kms/awskms.mdx
@@ -33,6 +33,8 @@ These parameters apply to the `kms` stanza in the Boundary configuration file:
 - `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
    `root`, `previous-root`, `recovery`, `bsr`, or `config`.
 
+   To [enable session recording](/boundary/docs/configuration/session-recording/enable-session-recording), you must configure the `bsr` value for the `purpose`.
+
 - `region` `(string: "us-east-1")`: The AWS region where the encryption key
   lives. If not provided, may be populated from the `AWS_REGION` or
   `AWS_DEFAULT_REGION` environment variables, from your `~/.aws/config` file,

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -70,6 +70,51 @@ At this time, the only supported storage is AWS S3.
       "Resource": "arn:aws:kms:us-east-1:1234567890:key/uuid"
    }
    ```
+   The following is an example working policy with KMS encryption configured on the S3 bucket:
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+         {
+            "Sid": "S3Permissions",
+            "Effect": "Allow",
+            "Action": [
+               "s3:PutObject",
+               "s3:GetObject",
+               "s3:GetObjectAttributes"
+            ],
+            "Resource": [
+               "arn:aws:s3:::test-session-recording-bucket/*"
+            ]
+         },
+         {
+            "Sid": "UserPermissions",
+            "Effect": "Allow",
+            "Action": [
+               "iam:DeleteAccessKey",
+               "iam:GetUser",
+               "iam:CreateAccessKey"
+            ],
+            "Resource": [
+               "arn:aws:iam::1234567890:user/test-boundary"
+            ]
+         },
+         {
+            "Sid": "KMSPermissions",
+            "Effect": "Allow",
+            "Action": [
+               "kms:Decrypt",
+               "kms:GenerateDataKey",
+               "kms:DescribeKey"
+            ],
+            "Resource": [
+               "arn:aws:kms:us-east-2:1234567890:key/4b887395-c376-4936-8f37-80c592ea582c"
+            ]
+         }
+      ]
+   }
+
+    ```
 
 ### Boundary workers requirements
 

--- a/website/content/docs/configuration/session-recording/enable-session-recording.mdx
+++ b/website/content/docs/configuration/session-recording/enable-session-recording.mdx
@@ -1,6 +1,6 @@
 ---
 layout: docs
-page_title: Create a storage bucket
+page_title: Enable session recording on a target
 description: |-
   How to enable session recording on a target in Boundary
 ---


### PR DESCRIPTION
Per [SPE-249](https://hashicorp.atlassian.net/browse/SPE-249), there is some information missing from the session recording configuration docs. The example policy in the topic [Create a storage bucket](https://developer.hashicorp.com/boundary/docs/configuration/session-recording/create-storage-bucket) does not include KMS encryption, which most customers would use. This PR adds an additional example policy that includes KMS encryption settings.

Additionally, in the AWSKMS configuration topic, it is not apparent that `bsr` is a required parameter to enable session recording. I added an additional note to help clarify.

Finally, the metadata for one of the topic titles was incorrect. I corrected the error.

View the updates in the preview deployment:

- [Create a storage bucket](https://boundary-8etu4qlm2-hashicorp.vercel.app/boundary/docs/configuration/session-recording/create-storage-bucket)
- [awskms](https://boundary-8etu4qlm2-hashicorp.vercel.app/boundary/docs/configuration/kms/awskms)

[SPE-249]: https://hashicorp.atlassian.net/browse/SPE-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ