### PR TITLE
Telemetry: role.proto

### DIFF
--- a/internal/gen/controller/api/services/role_service.pb.go
+++ b/internal/gen/controller/api/services/role_service.pb.go
@@ -32,7 +32,7 @@ type GetRoleRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *GetRoleRequest) Reset() {
@@ -126,7 +126,7 @@ type ListRolesRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"`     // @gotags: `class:"public"`
+	ScopeId   string `protobuf:"bytes,1,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"`     // @gotags: `class:"public" eventstream:"observation"`
 	Recursive bool   `protobuf:"varint,20,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public"` // @gotags: `class:"public"`
 	Filter    string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty" class:"public"`        // @gotags: `class:"public"`
 }
@@ -338,7 +338,7 @@ type UpdateRoleRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Item       *roles.Role            `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 	UpdateMask *fieldmaskpb.FieldMask `protobuf:"bytes,3,opt,name=update_mask,proto3" json:"update_mask,omitempty"`
 }
@@ -448,7 +448,7 @@ type DeleteRoleRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *DeleteRoleRequest) Reset() {
@@ -533,11 +533,11 @@ type AddRolePrincipalsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`            // @gotags: `class:"public"`
-	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public"` // @gotags: `class:"public"`
+	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *AddRolePrincipalsRequest) Reset() {
@@ -645,11 +645,11 @@ type SetRolePrincipalsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`            // @gotags: `class:"public"`
-	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public"` // @gotags: `class:"public"`
+	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *SetRolePrincipalsRequest) Reset() {
@@ -757,11 +757,11 @@ type RemoveRolePrincipalsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version      uint32   `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"`            // @gotags: `class:"public"`
-	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public"` // @gotags: `class:"public"`
+	PrincipalIds []string `protobuf:"bytes,3,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *RemoveRolePrincipalsRequest) Reset() {

--- a/internal/proto/controller/api/resources/roles/v1/role.proto
+++ b/internal/proto/controller/api/resources/roles/v1/role.proto
@@ -14,13 +14,13 @@ option go_package = "github.com/hashicorp/boundary/sdk/pbs/controller/api/resour
 
 message Principal {
   // Output only. The ID of the principal.
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The type of the principal.
-  string type = 2; // @gotags: `class:"public"`
+  string type = 2; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The Scope of the principal.
-  string scope_id = 3 [json_name = "scope_id"]; // @gotags: `class:"public"`
+  string scope_id = 3 [json_name = "scope_id"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message GrantJson {
@@ -52,10 +52,10 @@ message Grant {
 // Role contains all fields related to a Role resource
 message Role {
   // Output only. The ID of the Role.
-  string id = 10; // @gotags: `class:"public"`
+  string id = 10; // @gotags: `class:"public" eventstream:"observation"`
 
   // The ID of the Scope containing this Role.
-  string scope_id = 20 [json_name = "scope_id"]; // @gotags: `class:"public"`
+  string scope_id = 20 [json_name = "scope_id"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. Scope information for this resource.
   resources.scopes.v1.ScopeInfo scope = 30;
@@ -79,10 +79,10 @@ message Role {
   ]; // @gotags: `class:"public"`
 
   // Output only. The time this resource was created.
-  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp created_time = 60 [json_name = "created_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The time this resource was last updated.
-  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp updated_time = 70 [json_name = "updated_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
@@ -96,10 +96,10 @@ message Role {
       this: "grant_scope_id"
       that: "GrantScopeId"
     }
-  ]; // @gotags: `class:"public"`
+  ]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The IDs (only) of principals that are assigned to this role.
-  repeated string principal_ids = 100 [json_name = "principal_ids"]; // @gotags: `class:"public"`
+  repeated string principal_ids = 100 [json_name = "principal_ids"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The principals that are assigned to this role.
   repeated Principal principals = 110;

--- a/internal/proto/controller/api/services/v1/role_service.proto
+++ b/internal/proto/controller/api/services/v1/role_service.proto
@@ -155,7 +155,7 @@ service RoleService {
 }
 
 message GetRoleRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message GetRoleResponse {
@@ -163,7 +163,7 @@ message GetRoleResponse {
 }
 
 message ListRolesRequest {
-  string scope_id = 1 [json_name = "scope_id"]; // @gotags: `class:"public"`
+  string scope_id = 1 [json_name = "scope_id"]; // @gotags: `class:"public" eventstream:"observation"`
   bool recursive = 20 [json_name = "recursive"]; // @gotags: `class:"public"`
   string filter = 30 [json_name = "filter"]; // @gotags: `class:"public"`
 }
@@ -182,7 +182,7 @@ message CreateRoleResponse {
 }
 
 message UpdateRoleRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   resources.roles.v1.Role item = 2;
   google.protobuf.FieldMask update_mask = 3 [json_name = "update_mask"];
 }
@@ -192,17 +192,17 @@ message UpdateRoleResponse {
 }
 
 message DeleteRoleRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message DeleteRoleResponse {}
 
 message AddRolePrincipalsRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 2; // @gotags: `class:"public"`
-  repeated string principal_ids = 3 [json_name = "principal_ids"]; // @gotags: `class:"public"`
+  repeated string principal_ids = 3 [json_name = "principal_ids"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message AddRolePrincipalsResponse {
@@ -210,11 +210,11 @@ message AddRolePrincipalsResponse {
 }
 
 message SetRolePrincipalsRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 2; // @gotags: `class:"public"`
-  repeated string principal_ids = 3 [json_name = "principal_ids"]; // @gotags: `class:"public"`
+  repeated string principal_ids = 3 [json_name = "principal_ids"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message SetRolePrincipalsResponse {
@@ -222,11 +222,11 @@ message SetRolePrincipalsResponse {
 }
 
 message RemoveRolePrincipalsRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   // Version is used to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 2; // @gotags: `class:"public"`
-  repeated string principal_ids = 3 [json_name = "principal_ids"]; // @gotags: `class:"public"`
+  repeated string principal_ids = 3 [json_name = "principal_ids"]; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message RemoveRolePrincipalsResponse {

--- a/sdk/pbs/controller/api/resources/roles/role.pb.go
+++ b/sdk/pbs/controller/api/resources/roles/role.pb.go
@@ -33,11 +33,11 @@ type Principal struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the principal.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The type of the principal.
-	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
+	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The Scope of the principal.
-	ScopeId string `protobuf:"bytes,3,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	ScopeId string `protobuf:"bytes,3,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *Principal) Reset() {
@@ -245,9 +245,9 @@ type Role struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the Role.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// The ID of the Scope containing this Role.
-	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	ScopeId string `protobuf:"bytes,20,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. Scope information for this resource.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,30,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Optional name for identification purposes.
@@ -255,16 +255,16 @@ type Role struct {
 	// Optional user-set description for identification purposes.
 	Description *wrapperspb.StringValue `protobuf:"bytes,50,opt,name=description,proto3" json:"description,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The time this resource was last updated.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,70,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version uint32 `protobuf:"varint,80,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The Scope the grants will apply to. If the Role is at the global scope, this can be an org or project. If the Role is at an org scope, this can be a project within the org. It is invalid for this to be anything other than the Role's scope when the Role's scope is a project.
-	GrantScopeId *wrapperspb.StringValue `protobuf:"bytes,90,opt,name=grant_scope_id,proto3" json:"grant_scope_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	GrantScopeId *wrapperspb.StringValue `protobuf:"bytes,90,opt,name=grant_scope_id,proto3" json:"grant_scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The IDs (only) of principals that are assigned to this role.
-	PrincipalIds []string `protobuf:"bytes,100,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public"` // @gotags: `class:"public"`
+	PrincipalIds []string `protobuf:"bytes,100,rep,name=principal_ids,proto3" json:"principal_ids,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The principals that are assigned to this role.
 	Principals []*Principal `protobuf:"bytes,110,rep,name=principals,proto3" json:"principals,omitempty"`
 	// Output only. The grants that this role provides for its principals.


### PR DESCRIPTION
This PR adds observation gotags into `role.proto` and `role_service.proto` for telemetry purposes
cc: @jimlambrt  @ajayreshc 