### PR TITLE
docs: Update automated license reporting topic

### DIFF
--- a/website/content/docs/enterprise/automated-license-reporting.mdx
+++ b/website/content/docs/enterprise/automated-license-reporting.mdx
@@ -9,7 +9,7 @@ description: >-
 
 Automated license utilization reporting sends license utilization data to HashiCorp without requiring you to manually collect and report them. It also lets you review your license usage with the monitoring solution you already use (for example Splunk, Datadog, or others) so you can optimize and manage your deployments. Use these reports to understand how much more you can deploy under your current contract, protect against overutilization, and budget for predicted consumption.
 
-Automated reporting shares the minimum data required to validate license utilization as defined in our contracts. They consist of mostly computed metrics and will never contain Personal Identifiable Information (PII) or other sensitive information. Automated reporting shares the data with HashiCorp using a secure, unidirectional HTTPS API and makes an auditable record in the product logs each time it submits a report. This process is GDPR compliant.
+Automated reporting shares the minimum data required to validate license utilization as defined in our contracts. They consist of mostly computed metrics and will never contain Personal Identifiable Information (PII) or other sensitive information. Automated reporting shares the data with HashiCorp using a secure, unidirectional HTTPS API and makes an auditable record in the product logs each time it submits a report. This process is GDPR compliant and submits reports roughly once every 24 hours.
 
 ## Enable automated reporting
 

--- a/website/content/docs/enterprise/automated-license-reporting.mdx
+++ b/website/content/docs/enterprise/automated-license-reporting.mdx
@@ -9,7 +9,7 @@ description: >-
 
 Automated license utilization reporting sends license utilization data to HashiCorp without requiring you to manually collect and report them. It also lets you review your license usage with the monitoring solution you already use (for example Splunk, Datadog, or others) so you can optimize and manage your deployments. Use these reports to understand how much more you can deploy under your current contract, protect against overutilization, and budget for predicted consumption.
 
-Automated reporting shares the minimum data required to validate license utilization as defined in our contracts. They consist of mostly computed metrics and will never contain Personal Identifiable Information (PII) or other sensitive information. Automated reporting shares the data with HashiCorp using a secure, unidirectional HTTPS API and makes an auditable record in the product logs each time it submits a report. This process is GDPR compliant and submits reports roughly once every 24 hours.
+Automated reporting shares the minimum data required to validate license utilization as defined in our contracts. They consist of mostly computed metrics and will never contain Personal Identifiable Information (PII) or other sensitive information. Automated reporting shares the data with HashiCorp using a secure, unidirectional HTTPS API and makes an auditable record in the product logs each time it submits a report. The reporting process is GDPR compliant and submits reports roughly once every 24 hours.
 
 ## Enable automated reporting
 


### PR DESCRIPTION
The language on the automated license utilization reporting topic is carefully controlled. The PM has asked that we make a minor update to bring the Boundary topic in line with the changes that were applied in [Vault PR #22026](https://github.com/hashicorp/vault/pull/22026).

The Vault PR has minor wording updates on lines #58 and #195, but these were already applied to the existing Boundary topic in [PR #3491](https://github.com/hashicorp/boundary/pull/3491):

Line [#58](https://github.com/hashicorp/vault/pull/22026/files#diff-13490f1ee5e6b5cbb1370b297aeba8eb2c97815681b4479853631d2326b7b606R58):

<img width="696" alt="image" src="https://github.com/hashicorp/boundary/assets/76443935/8ad3ffe9-dd3c-4b06-b719-34edb79b5751">

Line [#195](https://github.com/hashicorp/vault/pull/22026/files#diff-13490f1ee5e6b5cbb1370b297aeba8eb2c97815681b4479853631d2326b7b606R195):

<img width="697" alt="image" src="https://github.com/hashicorp/boundary/assets/76443935/c1e0cf01-168a-4688-850f-b70caf2fe708">

Therefore, this PR contains only the remaining minor text change on line [#25](https://github.com/hashicorp/vault/pull/22026/files#diff-13490f1ee5e6b5cbb1370b297aeba8eb2c97815681b4479853631d2326b7b606R25) from the Vault PR.