### PR TITLE
Update linux package license to BUSL-1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,7 @@ jobs:
           version: ${{ needs.set-product-version.outputs.product-version }}
           maintainer: "HashiCorp"
           homepage: "https://github.com/hashicorp/boundary"
-          license: "MPL-2.0"
+          license: "BUSL-1.1"
           binary: "dist/${{ env.PKG_NAME }}"
           deb_depends: "openssl"
           rpm_depends: "openssl"


### PR DESCRIPTION
This updates the linux package license to BUSL-1.1.
This PR should be merged to main so that the change is included in the next major release (#.X.#) that is cut from main.
License changes are not required on release branches (ongoing patch releases of current minor releases).
