### PR TITLE
Add 'credential-libraries' command docs

### DIFF
--- a/website/content/docs/api-clients/commands/accounts/update.mdx
+++ b/website/content/docs/api-clients/commands/accounts/update.mdx
@@ -1,5 +1,5 @@
 ---
-layout: docsboundary accounts update password -id=acctpw_w3N3PlV34D -name="tester" -login-name="test-engineer" -description="Only to be used for testing"
+layout: docs
 page_title: accounts update - Command
 description: |-
   The "accounts update" command allows Boundary admin to update an account resource.

--- a/website/content/docs/api-clients/commands/credential-libraries/create.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/create.mdx
@@ -1,0 +1,207 @@
+---
+layout: docs
+page_title: credential-libraries create - Command
+description: |-
+  The "credential-libraries create" command allows create operations on Boundary credential library resources.
+---
+
+# credential-libraries create
+
+Command: `boundary credential-libraries create`
+
+The `credential-libraries create` command creates a credential library resource
+in Boundary.
+
+## Examples
+
+Create a credential library for database credentials where Vault's database
+secrets engine provide dynamic credentials.
+
+```shell-session
+$ boundary credential-libraries create vault-generic \
+    -credential-store-id csvlt_5fvkRjCjou \
+    -vault-path "database/creds/dba" \
+    -name "northwind dba"
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential Library information:
+  Created Time:          Wed, 28 Sep 2022 08:50:32 MDT
+  Credential Store ID:   csvlt_Xqa6V6QwfM
+  ID:                    clvlt_Ex17uiP7FO
+  Name:                  northwind dba
+  Type:                  vault
+  Updated Time:          Wed, 28 Sep 2022 08:50:32 MDT
+  Version:               1
+
+  Scope:
+    ID:                  p_EZaXO0OZPX
+    Name:                db-project
+    Parent Scope ID:     o_R1QFYcO743
+    Type:                project
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+
+  Attributes:
+    HTTP Method:         GET
+    Path:                database/creds/dba
+```
+
+</CodeBlockConfig>
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-libraries create [type] [sub command] [options] [args]
+```
+
+</CodeBlockConfig>
+
+The available types are `vault-generic` and `vault-ssh-certificate`.
+
+<Note>
+
+A credential library type, `vault` is deprecated, so use `vault-generic` type
+instead.
+
+</Note>
+
+### Command options
+
+- `-credential-store-id` `(string: "")` - The credential-store resource to use
+      for the operation. This can also be specified via the
+      `BOUNDARY_CREDENTIAL_STORE_ID` environment variable.
+
+- `-description` `(string: "")` - Description to set on the credential library.
+
+- `-name` `(string: "")` - Name to set on the credential library.
+
+
+#### Usages by type
+
+<Tabs>
+<Tab heading="Vault">
+
+Create a credential library of `vault-generic` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-libraries create vault-generic [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Vault credential library options
+
+The following are Vault credential library specific options in addition to the
+command options.
+
+- `-credential-mapping-override` `(bool: false)` - The credential mapping
+  override.
+
+- `-credential-type` `(string: "")` - The type of credential this library will
+  issue, defaults to Unspecified.
+
+- `-vault-http-method` `(string: "")` - The http method the library should use
+  when communicating with vault.
+
+- `-vault-http-request-body` `(string: "")` - The http request body the library
+   uses to communicate with Vault. This can be the value itself, refer to a file
+   on disk (`file://`) from which the value will be read, or an env var
+   (`env://`) from which the value will be read.
+
+- `-vault-path` `(string: "")` - The path in vault to request credentials from.
+
+
+#### Example
+
+```shell-session
+$ boundary credential-libraries create vault-generic \
+   -credential-store-id csvlt_1234567890 \
+   -vault-path "database/creds/dba"
+```
+
+</Tab>
+<Tab heading="Vault SSH certificate">
+
+Create a credential library of `vault-ssh-certificate` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-libraries create vault-ssh-certificate [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Vault SSH certificate credential library options
+
+The following are Vault SSH certificate credential library specific options in
+addition to the command options.
+
+- `-critical-option` `(bool: false)` - A key=value pair to add to the request's
+   critical-options map. This can also be a key value only which will set a JSON
+   null as the value. If a value is provided, the type is automatically
+   inferred. Use `-string-critical-option`, `-bool-critical-option`, or
+   `-num-critical-option` if the type needs to be overridden. Can be specified
+   multiple times. Supports sourcing values from files via "file://" and env
+   vars via "env://".
+
+- `-critical-options` `(string: "")` - A JSON  map value to use as the entirety
+   of the request's critical-options map. Usually this will be sourced from a
+   file via "file://" syntax. Is exclusive with the other critical-option flags.
+
+- `-extension` `(bool: false)` - A key=value pair to add to the request's
+   extensions map. This can also be a key value only which will set a JSON null
+   as the value. If a value is provided, the type is automatically inferred. Use
+   `-string-extension`, `-bool-extension`, or `-num-extension` if the type needs to be
+   overridden. Can be specified multiple times. Supports sourcing values from
+   files via "file://" and env vars via "env://".
+
+- `-extensions` `(string: "")` - A JSON map value to use as the entirety of
+   the request's extensions map. Usually this will be sourced from a file via
+   "file://" syntax. Is exclusive with the other extension flags.
+
+- `-key-bits` `(string: "")` - The number of bits when generating the ssh
+   private key. Depends on key_type. If ed25519 this should not be set, or set
+   to 0, if ecdsa one of 256, 384, 521, if rsa one of 2048, 3072, 4096.
+
+- `-key-id` `(string: "")` - The key id that the created certificate should
+  have.
+
+- `-key-type` `(string: "")` - The key type for the generated ssh private key.
+   One of: ed25519, ecdsa, rsa.
+
+- `-ttl` `(string: "")` - The time-to-live for the generated certificate.
+
+- `-username` `(string: "")` - The username to use with the ssh certificate.
+
+- `-vault-path` `(string: "")` - The path in vault to request credentials from.
+
+
+#### Example
+
+```shell-session
+$ boundary credential-libraries create vault-ssh-certificate \
+   -credential-store-id  csvlt_1234567890 \
+   -vault-path "/ssh/sign/role" \
+   -username user
+```
+
+</Tab>
+</Tabs>
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-libraries/delete.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/delete.mdx
@@ -1,0 +1,38 @@
+---
+layout: docs
+page_title: credential-libraries delete - Command
+description: |-
+  The "credential-libraries delete" command allows Boundary admin to delete a credential library resource.
+---
+
+# credential-libraries delete
+
+Command: `boundary credential-libraries delete`
+
+The `credential-libraries delete` command deletes an existing credential library
+resource.
+
+## Examples
+
+Delete a credential library with the given ID. 
+
+```shell-session
+$ boundary credential-libraries delete -id csvlt_5fvkRjCjou
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-libraries delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-id` `(string: "")` - ID of the credential library on which to operate.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-libraries/index.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/index.mdx
@@ -1,0 +1,89 @@
+---
+layout: docs
+page_title: credential-libraries - Command
+description: |-
+  The "credential-libraries" command allows Boundary admin to create and manage the credential libraries.
+---
+
+# credential-libraries
+
+Command: `boundary credential-libraries`
+
+The `credential-libraries` command allows operations on Boundary credential
+library resources. A credential library provides credentials for sessions. All
+credentials returned by a library must be equivalent from an access control
+perspective. A credential library is responsible for managing the lifecycle of
+the credentials it returns. For dynamic secrets, this includes creation,
+renewal, and revocation. For rotating credentials, this includes check-out,
+check-in, and rotation of secrets. The system retrieves credentials from a
+library for a session and notifies the library when the session has been
+terminated. A credential library belongs to a single credential store.
+
+## Examples
+
+Retrieve a credential library information for a given ID, `clvlt_QYnQPAjA24`.
+
+```shell-session
+$ boundary credential-libraries read -id clvlt_QYnQPAjA24
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential Library information:
+  Created Time:          Fri, 18 Aug 2023 16:22:29 PDT
+  Credential Store ID:   csvlt_5fvkRjCjou
+  ID:                    clvlt_QYnQPAjA24
+  Name:                  northwind dba
+  Type:                  vault-generic
+  Updated Time:          Fri, 18 Aug 2023 16:22:29 PDT
+  Version:               1
+
+  Scope:
+    ID:                  p_tnqESc86qE
+    Name:                db-project
+    Parent Scope ID:     o_4VUR6ZATqW
+    Type:                project
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+
+  Attributes:
+    HTTP Method:         GET
+    Path:                database/creds/dba
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary credential-libraries [sub command] [options] [args]
+
+  # ...
+
+Subcommands:
+    create    Create a credential library
+    delete    Delete a credential library
+    list      List a credential library
+    read      Read a credential library
+    update    Update a credential library
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [create](/boundary/docs/api-clients/commands/credential-libraries/create)
+- [delete](/boundary/docs/api-clients/commands/credential-libraries/delete)
+- [read](/boundary/docs/api-clients/commands/credential-libraries/read)
+- [update](/boundary/docs/api-clients/commands/credential-libraries/update)
+- [list](/boundary/docs/api-clients/commands/credential-libraries/list)

--- a/website/content/docs/api-clients/commands/credential-libraries/list.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/list.mdx
@@ -1,0 +1,65 @@
+---
+layout: docs
+page_title: credential-libraries list - Command
+description: |-
+  The "credential-libraries list" command lists credential libraries within an enclosing scope or resource.
+---
+
+# credential-libraries list
+
+Command: `boundary credential-libraries list`
+
+The `credential-libraries list` command lists credential libraries within an
+enclosing scope or resource.
+
+## Examples
+
+List all credential libraries for a given credential store.
+
+```shell-session
+$ boundary credential-libraries list \
+   -credential-store-id clvlt_QYnQPAjA24
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential Library information:
+  ID:                    clvlt_QYnQPAjA24
+    Version:             1
+    Type:                vault-generic
+    Name:                northwind dba
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-libraries list [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-credential-store-id` `(string: "")` - The credential-store resource to use
+  for the operation. This can also be specified via the
+  `BOUNDARY_CREDENTIAL_STORE_ID` environment variable.
+
+- `-filter` `(string: "")` - If set, the list operation will be filtered before
+   being returned. The filter operates against each item in the list. Using
+   single quotes is recommended as filters contain double quotes. 
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-libraries/read.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/read.mdx
@@ -1,0 +1,72 @@
+---
+layout: docs
+page_title: credential-libraries read - Command
+description: |-
+  The "credential-libraries read" command allows Boundary admin to read a credential library information.
+---
+
+# credential-libraries read
+
+Command: `boundary credential-libraries read`
+
+The `credential-libraries read` command reads a credential library information
+of a specific ID.
+
+
+## Examples
+
+Retrieve a credential library information for a given ID, `clvlt_QYnQPAjA24`.
+
+```shell-session
+$ boundary credential-libraries read -id clvlt_QYnQPAjA24
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential Library information:
+  Created Time:          Fri, 18 Aug 2023 16:22:29 PDT
+  Credential Store ID:   csvlt_5fvkRjCjou
+  ID:                    clvlt_QYnQPAjA24
+  Name:                  northwind dba
+  Type:                  vault-generic
+  Updated Time:          Fri, 18 Aug 2023 16:22:29 PDT
+  Version:               1
+
+  Scope:
+    ID:                  p_tnqESc86qE
+    Name:                db-project
+    Parent Scope ID:     o_4VUR6ZATqW
+    Type:                project
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+
+  Attributes:
+    HTTP Method:         GET
+    Path:                database/creds/dba
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-libraries read [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-id` `(string: "")` - ID of the credential library on which to operate.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-libraries/update.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/update.mdx
@@ -1,0 +1,206 @@
+---
+layout: doc
+page_title: credential-libraries update - Command
+description: |-
+  The "credential-libraries update" command allows Boundary admin to update a credential library resource.
+---
+
+# credential-libraries update
+
+Command: `boundary credential-libraries update`
+
+The `credential-libraries update` command updates operations on Boundary
+credential library resources. update operations on Boundary credential library
+resources.
+
+## Examples
+
+Update an existing Vault credential library to point to a new Vault secrets
+engine path.
+
+```shell-session
+$ boundary credential-libraries update vault-generic \
+    -id csvlt_5fvkRjCjou \
+    -vault-path "database/creds/db-mysql"
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential Library information:
+  Created Time:          Fri, 18 Aug 2023 16:22:29 PDT
+  Credential Store ID:   csvlt_5fvkRjCjou
+  ID:                    clvlt_QYnQPAjA24
+  Name:                  northwind dba
+  Type:                  vault-generic
+  Updated Time:          Fri, 18 Aug 2023 20:04:27 PDT
+  Version:               2
+
+  Scope:
+    ID:                  p_tnqESc86qE
+    Name:                db-project
+    Parent Scope ID:     o_4VUR6ZATqW
+    Type:                project
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+
+  Attributes:
+    HTTP Method:         GET
+    Path:                database/creds/db-mysql
+```
+
+</CodeBlockConfig>
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-libraries update vault [options] [args]
+```
+
+</CodeBlockConfig>
+
+The available types are `vault-generic` and `vault-ssh-certificate`.
+
+<Note>
+
+A credential library type, `vault` is deprecated, so use `vault-generic` type
+instead.
+
+</Note>
+
+### Command options
+
+- `-description` `(string: "")` - Description to set on the credential library.
+
+- `-id` `(string: "")` - ID of the credential library on which to operate.
+
+- `-name` `(string: "")` - Name to set on the credential library.
+
+- `-version` `(int: 0)` - The version of the credential library against which to
+   perform an update operation. If not specified, the command will perform a
+   check-and-set automatically.
+
+#### Usages by type
+
+<Tabs>
+<Tab heading="Vault">
+
+Update a credential library of `vault-generic` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-libraries create vault-generic [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Vault credential library options
+
+The following are Vault credential library specific options in addition to the
+command options.
+
+- `-credential-mapping-override` `(bool: false)` - The credential mapping
+  override.
+
+- `-vault-http-method` `(string: "")` - The http method the library should use
+  when communicating with Vault.
+
+- `-vault-http-request-body` `(strinboundary credential-libraries update vault-ssh-certificate -id clvsclt_1234567890 -name devops -description "For DevOps usage": "")` - The http request body the library
+   uses to communicate with vault. This can be the value itself, refer to a file
+   on disk (`file://`) from which the value will be read, or an env var
+   (`env://`) from which the value will be read.
+
+- `-vault-path` `(string: "")` - The path in vault to request credentials from.
+
+
+#### Example
+
+```shell-session
+$ boundary credential-libraries update vault-generic \
+   -id clvlt_1234567890 \
+   -name devops \
+   -description "For DevOps usage"
+```
+
+</Tab>
+<Tab heading="Vault SSH certificate">
+
+Update a credential library of `vault-ssh-certificate` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-libraries update vault-ssh-certificate [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Vault SSH certificate credential library options
+
+The following are Vault SSH certificate credential library specific options in
+addition to the command options.
+
+- `-critical-option` `(bool: false)` - A key=value pair to add to the request's
+   critical-options map. This can also be a key value only which will set a JSON
+   null as the value. If a value is provided, the type is automatically
+   inferred. Use `-string-critical-option`, `-bool-critical-option`, or
+   `-num-critical-option` if the type needs to be overridden. Can be specified
+   multiple times. Supports sourcing values from files via "file://" and env
+   vars via "env://".
+
+- `-critical-options` `(string: "")` - A JSON map value to use as the entirety
+   of the request's critical-options map. Usually this will be sourced from a
+   file via "file://" syntax. Is exclusive with the other critical-option flags.
+
+- `-extension` `(bool: false)` - A key=value pair to add to the request's
+   extensions map. This can also be a key value only which will set a JSON null
+   as the value. If a value is provided, the type is automatically inferred. Use
+   `-string-extension`, `-bool-extension`, or `-num-extension` if the type needs to be
+   overridden. Can be specified multiple times. Supports sourcing values from
+   files via "file://" and env vars via "env://".
+
+- `-extensions` `(string: "")` - A JSON map value to use as the entirety of
+   the request's extensions map. Usually this will be sourced from a file via
+   "file://" syntax. Is exclusive with the other extension flags.
+
+- `-key-bits` `(string: "")` - The number of bits when generating the ssh
+   private key. Depends on key_type. If ed25519 this should not be set, or set
+   to 0, if ecdsa one of 256, 384, 521, if rsa one of 2048, 3072, 4096.
+
+- `-key-id` `(string: "")` - The key id that the created certificate should
+  have.
+
+- `-key-type` `(string: "")` - The key type for the generated ssh private key.
+   One of: ed25519, ecdsa, rsa.
+
+- `-ttl` `(string: "")` - The time-to-live for the generated certificate.
+
+- `-username` `(string: "")` - The username to use with the ssh certificate.
+
+- `-vault-path` `(string: "")` - The path in vault to request credentials from.
+
+
+#### Example
+
+```shell-session
+$ boundary credential-libraries update vault-ssh-certificate \
+   -id clvsclt_1234567890 \
+   -name devops \
+   -description "For DevOps usage"
+```
+
+</Tab>
+</Tabs>
+
+
+@include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -677,6 +677,35 @@
             ]
           },
           {
+            "title": "credential-libraries",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/credential-libraries"
+              },
+              {
+                "title": "create",
+                "path": "api-clients/commands/credential-libraries/create"
+              },
+              {
+                "title": "delete",
+                "path": "api-clients/commands/credential-libraries/delete"
+              },
+              {
+                "title": "list",
+                "path": "api-clients/commands/credential-libraries/list"
+              },
+              {
+                "title": "read",
+                "path": "api-clients/commands/credential-libraries/read"
+              },
+              {
+                "title": "update",
+                "path": "api-clients/commands/credential-libraries/update"
+              }
+            ]
+          },
+          {
             "title": "dev",
             "path": "api-clients/commands/dev"
           },


### PR DESCRIPTION
This PR adds docs for `credential-libraries` command on top of https://github.com/hashicorp/boundary/pull/3411