### PR TITLE
genapi: add pagination support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## Next
 
+* List Endpoint Pagination: All list endpoints now support paginating through
+  results.
+  * api: All list endpoint functions have added support for pagination. The new
+    WithRefreshToken and WithPageSize options can be used to control pagination.
+    If no refresh token is provided, the list endpoint function will automatically
+    page through the whole result set.
+
 ### Bug Fixes
 
 * LDAP auth methods: allow bind-dn and bind-password to be updated

--- a/api/accounts/account.gen.go
+++ b/api/accounts/account.gen.go
@@ -62,12 +62,32 @@ func (n AccountDeleteResult) GetResponse() *api.Response {
 }
 
 type AccountListResult struct {
-	Items    []*Account
-	response *api.Response
+	Items        []*Account `json:"items,omitempty"`
+	EstItemCount uint       `json:"est_item_count,omitempty"`
+	RemovedIds   []string   `json:"removed_ids,omitempty"`
+	RefreshToken string     `json:"refresh_token,omitempty"`
+	ResponseType string     `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n AccountListResult) GetItems() []*Account {
 	return n.Items
+}
+
+func (n AccountListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n AccountListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n AccountListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n AccountListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n AccountListResult) GetResponse() *api.Response {
@@ -320,5 +340,47 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "accounts", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(AccountListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }

--- a/api/accounts/option.gen.go
+++ b/api/accounts/option.gen.go
@@ -5,6 +5,7 @@
 package accounts
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -25,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -48,6 +51,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	return opts, apiOpts
 }
 
@@ -66,6 +75,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/authmethods/option.gen.go
+++ b/api/authmethods/option.gen.go
@@ -26,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -50,6 +52,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -71,6 +79,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -60,12 +60,32 @@ func (n AuthTokenDeleteResult) GetResponse() *api.Response {
 }
 
 type AuthTokenListResult struct {
-	Items    []*AuthToken
-	response *api.Response
+	Items        []*AuthToken `json:"items,omitempty"`
+	EstItemCount uint         `json:"est_item_count,omitempty"`
+	RemovedIds   []string     `json:"removed_ids,omitempty"`
+	RefreshToken string       `json:"refresh_token,omitempty"`
+	ResponseType string       `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n AuthTokenListResult) GetItems() []*AuthToken {
 	return n.Items
+}
+
+func (n AuthTokenListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n AuthTokenListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n AuthTokenListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n AuthTokenListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n AuthTokenListResult) GetResponse() *api.Response {
@@ -211,5 +231,47 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "auth-tokens", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(AuthTokenListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }

--- a/api/authtokens/option.gen.go
+++ b/api/authtokens/option.gen.go
@@ -26,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -50,6 +52,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -61,6 +69,22 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/credentiallibraries/credential_library.gen.go
+++ b/api/credentiallibraries/credential_library.gen.go
@@ -63,12 +63,32 @@ func (n CredentialLibraryDeleteResult) GetResponse() *api.Response {
 }
 
 type CredentialLibraryListResult struct {
-	Items    []*CredentialLibrary
-	response *api.Response
+	Items        []*CredentialLibrary `json:"items,omitempty"`
+	EstItemCount uint                 `json:"est_item_count,omitempty"`
+	RemovedIds   []string             `json:"removed_ids,omitempty"`
+	RefreshToken string               `json:"refresh_token,omitempty"`
+	ResponseType string               `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n CredentialLibraryListResult) GetItems() []*CredentialLibrary {
 	return n.Items
+}
+
+func (n CredentialLibraryListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n CredentialLibraryListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n CredentialLibraryListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n CredentialLibraryListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n CredentialLibraryListResult) GetResponse() *api.Response {
@@ -326,5 +346,47 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "credential-libraries", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(CredentialLibraryListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }

--- a/api/credentiallibraries/option.gen.go
+++ b/api/credentiallibraries/option.gen.go
@@ -5,6 +5,7 @@
 package credentiallibraries
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -25,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -48,6 +51,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	return opts, apiOpts
 }
 
@@ -66,6 +75,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/credentials/credential.gen.go
+++ b/api/credentials/credential.gen.go
@@ -61,12 +61,32 @@ func (n CredentialDeleteResult) GetResponse() *api.Response {
 }
 
 type CredentialListResult struct {
-	Items    []*Credential
-	response *api.Response
+	Items        []*Credential `json:"items,omitempty"`
+	EstItemCount uint          `json:"est_item_count,omitempty"`
+	RemovedIds   []string      `json:"removed_ids,omitempty"`
+	RefreshToken string        `json:"refresh_token,omitempty"`
+	ResponseType string        `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n CredentialListResult) GetItems() []*Credential {
 	return n.Items
+}
+
+func (n CredentialListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n CredentialListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n CredentialListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n CredentialListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n CredentialListResult) GetResponse() *api.Response {
@@ -324,5 +344,47 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "credentials", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(CredentialListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }

--- a/api/credentials/option.gen.go
+++ b/api/credentials/option.gen.go
@@ -5,6 +5,7 @@
 package credentials
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -25,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -48,6 +51,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	return opts, apiOpts
 }
 
@@ -66,6 +75,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/credentialstores/credential_store.gen.go
+++ b/api/credentialstores/credential_store.gen.go
@@ -62,12 +62,32 @@ func (n CredentialStoreDeleteResult) GetResponse() *api.Response {
 }
 
 type CredentialStoreListResult struct {
-	Items    []*CredentialStore
-	response *api.Response
+	Items        []*CredentialStore `json:"items,omitempty"`
+	EstItemCount uint               `json:"est_item_count,omitempty"`
+	RemovedIds   []string           `json:"removed_ids,omitempty"`
+	RefreshToken string             `json:"refresh_token,omitempty"`
+	ResponseType string             `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n CredentialStoreListResult) GetItems() []*CredentialStore {
 	return n.Items
+}
+
+func (n CredentialStoreListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n CredentialStoreListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n CredentialStoreListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n CredentialStoreListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n CredentialStoreListResult) GetResponse() *api.Response {
@@ -325,5 +345,47 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "credential-stores", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(CredentialStoreListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }

--- a/api/credentialstores/option.gen.go
+++ b/api/credentialstores/option.gen.go
@@ -26,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -50,6 +52,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -71,6 +79,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/groups/option.gen.go
+++ b/api/groups/option.gen.go
@@ -26,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -50,6 +52,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -71,6 +79,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/hostcatalogs/host_catalog.gen.go
+++ b/api/hostcatalogs/host_catalog.gen.go
@@ -67,12 +67,32 @@ func (n HostCatalogDeleteResult) GetResponse() *api.Response {
 }
 
 type HostCatalogListResult struct {
-	Items    []*HostCatalog
-	response *api.Response
+	Items        []*HostCatalog `json:"items,omitempty"`
+	EstItemCount uint           `json:"est_item_count,omitempty"`
+	RemovedIds   []string       `json:"removed_ids,omitempty"`
+	RefreshToken string         `json:"refresh_token,omitempty"`
+	ResponseType string         `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n HostCatalogListResult) GetItems() []*HostCatalog {
 	return n.Items
+}
+
+func (n HostCatalogListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n HostCatalogListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n HostCatalogListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n HostCatalogListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n HostCatalogListResult) GetResponse() *api.Response {
@@ -330,5 +350,47 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "host-catalogs", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(HostCatalogListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }

--- a/api/hostcatalogs/option.gen.go
+++ b/api/hostcatalogs/option.gen.go
@@ -27,6 +27,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -51,6 +53,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -72,6 +80,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/hosts/host.gen.go
+++ b/api/hosts/host.gen.go
@@ -68,12 +68,32 @@ func (n HostDeleteResult) GetResponse() *api.Response {
 }
 
 type HostListResult struct {
-	Items    []*Host
-	response *api.Response
+	Items        []*Host  `json:"items,omitempty"`
+	EstItemCount uint     `json:"est_item_count,omitempty"`
+	RemovedIds   []string `json:"removed_ids,omitempty"`
+	RefreshToken string   `json:"refresh_token,omitempty"`
+	ResponseType string   `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n HostListResult) GetItems() []*Host {
 	return n.Items
+}
+
+func (n HostListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n HostListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n HostListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n HostListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n HostListResult) GetResponse() *api.Response {
@@ -326,5 +346,47 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "hosts", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(HostListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }

--- a/api/hosts/option.gen.go
+++ b/api/hosts/option.gen.go
@@ -5,6 +5,7 @@
 package hosts
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -25,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -48,6 +51,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	return opts, apiOpts
 }
 
@@ -66,6 +75,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/hostsets/host_set.gen.go
+++ b/api/hostsets/host_set.gen.go
@@ -66,12 +66,32 @@ func (n HostSetDeleteResult) GetResponse() *api.Response {
 }
 
 type HostSetListResult struct {
-	Items    []*HostSet
-	response *api.Response
+	Items        []*HostSet `json:"items,omitempty"`
+	EstItemCount uint       `json:"est_item_count,omitempty"`
+	RemovedIds   []string   `json:"removed_ids,omitempty"`
+	RefreshToken string     `json:"refresh_token,omitempty"`
+	ResponseType string     `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n HostSetListResult) GetItems() []*HostSet {
 	return n.Items
+}
+
+func (n HostSetListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n HostSetListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n HostSetListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n HostSetListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n HostSetListResult) GetResponse() *api.Response {
@@ -324,7 +344,49 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "host-sets", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(HostSetListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }
 
 func (c *Client) AddHosts(ctx context.Context, id string, version uint32, hostIds []string, opt ...Option) (*HostSetUpdateResult, error) {

--- a/api/hostsets/option.gen.go
+++ b/api/hostsets/option.gen.go
@@ -5,6 +5,7 @@
 package hostsets
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -25,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -48,6 +51,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	return opts, apiOpts
 }
 
@@ -66,6 +75,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/managedgroups/managedgroups.gen.go
+++ b/api/managedgroups/managedgroups.gen.go
@@ -62,12 +62,32 @@ func (n ManagedGroupDeleteResult) GetResponse() *api.Response {
 }
 
 type ManagedGroupListResult struct {
-	Items    []*ManagedGroup
-	response *api.Response
+	Items        []*ManagedGroup `json:"items,omitempty"`
+	EstItemCount uint            `json:"est_item_count,omitempty"`
+	RemovedIds   []string        `json:"removed_ids,omitempty"`
+	RefreshToken string          `json:"refresh_token,omitempty"`
+	ResponseType string          `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n ManagedGroupListResult) GetItems() []*ManagedGroup {
 	return n.Items
+}
+
+func (n ManagedGroupListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n ManagedGroupListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n ManagedGroupListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n ManagedGroupListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n ManagedGroupListResult) GetResponse() *api.Response {
@@ -320,5 +340,47 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "managed-groups", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(ManagedGroupListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }

--- a/api/managedgroups/option.gen.go
+++ b/api/managedgroups/option.gen.go
@@ -5,6 +5,7 @@
 package managedgroups
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -25,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -48,6 +51,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	return opts, apiOpts
 }
 
@@ -66,6 +75,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/roles/option.gen.go
+++ b/api/roles/option.gen.go
@@ -26,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -50,6 +52,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -71,6 +79,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/roles/role.gen.go
+++ b/api/roles/role.gen.go
@@ -64,12 +64,32 @@ func (n RoleDeleteResult) GetResponse() *api.Response {
 }
 
 type RoleListResult struct {
-	Items    []*Role
-	response *api.Response
+	Items        []*Role  `json:"items,omitempty"`
+	EstItemCount uint     `json:"est_item_count,omitempty"`
+	RemovedIds   []string `json:"removed_ids,omitempty"`
+	RefreshToken string   `json:"refresh_token,omitempty"`
+	ResponseType string   `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n RoleListResult) GetItems() []*Role {
 	return n.Items
+}
+
+func (n RoleListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n RoleListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n RoleListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n RoleListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n RoleListResult) GetResponse() *api.Response {
@@ -322,7 +342,49 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "roles", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(RoleListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }
 
 func (c *Client) AddGrants(ctx context.Context, id string, version uint32, grantStrings []string, opt ...Option) (*RoleUpdateResult, error) {

--- a/api/scopes/option.gen.go
+++ b/api/scopes/option.gen.go
@@ -27,6 +27,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -51,6 +53,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -72,6 +80,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/scopes/scope.gen.go
+++ b/api/scopes/scope.gen.go
@@ -61,12 +61,32 @@ func (n ScopeDeleteResult) GetResponse() *api.Response {
 }
 
 type ScopeListResult struct {
-	Items    []*Scope
-	response *api.Response
+	Items        []*Scope `json:"items,omitempty"`
+	EstItemCount uint     `json:"est_item_count,omitempty"`
+	RemovedIds   []string `json:"removed_ids,omitempty"`
+	RefreshToken string   `json:"refresh_token,omitempty"`
+	ResponseType string   `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n ScopeListResult) GetItems() []*Scope {
 	return n.Items
+}
+
+func (n ScopeListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n ScopeListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n ScopeListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n ScopeListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n ScopeListResult) GetResponse() *api.Response {
@@ -319,5 +339,47 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Scop
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "scopes", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(ScopeListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }

--- a/api/sessionrecordings/option.gen.go
+++ b/api/sessionrecordings/option.gen.go
@@ -25,6 +25,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -49,6 +51,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -60,6 +68,22 @@ func getOpts(opt ...Option) (options, []api.Option) {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/sessions/option.gen.go
+++ b/api/sessions/option.gen.go
@@ -27,6 +27,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -51,6 +53,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -72,6 +80,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/sessions/session.gen.go
+++ b/api/sessions/session.gen.go
@@ -69,12 +69,32 @@ func (n SessionDeleteResult) GetResponse() *api.Response {
 }
 
 type SessionListResult struct {
-	Items    []*Session
-	response *api.Response
+	Items        []*Session `json:"items,omitempty"`
+	EstItemCount uint       `json:"est_item_count,omitempty"`
+	RemovedIds   []string   `json:"removed_ids,omitempty"`
+	RefreshToken string     `json:"refresh_token,omitempty"`
+	ResponseType string     `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n SessionListResult) GetItems() []*Session {
 	return n.Items
+}
+
+func (n SessionListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n SessionListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n SessionListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n SessionListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n SessionListResult) GetResponse() *api.Response {
@@ -178,5 +198,47 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "sessions", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(SessionListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }

--- a/api/storagebuckets/option.gen.go
+++ b/api/storagebuckets/option.gen.go
@@ -27,6 +27,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -51,6 +53,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -72,6 +80,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/storagebuckets/storage_bucket.gen.go
+++ b/api/storagebuckets/storage_bucket.gen.go
@@ -69,12 +69,32 @@ func (n StorageBucketDeleteResult) GetResponse() *api.Response {
 }
 
 type StorageBucketListResult struct {
-	Items    []*StorageBucket
-	response *api.Response
+	Items        []*StorageBucket `json:"items,omitempty"`
+	EstItemCount uint             `json:"est_item_count,omitempty"`
+	RemovedIds   []string         `json:"removed_ids,omitempty"`
+	RefreshToken string           `json:"refresh_token,omitempty"`
+	ResponseType string           `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n StorageBucketListResult) GetItems() []*StorageBucket {
 	return n.Items
+}
+
+func (n StorageBucketListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n StorageBucketListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n StorageBucketListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n StorageBucketListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n StorageBucketListResult) GetResponse() *api.Response {
@@ -327,5 +347,47 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Stor
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "storage-buckets", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(StorageBucketListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }

--- a/api/targets/option.gen.go
+++ b/api/targets/option.gen.go
@@ -26,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -50,6 +52,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -71,6 +79,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/targets/target.gen.go
+++ b/api/targets/target.gen.go
@@ -75,12 +75,32 @@ func (n TargetDeleteResult) GetResponse() *api.Response {
 }
 
 type TargetListResult struct {
-	Items    []*Target
-	response *api.Response
+	Items        []*Target `json:"items,omitempty"`
+	EstItemCount uint      `json:"est_item_count,omitempty"`
+	RemovedIds   []string  `json:"removed_ids,omitempty"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	ResponseType string    `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n TargetListResult) GetItems() []*Target {
 	return n.Items
+}
+
+func (n TargetListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n TargetListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n TargetListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n TargetListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n TargetListResult) GetResponse() *api.Response {
@@ -338,7 +358,49 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "targets", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(TargetListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }
 
 func (c *Client) AddCredentialSources(ctx context.Context, id string, version uint32, opt ...Option) (*TargetUpdateResult, error) {

--- a/api/users/option.gen.go
+++ b/api/users/option.gen.go
@@ -26,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -50,6 +52,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -71,6 +79,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/users/user.gen.go
+++ b/api/users/user.gen.go
@@ -65,12 +65,32 @@ func (n UserDeleteResult) GetResponse() *api.Response {
 }
 
 type UserListResult struct {
-	Items    []*User
-	response *api.Response
+	Items        []*User  `json:"items,omitempty"`
+	EstItemCount uint     `json:"est_item_count,omitempty"`
+	RemovedIds   []string `json:"removed_ids,omitempty"`
+	RefreshToken string   `json:"refresh_token,omitempty"`
+	ResponseType string   `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n UserListResult) GetItems() []*User {
 	return n.Items
+}
+
+func (n UserListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n UserListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n UserListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n UserListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n UserListResult) GetResponse() *api.Response {
@@ -323,7 +343,49 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*User
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "users", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(UserListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }
 
 func (c *Client) AddAccounts(ctx context.Context, id string, version uint32, accountIds []string, opt ...Option) (*UserUpdateResult, error) {

--- a/api/workers/option.gen.go
+++ b/api/workers/option.gen.go
@@ -26,6 +26,8 @@ type options struct {
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
 	withFilter              string
+	withRefreshToken        string
+	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -50,6 +52,12 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withFilter != "" {
 		opts.queryMap["filter"] = opts.withFilter
 	}
+	if opts.withRefreshToken != "" {
+		opts.queryMap["refresh_token"] = opts.withRefreshToken
+	}
+	if opts.withPageSize != 0 {
+		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
+	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -71,6 +79,22 @@ func WithAutomaticVersioning(enable bool) Option {
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
 		o.withSkipCurlOutput = true
+	}
+}
+
+// WithRefreshToken tells the API to use the provided refresh token
+// for listing operations on this resource.
+func WithRefreshToken(refreshToken string) Option {
+	return func(o *options) {
+		o.withRefreshToken = refreshToken
+	}
+}
+
+// WithPageSize tells the API use the provided page size for listing
+// opertaions on this resource.
+func WithPageSize(pageSize uint) Option {
+	return func(o *options) {
+		o.withPageSize = pageSize
 	}
 }
 

--- a/api/workers/worker.gen.go
+++ b/api/workers/worker.gen.go
@@ -70,12 +70,32 @@ func (n WorkerDeleteResult) GetResponse() *api.Response {
 }
 
 type WorkerListResult struct {
-	Items    []*Worker
-	response *api.Response
+	Items        []*Worker `json:"items,omitempty"`
+	EstItemCount uint      `json:"est_item_count,omitempty"`
+	RemovedIds   []string  `json:"removed_ids,omitempty"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	ResponseType string    `json:"response_type,omitempty"`
+	response     *api.Response
 }
 
 func (n WorkerListResult) GetItems() []*Worker {
 	return n.Items
+}
+
+func (n WorkerListResult) GetEstItemCount() uint {
+	return n.EstItemCount
+}
+
+func (n WorkerListResult) GetRemovedIds() []string {
+	return n.RemovedIds
+}
+
+func (n WorkerListResult) GetRefreshToken() string {
+	return n.RefreshToken
+}
+
+func (n WorkerListResult) GetResponseType() string {
+	return n.ResponseType
 }
 
 func (n WorkerListResult) GetResponse() *api.Response {
@@ -377,7 +397,49 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Work
 		return nil, apiErr
 	}
 	target.response = resp
-	return target, nil
+	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+		return target, nil
+	}
+	// if refresh token is not set explicitly and there are more results,
+	// automatically fetch the rest of the results.
+	for {
+		req, err := c.client.NewRequest(ctx, "GET", "workers", nil, apiOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating List request: %w", err)
+		}
+
+		opts.queryMap["refresh_token"] = target.RefreshToken
+		if len(opts.queryMap) > 0 {
+			q := url.Values{}
+			for k, v := range opts.queryMap {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error performing client request during List call: %w", err)
+		}
+
+		page := new(WorkerListResult)
+		apiErr, err := resp.Decode(page)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding List response: %w", err)
+		}
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		target.Items = append(target.Items, page.Items...)
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
+		target.EstItemCount = page.EstItemCount
+		target.RefreshToken = page.RefreshToken
+		target.ResponseType = page.ResponseType
+		target.response = resp
+		if target.ResponseType == "complete" {
+			return target, nil
+		}
+	}
 }
 
 func (c *Client) AddWorkerTags(ctx context.Context, id string, version uint32, apiTags map[string][]string, opt ...Option) (*WorkerUpdateResult, error) {


### PR DESCRIPTION
Adds the `WithRefreshToken` and `WithPageSize` options to specify list pagination parameters. If a refresh token is not set, list functions will automatically page through the entire result set.

This new functionality is exercised by https://github.com/hashicorp/boundary/blob/main/internal/daemon/controller/gateway_test.go.