### PR TITLE
Add telemetry observation tags to plugin.proto

### DIFF
--- a/internal/proto/controller/api/resources/plugins/v1/plugin.proto
+++ b/internal/proto/controller/api/resources/plugins/v1/plugin.proto
@@ -9,7 +9,7 @@ option go_package = "github.com/hashicorp/boundary/sdk/pbs/controller/api/resour
 
 message PluginInfo {
   // Output only. The ID of the Plugin.
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
 
   // Output only. The name of the plugin resource in boundary, if any.
   string name = 2; // @gotags: `class:"public"`

--- a/sdk/pbs/controller/api/resources/plugins/plugin.pb.go
+++ b/sdk/pbs/controller/api/resources/plugins/plugin.pb.go
@@ -29,7 +29,7 @@ type PluginInfo struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Output only. The ID of the Plugin.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
 	// Output only. The name of the plugin resource in boundary, if any.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The description of the plugin in boundary, if any.


### PR DESCRIPTION
Add eventstream:"observation" tags to plugin.proto field.

Closed a previous PR (3591) and created it fresh, as there was an issue with a rebase in the my branch.