### PR TITLE
Telemetry: managed_group.proto

### DIFF
--- a/internal/gen/controller/api/services/managed_group_service.pb.go
+++ b/internal/gen/controller/api/services/managed_group_service.pb.go
@@ -33,7 +33,7 @@ type GetManagedGroupRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *GetManagedGroupRequest) Reset() {
@@ -127,7 +127,7 @@ type ListManagedGroupsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	AuthMethodId string `protobuf:"bytes,1,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	AuthMethodId string `protobuf:"bytes,1,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Filter       string `protobuf:"bytes,30,opt,name=filter,proto3" json:"filter,omitempty" class:"public"`                // @gotags: `class:"public"`
 }
 
@@ -331,7 +331,7 @@ type UpdateManagedGroupRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id         string                      `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id         string                      `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Item       *managedgroups.ManagedGroup `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
 	UpdateMask *fieldmaskpb.FieldMask      `protobuf:"bytes,3,opt,name=update_mask,proto3" json:"update_mask,omitempty"`
 }
@@ -441,7 +441,7 @@ type DeleteManagedGroupRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *DeleteManagedGroupRequest) Reset() {

--- a/internal/proto/controller/api/resources/managedgroups/v1/managed_group.proto
+++ b/internal/proto/controller/api/resources/managedgroups/v1/managed_group.proto
@@ -17,7 +17,7 @@ option go_package = "github.com/hashicorp/boundary/sdk/pbs/controller/api/resour
 // ManagedGroup contains all fields related to an ManagedGroup resource
 message ManagedGroup {
   // Output only. The ID of the ManagedGroup.
-  string id = 10; // @gotags: `class:"public"`
+  string id = 10; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. Scope information for the ManagedGroup.
   resources.scopes.v1.ScopeInfo scope = 20;
@@ -41,23 +41,23 @@ message ManagedGroup {
   ]; // @gotags: `class:"public"`
 
   // Output only. The time this resource was created.
-  google.protobuf.Timestamp created_time = 50 [json_name = "created_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp created_time = 50 [json_name = "created_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The time this resource was last updated.
-  google.protobuf.Timestamp updated_time = 60 [json_name = "updated_time"]; // @gotags: `class:"public"`
+  google.protobuf.Timestamp updated_time = 60 [json_name = "updated_time"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
   // The mutation will fail if the version does not match the latest known good version.
   uint32 version = 70; // @gotags: `class:"public"`
 
   // The type of this ManagedGroup.
-  string type = 80; // @gotags: `class:"public"`
+  string type = 80; // @gotags: `class:"public" eventstream:"observation"`
 
   // The ID of the Auth Method that is associated with this ManagedGroup.
   string auth_method_id = 90 [
     json_name = "auth_method_id",
     (custom_options.v1.subtype_source_id) = true
-  ]; // @gotags: `class:"public"`
+  ]; // @gotags: `class:"public" eventstream:"observation"`
 
   oneof attrs {
     // The attributes that are applicable for the specific ManagedGroup type.
@@ -78,7 +78,7 @@ message ManagedGroup {
   }
 
   // Output only. The IDs of the current set of members (accounts) that are associated with this ManagedGroup.
-  repeated string member_ids = 110 [json_name = "member_ids"]; // @gotags: `class:"public"`
+  repeated string member_ids = 110 [json_name = "member_ids"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The available actions on this resource for this user.
   repeated string authorized_actions = 300 [json_name = "authorized_actions"]; // @gotags: `class:"public"`

--- a/internal/proto/controller/api/services/v1/managed_group_service.proto
+++ b/internal/proto/controller/api/services/v1/managed_group_service.proto
@@ -76,7 +76,7 @@ service ManagedGroupService {
 }
 
 message GetManagedGroupRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message GetManagedGroupResponse {
@@ -84,7 +84,7 @@ message GetManagedGroupResponse {
 }
 
 message ListManagedGroupsRequest {
-  string auth_method_id = 1 [json_name = "auth_method_id"]; // @gotags: `class:"public"`
+  string auth_method_id = 1 [json_name = "auth_method_id"]; // @gotags: `class:"public" eventstream:"observation"`
   string filter = 30 [json_name = "filter"]; // @gotags: `class:"public"`
 }
 
@@ -102,7 +102,7 @@ message CreateManagedGroupResponse {
 }
 
 message UpdateManagedGroupRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
   resources.managedgroups.v1.ManagedGroup item = 2;
   google.protobuf.FieldMask update_mask = 3 [json_name = "update_mask"];
 }
@@ -112,7 +112,7 @@ message UpdateManagedGroupResponse {
 }
 
 message DeleteManagedGroupRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message DeleteManagedGroupResponse {}

--- a/sdk/pbs/controller/api/resources/managedgroups/managed_group.pb.go
+++ b/sdk/pbs/controller/api/resources/managedgroups/managed_group.pb.go
@@ -36,7 +36,7 @@ type ManagedGroup struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the ManagedGroup.
-	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,10,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. Scope information for the ManagedGroup.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,20,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Optional name for identification purposes.
@@ -44,16 +44,16 @@ type ManagedGroup struct {
 	// Optional user-set description for identification purposes.
 	Description *wrapperspb.StringValue `protobuf:"bytes,40,opt,name=description,proto3" json:"description,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The time this resource was created.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,50,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,50,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The time this resource was last updated.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: `class:"public"`
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,60,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Version is used in mutation requests, after the initial creation, to ensure this resource has not changed.
 	// The mutation will fail if the version does not match the latest known good version.
 	Version uint32 `protobuf:"varint,70,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The type of this ManagedGroup.
-	Type string `protobuf:"bytes,80,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
+	Type string `protobuf:"bytes,80,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// The ID of the Auth Method that is associated with this ManagedGroup.
-	AuthMethodId string `protobuf:"bytes,90,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	AuthMethodId string `protobuf:"bytes,90,opt,name=auth_method_id,proto3" json:"auth_method_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Types that are assignable to Attrs:
 	//
 	//	*ManagedGroup_Attributes
@@ -61,7 +61,7 @@ type ManagedGroup struct {
 	//	*ManagedGroup_LdapManagedGroupAttributes
 	Attrs isManagedGroup_Attrs `protobuf_oneof:"attrs"`
 	// Output only. The IDs of the current set of members (accounts) that are associated with this ManagedGroup.
-	MemberIds []string `protobuf:"bytes,110,rep,name=member_ids,proto3" json:"member_ids,omitempty" class:"public"` // @gotags: `class:"public"`
+	MemberIds []string `protobuf:"bytes,110,rep,name=member_ids,proto3" json:"member_ids,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The available actions on this resource for this user.
 	AuthorizedActions []string `protobuf:"bytes,300,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public"` // @gotags: `class:"public"`
 }


### PR DESCRIPTION
This PR adds observation gotags into `managed_group.proto` and `managed_group_service.proto` for telemetry purposes
cc: @jimlambrt @ajayreshc 