### PR TITLE
Telemetry: servers proto

### DIFF
--- a/internal/gen/controller/servers/servers.pb.go
+++ b/internal/gen/controller/servers/servers.pb.go
@@ -86,7 +86,7 @@ type ServerWorkerStatus struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Id of the worker.
-	PublicId string `protobuf:"bytes,10,opt,name=public_id,json=publicId,proto3" json:"public_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	PublicId string `protobuf:"bytes,10,opt,name=public_id,json=publicId,proto3" json:"public_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Name of the resource (optional)
 	Name string `protobuf:"bytes,20,opt,name=name,proto3" json:"name,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Description of the resource (optional)
@@ -98,9 +98,9 @@ type ServerWorkerStatus struct {
 	// The key id for this worker, if applicable (optional)
 	KeyId string `protobuf:"bytes,50,opt,name=key_id,json=keyId,proto3" json:"key_id,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The version of Boundary the worker binary is running
-	ReleaseVersion string `protobuf:"bytes,60,opt,name=release_version,proto3" json:"release_version,omitempty" class:"public"` // @gotags: `class:"public"`
+	ReleaseVersion string `protobuf:"bytes,60,opt,name=release_version,proto3" json:"release_version,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// The state of the worker, to indicate if the worker is active or in shutdown.
-	OperationalState string `protobuf:"bytes,70,opt,name=operational_state,json=operationalState,proto3" json:"operational_state,omitempty" class:"public"` // @gotags: `class:"public"`
+	OperationalState string `protobuf:"bytes,70,opt,name=operational_state,json=operationalState,proto3" json:"operational_state,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *ServerWorkerStatus) Reset() {

--- a/internal/gen/controller/servers/services/server_coordination_service.pb.go
+++ b/internal/gen/controller/servers/services/server_coordination_service.pb.go
@@ -328,7 +328,7 @@ type Connection struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ConnectionId string           `protobuf:"bytes,1,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	ConnectionId string           `protobuf:"bytes,1,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Status       CONNECTIONSTATUS `protobuf:"varint,2,opt,name=status,proto3,enum=controller.servers.services.v1.CONNECTIONSTATUS" json:"status,omitempty"`
 	BytesUp      int64            `protobuf:"varint,3,opt,name=bytes_up,json=bytesUp,proto3" json:"bytes_up,omitempty" class:"public"`       // @gotags: `class:"public"`
 	BytesDown    int64            `protobuf:"varint,4,opt,name=bytes_down,json=bytesDown,proto3" json:"bytes_down,omitempty" class:"public"` // @gotags: `class:"public"`
@@ -399,7 +399,7 @@ type SessionJobInfo struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	SessionId       string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	SessionId       string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	Status          SESSIONSTATUS          `protobuf:"varint,2,opt,name=status,proto3,enum=controller.servers.services.v1.SESSIONSTATUS" json:"status,omitempty"`
 	Connections     []*Connection          `protobuf:"bytes,3,rep,name=connections,proto3" json:"connections,omitempty"`
 	ProcessingError SessionProcessingError `protobuf:"varint,4,opt,name=processing_error,json=processingError,proto3,enum=controller.servers.services.v1.SessionProcessingError" json:"processing_error,omitempty" class:"public"` // @gotags: `class:"public"`
@@ -470,7 +470,7 @@ type MonitorSessionJobInfo struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	SessionId       string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public"`                                                                               // @gotags: `class:"public"`
+	SessionId       string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public" eventstream:"observation"`                                                                               // @gotags: `class:"public" eventstream:"observation"`
 	Status          SESSIONSTATUS          `protobuf:"varint,2,opt,name=status,proto3,enum=controller.servers.services.v1.SESSIONSTATUS" json:"status,omitempty" class:"public"`                                                   // @gotags: `class:"public"`
 	ProcessingError SessionProcessingError `protobuf:"varint,3,opt,name=processing_error,json=processingError,proto3,enum=controller.servers.services.v1.SessionProcessingError" json:"processing_error,omitempty" class:"public"` // @gotags: `class:"public"`
 }
@@ -1014,7 +1014,7 @@ type StatusResponse struct {
 	CalculatedUpstreams []*UpstreamServer `protobuf:"bytes,30,rep,name=calculated_upstreams,json=calculatedUpstreams,proto3" json:"calculated_upstreams,omitempty"`
 	// The ID of the worker which made the request. The worker can send this value in subsequent requests so the
 	// controller does not need to do a database lookup for the id using the name field.
-	WorkerId string `protobuf:"bytes,40,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	WorkerId string `protobuf:"bytes,40,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Of the worker key identifiers provided in the request, these are the ones
 	// which are authorized to remain connected.
 	// This is deprecated.  Use authorized_downstream_workers instead. This

--- a/internal/gen/controller/servers/services/session_service.pb.go
+++ b/internal/gen/controller/servers/services/session_service.pb.go
@@ -32,10 +32,10 @@ type LookupSessionRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The session ID from the client
-	SessionId string `protobuf:"bytes,10,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	SessionId string `protobuf:"bytes,10,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// The id of the requesting worker, used for filtering to ensure this worker
 	// can handle this session
-	WorkerId string `protobuf:"bytes,20,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	WorkerId string `protobuf:"bytes,20,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *LookupSessionRequest) Reset() {
@@ -95,14 +95,14 @@ type LookupSessionResponse struct {
 	TofuToken       string                            `protobuf:"bytes,20,opt,name=tofu_token,json=tofuToken,proto3" json:"tofu_token,omitempty" class:"secret"`                             // @gotags: `class:"secret"`
 	Version         uint32                            `protobuf:"varint,30,opt,name=version,proto3" json:"version,omitempty" class:"public"`                                                 // @gotags: `class:"public"`
 	Endpoint        string                            `protobuf:"bytes,40,opt,name=endpoint,proto3" json:"endpoint,omitempty" class:"public"`                                                // @gotags: `class:"public"`
-	Expiration      *timestamppb.Timestamp            `protobuf:"bytes,50,opt,name=expiration,proto3" json:"expiration,omitempty" class:"public"`                                            // @gotags: `class:"public"`
-	Status          SESSIONSTATUS                     `protobuf:"varint,60,opt,name=status,proto3,enum=controller.servers.services.v1.SESSIONSTATUS" json:"status,omitempty" class:"public"` // @gotags: `class:"public"`
+	Expiration      *timestamppb.Timestamp            `protobuf:"bytes,50,opt,name=expiration,proto3" json:"expiration,omitempty" class:"public" eventstream:"observation"`                                            // @gotags: `class:"public" eventstream:"observation"`
+	Status          SESSIONSTATUS                     `protobuf:"varint,60,opt,name=status,proto3,enum=controller.servers.services.v1.SESSIONSTATUS" json:"status,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	ConnectionLimit int32                             `protobuf:"varint,70,opt,name=connection_limit,json=connectionLimit,proto3" json:"connection_limit,omitempty" class:"public"`          // @gotags: `class:"public"`
 	ConnectionsLeft int32                             `protobuf:"varint,80,opt,name=connections_left,json=connectionsLeft,proto3" json:"connections_left,omitempty" class:"public"`          // @gotags: `class:"public"`
-	HostId          string                            `protobuf:"bytes,90,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty" class:"public"`                                      // @gotags: `class:"public"`
-	HostSetId       string                            `protobuf:"bytes,100,opt,name=host_set_id,json=hostSetId,proto3" json:"host_set_id,omitempty" class:"public"`                          // @gotags: `class:"public"`
-	TargetId        string                            `protobuf:"bytes,110,opt,name=target_id,json=targetId,proto3" json:"target_id,omitempty" class:"public"`                               // @gotags: `class:"public"`
-	UserId          string                            `protobuf:"bytes,120,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty" class:"public"`                                     // @gotags: `class:"public"`
+	HostId          string                            `protobuf:"bytes,90,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty" class:"public" eventstream:"observation"`                                      // @gotags: `class:"public" eventstream:"observation"`
+	HostSetId       string                            `protobuf:"bytes,100,opt,name=host_set_id,json=hostSetId,proto3" json:"host_set_id,omitempty" class:"public" eventstream:"observation"`                          // @gotags: `class:"public" eventstream:"observation"`
+	TargetId        string                            `protobuf:"bytes,110,opt,name=target_id,json=targetId,proto3" json:"target_id,omitempty" class:"public" eventstream:"observation"`                               // @gotags: `class:"public" eventstream:"observation"`
+	UserId          string                            `protobuf:"bytes,120,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty" class:"public" eventstream:"observation"`                                     // @gotags: `class:"public" eventstream:"observation"`
 	// credentials is deprecated on this response message.  Instead use the
 	// credentials field inside the ProtocolContext message.
 	//
@@ -251,10 +251,10 @@ type ActivateSessionRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	SessionId string        `protobuf:"bytes,10,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public"`                             // @gotags: `class:"public"`
+	SessionId string        `protobuf:"bytes,10,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public" eventstream:"observation"`                             // @gotags: `class:"public" eventstream:"observation"`
 	TofuToken string        `protobuf:"bytes,20,opt,name=tofu_token,json=tofuToken,proto3" json:"tofu_token,omitempty" class:"secret"`                             // @gotags: `class:"secret"`
 	Version   uint32        `protobuf:"varint,30,opt,name=version,proto3" json:"version,omitempty" class:"public"`                                                 // @gotags: `class:"public"`
-	Status    SESSIONSTATUS `protobuf:"varint,50,opt,name=status,proto3,enum=controller.servers.services.v1.SESSIONSTATUS" json:"status,omitempty" class:"public"` // @gotags: `class:"public"`
+	Status    SESSIONSTATUS `protobuf:"varint,50,opt,name=status,proto3,enum=controller.servers.services.v1.SESSIONSTATUS" json:"status,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *ActivateSessionRequest) Reset() {
@@ -322,7 +322,7 @@ type ActivateSessionResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Status SESSIONSTATUS `protobuf:"varint,10,opt,name=status,proto3,enum=controller.servers.services.v1.SESSIONSTATUS" json:"status,omitempty" class:"public"` // @gotags: `class:"public"`
+	Status SESSIONSTATUS `protobuf:"varint,10,opt,name=status,proto3,enum=controller.servers.services.v1.SESSIONSTATUS" json:"status,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *ActivateSessionResponse) Reset() {
@@ -369,7 +369,7 @@ type CancelSessionRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	SessionId string `protobuf:"bytes,10,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	SessionId string `protobuf:"bytes,10,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *CancelSessionRequest) Reset() {
@@ -416,7 +416,7 @@ type CancelSessionResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Status SESSIONSTATUS `protobuf:"varint,10,opt,name=status,proto3,enum=controller.servers.services.v1.SESSIONSTATUS" json:"status,omitempty" class:"public"` // @gotags: `class:"public"`
+	Status SESSIONSTATUS `protobuf:"varint,10,opt,name=status,proto3,enum=controller.servers.services.v1.SESSIONSTATUS" json:"status,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *CancelSessionResponse) Reset() {
@@ -463,8 +463,8 @@ type AuthorizeConnectionRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	SessionId string `protobuf:"bytes,10,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public"` // @gotags: `class:"public"`
-	WorkerId  string `protobuf:"bytes,20,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty" class:"public"`    // @gotags: `class:"public"`
+	SessionId string `protobuf:"bytes,10,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
+	WorkerId  string `protobuf:"bytes,20,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty" class:"public" eventstream:"observation"`    // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *AuthorizeConnectionRequest) Reset() {
@@ -518,8 +518,8 @@ type AuthorizeConnectionResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ConnectionId    string           `protobuf:"bytes,10,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty" class:"public"`                       // @gotags: `class:"public"`
-	Status          CONNECTIONSTATUS `protobuf:"varint,20,opt,name=status,proto3,enum=controller.servers.services.v1.CONNECTIONSTATUS" json:"status,omitempty" class:"public"` // @gotags: `class:"public"`
+	ConnectionId    string           `protobuf:"bytes,10,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty" class:"public" eventstream:"observation"`                       // @gotags: `class:"public" eventstream:"observation"`
+	Status          CONNECTIONSTATUS `protobuf:"varint,20,opt,name=status,proto3,enum=controller.servers.services.v1.CONNECTIONSTATUS" json:"status,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	ConnectionsLeft int32            `protobuf:"varint,30,opt,name=connections_left,json=connectionsLeft,proto3" json:"connections_left,omitempty" class:"public"`             // @gotags: `class:"public"`
 	// protocol_context contains information specific to the protocol being
 	// proxied.  This is not needed to be set for tcp sessions.
@@ -600,12 +600,12 @@ type ConnectConnectionRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ConnectionId       string `protobuf:"bytes,10,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty" class:"public"`                     // @gotags: `class:"public"`
+	ConnectionId       string `protobuf:"bytes,10,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty" class:"public" eventstream:"observation"`                     // @gotags: `class:"public" eventstream:"observation"`
 	ClientTcpAddress   string `protobuf:"bytes,20,opt,name=client_tcp_address,json=clientTcpAddress,proto3" json:"client_tcp_address,omitempty" class:"public"`       // @gotags: `class:"public"`
 	ClientTcpPort      uint32 `protobuf:"varint,30,opt,name=client_tcp_port,json=clientTcpPort,proto3" json:"client_tcp_port,omitempty" class:"public"`               // @gotags: `class:"public"`
 	EndpointTcpAddress string `protobuf:"bytes,40,opt,name=endpoint_tcp_address,json=endpointTcpAddress,proto3" json:"endpoint_tcp_address,omitempty" class:"public"` // @gotags: `class:"public"`
 	EndpointTcpPort    uint32 `protobuf:"varint,50,opt,name=endpoint_tcp_port,json=endpointTcpPort,proto3" json:"endpoint_tcp_port,omitempty" class:"public"`         // @gotags: `class:"public"`
-	Type               string `protobuf:"bytes,60,opt,name=type,proto3" json:"type,omitempty" class:"public"`                                                         // @gotags: `class:"public"`
+	Type               string `protobuf:"bytes,60,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"`                                                         // @gotags: `class:"public" eventstream:"observation"`
 	// user_client_ip is the user's client ip for the connection as determined by
 	// the inbound http request handler
 	UserClientIp string `protobuf:"bytes,70,opt,name=user_client_ip,json=userClientIp,proto3" json:"user_client_ip,omitempty" class:"public"` // @gotags: `class:"public"
@@ -697,7 +697,7 @@ type ConnectConnectionResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Status CONNECTIONSTATUS `protobuf:"varint,10,opt,name=status,proto3,enum=controller.servers.services.v1.CONNECTIONSTATUS" json:"status,omitempty" class:"public"` // @gotags: `class:"public"`
+	Status CONNECTIONSTATUS `protobuf:"varint,10,opt,name=status,proto3,enum=controller.servers.services.v1.CONNECTIONSTATUS" json:"status,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *ConnectConnectionResponse) Reset() {
@@ -744,7 +744,7 @@ type CloseConnectionRequestData struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ConnectionId string `protobuf:"bytes,10,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty" class:"public"` // @gotags: `class:"public"`
+	ConnectionId string `protobuf:"bytes,10,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	BytesUp      int64  `protobuf:"varint,20,opt,name=bytes_up,json=bytesUp,proto3" json:"bytes_up,omitempty" class:"public"`               // @gotags: `class:"public"`
 	BytesDown    int64  `protobuf:"varint,30,opt,name=bytes_down,json=bytesDown,proto3" json:"bytes_down,omitempty" class:"public"`         // @gotags: `class:"public"`
 	Reason       string `protobuf:"bytes,40,opt,name=reason,proto3" json:"reason,omitempty" class:"public"`                                 // @gotags: `class:"public"`
@@ -815,7 +815,7 @@ type CloseConnectionRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	CloseRequestData []*CloseConnectionRequestData `protobuf:"bytes,10,rep,name=close_request_data,json=closeRequestData,proto3" json:"close_request_data,omitempty" class:"public"` // @gotags: `class:"public"`
+	CloseRequestData []*CloseConnectionRequestData `protobuf:"bytes,10,rep,name=close_request_data,json=closeRequestData,proto3" json:"close_request_data,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *CloseConnectionRequest) Reset() {
@@ -863,7 +863,7 @@ type CloseConnectionResponseData struct {
 	unknownFields protoimpl.UnknownFields
 
 	ConnectionId string           `protobuf:"bytes,10,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty"`
-	Status       CONNECTIONSTATUS `protobuf:"varint,20,opt,name=status,proto3,enum=controller.servers.services.v1.CONNECTIONSTATUS" json:"status,omitempty" class:"public"` // @gotags: `class:"public"`
+	Status       CONNECTIONSTATUS `protobuf:"varint,20,opt,name=status,proto3,enum=controller.servers.services.v1.CONNECTIONSTATUS" json:"status,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *CloseConnectionResponseData) Reset() {
@@ -917,7 +917,7 @@ type CloseConnectionResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	CloseResponseData []*CloseConnectionResponseData `protobuf:"bytes,10,rep,name=close_response_data,json=closeResponseData,proto3" json:"close_response_data,omitempty" class:"public"` // @gotags: `class:"public"`
+	CloseResponseData []*CloseConnectionResponseData `protobuf:"bytes,10,rep,name=close_response_data,json=closeResponseData,proto3" json:"close_response_data,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 }
 
 func (x *CloseConnectionResponse) Reset() {

--- a/internal/proto/controller/servers/services/v1/server_coordination_service.proto
+++ b/internal/proto/controller/servers/services/v1/server_coordination_service.proto
@@ -27,7 +27,7 @@ enum CONNECTIONSTATUS {
 }
 
 message Connection {
-  string connection_id = 1; // @gotags: `class:"public"`
+  string connection_id = 1; // @gotags: `class:"public" eventstream:"observation"`
   CONNECTIONSTATUS status = 2;
   int64 bytes_up = 3; // @gotags: `class:"public"`
   int64 bytes_down = 4; // @gotags: `class:"public"`
@@ -42,7 +42,7 @@ enum SESSIONSTATUS {
 }
 
 message SessionJobInfo {
-  string session_id = 1; // @gotags: `class:"public"`
+  string session_id = 1; // @gotags: `class:"public" eventstream:"observation"`
   SESSIONSTATUS status = 2;
   repeated Connection connections = 3;
   SessionProcessingError processing_error = 4; // @gotags: `class:"public"`
@@ -54,7 +54,7 @@ enum SessionProcessingError {
 }
 
 message MonitorSessionJobInfo {
-  string session_id = 1; // @gotags: `class:"public"`
+  string session_id = 1; // @gotags: `class:"public" eventstream:"observation"`
   SESSIONSTATUS status = 2; // @gotags: `class:"public"`
   SessionProcessingError processing_error = 3; // @gotags: `class:"public"`
 }
@@ -173,7 +173,7 @@ message StatusResponse {
 
   // The ID of the worker which made the request. The worker can send this value in subsequent requests so the
   // controller does not need to do a database lookup for the id using the name field.
-  string worker_id = 40; // @gotags: `class:"public"`
+  string worker_id = 40; // @gotags: `class:"public" eventstream:"observation"`
 
   // Of the worker key identifiers provided in the request, these are the ones
   // which are authorized to remain connected.

--- a/internal/proto/controller/servers/services/v1/session_service.proto
+++ b/internal/proto/controller/servers/services/v1/session_service.proto
@@ -36,10 +36,10 @@ service SessionService {
 
 message LookupSessionRequest {
   // The session ID from the client
-  string session_id = 10; // @gotags: `class:"public"`
+  string session_id = 10; // @gotags: `class:"public" eventstream:"observation"`
   // The id of the requesting worker, used for filtering to ensure this worker
   // can handle this session
-  string worker_id = 20; // @gotags: `class:"public"`
+  string worker_id = 20; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 // LookupSessionResponse contains information necessary for a client to
@@ -49,14 +49,14 @@ message LookupSessionResponse {
   string tofu_token = 20; // @gotags: `class:"secret"`
   uint32 version = 30; // @gotags: `class:"public"`
   string endpoint = 40; // @gotags: `class:"public"`
-  google.protobuf.Timestamp expiration = 50; // @gotags: `class:"public"`
-  controller.servers.services.v1.SESSIONSTATUS status = 60; // @gotags: `class:"public"`
+  google.protobuf.Timestamp expiration = 50; // @gotags: `class:"public" eventstream:"observation"`
+  controller.servers.services.v1.SESSIONSTATUS status = 60; // @gotags: `class:"public" eventstream:"observation"`
   int32 connection_limit = 70; // @gotags: `class:"public"`
   int32 connections_left = 80; // @gotags: `class:"public"`
-  string host_id = 90; // @gotags: `class:"public"`
-  string host_set_id = 100; // @gotags: `class:"public"`
-  string target_id = 110; // @gotags: `class:"public"`
-  string user_id = 120; // @gotags: `class:"public"`
+  string host_id = 90; // @gotags: `class:"public" eventstream:"observation"`
+  string host_set_id = 100; // @gotags: `class:"public" eventstream:"observation"`
+  string target_id = 110; // @gotags: `class:"public" eventstream:"observation"`
+  string user_id = 120; // @gotags: `class:"public" eventstream:"observation"`
 
   // credentials is deprecated on this response message.  Instead use the
   // credentials field inside the ProtocolContext message.
@@ -69,32 +69,32 @@ message ActivateSessionRequest {
   reserved 40;
   reserved "worker_id";
 
-  string session_id = 10; // @gotags: `class:"public"`
+  string session_id = 10; // @gotags: `class:"public" eventstream:"observation"`
   string tofu_token = 20; // @gotags: `class:"secret"`
   uint32 version = 30; // @gotags: `class:"public"`
-  controller.servers.services.v1.SESSIONSTATUS status = 50; // @gotags: `class:"public"`
+  controller.servers.services.v1.SESSIONSTATUS status = 50; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message ActivateSessionResponse {
-  controller.servers.services.v1.SESSIONSTATUS status = 10; // @gotags: `class:"public"`
+  controller.servers.services.v1.SESSIONSTATUS status = 10; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message CancelSessionRequest {
-  string session_id = 10; // @gotags: `class:"public"`
+  string session_id = 10; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message CancelSessionResponse {
-  controller.servers.services.v1.SESSIONSTATUS status = 10; // @gotags: `class:"public"`
+  controller.servers.services.v1.SESSIONSTATUS status = 10; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message AuthorizeConnectionRequest {
-  string session_id = 10; // @gotags: `class:"public"`
-  string worker_id = 20; // @gotags: `class:"public"`
+  string session_id = 10; // @gotags: `class:"public" eventstream:"observation"`
+  string worker_id = 20; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message AuthorizeConnectionResponse {
-  string connection_id = 10; // @gotags: `class:"public"`
-  controller.servers.services.v1.CONNECTIONSTATUS status = 20; // @gotags: `class:"public"`
+  string connection_id = 10; // @gotags: `class:"public" eventstream:"observation"`
+  controller.servers.services.v1.CONNECTIONSTATUS status = 20; // @gotags: `class:"public" eventstream:"observation"`
   int32 connections_left = 30; // @gotags: `class:"public"`
 
   // protocol_context contains information specific to the protocol being
@@ -106,12 +106,12 @@ message AuthorizeConnectionResponse {
 }
 
 message ConnectConnectionRequest {
-  string connection_id = 10; // @gotags: `class:"public"`
+  string connection_id = 10; // @gotags: `class:"public" eventstream:"observation"`
   string client_tcp_address = 20; // @gotags: `class:"public"`
   uint32 client_tcp_port = 30; // @gotags: `class:"public"`
   string endpoint_tcp_address = 40; // @gotags: `class:"public"`
   uint32 endpoint_tcp_port = 50; // @gotags: `class:"public"`
-  string type = 60; // @gotags: `class:"public"`
+  string type = 60; // @gotags: `class:"public" eventstream:"observation"`
 
   // user_client_ip is the user's client ip for the connection as determined by
   // the inbound http request handler
@@ -119,25 +119,25 @@ message ConnectConnectionRequest {
 }
 
 message ConnectConnectionResponse {
-  controller.servers.services.v1.CONNECTIONSTATUS status = 10; // @gotags: `class:"public"`
+  controller.servers.services.v1.CONNECTIONSTATUS status = 10; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message CloseConnectionRequestData {
-  string connection_id = 10; // @gotags: `class:"public"`
+  string connection_id = 10; // @gotags: `class:"public" eventstream:"observation"`
   int64 bytes_up = 20; // @gotags: `class:"public"`
   int64 bytes_down = 30; // @gotags: `class:"public"`
   string reason = 40; // @gotags: `class:"public"`
 }
 
 message CloseConnectionRequest {
-  repeated CloseConnectionRequestData close_request_data = 10; // @gotags: `class:"public"`
+  repeated CloseConnectionRequestData close_request_data = 10; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message CloseConnectionResponseData {
   string connection_id = 10;
-  controller.servers.services.v1.CONNECTIONSTATUS status = 20; // @gotags: `class:"public"`
+  controller.servers.services.v1.CONNECTIONSTATUS status = 20; // @gotags: `class:"public" eventstream:"observation"`
 }
 
 message CloseConnectionResponse {
-  repeated CloseConnectionResponseData close_response_data = 10; // @gotags: `class:"public"`
+  repeated CloseConnectionResponseData close_response_data = 10; // @gotags: `class:"public" eventstream:"observation"`
 }

--- a/internal/proto/controller/servers/v1/servers.proto
+++ b/internal/proto/controller/servers/v1/servers.proto
@@ -16,7 +16,7 @@ message TagPair {
 // ServerWorkerStatus is the new message used in place of Server to relay status request info.
 message ServerWorkerStatus {
   // Id of the worker.
-  string public_id = 10; // @gotags: `class:"public"`
+  string public_id = 10; // @gotags: `class:"public" eventstream:"observation"`
 
   // Name of the resource (optional)
   string name = 20; // @gotags: `class:"public"`
@@ -34,8 +34,8 @@ message ServerWorkerStatus {
   string key_id = 50; // @gotags: `class:"public"`
 
   // The version of Boundary the worker binary is running
-  string release_version = 60 [json_name = "release_version"]; // @gotags: `class:"public"`
+  string release_version = 60 [json_name = "release_version"]; // @gotags: `class:"public" eventstream:"observation"`
 
   // The state of the worker, to indicate if the worker is active or in shutdown.
-  string operational_state = 70; // @gotags: `class:"public"`
+  string operational_state = 70; // @gotags: `class:"public" eventstream:"observation"`
 }


### PR DESCRIPTION
This PR adds observation gotags into `servers.proto` and `session_service.proto` in the servers package for telemetry purposes.
cc: @jimlambrt @ajayreshc