### PR TITLE
fix (migrations): drop constraint iam_scope_fkey on oplog_entry

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/76/01_oplog_entry_drop_scope_id_fk.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/76/01_oplog_entry_drop_scope_id_fk.up.sql
@@ -1,0 +1,9 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+
+  alter table oplog_entry
+    drop constraint iam_scope_fkey;
+
+commit;


### PR DESCRIPTION
The existing FK from iam_scope(public_id) means that oplog entries are deleted when a scope is deleted.  We should not be deleting these oplog entries.  Dropping the FK will stop this cascading delete.  Of course, we still need the scope_id on in the oplog_entry table and the existing on insert trigger will make sure the scope id is valid.