### PR TITLE
Telemetry: target.proto

### DIFF
--- a/internal/gen/controller/api/services/target_service.pb.go
+++ b/internal/gen/controller/api/services/target_service.pb.go
@@ -33,7 +33,7 @@ type GetTargetRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *GetTargetRequest) Reset() {
@@ -127,8 +127,8 @@ type ListTargetsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
-	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public"`          // @gotags: `class:"public"`
+	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
+	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public" eventstream:"observation"`          // @gotags: `class:"public" eventstream:"observation"`
 	Filter    string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty" class:"public"`                 // @gotags: `class:"public"`
 }
 
@@ -284,7 +284,7 @@ type CreateTargetResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Uri  string          `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public"` // @gotags: `class:"public"`
+	Uri  string          `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Item *targets.Target `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 }
 
@@ -339,7 +339,7 @@ type UpdateTargetRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Item       *targets.Target        `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 	UpdateMask *fieldmaskpb.FieldMask `protobuf:"bytes,3,opt,name=update_mask,proto3" json:"update_mask,omitempty"`
 }
@@ -449,7 +449,7 @@ type DeleteTargetRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *DeleteTargetRequest) Reset() {
@@ -534,11 +534,11 @@ type AddTargetHostSourcesRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version       uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`                // @gotags: `class:"public"`
-	HostSourceIds []string `protobuf:"bytes,3,rep,name=host_source_ids,proto3" json:"host_source_ids,omitempty" class:"public"` // @gotags: `class:"public"`
+	HostSourceIds []string `protobuf:"bytes,3,rep,name=host_source_ids,proto3" json:"host_source_ids,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *AddTargetHostSourcesRequest) Reset() {
@@ -646,11 +646,11 @@ type SetTargetHostSourcesRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version       uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`                // @gotags: `class:"public"`
-	HostSourceIds []string `protobuf:"bytes,3,rep,name=host_source_ids,proto3" json:"host_source_ids,omitempty" class:"public"` // @gotags: `class:"public"`
+	HostSourceIds []string `protobuf:"bytes,3,rep,name=host_source_ids,proto3" json:"host_source_ids,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *SetTargetHostSourcesRequest) Reset() {
@@ -758,11 +758,11 @@ type RemoveTargetHostSourcesRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version       uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`                // @gotags: `class:"public"`
-	HostSourceIds []string `protobuf:"bytes,3,rep,name=host_source_ids,proto3" json:"host_source_ids,omitempty" class:"public"` // @gotags: `class:"public"`
+	HostSourceIds []string `protobuf:"bytes,3,rep,name=host_source_ids,proto3" json:"host_source_ids,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *RemoveTargetHostSourcesRequest) Reset() {
@@ -1281,15 +1281,15 @@ type AuthorizeSessionRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the target. Required unless some combination of scope_id/scope_name and name are set.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// The name of the target. When using this, scope_id or scope_name must be set.
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The scope ID containing the target, if specifying the target by name.
-	ScopeId string `protobuf:"bytes,4,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	ScopeId string `protobuf:"bytes,4,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// The scope name containing the target, if specifying the target by name.
 	ScopeName string `protobuf:"bytes,5,opt,name=scope_name,json=scopeName,proto3" json:"scope_name,omitempty" class:"public"` // @gotags: `class:"public"`
 	// An optional parameter allowing specification of the particular Host within the Target's configured Host Sets to connect to during this Session.
-	HostId string `protobuf:"bytes,2,opt,name=host_id,proto3" json:"host_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	HostId string `protobuf:"bytes,2,opt,name=host_id,proto3" json:"host_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *AuthorizeSessionRequest) Reset() {

--- a/internal/proto/controller/api/resources/targets/v1/target.proto
+++ b/internal/proto/controller/api/resources/targets/v1/target.proto
@@ -16,10 +16,10 @@ option go_package = "github.com/hashicorp/boundary/sdk/pbs/controller/api/resour
 
 message HostSource {
   // Output only. The ID of the Host Set.
-  string id = 10; // @gotags: `class:"public"`
+  string id = 10; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The Host Catalog to which this Host Source belongs.
-  string host_catalog_id = 20 [json_name = "host_catalog_id"]; // @gotags: `class:"public"`
+  string host_catalog_id = 20 [json_name = "host_catalog_id"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message CredentialSource {
@@ -72,10 +72,10 @@ message SessionCredential {
 // Target contains all fields related to a Target resource
 message Target {
   // Output only. The ID of the resource.
-  string id = 10; // @gotags: `class:"public"`
+  string id = 10; // @gotags: `class:"public" eventstream:"observation"`
 
   // The Scope of of this resource. This must be defined for creation of this resource, but is otherwise output only.
-  string scope_id = 20 [json_name = "scope_id"]; // @gotags: `class:"public"`
+  string scope_id = 20 [json_name = "scope_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. Scope information for this resource.
   resources.scopes.v1.ScopeInfo scope = 30;
@@ -99,20 +99,20 @@ message Target {
   ]; // @gotags: `class:"public"`
 
   // Output only. The time this resource was created.
-  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The time this resource was last updated.
-  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 80; // @gotags: `class:"public"`
 
   // The type of the Target.
-  string type = 90; // @gotags: `class:"public"`
+  string type = 90; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The IDs of the Host Sources associated with this Target.
-  repeated string host_source_ids = 420 [json_name = "host_source_ids"]; // @gotags: `class:"public"`
+  repeated string host_source_ids = 420 [json_name = "host_source_ids"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The Host Sources associated with this Target.
   repeated HostSource host_sources = 430 [json_name = "host_sources"];
@@ -297,7 +297,7 @@ message SshTargetAttributes {
       this: "attributes.enable_session_recording"
       that: "EnableSessionRecording"
     }
-  ]; // @gotags: `class:"public"`
+  ]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 // WorkerInfo contains information about workers, returned in to the client in SessionAuthorization
@@ -309,19 +309,19 @@ message WorkerInfo {
 // SessionAuthorizationData contains the fields needed by the proxy command to connect to a worker. It is marshaled inside the SessionAuthorization message.
 message SessionAuthorizationData {
   // Output only. The ID of the session.
-  string session_id = 10 [json_name = "session_id"]; // @gotags: `class:"public"`
+  string session_id = 10 [json_name = "session_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The ID of the Target authorizing this session.
-  string target_id = 20 [json_name = "target_id"]; // @gotags: `class:"public"`
+  string target_id = 20 [json_name = "target_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. Scope information for this the Target that authorized this session.
   resources.scopes.v1.ScopeInfo scope = 30;
 
   // Output only. The time this resource was created.
-  google.protobuf.Timestamp created_time = 40 [json_name = "created_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp created_time = 40 [json_name = "created_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. Type of the session (e.g. tcp, ssh, etc.).
-  string type = 80; // @gotags: `class:"public"`
+  string type = 80; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The connection limit being applied to this session. -1 means unlimited. This is not actually enforced on the client side but it provides for better listener handling by including it.
   int32 connection_limit = 90 [json_name = "connection_limit"];
@@ -333,7 +333,7 @@ message SessionAuthorizationData {
   bytes private_key = 130 [json_name = "private_key"]; // @gotags: `class:"secret"`
 
   // Output only. The host ID...not used for security purposes, but for some special command handling (e.g. ssh host key aliasing).
-  string host_id = 140; // @gotags: `class:"public"`
+  string host_id = 140; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The endpoint, for some special command handling.
   string endpoint = 141; // @gotags: `class:"public"`
@@ -348,28 +348,28 @@ message SessionAuthorizationData {
 // SessionAuthorization contains all fields related to authorization for a Session. It's in the Targets package because it's returned by a Target's authorize action.
 message SessionAuthorization {
   // Output only. The ID of the Session.
-  string session_id = 10 [json_name = "session_id"]; // @gotags: `class:"public"`
+  string session_id = 10 [json_name = "session_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The ID of the Target authorizing this Session.
-  string target_id = 20 [json_name = "target_id"]; // @gotags: `class:"public"`
+  string target_id = 20 [json_name = "target_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. Scope information for this resource.
   resources.scopes.v1.ScopeInfo scope = 30;
 
   // Output only. The time this resource was created.
-  google.protobuf.Timestamp created_time = 40 [json_name = "created_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp created_time = 40 [json_name = "created_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The User for which this Session was authorized.
-  string user_id = 50 [json_name = "user_id"]; // @gotags: `class:"public"`
+  string user_id = 50 [json_name = "user_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The Host Set containing the Host being used for this Session.
-  string host_set_id = 60 [json_name = "host_set_id"]; // @gotags: `class:"public"`
+  string host_set_id = 60 [json_name = "host_set_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The Host whose address is being used as the endpoint for this Session.
-  string host_id = 70 [json_name = "host_id"]; // @gotags: `class:"public"`
+  string host_id = 70 [json_name = "host_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. Type of the Session (e.g. tcp, ssh, etc.).
-  string type = 80; // @gotags: `class:"public"`
+  string type = 80; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The marshaled SessionAuthorizationData message containing all information that the proxy needs.
   string authorization_token = 90 [json_name = "authorization_token"]; // @gotags: `class:"secret"`

--- a/internal/proto/controller/api/services/v1/target_service.proto
+++ b/internal/proto/controller/api/services/v1/target_service.proto
@@ -187,7 +187,7 @@ service TargetService {
 }
 
 message GetTargetRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message GetTargetResponse {
@@ -195,8 +195,8 @@ message GetTargetResponse {
 }
 
 message ListTargetsRequest {
-  string scope_id = 1; // @gotags: `class:"public"`
-  bool recursive = 20 [json_name = "recursive"]; // @gotags: `class:"public"`
+  string scope_id = 1; // @gotags: `class:"public" eventstream:"observation"`
+  bool recursive = 20 [json_name = "recursive"]; // @gotags: `class:"public" eventstream:"observation"`
   string filter = 30 [json_name = "filter"]; // @gotags: `class:"public"`
 }
 
@@ -209,12 +209,12 @@ message CreateTargetRequest {
 }
 
 message CreateTargetResponse {
-  string uri = 1; // @gotags: `class:"public"`
+  string uri = 1; // @gotags: `class:"public" eventstream:"observation"`
   resources.targets.v1.Target item = 2;
 }
 
 message UpdateTargetRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   resources.targets.v1.Target item = 2;
   google.protobuf.FieldMask update_mask = 3 [json_name = "update_mask"];
 }
@@ -224,17 +224,17 @@ message UpdateTargetResponse {
 }
 
 message DeleteTargetRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message DeleteTargetResponse {}
 
 message AddTargetHostSourcesRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 2; // @gotags: `class:"public"`
-  repeated string host_source_ids = 3 [json_name = "host_source_ids"]; // @gotags: `class:"public"`
+  repeated string host_source_ids = 3 [json_name = "host_source_ids"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message AddTargetHostSourcesResponse {
@@ -242,11 +242,11 @@ message AddTargetHostSourcesResponse {
 }
 
 message SetTargetHostSourcesRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 2; // @gotags: `class:"public"`
-  repeated string host_source_ids = 3 [json_name = "host_source_ids"]; // @gotags: `class:"public"`
+  repeated string host_source_ids = 3 [json_name = "host_source_ids"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message SetTargetHostSourcesResponse {
@@ -254,11 +254,11 @@ message SetTargetHostSourcesResponse {
 }
 
 message RemoveTargetHostSourcesRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 2; // @gotags: `class:"public"`
-  repeated string host_source_ids = 3 [json_name = "host_source_ids"]; // @gotags: `class:"public"`
+  repeated string host_source_ids = 3 [json_name = "host_source_ids"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message RemoveTargetHostSourcesResponse {
@@ -356,19 +356,19 @@ message RemoveTargetCredentialSourcesResponse {
 
 message AuthorizeSessionRequest {
   // The ID of the target. Required unless some combination of scope_id/scope_name and name are set.
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 
   // The name of the target. When using this, scope_id or scope_name must be set.
   string name = 3; // @gotags: `class:"public"`
 
   // The scope ID containing the target, if specifying the target by name.
-  string scope_id = 4; // @gotags: `class:"public"`
+  string scope_id = 4; // @gotags: `class:"public" eventstream:"observation"`
 
   // The scope name containing the target, if specifying the target by name.
   string scope_name = 5; // @gotags: `class:"public"`
 
   // An optional parameter allowing specification of the particular Host within the Target's configured Host Sets to connect to during this Session.
-  string host_id = 2 [json_name = "host_id"]; // @gotags: `class:"public"`
+  string host_id = 2 [json_name = "host_id"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message AuthorizeSessionResponse {

--- a/sdk/pbs/controller/api/resources/targets/target.pb.go
+++ b/sdk/pbs/controller/api/resources/targets/target.pb.go
@@ -35,9 +35,9 @@ type HostSource struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the Host Set.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The Host Catalog to which this Host Source belongs.
-	HostCatalogId string `protobuf:"bytes,20,opt,name=host_catalog_id,proto3" json:"host_catalog_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	HostCatalogId string `protobuf:"bytes,20,opt,name=host_catalog_id,proto3" json:"host_catalog_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *HostSource) Reset() {
@@ -313,9 +313,9 @@ type Target struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the resource.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// The Scope of of this resource. This must be defined for creation of this resource, but is otherwise output only.
-	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. Scope information for this resource.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,30,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Required name for identification purposes.
@@ -323,16 +323,16 @@ type Target struct {
 	// Optional user-set description for identification purposes.
 	Description *wrapperspb.StringValue `protobuf:"bytes,50,opt,name=description,proto3" json:"description,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The time this resource was last updated.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The type of the Target.
-	Type string `protobuf:"bytes,90,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
+	Type string `protobuf:"bytes,90,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The IDs of the Host Sources associated with this Target.
-	HostSourceIds []string `protobuf:"bytes,420,rep,name=host_source_ids,proto3" json:"host_source_ids,omitempty" class:"public"` // @gotags: `class:"public"`
+	HostSourceIds []string `protobuf:"bytes,420,rep,name=host_source_ids,proto3" json:"host_source_ids,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The Host Sources associated with this Target.
 	HostSources []*HostSource `protobuf:"bytes,430,rep,name=host_sources,proto3" json:"host_sources,omitempty"`
 	// Maximum total lifetime of a created Session, in seconds.
@@ -705,7 +705,7 @@ type SshTargetAttributes struct {
 	// PublicId of the storage bucket associated with the target
 	StorageBucketId *wrapperspb.StringValue `protobuf:"bytes,30,opt,name=storage_bucket_id,proto3" json:"storage_bucket_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// A boolean indicating if session recording has been enabled
-	EnableSessionRecording *wrapperspb.BoolValue `protobuf:"bytes,40,opt,name=enable_session_recording,proto3" json:"enable_session_recording,omitempty" class:"public"` // @gotags: `class:"public"`
+	EnableSessionRecording *wrapperspb.BoolValue `protobuf:"bytes,40,opt,name=enable_session_recording,proto3" json:"enable_session_recording,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *SshTargetAttributes) Reset() {
@@ -824,15 +824,15 @@ type SessionAuthorizationData struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the session.
-	SessionId string `protobuf:"bytes,10,opt,name=session_id,proto3" json:"session_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	SessionId string `protobuf:"bytes,10,opt,name=session_id,proto3" json:"session_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The ID of the Target authorizing this session.
-	TargetId string `protobuf:"bytes,20,opt,name=target_id,proto3" json:"target_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	TargetId string `protobuf:"bytes,20,opt,name=target_id,proto3" json:"target_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. Scope information for this the Target that authorized this session.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,30,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,40,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,40,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. Type of the session (e.g. tcp, ssh, etc.).
-	Type string `protobuf:"bytes,80,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
+	Type string `protobuf:"bytes,80,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The connection limit being applied to this session. -1 means unlimited. This is not actually enforced on the client side but it provides for better listener handling by including it.
 	ConnectionLimit int32 `protobuf:"varint,90,opt,name=connection_limit,proto3" json:"connection_limit,omitempty"`
 	// Output only. The certificate to use when connecting. Raw DER bytes.
@@ -840,7 +840,7 @@ type SessionAuthorizationData struct {
 	// Output only. The private key to use when connecting. We are using Ed25519, so this is purely raw bytes, no marshaling.
 	PrivateKey []byte `protobuf:"bytes,130,opt,name=private_key,proto3" json:"private_key,omitempty" class:"secret"` // @gotags: `class:"secret"`
 	// Output only. The host ID...not used for security purposes, but for some special command handling (e.g. ssh host key aliasing).
-	HostId string `protobuf:"bytes,140,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	HostId string `protobuf:"bytes,140,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The endpoint, for some special command handling.
 	Endpoint string `protobuf:"bytes,141,opt,name=endpoint,proto3" json:"endpoint,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. Worker information. The first worker in the array should be prioritized.
@@ -972,21 +972,21 @@ type SessionAuthorization struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the Session.
-	SessionId string `protobuf:"bytes,10,opt,name=session_id,proto3" json:"session_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	SessionId string `protobuf:"bytes,10,opt,name=session_id,proto3" json:"session_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The ID of the Target authorizing this Session.
-	TargetId string `protobuf:"bytes,20,opt,name=target_id,proto3" json:"target_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	TargetId string `protobuf:"bytes,20,opt,name=target_id,proto3" json:"target_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. Scope information for this resource.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,30,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,40,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,40,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The User for which this Session was authorized.
-	UserId string `protobuf:"bytes,50,opt,name=user_id,proto3" json:"user_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	UserId string `protobuf:"bytes,50,opt,name=user_id,proto3" json:"user_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The Host Set containing the Host being used for this Session.
-	HostSetId string `protobuf:"bytes,60,opt,name=host_set_id,proto3" json:"host_set_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	HostSetId string `protobuf:"bytes,60,opt,name=host_set_id,proto3" json:"host_set_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The Host whose address is being used as the endpoint for this Session.
-	HostId string `protobuf:"bytes,70,opt,name=host_id,proto3" json:"host_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	HostId string `protobuf:"bytes,70,opt,name=host_id,proto3" json:"host_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. Type of the Session (e.g. tcp, ssh, etc.).
-	Type string `protobuf:"bytes,80,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
+	Type string `protobuf:"bytes,80,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The marshaled SessionAuthorizationData message containing all information that the proxy needs.
 	AuthorizationToken string `protobuf:"bytes,90,opt,name=authorization_token,proto3" json:"authorization_token,omitempty" class:"secret"` // @gotags: `class:"secret"`
 	// Output only. The endpoint address that the worker will connect to, useful for setting TLS parameters.


### PR DESCRIPTION
This PR adds observation gotags into `target.proto` and `target_service.proto` for telemetry purposes