### PR TITLE
docs: Add `storage-bucket` commands - update

### DIFF
--- a/website/content/docs/api-clients/commands/storage-buckets/create.mdx
+++ b/website/content/docs/api-clients/commands/storage-buckets/create.mdx
@@ -1,0 +1,39 @@
+---
+layout: docs
+page_title: storage-buckets create - Command
+description: |-
+  The "storage-buckets create" command lets you create Boundary storage buckets.
+---
+
+# storage-buckets create
+
+Command: `boundary storage-buckets create`
+
+The `boundary storage-buckets create` command lets you create Boundary storage buckets.
+
+## Example
+
+This example creates a storage bucket with the name `prodops` and the description `storage bucket for ProdOps`:
+
+```shell-session
+$ boundary storage-buckets create -name prodops -description "storage bucket for ProdOps"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary storage-buckets create [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-bucket-name=<string>` - The name of the bucket you are creating.
+The bucket name must be within the external object store.
+- `-bucket-prefix==<string>` - An optional prefix to set on the bucket.
+- `-worker-filter=<string>` - A boolean expression to filter which workers can process communication to this storage bucket.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/storage-buckets/delete.mdx
+++ b/website/content/docs/api-clients/commands/storage-buckets/delete.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: storage-buckets delete - Command
+description: |-
+  The "storage-buckets delete" command lets you delete Boundary storage buckets.
+---
+
+# storage-buckets delete
+
+Command: `boundary storage-buckets delete`
+
+The `boundary storage-buckets delete` command lets you delete Boundary storage buckets.
+
+## Example
+
+This example deletes a storage bucket with the ID `_1234567890`:
+
+```shell-session
+$ boundary storage-buckets delete -id _1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary storage-buckeets delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - The ID of the bucket you want to delete.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/storage-buckets/index.mdx
+++ b/website/content/docs/api-clients/commands/storage-buckets/index.mdx
@@ -1,0 +1,46 @@
+---
+layout: docs
+page_title: storage-buckets - Command
+description: |-
+  The "storage-buckets" command lets you perform operations on Boundary storage bucket resources.
+---
+
+# storage-buckets
+
+Command: `boundary storage-buckets`
+
+The `storage-buckets` command lets you perform operations on Boundary storage bucket resources.
+
+## Example
+
+The following command reads a storage bucket with the id `sb_1234567890`:
+
+```shell-session
+$ boundary storage-buckets read -id sb_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary storage-buckets <subcommand> [options] [args]
+  # ...
+Subcommands:
+    create    Create a storage bucket
+    delete    Delete a storage bucket
+    list      List a storage bucket
+    read      Read a storage bucket
+    update    Update a storage bucket
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [create](/boundary/docs/api-clients/commands/storage-buckets/create)
+- [delete](/boundary/docs/api-clients/commands/storage-buckets/delete)
+- [list](/boundary/docs/api-clients/commands/storage-buckets/list)
+- [read](/boundary/docs/api-clients/commands/storage-buckets/read)
+- [update](/boundary/docs/api-clients/commands/storage-buckets/update)

--- a/website/content/docs/api-clients/commands/storage-buckets/list.mdx
+++ b/website/content/docs/api-clients/commands/storage-buckets/list.mdx
@@ -1,0 +1,45 @@
+---
+layout: docs
+page_title: storage-buckets list - Command
+description: |-
+  The "storage-buckets list" command lists the storage buckets within a given scope or resource.
+---
+
+# storage-buckets list
+
+Command: `storage-buckets list`
+
+The `storage-buckets list` command lets you list the storage buckets within a given scope or resource.
+
+## Example
+
+This example lists all storage buckets within the scope `s_1234567890`.
+The `recursive` option means Boundary runs the operation recursively on any child scopes, if applicable:
+
+```shell-session
+$ boundary storage-buckets list -scope-id s_1234567890 -recursive
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary storage-buckets list [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-filter=<string>` - If you set this value, Boundary filters the list operation before the results are returned.
+The filter operates against each item in the list.
+We recommend that you use single quotes, because the filters contain double quotes.
+Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
+- `recursive` - If you set this value, Boundary runs the list operation recursively on any child scopes, if the type supports it.
+The default value is `false`.
+- `scope-id=<string>` - The scope from which to list the storage buckets.
+The default value is `global`.
+You can also specify this value using the BOUNDARY_SCOPE_ID environment variable.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/storage-buckets/read.mdx
+++ b/website/content/docs/api-clients/commands/storage-buckets/read.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: storage-buckets read - Command
+description: |-
+  The "storage-buckets read" command lets you read Boundary storage buckets.
+---
+
+# storage-buckets read
+
+Command: `boundary storage-buckets read`
+
+The `boundary storage-buckets read` command lets you read Boundary storage buckets.
+
+## Example
+
+This example reads a storage bucket with the ID `_1234567890`:
+
+```shell-session
+$ boundary storage-buckets read -id _1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary storage-buckets read [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - The ID of the bucket you want to read.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/storage-buckets/update.mdx
+++ b/website/content/docs/api-clients/commands/storage-buckets/update.mdx
@@ -1,0 +1,86 @@
+---
+layout: docs
+page_title: storage-buckets update - Command
+description: |-
+  The "storage-buckets update" command lets you update Boundary storage buckets.
+---
+
+# storage-buckets update
+
+Command: `boundary storage-buckets update`
+
+The `boundary storage-buckets update` command lets you update Boundary storage buckets by ID.
+
+## Example
+
+This example updates a storage bucket with the ID `_1234567890` to add the name `devops` and the description `storage bucket for DevOps`:
+
+```shell-session
+$ boundary storage-buckets update -id _1234567890 -name devops -description "storage bucket for DevOps"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary storage-buckets update [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-description=<string>` - The description to set for the storage bucket.
+- `-id=<string>` - The ID of the storage bucket to update.
+- `-name=<string>` - The name to set for the storage bucket.
+- `-version=<int>` - The version of the storage bucket against which to perform the update operation.
+If you do not specify a version, the command performs a check-and-set operation automatically.
+
+### Attribute options
+
+- `-attr` - A key=value pair to add to the request's attribute map.
+This option can also be a key value only, which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+You can override the type using `-string-attr`, `-bool-attr`, or `-num-attr`.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-attributes=<string>` - A JSON map value that you can use as the entirety of the request's attributes map.
+Usually this value is sourced from file using "file://" syntax.
+This option is exclusive with other attr flags.
+- `-bool-attr` - A key=value Boolean value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-num-attr` - A key=value numeric value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This attribute supports values from files using "file://" and environment variables using "env://".
+- `-string-attr` - A key=value string value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+
+### Secrets options
+
+- `-bool-secret` - A key=value Boolean value that you can add to the request's secrets map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-num-secret` - A key=value numeric value that you can add to the request's secrets map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-secret` - A key=value pair that you can add to the request's secrets map.
+This option can also be a key value only, which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+You can override the type using `-string-secret`, `-bool-secret`, or `-num-secret`.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-secrets=<string>` - A JSON map value that you can use as the entirety of the request's secrets map.
+Usually this value is sourced from file using "file://" syntax.
+This option is exclusive with other secret flags.
+- `-string-secret` - A key=value string value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+
+### Storage bucket options
+
+- `-worker-filter=<string>` - A Boolean expression that you can use to filter which workers can process communication to the storage bucket.
+
+@include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -747,6 +747,35 @@
             "path": "api-clients/commands/server"
           },
           {
+            "title": "storage-buckets",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/storage-buckets"
+              },
+              {
+                "title": "create",
+                "path": "api-clients/commands/storage-buckets/create"
+              },
+              {
+                "title": "delete",
+                "path": "api-clients/commands/storage-buckets/delete"
+              },
+              {
+                "title": "list",
+                "path": "api-clients/commands/storage-buckets/list"
+              },
+              {
+                "title": "read",
+                "path": "api-clients/commands/storage-buckets/read"
+              },
+              {
+                "title": "update",
+                "path": "api-clients/commands/storage-buckets/update"
+              }
+            ]
+          },
+          {
             "title": "targets",
             "routes": [
               {


### PR DESCRIPTION
Adds the storage-buckets commands on top of the existing assembly branch for CLI commands #3411.

Use this PR in favor of #3613.