### PR TITLE
docs: Add `users` commands

### DIFF
--- a/website/content/docs/api-clients/commands/users/add-accounts.mdx
+++ b/website/content/docs/api-clients/commands/users/add-accounts.mdx
@@ -1,0 +1,40 @@
+---
+layout: docs
+page_title: users add-accounts - Command
+description: |-
+  The "users add-accounts" command associates accounts with a user.
+---
+
+# users add-accounts
+
+Command: `users add-accounts`
+
+The `users add-accounts` command lets you associate accounts with a user.
+
+## Example
+
+This example associates a user `u_1234567890` with an account `a_1234567890`:
+
+```shell-session
+$ boundary users add-accounts -id u_1234567890 -account a_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary users add-accounts [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-account=<string>` - The accounts to add, remove, or set.
+You can specify an `-account=<string>` value multiple times.
+- `-id=<string>` - The ID of the user you want to associate an account with.
+- `-version=<int>` - The version of the user against which to perform an update operation.
+If you do not specify a version, the command automatically performs a check-and-set.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/users/create.mdx
+++ b/website/content/docs/api-clients/commands/users/create.mdx
@@ -1,0 +1,40 @@
+---
+layout: docs
+page_title: users create - Command
+description: |-
+  The "users create" command lets you create a new user.
+---
+
+# users create
+
+Command: `users create`
+
+The `users create` command lets you create a new user.
+
+## Example
+
+This example creates a user `prodops` with the description `User for ProdOps`:
+
+```shell-session
+$ boundary users create -name prodops -description "User for ProdOps"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary users create [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-description=<string>` - A description to assign to the user.
+- `-name=<string>` - The name you want to give the user.
+- `-scope-id=<string>` - The scope in which to create the user.
+The default is `global`.
+You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/users/delete.mdx
+++ b/website/content/docs/api-clients/commands/users/delete.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: users delete - Command
+description: |-
+  The "users delete" command lets you delete a user.
+---
+
+# users delete
+
+Command: `users delete`
+
+The `users delete` command lets you delete a user.
+
+## Example
+
+This example deletes a user with the id `u_1234567890`:
+
+```shell-session
+$ boundary users delete -id u_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary users delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - ID of the user to delete.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/users/index.mdx
+++ b/website/content/docs/api-clients/commands/users/index.mdx
@@ -1,0 +1,47 @@
+---
+layout: docs
+page_title: users - Command
+description: |-
+  The "users" command performs operations on Boundary user resources.
+---
+
+# users
+
+Command: `boundary users`
+
+The `users` command lets you perform operations on Boundary user resources.
+
+## Example
+
+The following command creates a user with the name `prodops` and the description `For ProdOps usage`:
+
+```shell-session
+$ boundary users create -name prodops -description "For ProdOps usage"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary users <subcommand> [options] [args]
+
+  # ...
+
+Subcommands:
+    add-accounts       Add accounts to a user within Boundary
+    create             Create a user
+    delete             Delete a user
+    list               List a user
+    read               Read a user
+    remove-accounts    Remove accounts from a user within Boundary
+    set-accounts       Set the full contents of the accounts on a user within Boundary
+    update             Update a user
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [add-worker-tags](/boundary/docs/api-clients/commands/workers/add-worker-tags)

--- a/website/content/docs/api-clients/commands/users/list.mdx
+++ b/website/content/docs/api-clients/commands/users/list.mdx
@@ -1,0 +1,46 @@
+---
+layout: docs
+page_title: users list - Command
+description: |-
+  The "users list" command lists users from the specified scope or resource.
+---
+
+# users list
+
+Command: `users list`
+
+The `users list` command lets you list the users who belong to the scope or resource you specify.
+
+## Example
+
+This example lists users in the scope `s_1234567890`:
+
+```shell-session
+$ boundary users list -scope-id s_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary users list [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-filter=<string>` - If you set this value, the list operation is filtered before it is returned.
+The filter operates against each item in the list.
+We recommend that you use single quotes, as filters contain double quotes.
+Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
+
+- `-recursive` - If you set this value, the list operation is applied recursively into child scopes, if the type supports it.
+The default value is `false`.
+
+- `-scope-id=<string>` - Designates the scope from which to list the users.
+The default value is `global`.
+You can also specify this value using the BOUNDARY_SCOPE_ID environment variable.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/users/read.mdx
+++ b/website/content/docs/api-clients/commands/users/read.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: users read - Command
+description: |-
+  The "users read" command lists users from the specified scope or resource.
+---
+
+# users read
+
+Command: `users read`
+
+The `users read` command lets you read users by their user ID.
+
+## Example
+
+This example reads a user with the ID `u_1234567890`:
+
+```shell-session
+$ boundary users read -id u_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary users read [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - Indicates the ID of the user you want to read.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/users/remove-accounts.mdx
+++ b/website/content/docs/api-clients/commands/users/remove-accounts.mdx
@@ -1,0 +1,40 @@
+---
+layout: docs
+page_title: users remove-accounts - Command
+description: |-
+  The "users remove-accounts" command disassociates accounts from a user.
+---
+
+# users remove-accounts
+
+Command: `users remove-accounts`
+
+The `users remove-accounts` command lets you disassociate accounts from a user.
+
+## Example
+
+This example disassociates a user `u_1234567890` from an account `a_1234567890`:
+
+```shell-session
+$ boundary users remove-accounts -id u_1234567890 -account a_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary users remove-accounts [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-account=<string>` - The accounts to add, remove, or set.
+You can specify an `-account=<string>` value multiple times.
+- `-id=<string>` - The ID of the user you want to disassociate from an account.
+- `-version=<int>` - The version of the user against which to perform an update operation.
+If you do not specify a version, the command automatically performs a check-and-set.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/users/set-accounts.mdx
+++ b/website/content/docs/api-clients/commands/users/set-accounts.mdx
@@ -1,0 +1,40 @@
+---
+layout: docs
+page_title: users set-accounts - Command
+description: |-
+  The "users set-accounts" command sets the complete set of associated acounts on a user.
+---
+
+# users set-accounts
+
+Command: `users set-accounts`
+
+The `users set-accounts` command lets you set a complete set of associated accounts on a user.
+
+## Example
+
+This example sets the accounts `a_0987654321` and `a_1234567890` on a user `u_1234567890`:
+
+```shell-session
+$ boundary users set-accounts -id u_1234567890 -account a_0987654321 -account a_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary users set-accounts [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-account=<string>` - The accounts to add, remove, or set.
+You can specify an `-account=<string>` value multiple times.
+- `-id=<string>` - The ID of the user you want to set accounts for.
+- `-version=<int>` - The version of the user against which to perform an update operation.
+If you do not specify a version, the command automatically performs a check-and-set.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/users/update.mdx
+++ b/website/content/docs/api-clients/commands/users/update.mdx
@@ -1,0 +1,40 @@
+---
+layout: docs
+page_title: users update - Command
+description: |-
+  The "users update" command lets you update a user.
+---
+
+# users update
+
+Command: `users update`
+
+The `users update` command lets you update a user.
+
+## Example
+
+This example updates a user with the ID `u_1234567890` to add the name `devops` and the description `User for DevOps`:
+
+```shell-session
+$ boundary users update -id u_1234567890 -name "devops" -description "User for DevOps"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary users update [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-description=<string>` - A description to assign to the user.
+- `-id=<string>` - ID of the user to update.
+- `-name=<string>` - The name you want to give the user.
+- `-version=<int>` - The version of the user against which to perform an update operation.
+If you do not specify a version, the command performs a check-and-set automatically.
+
+@include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -689,6 +689,31 @@
             "path": "api-clients/commands/server"
           },
           {
+            "title": "users",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/users"
+              },
+              {
+                "title": "add-accounts",
+                "path": "api-clients/commands/users/add-accounts"
+              },
+              {
+                "title": "create",
+                "path": "api-clients/commands/users/create"
+              },
+              {
+                "title": "delete",
+                "path": "api-clients/commands/users/delete"
+              },
+              {
+                "title": "list",
+                "path": "api-clients/commands/users/list"
+              }
+            ]
+          },
+          {
             "title": "workers",
             "routes": [
               {

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -710,6 +710,22 @@
               {
                 "title": "list",
                 "path": "api-clients/commands/users/list"
+              },
+              {
+                "title": "read",
+                "path": "api-clients/commands/users/read"
+              },
+              {
+                "title": "remove-accounts",
+                "path": "api-clients/commands/users/remove-accounts"
+              },
+              {
+                "title": "set-accounts",
+                "path": "api-clients/commands/users/set-accounts"
+              },
+              {
+                "title": "update",
+                "path": "api-clients/commands/users/update"
               }
             ]
           },


### PR DESCRIPTION
Adds the `users` commands on top of the existing assembly branch for CLI commands #3411.