### PR TITLE
Add config command docs

### DIFF
--- a/website/content/docs/api-clients/commands/config/autocomplete.mdx
+++ b/website/content/docs/api-clients/commands/config/autocomplete.mdx
@@ -1,0 +1,54 @@
+---
+layout: docs
+page_title: config autocomplete - Command
+description: |-
+  The "config autocomplete" command installs or uninstalls autocompletion support for Boundary's CLI.
+---
+
+# config autocomplete
+
+Command: `boundary config autocomplete`
+
+The `config autocomplete` command installs or uninstalls autocompletion support
+for Boundary's CLI.
+
+
+## Examples
+
+Installs autocompletion support for Boundary's CLI.
+
+```shell-session
+$ boundary config autocomplete install
+```
+
+Uninstalls autocompletion support for Boundary's CLI.
+
+```shell-session
+$ boundary config autocomplete uninstall
+```
+
+## Usage
+
+**Install:**
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary config autocomplete install [options] [args]
+```
+
+</CodeBlockConfig>
+
+**Uninstsall:**
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary config autocomplete uninstall [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+@include 'cmd-option-note.mdx'
+

--- a/website/content/docs/api-clients/commands/config/decrypt.mdx
+++ b/website/content/docs/api-clients/commands/config/decrypt.mdx
@@ -1,0 +1,68 @@
+---
+layout: docs
+page_title: config decrypt - Command
+description: |-
+  The "config decrypt" command decrypts sensitive values in a Boundary's configuration file. These values must be marked with {{decrypt()}} as appropriate.
+---
+
+# config decrypt
+
+Command: `boundary config decrypt`
+
+The `config decrypt` command decrypts sensitive values in a Boundary's
+configuration file. These values must be marked with `{{decrypt()}}` as
+appropriate. For example, `key = {{decrypt(encrypted_value)}}`.
+
+## Examples
+
+Overwrite into the existing config file use the `-overwrite` flag.
+
+```shell-session
+$ boundary config decrypt -overwrite config.hcl
+```
+
+In order for this command to perform its task, a "kms" block must be defined
+within a configuration file. 
+
+```hcl
+kms "aead" {
+   purpose = "config"
+   aead_type = "aes-gcm"
+   key = "7xtkEoS5EXPbgynwd+dDLHopaCqK8cq0Rpep4eooaTs="
+}
+```
+
+The "kms" block can be defined in the configuration file or via the `-config`
+flag. If defined in the configuration file, only string parameters are
+supported, and the markers must be inside the quote marks delimiting the string.
+Additionally, if the block is defined inline, do not use an "aead" block with
+the key defined in the configuration file as it provides no protection.
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary config decrypt [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-config` `(string: "")` - The configuration file upon which to perform
+  encryption or decryption
+
+- `-config-kms` `(string: "")` - If specified, the given file will be parsed for
+   a "kms" block with purpose "config" and will use it to perform the command.
+   If not set, the command will expect a block inline with the configuration
+   file, and will only be able to support quoted string parameters.
+
+- `-overwrite` `(bool: false)` - Overwrite the existing file. The default is
+  false.
+
+- `-strip` `(bool: false)` - Strip the declarations from the file afterwards.
+  The default is false.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/config/encrypt.mdx
+++ b/website/content/docs/api-clients/commands/config/encrypt.mdx
@@ -1,0 +1,69 @@
+---
+layout: docs
+page_title: config encrypt - Command
+description: |-
+  The "config encrypt" command encrypts sensitive values in a Boundary's configuration file. These values must be marked with {{encrypt()}} as appropriate.
+---
+
+# config encrypt
+
+Command: `boundary config encrypt`
+
+The `config encrypt` command encrypts sensitive values in a Boundary's
+configuration file. These values must be marked with `{{encrypt()}}` as
+appropriate. For example, `key = {{encrypt(key_value)}}`.
+
+
+## Examples
+
+Overwrite into the existing config file use the `-overwrite` flag.
+
+```shell-session
+$ boundary config encrypt -overwrite config.hcl
+```
+
+In order for this command to perform its task, a "kms" block must be defined
+within a configuration file. 
+
+```hcl
+kms "aead" {
+   purpose = "config"
+   aead_type = "aes-gcm"
+   key = "7xtkEoS5EXPbgynwd+dDLHopaCqK8cq0Rpep4eooaTs="
+}
+```
+
+The "kms" block can be defined in the configuration file or via the -config
+flag. If defined in the configuration file, only string parameters are
+supported, and the markers must be inside the quote marks delimiting the string.
+Additionally, if the block is defined inline, do not use an "aead" block with
+the key defined in the configuration file as it provides no protection.
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary config encrypt [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-config` `(string: "")` - The configuration file upon which to perform
+  encryption or encryption
+
+- `-config-kms` `(string: "")` - If specified, the given file will be parsed for
+   a "kms" block with purpose "config" and will use it to perform the command.
+   If not set, the command will expect a block inline with the configuration
+   file, and will only be able to support quoted string parameters.
+
+- `-overwrite` `(bool: false)` - Overwrite the existing file. The default is
+  false.
+
+- `-strip` `(bool: false)` - Strip the declarations from the file afterwards.
+  The default is false.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/config/get-token.mdx
+++ b/website/content/docs/api-clients/commands/config/get-token.mdx
@@ -1,0 +1,88 @@
+---
+layout: docs
+page_title: config get-token - Command
+description: |-
+  The "config get-token" command fetches a token stored by the Boundary CLI.
+---
+
+# config get-token
+
+Command: `boundary config get-token`
+
+The `config get-token` command fetches a token stored by the Boundary CLI.
+
+## Examples
+
+Get the token stored by the Boundary CLI.
+
+```shell-session
+$ boundary config get-token
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+at_yczA5UPS7Y_s13B5PWh7KENvtKQKgDxaEvP682FMfq5eXrpzKNTpmaHgLS2ucRexrTQ7ueMhDFY5MdFvNuzuTWzUzYgacitnSBaPo75b3XZU4Zp6wmdsXqmkPNY3U
+```
+
+</CodeBlockConfig>
+
+This can be useful in various situations. For example, a line such as the
+following could be in a shell script shared by developers, such that each
+developer on their own machine executing the script ends up using their own
+Boundary token:
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ curl --header "Authorization: Bearer $(boundary config get-token)" \
+   --header "Content-Type: application/json" \
+   http://127.0.0.1:9200/v1/roles/r_1234567890
+```
+
+</CodeBlockConfig>
+
+This command keeps parity with the behavior of other Boundary commands; if the
+`BOUNDARY_TOKEN` environment variable it set, it will override the value loaded
+from the system store. Not only does this keep parity, but it also allows
+examples such as the one above to work even if there is no stored token but if
+an environment variable is specified.
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary config get-token [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-account-id` `(bool: false)` - If specified, print out the account ID
+      associated with the token instead of the token itself. The default is
+      false.
+
+- `-auth-method-id` `(bool: false)` - If specified, print out the auth method ID
+   associated with the token instead of the token itself. The default is false.
+
+- `-keyring-type` `(string: "")` - The type of keyring to use. Defaults to
+   "auto" which will use the Windows credential manager, OSX keychain, or
+   cross-platform password store depending on platform. Set to "none" to disable
+   keyring functionality. Available types, depending on platform, are:
+   "wincred", "keychain", "pass", and "secret-service". The default is auto.
+   This can also be specified via the BOUNDARY_KEYRING_TYPE environment
+   variable.
+
+- `-token-name` `(string: "")` - If specified, the given value will be used as
+   the name when loading the token from the system credential store. This must
+   correspond to a name used when authenticating. This can also be specified via
+   the BOUNDARY_TOKEN_NAME environment variable.
+
+- `-user-id` `(bool: false)` - If specified, print out the user ID associated
+   with the token instead of the token itself. The default is false.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/config/index.mdx
+++ b/website/content/docs/api-clients/commands/config/index.mdx
@@ -1,0 +1,60 @@
+---
+layout: docs
+page_title: config - Command
+description: |-
+  The "config" command groups subcommands for operators interacting with Boundary's config files.
+---
+
+# config
+
+Command: `boundary config`
+
+The `config` command groups subcommands for operators interacting with
+Boundary's config files.
+
+## Examples
+
+Encrypt sensitive values in a config file
+
+```shell-session
+$ boundary config encrypt config.hcl
+```
+
+Decrypt sensitive values in a config file.
+
+```shell-session
+$ boundary config decrypt config.hcl
+```
+
+Read a stored token out.
+
+```shell-session
+$ boundary config get-token
+```
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary config <subcommand> [options] [args]
+
+  # ...
+
+Subcommands:
+    autocomplete    Install or uninstall autocompletion for Boundary's CLI
+    decrypt         Decrypt sensitive values in Boundary's configuration file
+    encrypt         Encrypt sensitive values in Boundary's configuration file
+    get-token       Get the stored token, or its properties
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [autocomplete](/boundary/docs/api-clients/commands/config/autocomplete)
+- [decrypt](/boundary/docs/api-clients/commands/config/decrypt)
+- [encrypt](/boundary/docs/api-clients/commands/config/encrypt)
+- [get-token](/boundary/docs/api-clients/commands/config/get-token)

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -623,6 +623,31 @@
             ]
           },
           {
+            "title": "config",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/config"
+              },
+              {
+                "title": "autocomplete",
+                "path": "api-clients/commands/config/autocomplete"
+              },
+              {
+                "title": "decrypt",
+                "path": "api-clients/commands/config/decrypt"
+              },
+              {
+                "title": "encrypt",
+                "path": "api-clients/commands/config/encrypt"
+              },
+              {
+                "title": "get-token",
+                "path": "api-clients/commands/config/get-token"
+              }
+            ]
+          },
+          {
             "title": "connect",
             "routes": [
               {


### PR DESCRIPTION
This adds `boundary config` command doc on top of https://github.com/hashicorp/boundary/pull/3411

🔍 [Deploy preview](https://boundary-git-config-command-doc-hashicorp.vercel.app/boundary/docs/api-clients/commands/config)