### PR TITLE
docs: Add `targets` commands

### DIFF
--- a/website/content/docs/api-clients/commands/targets/add-credential-sources.mdx
+++ b/website/content/docs/api-clients/commands/targets/add-credential-sources.mdx
@@ -1,0 +1,50 @@
+---
+layout: docs
+page_title: targets add-credential-sources - Command
+description: |-
+  The "targets add-credential-sources" lets you add credential sources to target resources.
+---
+
+# targets add-credential-sources
+
+Command: `targets add-credential-sources`
+
+The `targets add-credential-sources` command lets you add credential sources to target resources.
+
+## Example
+
+This example adds brokered credential sources to a TCP target with the ID `ttcp_1234567890`:
+
+```shell-session
+$ boundary targets add-credential-sources -id ttcp_1234567890 -brokered-credential-source clvlt_1234567890 -brokered-credential-source clvlt_0987654321
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets add-credential-sources [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-application-credential-source=<string>` - This option is deprecated.
+Use `-brokered-credential-source` instead.
+
+- `-brokered-credential-source=<string>` - The credential source to add.
+Boundary returns the credential source to the user when it creates a connection.
+You may specify multiple credential sources.
+
+- `-id=<string>` - ID of the target to add the credential source to.
+
+- `-injected-application-credential-source=<string>` - The credential source to add.
+Boundary injects the credential source when it creates a connection.
+You may specify multiple credential sources.
+
+- `-version=<int>` - The version of the target to perform the operation on.
+If you do not specify a version, the command performs a check-and-set automatically.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/targets/add-host-sources.mdx
+++ b/website/content/docs/api-clients/commands/targets/add-host-sources.mdx
@@ -1,0 +1,40 @@
+---
+layout: docs
+page_title: targets add-host-sources - Command
+description: |-
+  The "targets add-host-sources" lets you add host sources to target resources.
+---
+
+# targets add-host-sources
+
+Command: `targets add-host-sources`
+
+The `targets add-host-sources` command lets you add host sources to target resources.
+
+## Example
+
+This example adds multiple host sources to a TCP target with the ID `ttcp_1234567890`:
+
+```shell-session
+$ boundary targets add-host-sources -id ttcp_1234567890 -host-source hsst_1234567890 -host-source hsst_0987654321
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets add-host-sources [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-host-source=<string>` -  The host source to add.
+You may specify multiple host sources.
+- `-id=<string>` - ID of the target you want to add a host source to.
+- `-version=<int>` - The version of the target to perform the operation on.
+If you do not specify a version, the command performs a check-and-set automatically.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/targets/authorize-session.mdx
+++ b/website/content/docs/api-clients/commands/targets/authorize-session.mdx
@@ -1,0 +1,53 @@
+---
+layout: docs
+page_title: targets authorize-session - Command
+description: |-
+  The "targets authorize-session" lets you fetch session authorization credentials for a target.
+---
+
+# targets authorize-session
+
+Command: `targets authorize-session`
+
+The `targets authorize-session` command lets you fetch session authorization credentials for a target so that you can start a session later.
+
+## Examples
+
+This example fetches authorization credentials for a target with the ID `ttcp_wtXnow8Krb` and a specific host with the ID `hst_DHei2VpkBH`:
+
+```shell-session
+$ boundary targets authorize-session -id=ttcp_wtXnow8Krb -host-id=hst_DHei2VpkBH
+```
+
+You can also request an authorized session using the scope ID and target name.
+This example requests authorization credentials using the scope ID `o_1234567890` and the target name `prod-ssh`:
+
+```shell-session
+$ boundary targets authorize-session -scope-id o_1234567890 -name prod-ssh
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets authorize-session [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-host-id=<string>` -  The ID of a specific host from the target's host sets.
+If you specify a host, Boundary uses that host for the connection.
+If you do not specify a host, Boundary chooses one at random.
+- `-id=<string>` - ID of the target for which you want to authorize a session.
+- `-name=<string>` - The name of the target, if you want to authorize the session using scope parameters and target name.
+- `-scope-id=<string>` - The target scope ID, if you want to authorize the session using scope parameters and target name.
+Alternatively, you can specify a scope ID using the BOUNDARY_SCOPE_ID environment variable.
+You cannot specfiy a scope ID if you specify a `-scope-name<string>`.
+- `-scope-name=<string>` - The target scope name, if you want to authoirze the session using scope parameters and target name.
+Alternatively, you can specify a scope name using the BOUNDARY_SCOPE_NAME environment variable.
+You cannot specfiy a scope name if you specfiy a `-scope-id<string>`.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/targets/create.mdx
+++ b/website/content/docs/api-clients/commands/targets/create.mdx
@@ -1,0 +1,124 @@
+---
+layout: docs
+page_title: targets create - Command
+description: |-
+  The "targets create" command lets you create a new target.
+---
+
+# targets create
+
+Command: `targets create`
+
+The `targets create` command lets you create a new target.
+
+## Example
+
+This example creates a TCP target with the name `prodops` and the description `For ProdOps usage`:
+
+```shell-session
+$ boundary targets create tcp -name prodops -description "For ProdOps usage"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets create [type] [sub command] [options] [args]
+
+Please see the typed subcommand help for detailed usage information.
+
+Subcommands:
+    ssh    Create a ssh-type target (HCP only)
+    tcp    Create a tcp-type target
+```
+
+</CodeBlockConfig>
+
+### Usages by type
+
+You can create SSH or TCP targets.
+
+<Tabs>
+<Tab heading="SSH">
+
+The `boundary targets create ssh` command lets you create SSH targets.
+
+#### Example
+
+This example creates an SSH target with the name `prodops` and the description `SSH target for ProdOps`:
+
+```shell-session
+$ boundary targets create ssh -name prodops -description "SSH target for ProdOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets create ssh [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### SSH target options
+
+- `-address=<string>` - An optional valid network address for the target to connect to.
+You cannot use an address alongside host sources.
+- `-default-client-port=<string>` - The default client port on the target.
+- `-default-port=<string>` - The default port on the target.
+If you do not specify a default port, Boundary uses port 22.
+- `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
+- `-enable-session-recording=<string>` - A Boolean expression you can use to enable session recording for the target.
+- `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
+- `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.
+A value of `-1` means the connections are unlimited.
+- `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
+You can specify an integer number of seconds or a duration string.
+- `-storage-bucket-id=<string>` - The public ID of the storage bucket to associate with the target.
+
+
+</Tab>
+<Tab heading="TCP">
+
+The `boundary targets create tcp` command lets you create TCP targets.
+
+#### Example
+
+This example creates a TCP target with the name `prodops` and the description `TCP target for ProdOps`:
+
+```shell-session
+$ boundary targets create tcp -name prodops -description "TCP target for ProdOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets create tcp [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### TCP target options
+
+- `-address=<string>` - An optional valid network address for the target to connect to.
+You cannot use an address alongside host sources.
+- `-default-client-port=<string>` - The default client port on the target.
+- `-default-port=<string>` - The default port on the target.
+If you do not specify a default port, Boundary uses port 22.
+- `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
+- `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
+- `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.
+A value of `-1` means the connections are unlimited.
+- `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
+You can specify an integer number of seconds or a duration string.
+
+</Tab>
+</Tabs>
+
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/targets/delete.mdx
+++ b/website/content/docs/api-clients/commands/targets/delete.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: targets delete - Command
+description: |-
+  The "targets delete" command lets you delete a target.
+---
+
+# targets delete
+
+Command: `targets delete`
+
+The `targets delete` command lets you delete a target.
+
+## Example
+
+This example deletes a target with the ID `t_1234567890`:
+
+```shell-session
+$ boundary targets delete -id t_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - ID of the target to delete.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/targets/index.mdx
+++ b/website/content/docs/api-clients/commands/targets/index.mdx
@@ -1,0 +1,62 @@
+---
+layout: docs
+page_title: targets - Command
+description: |-
+  The "targets" command performs operations on Boundary target resources.
+---
+
+# targets
+
+Command: `boundary targets`
+
+The `targets` command lets you perform operations on Boundary target resources.
+
+## Example
+
+The following command updates the description for a target with the ID `ttcp_1234567890`:
+
+```shell-session
+ $ boundary targets update -id ttcp_1234567890 -description "updated postgres target"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+boundary targets [sub command] [options] [args]
+
+  # ...
+
+Subcommands:
+    add-credential-sources       Add credential sources to a target
+    add-host-sources             Add host sources to a target
+    authorize-session            Request session authorization against the target
+    create                       Create a target
+    delete                       Delete a target
+    list                         List a target
+    read                         Read a target
+    remove-credential-sources    Remove credential sources from a target
+    remove-host-sources          Remove host sources from a target
+    set-credential-sources       Set the full contents of the credential sources on a target
+    set-host-sources             Set the full contents of the host sources on a target
+    update                       Update a target
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [add-credential-sources](/boundary/docs/api-clients/commands/targets/add-credential-sources)
+- [add-host-sources](/boundary/docs/api-clients/commands/targets/add-host-sources)
+- [authorize-session](/boundary/docs/api-clients/commands/targets/authorize-session)
+- [create](/boundary/docs/api-clients/commands/targets/create)
+- [delete](/boundary/docs/api-clients/commands/targets/delete)
+- [list](/boundary/docs/api-clients/commands/targets/list)
+- [read](/boundary/docs/api-clients/commands/targets/read)
+- [remove-credential-sources](/boundary/docs/api-clients/commands/targets/remove-credential-sources)
+- [remove-host-sources](/boundary/docs/api-clients/commands/targets/remove-host-sources)
+- [set-credential-sources](/boundary/docs/api-clients/commands/targets/set-credential-sources)
+- [set-host-sources](/boundary/docs/api-clients/commands/targets/set-host-sources)
+- [update](/boundary/docs/api-clients/commands/targets/update)

--- a/website/content/docs/api-clients/commands/targets/list.mdx
+++ b/website/content/docs/api-clients/commands/targets/list.mdx
@@ -1,22 +1,23 @@
 ---
 layout: docs
-page_title: workers list - Command
+page_title: targets list - Command
 description: |-
-  The "workers list" command lets you list Boundary workers in a scope or resource.
+  The "targets list" command lists the targets within a given scope or resource.
 ---
 
-# workers list
+# targets list
 
-Command: `boundary workers list`
+Command: `targets list`
 
-The `boundary workers list` command lets you list the Boundary workers in a scope or resource.
+The `targets list` command lets you list the targets within a given scope or resource.
 
 ## Example
 
-This example lists workers:
+This example lists all targets within the scope `s_1234567890`.
+The `recursive` option means Boundary runs the operation recursively on any child scopes, if applicable:
 
 ```shell-session
-$ boundary workers list
+$ boundary targets list -scope-id s_1234567890 -recursive
 ```
 
 ## Usage
@@ -24,7 +25,7 @@ $ boundary workers list
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary workers list [options] [args]
+$ boundary targets list [options] [args]
 ```
 
 </CodeBlockConfig>
@@ -37,7 +38,7 @@ We recommend that you use single quotes, because the filters contain double quot
 Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
 - `recursive` - If you set this value, Boundary runs the list operation recursively on any child scopes, if the type supports it.
 The default value is `false`.
-- `scope-id=<string>` - The scope from which to list the workers.
+- `scope-id=<string>` - The scope from which to list the targets.
 The default value is `global`.
 You can also specify this value using the BOUNDARY_SCOPE_ID environment variable.
 

--- a/website/content/docs/api-clients/commands/targets/read.mdx
+++ b/website/content/docs/api-clients/commands/targets/read.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: targets read - Command
+description: |-
+  The "targets read" command reads a target with a given ID.
+---
+
+# targets read
+
+Command: `targets read`
+
+The `targets read` command lets you read a target with a given ID.
+
+## Example
+
+This example reads a target with the ID `t_1234567890`:
+
+```shell-session
+$ boundary targets read -id t_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets read [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - ID of the target to read.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/targets/remove-credential-sources.mdx
+++ b/website/content/docs/api-clients/commands/targets/remove-credential-sources.mdx
@@ -1,0 +1,48 @@
+---
+layout: docs
+page_title: targets remove-credential-sources - Command
+description: |-
+  The "targets remove-credential-sources" lets you remove credential sources from target resources.
+---
+
+# targets remove-credential-sources
+
+Command: `targets remove-credential-sources`
+
+The `targets remove-credential-sources` command lets you remove credential sources from target resources.
+
+## Example
+
+This example removes brokered credential sources from a TCP target with the ID `ttcp_1234567890`:
+
+```shell-session
+$ boundary targets remove-credential-sources -id ttcp_1234567890 -brokered-credential-source clvlt_1234567890 -brokered-credential-source clvlt_0987654321
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets remove-credential-sources [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-application-credential-source=<string>` - This option is deprecated.
+Use `-brokered-credential-source` instead.
+
+- `-brokered-credential-source=<string>` - The credential source to remove.
+You may specify multiple credential sources.
+
+- `-id=<string>` - ID of the target to remove the credential source from.
+
+- `-injected-application-credential-source=<string>` - The credential source to remove.
+You may specify multiple credential sources.
+
+- `-version=<int>` - The version of the target to perform the operation on.
+If you do not specify a version, the command performs a check-and-set automatically.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/targets/remove-host-sources.mdx
+++ b/website/content/docs/api-clients/commands/targets/remove-host-sources.mdx
@@ -1,0 +1,40 @@
+---
+layout: docs
+page_title: targets remove-host-sources - Command
+description: |-
+  The "targets remove-host-sources" lets you remove host sources from target resources.
+---
+
+# targets remove-host-sources
+
+Command: `targets remove-host-sources`
+
+The `targets remove-host-sources` command lets you remove host sources from target resources.
+
+## Example
+
+This example removes multiple host sources from a target with the ID `ttcp_1234567890`:
+
+```shell-session
+$ boundary targets remove-host-sources -id ttcp_1234567890 -host-source hsst_1234567890 -host-source hsst_0987654321
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary target remove-host-sources [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-host-source=<string>` -  The host source to remove.
+You may specify multiple host sources.
+- `-id=<string>` - ID of the target you want to remove a host source from.
+- `-version=<int>` - The version of the target to perform the operation on.
+If you do not specify a version, the command performs a check-and-set automatically.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/targets/set-credential-sources.mdx
+++ b/website/content/docs/api-clients/commands/targets/set-credential-sources.mdx
@@ -1,0 +1,50 @@
+---
+layout: docs
+page_title: targets set-credential-sources - Command
+description: |-
+  The "targets set-credential-sources" lets you set credential sources on target resources.
+---
+
+# targets set-credential-sources
+
+Command: `targets set-credential-sources`
+
+The `targets set-credential-sources` command lets you set credential sources on target resources.
+
+## Example
+
+This example sets a brokered credential source on a target with the ID `ttcp_1234567890`:
+
+```shell-session
+$ boundary targets set-credential-sources -id ttcp_1234567890 -brokered-credential-source clvlt_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets set-credential-sources [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-application-credential-source=<string>` - This option is deprecated.
+Use `-brokered-credential-source` instead.
+
+- `-brokered-credential-source=<string>` - The credential source to set.
+Boundary returns the credential source to the user when it creates a connection.
+You may specify multiple credential sources.
+
+- `-id=<string>` - ID of the target to set the credential source on.
+
+- `-injected-application-credential-source=<string>` - The credential source to set.
+Boundary injects the credential source when it creates a connection.
+You may specify multiple credential sources.
+
+- `-version=<int>` - The version of the target to perform the operation on.
+If you do not specify a version, the command performs a check-and-set automatically.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/targets/set-host-sources.mdx
+++ b/website/content/docs/api-clients/commands/targets/set-host-sources.mdx
@@ -1,0 +1,40 @@
+---
+layout: docs
+page_title: targets set-host-sources - Command
+description: |-
+  The "targets set-host-sources" lets you set host sources on target resources.
+---
+
+# targets set-host-sources
+
+Command: `targets set-host-sources`
+
+The `targets set-host-sources` command lets you set host sources on target resources.
+
+## Example
+
+This example sets host sources on a target with the ID `ttcp_1234567890`:
+
+```shell-session
+$ boundary targets set-host-sources -id ttcp_1234567890 -host-source hsst_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets set-host-sources [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-host-source=<string>` -  The host source to set.
+You may specify multiple host sources.
+- `-id=<string>` - ID of the target you want to set a host source on.
+- `-version=<int>` - The version of the target to perform the operation on.
+If you do not specify a version, the command performs a check-and-set automatically.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/targets/update.mdx
+++ b/website/content/docs/api-clients/commands/targets/update.mdx
@@ -1,0 +1,124 @@
+---
+layout: docs
+page_title: targets update - Command
+description: |-
+  The "targets update" command lets you update a target.
+---
+
+# targets update
+
+Command: `targets update`
+
+The `targets update` command lets you update a target.
+
+## Example
+
+This example updates a TCP target with the ID `ttcp_1234567890` to add the name `devops` and the description `For DevOps usage`:
+
+```shell-session
+$ boundary targets update tcp -id ttcp_1234567890 -name devops -description "For DevOps usage"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets update [type] [sub command] [options] [args]
+
+Please see the typed subcommand help for detailed usage information.
+
+Subcommands:
+    ssh    Update a ssh-type target (HCP only)
+    tcp    Update a tcp-type target
+```
+
+</CodeBlockConfig>
+
+### Usages by type
+
+You can update SSH or TCP targets.
+
+<Tabs>
+<Tab heading="SSH">
+
+The `boundary targets update ssh` command lets you update SSH targets.
+
+#### Example
+
+This example updates an SSH target with the ID `tssh_1234567890` to add the name `devops` and the description `SSH target for DevOps`:
+
+```shell-session
+$ boundary targets update ssh -id tssh_1234567890 -name "devops" -description "SSH target for DevOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets update ssh [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### SSH target options
+
+- `-address=<string>` - An optional valid network address for the target to connect to.
+You cannot use an address alongside host sources.
+- `-default-client-port=<string>` - The default client port on the target.
+- `-default-port=<string>` - The default port on the target.
+If you do not specify a default port, Boundary uses port 22.
+- `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
+- `-enable-session-recording=<string>` - A Boolean expression you can use to enable session recording for the target.
+- `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
+- `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.
+A value of `-1` means the connections are unlimited.
+- `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
+You can specify an integer number of seconds or a duration string.
+- `-storage-bucket-id=<string>` - The public ID of the storage bucket to associate with the target.
+
+
+</Tab>
+<Tab heading="TCP">
+
+The `boundary targets update tcp` command lets you update TCP targets.
+
+#### Example
+
+This example updates a TCP target with the ID `ttcp_1234567890` to add the name `devops` and the description `TCP target for DevOps`:
+
+```shell-session
+$ boundary targets update tcp -id ttcp_1234567890 -name "devops" -description "TCP target for DevOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary targets update tcp [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### TCP target options
+
+- `-address=<string>` - An optional valid network address for the target to connect to.
+You cannot use an address alongside host sources.
+- `-default-client-port=<string>` - The default client port on the target.
+- `-default-port=<string>` - The default port on the target.
+If you do not specify a default port, Boundary uses port 22.
+- `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
+- `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
+- `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.
+A value of `-1` means the connections are unlimited.
+- `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
+You can specify an integer number of seconds or a duration string.
+- `-worker-filter=<string>` - This option is deprecated.
+Use the egress or ingress filters instead.
+
+</Tab>
+</Tabs>
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/users/add-accounts.mdx
+++ b/website/content/docs/api-clients/commands/users/add-accounts.mdx
@@ -34,7 +34,7 @@ $ boundary users add-accounts [options] [args]
 - `-account=<string>` - The accounts to add, remove, or set.
 You can specify an `-account=<string>` value multiple times.
 - `-id=<string>` - The ID of the user you want to associate an account with.
-- `-version=<int>` - The version of the user against which to perform an update operation.
-If you do not specify a version, the command automatically performs a check-and-set.
+- `-version=<int>` - The version of the user to perform the operation on.
+If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/users/index.mdx
+++ b/website/content/docs/api-clients/commands/users/index.mdx
@@ -44,4 +44,11 @@ Subcommands:
 For more information, examples, and usage about a subcommand, click on the name
 of the subcommand in the sidebar or one of the links below:
 
-- [add-worker-tags](/boundary/docs/api-clients/commands/workers/add-worker-tags)
+- [add-accounts](/boundary/docs/api-clients/commands/users/add-accounts)
+- [create](/boundary/docs/api-clients/commands/users/create)
+- [delete](/boundary/docs/api-clients/commands/users/delete)
+- [list](/boundary/docs/api-clients/commands/users/list)
+- [read](/boundary/docs/api-clients/commands/users/read)
+- [remove-accounts](/boundary/docs/api-clients/commands/users/remove-accounts)
+- [set-accounts](/boundary/docs/api-clients/commands/users/set-accounts)
+- [update](/boundary/docs/api-clients/commands/users/update)

--- a/website/content/docs/api-clients/commands/users/list.mdx
+++ b/website/content/docs/api-clients/commands/users/list.mdx
@@ -35,10 +35,8 @@ $ boundary users list [options] [args]
 The filter operates against each item in the list.
 We recommend that you use single quotes, as filters contain double quotes.
 Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
-
 - `-recursive` - If you set this value, the list operation is applied recursively into child scopes, if the type supports it.
 The default value is `false`.
-
 - `-scope-id=<string>` - Designates the scope from which to list the users.
 The default value is `global`.
 You can also specify this value using the BOUNDARY_SCOPE_ID environment variable.

--- a/website/content/docs/api-clients/commands/users/remove-accounts.mdx
+++ b/website/content/docs/api-clients/commands/users/remove-accounts.mdx
@@ -34,7 +34,7 @@ $ boundary users remove-accounts [options] [args]
 - `-account=<string>` - The accounts to add, remove, or set.
 You can specify an `-account=<string>` value multiple times.
 - `-id=<string>` - The ID of the user you want to disassociate from an account.
-- `-version=<int>` - The version of the user against which to perform an update operation.
-If you do not specify a version, the command automatically performs a check-and-set.
+- `-version=<int>` - The version of the user to perform the operation on.
+If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/users/set-accounts.mdx
+++ b/website/content/docs/api-clients/commands/users/set-accounts.mdx
@@ -34,7 +34,7 @@ $ boundary users set-accounts [options] [args]
 - `-account=<string>` - The accounts to add, remove, or set.
 You can specify an `-account=<string>` value multiple times.
 - `-id=<string>` - The ID of the user you want to set accounts for.
-- `-version=<int>` - The version of the user against which to perform an update operation.
-If you do not specify a version, the command automatically performs a check-and-set.
+- `-version=<int>` - The version of the user to perform the operation on.
+If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/users/update.mdx
+++ b/website/content/docs/api-clients/commands/users/update.mdx
@@ -34,7 +34,7 @@ $ boundary users update [options] [args]
 - `-description=<string>` - A description to assign to the user.
 - `-id=<string>` - ID of the user to update.
 - `-name=<string>` - The name you want to give the user.
-- `-version=<int>` - The version of the user against which to perform an update operation.
+- `-version=<int>` - The version of the user to perform the operation on.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/workers/add-worker-tags.mdx
+++ b/website/content/docs/api-clients/commands/workers/add-worker-tags.mdx
@@ -33,10 +33,8 @@ $ boundary workers add-worker-tags [sub command] [args]
 ### Command options
 
 - `-id=<string>` - ID of the worker you want to perform the operation on.
-
 - `tag=<key=val-a, key2=val-b,val-c>` - The API tag resources you can add, remove, or set on workers.
-
-- `version=<int>` - The version of the worker against which to perform an update operation.
+- `version=<int>` - The version of the worker to perform the operation on.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/workers/remove-worker-tags.mdx
+++ b/website/content/docs/api-clients/commands/workers/remove-worker-tags.mdx
@@ -33,10 +33,8 @@ $ boundary workers remove-worker-tags [sub command] [args]
 ### Command options
 
 - `-id=<string>` - ID of the worker you want to remove the tag from.
-
 - `tag=<key=val-a, key2=val-b,val-c>` - The API tag resources you can add, remove, or set on workers.
-
-- `version=<int>` - The version of the worker against which to perform an update operation.
+- `version=<int>` - The version of the worker to perform the operation on.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/workers/set-worker-tags.mdx
+++ b/website/content/docs/api-clients/commands/workers/set-worker-tags.mdx
@@ -33,10 +33,8 @@ $ boundary workers set-worker-tags [sub command] [args]
 ### Command options
 
 - `-id=<string>` - ID of the worker you want to set the tag for.
-
 - `tag=<key=val-a, key2=val-b,val-c>` - The API tag resources you can add, remove, or set on workers.
-
-- `version=<int>` - The version of the worker against which to perform an update operation.
+- `version=<int>` - The version of the worker to perform the operation on.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/workers/update.mdx
+++ b/website/content/docs/api-clients/commands/workers/update.mdx
@@ -34,7 +34,7 @@ $ boundary workers update [options] [args]
 - `description=<string>` - Description to set on the worker.
 - `id=<string>` - ID of the worker you want to update.
 - `name=<string>` -  Name to set on the worker.
-- `version=<int>` - The version of the worker on which to perform the update operation.
+- `version=<int>` - The version of the worker to perform the operation on.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -689,6 +689,63 @@
             "path": "api-clients/commands/server"
           },
           {
+            "title": "targets",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/targets"
+              },
+              {
+                "title": "add-credential-sources",
+                "path": "api-clients/commands/targets/add-credential-sources"
+              },
+              {
+                "title": "add-host-sources",
+                "path": "api-clients/commands/targets/add-host-sources"
+              },
+              {
+                "title": "authorize-session",
+                "path": "api-clients/commands/targets/authorize-session"
+              },
+              {
+                "title": "create",
+                "path": "api-clients/commands/targets/create"
+              },
+              {
+                "title": "delete",
+                "path": "api-clients/commands/targets/delete"
+              },
+              {
+                "title": "list",
+                "path": "api-clients/commands/targets/list"
+              },
+              {
+                "title": "read",
+                "path": "api-clients/commands/targets/read"
+              },
+              {
+                "title": "remove-credential-source",
+                "path": "api-clients/commands/targets/remove-credential-sources"
+              },
+              {
+                "title": "remove-host-sources",
+                "path": "api-clients/commands/targets/remove-host-sources"
+              },
+              {
+                "title": "set-credential-sources",
+                "path": "api-clients/commands/targets/set-credential-sources"
+              },
+              {
+                "title": "set-host-sources",
+                "path": "api-clients/commands/targets/set-host-sources"
+              },
+              {
+                "title": "update",
+                "path": "api-clients/commands/targets/update"
+              }
+            ]
+          },
+          {
             "title": "users",
             "routes": [
               {


### PR DESCRIPTION
Adds the `targets` commands on top of the existing assembly branch for CLI commands #3411.