### PR TITLE
Re-enable copywrite with hack

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,5 @@ f69fbf22552deac9ec81503d629fb70919acabdb
 3c29308673a9fb64c68ca27e15b4c9017a2d597e
 # Upgraded buf which updated protobuf files
 982c9c263c5d7f9822cdae4d8fe38cac8e1ff98f
+# Updated license to BUSL
+29da0bcb923236b59fad97c3a66708b4d7e15bfb

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ perms-table:
 	@go run internal/website/permstable/permstable.go
 
 .PHONY: gen
-gen: cleangen proto api cli perms-table fmt
+gen: cleangen proto api cli perms-table fmt copywrite
 
 ### oplog requires protoc-gen-go v1.20.0 or later
 # GO111MODULE=on go get -u github.com/golang/protobuf/protoc-gen-go@v1.40
@@ -263,6 +263,11 @@ protolint:
 .PHONY: copywrite
 copywrite:
 	copywrite headers
+	# In the protobuf API directories, remove the BUSL headers
+	# and rerun copywrite with the directory specific configuration.
+	cd internal/proto/controller/api && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + &&  copywrite headers
+	cd internal/proto/controller/custom_options && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + &&  copywrite headers
+	cd internal/proto/plugin && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + && copywrite headers
 
 .PHONY: website
 # must have nodejs and npm installed

--- a/internal/proto/controller/api/.copywrite.hcl
+++ b/internal/proto/controller/api/.copywrite.hcl
@@ -1,0 +1,8 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2020
+
+  header_ignore = []
+}

--- a/internal/proto/controller/custom_options/.copywrite.hcl
+++ b/internal/proto/controller/custom_options/.copywrite.hcl
@@ -1,0 +1,8 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2020
+
+  header_ignore = []
+}

--- a/internal/proto/plugin/.copywrite.hcl
+++ b/internal/proto/plugin/.copywrite.hcl
@@ -1,0 +1,8 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2020
+
+  header_ignore = []
+}


### PR DESCRIPTION
## [Re-enable copywrite with hack](https://github.com/hashicorp/boundary/commit/d54a2f7998ff57a4d70e289f6b28c24d00160452)

Adds a hack that removes existing copyright headers
from files before rerunning copywrite with directory
specific configuration.

Also remove the massive copyright change commit from blame