### PR TITLE
docs: Add `host-sets` commands

### DIFF
--- a/website/content/docs/api-clients/commands/host-sets/add-hosts.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/add-hosts.mdx
@@ -1,0 +1,40 @@
+---
+layout: docs
+page_title: host-sets add-hosts - Command
+description: |-
+  The "host-sets add-hosts" command lets you add hosts to host set resources, if the types match and the operation is allowed by the host set type.
+---
+
+# host-sets add-hosts
+
+Command: `host-sets add-hosts`
+
+The `host-sets add-hosts` command lets you add hosts to host sets, if the types match and it is allowed by the host set type.
+
+## Example
+
+This example adds the hosts `hst_1234567890` and `hst_0987654321` to the host set `hsst_1234567890`:
+
+```shell-session
+$ boundary host-sets add-hosts -id hsst_1234567890 -host hst_1234567890 -host hst_0987654321
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets add-hosts <subcommand> [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-host=<string>` - The hosts to add to the host set.
+You can specify multiple hosts.
+- `-id=<string>` - ID of the host set to add hosts to.
+- `-version=<int>` The version of the host set.
+If you do not specify a version, the command performs a check-and-set automatically.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/add-hosts.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/add-hosts.mdx
@@ -33,7 +33,7 @@ $ boundary host-sets add-hosts <subcommand> [options] [args]
 
 - `-host=<string>` - The hosts to add to the host set.
 You can specify multiple hosts.
-- `-id=<string>` - ID of the host set to add hosts to.
+- `-id=<string>` - The ID of the host set to add hosts to.
 - `-version=<int>` The version of the host set.
 If you do not specify a version, the command performs a check-and-set automatically.
 

--- a/website/content/docs/api-clients/commands/host-sets/create.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/create.mdx
@@ -1,0 +1,140 @@
+---
+layout: docs
+page_title: host-sets create - Command
+description: |-
+  The "host-sets create" command lets you create a new host set.
+---
+
+# host-sets create
+
+Command: `host-sets create`
+
+The `host-sets create` command lets you create a new host set.
+
+## Example
+
+This example creates a static host set with the name `prodops` and the description `For ProdOps usage`:
+
+```shell-session
+$ boundary host-sets create static -name prodops -description "For ProdOps usage"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets create [type] <subcommand> [options] [args]
+
+Please see the typed subcommand help for detailed usage information.
+
+Subcommands:
+    plugin    Create a plugin-type host set
+    static    Create a static-type host set
+```
+
+</CodeBlockConfig>
+
+### Usages by type
+
+You can create plugin or static host set types.
+
+<Tabs>
+<Tab heading="plugin">
+
+The `boundary host-sets create plugin` command lets you create a plugin type host set.
+
+#### Example
+
+This example creates a plugin type host set with the name `prodops` and the description `Plugin host-set for ProdOps` and adds it to a host catalog with the ID `hcst_1234567890`.
+
+```shell-session
+$ boundary host-sets create plugin -host-catalog-id hcst_1234567890 -name prodops -description "Plugin host-set for ProdOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets create plugin [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### Command options
+
+- `-description=<string>` - The description to set for the plugin host set.
+- `-host-catalog-id=<string>` - The host catalog resource to use for the operation.
+You can also specfiy the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
+- `-name=<string>` - The name to set for the plugin host set.
+
+#### Attribute options
+
+- `-attr` - A key=value pair to add to the request's attribute map.
+This option can also be a key value only, which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+You can override the type using `-string-attr`, `-bool-attr`, or `-num-attr`.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-attributes=<string>` - A JSON map value that you can use as the entirety of the request's attributes map.
+Usually this value is sourced from file using "file://" syntax.
+This option is exclusive with other attr flags.
+- `-bool-attr` - A key=value Boolean value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-num-attr` - A key=value numeric value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This attribute supports values from files using "file://" and environment variables using "env://".
+- `-string-attr` - A key=value string value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+
+#### Plugin host-set options
+
+- `-preferred-endpoint=<string>` - An endpoint prference that specifies which IP address or DNS name out of a host's available options is preferred.
+You can specify the preference using `cidr:<valid IPv4/6 CIDR>` or `dns:<globbed name>`.
+You can specify multiple preferences which create an order of preferences.
+If you do not specify a preference, Boundary chooses a value from all available values using a built-in priority order.
+The endpoint preference option may not be valid for all plugin types.
+- `-sync-interval=<string>` - An integer number of a seconds or a string such as `400s`, `5m`, or `6h` that indicates the interval of time between sync operations on the host set.
+The interval is applied to the end of the previous sync operation, not the beginning.
+If you set the interval to a negative value, it disables synchronization for that host set.
+If you set the interval to null, Boundary uses the default value.
+The default value may change between releases.
+
+</Tab>
+
+<Tab heading="static">
+
+The `boundary host-sets create static` command lets you create a static type host set.
+
+#### Example
+
+This example creates a static type host set with the name `prodops` and the description `Static host for ProdOps`:
+
+```shell-session
+$ boundary host-sets create static -name prodops -description "Static host-set for ProdOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets create static [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### Command options
+
+- `-description=<string>` - The description to set for the static host set.
+- `-host-catalog-id=<string>` - The host catalog resource to use for the operation.
+You can also specfiy the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
+- `-name=<string>` - The name to set for the static host set.
+
+</Tab>
+</Tabs>
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/create.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/create.mdx
@@ -46,7 +46,7 @@ The `boundary host-sets create plugin` command lets you create a plugin type hos
 
 #### Example
 
-This example creates a plugin type host set with the name `prodops` and the description `Plugin host-set for ProdOps` and adds it to a host catalog with the ID `hcst_1234567890`.
+This example creates a plugin type host set with the name `prodops` and the description `Plugin host-set for ProdOps`, and adds it to a host catalog with the ID `hcst_1234567890`.
 
 ```shell-session
 $ boundary host-sets create plugin -host-catalog-id hcst_1234567890 -name prodops -description "Plugin host-set for ProdOps"
@@ -66,7 +66,7 @@ $ boundary host-sets create plugin [options] [args]
 
 - `-description=<string>` - The description to set for the plugin host set.
 - `-host-catalog-id=<string>` - The host catalog resource to use for the operation.
-You can also specfiy the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
+You can also specify the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
 - `-name=<string>` - The name to set for the plugin host set.
 
 #### Attribute options
@@ -92,7 +92,7 @@ This option supports values from files using "file://" and environment variables
 
 #### Plugin host-set options
 
-- `-preferred-endpoint=<string>` - An endpoint prference that specifies which IP address or DNS name out of a host's available options is preferred.
+- `-preferred-endpoint=<string>` - An endpoint preference that specifies which IP address or DNS name out of a host's available options is preferred.
 You can specify the preference using `cidr:<valid IPv4/6 CIDR>` or `dns:<globbed name>`.
 You can specify multiple preferences which create an order of preferences.
 If you do not specify a preference, Boundary chooses a value from all available values using a built-in priority order.
@@ -131,7 +131,7 @@ $ boundary host-sets create static [options] [args]
 
 - `-description=<string>` - The description to set for the static host set.
 - `-host-catalog-id=<string>` - The host catalog resource to use for the operation.
-You can also specfiy the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
+You can also specify the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
 - `-name=<string>` - The name to set for the static host set.
 
 </Tab>

--- a/website/content/docs/api-clients/commands/host-sets/delete.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/delete.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: host-sets delete - Command
+description: |-
+  The "host-sets delete" command lets you delete a host set.
+---
+
+# host-sets delete
+
+Command: `host-sets delete`
+
+The `host-sets delete` command lets you delete an existing host set by providing the ID.
+
+## Example
+
+This example deletes a host set with the ID `_1234567890`:
+
+```shell-session
+$ boundary host-sets delete -id _1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - ID of the host set to delete.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/delete.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/delete.mdx
@@ -31,6 +31,6 @@ $ boundary host-sets delete [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the host set to delete.
+- `-id=<string>` - The ID of the host set to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/index.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/index.mdx
@@ -1,0 +1,52 @@
+---
+layout: docs
+page_title: host-sets - Command
+description: |-
+  The "host-sets" command lets you perform operations on Boundary host set resources.
+---
+
+# host-sets
+
+Command: `boundary host-sets`
+
+The `host-sets` command lets you perform operations on Boundary host set resources.
+
+## Example
+
+The following command reads a host set with the ID `hsst_1234567890`:
+
+```shell-session
+$ boundary host-sets read -id hsst_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary host-setss <subcommand> [options] [args]
+  # ...
+Subcommands:
+    add-hosts       Add hosts to the specified host set
+    create          Create a host set
+    delete          Delete a host set
+    list            List a host set
+    read            Read a host set
+    remove-hosts    Remove hosts from the specified host set
+    set-hosts       Set the full contents of the hosts on the specified host set
+    update          Update a host set
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [add-hosts](/boundary/docs/api-clients/commands/host-sets/add-hosts)
+- [create](/boundary/docs/api-clients/commands/host-sets/create)
+- [delete](/boundary/docs/api-clients/commands/host-sets/delete)
+- [list](/boundary/docs/api-clients/commands/host-sets/list)
+- [read](/boundary/docs/api-clients/commands/host-sets/read)
+- [remove-hosts](/boundary/docs/api-clients/commands/host-sets/remove-hosts)
+- [set-hosts](/boundary/docs/api-clients/commands/host-sets/set-hosts)
+- [update](/boundary/docs/api-clients/commands/host-sets/update)

--- a/website/content/docs/api-clients/commands/host-sets/index.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/index.mdx
@@ -24,7 +24,7 @@ $ boundary host-sets read -id hsst_1234567890
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-Usage: boundary host-setss <subcommand> [options] [args]
+Usage: boundary host-sets <subcommand> [options] [args]
   # ...
 Subcommands:
     add-hosts       Add hosts to the specified host set

--- a/website/content/docs/api-clients/commands/host-sets/list.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/list.mdx
@@ -1,0 +1,41 @@
+---
+layout: docs
+page_title: host-sets list - Command
+description: |-
+  The "host-sets list" command lists the host sets within a given scope or resource.
+---
+
+# host-sets list
+
+Command: `boundary host-sets list`
+
+The `boundary host-sets list` command lets you list the Boundary host sets within a given scope or resource.
+
+## Example
+
+This example lists all host sets within the host catalog `_1234567890`:
+
+```shell-session
+$ boundary host-sets list -host-catalog-id _1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets list [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-filter=<string>` - If you set this value, Boundary filters the list operation before the results are returned.
+The filter operates against each item in the list.
+We recommend that you use single quotes, because the filters contain double quotes.
+Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
+- `-host-catalog-id=<string>` - The host catalog resource to use to produce the list.
+You can also specify the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/read.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/read.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: host-sets read - Command
+description: |-
+  The "host-sets read" command lets you read a host set with a given ID.
+---
+
+# host-sets read
+
+Command: `boundary host-sets read`
+
+The `boundary host-sets read` command lets you read a Boundary host set using its given ID.
+
+## Example
+
+This example reads a host set with the ID `_1234567890`:
+
+```shell-session
+$ boundary host-sets read -id _1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets read [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - ID of the host set to read.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/remove-hosts.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/remove-hosts.mdx
@@ -33,7 +33,7 @@ $ boundary host-sets remove-hosts <subcommand> [options] [args]
 
 - `-host=<string>` - The hosts to remove from the host set.
 You can specify multiple hosts.
-- `-id=<string>` - ID of the host set to remove hosts from.
+- `-id=<string>` - The ID of the host set to remove hosts from.
 - `-version=<int>` The version of the host set.
 If you do not specify a version, the command performs a check-and-set automatically.
 

--- a/website/content/docs/api-clients/commands/host-sets/remove-hosts.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/remove-hosts.mdx
@@ -1,0 +1,40 @@
+---
+layout: docs
+page_title: host-sets remove-hosts - Command
+description: |-
+  The "host-sets remove-hosts" command lets you remove hosts from host set resources, if the types match and the operation is allowed by the host set type.
+---
+
+# host-sets remove-hosts
+
+Command: `host-sets remove-hosts`
+
+The `host-sets remove-hosts` command lets you remove hosts from host sets, if the types match and it is allowed by the host set type.
+
+## Example
+
+This example removes the host `hst_0987654321` from the host set `hsst_1234567890`:
+
+```shell-session
+$ boundary host-sets remove-hosts -id hsst_1234567890 -host hst_0987654321
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets remove-hosts <subcommand> [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-host=<string>` - The hosts to remove from the host set.
+You can specify multiple hosts.
+- `-id=<string>` - ID of the host set to remove hosts from.
+- `-version=<int>` The version of the host set.
+If you do not specify a version, the command performs a check-and-set automatically.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/set-hosts.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/set-hosts.mdx
@@ -33,7 +33,7 @@ $ boundary host-sets set-hosts <subcommand> [options] [args]
 
 - `-host=<string>` - The hosts to set on the host set.
 You can specify multiple hosts.
-- `-id=<string>` - ID of the host set to set hosts on.
+- `-id=<string>` - The ID of the host set to set hosts on.
 - `-version=<int>` The version of the host set.
 If you do not specify a version, the command performs a check-and-set automatically.
 

--- a/website/content/docs/api-clients/commands/host-sets/set-hosts.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/set-hosts.mdx
@@ -1,0 +1,40 @@
+---
+layout: docs
+page_title: host-sets set-hosts - Command
+description: |-
+  The "host-sets set-hosts" command lets you set the complete set of hosts on host source resources, if the types match and the operation is allowed by the host set type.
+---
+
+# host-sets set-hosts
+
+Command: `host-sets set-hosts`
+
+The `host-sets set-hosts` command lets you set the complete set of hosts on a host set resource, if the types match and it is allowed by the host set type.
+
+## Example
+
+This example sets the host `hst_1234567890` on the host set `hsst_1234567890`:
+
+```shell-session
+$ boundary host-sets set-hosts -id hsst_1234567890 -host hst_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets set-hosts <subcommand> [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-host=<string>` - The hosts to set on the host set.
+You can specify multiple hosts.
+- `-id=<string>` - ID of the host set to set hosts on.
+- `-version=<int>` The version of the host set.
+If you do not specify a version, the command performs a check-and-set automatically.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/update.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/update.mdx
@@ -65,7 +65,7 @@ $ boundary host-sets update plugin [options] [args]
 #### Command options
 
 - `-description=<string>` - The description to set for the plugin host set.
-- `-id=<string>` - ID of the plugin type host set to update.
+- `-id=<string>` - The ID of the plugin type host set to update.
 - `-name=<string>` - The name to set for the plugin host set.
 - `-version=<int>` - The version of the plugin host set to update.
 If you do not specify a version, the command automatically performs a check-and-set.
@@ -93,7 +93,7 @@ This option supports values from files using "file://" and environment variables
 
 #### Plugin host-set options
 
-- `-preferred-endpoint=<string>` - An endpoint prference that specifies which IP address or DNS name out of a host's available options is preferred.
+- `-preferred-endpoint=<string>` - An endpoint preference that specifies which IP address or DNS name out of a host's available options is preferred.
 You can specify the preference using `cidr:<valid IPv4/6 CIDR>` or `dns:<globbed name>`.
 You can specify multiple preferences which create an order of preferences.
 If you do not specify a preference, Boundary chooses a value from all available values using a built-in priority order.

--- a/website/content/docs/api-clients/commands/host-sets/update.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/update.mdx
@@ -1,0 +1,142 @@
+---
+layout: docs
+page_title: host-sets update - Command
+description: |-
+  The "host-sets update" command lets you update an existing host set.
+---
+
+# host-sets update
+
+Command: `host-sets update`
+
+The `host-sets update` command lets you update an existing host set.
+
+## Example
+
+This example updates a static host set with the ID `hsst_1234567890` to add the name `devops` and the description `For DevOps usage`:
+
+```shell-session
+$ boundary host-sets update static -id hsst_1234567890 -name devops -description "For DevOps usage"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets update [type] <subcommand> [options] [args]
+
+Please see the typed subcommand help for detailed usage information.
+
+Subcommands:
+    plugin    Update a plugin-type host set
+    static    Update a static-type host set
+```
+
+</CodeBlockConfig>
+
+### Usages by type
+
+You can update plugin or static host set types.
+
+<Tabs>
+<Tab heading="plugin">
+
+The `boundary host-sets update plugin` command lets you update a plugin type host set.
+
+#### Example
+
+This example updates a plugin type host set with the ID `hsplg_1234567890` to add the name `devops` and the description `Plugin host-set for DevOps`.
+
+```shell-session
+$ boundary host-sets update plugin -id hsplg_1234567890 -name "devops" -description "Plugin host-set for DevOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets update plugin [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### Command options
+
+- `-description=<string>` - The description to set for the plugin host set.
+- `-id=<string>` - ID of the plugin type host set to update.
+- `-name=<string>` - The name to set for the plugin host set.
+- `-version=<int>` - The version of the plugin host set to update.
+If you do not specify a version, the command automatically performs a check-and-set.
+
+#### Attribute options
+
+- `-attr` - A key=value pair to add to the request's attribute map.
+This option can also be a key value only, which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+You can override the type using `-string-attr`, `-bool-attr`, or `-num-attr`.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-attributes=<string>` - A JSON map value that you can use as the entirety of the request's attributes map.
+Usually this value is sourced from file using "file://" syntax.
+This option is exclusive with other attr flags.
+- `-bool-attr` - A key=value Boolean value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-num-attr` - A key=value numeric value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This attribute supports values from files using "file://" and environment variables using "env://".
+- `-string-attr` - A key=value string value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+
+#### Plugin host-set options
+
+- `-preferred-endpoint=<string>` - An endpoint prference that specifies which IP address or DNS name out of a host's available options is preferred.
+You can specify the preference using `cidr:<valid IPv4/6 CIDR>` or `dns:<globbed name>`.
+You can specify multiple preferences which create an order of preferences.
+If you do not specify a preference, Boundary chooses a value from all available values using a built-in priority order.
+The endpoint preference option may not be valid for all plugin types.
+- `-sync-interval=<string>` - An integer number of a seconds or a string such as `400s`, `5m`, or `6h` that indicates the interval of time between sync operations on the host set.
+The interval is applied to the end of the previous sync operation, not the beginning.
+If you set the interval to a negative value, it disables synchronization for that host set.
+If you set the interval to null, Boundary uses the default value.
+The default value may change between releases.
+
+</Tab>
+
+<Tab heading="static">
+
+The `boundary host-sets update static` command lets you update a static type host set.
+
+#### Example
+
+This example updates a static type host set with the ID `hsst_1234567890` to add the name `devops` and the description `Static host-set for DevOps`:
+
+```shell-session
+$ boundary host-sets update static -id hsst_1234567890 -name "devops" -description "Static host-set for DevOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-sets update static [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### Command options
+
+- `-description=<string>` - The description to set for the static host set.
+- `-id=<string>` - The ID of the static type host set to update.
+- `-name=<string>` - The name to set for the static host set.
+- `-version=<int>` - The version of the static type host set to update.
+If you do not specify a version, the command automatically performs a check-and-set.
+
+</Tab>
+</Tabs>
+
+@include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -785,6 +785,47 @@
             "path": "api-clients/commands/dev"
           },
           {
+            "title": "host-sets",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/host-sets"
+              },
+              {
+                "title": "add-hosts",
+                "path": "api-clients/commands/host-sets/add-hosts"
+              },
+              {
+                "title": "create",
+                "path": "api-clients/commands/host-sets/create"
+              },
+              {
+                "title": "delete",
+                "path": "api-clients/commands/host-sets/delete"
+              },
+              {
+                "title": "list",
+                "path": "api-clients/commands/host-sets/list"
+              },
+              {
+                "title": "read",
+                "path": "api-clients/commands/host-sets/read"
+              },
+              {
+                "title": "remove-hosts",
+                "path": "api-clients/commands/host-sets/remove-hosts"
+              },
+              {
+                "title": "set-hosts",
+                "path": "api-clients/commands/host-sets/set-hosts"
+              },
+              {
+                "title": "update",
+                "path": "api-clients/commands/host-sets/update"
+              }
+            ]
+          },
+          {
             "title": "hosts",
             "routes": [
               {


### PR DESCRIPTION
Adds the `host-sets` commands on top of the existing assembly branch for CLI commands #3411.