### PR TITLE
Add 'credentials' command docs

### DIFF
--- a/website/content/docs/api-clients/commands/credential-stores/create.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/create.mdx
@@ -70,6 +70,7 @@ $ boundary credential-stores create [type] [sub command] [options] [args]
 
 </CodeBlockConfig>
 
+The available types are `static` and `vault`.
 
 ### Command options
 

--- a/website/content/docs/api-clients/commands/credentials/create.mdx
+++ b/website/content/docs/api-clients/commands/credentials/create.mdx
@@ -1,0 +1,217 @@
+---
+layout: docs
+page_title: credentials create - Command
+description: |-
+  The "credentials create" command allows create operations on Boundary credential resources.
+---
+
+# credentials create
+
+Command: `boundary credentials create`
+
+The `credentials create` command allows create operations on Boundary credential
+resources.
+
+
+## Examples
+
+Define a new `username_password` credential within a static credential store.
+
+```shell-session
+$ boundary credentials create username-password \
+   -name ssh-user \
+   -credential-store-id credup_J15mtU4qmy\
+   -username ssh-user \
+   -password env://SSH_USER_PASS
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential information:
+  Created Time:          Tue, 22 Aug 2023 15:56:07 PDT
+  Credential Store ID:   csst_5GGWwRngd7
+  ID:                    credup_J15mtU4qmy
+  Name:                  ssh-user
+  Type:                  username_password
+  Updated Time:          Tue, 22 Aug 2023 15:56:07 PDT
+  Version:               1
+
+  Scope:
+    ID:                  p_1zMlAwGHtH
+    Name:                quick-start-project
+    Parent Scope ID:     o_R0wbo0H6Zl
+    Type:                project
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+
+  Attributes:
+    Password HMAC:       bXhHJHgaGz6fpolEpQPd0azcICSgmbVuSLfyhJhmqJY
+    Username:            ssh-user
+```
+
+</CodeBlockConfig>
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credentials create [type] [sub command] [options] [args]
+```
+
+</CodeBlockConfig>
+
+The available types are `json`, `ssh-private-key`, and `username-password`.
+
+
+### Command options
+
+- `-credential-store-id` `(string: "")` - The credential-store resource to use
+   for the operation. This can also be specified via the
+   `BOUNDARY_CREDENTIAL_STORE_ID` environment variable.
+
+- `-description` `(string: "")` - Description to set on the credential.
+
+- `-name` `(string: "")` - Name to set on the credential.
+
+
+#### Usages by type
+
+<Tabs>
+<Tab heading="JSON">
+
+Create a credential of `json` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credentials create json [options] [args]
+```
+
+</CodeBlockConfig>
+
+### JSON cedential options:
+
+The following are JSON credential specific options in addition to the
+command options.
+
+
+- `-bool-kv` `(map: {})` – A key=value bool value to add to the request's object
+   map. Can be specified multiple times. Supports sourcing values from files via
+   "file://" and env vars via "env://".
+
+- `-kv` `(map: {})` – A key=value pair to add to the request's object map. This
+   can also be a key value only which will set a JSON null as the value. If a
+   value is provided, the type is automatically inferred. Use `-string-kv`,
+   `-bool-kv`, or `-num-kv` if the type needs to be overridden. Can be specified
+   multiple times. Supports sourcing values from files via "file://" and env
+   vars via "env://".
+
+- `-num-kv` `(map: {})` – A key=value numeric value to add to the request's
+   object map. Can be specified multiple times. Supports sourcing values from
+   files via "file://" and env vars via "env://".
+
+- `-object` `(string: "")` - A JSON map value to use as the entirety of the
+   request's object map. Usually this will be sourced from a file via "file://"
+   syntax. Is exclusive with the other kv flags.
+
+- `-string-kv` `(map: {})` – A key=value string value to add to the request's
+   object map. Can be specified multiple times. Supports sourcing values from
+   files via "file://" and env vars via "env://".
+
+#### Example
+
+```shell-session
+$ boundary credentials create json \
+   -credential-store-id csst_1234567890 \
+   -object file:///home/user/secret
+```
+
+</Tab>
+<Tab heading="SSH private key">
+
+Create a credential of `ssh-private-key` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credentials create ssh-private-key [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### SSH private key cedential options:
+
+The following are SSH private key credentials specific options in addition to
+the command options.
+
+- `-private-key` `(string: "")` - The SSH private key associated with the
+   credential. This can refer to a file on disk (file://) from which the value
+   will be read or an env var (env://) from which the value will be read.
+
+- `-private-key-passphrase` `(string: "")` - The passphrase associated with the
+   SSH private key. This value is ignored if the private key does not require a
+   passphrase or if no private key is supplied. This can refer to a file on disk
+   (file://) from which the value will be read, or an env var (env://) from
+   which the value will be read. Or, if left empty, if the key requires a
+   passphrase it can be entered manually.
+
+- `-username` `(string: "")` - The username associated with the credential.
+
+
+#### Example
+
+```shell-session
+$ boundary credentials create ssh-private-key \
+   -credential-store-id csvlt_1234567890 \
+   -username user \
+   -private-key file:///home/user/.ssh/id_ed25519
+```
+
+</Tab>
+<Tab heading="Username/password">
+
+Create a credential of `username-password` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credentials create username-password [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Username/password cedential options:
+
+The following are username/password credentials specific options in addition to
+the command options.
+
+- `-password` `(string: "")` - The password associated with the credential. This
+   can be a file on disk (`file://`) from which the value will be read, or an
+   env var (`env://`) from which the value will be read.
+
+- `-username` `(string: "")` - The username associated with the credential.
+
+#### Example
+
+```shell-session
+$ boundary credentials create username-password \
+   -credential-store-id csvlt_1234567890 \
+   -username user -password pass
+```
+
+</Tab>
+</Tabs>
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credentials/create.mdx
+++ b/website/content/docs/api-clients/commands/credentials/create.mdx
@@ -98,9 +98,9 @@ $ boundary credentials create json [options] [args]
 
 </CodeBlockConfig>
 
-### JSON cedential options:
+### JSON object credential options:
 
-The following are JSON credential specific options in addition to the
+The following are object (JSON) credential specific options in addition to the
 command options.
 
 
@@ -149,7 +149,7 @@ $ boundary credentials create ssh-private-key [options] [args]
 </CodeBlockConfig>
 
 
-### SSH private key cedential options:
+### SSH private key credential options:
 
 The following are SSH private key credentials specific options in addition to
 the command options.
@@ -185,13 +185,13 @@ Create a credential of `username-password` type.
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary credentials create username-password [options] [args]
+$ boundary credentials create username-password -credential-store-id [options] [args]
 ```
 
 </CodeBlockConfig>
 
 
-### Username/password cedential options:
+### Username/password credential options:
 
 The following are username/password credentials specific options in addition to
 the command options.

--- a/website/content/docs/api-clients/commands/credentials/delete.mdx
+++ b/website/content/docs/api-clients/commands/credentials/delete.mdx
@@ -1,0 +1,38 @@
+---
+layout: docs
+page_title: credentials delete - Command
+description: |-
+  The "credentials delete" command allows Boundary admin to delete a credential resource.
+---
+
+# credentials delete
+
+Command: `boundary credentials delete`
+
+The `credentials delete` command deletes a credential given its ID.
+
+## Examples
+
+Delete a credential of the given ID. 
+
+```shell-session
+$ boundary credentials delete -id credup_6zHHwQWvUS
+The delete operation completed successfully.
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credentials delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-id` `(string: "")` - ID of the credential on which to operate.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credentials/index.mdx
+++ b/website/content/docs/api-clients/commands/credentials/index.mdx
@@ -1,0 +1,84 @@
+---
+layout: docs
+page_title: credentials - Command
+description: |-
+  The "credentials" command allows operations on Boundary credential resources.
+---
+
+# credentials
+
+Command: `boundary credentials`
+
+The `credentials` command allows operations on Boundary credential resources.
+
+A credential is a data structure containing one or more secrets that binds an
+identity to a set of permissions or capabilities on a host for a session.
+
+## Examples
+
+Retrieve the information about the credential with ID, "credup_J15mtU4qmy".
+
+```shell-session
+$ boundary credentials read -id credup_J15mtU4qmy
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential information:
+  Created Time:          Tue, 22 Aug 2023 15:56:07 PDT
+  Credential Store ID:   csst_5GGWwRngd7
+  ID:                    credup_J15mtU4qmy
+  Name:                  ssh-user
+  Type:                  username_password
+  Updated Time:          Tue, 22 Aug 2023 15:56:07 PDT
+  Version:               1
+
+  Scope:
+    ID:                  p_1zMlAwGHtH
+    Name:                quick-start-project
+    Parent Scope ID:     o_R0wbo0H6Zl
+    Type:                project
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+
+  Attributes:
+    Password HMAC:       bXhHJHgaGz6fpolEpQPd0azcICSgmbVuSLfyhJhmqJY
+    Username:            ssh-user
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary credentials [sub command] [options] [args]
+
+  # ...
+
+Subcommands:
+    create    Create a credential
+    delete    Delete a credential
+    list      List a credential
+    read      Read a credential
+    update    Update a credential
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [create](/boundary/docs/api-clients/commands/credentials/create)
+- [delete](/boundary/docs/api-clients/commands/credentials/delete)
+- [read](/boundary/docs/api-clients/commands/credentials/read)
+- [update](/boundary/docs/api-clients/commands/credentials/update)
+- [list](/boundary/docs/api-clients/commands/credentials/list)

--- a/website/content/docs/api-clients/commands/credentials/list.mdx
+++ b/website/content/docs/api-clients/commands/credentials/list.mdx
@@ -1,0 +1,84 @@
+---
+layout: docs
+page_title: credentials list - Command
+description: |-
+  The "credentials list" command lists credentials within an enclosing scope or resource.
+---
+
+# credentials list
+
+Command: `boundary credentials list`
+
+The `credentials list` command lists credentials within an enclosing
+scope or resource.
+
+## Examples
+
+List all credentials for a given credential store ID.
+
+```shell-session
+$ credentials list -credential-store-id csst_5GGWwRngd7
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential information:
+  ID:                    credup_29IUJANN59
+    Version:             1
+    Type:                username_password
+    Name:                tester
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+
+  ID:                    credup_6zHHwQWvUS
+    Version:             1
+    Type:                username_password
+    Name:                support-eng
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+
+  ID:                    credup_J15mtU4qmy
+    Version:             1
+    Type:                username_password
+    Name:                ssh-user
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credentials list [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-credential-store-id` `(string: "")` - The credential-store resource to use
+   for the operation. This can also be specified via the
+   `BOUNDARY_CREDENTIAL_STORE_ID` environment variable.
+
+- `-filter` `(string: "")` - If set, the list operation will be filtered before
+   being returned. The filter operates against each item in the list. Using
+   single quotes is recommended as filters contain double quotes. 
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credentials/read.mdx
+++ b/website/content/docs/api-clients/commands/credentials/read.mdx
@@ -1,0 +1,72 @@
+---
+layout: docs
+page_title: credentials read - Command
+description: |-
+  The "credentials read" command reads a credential given its ID.
+---
+
+# credentials read
+
+Command: `boundary credentials read`
+
+The `credentials read` command retrieves a credential information
+of a specified ID.
+
+
+## Examples
+
+Retrieve a credential information for a given ID, `clvlt_QYnQPAjA24`.
+
+```shell-session
+$ boundary credentials read -id credup_29IUJANN59
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential information:
+  Created Time:          Tue, 22 Aug 2023 18:26:06 PDT
+  Credential Store ID:   csst_5GGWwRngd7
+  ID:                    credup_29IUJANN59
+  Name:                  tester
+  Type:                  username_password
+  Updated Time:          Tue, 22 Aug 2023 18:26:06 PDT
+  Version:               1
+
+  Scope:
+    ID:                  p_1zMlAwGHtH
+    Name:                quick-start-project
+    Parent Scope ID:     o_R0wbo0H6Zl
+    Type:                project
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+
+  Attributes:
+    Password HMAC:       bXhHJHgaGz6fpolEpQPd0azcICSgmbVuSLfyhJhmqJY
+    Username:            tester
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credentials read [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-id` `(string: "")` - ID of the credential on which to operate.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credentials/update.mdx
+++ b/website/content/docs/api-clients/commands/credentials/update.mdx
@@ -99,9 +99,9 @@ $ boundary credentials update json [options] [args]
 
 </CodeBlockConfig>
 
-### JSON cedential options:
+### JSON object credential options:
 
-The following are JSON credential specific options in addition to the
+The following are object (JSON) credential specific options in addition to the
 command options.
 
 
@@ -151,7 +151,7 @@ $ boundary credentials update ssh-private-key [options] [args]
 </CodeBlockConfig>
 
 
-### SSH private key cedential options:
+### SSH private key credential options:
 
 The following are SSH private key credentials specific options in addition to
 the command options.
@@ -193,7 +193,7 @@ $ boundary credentials update username-password [options] [args]
 </CodeBlockConfig>
 
 
-### Username/password cedential options:
+### Username/password credential options:
 
 The following are username/password credentials specific options in addition to
 the command options.

--- a/website/content/docs/api-clients/commands/credentials/update.mdx
+++ b/website/content/docs/api-clients/commands/credentials/update.mdx
@@ -1,0 +1,220 @@
+---
+layout: doc
+page_title: credentials update - Command
+description: |-
+  The "credentials update" command allows Boundary admin to update a credential resource.
+---
+
+# credentials update
+
+Command: `boundary credentials update`
+
+The `credentials update` command performs update operations on Boundary
+credential resources.
+
+## Examples
+
+Update an existing user/password credential with new password.
+
+```shell-session
+$ export NEW_SSH_USER_PASSWORD="my-new-long-password"
+
+$ boundary credentials update username-password -id credup_J15mtU4qmy \
+   -password env://NEW_SSH_USER_PASSWORD
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Credential information:
+  Created Time:          Tue, 22 Aug 2023 15:56:07 PDT
+  Credential Store ID:   csst_5GGWwRngd7
+  Description:           Ops admin who needs to access the machine
+  ID:                    credup_J15mtU4qmy
+  Name:                  ssh-user
+  Type:                  username_password
+  Updated Time:          Tue, 22 Aug 2023 21:26:34 PDT
+  Version:               2
+
+  Scope:
+    ID:                  p_1zMlAwGHtH
+    Name:                quick-start-project
+    Parent Scope ID:     o_R0wbo0H6Zl
+    Type:                project
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+
+  Attributes:
+    Password HMAC:       JxqSB5DJ_dBlTCJAfkX6k-o-6CwjgEDmmnbrTxvQ7_g
+    Username:            ssh-user
+```
+
+</CodeBlockConfig>
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credentials update [type] [sub command] [options] [args]
+```
+
+</CodeBlockConfig>
+
+The available types are `json`, `ssh-private-key`, and `username-password`.
+
+
+### Command options
+
+- `-description` `(string: "")` - Description to set on the credential.
+
+- `-id` `(string: "")` - ID of the credential on which to operate.
+
+- `-name` `(string: "")` - Name to set on the credential.
+
+- `-version` `(int: 0)` - The version of the credential against which to perform
+   an update operation. If not specified, the command will perform a
+   check-and-set automatically.
+
+
+#### Usages by type
+
+<Tabs>
+<Tab heading="JSON">
+
+Update a credential of `json` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credentials update json [options] [args]
+```
+
+</CodeBlockConfig>
+
+### JSON cedential options:
+
+The following are JSON credential specific options in addition to the
+command options.
+
+
+- `-bool-kv` `(map: {})` – A key=value bool value to add to the request's object
+   map. Can be specified multiple times. Supports sourcing values from files via
+   "file://" and env vars via "env://".
+
+- `-kv` `(map: {})` – A key=value pair to add to the request's object map. This
+   can also be a key value only which will set a JSON null as the value. If a
+   value is provided, the type is automatically inferred. Use `-string-kv`,
+   `-bool-kv`, or `-num-kv` if the type needs to be overridden. Can be specified
+   multiple times. Supports sourcing values from files via "file://" and env
+   vars via "env://".
+
+- `-num-kv` `(map: {})` – A key=value numeric value to add to the request's
+   object map. Can be specified multiple times. Supports sourcing values from
+   files via "file://" and env vars via "env://".
+
+- `-object` `(string: "")` - A JSON map value to use as the entirety of the
+   request's object map. Usually this will be sourced from a file via "file://"
+   syntax. Is exclusive with the other kv flags.
+
+- `-string-kv` `(map: {})` – A key=value string value to add to the request's
+   object map. Can be specified multiple times. Supports sourcing values from
+   files via "file://" and env vars via "env://".
+
+#### Example
+
+```shell-session
+$ boundary credentials update json \
+   -id csst_1234567890 \
+   -name devops \
+   -description "For DevOps usage"
+```
+
+</Tab>
+<Tab heading="SSH private key">
+
+Update a credential of `ssh-private-key` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credentials update ssh-private-key [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### SSH private key cedential options:
+
+The following are SSH private key credentials specific options in addition to
+the command options.
+
+- `-private-key` `(string: "")` - The SSH private key associated with the
+   credential. This can refer to a file on disk (file://) from which the value
+   will be read or an env var (env://) from which the value will be read.
+
+- `-private-key-passphrase` `(string: "")` - The passphrase associated with the
+   SSH private key. This value is ignored if the private key does not require a
+   passphrase or if no private key is supplied. This can refer to a file on disk
+   (file://) from which the value will be read, or an env var (env://) from
+   which the value will be read. Or, if left empty, if the key requires a
+   passphrase it can be entered manually.
+
+- `-username` `(string: "")` - The username associated with the credential.
+
+
+#### Example
+
+```shell-session
+$ boundary credentials update ssh-private-key \
+   -id clvlt_1234567890 \
+   -name devops \
+   -description "For DevOps usage"
+```
+
+</Tab>
+<Tab heading="Username/password">
+
+Update a credential of `username-password` type.
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary credentials update username-password [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Username/password cedential options:
+
+The following are username/password credentials specific options in addition to
+the command options.
+
+- `-password` `(string: "")` - The password associated with the credential. This
+   can be a file on disk (`file://`) from which the value will be read, or an
+   env var (`env://`) from which the value will be read.
+
+- `-username` `(string: "")` - The username associated with the credential.
+
+#### Example
+
+```shell-session
+$ boundary credentials update username-password \
+   -id clvlt_1234567890 \
+   -name devops \
+   -description "For DevOps usage"
+```
+
+</Tab>
+</Tabs>
+
+
+@include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -735,6 +735,35 @@
             ]
           },
           {
+            "title": "credentials",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/credentials"
+              },
+              {
+                "title": "create",
+                "path": "api-clients/commands/credentials/create"
+              },
+              {
+                "title": "delete",
+                "path": "api-clients/commands/credentials/delete"
+              },
+              {
+                "title": "list",
+                "path": "api-clients/commands/credentials/list"
+              },
+              {
+                "title": "read",
+                "path": "api-clients/commands/credentials/read"
+              },
+              {
+                "title": "update",
+                "path": "api-clients/commands/credentials/update"
+              }
+            ]
+          },
+          {
             "title": "dev",
             "path": "api-clients/commands/dev"
           },


### PR DESCRIPTION
This PR adds the `boundary credentials` command docs on top of https://github.com/hashicorp/boundary/pull/3411

🔍 [Deploy preview](https://boundary-git-credentials-docs-hashicorp.vercel.app/boundary/docs/api-clients/commands/credentials)