### PR TITLE
Add 'boundary groups' command docs

### DIFF
--- a/website/content/docs/api-clients/commands/accounts/read.mdx
+++ b/website/content/docs/api-clients/commands/accounts/read.mdx
@@ -65,6 +65,6 @@ $ boundary accounts read [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the account to delete.
+- `-id` `(string: "")` - ID of the account to operate.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/add-members.mdx
+++ b/website/content/docs/api-clients/commands/groups/add-members.mdx
@@ -1,0 +1,77 @@
+---
+layout: docs
+page_title: groups add-members - Command
+description: |-
+  The "groups add-members" command allows Boundary admin to add members (users) to a group.
+---
+
+# groups add-members
+
+Command: `boundary groups add-members`
+
+The `groups add-members` command adds members (users) to a group given its ID.
+
+## Examples
+
+Add a user with ID, "u_qboadM3Q25" to the group with ID, "g_XzlDiNLgoz".
+
+```shell-session
+$ boundary groups add-members -id g_XzlDiNLgoz -member u_qboadM3Q25
+```
+
+**Example output:** 
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Group information:
+  Created Time:        Thu, 24 Aug 2023 09:51:44 PDT
+  Description:         A test group
+  ID:                  g_XzlDiNLgoz
+  Name:                group01
+  Updated Time:        Thu, 24 Aug 2023 11:12:31 PDT
+  Version:             2
+
+  Scope:
+    ID:                o_R0wbo0H6Zl
+    Name:              quick-start-org
+    Parent Scope ID:   global
+    Type:              org
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    add-members
+    set-members
+    remove-members
+
+  Members:
+    ID:                u_qboadM3Q25
+    Scope ID:          o_R0wbo0H6Zl
+```
+
+</CodeBlockConfig>
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$  boundary groups add-members [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-id` `(string: "")` - ID of the group on which to operate.
+
+- `-member` `(string: "")` - ID of the user to be added to the group. The
+  `-member` flag can be specified multiple times.
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/create.mdx
+++ b/website/content/docs/api-clients/commands/groups/create.mdx
@@ -1,0 +1,78 @@
+---
+layout: docs
+page_title: groups create - Command
+description: |-
+  The "groups create" command allows Boundary admin to create a group.
+---
+
+# groups create
+
+Command: `boundary groups create`
+
+The `groups create` command creates a new group.
+
+## Examples
+
+Create a group, "group01" under the "IT_Support" organization.
+
+```shell-session
+$ boundary groups create -name "group01" \
+   -description "A test group" \
+   -scope-id o_R0wbo0H6Zl
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Group information:
+  Created Time:        Thu, 24 Aug 2023 09:51:44 PDT
+  Description:         A test group
+  ID:                  g_XzlDiNLgoz
+  Name:                group01
+  Updated Time:        Thu, 24 Aug 2023 09:51:44 PDT
+  Version:             1
+
+  Scope:
+    ID:                o_R0wbo0H6Zl
+    Name:              quick-start-org
+    Parent Scope ID:   global
+    Type:              org
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    add-members
+    set-members
+    remove-members
+```
+
+</CodeBlockConfig>
+
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary groups create [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-description` `(string: "")` - Description to set on the group.
+
+- `-name` `(string: "")` - Name to set on the group.
+
+- `-scope-id` `(string: "")` - Scope in which to make the request. The default
+   is global. This can also be specified via the BOUNDARY_SCOPE_ID environment
+   variable.
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/delete.mdx
+++ b/website/content/docs/api-clients/commands/groups/delete.mdx
@@ -1,0 +1,39 @@
+---
+layout: docs
+page_title: groups delete - Command
+description: |-
+  The "groups delete" command allows Boundary admin to delete a group resource.
+---
+
+# groups delete
+
+Command: `boundary groups delete`
+
+The `groups delete` command deletes an existing group.
+
+
+## Examples
+
+Delete a group with the given ID (`g_FNVVhAd0on`). 
+
+```shell-session
+$ boundary groups delete -id g_FNVVhAd0on
+The delete operation completed successfully.
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary groups delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-id` `(string: "")` - ID of the groups to delete.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/index.mdx
+++ b/website/content/docs/api-clients/commands/groups/index.mdx
@@ -1,0 +1,94 @@
+---
+layout: docs
+page_title: groups - Command
+description: |-
+  The "groups" command allows Boundary admin to create and manage the group resources.
+---
+
+# groups
+
+Command: `boundary groups`
+
+The `groups` command create and manage the group resource in Boundary.
+
+A group in Boundary is a resource that represents a collection of users that are
+treated equally for the purposes of access control. A group is a principal,
+which allows it to be assigned to roles. Roles assigned to a group are
+indirectly assigned to the users in the group, and users receive all permissions
+of the assigned roles. Groups can be defined at the global, organization, or
+project scope.
+
+## Examples
+
+Create a group, "group01" under the "IT_Support" organization.
+
+```shell-session
+$ boundary groups create -name "group01" \
+   -description "A test group" \
+   -scope-id o_R0wbo0H6Zl
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Group information:
+  Created Time:        Thu, 24 Aug 2023 09:51:44 PDT
+  Description:         A test group
+  ID:                  g_XzlDiNLgoz
+  Name:                group01
+  Updated Time:        Thu, 24 Aug 2023 09:51:44 PDT
+  Version:             1
+
+  Scope:
+    ID:                o_R0wbo0H6Zl
+    Name:              quick-start-org
+    Parent Scope ID:   global
+    Type:              org
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    add-members
+    set-members
+    remove-members
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary groups [sub command] [options] [args]
+
+  # ...
+
+Subcommands:
+    add-members       Add members to a group
+    create            Create a group
+    delete            Delete a group
+    list              List a group
+    read              Read a group
+    remove-members    Remove members from a group
+    set-members       Set the full contents of the members on a group
+    update            Update a group
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [add-members](/boundary/docs/api-clients/commands/groups/add-members)
+- [create](/boundary/docs/api-clients/commands/groups/create)
+- [delete](/boundary/docs/api-clients/commands/groups/delete)
+- [list](/boundary/docs/api-clients/commands/groups/list)
+- [read](/boundary/docs/api-clients/commands/groups/read)
+- [remove-members](/boundary/docs/api-clients/commands/groups/remove-members)
+- [set-members](/boundary/docs/api-clients/commands/groups/set-members)
+- [update](/boundary/docs/api-clients/commands/groups/update)

--- a/website/content/docs/api-clients/commands/groups/list.mdx
+++ b/website/content/docs/api-clients/commands/groups/list.mdx
@@ -1,0 +1,98 @@
+---
+layout: docs
+page_title: groups list - Command
+description: |-
+  The "groups list" command allows Boundary admin to list groups within an enclosing scope or resource.
+---
+
+# groups list
+
+Command: `boundary groups list`
+
+The `groups list` command lists all groups within an enclosing scope or
+resource.
+
+## Examples
+
+List all groups defined within an organization where the org ID is
+"o_R0wbo0H6Zl". 
+
+```shell-session
+$ boundary groups list -scope-id o_R0wbo0H6Zl
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Group information:
+  ID:                    g_XzlDiNLgoz
+    Version:             2
+    Name:                group01
+    Description:         A test group
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+      add-members
+      set-members
+      remove-members
+
+  ID:                    g_FNVVhAd0on
+    Version:             1
+    Name:                webdev
+    Description:         Web dev group
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+      add-members
+      set-members
+      remove-members
+
+  ID:                    g_9SpLKOoTse
+    Version:             1
+    Name:                support
+    Description:         Support engineering group
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+      add-members
+      set-members
+      remove-members
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary groups list [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-filter` `(string: "")` - If set, the list operation will be filtered before
+   being returned. The filter operates against each item in the list. Using
+   single quotes is recommended as filters contain double quotes. 
+
+- `-recursive`  - If set, the list operation will be applied
+   recursively into child scopes, if supported by the type. The default is
+   false.
+
+- `-scope-id ``(string: "")` - Scope in which to make the request. The default
+  is global. This can also be specified via the `BOUNDARY_SCOPE_ID` environment
+  variable.
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/read.mdx
+++ b/website/content/docs/api-clients/commands/groups/read.mdx
@@ -1,0 +1,73 @@
+---
+layout: docs
+page_title: groups read - Command
+description: |-
+  The "groups read" command allows Boundary admin to read a group resource.
+---
+
+# groups read
+
+Command: `boundary groups read`
+
+The `groups read` command retrieves the group details for a given ID.
+
+
+## Examples
+
+Retrieves the group information for a group with ID, `g_XzlDiNLgoz`.
+
+```shell-session
+$ boundary groups read -id g_XzlDiNLgoz
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Group information:
+  Created Time:        Thu, 24 Aug 2023 09:51:44 PDT
+  Description:         A test group
+  ID:                  g_XzlDiNLgoz
+  Name:                group01
+  Updated Time:        Thu, 24 Aug 2023 11:12:31 PDT
+  Version:             2
+
+  Scope:
+    ID:                o_R0wbo0H6Zl
+    Name:              quick-start-org
+    Parent Scope ID:   global
+    Type:              org
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    add-members
+    set-members
+    remove-members
+
+  Members:
+    ID:                u_qboadM3Q25
+    Scope ID:          o_R0wbo0H6Zl
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary groups read [options] [args]
+```
+
+</CodeBlockConfig>
+
+
+### Command options
+
+- `-id` `(string: "")` - ID of the groups to operate.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/remove-members.mdx
+++ b/website/content/docs/api-clients/commands/groups/remove-members.mdx
@@ -1,0 +1,79 @@
+---
+layout: docs
+page_title: groups remove-members - Command
+description: |-
+  The "groups remove-members" command allows Boundary admin to remove members (users) from a group given its ID..
+---
+
+# groups remove-members
+
+Command: `boundary groups remove-members`
+
+The `groups remove-members` command removes members (users) from a group given
+its ID.
+
+## Examples
+
+Remove a user with ID, `u_J5l9FWB7yq` from "webdev" group where its group ID is
+`g_FNVVhAd0on`.
+
+```shell-session
+$ boundary groups remove-members -id g_FNVVhAd0on \
+   -member u_J5l9FWB7yq
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Group information:
+  Created Time:        Thu, 24 Aug 2023 13:58:23 PDT
+  Description:         Web dev group
+  ID:                  g_FNVVhAd0on
+  Name:                webdev
+  Updated Time:        Thu, 24 Aug 2023 14:21:05 PDT
+  Version:             3
+
+  Scope:
+    ID:                o_R0wbo0H6Zl
+    Name:              quick-start-org
+    Parent Scope ID:   global
+    Type:              org
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    add-members
+    set-members
+    remove-members
+
+  Members:
+    ID:                u_ad8tbsXHJP
+    Scope ID:          o_R0wbo0H6Zl
+```
+
+</CodeBlockConfig>
+
+The output displays the group information.
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary groups remove-members [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id` `(string: "")` - ID of the group on which to operate.
+
+- `-member` `(string: "")` - ID of the user to be added to the group. The
+  `-member` flag can be specified multiple times.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/set-members.mdx
+++ b/website/content/docs/api-clients/commands/groups/set-members.mdx
@@ -1,0 +1,84 @@
+---
+layout: docs
+page_title: groups set-members - Command
+description: |-
+  The "groups set-members" command allows Boundary admin to set the complete set of members (users) on a group given its ID. 
+---
+
+# groups set-members
+
+Command: `boundary groups set-members`
+
+The `groups set-members` command sets the complete set of members (users) on a
+group given its ID. 
+
+## Examples
+
+Set users with ID, "`u_ad8tbsXHJP`" and "`u_J5l9FWB7yq`" as group members to
+"webdev" group where its group ID is `g_FNVVhAd0on`.
+
+```shell-session
+$ boundary groups set-members -id g_FNVVhAd0on \
+   -member u_ad8tbsXHJP \
+   -member u_J5l9FWB7yq
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Group information:
+  Created Time:        Thu, 24 Aug 2023 13:58:23 PDT
+  Description:         Web dev group
+  ID:                  g_FNVVhAd0on
+  Name:                webdev
+  Updated Time:        Thu, 24 Aug 2023 14:12:35 PDT
+  Version:             2
+
+  Scope:
+    ID:                o_R0wbo0H6Zl
+    Name:              quick-start-org
+    Parent Scope ID:   global
+    Type:              org
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    add-members
+    set-members
+    remove-members
+
+  Members:
+    ID:                u_ad8tbsXHJP
+    Scope ID:          o_R0wbo0H6Zl
+
+    ID:                u_J5l9FWB7yq
+    Scope ID:          o_R0wbo0H6Z
+```
+
+</CodeBlockConfig>
+
+The output displays the group information.
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary groups set-members [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id` `(string: "")` - ID of the group on which to operate.
+
+- `-member` `(string: "")` - ID of the user to be added to the group. The
+  `-member` flag can be specified multiple times.
+
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/update.mdx
+++ b/website/content/docs/api-clients/commands/groups/update.mdx
@@ -1,0 +1,94 @@
+---
+layout: docs
+page_title: groups update - Command
+description: |-
+  The "groups update" command allows Boundary admin to update a group resource.
+---
+
+# groups update
+
+Command: `boundary groups update`
+
+The `groups update` command updates an existing group information.
+
+## Examples
+
+An existing group (`g_9SpLKOoTse`) has the following detail. 
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Group information:
+  Created Time:        Thu, 24 Aug 2023 13:58:50 PDT
+  Description:         Support engineering group
+  ID:                  g_9SpLKOoTse
+  Name:                support
+  Updated Time:        Thu, 24 Aug 2023 13:58:50 PDT
+  Version:             3
+
+...snip...
+```
+
+</CodeBlockConfig>
+
+Update the name, login name, and description.
+
+```shell-session
+$ boundary groups update -id g_9SpLKOoTse \
+   -description "Customer support for product XXX" \
+   -version 3
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard highlight="3,7">
+
+```plaintext
+Group information:
+  Created Time:        Thu, 24 Aug 2023 13:58:50 PDT
+  Description:         Customer support for product XXX
+  ID:                  g_9SpLKOoTse
+  Name:                support
+  Updated Time:        Thu, 24 Aug 2023 14:33:18 PDT
+  Version:             4
+
+  Scope:
+    ID:                o_R0wbo0H6Zl
+    Name:              quick-start-org
+    Parent Scope ID:   global
+    Type:              org
+
+  Authorized Actions:
+    no-op
+    read
+    update
+    delete
+    add-members
+    set-members
+    remove-members
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary groups update [options] [args]
+```
+
+</CodeBlockConfig>
+
+The available types are: `ldap`, `oidc`, and `password`.
+
+### Command options
+
+- `-description` `(string: "")` - Description to set on the groups.
+- `-id` `(string: "")` - ID of the groups on which to operate.
+- `-name` `(string: "")` - Name to set on the groups.
+- `-version` `(string: "")` - The version of the groups against which to
+   perform an update operation. If not specified, the command will perform a
+   check-and-set automatically.
+
+@include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -785,6 +785,47 @@
             "path": "api-clients/commands/dev"
           },
           {
+            "title": "groups",
+            "routes": [
+              {
+                "title": "Overview",
+                "path": "api-clients/commands/groups"
+              },
+              {
+                "title": "add-members",
+                "path": "api-clients/commands/groups/add-members"
+              },
+              {
+                "title": "create",
+                "path": "api-clients/commands/groups/create"
+              },
+              {
+                "title": "delete",
+                "path": "api-clients/commands/groups/delete"
+              },
+              {
+                "title": "list",
+                "path": "api-clients/commands/groups/list"
+              },
+              {
+                "title": "read",
+                "path": "api-clients/commands/groups/read"
+              },
+              {
+                "title": "remove-members",
+                "path": "api-clients/commands/groups/remove-members"
+              },
+              {
+                "title": "set-members",
+                "path": "api-clients/commands/groups/set-members"
+              },
+              {
+                "title": "update",
+                "path": "api-clients/commands/groups/update"
+              }
+            ]
+          },
+          {
             "title": "logout",
             "path": "api-clients/commands/logout"
           },


### PR DESCRIPTION
This PR adds the docs for `boundary groups` commands on top of https://github.com/hashicorp/boundary/pull/3411