### PR TITLE
test(e2e): Refactor migration test docker repo definition

### DIFF
--- a/testing/internal/e2e/infra/docker.go
+++ b/testing/internal/e2e/infra/docker.go
@@ -28,9 +28,15 @@ type Container struct {
 
 // StartBoundaryDatabase spins up a postgres database in a docker container.
 // Returns information about the container
-func StartBoundaryDatabase(t testing.TB, pool *dockertest.Pool, network *dockertest.Network) *Container {
+func StartBoundaryDatabase(t testing.TB, pool *dockertest.Pool, network *dockertest.Network, repository, tag string) *Container {
 	t.Log("Starting postgres database...")
 	c, err := LoadConfig()
+	require.NoError(t, err)
+
+	err = pool.Client.PullImage(docker.PullImageOptions{
+		Repository: repository,
+		Tag:        tag,
+	}, docker.AuthConfiguration{})
 	require.NoError(t, err)
 
 	networkAlias := "e2epostgres"
@@ -41,8 +47,8 @@ func StartBoundaryDatabase(t testing.TB, pool *dockertest.Pool, network *dockert
 	require.NoError(t, err)
 
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: c.DockerMirror + "/library/postgres",
-		Tag:        "latest",
+		Repository: fmt.Sprintf("%s/%s", c.DockerMirror, repository),
+		Tag:        tag,
 		Cmd:        []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
 		Env: []string{
 			"POSTGRES_DB=" + postgresDb,
@@ -77,7 +83,7 @@ func StartBoundaryDatabase(t testing.TB, pool *dockertest.Pool, network *dockert
 // InitBoundaryDatabase starts a boundary container (of the latest released version) and initializes a
 // postgres database (using `boundary database init`) at the specified postgres URI.
 // Returns information about the container
-func InitBoundaryDatabase(t testing.TB, pool *dockertest.Pool, network *dockertest.Network, postgresURI string) *Container {
+func InitBoundaryDatabase(t testing.TB, pool *dockertest.Pool, network *dockertest.Network, repository, tag, postgresURI string) *Container {
 	t.Log("Initializing postgres database...")
 	c, err := LoadConfig()
 	require.NoError(t, err)
@@ -85,9 +91,15 @@ func InitBoundaryDatabase(t testing.TB, pool *dockertest.Pool, network *dockerte
 	boundaryConfigFilePath, err := filepath.Abs("testdata/boundary-config.hcl")
 	require.NoError(t, err)
 
+	err = pool.Client.PullImage(docker.PullImageOptions{
+		Repository: repository,
+		Tag:        tag,
+	}, docker.AuthConfiguration{})
+	require.NoError(t, err)
+
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: c.DockerMirror + "/hashicorp/boundary",
-		Tag:        "latest",
+		Repository: fmt.Sprintf("%s/%s", c.DockerMirror, repository),
+		Tag:        tag,
 		Cmd:        []string{"boundary", "database", "init", "-config", "/boundary/boundary-config.hcl", "-format", "json"},
 		Env: []string{
 			"BOUNDARY_POSTGRES_URL=" + postgresURI,
@@ -132,7 +144,7 @@ func GetDbInitInfoFromContainer(t testing.TB, pool *dockertest.Pool, container *
 // StartBoundary starts a boundary container and spins up an instance of boundary using the
 // specified database at postgresURI.
 // Returns information about the container.
-func StartBoundary(t testing.TB, pool *dockertest.Pool, network *dockertest.Network, postgresURI string) *Container {
+func StartBoundary(t testing.TB, pool *dockertest.Pool, network *dockertest.Network, repository, tag, postgresURI string) *Container {
 	t.Log("Starting Boundary...")
 	c, err := LoadConfig()
 	require.NoError(t, err)
@@ -140,12 +152,19 @@ func StartBoundary(t testing.TB, pool *dockertest.Pool, network *dockertest.Netw
 	boundaryConfigFilePath, err := filepath.Abs("testdata/boundary-config.hcl")
 	require.NoError(t, err)
 
+	err = pool.Client.PullImage(docker.PullImageOptions{
+		Repository: fmt.Sprintf("%s/%s", c.DockerMirror, repository),
+		Tag:        tag,
+	}, docker.AuthConfiguration{})
+	require.NoError(t, err)
+
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: c.DockerMirror + "/hashicorp/boundary",
-		Tag:        "latest",
+		Repository: fmt.Sprintf("%s/%s", c.DockerMirror, repository),
+		Tag:        tag,
 		Cmd:        []string{"boundary", "server", "-config", "/boundary/boundary-config.hcl"},
 		Env: []string{
-			"BOUNDARY_POSTGRES_URL=" + postgresURI,
+			fmt.Sprintf("BOUNDARY_LICENSE=%s", c.BoundaryLicense),
+			fmt.Sprintf("BOUNDARY_POSTGRES_URL=%s", postgresURI),
 			"HOSTNAME=boundary",
 			"SKIP_CHOWN=true",
 		},
@@ -172,15 +191,21 @@ func StartBoundary(t testing.TB, pool *dockertest.Pool, network *dockertest.Netw
 
 // StartVault starts a vault container.
 // Returns information about the container.
-func StartVault(t testing.TB, pool *dockertest.Pool, network *dockertest.Network) (*Container, string) {
+func StartVault(t testing.TB, pool *dockertest.Pool, network *dockertest.Network, repository, tag string) (*Container, string) {
 	t.Log("Starting Vault...")
 	c, err := LoadConfig()
 	require.NoError(t, err)
 
+	err = pool.Client.PullImage(docker.PullImageOptions{
+		Repository: fmt.Sprintf("%s/%s", c.DockerMirror, repository),
+		Tag:        tag,
+	}, docker.AuthConfiguration{})
+	require.NoError(t, err)
+
 	vaultToken := "boundarytok"
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: c.DockerMirror + "/hashicorp/vault",
-		Tag:        "latest",
+		Repository: fmt.Sprintf("%s/%s", c.DockerMirror, repository),
+		Tag:        tag,
 		Env: []string{
 			"VAULT_DEV_ROOT_TOKEN_ID=" + vaultToken,
 		},
@@ -207,14 +232,14 @@ func StartVault(t testing.TB, pool *dockertest.Pool, network *dockertest.Network
 // ConnectToTarget starts a boundary container and attempts to connect to the specified target. The
 // goal of this method is to create a session entry in the database.
 // Returns information about the container.
-func ConnectToTarget(t testing.TB, pool *dockertest.Pool, network *dockertest.Network, boundaryAddr string, token string, targetId string) *Container {
+func ConnectToTarget(t testing.TB, pool *dockertest.Pool, network *dockertest.Network, repository, tag, boundaryAddr, token, targetId string) *Container {
 	t.Log("Connecting to target...")
 	c, err := LoadConfig()
 	require.NoError(t, err)
 
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: c.DockerMirror + "/hashicorp/boundary",
-		Tag:        "latest",
+		Repository: fmt.Sprintf("%s/%s", c.DockerMirror, repository),
+		Tag:        tag,
 		Cmd: []string{
 			"boundary", "connect",
 			"-token", "env://E2E_AUTH_TOKEN",
@@ -239,9 +264,15 @@ func ConnectToTarget(t testing.TB, pool *dockertest.Pool, network *dockertest.Ne
 
 // StartOpenSshServer starts an openssh container to serve as a target for Boundary.
 // Returns information about the container.
-func StartOpenSshServer(t testing.TB, pool *dockertest.Pool, network *dockertest.Network, user string, privateKeyFilePath string) *Container {
+func StartOpenSshServer(t testing.TB, pool *dockertest.Pool, network *dockertest.Network, repository, tag, user, privateKeyFilePath string) *Container {
 	t.Log("Starting openssh-server to serve as target...")
 	c, err := LoadConfig()
+	require.NoError(t, err)
+
+	err = pool.Client.PullImage(docker.PullImageOptions{
+		Repository: fmt.Sprintf("%s/%s", c.DockerMirror, repository),
+		Tag:        tag,
+	}, docker.AuthConfiguration{})
 	require.NoError(t, err)
 
 	privateKeyRaw, err := os.ReadFile(privateKeyFilePath)
@@ -251,7 +282,8 @@ func StartOpenSshServer(t testing.TB, pool *dockertest.Pool, network *dockertest
 
 	networkAlias := "target"
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: c.DockerMirror + "/linuxserver/openssh-server",
+		Repository: fmt.Sprintf("%s/%s", c.DockerMirror, repository),
+		Tag:        tag,
 		Env: []string{
 			"PUID=1000",
 			"PGID=1000",


### PR DESCRIPTION
This PR updates the e2e migration test based on a comment here: https://github.com/hashicorp/boundary-enterprise/pull/670#discussion_r1291668121

It refactors where `docker pull` is executed in order to reduce the number of places where a docker repo needs to be specified (In the comment above, I had modified the image that `docker run` would use, but did not modify the corresponding `docker pull`). Additionally, this makes it simpler to modify which version of Boundary to use in the event we want to run the migration test on a different starting version.