### PR TITLE
Finish Uploading BSR During Forced Worker Shutdown

### DIFF
--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -257,7 +257,8 @@ func New(ctx context.Context, conf *Config) (*Worker, error) {
 			}
 		}
 
-		s, err := recordingStorageFactory(ctx, w.conf.RawConfig.Worker.RecordingStoragePath, plgClients, enableStorageLoopback)
+		// passing in an empty context so that storage can finish syncing during an emergency shutdown or interrupt
+		s, err := recordingStorageFactory(context.Background(), w.conf.RawConfig.Worker.RecordingStoragePath, plgClients, enableStorageLoopback)
 		if err != nil {
 			return nil, fmt.Errorf("error create recording storage: %w", err)
 		}


### PR DESCRIPTION
give the storage struct an empty context so that it can close cleanly during a forced shutdown. fixes an issue where if a worker is forced to shut down via double ctrl-c, the session recording is missing all recording data. (bsr file only contained keys on aws)

tested via command line worker and killed with double ctrl-c