### PR TITLE
Set license to BUSL in CRT config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,7 @@ jobs:
           version: ${{ needs.set-product-version.outputs.product-version }}
           maintainer: "HashiCorp"
           homepage: "https://github.com/hashicorp/boundary"
-          license: "MPL-2.0"
+          license: "BUSL-1.1"
           binary: "dist/${{ env.PKG_NAME }}"
           deb_depends: "openssl"
           rpm_depends: "openssl"


### PR DESCRIPTION
Seems like this was missed in the original PR.