### PR TITLE
chore: Add education approvers to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 /.release/                              @hashicorp/release-engineering @hashicorp/github-secure-boundary
 /.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-secure-boundary
-/website/content/                       @hashicorp/Terraform Education/boundary-education-approvers
+/website/content/                       @hashicorp/terraform-education/boundary-education-approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 /.release/                              @hashicorp/release-engineering @hashicorp/github-secure-boundary
 /.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-secure-boundary
-/website/content/                       @hashicorp/boundary-education-approvers
+/website/content/                       @hashicorp/education/boundary-education-approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,4 @@
 /.release/                              @hashicorp/release-engineering @hashicorp/github-secure-boundary
 /.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-secure-boundary
 /website/content/                       @hashicorp/terraform-education/boundary-education-approvers
+/website/content/   @hashicorp/boundary-education-approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 /.release/                              @hashicorp/release-engineering @hashicorp/github-secure-boundary
 /.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-secure-boundary
-/website/content/                       @hashicorp/boundary-education-approvers
+/website/content/                       @hashicorp/Terraform Education/boundary-education-approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,5 @@
 
 /.release/                              @hashicorp/release-engineering @hashicorp/github-secure-boundary
 /.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-secure-boundary
+
+/website/content/                       @hashicorp/boundary-education-approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,5 +6,4 @@
 
 /.release/                              @hashicorp/release-engineering @hashicorp/github-secure-boundary
 /.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-secure-boundary
-
 /website/content/                       @hashicorp/boundary-education-approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,5 +6,4 @@
 
 /.release/                              @hashicorp/release-engineering @hashicorp/github-secure-boundary
 /.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-secure-boundary
-/website/content/                       @hashicorp/terraform-education/boundary-education-approvers
-/website/content/   @hashicorp/boundary-education-approvers
+/website/content/                       @hashicorp/boundary-education-approvers


### PR DESCRIPTION
The Edu team would like to add ourselves as codeowners for updates to the website/content directory if possible.