### PR TITLE
docs: Update listener ports in worker config

### DIFF
--- a/website/content/docs/install-boundary/configure-workers.mdx
+++ b/website/content/docs/install-boundary/configure-workers.mdx
@@ -74,7 +74,7 @@ disable_mlock = true
 
 # listener denoting this is a worker proxy
 listener "tcp" {
-  address = "0.0.0.0:9201"
+  address = "0.0.0.0:9202"
   purpose = "proxy"
 }
 
@@ -143,7 +143,7 @@ disable_mlock = true
 
 # listener denoting this is a worker proxy
 listener "tcp" {
-  address = "0.0.0.0:9201"
+  address = "0.0.0.0:9202"
   purpose = "proxy"
 }
 
@@ -151,7 +151,7 @@ listener "tcp" {
 # worker service
 worker {
   public_addr = "<worker_public_addr>"
-  initial_upstreams = ["<ingress_worker_address>:9201"]
+  initial_upstreams = ["<ingress_worker_address>:9202"]
   auth_storage_path = "/etc/boundary.d/auth_storage/"
   tags {
     type = ["worker2", "intermediate"]
@@ -212,7 +212,7 @@ disable_mlock = true
 
 # listener denoting this is a worker proxy
 listener "tcp" {
-  address = "0.0.0.0:9201"
+  address = "0.0.0.0:9202"
   purpose = "proxy"
 }
 
@@ -220,7 +220,7 @@ listener "tcp" {
 # worker service
 worker {
   public_addr = "<worker_public_addr>"
-  initial_upstreams = ["<intermediate_worker_address>:9201"]
+  initial_upstreams = ["<intermediate_worker_address>:9202"]
   auth_storage_path = "/etc/boundary.d/auth_storage/"
   tags {
     type = ["worker3", "egress"]


### PR DESCRIPTION
The default listener ports were listed incorrectly in the configure workers topic. This PR fixes them.

From a Slack conversation: https://hashicorp.slack.com/archives/C01AQDJF3SA/p1690860684124889

These changes were already applied to the Boundary ENT deployment guide tutorial: [#1579](https://github.com/hashicorp/tutorials/pull/1579).