### PR TITLE
test(e2e): Mitigate aws dependencies error

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -245,7 +245,7 @@ jobs:
         run: |
           mkdir -p ./enos/terraform-plugin-cache
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
-          enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
+          enos scenario launch --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
       - name: Upload e2e tests output
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
@@ -264,7 +264,7 @@ jobs:
         if: steps.run.outcome == 'failure'
         run: |
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
-          enos scenario run --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
+          enos scenario launch --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
       - name: Upload Debug Data
         if: ${{ always() && steps.run_retry.outcome == 'failure' }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
@@ -274,7 +274,14 @@ jobs:
           path: ${{ env.ENOS_DEBUG_DATA_ROOT_DIR }}
           retention-days: 30
       - name: Destroy Enos scenario
-        if: ${{ always() && steps.run_retry.outcome == 'failure' }}
+        id: destroy
+        continue-on-error: true
+        if: ${{ always() }}
+        run: |
+          export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
+          enos scenario destroy --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
+      - name: Destroy Enos scenario (Retry)
+        if: ${{ always() && steps.destroy.outcome == 'failure' }}
         run: |
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario destroy --timeout 60m0s --chdir ./enos ${{ matrix.filter }}


### PR DESCRIPTION
This PR mitigates a common flaky failure in e2e tests and prevents the job from failing as this is not a test error.

The e2e test framework is organized by “scenarios”, which define a series of steps to set up infrastructure and execute tests.
```
scenario "scenario name" {
  step "build_boundary_executable" { ... }
  step "create_aws_boundary_cluster" { ... }
  step "create_aws_target" { ... }
  step "run_tests" { ... }
}
```
You can then use the enos cli to control execution. Operations include…
```
# `Launch` executes a scenario and leaves the infrastructure up
enos scenario launch <scenario name> 

# `Destroy` tears down any created infrastructure
enos scenario destroy <scenario name>

# `Run` combines launch and destroy (executes a scenario and tears it down)
enos scenario run <scenario name>
```

The [GitHub Actions workflow](https://github.com/hashicorp/boundary/blob/main/.github/workflows/enos-run.yml) currently uses the following logic
```
...
enos scenario run

# If there was any failure, try running again
if: run == 'failure'
  enos scenario run  # if this fails, mark the job as failed

# Clean up if retry failed
if: retry == 'failure'
  enos scenario destroy
...
```

This logic, however, can report job failures for cases that are not test execution errors. Currently, the most commonly reported failure is an issue with the aws terraform provider where resources sometimes get cleaned up out of order resulting in a dependency violation.

```
# Failure occurs on the destroy of the first `run`
Error: deleting EC2 Internet Gateway (igw-0f3064f9f688927a8): DependencyViolation: The internetGateway 'igw-0f3064f9f688927a8' has dependencies and cannot be deleted.
    status code: 400, request id: 086e18ab-7659-4417-91e5-dc0864f637d6

# The retry `run` hits this error during its launch and marks the job as a failure, skipping the destroy of this `run`
Error: updating EC2 Internet Gateway (igw-0f3064f9f688927a8): attaching EC2 Internet Gateway (igw-0f3064f9f688927a8) to VPC (vpc-0c211693fd0d9e66b): Resource.AlreadyAssociated: resource igw-0f3064f9f688927a8 is already attached to network vpc-0c211693fd0d9e66b
    status code: 400, request id: 0b83c418-cd04-4c7a-ab9d-20b7915ec7f7
```

This PR proposes to modify the logic to the following:
```
...
# Setup and run the tests
enos scenario launch

# If there was any failure, try again
if: launch == 'failure'
  enos scenario launch  # if this fails, mark the job as failed

# Clean up
if: always()
  continue-on-error: true
  enos scenario destroy

# If cleanup failed, try again
if: destroy == 'failure'
  enos scenario destroy
...
```