### PR TITLE
test(e2e): Add license env to migration test

### DIFF
--- a/testing/internal/e2e/infra/docker.go
+++ b/testing/internal/e2e/infra/docker.go
@@ -102,7 +102,8 @@ func InitBoundaryDatabase(t testing.TB, pool *dockertest.Pool, network *dockerte
 		Tag:        tag,
 		Cmd:        []string{"boundary", "database", "init", "-config", "/boundary/boundary-config.hcl", "-format", "json"},
 		Env: []string{
-			"BOUNDARY_POSTGRES_URL=" + postgresURI,
+			fmt.Sprintf("BOUNDARY_LICENSE=%s", c.BoundaryLicense),
+			fmt.Sprintf("BOUNDARY_POSTGRES_URL=%s", postgresURI),
 			"SKIP_CHOWN=true",
 		},
 		Mounts:   []string{path.Dir(boundaryConfigFilePath) + ":/boundary/"},


### PR DESCRIPTION
This PR is a follow-up to https://github.com/hashicorp/boundary/pull/3578.

The enterprise version of the test needs one more place where the BOUNDARY_LICENSE env needs to be set.