### PR TITLE
Add 'credential-stores' command docs

### DIFF
--- a/website/content/docs/api-clients/commands/credential-libraries/update.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/update.mdx
@@ -9,9 +9,8 @@ description: |-
 
 Command: `boundary credential-libraries update`
 
-The `credential-libraries update` command updates operations on Boundary
-credential library resources. update operations on Boundary credential library
-resources.
+The `credential-libraries update` command performs update operations on Boundary
+credential library resources. 
 
 ## Examples
 

--- a/website/content/docs/api-clients/commands/credential-stores/create.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/create.mdx
@@ -1,0 +1,167 @@
+---
+layout: docs
+page_title: credential-stores create - Command
+description: |-
+  The "credential-stores create" command create operations on Boundary credential store resources.
+---
+
+# credential-stores create
+
+Command: `boundary credential-stores create`
+
+The `credential-stores create` command creates a credential store resource
+in Boundary.
+
+## Examples
+
+Create a credential store resource in a project scope. 
+
+```shell-session
+$ boundary credential-stores create vault -scope-id p_tnqESc86qE \
+  -vault-address $VAULT_ADDR \
+  -vault-token $VAULT_TOKEN \
+  -vault-namespace $VAULT_NAMESPACE
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential Store information:
+  Created Time:        Thu, 28 Jul 2022 15:08:12 MDT
+  ID:                  csvlt_ytzGHsfp3r
+  Type:                vault
+  Updated Time:        Thu, 28 Jul 2022 15:08:12 MDT
+  Version:             1
+
+  Scope:
+    ID:                p_jd7lspegXk
+    Name:              ssh-project
+    Parent Scope ID:   o_SN2K0DAGpi
+    Type:              project
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+
+  Authorized Actions on Credential Store's Collections:
+    credential-libraries:
+      create
+      list
+
+  Attributes:
+    Address:           https://vault-cluster-boundary.vault.11eb3a47-8920-4714-ba99-0242ac11000e.aws.hashicorp.cloud:8200
+    Token HMAC:        NZJWT74Jyq09gLQfP4RiK5eDWfY7NWXYHoKL4nKQFDY
+```
+
+</CodeBlockConfig>
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-stores create [type] [sub command] [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-description` `(string: "")` - Description to set on the credential store.
+
+- `-name` `(string: "")` - Name to set on the credential store.
+
+- `-scope-id` `(string: "")` - Scope in which to make the request. The default
+  is global. This can also be specified via the `BOUNDARY_SCOPE_ID` environment
+  variable.
+
+#### Usages by type
+
+<Tabs>
+<Tab heading="Static">
+
+Create a static-type credential store.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-stores create static [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### Example
+
+```shell-session
+$ boundary credential-stores create static -scope-id p_1234567890
+```
+
+</Tab>
+<Tab heading="Vault">
+
+Create a credential stores of `vault` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-stores create vault [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Vault credential stores options
+
+The following are Vault credential stores specific options in addition to the
+command options.
+
+- `-vault-address` `(string: "")` - The address of the Vault server. This should
+  be a complete URL such as https://127.0.0.1:8200
+
+- `-vault-ca-cert` `(string: "")` - The CA Cert to use when connecting to vault.
+  This can be the value itself, refer to a file on disk (`file://`) from which the
+   value will be read, or an env var (env://) from which the value will be read.
+
+- `-vault-client-certificate` `(string: "")` - The client certificate to use
+  when boundary connects to vault for this store. This can be the value itself,
+  refer to a file on disk (`file://`) from which the value will be read, or an env
+  var (`env://`) from which the value will be read.
+
+- `-vault-client-certificate-key` `(string: "")` - The client certificate's
+  private key to use when boundary connects to vault for this store. This can be
+  the value itself, refer to a file on disk (`file://`) from which the value will
+  be read, or an env var (`env://`) from which the value will be read.
+
+- `-vault-namespace` `(string: "")` - The vault namespace the store should use.
+
+- `-vault-tls-server-name` `(string: "")` - Name to use as the SNI host when
+  connecting via TLS.
+
+- `-vault-tls-skip-verify` `(bool: false)` - Whether to skip tls verification.
+The default is false.
+
+- `-vault-token` `(string: "")` - The vault token to use when boundary connects
+  to vault for this store.
+
+- `-worker-filter` `(string: "")` - A boolean expression to filter which workers
+  can handle Vault commands for this credential store.
+
+
+#### Example
+
+```shell-session
+$ boundary credential-stores create vault \
+   -vault-address "http://127.0.0.1:8200" \
+   -vault-token "hvs.tFEYXtEJbJ0tOpt1V38JrbbH"
+```
+
+</Tab>
+</Tabs>
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-stores/delete.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/delete.mdx
@@ -1,0 +1,37 @@
+---
+layout: docs
+page_title: credential-stores delete - Command
+description: |-
+  The "credential-stores delete" command allows Boundary admin to delete a credential store resource.
+---
+
+# credential-stores delete
+
+Command: `boundary credential-stores delete`
+
+The `credential-stores delete` command deletes a credential store given its ID.
+
+## Examples
+
+Delete a credential store of the given ID. 
+
+```shell-session
+$ boundary credential-stores delete -id csvlt_5fvkRjCjou
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-stores delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-id` `(string: "")` - ID of the credential store on which to operate.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-stores/delete.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/delete.mdx
@@ -17,6 +17,7 @@ Delete a credential store of the given ID.
 
 ```shell-session
 $ boundary credential-stores delete -id csvlt_5fvkRjCjou
+The delete operation completed successfully.
 ```
 
 ## Usage

--- a/website/content/docs/api-clients/commands/credential-stores/index.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/index.mdx
@@ -1,0 +1,72 @@
+---
+layout: docs
+page_title: credential-stores - Command
+description: |-
+  The "credential-stores" command allows Boundary admin to create and manage the credential libraries.
+---
+
+# credential-stores
+
+Command: `boundary credential-stores`
+
+The `credential-stores` command allows operations on Boundary credential
+library resources. 
+
+A credential store belongs to a scope and must support the principle of least
+privilege by providing mechanisms to limit the credentials it can access to the
+minimum necessary for the scope it is in.
+
+
+## Examples
+
+List all credential stores for a given scope ID.
+
+```shell-session
+$ boundary credential-stores list -scope-id p_tnqESc86qE
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential Store information:
+  ID:                    csvlt_5fvkRjCjou
+    Version:             1
+    Type:                vault
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary credential-stores [sub command] [options] [args]
+
+  # ...
+
+Subcommands:
+    create    Create a credential store
+    delete    Delete a credential store
+    list      List a credential store
+    read      Read a credential store
+    update    Update a credential store
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [create](/boundary/docs/api-clients/commands/credential-stores/create)
+- [delete](/boundary/docs/api-clients/commands/credential-stores/delete)
+- [read](/boundary/docs/api-clients/commands/credential-stores/read)
+- [update](/boundary/docs/api-clients/commands/credential-stores/update)
+- [list](/boundary/docs/api-clients/commands/credential-stores/list)

--- a/website/content/docs/api-clients/commands/credential-stores/list.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/list.mdx
@@ -1,0 +1,67 @@
+---
+layout: docs
+page_title: credential-stores list - Command
+description: |-
+  The "credential-stores list" command lists credential stores within an enclosing scope or resource.
+---
+
+# credential-stores list
+
+Command: `boundary credential-stores list`
+
+The `credential-stores list` command lists credential stores within an enclosing
+scope or resource.
+
+## Examples
+
+List all credential stores for a given scope ID.
+
+```shell-session
+$ boundary credential-stores list -scope-id p_tnqESc86qE
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential Store information:
+  ID:                    csvlt_5fvkRjCjou
+    Version:             1
+    Type:                vault
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-stores list [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-filter` `(string: "")` - If set, the list operation will be filtered before
+   being returned. The filter operates against each item in the list. Using
+   single quotes is recommended as filters contain double quotes. 
+
+- `-recursive` `(bool: false)` - If set, the list operation will be applied
+   recursively into child scopes, if supported by the type. The default is
+   false.
+
+- `-scope-id ``(string: "")` - Scope in which to make the request. The default
+  is global. This can also be specified via the `BOUNDARY_SCOPE_ID` environment
+  variable.
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-stores/read.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/read.mdx
@@ -15,7 +15,7 @@ of a specific ID.
 
 ## Examples
 
-Retrieve a credential stores information for a given ID, `clvlt_QYnQPAjA24`.
+Retrieve a credential store information for a given ID, `clvlt_QYnQPAjA24`.
 
 ```shell-session
 $ boundary credential-stores read -id csvlt_5fvkRjCjou

--- a/website/content/docs/api-clients/commands/credential-stores/read.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/read.mdx
@@ -1,0 +1,76 @@
+---
+layout: docs
+page_title: credential-stores read - Command
+description: |-
+  The "credential-stores read" command allows Boundary admin to read a credential store information.
+---
+
+# credential-stores read
+
+Command: `boundary credential-stores read`
+
+The `credential-stores read` command reads a credential store information
+of a specific ID.
+
+
+## Examples
+
+Retrieve a credential stores information for a given ID, `clvlt_QYnQPAjA24`.
+
+```shell-session
+$ boundary credential-stores read -id csvlt_5fvkRjCjou
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential Store information:
+  Created Time:        Fri, 18 Aug 2023 16:22:02 PDT
+  ID:                  csvlt_5fvkRjCjou
+  Type:                vault
+  Updated Time:        Fri, 18 Aug 2023 16:22:02 PDT
+  Version:             1
+
+  Scope:
+    ID:                p_tnqESc86qE
+    Name:              db-project
+    Parent Scope ID:   o_4VUR6ZATqW
+    Type:              project
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+
+  Authorized Actions on Credential Store's Collections:
+    credential-libraries:
+      create
+      list
+
+  Attributes:
+    Address:           http://127.0.0.1:8200
+    Token Status:      expired
+    Worker Filter:     "worker" in "/tags/type"
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-stores read [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-id` `(string: "")` - ID of the credential stores on which to operate.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-stores/update.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/update.mdx
@@ -14,7 +14,7 @@ credential store resources.
 
 ## Examples
 
-Update an existing Vault credential stores.
+Update an existing Vault credential store.
 
 ```shell-session
 $ boundary credential-stores update vault -id csvlt_5fvkRjCjou \
@@ -90,7 +90,7 @@ $ boundary credential-stores update vault [options] [args]
 <Tabs>
 <Tab heading="Static">
 
-Update a credential stores of `static` type.
+Update a credential store of `static` type.
 
 <CodeBlockConfig hideClipboard>
 
@@ -111,7 +111,7 @@ $ boundary credential-stores update static \
 </Tab>
 <Tab heading="Vault">
 
-Update a credential stores of `vault` type.
+Update a credential store of `vault` type.
 
 <CodeBlockConfig hideClipboard>
 

--- a/website/content/docs/api-clients/commands/credential-stores/update.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/update.mdx
@@ -1,0 +1,174 @@
+---
+layout: doc
+page_title: credential-stores update - Command
+description: |-
+  The "credential-stores update" command allows Boundary admin to update a credential store resource.
+---
+
+# credential-stores update
+
+Command: `boundary credential-stores update`
+
+The `credential-stores update` command performs update operations on Boundary
+credential store resources.
+
+## Examples
+
+Update an existing Vault credential stores.
+
+```shell-session
+$ boundary credential-stores update vault -id csvlt_5fvkRjCjou \
+   -description "For DevOps usage" \
+   -vault-namespace "devops"
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential Store information:
+  Created Time:        Fri, 18 Aug 2023 16:22:02 PDT
+  Description:         For DevOps usage
+  ID:                  csvlt_5fvkRjCjou
+  Type:                vault
+  Updated Time:        Sun, 20 Aug 2023 22:21:25 PDT
+  Version:             2
+
+  Scope:
+    ID:                p_tnqESc86qE
+    Name:              db-project
+    Parent Scope ID:   o_4VUR6ZATqW
+    Type:              project
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+
+  Authorized Actions on Credential Store's Collections:
+    credential-libraries:
+      create
+      list
+
+  Attributes:
+    Address:           http://127.0.0.1:8200
+    Namespace:         devops
+    Token Status:      current
+    Worker Filter:     "worker" in "/tags/type"
+```
+
+</CodeBlockConfig>
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-stores update vault [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-description` `(string: "")` - Description to set on the credential store.
+
+- `-id` `(string: "")` - ID of the credential store on which to operate.
+
+- `-name` `(string: "")` - Name to set on the credential store.
+
+- `-version` `(int: 0)` - The version of the credential store against which to
+   perform an update operation. If not specified, the command will perform a
+   check-and-set automatically.
+
+
+#### Usages by type
+
+<Tabs>
+<Tab heading="Static">
+
+Update a credential stores of `static` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-stores update static [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### Example
+
+```shell-session
+$ boundary credential-stores update static \
+   -name devops \
+   -description "For DevOps usage"
+```
+
+</Tab>
+<Tab heading="Vault">
+
+Update a credential stores of `vault` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credential-stores update vault [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Vault credential store options
+
+The following are Vault credential store specific options in addition to the
+command options.
+
+- `-vault-address` `(string: "")` - The address of the Vault server. This should
+  be a complete URL such as https://127.0.0.1:8200
+
+- `-vault-ca-cert` `(string: "")` - The CA Cert to use when connecting to vault.
+  This can be the value itself, refer to a file on disk (`file://`) from which the
+   value will be read, or an env var (env://) from which the value will be read.
+
+- `-vault-client-certificate` `(string: "")` - The client certificate to use
+  when boundary connects to vault for this store. This can be the value itself,
+  refer to a file on disk (`file://`) from which the value will be read, or an env
+  var (`env://`) from which the value will be read.
+
+- `-vault-client-certificate-key` `(string: "")` - The client certificate's
+  private key to use when boundary connects to vault for this store. This can be
+  the value itself, refer to a file on disk (`file://`) from which the value will
+  be read, or an env var (`env://`) from which the value will be read.
+
+- `-vault-namespace` `(string: "")` - The vault namespace the store should use.
+
+- `-vault-tls-server-name` `(string: "")` - Name to use as the SNI host when
+  connecting via TLS.
+
+- `-vault-tls-skip-verify` `(bool: false)` - Whether to skip tls verification.
+The default is false.
+
+- `-vault-token` `(string: "")` - The vault token to use when boundary connects
+  to vault for this store.
+
+- `-worker-filter` `(string: "")` - A boolean expression to filter which workers
+  can handle Vault commands for this credential store.
+
+
+#### Example
+
+```shell-session
+$ boundary credential-stores update vault \
+   -id csvlt_1234567890 \
+   -name devops \
+   -description "For DevOps usage"
+```
+
+</Tab>
+</Tabs>
+
+
+@include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -706,6 +706,35 @@
             ]
           },
           {
+            "title": "credential-stores",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/credential-stores"
+              },
+              {
+                "title": "create",
+                "path": "api-clients/commands/credential-stores/create"
+              },
+              {
+                "title": "delete",
+                "path": "api-clients/commands/credential-stores/delete"
+              },
+              {
+                "title": "list",
+                "path": "api-clients/commands/credential-stores/list"
+              },
+              {
+                "title": "read",
+                "path": "api-clients/commands/credential-stores/read"
+              },
+              {
+                "title": "update",
+                "path": "api-clients/commands/credential-stores/update"
+              }
+            ]
+          },
+          {
             "title": "dev",
             "path": "api-clients/commands/dev"
           },


### PR DESCRIPTION
Add the `credential-stores` command docs on top of https://github.com/hashicorp/boundary/pull/3411

🔍 [Deploy preview](https://boundary-git-cred-stores-docs-hashicorp.vercel.app/boundary/docs/api-clients/commands/credential-stores)