### PR TITLE
docs: Add `session-recordings` commands

### DIFF
--- a/website/content/docs/api-clients/commands/session-recordings/download.mdx
+++ b/website/content/docs/api-clients/commands/session-recordings/download.mdx
@@ -1,0 +1,43 @@
+---
+layout: docs
+page_title: session-recordings download - Command
+description: |-
+  The "session-recordings download" command lets you download Boundary session recording resources.
+---
+
+# session-recordings download
+
+Command: `boundary session-recordings download`
+
+The `boundary session-recordings download` command lets you download a Boundary session recording.
+
+## Example
+
+The following command downloads a session recording with the id `chr_1234567890`:
+
+```shell-session
+$ boundary session-recordings download -id chr_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary session-recordings download [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - ID of the session recording resource to download.
+- `-no-clobber` - Enable this option to prevent downloads from overwriting existing files.
+This option is aliased as `-nc`.
+The default value is `false`.
+- `-output=<string>` - An optional output file for the download.
+If you do not provide a value, the recording ID is given a ".cast" extension.
+Use `-` for stdout.
+This option is aliased as `-o`.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/session-recordings/index.mdx
+++ b/website/content/docs/api-clients/commands/session-recordings/index.mdx
@@ -1,0 +1,42 @@
+---
+layout: docs
+page_title: session-recordings - Command
+description: |-
+  The "session-recordings" command lets you perform operations on Boundary session recording resources.
+---
+
+# session-recordings
+
+Command: `boundary session-recordings`
+
+The `session-recordings` command lets you perform operations on Boundary session recording resources.
+
+## Example
+
+The following command downloads a session recording with the id `chr_1234567890`:
+
+```shell-session
+$ boundary session-recordings download -id chr_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary session-recordings <subcommand> [options] [args]
+  # ...
+Subcommands:
+    download    Download a session recording
+    list        List a session recording
+    read        Read a session recording
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [download](/boundary/docs/api-clients/commands/session-recordings/download)
+- [list](/boundary/docs/api-clients/commands/session-recordings/list)
+- [read](/boundary/docs/api-clients/commands/session-recordings/read)

--- a/website/content/docs/api-clients/commands/session-recordings/list.mdx
+++ b/website/content/docs/api-clients/commands/session-recordings/list.mdx
@@ -1,0 +1,41 @@
+---
+layout: docs
+page_title: session-recordings list - Command
+description: |-
+  The "session-recordings list" command lists the session recordings within a given scope or resource.
+---
+
+# session-recordings list
+
+Command: `boundary session-recordings list`
+
+The `boundary session-recordings list` command lets you list the Boundary session recordings within a given scope or resource.
+
+## Example
+
+This example lists all session recordings within the scope `s_1234567890`.
+The `recursive` option means Boundary runs the operation recursively on any child scopes, if applicable:
+
+```shell-session
+$ boundary session-recordings list -scope-id s_1234567890 -recursive
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary session-recordings list [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `recursive` - If you set this value, Boundary runs the list operation recursively on any child scopes, if the type supports it.
+The default value is `false`.
+- `scope-id=<string>` - The scope from which to list the session recordings.
+The default value is `global`.
+You can also specify this value using the BOUNDARY_SCOPE_ID environment variable.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/session-recordings/read.mdx
+++ b/website/content/docs/api-clients/commands/session-recordings/read.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: session-recordings read - Command
+description: |-
+  The "session-recordings read" command lets you read Boundary session recordings by ID.
+---
+
+# session-recordings read
+
+Command: `boundary session-recordings read`
+
+The `boundary session-recordings read` command lets you read a Boundary session recording by providing the ID.
+
+## Example
+
+This example reads a session recording with the ID `s_1234567890`:
+
+```shell-session
+$ boundary session-recordings read -id s_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary session-recordings read [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - ID of the session recording to read.
+
+@include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -747,6 +747,27 @@
             "path": "api-clients/commands/server"
           },
           {
+            "title": "session-recordings",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/session-recordings"
+              },
+              {
+                "title": "download",
+                "path": "api-clients/commands/session-recordings/download"
+              },
+              {
+                "title": "list",
+                "path": "api-clients/commands/session-recordings/list"
+              },
+              {
+                "title": "read",
+                "path": "api-clients/commands/session-recordings/read"
+              }
+            ]
+          },
+          {
             "title": "sessions",
             "routes": [
               {


### PR DESCRIPTION
Adds the `session-recordings` commands on top of the existing assembly branch for CLI commands #3411.