### PR TITLE
Add 'database' command docs

### DIFF
--- a/website/content/docs/api-clients/commands/auth-methods/change-state.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/change-state.mdx
@@ -108,7 +108,7 @@ $ boundary auth-methods change-state oidc [options] [args]
 
 ### OIDC auth method options
 
-- `-disable-discovered-config-validation` `(bool: false)` - Disable validating
+- `-disable-discovered-config-validation`  - Disable validating
    the given auth method against configuration from the authorization server's
    discovery URL. This must be specified every time an unvalidatable auth method
    is updated or state changed; not specifying it is equivalent to setting it to

--- a/website/content/docs/api-clients/commands/auth-methods/create.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/create.mdx
@@ -115,7 +115,7 @@ $ boundary auth-methods create ldap [options] [args]
 The following are LDAP specific options in addition to the command
 options.
 
-- `-anon-group-search` `(bool: false)` - Use anon bind when performing LDAP
+- `-anon-group-search`  - Use anon bind when performing LDAP
    group searches (optional). The default is false.
 
 - `-bind-dn` `(string: "")` - The distinguished name of entry to bind when
@@ -136,10 +136,10 @@ options.
    certificate key in PKCS #8, ASN.1 DER form used with the client certificate
    (optional).
 
-- `-discover-dn` `(bool: false)` - Use anon bind to discover the bind DN of a
+- `-discover-dn`  - Use anon bind to discover the bind DN of a
    user (optional). The default is false.
 
-- `-enable-groups` `(bool: false)` - Find the authenticated user's groups during
+- `-enable-groups`  - Find the authenticated user's groups during
    authentication (optional). The default is false.
 
 - `-group-attr` `(string: "")` - The attribute that enumerates a user's group
@@ -150,10 +150,10 @@ options.
 - `-group-filter` `(string: "")` - A go template used to construct a LDAP group
    search filter (optional).
 
-- `-insecure-tls` `(bool: false)` - Skip the LDAP server SSL certificate
+- `-insecure-tls`  - Skip the LDAP server SSL certificate
    validation (optional) - insecure and use with caution. The default is false.
 
-- `-start-tls` `(bool: false)` - Issue StartTLS command after connecting
+- `-start-tls`  - Issue StartTLS command after connecting
    (optional). The default is false.
 
 - `-state` `(string: "")` - The desired operational state of the auth method.
@@ -164,7 +164,7 @@ options.
 - `-urls` `(string: "")` - The LDAP URLs that specify LDAP servers to connect to
    (required). May be specified multiple times.
 
-- `-use-token-groups` `(bool: false)` - Use the Active Directory tokenGroups
+- `-use-token-groups`  - Use the Active Directory tokenGroups
    constructed attribute of the user to find the group memberships (optional).
    The default is false.
 

--- a/website/content/docs/api-clients/commands/auth-methods/list.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/list.mdx
@@ -88,7 +88,7 @@ $ boundary auth-methods list [options] [args]
    being returned. The filter operates against each item in the list. Using
    single quotes is recommended as filters contain double quotes. 
 
-- `-recursive` `(bool: false)` - If set, the list operation will be applied
+- `-recursive`  - If set, the list operation will be applied
    recursively into child scopes, if supported by the type. The default is
    false.
 

--- a/website/content/docs/api-clients/commands/auth-methods/update.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/update.mdx
@@ -114,7 +114,7 @@ $ boundary auth-methods update ldap [options] [args]
 The following are LDAP specific options in addition to the command
 options.
 
-- `-anon-group-search` `(bool: false)` - Use anon bind when performing LDAP
+- `-anon-group-search`  - Use anon bind when performing LDAP
    group searches (optional). The default is false.
 
 - `-bind-dn` `(string: "")` - The distinguished name of entry to bind when
@@ -135,10 +135,10 @@ options.
    certificate key in PKCS #8, ASN.1 DER form used with the client certificate
    (optional).
 
-- `-discover-dn` `(bool: false)` - Use anon bind to discover the bind DN of a
+- `-discover-dn`  - Use anon bind to discover the bind DN of a
    user (optional). The default is false.
 
-- `-enable-groups` `(bool: false)` - Find the authenticated user's groups during
+- `-enable-groups`  - Find the authenticated user's groups during
    authentication (optional). The default is false.
 
 - `-group-attr` `(string: "")` - The attribute that enumerates a user's group
@@ -149,10 +149,10 @@ options.
 - `-group-filter` `(string: "")` - A go template used to construct a LDAP group
    search filter (optional).
 
-- `-insecure-tls` `(bool: false)` - Skip the LDAP server SSL certificate
+- `-insecure-tls`  - Skip the LDAP server SSL certificate
    validation (optional) - insecure and use with caution. The default is false.
 
-- `-start-tls` `(bool: false)` - Issue StartTLS command after connecting
+- `-start-tls`  - Issue StartTLS command after connecting
    (optional). The default is false.
 
 - `-state` `(string: "")` - The desired operational state of the auth method.
@@ -163,7 +163,7 @@ options.
 - `-urls` `(string: "")` - The LDAP URLs that specify LDAP servers to connect to
    (required). May be specified multiple times.
 
-- `-use-token-groups` `(bool: false)` - Use the Active Directory tokenGroups
+- `-use-token-groups`  - Use the Active Directory tokenGroups
    constructed attribute of the user to find the group memberships (optional).
    The default is false.
 
@@ -226,13 +226,13 @@ options.
    can be used as trust anchors when connecting to an OIDC provider. May be
    specified multiple times.
 
-- `-disable-discovered-config-validation` `(bool: false)` - Disable validating
+- `-disable-discovered-config-validation`  - Disable validating
    the given auth method against configuration from the authorization server's
    discovery URL. This must be specified every time an unvalidatable auth method
    is updated or state changed; not specifying it is equivalent to setting it to
    false. The default is false.
 
-- `-dry-run` `(bool: false)` - Performs all completeness and validation checks
+- `-dry-run`  - Performs all completeness and validation checks
    with any newly-provided values without persisting the changes. The default is
    false.
 

--- a/website/content/docs/api-clients/commands/auth-tokens/list.mdx
+++ b/website/content/docs/api-clients/commands/auth-tokens/list.mdx
@@ -76,7 +76,7 @@ $ boundary auth-tokens list [options] [args]
    being returned. The filter operates against each item in the list. Using
    single quotes is recommended as filters contain double quotes. 
 
-- `-recursive` `(bool: false)` - If set, the list operation will be applied
+- `-recursive`  - If set, the list operation will be applied
    recursively into child scopes, if supported by the type. The default is
    false.
 

--- a/website/content/docs/api-clients/commands/config/decrypt.mdx
+++ b/website/content/docs/api-clients/commands/config/decrypt.mdx
@@ -59,10 +59,10 @@ $ boundary config decrypt [options] [args]
    If not set, the command will expect a block inline with the configuration
    file, and will only be able to support quoted string parameters.
 
-- `-overwrite` `(bool: false)` - Overwrite the existing file. The default is
+- `-overwrite`  - Overwrite the existing file. The default is
   false.
 
-- `-strip` `(bool: false)` - Strip the declarations from the file afterwards.
+- `-strip`  - Strip the declarations from the file afterwards.
   The default is false.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/config/encrypt.mdx
+++ b/website/content/docs/api-clients/commands/config/encrypt.mdx
@@ -60,10 +60,10 @@ $ boundary config encrypt [options] [args]
    If not set, the command will expect a block inline with the configuration
    file, and will only be able to support quoted string parameters.
 
-- `-overwrite` `(bool: false)` - Overwrite the existing file. The default is
+- `-overwrite`  - Overwrite the existing file. The default is
   false.
 
-- `-strip` `(bool: false)` - Strip the declarations from the file afterwards.
+- `-strip`  - Strip the declarations from the file afterwards.
   The default is false.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/config/get-token.mdx
+++ b/website/content/docs/api-clients/commands/config/get-token.mdx
@@ -62,11 +62,11 @@ $ boundary config get-token [options] [args]
 
 ### Command options
 
-- `-account-id` `(bool: false)` - If specified, print out the account ID
+- `-account-id`  - If specified, print out the account ID
       associated with the token instead of the token itself. The default is
       false.
 
-- `-auth-method-id` `(bool: false)` - If specified, print out the auth method ID
+- `-auth-method-id`  - If specified, print out the auth method ID
    associated with the token instead of the token itself. The default is false.
 
 - `-keyring-type` `(string: "")` - The type of keyring to use. Defaults to
@@ -82,7 +82,7 @@ $ boundary config get-token [options] [args]
    correspond to a name used when authenticating. This can also be specified via
    the BOUNDARY_TOKEN_NAME environment variable.
 
-- `-user-id` `(bool: false)` - If specified, print out the user ID associated
+- `-user-id`  - If specified, print out the user ID associated
    with the token instead of the token itself. The default is false.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/connect/http.mdx
+++ b/website/content/docs/api-clients/commands/connect/http.mdx
@@ -39,32 +39,28 @@ existing authorization token) and launches a proxied http connection.
 
 ### HTTP Options:
 
-- `-host=<string>`
-  Specifies the host value to use, overriding the endpoint address from
-  the session information. The specified hostname will be passed through
-  to the client (if supported) for use in the Host header and TLS SNI
-  value. This can also be specified via the BOUNDARY_CONNECT_HTTP_HOST
+- `-host` `(string: "")` - Specifies the host value to use, overriding the
+  endpoint address from the session information. The specified hostname will be
+  passed through to the client (if supported) for use in the Host header and TLS
+  SNI value. This can also be specified via the `BOUNDARY_CONNECT_HTTP_HOST`
   environment variable.
 
-- `-method=<string>`
-  Specifies the method to use. If not set, will use the client's default.
-  This can also be specified via the BOUNDARY_CONNECT_HTTP_METHOD
+- `-method` `(string: "")` - Specifies the method to use. If not set, will use
+  the client's default. This can also be specified via the
+  `BOUNDARY_CONNECT_HTTP_METHOD` environment variable.
+
+- `-path` `(string: "")` - Specifies a path that will be appended to the
+  generated URL. This can also be specified via the `BOUNDARY_CONNECT_HTTP_PATH`
   environment variable.
 
-- `-path=<string>`
-  Specifies a path that will be appended to the generated URL. This
-  can also be specified via the BOUNDARY_CONNECT_HTTP_PATH environment
+- `-scheme` `(string: "")` - Specifies the scheme to use. The default is https.
+  This can also be specified via the `BOUNDARY_CONNECT_HTTP_SCHEME` environment
   variable.
 
-- `-scheme=<string>`
-  Specifies the scheme to use. The default is https. This can also be
-  specified via the BOUNDARY_CONNECT_HTTP_SCHEME environment variable.
-
-- `-style=<string>`
-  Specifies how the CLI will attempt to invoke an HTTP client. This will
-  also set a suitable default for -exec if a value was not specified.
-  Currently-understood values are "curl". The default is curl. This
-  can also be specified via the BOUNDARY_CONNECT_HTTP_STYLE environment
+- `-style` `(string: "")` - Specifies how the CLI will attempt to invoke an HTTP
+  client. This will also set a suitable default for -exec if a value was not
+  specified. Currently-understood values are "curl". The default is curl. This
+  can also be specified via the `BOUNDARY_CONNECT_HTTP_STYLE` environment
   variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-libraries/create.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/create.mdx
@@ -108,7 +108,7 @@ $ boundary credential-libraries create vault-generic [options] [args]
 The following are Vault credential library specific options in addition to the
 command options.
 
-- `-credential-mapping-override` `(bool: false)` - The credential mapping
+- `-credential-mapping-override`  - The credential mapping
   override.
 
 - `-credential-type` `(string: "")` - The type of credential this library will
@@ -151,7 +151,7 @@ $ boundary credential-libraries create vault-ssh-certificate [options] [args]
 The following are Vault SSH certificate credential library specific options in
 addition to the command options.
 
-- `-critical-option` `(bool: false)` - A key=value pair to add to the request's
+- `-critical-option`  - A key=value pair to add to the request's
    critical-options map. This can also be a key value only which will set a JSON
    null as the value. If a value is provided, the type is automatically
    inferred. Use `-string-critical-option`, `-bool-critical-option`, or
@@ -163,7 +163,7 @@ addition to the command options.
    of the request's critical-options map. Usually this will be sourced from a
    file via "file://" syntax. Is exclusive with the other critical-option flags.
 
-- `-extension` `(bool: false)` - A key=value pair to add to the request's
+- `-extension`  - A key=value pair to add to the request's
    extensions map. This can also be a key value only which will set a JSON null
    as the value. If a value is provided, the type is automatically inferred. Use
    `-string-extension`, `-bool-extension`, or `-num-extension` if the type needs to be

--- a/website/content/docs/api-clients/commands/credential-libraries/update.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/update.mdx
@@ -108,7 +108,7 @@ $ boundary credential-libraries create vault-generic [options] [args]
 The following are Vault credential library specific options in addition to the
 command options.
 
-- `-credential-mapping-override` `(bool: false)` - The credential mapping
+- `-credential-mapping-override`  - The credential mapping
   override.
 
 - `-vault-http-method` `(string: "")` - The http method the library should use
@@ -149,7 +149,7 @@ $ boundary credential-libraries update vault-ssh-certificate [options] [args]
 The following are Vault SSH certificate credential library specific options in
 addition to the command options.
 
-- `-critical-option` `(bool: false)` - A key=value pair to add to the request's
+- `-critical-option`  - A key=value pair to add to the request's
    critical-options map. This can also be a key value only which will set a JSON
    null as the value. If a value is provided, the type is automatically
    inferred. Use `-string-critical-option`, `-bool-critical-option`, or
@@ -161,7 +161,7 @@ addition to the command options.
    of the request's critical-options map. Usually this will be sourced from a
    file via "file://" syntax. Is exclusive with the other critical-option flags.
 
-- `-extension` `(bool: false)` - A key=value pair to add to the request's
+- `-extension`  - A key=value pair to add to the request's
    extensions map. This can also be a key value only which will set a JSON null
    as the value. If a value is provided, the type is automatically inferred. Use
    `-string-extension`, `-bool-extension`, or `-num-extension` if the type needs to be

--- a/website/content/docs/api-clients/commands/credential-stores/create.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/create.mdx
@@ -143,7 +143,7 @@ command options.
 - `-vault-tls-server-name` `(string: "")` - Name to use as the SNI host when
   connecting via TLS.
 
-- `-vault-tls-skip-verify` `(bool: false)` - Whether to skip tls verification.
+- `-vault-tls-skip-verify`  - Whether to skip tls verification.
 The default is false.
 
 - `-vault-token` `(string: "")` - The vault token to use when boundary connects

--- a/website/content/docs/api-clients/commands/credential-stores/list.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/list.mdx
@@ -55,7 +55,7 @@ $ boundary credential-stores list [options] [args]
    being returned. The filter operates against each item in the list. Using
    single quotes is recommended as filters contain double quotes. 
 
-- `-recursive` `(bool: false)` - If set, the list operation will be applied
+- `-recursive`  - If set, the list operation will be applied
    recursively into child scopes, if supported by the type. The default is
    false.
 

--- a/website/content/docs/api-clients/commands/credential-stores/update.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/update.mdx
@@ -148,7 +148,7 @@ command options.
 - `-vault-tls-server-name` `(string: "")` - Name to use as the SNI host when
   connecting via TLS.
 
-- `-vault-tls-skip-verify` `(bool: false)` - Whether to skip tls verification.
+- `-vault-tls-skip-verify`  - Whether to skip tls verification.
 The default is false.
 
 - `-vault-token` `(string: "")` - The vault token to use when boundary connects

--- a/website/content/docs/api-clients/commands/database/index.mdx
+++ b/website/content/docs/api-clients/commands/database/index.mdx
@@ -1,0 +1,56 @@
+---
+layout: docs
+page_title: database - Command
+description: |-
+  The "database" command allows operations on Boundary's database.
+---
+
+# database
+
+Command: `boundary database`
+
+The `database` command allows operations on Boundary's database.
+
+Boundary manages its state and configuration in a relational database management
+system (RDBMS), namely PostgreSQL. You need to create, set up, and make the
+PostgreSQL database accessible to the Boundary controller nodes before you
+configure the nodes themselves.
+
+## Examples
+
+Initialize the Boundary database:
+
+```shell-session
+$ boundary database init \
+   -skip-auth-method-creation \
+   -skip-host-resources-creation \
+   -skip-scopes-creation \
+   -skip-target-creation \
+   -config /etc/boundary.d/controller.hcl
+```
+
+Before you can start Boundary, you must initialize the database from one
+Boundary controller. This operation is only required once which will execute the
+required database migrations for the Boundary cluster to operate.
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary database [sub command] [options] [args]
+
+  # ...
+
+Subcommands:
+    init       Initialize Boundary's database
+    migrate    Migrate Boundary's database to the most recent schema supported by this binary.
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [init](/boundary/docs/api-clients/commands/database/init)
+- [migrate](/boundary/docs/api-clients/commands/database/migrate)

--- a/website/content/docs/api-clients/commands/database/init.mdx
+++ b/website/content/docs/api-clients/commands/database/init.mdx
@@ -1,0 +1,136 @@
+---
+layout: docs
+page_title: database init - Command
+description: |-
+  The "database init" command initializes Boundary's database.
+---
+
+# database init
+
+Command: `boundary database init`
+
+The `database init` command initializes Boundary's database.
+
+## Examples
+
+Initialize a Boundary's database with configuration specified in the
+`/etc/boundary/controller.hcl` file.
+
+```shell-session
+$ boundary database init -config=/etc/boundary/controller.hcl
+```
+
+The `controller.hcl` file contains database URL.
+
+<CodeBlockConfig filename="/etc/boundary.d/controller.hcl" hideClipboard highlight="19-23">
+
+```hcl
+...snip...
+
+# Controller configuration block
+controller {
+  # This name attr must be unique across all controller instances if running in HA mode
+  name = "boundary-controller-1"
+  description = "Boundary controller number one"
+
+  # This is the public hostname or IP where the workers can reach the
+  # controller. This should typically be a load balancer address
+  public_cluster_addr = "example-cluster-lb.example.com"
+
+  # Enterprise license file, can also be the raw value or env:// value
+  license = "file:///path/to/license/file.hclic"
+
+  # After receiving a shutdown signal, Boundary will wait 10s before initiating the shutdown process.
+  graceful_shutdown_wait_duration = "10s"
+
+  # Database URL for postgres. This is set in boundary.env and
+  #consumed via the “env://” notation.
+  database {
+      url = "env://POSTGRESQL_CONNECTION_STRING"
+  }
+}
+
+...snip...
+```
+
+</CodeBlockConfig>
+
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary database init [options] [args]
+```
+
+</CodeBlockConfig>
+
+Unless told not to via flags, some initial resources will be created, in the
+following order and in the indicated scopes:
+
+- Initial Login Role (global)
+- Password-Type Auth Method (global)
+- Org Scope (global)
+- Project Scope (org)
+   - Static-Type Host Catalog (project)
+      - Static-Type Host Set
+      - Static-Type Host
+   - Target (project)
+
+<Tip>
+
+If flags are used to skip any of these resources, any resources that would be
+created afterwards are also skipped. Refer to the following [init
+options](#init-options) for the available flags.
+
+</Tip>
+
+### Command options
+
+- `-config` `(string: "")` - Path to the configuration file.
+
+- `-config-kms` `(string: "")` - Path to a configuration file containing a "kms"
+   block marked for "config" purpose, to perform decryption of the main
+   configuration file. If not set, will look for such a block in the main
+   configuration file, which has some drawbacks; see the help output for
+   "boundary config encrypt -h" for details.
+
+- `-log-format` `(string: "")` - Log format. Supported values are "standard" and
+  "json".
+
+- `-log-level` `(string: "")` - Log verbosity level. Supported values (in order
+   of more detail to less) are "trace", "debug", "info", "warn", and "err". This
+   can also be specified via the `BOUNDARY_LOG_LEVEL` environment variable.
+
+### Init options:
+
+- `-migration-url` `(string: "")` - If set, overrides a migration URL set in
+   config, and specifies the URL used to connect to the database for
+   initialization. This can allow different permissions for the user running
+   initialization vs. normal operation. This can refer to a file on disk
+   (`file://`) from which a URL will be read; an env var (`env://`) from which the
+   URL will be read; or a direct database URL.
+
+- `-skip-auth-method-creation` - If not set, an auth method will
+   not be created as part of initialization. If set, the recovery KMS will be
+   needed to perform any actions. The default is false.
+
+- `-skip-host-resources-creation` - If not set, host resources
+   (host catalog, host set, host) will not be created as part of initialization.
+   The default is false.
+
+- `-skip-initial-login-role-creation` - If not set, a default
+   role allowing necessary grants for logging in will not be created as part of
+   initialization. If set, the recovery KMS will be needed to perform any
+   actions. The default is false.
+
+- `-skip-scopes-creation` - If not set, scopes will not be
+   created as part of initialization. The default is false.
+
+- `-skip-target-creation` - If not set, a target will not be
+   created as part of initialization. The default is false.
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/database/init.mdx
+++ b/website/content/docs/api-clients/commands/database/init.mdx
@@ -56,7 +56,6 @@ controller {
 </CodeBlockConfig>
 
 
-
 ## Usage
 
 <CodeBlockConfig hideClipboard>

--- a/website/content/docs/api-clients/commands/database/migrate.mdx
+++ b/website/content/docs/api-clients/commands/database/migrate.mdx
@@ -1,0 +1,65 @@
+---
+layout: docs
+page_title: database migrate - Command
+description: |-
+  The "database migrate" command migrates database within an enclosing scope or resource.
+---
+
+# database migrate
+
+Command: `boundary database migrate`
+
+The `database migrate` command migrates database within an enclosing
+scope or resource.
+
+## Examples
+
+Migrate Boundary's database to the database URL specified in the controller
+configuration file.
+
+```shell-session
+$ boundary database migrate -config=/etc/boundary/controller.hcl
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary database migrate [options]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-config` `(string: "")` - Path to the configuration file.
+
+- `-config-kms` `(string: "")` - Path to a configuration file containing a "kms"
+   block marked for "config" purpose, to perform decryption of the main
+   configuration file. If not set, will look for such a block in the main
+   configuration file, which has some drawbacks; see the help output for
+   "boundary config encrypt -h" for details.
+
+- `-log-format` `(string: "")` - Log format. Supported values are "standard" and
+  "json".
+
+- `-log-level` `(string: "")` - Log verbosity level. Supported values (in order
+   of more detail to less) are "trace", "debug", "info", "warn", and "err". This
+   can also be specified via the `BOUNDARY_LOG_LEVEL` environment variable.
+
+### Migration options:
+
+- `-migration-url` `(string: "")` - If set, overrides a migration URL set in
+   config, and specifies the URL used to connect to the database for migration.
+   This can allow different permissions for the user running initialization or
+   migration vs. normal operation. This can refer to a file on disk (`file://`)
+   from which a URL will be read; an env var (`env://)` from which the URL will
+   be read; or a direct database URL.
+
+- `-repair` `(string: "")` - Run the repair function for the provided migration
+  version.
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/dev.mdx
+++ b/website/content/docs/api-clients/commands/dev.mdx
@@ -116,14 +116,14 @@ $ boundary dev [options]
    be a Unix domain socket path. This can also be specified via the
    **BOUNDARY_DEV_CONTROLLER_CLUSTER_LISTEN_ADDRESS** environment variable.
 
-- `-combine-logs` `(bool: false)` - If set, both startup information and logs
+- `-combine-logs`  - If set, both startup information and logs
    will be sent to stdout. If not set (the default), startup information will go
    to stdout and logs will be sent to stderr. The default is false.
 
 - `-container-image` `(string: "")` - Specifies a container image to be
    utilized. Must be in `<repo>:<tag>` format
 
-- `-controller-only` `(bool: false)` - If set, only a dev controller will be
+- `-controller-only`  - If set, only a dev controller will be
    started instead of both a dev controller and dev worker The default is false.
 
 - `-controller-public-cluster-address` `(string: "")` - Public address at which
@@ -137,7 +137,7 @@ $ boundary dev [options]
    be read; an env var (`env://`) from which the URL will be read; or a direct
    database URL.
 
-- `-disable-database-destruction` `(bool: false)` - If set, if a database is
+- `-disable-database-destruction`  - If set, if a database is
    created automatically in Docker, it will not be removed when the dev server
    is shut down. The default is false.
 
@@ -237,7 +237,7 @@ $ boundary dev [options]
    is password. This can also be specified via the
    **BOUNDARY_DEV_UNPRIVILEGED_PASSWORD** environment variable.
 
-- `-worker-auth-enable-debugging` `(bool: false)` - Turn on debug logging of the
+- `-worker-auth-enable-debugging`  - Turn on debug logging of the
    worker authentication process. The default is false.
 
 - `-worker-auth-key` `(string: "")` - If set, a valid base64-encoded AES key to
@@ -252,7 +252,7 @@ $ boundary dev [options]
    file storage at the specified location; otherwise in-memory storage or a
    temporary directory will be used.
 
-- `-worker-auth-storage-skip-cleanup` `(bool: false)` - Prevents deletion of
+- `-worker-auth-storage-skip-cleanup`  - Prevents deletion of
    worker credential storage directory if set. Has no effect unless
    worker-auth-storage-dir is specified. The default is false.
 

--- a/website/content/docs/api-clients/commands/index.mdx
+++ b/website/content/docs/api-clients/commands/index.mdx
@@ -230,7 +230,7 @@ $ boundary dev -help
   private key matching the client certificate from `-client-cert`. This can also
   be specified via the `BOUNDARY_CLIENT_KEY` environment variable.
 
-- `-tls-insecure` `(bool: false)` - Disable verification of TLS certificates.
+- `-tls-insecure`  - Disable verification of TLS certificates.
   Using this option is highly discouraged as it decreases the security of data
   transmissions to and from the Boundary server. The default is `false`. This
   can also be specified via the `BOUNDARY_TLS_INSECURE` environment variable.
@@ -251,7 +251,7 @@ client options. Some notable options:
   `keychain`, `pass`, and `secret-service`. The default is auto. This can also
   be specified via the `BOUNDARY_KEYRING_TYPE` environment variable.
 
-- `-output-curl-string` `(bool: false)` - This will format the command that
+- `-output-curl-string`  - This will format the command that
   would have been run as a string using `curl` that can be used directly on the
   command line. This is a great way to discover how CLI functions map to API
   calls. The default is `false`.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -764,6 +764,23 @@
             ]
           },
           {
+            "title": "database",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/database"
+              },
+              {
+                "title": "init",
+                "path": "api-clients/commands/database/init"
+              },
+              {
+                "title": "migrate",
+                "path": "api-clients/commands/database/migrate"
+              }
+            ]
+          },
+          {
             "title": "dev",
             "path": "api-clients/commands/dev"
           },


### PR DESCRIPTION
This PR adds the docs for `boundary database` command on top of https://github.com/hashicorp/boundary/pull/3411

🔍 [Deploy preview](https://boundary-git-database-docs-hashicorp.vercel.app/boundary/docs/api-clients/commands/database)