### PR TITLE
test(e2e): Add pieces necessary for enterprise migration test

### DIFF
--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -12,11 +12,22 @@ scenario "e2e_database" {
   locals {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     local_boundary_dir       = abspath(var.local_boundary_dir)
+    license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+
     tags = merge({
       "Project Name" : var.project_name
       "Project" : "Enos",
       "Environment" : "ci"
     }, var.tags)
+  }
+
+  step "read_license" {
+    skip_step = var.boundary_edition == "oss"
+    module    = module.read_license
+
+    variables {
+      file_name = local.license_path
+    }
   }
 
   step "find_azs" {
@@ -109,6 +120,7 @@ scenario "e2e_database" {
     variables {
       test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/database"
       debug_no_run             = var.e2e_debug_no_run
+      boundary_license         = var.boundary_edition != "oss" ? step.read_license.license : ""
       local_boundary_dir       = local.local_boundary_dir
       target_user              = "ubuntu"
       aws_ssh_private_key_path = local.aws_ssh_private_key_path

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -135,6 +135,10 @@ variable "test_timeout" {
   type    = string
   default = "15m"
 }
+variable "boundary_license" {
+  type    = string
+  default = ""
+}
 
 locals {
   aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
@@ -149,6 +153,7 @@ resource "enos_local_exec" "run_e2e_test" {
   environment = {
     E2E_TESTS                     = "true",
     BOUNDARY_ADDR                 = var.alb_boundary_api_addr,
+    BOUNDARY_LICENSE              = var.boundary_license,
     E2E_PASSWORD_AUTH_METHOD_ID   = var.auth_method_id,
     E2E_PASSWORD_ADMIN_LOGIN_NAME = var.auth_login_name,
     E2E_PASSWORD_ADMIN_PASSWORD   = var.auth_password,

--- a/testing/internal/e2e/infra/env.go
+++ b/testing/internal/e2e/infra/env.go
@@ -6,7 +6,8 @@ package infra
 import "github.com/kelseyhightower/envconfig"
 
 type Config struct {
-	DockerMirror string `envconfig:"DOCKER_MIRROR" default:"docker.mirror.hashicorp.services"`
+	DockerMirror    string `envconfig:"DOCKER_MIRROR" default:"docker.mirror.hashicorp.services"`
+	BoundaryLicense string `envconfig:"BOUNDARY_LICENSE" default:""`
 }
 
 func LoadConfig() (*Config, error) {

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -53,12 +53,16 @@ func TestDatabaseMigration(t *testing.T) {
 	err = te.Pool.Client.StopContainer(te.Boundary.Resource.Container.ID, 10)
 	require.NoError(t, err)
 
-	bonfigFilePath, err := filepath.Abs("testdata/boundary-config.hcl")
+	output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("version"))
+	require.NoError(t, err)
+	t.Logf("Upgrading to version: %s", output.Stdout)
+
+	bConfigFilePath, err := filepath.Abs("testdata/boundary-config.hcl")
 	require.NoError(t, err)
 
 	t.Log("Starting database migration...")
-	output := e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs("database", "migrate", "-config", bonfigFilePath),
+	output = e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs("database", "migrate", "-config", bConfigFilePath),
 		e2e.WithEnv("BOUNDARY_POSTGRES_URL", te.Database.UriLocalhost),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))


### PR DESCRIPTION
This PR adds updates to the e2e test suite to support a `boundary-enterprise` version of the migration test. Specifically, we need to pass in the BoundaryLicense value from the enos scenario to the test suite.

There will be a follow-up PR in `boundary-enterprise` to add in the test.