### PR TITLE
adds tabs for Enterprise vs Community

### DIFF
--- a/website/content/docs/install-boundary/install.mdx
+++ b/website/content/docs/install-boundary/install.mdx
@@ -7,25 +7,43 @@ description: |-
 
 # Install Boundary
 
-This guide outlines the required steps to manually install and configure a single HashiCorp Boundary cluster as defined in the [Recommended architecture](/boundary/docs/install-boundary/recommended-architecture) topic.
-It assumes you install Boundary on virtual machines (VMs) or bare-metal servers running a Debian or Red Hat-based Linux distribution.
+This guide outlines the required steps to manually install and configure a
+single HashiCorp Boundary cluster as defined in the [Recommended
+architecture](/boundary/docs/install-boundary/recommended-architecture) topic.
+It assumes you install Boundary on virtual machines (VMs) or bare-metal servers
+running a Debian or Red Hat-based Linux distribution.
 
-This document includes general guidance as well as specific recommendations for popular cloud infrastructure platforms.
-These recommendations have also been encoded into official Terraform reference architectures for [AWS](https://github.com/hashicorp/boundary-reference-architecture/tree/main/deployment/aws), [Azure](https://github.com/hashicorp/boundary-reference-architecture/tree/main/deployment/azure), and [GCP](https://github.com/hashicorp/boundary-reference-architecture/tree/main/deployment/gcp).
+This document includes general guidance as well as specific recommendations for
+popular cloud infrastructure platforms. These recommendations have also been
+encoded into official Terraform reference architectures for
+[AWS](https://github.com/hashicorp/boundary-reference-architecture/tree/main/deployment/aws),
+[Azure](https://github.com/hashicorp/boundary-reference-architecture/tree/main/deployment/azure),
+and
+[GCP](https://github.com/hashicorp/boundary-reference-architecture/tree/main/deployment/gcp).
 
-Pre-built Boundary packages are available from the [HashiCorp Linux Repository](https://www.hashicorp.com/blog/announcing-the-hashicorp-linux-repository).
-In addition to installing the Boundary binary, the official package also provides a systemd service unit, and a local `boundary` user account under which the service runs.
+Pre-built Boundary packages are available from the [HashiCorp Linux
+Repository](https://www.hashicorp.com/blog/announcing-the-hashicorp-linux-repository).
+In addition to installing the Boundary binary, the official package also
+provides a systemd service unit, and a local `boundary` user account under which
+the service runs.
 
-You must complete the following steps for each Boundary controller and worker node that you want to deploy.
-The binary operates as either a worker or controller, depending on the subsequent configuration that you generate for the Boundary binary.
+You must complete the following steps for each Boundary controller and worker
+node that you want to deploy. The binary operates as either a worker or
+controller, depending on the subsequent configuration that you generate for the
+Boundary binary.
 
 The steps vary by Linux distribution.
-Select your distribution, and complete the steps to install Boundary.
 
+Select your distribution of Boundary, and complete the steps to install the
+binary.
+
+<Tabs>
+<Tab heading="Enterprise">
 <Tabs>
 <Tab heading="Ubuntu/Debian">
 
-1. Use the following command to add the HashiCorp GPC key as a trusted package-signing key:
+1. Use the following command to add the HashiCorp GPC key as a trusted
+   package-signing key:
 
     ```shell-session
     $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
@@ -42,16 +60,17 @@ Select your distribution, and complete the steps to install Boundary.
     $ sudo apt update
     ```
 
-1. Install Boundary:
+1. Install Boundary Enterprise:
 
     ```shell-session
-    $ sudo apt install boundary
+    $ sudo apt install boundary-enterprise
     ```
 
 </Tab>
 <Tab heading="CentOS/RHEL">
 
-1. Use the following command to install `yum-config-manager` to manage your repositories:
+1. Use the following command to install `yum-config-manager` to manage your
+   repositories:
 
     ```shell-session
     $ sudo yum install -y yum-utils
@@ -63,17 +82,17 @@ Select your distribution, and complete the steps to install Boundary.
     $ sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
     ```
 
-3. Install Boundary:
+3. Install Boundary Enterprise:
 
     ```shell-session
     $ sudo yum -y install boundary-enterprise
     ```
 
 </Tab>
-
 <Tab heading="Amazon Linux">
 
-1. Use the following command to install `yum-config-manager` to manage your repositories:
+1. Use the following command to install `yum-config-manager` to manage your
+   repositories:
 
     ```shell-session
     $ sudo yum install -y yum-utils shadow-utils
@@ -85,7 +104,7 @@ Select your distribution, and complete the steps to install Boundary.
     $ sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo
     ```
 
-3. Install Boundary:
+3. Install Boundary Enterprise:
 
     ```shell-session
     $ sudo yum -y install boundary-enterprise
@@ -93,3 +112,81 @@ Select your distribution, and complete the steps to install Boundary.
 
 </Tab>
 </Tabs>
+</Tab>
+<Tab heading="Community edition">
+<Tabs>
+<Tab heading="Ubuntu/Debian">
+
+1. Use the following command to add the HashiCorp GPC key as a trusted
+   package-signing key:
+
+    ```shell-session
+    $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+    ```
+1. Add the official HashiCorp Linux repository:
+
+    ```shell-session
+    $ sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+    ```
+
+1. Update the package index:
+
+    ```shell-session
+    $ sudo apt update
+    ```
+
+1. Install Boundary Community Edition:
+
+    ```shell-session
+    $ sudo apt install boundary
+    ```
+
+</Tab>
+<Tab heading="CentOS/RHEL">
+
+1. Use the following command to install `yum-config-manager` to manage your
+   repositories:
+
+    ```shell-session
+    $ sudo yum install -y yum-utils
+    ```
+
+2. Add the official HashiCorp Linux repository:
+
+    ```shell-session
+    $ sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
+    ```
+
+3. Install Boundary Community Edition:
+
+    ```shell-session
+    $ sudo yum -y install boundary
+    ```
+
+</Tab>
+
+<Tab heading="Amazon Linux">
+
+1. Use the following command to install `yum-config-manager` to manage your
+   repositories:
+
+    ```shell-session
+    $ sudo yum install -y yum-utils shadow-utils
+    ```
+
+2. Add the official HashiCorp Linux repository:
+
+    ```shell-session
+    $ sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo
+    ```
+
+3. Install Boundary Community Edition:
+
+    ```shell-session
+    $ sudo yum -y install boundary
+    ```
+
+</Tab>
+</Tabs>
+</Tab>
+<Tabs>

--- a/website/content/docs/install-boundary/install.mdx
+++ b/website/content/docs/install-boundary/install.mdx
@@ -113,7 +113,7 @@ binary:
 </Tab>
 </Tabs>
 </Tab>
-<Tab heading="Community edition">
+<Tab heading="Community Edition">
 <Tabs>
 <Tab heading="Ubuntu/Debian">
 

--- a/website/content/docs/install-boundary/install.mdx
+++ b/website/content/docs/install-boundary/install.mdx
@@ -35,7 +35,7 @@ Boundary binary.
 The steps vary by Linux distribution.
 
 Select your distribution of Boundary, and complete the steps to install the
-binary.
+binary:
 
 <Tabs>
 <Tab heading="Enterprise">

--- a/website/content/docs/install-boundary/install.mdx
+++ b/website/content/docs/install-boundary/install.mdx
@@ -189,4 +189,4 @@ binary:
 </Tab>
 </Tabs>
 </Tab>
-<Tabs>
+</Tabs>


### PR DESCRIPTION
This PR updates the Install Boundary topic by adding installation tabs to distinguish between the Enterprise and Community binaries.