### PR TITLE
docs: Add `host-catalogs` commands

### DIFF
--- a/website/content/docs/api-clients/commands/host-catalogs/create.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/create.mdx
@@ -1,0 +1,152 @@
+---
+layout: docs
+page_title: host-catalogs create - Command
+description: |-
+  The "host-catalogs create" command lets you create a new host catalog.
+---
+
+# host-catalogs create
+
+Command: `host-catalogs create`
+
+The `host-catalogs create` command lets you create a new host catalog.
+
+## Example
+
+This example creates a static host catalog with the name `prodops` and the description `For ProdOps usage`:
+
+```shell-session
+$ boundary host-catalogs create static -name prodops -description "For ProdOps usage"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-catalogs create [type] <subcommand> [options] [args]
+
+Please see the typed subcommand help for detailed usage information.
+
+Subcommands:
+    plugin    Create a plugin-type host catalog
+    static    Create a static-type host catalog
+```
+
+</CodeBlockConfig>
+
+### Usages by type
+
+You can create plugin or static host catalog types.
+
+<Tabs>
+<Tab heading="plugin">
+
+The `boundary host-catalogs create plugin` command lets you create a plugin type host catalog.
+
+#### Example
+
+This example creates a plugin type host catalog with the name `prodops` and the description `Plugin host-catalog for ProdOps`, and adds it to a scope with the ID `p_1234567890`.
+
+```shell-session
+$ boundary host-catalogs create plugin -scope-id p_1234567890 -name prodops -description "Plugin host-catalog for ProdOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-catalogs create plugin [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### Command options
+
+- `-description=<string>` - The description to set for the plugin host catalog.
+- `-name=<string>` - The name to set for the plugin host catalog.
+- `-plugin-id=<string>` - The ID of the plugin associated with the host catalog you are creating.
+- `-plugin-name=<string>` - The name of the plugin associated with the host catalog you are creating.
+- `-scope-id=<string>` - The scope in which you want to create the host catalog.
+The default scope is `global`.
+You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
+
+#### Attribute options
+
+- `-attr` - A key=value pair to add to the request's attribute map.
+This option can also be a key value only, which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+You can override the type using `-string-attr`, `-bool-attr`, or `-num-attr`.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-attributes=<string>` - A JSON map value that you can use as the entirety of the request's attributes map.
+Usually this value is sourced from file using "file://" syntax.
+This option is exclusive with other attr flags.
+- `-bool-attr` - A key=value Boolean value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-num-attr` - A key=value numeric value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This attribute supports values from files using "file://" and environment variables using "env://".
+- `-string-attr` - A key=value string value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+
+#### Secrets options
+
+- `-bool-secret` - A key=value Boolean value that you can add to the request's secrets map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-num-secret` - A key=value numeric value that you can add to the request's secrets map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-secret` - A key=value pair that you can add to the request's secrets map.
+This option can also be a key value only, which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+You can override the type using `-string-secret`, `-bool-secret`, or `-num-secret`.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-secrets=<string>` - A JSON map value that you can use as the entirety of the request's secrets map.
+Usually this value is sourced from file using "file://" syntax.
+This option is exclusive with other secret flags.
+- `-string-secret` - A key=value string value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+
+</Tab>
+
+<Tab heading="static">
+
+The `boundary host-catalogs create static` command lets you create a static type host catalog.
+
+#### Example
+
+This example creates a static type host catalog with the name `prodops` and the description `Static host-catalog for ProdOps` and adds it to the scope `p_1234567890`:
+
+```shell-session
+$ boundary host-catalogs create static -scope-id p_1234567890 -name prodops -description "Static host-catalog for ProdOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-catalogs create static [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### Command options
+
+- `-description=<string>` - The description to set for the static host catalog.
+- `-name=<string>` - The name to set for the static host catalog.
+- `-scope-id=<string>` - The scope in which to create the static host catalog.
+The default scope is `global`.
+You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable,
+
+</Tab>
+</Tabs>
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-catalogs/delete.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/delete.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: host-catalogs delete - Command
+description: |-
+  The "host-catalogs delete" command lets you delete a host catalog.
+---
+
+# host-catalogs delete
+
+Command: `host-catalogs delete`
+
+The `host-catalogs delete` command lets you delete an existing host catalog by providing the ID.
+
+## Example
+
+This example deletes a host catalog with the ID `_1234567890`:
+
+```shell-session
+$ boundary host-catalogs delete -id _1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-catalogs delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - The ID of the host catalog to delete.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-catalogs/index.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/index.mdx
@@ -1,0 +1,46 @@
+---
+layout: docs
+page_title: host-catalogs - Command
+description: |-
+  The "host-catalogs" command lets you perform operations on Boundary host catalog resources.
+---
+
+# host-catalogs
+
+Command: `boundary host-catalogs`
+
+The `host-catalogs` command lets you perform operations on Boundary host catalog resources.
+
+## Example
+
+The following command reads a host catalog with the ID `hcst_1234567890`:
+
+```shell-session
+$ boundary host-catalogs read -id hcst_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary host-catalogs <subcommand> [options] [args]
+  # ...
+Subcommands:
+    create    Create a host catalog
+    delete    Delete a host catalog
+    list      List a host catalog
+    read      Read a host catalog
+    update    Update a host catalog
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [create](/boundary/docs/api-clients/commands/host-catalogs/create)
+- [delete](/boundary/docs/api-clients/commands/host-catalogs/delete)
+- [list](/boundary/docs/api-clients/commands/host-catalogs/list)
+- [read](/boundary/docs/api-clients/commands/host-catalogs/read)
+- [update](/boundary/docs/api-clients/commands/host-catalogs/update)

--- a/website/content/docs/api-clients/commands/host-catalogs/list.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/list.mdx
@@ -1,0 +1,44 @@
+---
+layout: docs
+page_title: host-catalogs list - Command
+description: |-
+  The "host-catalogs list" command lists the host catalogs within a given scope or resource.
+---
+
+# host-catalogs list
+
+Command: `boundary host-catalogs list`
+
+The `boundary host-catalogs list` command lets you list the Boundary host catalogs within a given scope or resource.
+
+## Example
+
+This example lists all host catalogs in the scope `_1234567890`.
+The `recursive` option means Boundary runs the operation recursively on any child scopes, if applicable:
+
+```shell-session
+$ boundary host-catalogs list -scope-id _1234567890 -recursive
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-catalogs list [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-filter=<string>` - If you set this value, Boundary filters the list operation before the results are returned.
+The filter operates against each item in the list.
+We recommend that you use single quotes, because the filters contain double quotes.
+Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
+- `-recursive` - If you set this value, Boundary runs the list operation recursively on any child scopes, if the type supports it.
+- `-scope-id=<string>` - The scope from which you want to list host catalogs.
+The default scope is `global`.
+You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-catalogs/read.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/read.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: host-catalogs read - Command
+description: |-
+  The "host-catalogs read" command lets you read a host catalog with a given ID.
+---
+
+# host-catalogs read
+
+Command: `boundary host-catalogs read`
+
+The `boundary host-catalogs read` command lets you read a Boundary host catalog using its given ID.
+
+## Example
+
+This example reads a host catalog with the ID `_1234567890`:
+
+```shell-session
+$ boundary host-catalogs read -id _1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-catalogs read [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - The ID of the host catalog to read.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-catalogs/update.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/update.mdx
@@ -1,0 +1,150 @@
+---
+layout: docs
+page_title: host-catalogs update - Command
+description: |-
+  The "host-catalogs update" command lets you update an existing host catalog.
+---
+
+# host-catalogs update
+
+Command: `host-catalogs update`
+
+The `host-catalogs update` command lets you update an existing host catalog.
+
+## Example
+
+This example updates a static host catalog with the ID `hcst_1234567890` to add the name `devops` and the description `For DevOps usage`:
+
+```shell-session
+$ boundary host-catalogs update static -id hcst_1234567890 -name devops -description "For DevOps usage"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-catalogs update [type] <subcommand> [options] [args]
+
+Please see the typed subcommand help for detailed usage information.
+
+Subcommands:
+    plugin    Update a plugin-type host catalog
+    static    Update a static-type host catalog
+```
+
+</CodeBlockConfig>
+
+### Usages by type
+
+You can update plugin or static host set types.
+
+<Tabs>
+<Tab heading="plugin">
+
+The `boundary host-catalogs update plugin` command lets you update a plugin type host catalog.
+
+#### Example
+
+This example updates a plugin type host catalog with the ID `hc_1234567890` to add the name `devops` and the description `Plugin host-catalog for DevOps`.
+
+```shell-session
+$ boundary host-catalogs update plugin -id hc_1234567890 -name "devops" -description "Plugin host-catalog for DevOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-catalogs update plugin [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### Command options
+
+- `-description=<string>` - The description to set for the plugin host catalog.
+- `-id=<string>` - The ID of the plugin type host catalog to update.
+- `-name=<string>` - The name to set for the plugin host catalog.
+- `-version=<int>` - The version of the plugin host catalog to update.
+If you do not specify a version, the command automatically performs a check-and-set.
+
+#### Attribute options
+
+- `-attr` - A key=value pair to add to the request's attribute map.
+This option can also be a key value only, which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+You can override the type using `-string-attr`, `-bool-attr`, or `-num-attr`.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-attributes=<string>` - A JSON map value that you can use as the entirety of the request's attributes map.
+Usually this value is sourced from file using "file://" syntax.
+This option is exclusive with other attr flags.
+- `-bool-attr` - A key=value Boolean value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-num-attr` - A key=value numeric value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This attribute supports values from files using "file://" and environment variables using "env://".
+- `-string-attr` - A key=value string value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+
+### Secrets options
+
+- `-bool-secret` - A key=value Boolean value that you can add to the request's secrets map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-num-secret` - A key=value numeric value that you can add to the request's secrets map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-secret` - A key=value pair that you can add to the request's secrets map.
+This option can also be a key value only, which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+You can override the type using `-string-secret`, `-bool-secret`, or `-num-secret`.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+- `-secrets=<string>` - A JSON map value that you can use as the entirety of the request's secrets map.
+Usually this value is sourced from file using "file://" syntax.
+This option is exclusive with other secret flags.
+- `-string-secret` - A key=value string value that you can add to the request's attributes map.
+You can specify this value multiple times.
+This option supports values from files using "file://" and environment variables using "env://".
+
+</Tab>
+
+<Tab heading="static">
+
+The `boundary host-catalogs update static` command lets you update a static type host catalog.
+
+#### Example
+
+This example updates a static type host catalog with the ID `hcst_1234567890` to add the name `devops` and the description `Static host-catalog for DevOps`:
+
+```shell-session
+$ boundary host-catalogs update static -id hcst_1234567890 -name "devops" -description "Static host-catalog for DevOps"
+```
+
+#### Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary host-catalogs update static [options] [args]
+```
+
+</CodeBlockConfig>
+
+#### Command options
+
+- `-description=<string>` - The description to set for the static host catalog.
+- `-id=<string>` - The ID of the static type host catalog to update.
+- `-name=<string>` - The name to set for the static host catalog.
+- `-version=<int>` - The version of the static type host catalog to update.
+If you do not specify a version, the command automatically performs a check-and-set.
+
+</Tab>
+</Tabs>
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/read.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/read.mdx
@@ -31,6 +31,6 @@ $ boundary host-sets read [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the host set to read.
+- `-id=<string>` - The ID of the host set to read.
 
 @include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -785,6 +785,35 @@
             "path": "api-clients/commands/dev"
           },
           {
+            "title": "host-catalogs",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/host-catalogs"
+              },
+              {
+                "title": "create",
+                "path": "api-clients/commands/host-catalogs/create"
+              },
+              {
+                "title": "delete",
+                "path": "api-clients/commands/host-catalogs/delete"
+              },
+              {
+                "title": "list",
+                "path": "api-clients/commands/host-catalogs/list"
+              },
+              {
+                "title": "read",
+                "path": "api-clients/commands/host-catalogs/read"
+              },
+              {
+                "title": "update",
+                "path": "api-clients/commands/host-catalogs/update"
+              }
+            ]
+          },
+          {
             "title": "host-sets",
             "routes": [
               {


### PR DESCRIPTION
Adds the `host-catalogs` commands on top of the existing assembly branch for CLI commands #3411.