### PR TITLE
test(e2e): Build docker image based on host architecture

### DIFF
--- a/enos/modules/build_boundary_docker_local/build.sh
+++ b/enos/modules/build_boundary_docker_local/build.sh
@@ -9,6 +9,7 @@ root_dir="$(git rev-parse --show-toplevel)"
 pushd "${root_dir}" > /dev/null
 
 # make docker image
+export DEV_DOCKER_GOARCH=$(uname -m)
 export IMAGE_TAG_DEV="${IMAGE_NAME}"
 make build-ui docker-build-dev
 


### PR DESCRIPTION
This PR addresses an issue with a script that builds a docker image locally prior to running e2e tests. 

I ran into this issue after restarting my VS Code instance. Now, the script will set an environment variable based on the host's architecture (the `Makefile` defaults to `amd64`). I'm assuming I just always had that environment variable set whenever I was testing. 