### PR TITLE
chore(connect): improve messaging if tofu token already used

### DIFF
--- a/internal/cmd/commands/connect/connect.go
+++ b/internal/cmd/commands/connect/connect.go
@@ -758,7 +758,7 @@ func (c *Command) runTcpProxyV1(
 		case strings.Contains(err.Error(), "tofu token not allowed"):
 			// Nothing will be able to be done here, so cancel the context too
 			c.proxyCancel()
-			return errors.New("Session is already in use")
+			return errors.New("Session token has already been used")
 		default:
 			return fmt.Errorf("error reading handshake result: %w", err)
 		}


### PR DESCRIPTION
The message `"Session is already in use"` can appear if an authz token is reused after tearing down a session.
Updated the messaging to be a bit clearer.