### PR TITLE
docs: Edit `auth-methods` options

### DIFF
--- a/website/content/docs/api-clients/commands/auth-methods/change-state.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/change-state.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: auth-methods change-state - Command
 description: |-
-  The "auth-methods change-state" command allows Boundary admin to change-state of an auth method.
+  The "auth-methods change-state" command lets Boundary admin change the state of an auth method.
 ---
 
 # auth-methods change-state
@@ -10,34 +10,32 @@ description: |-
 Command: `boundary auth-methods change-state`
 
 The `auth-methods change-state` command changes the active and visibility state
-of an oidc-type auth method given its ID. 
+of an OIDC-type auth method given its ID.
 
 An OIDC auth method can be in one of several different states: Inactive, Active
 Private, and Active Public. The current state of an OIDC auth method
 affects how endpoints respond to requests and, in some cases, whether access to
 an endpoint requires authentication.
 
-- **MakeInactive** transitions an OIDC auth method from either the Active Private
-  or the Active Public state into the Inactive state.
-- **MakePrivate** transitions an OIDC auth method from either the Inactive or the
-  Active Public state into the Active Private state. If transitioning from the
-  Inactive state, the transition will only succeed if the configuration is
+- **MakeInactive** transitions an OIDC auth method from either the **Active Private**
+  or the **Active Public** state into the **Inactive** state.
+- **MakePrivate** transitions an OIDC auth method from either the **Inactive** or the
+  **Active Public** state into the **Active Private** state. If the transition is from the
+  **Inactive** state, it will only succeed if the configuration is
   valid.
-- **MakePublic** transitions an OIDC auth method from either the Inactive or the
-  Active Private state into the Active Public state. If transitioning from the
-  Inactive state, the transition will only succeed if the configuration is
+- **MakePublic** transitions an OIDC auth method from either the **Inactive** or the
+  **Active Private** state into the **Active Public** state. If the transition is from the
+  **Inactive** state, it will only succeed if the configuration is
   valid.
 
-Before changing the state of an auth-method, Boundary will retrieve the
-Provider’s discovery document for the auth method’s issuer and attempt to
+Before you change the state of an auth-method, Boundary retrieves the provider’s discovery document for the auth method’s issuer and attempts to
 validate the auth-method’s configuration against this published information. If
-Boundary is unable to validate the configuration an error is returned and the
-state change is not made.
-
+Boundary is unable to validate the configuration, an error is returned and the
+state change is not successful.
 
 ## Examples
 
-Change the OIDC auth method's state to active-public
+The following example changes the OIDC auth method's state to `active-public`:
 
 ```shell-session
 $ boundary auth-methods change-state oidc -id amoidc_oHt4HQFCrN \
@@ -91,7 +89,6 @@ Auth Method information:
 
 </CodeBlockConfig>
 
-
 ## Usage
 
 <CodeBlockConfig hideClipboard>
@@ -104,32 +101,32 @@ $ boundary auth-methods change-state oidc [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the oidc-type auth method on which to operate.
+- `-id` `(string: "")` - Specifies the ID of the oidc-type auth method on which to operate.
 
 ### OIDC auth method options
 
-- `-disable-discovered-config-validation`  - Disable validating
+- `-disable-discovered-config-validation`  - Disables validating
    the given auth method against configuration from the authorization server's
-   discovery URL. This must be specified every time an unvalidatable auth method
-   is updated or state changed; not specifying it is equivalent to setting it to
-   false. The default is false.
+   discovery URL. You must specify this value every time an auth method that cannot be validated
+   is updated or state changed. Not specifying a value is equivalent to setting the value to
+   `false`. The default is `false`.
 
-- `-state` `(string: "")` - The desired operational state of the auth method.
+- `-state` `(string: "")` - Indicates the desired operational state of the auth method.
   Three different states exist for an authentication method:
 
    - `inactive` users can not authenticate with inactive auth methods and the
    inactive auth methods are not listed for unauthenticated users.
    - `active-private` users can authenticate with active-private auth methods
    and active-private auth methods are not listed for unauthenticated users.
-   - `active-public` users can authenticate active-public auth methods and
+   - `active-public` users can authenticate with active-public auth methods and
    active-public auth methods are listed for unauthenticated users.
 
-If a change is made from `active-public` or `active-private` to `inactive`, all
+If you change an auth method from `active-public` or `active-private` to `inactive`, all
 in-flight authentications will succeed unless the auth method’s configuration is
 modified while the request is in-flight.
 
-When changing an auth method's state using `boundary auth-methods change-state`
-the `-disable-discovered-config-validation` flag is used to disable validation
+When you change an auth method's state using `boundary auth-methods change-state`,
+Boundary uses the `-disable-discovered-config-validation` flag to disable validation
 against the provider’s published discovery document. This allows for the very
 rare occurrence when the Provider has published an invalid discovery document.
 

--- a/website/content/docs/api-clients/commands/auth-methods/create.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/create.mdx
@@ -2,20 +2,19 @@
 layout: docs
 page_title: auth-methods create - Command
 description: |-
-  The "auth-methods create" command allows Boundary admin to create an auth method.
+  The "auth-methods create" command lets Boundary admin create an auth method.
 ---
 
 # auth-methods create
 
 Command: `boundary auth-methods create`
 
-The `auth-methods create` command allows create operations on Boundary auth
+The `auth-methods create` command lets you create Boundary auth
 method resources. The available auth method types are: LDAP, OIDC, and password.
 
 ## Examples
 
-Create an OIDC auth method by passing the OIDC provider's domain (`-issuer`),
-client ID, and client secret.
+The following example creates an OIDC auth method by passing the OIDC provider's domain (`-issuer`), client ID, and client secret:
 
 ```shell-session
 $ boundary auth-methods create oidc \
@@ -85,21 +84,30 @@ The available types are: `ldap`, `oidc`, and `password`.
 
 ### Command options:
 
-- `-description` `(string: "")` - Description to set on the ldap-type auth
-  method.
-- `-name` `(string: "")` - Name to set on the ldap-type auth method.
-- `-scope-id` `(string: "")` - Scope in which to make the request. The default
-   is global. This can also be specified via the `BOUNDARY_SCOPE_ID`
-   environment variable.
+- `-description` `(string: "")` - Specifies the description to set on the auth method.
+- `-name` `(string: "")` - Specifies the name to set on the auth method.
+- `-scope-id` `(string: "")` - Indicates the scope in which to make the request. The default
+   is `global`. You can also specify the scope using the `BOUNDARY_SCOPE_ID` environment variable.
 
 @include 'cmd-option-note.mdx'
 
-#### Usages by type
+### Usages by type
 
 <Tabs>
-<Tab heading="ldap">
+<Tab heading="LDAP">
 
-Create an auth method of `ldap` type.
+The `boundary auth-methods create ldap` command creates an LDAP auth method.
+
+#### Example
+
+The following example creates an LDAP auth method with the name `prodops` and the description `LDAP auth-method for ProdOps`:
+
+```shell-session
+$ boundary auth-methods create ldap -name prodops \
+   -description "LDAP auth-method for ProdOps"
+```
+
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -109,26 +117,25 @@ $ boundary auth-methods create ldap [options] [args]
 
 </CodeBlockConfig>
 
+#### LDAP auth method options
 
-#### LDAP auth method option
+The following are LDAP-specific options in addition to the command
+options:
 
-The following are LDAP specific options in addition to the command
-options.
+- `-anon-group-search`  - Uses anon bind when performing LDAP
+   group searches (optional). The default is `false`.
 
-- `-anon-group-search`  - Use anon bind when performing LDAP
-   group searches (optional). The default is false.
+- `-bind-dn` `(string: "")` - Uses the distinguished name of entry to bind when
+   performing user and group searches (optional).
 
-- `-bind-dn` `(string: "")` - The distinguished name of entry to bind when
-   performing user and group searches (optional). 
+- `-bind-password` `(string: "")` - Indicates the password to use along with bind-dn
+  performing user and group searches (optional).
 
-- `-bind-password` `(string: "")` - The password to use along with bind-dn
-  performing user and group searches (optional). 
-
-- `-certificate` `(string: "")` - PEM-encoded X.509 CA certificate in ASN.1 DER
+- `-certificate` `(string: "")` - Specifies a PEM-encoded X.509 CA certificate in ASN.1 DER
    form that can be used as a trust anchor when connecting to an LDAP
-   server(optional). This may be specified multiple times. 
+   server(optional). You can specify this value multiple times.
 
-- `-client-certificate` `(string: "")` - PEM-encoded X.509 client certificate in
+- `-client-certificate` `(string: "")` - Specifies a PEM-encoded X.509 client certificate in
    ASN.1 DER form that can be used to authenticate against an LDAP server
    (optional).
 
@@ -136,58 +143,62 @@ options.
    certificate key in PKCS #8, ASN.1 DER form used with the client certificate
    (optional).
 
-- `-discover-dn`  - Use anon bind to discover the bind DN of a
-   user (optional). The default is false.
+- `-discover-dn`  - Uses anon bind to discover the bind DN of a
+   user (optional). The default value is `false`.
 
-- `-enable-groups`  - Find the authenticated user's groups during
-   authentication (optional). The default is false.
+- `-enable-groups`  - Finds the authenticated user's groups during
+   authentication (optional). The default is `false`.
 
-- `-group-attr` `(string: "")` - The attribute that enumerates a user's group
+- `-group-attr` `(string: "")` - Indicates the attribute that enumerates a user's group
    membership from entries returned by a group search (optional).
 
-- `-group-dn` `(string: "")` - The base DN under which to perform group search.
+- `-group-dn` `(string: "")` - Specifies the base DN under which to perform group search.
 
-- `-group-filter` `(string: "")` - A go template used to construct a LDAP group
+- `-group-filter` `(string: "")` - Indicates a go template used to construct a LDAP group
    search filter (optional).
 
-- `-insecure-tls`  - Skip the LDAP server SSL certificate
-   validation (optional) - insecure and use with caution. The default is false.
+- `-insecure-tls`  - Skips the LDAP server SSL certificate
+   validation (optional). Use this option with caution; it is insecure. The default value is `false`.
 
-- `-start-tls`  - Issue StartTLS command after connecting
-   (optional). The default is false.
+- `-start-tls`  - Issues the StartTLS command after connecting
+   (optional). The default value is `false`.
 
-- `-state` `(string: "")` - The desired operational state of the auth method.
+- `-state` `(string: "")` - Indicates the desired operational state of the auth method.
 
-- `-upn-domain` `(string: "")` - The userPrincipalDomain used to construct the
+- `-upn-domain` `(string: "")` - Specifies the userPrincipalDomain used to construct the
    UPN string for the authenticating user (optional).
 
-- `-urls` `(string: "")` - The LDAP URLs that specify LDAP servers to connect to
-   (required). May be specified multiple times.
+- `-urls` `(string: "")` - Indicates the LDAP URLs that specify LDAP servers to connect to
+   (required). You can specify this value multiple times.
 
-- `-use-token-groups`  - Use the Active Directory tokenGroups
+- `-use-token-groups`  - Uses the Active Directory tokenGroups
    constructed attribute of the user to find the group memberships (optional).
-   The default is false.
+   The default value is `false`.
 
-- `-user-attr` `(string: "")` - The attribute on user entry matching the
-   username passed when authenticating (optional).
+- `-user-attr` `(string: "")` - Specifies the attribute on user entry that matches the
+   username that is passed during authentication (optional).
 
-- `-user-dn` `(string: "")` - The base DN under which to perform user search
+- `-user-dn` `(string: "")` - Indicates the base DN under which to perform user search
 (optional).
 
-- `-user-filter` `(string: "")` - A go template used to construct a LDAP user
+- `-user-filter` `(string: "")` - Specifies a go template used to construct a LDAP user
 search filter (optional).
+
+</Tab>
+<Tab heading="OIDC">
+
+The `boundary auth-methods create oidc` command creates an OIDC auth method.
 
 #### Example
 
+The following example creates an OIDC auth method with the name `prodops` and the description `Oidc auth-method for ProdOps`:
+
 ```shell-session
-$ boundary auth-methods create ldap -name prodops \
-   -description "LDAP auth-method for ProdOps"
+$ boundary auth-methods create oidc -name prodops \
+   -description "Oidc auth-method for ProdOps"
 ```
 
-</Tab>
-<Tab heading="oidc">
-
-Create an auth method of `oidc` type.
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -199,51 +210,52 @@ $ boundary auth-methods create oidc [options] [args]
 
 #### OIDC auth method options
 
-The following are OIDC auth-methods specific options in addition to the command
-options.
+The following are OIDC-specific options in addition to the command options:
 
-- `-account-claim-maps` `(string: "")` - The optional account claim maps from
+- `-account-claim-maps` `(string: "")` - Specifies the optional account claim maps from
    custom claims to the standard claims of sub, name and email. These maps are
    represented as key=value where the key equals the Provider from-claim and the
-   value equals the Boundary to-claim. For example "oid=sub". May be specified
+   value equals the Boundary to-claim. For example "oid=sub". You may specify this value
    multiple times for different to-claims.
 
-- `-allowed-audience` `(string: "")` - The acceptable audience ("aud") claim.
-  May be specified multiple times.
+- `-allowed-audience` `(string: "")` - Indicates the acceptable audience ("aud") claim.
+ You may specify this value multiple times.
 
-- `-api-url-prefix` `(string: "")` - The URL prefix used by the OIDC provider in
+- `-api-url-prefix` `(string: "")` - Specifies the URL prefix used by the OIDC provider in
   the authentication flow.
 
-- `-claims-scopes` `(tring: "")` - The optional claims scope requested. May be
-  specified multiple times. 
+- `-claims-scopes` `(tring: "")` - Indicates the optional claims scope requested. You may specify this value multiple times.
 
-- `-client-id` `(string: "")` - The OAuth 2.0 Client Identifier this auth method
+- `-client-id` `(string: "")` - Specifies the OAuth 2.0 Client Identifier this auth method
    should use with the provider.
 
-- `-client-secret` `(string: "")` - The corresponding client secret.
+- `-client-secret` `(string: "")` - Indicates the corresponding client secret.
 
-- `-idp-ca-cert` `(string: "")` - Optional PEM-encoded X.509 CA certificate that
-   can be used as trust anchors when connecting to an OIDC provider. May be
-   specified multiple times.
+- `-idp-ca-cert` `(string: "")` - Specifies an optional PEM-encoded X.509 CA certificate that
+   can be used as trust anchors when connecting to an OIDC provider. You may specify this value multiple times.
 
-- `-issuer` `(string: "")` - The provider's Issuer URL.
+- `-issuer` `(string: "")` - Indicates the provider's issuer URL.
 
-- `-max-age` `(string: "")` - The OIDC "max_age" parameter sent to the provider.
+- `-max-age` `(string: "")` - Indicates the OIDC "max_age" parameter that is sent to the provider.
 
-- `-signing-algorithm` `(string: "")` - The allowed signing algorithm. May be
-   specified multiple times for multiple values.
+- `-signing-algorithm` `(string: "")` - Indicates the allowed signing algorithm. You may specify this multiple times for multiple values.
+
+
+
+</Tab>
+<Tab heading="Password">
+
+The `boundary auth-methods create password` command creates a Password type auth method.
 
 #### Example
 
+The following example creates a Password type auth method with the name `prodops` and the description `Password auth-method for ProdOps`:
+
 ```shell-session
-$ boundary auth-methods create oidc -name prodops \
-   -description "Oidc auth-method for ProdOps"
+$ boundary auth-methods create password -name prodops \
+   -description "Password auth-method for ProdOps"
 ```
-
-</Tab>
-<Tab heading="password">
-
-Create an auth method of `password` type.
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -253,21 +265,14 @@ $ boundary accounts create password [options] [args]
 
 </CodeBlockConfig>
 
-### Password auth method options
+#### Password auth method options
 
 The following are password auth method specific options in addition to the
-command options.
+command options:
 
-- `-min-login-name-length` `(string: "")` - The minimum length of login names
+- `-min-login-name-length` `(string: "")` - Specifies the minimum length of login names.
 
-- `-min-password-length` `(string: "")` - The minimum length of passwords
-
-#### Example
-
-```shell-session
-$ boundary auth-methods create password -name prodops \
-   -description "Password auth-method for ProdOps"
-```
+- `-min-password-length` `(string: "")` - Specifies the minimum length of passwords.
 
 </Tab>
 </Tabs>

--- a/website/content/docs/api-clients/commands/auth-methods/delete.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/delete.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: auth-methods delete - Command
 description: |-
-  The "auth-methods delete" command allows Boundary admin to delete an auth method.
+  The "auth-methods delete" command lets Boundary admin delete an auth method.
 ---
 
 # auth-methods delete
@@ -11,14 +11,13 @@ Command: `boundary auth-methods delete`
 
 The `auth-methods delete` command deletes an auth method given its ID.
 
-## Examples
+## Example
 
-Delete an auth method with ID, "amoidc_oHt4HQFCrN".
+The following example deletes an auth method with the ID, `moidc_oHt4HQFCrN`.
 
 ```shell-session
 $ boundary auth-methods delete -id amoidc_oHt4HQFCrN
 ```
-
 
 ## Usage
 
@@ -30,9 +29,8 @@ $ boundary auth-methods delete [options] [args]
 
 </CodeBlockConfig>
 
-
 ### Command options
 
-- `-id` `(string: "")` - ID of the auth method to delete.
+- `-id` `(string: "")` - Specifies the ID of the auth method to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/auth-methods/index.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/index.mdx
@@ -2,22 +2,22 @@
 layout: docs
 page_title: auth-methods - Command
 description: |-
-  The "auth-methods" command create and manage Boundary authentication method configuration.
+  The "auth-methods" command lets you create and manage Boundary authentication method configuration.
 ---
 
 # auth-methods
 
 Command: `boundary auth-methods`
 
-The `auth-methods` command manages the auth method resource in Boundary. An auth
-method is a resource that provides a mechanism for users to authenticate to
+The `auth-methods` command lets you manage the auth method resource in Boundary. The auth
+method resource provides a mechanism for users to authenticate to
 Boundary. An auth method contains accounts which link an individual user to a
-set of credentials and managed groups which groups accounts that satisfy
-criteria and can be used as principals in roles. 
+set of credentials. They also contain managed groups which group accounts that satisfy
+specific criteria, and can be used as principals in roles.
 
 ## Examples
 
-The following command configures an OIDC auth method where Boundary cluster
+The following example configures an OIDC auth method where the Boundary cluster
 address is stored in the `BOUNDARY_ADDR`, the OIDC provider's client ID is
 stored in the `CLIENT_ID`, and the client secret is stored in the
 `CLIENT_SECRET` environment variables.
@@ -98,7 +98,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [change-state](/boundary/docs/api-clients/commands/auth-methods/change-state)

--- a/website/content/docs/api-clients/commands/auth-methods/list.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/list.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: auth-methods list - Command
 description: |-
-  The "auth-methods list" command allows Boundary admin to list available auth methods.
+  The "auth-methods list" command lets Boundary admin list available auth methods.
 ---
 
 # auth-methods list
@@ -15,7 +15,7 @@ resource.
 
 ## Examples
 
-List auth methods recursively into child scopes if applicable.
+The following example lists auth methods from the default `global` scope recursively from any child scopes, if applicable:
 
 ```shell-session
 $ boundary auth-methods list -recursive
@@ -84,16 +84,16 @@ $ boundary auth-methods list [options] [args]
 
 ### Command options
 
-- `-filter` `(string: "")` - If set, the list operation will be filtered before
-   being returned. The filter operates against each item in the list. Using
-   single quotes is recommended as filters contain double quotes. 
+- `-filter` `(string: "")` - Indicates whether the list operation should be filtered before
+   being returned. The filter operates against each item in the list. We recommend using
+   single quotes, because filters contain double quotes.
 
-- `-recursive`  - If set, the list operation will be applied
-   recursively into child scopes, if supported by the type. The default is
-   false.
+- `-recursive`  - Indicates whether the list operation should be applied
+   recursively into child scopes, if supported by the type. The default value is
+   `false`.
 
-- `-scope-id` `(string: "")` - Scope in which to make the request. The default
-   is global. This can also be specified via the BOUNDARY_SCOPE_ID environment
+- `-scope-id` `(string: "")` - Indicates the scope in which to make the request. The default
+   scope is `global`. You can also specify a scope using the **BOUNDARY_SCOPE_ID** environment
    variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/auth-methods/read.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/read.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: auth-methods read - Command
 description: |-
-  The "auth-methods read" command allows Boundary admin to read an auth method.
+  The "auth-methods read" command lets Boundary admin read an auth method.
 ---
 
 # auth-methods read
@@ -13,7 +13,7 @@ The `auth-methods read` command reads an auth method given its ID.
 
 ## Examples
 
-Read the auth method details where its ID is "amoidc_AliCbVihqv".
+The following example reads the auth method details for an auth method with the ID `amoidc_AliCbVihqv`.
 
 ```shell-session
 $ boundary auth-methods read -id amoidc_AliCbVihqv
@@ -76,6 +76,6 @@ $ boundary auth-methods read [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the auth method to delete.
+- `-id` `(string: "")` - Specifies the ID of the auth method to read.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/auth-methods/update.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/update.mdx
@@ -2,21 +2,19 @@
 layout: docs
 page_title: auth-methods update - Command
 description: |-
-  The "auth-methods update" command allows Boundary admin to update an auth method.
+  The "auth-methods update" command lets Boundary admin update an auth method.
 ---
 
 # auth-methods update
 
 Command: `boundary auth-methods update`
 
-The `auth-methods update` command allows update operations on Boundary auth
-method resources.
+The `auth-methods update` command lets you update Boundary auth method resources.
 
 ## Examples
 
-Update an auth method to set the `-max-age` option to `0`, which will force the
-user to re-authenticate if they are already logged in with the current browser
-session.
+The following example updates an auth method to set the `-max-age` option to `0`.
+This update forces the user to reauthenticate, if they are already logged in with the current browser session:
 
 ```shell-session
 $ boundary auth-methods update oidc -id amoidc_oHt4HQFCrN \
@@ -79,26 +77,36 @@ $ boundary auth-methods update [type] [sub command] [options] [args]
 
 </CodeBlockConfig>
 
-The available types are: `ldap`, `oidc`, and `password`.
-
 ### Command options:
 
-- `-description` `(string: "")` - Description to set on the ldap-type auth
-  method.
-- `-id` `(string: "")` - ID of the ldap-type auth method on which to operate.
-- `-name` `(string: "")` - Name to set on the ldap-type auth method.
-- `-version` `(int: 0)` - The version of the ldap-type auth method against which
-   to perform an update operation. If not specified, the command will perform
-   a check-and-set automatically.
+- `-description` `(string: "")` - Specifies a description to set on the auth method.
+- `-id` `(string: "")` - Indicates the ID of the auth method to update.
+- `-name` `(string: "")` - Specifies the name to set on the auth method.
+- `-version` `(int: 0)` - Indicates the version of the auth method to update.
+   If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'
 
-#### Usages by type
+### Usages by type
+
+The available types are: `ldap`, `oidc`, and `password`.
 
 <Tabs>
-<Tab heading="ldap">
+<Tab heading="LDAP">
 
-Update an auth method of `ldap` type.
+The `boundary auth-methods update ldap` command lets you update an LDAP auth method.
+
+#### Example
+
+The following example updates an LDAP auth method with the ID `amldap_1234567890` to add the name `devops` and the description `LDAP auth-method for DevOps`:
+
+```shell-session
+$ boundary auth-methods update ldap -id amldap_1234567890 \
+   -name "devops" \
+   -description "LDAP auth-method for DevOps"
+```
+
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -108,86 +116,88 @@ $ boundary auth-methods update ldap [options] [args]
 
 </CodeBlockConfig>
 
+#### LDAP auth method options
 
-#### LDAP auth method option
-
-The following are LDAP specific options in addition to the command
+The following are LDAP-specific options in addition to the command
 options.
 
-- `-anon-group-search`  - Use anon bind when performing LDAP
-   group searches (optional). The default is false.
+- `-anon-group-search`  - Uses anon bind when performing LDAP
+   group searches (optional). The default value is `false`.
 
-- `-bind-dn` `(string: "")` - The distinguished name of entry to bind when
-   performing user and group searches (optional). 
+- `-bind-dn` `(string: "")` - Uses the distinguished name of entry to bind when
+   performing user and group searches (optional).
 
-- `-bind-password` `(string: "")` - The password to use along with bind-dn
-  performing user and group searches (optional). 
+- `-bind-password` `(string: "")` - Indicates the password to use along with bind-dn
+  when performing user and group searches (optional).
 
-- `-certificate` `(string: "")` - PEM-encoded X.509 CA certificate in ASN.1 DER
+- `-certificate` `(string: "")` - Specifies a PEM-encoded X.509 CA certificate in ASN.1 DER
    form that can be used as a trust anchor when connecting to an LDAP
-   server(optional). This may be specified multiple times. 
+   server(optional). You can specify this value multiple times.
 
-- `-client-certificate` `(string: "")` - PEM-encoded X.509 client certificate in
+- `-client-certificate` `(string: "")` - Specifies a PEM-encoded X.509 client certificate in
    ASN.1 DER form that can be used to authenticate against an LDAP server
    (optional).
 
-- `-client-certificate-key` `(string: "")` - PEM-encoded X.509 client
+- `-client-certificate-key` `(string: "")` - Specifies a PEM-encoded X.509 client
    certificate key in PKCS #8, ASN.1 DER form used with the client certificate
    (optional).
 
-- `-discover-dn`  - Use anon bind to discover the bind DN of a
-   user (optional). The default is false.
+- `-discover-dn`  - Uses anon bind to discover the bind DN of a
+   user (optional). The default value is `false`.
 
-- `-enable-groups`  - Find the authenticated user's groups during
-   authentication (optional). The default is false.
+- `-enable-groups`  - Finds the authenticated user's groups during
+   authentication (optional). The default is `false`.
 
-- `-group-attr` `(string: "")` - The attribute that enumerates a user's group
+- `-group-attr` `(string: "")` - Specifies the attribute that enumerates a user's group
    membership from entries returned by a group search (optional).
 
-- `-group-dn` `(string: "")` - The base DN under which to perform group search.
+- `-group-dn` `(string: "")` - Specifies the base DN under which to perform group search.
 
-- `-group-filter` `(string: "")` - A go template used to construct a LDAP group
+- `-group-filter` `(string: "")` - Indicates a go template used to construct a LDAP group
    search filter (optional).
 
-- `-insecure-tls`  - Skip the LDAP server SSL certificate
-   validation (optional) - insecure and use with caution. The default is false.
+- `-insecure-tls`  - Skips the LDAP server SSL certificate
+   validation (optional). Use this option with caution, it is insecure. The default value is    `false`.
 
-- `-start-tls`  - Issue StartTLS command after connecting
-   (optional). The default is false.
+- `-start-tls`  - Issues the StartTLS command after connecting
+   (optional). The default is `false`.
 
-- `-state` `(string: "")` - The desired operational state of the auth method.
+- `-state` `(string: "")` - Indicates the desired operational state of the auth method.
 
-- `-upn-domain` `(string: "")` - The userPrincipalDomain used to construct the
+- `-upn-domain` `(string: "")` - Indicates the userPrincipalDomain used to construct the
    UPN string for the authenticating user (optional).
 
-- `-urls` `(string: "")` - The LDAP URLs that specify LDAP servers to connect to
-   (required). May be specified multiple times.
+- `-urls` `(string: "")` - Indicates the LDAP URLs that specify LDAP servers to connect to
+   (required). You may specify this value multiple times.
 
-- `-use-token-groups`  - Use the Active Directory tokenGroups
+- `-use-token-groups`  - Uses the Active Directory tokenGroups
    constructed attribute of the user to find the group memberships (optional).
-   The default is false.
+   The default value is `false`.
 
-- `-user-attr` `(string: "")` - The attribute on user entry matching the
-   username passed when authenticating (optional).
+- `-user-attr` `(string: "")` - Indicates the attribute on user entry matching the
+   username that is passed during authentication (optional).
 
-- `-user-dn` `(string: "")` - The base DN under which to perform user search
+- `-user-dn` `(string: "")` - Specifies the base DN under which to perform user search
    (optional).
 
-- `-user-filter` `(string: "")` - A go template used to construct a LDAP user
+- `-user-filter` `(string: "")` - Specifies a go template used to construct a LDAP user
    search filter (optional).
+
+</Tab>
+<Tab heading="OIDC">
+
+The `boundary auth-methods update oidc` command lets you update OIDC auth methods.
 
 #### Example
 
+The following example updates an OIDC auth method with the ID `amoidc_1234567890` to add the name `devops` and the description `Oidc auth-method for DevOps`:
+
 ```shell-session
-$ boundary auth-methods update ldap -id amldap_1234567890 \
+$ boundary auth-methods update oidc -id amoidc_1234567890 \
    -name "devops" \
-   -description "LDAP auth-method for DevOps"
+   -description "Oidc auth-method for DevOps"
 ```
-
-</Tab>
-<Tab heading="oidc">
-
-Update an auth method of `oidc` type.
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -199,34 +209,32 @@ $ boundary auth-methods update oidc [options] [args]
 
 #### OIDC auth method options
 
-The following are OIDC auth-methods specific options in addition to the command
-options.
+The following are options are specific to OIDC auth-methods in addition to the command options.
 
-- `-account-claim-maps` `(string: "")` - The optional account claim maps from
+- `-account-claim-maps` `(string: "")` - Indicates the optional account claim maps from
    custom claims to the standard claims of sub, name and email. These maps are
    represented as key=value where the key equals the Provider from-claim and the
-   value equals the Boundary to-claim. For example "oid=sub". May be specified
+   value equals the Boundary to-claim. For example "oid=sub". You may specify this value
    multiple times for different to-claims.
 
-- `-allowed-audience` `(string: "")` - The acceptable audience ("aud") claim.
-  May be specified multiple times.
+- `-allowed-audience` `(string: "")` - Indicates the acceptable audience ("aud") claim.
+  You may specify this value multiple times.
 
-- `-api-url-prefix` `(string: "")` - The URL prefix used by the OIDC provider in
+- `-api-url-prefix` `(string: "")` - Indicates the URL prefix used by the OIDC provider in
   the authentication flow.
 
-- `-claims-scopes` `(tring: "")` - The optional claims scope requested. May be
-  specified multiple times.
+- `-claims-scopes` `(tring: "")` - Specifies the optional claims scope requested. You may specify this value multiple times.
 
-- `-client-id` `(string: "")` - The OAuth 2.0 Client Identifier this auth method
+- `-client-id` `(string: "")` - Indicates the OAuth 2.0 Client Identifier this auth method
    should use with the provider.
 
-- `-client-secret` `(string: "")` - The corresponding client secret.
+- `-client-secret` `(string: "")` - Indicates the corresponding client secret.
 
-- `-idp-ca-cert` `(string: "")` - Optional PEM-encoded X.509 CA certificate that
+- `-idp-ca-cert` `(string: "")` - Specifies an optional PEM-encoded X.509 CA certificate that
    can be used as trust anchors when connecting to an OIDC provider. May be
    specified multiple times.
 
-- `-disable-discovered-config-validation`  - Disable validating
+- `-disable-discovered-config-validation`  - Disables validating
    the given auth method against configuration from the authorization server's
    discovery URL. This must be specified every time an unvalidatable auth method
    is updated or state changed; not specifying it is equivalent to setting it to
@@ -236,29 +244,33 @@ options.
    with any newly-provided values without persisting the changes. The default is
    false.
 
-- `-idp-ca-cert` `(tring: "")` - Optional PEM-encoded X.509 CA certificate that
-   can be used as trust anchors when connecting to an OIDC provider. May be
-   specified multiple times.
+- `-idp-ca-cert` `(tring: "")` - Indicates an optional PEM-encoded X.509 CA certificate that
+   can be used as trust anchors when connecting to an OIDC provider. You may specify this value multiple times.
 
-- `-issuer` `(string: "")` - The provider's Issuer URL.
+- `-issuer` `(string: "")` - Indicates the provider's Issuer URL.
 
-- `-max-age` `(string: "")` - The OIDC "max_age" parameter sent to the provider.
+- `-max-age` `(string: "")` - Indicates the OIDC "max_age" parameter sent to the provider.
 
-- `-signing-algorithm` `(string: "")` - The allowed signing algorithm. May be
-   specified multiple times for multiple values.
+- `-signing-algorithm` `(string: "")` - Indicates the allowed signing algorithm. You may specify this value multiple times for multiple values.
+
+
+
+</Tab>
+<Tab heading="Password">
+
+The `boundary auth-methods update password` command lets you update a Password-type auth method.
 
 #### Example
 
+The following example updates a Password-type auth method with the ID `ampw_1234567890` to add the name `devops` and the description `Password auth-method for DevOps`:
+
 ```shell-session
-$ boundary auth-methods update oidc -id amoidc_1234567890 \
+$ boundary auth-methods update password -id ampw_1234567890 \
    -name "devops" \
-   -description "Oidc auth-method for DevOps"
+   -description "Password auth-method for DevOps"
 ```
 
-</Tab>
-<Tab heading="password">
-
-Update an auth method of `password` type.
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -270,20 +282,12 @@ $ boundary auth-methods update password [options] [args]
 
 ### Password auth method options
 
-The following are password auth method specific options in addition to the
+The following options are specific to the Passwor-type auth method in addition to the
 command options.
 
-- `-min-login-name-length` `(string: "")` - The minimum length of login names
+- `-min-login-name-length` `(string: "")` - Specifies the minimum length of login names.
 
-- `-min-password-length` `(string: "")` - The minimum length of passwords
-
-#### Example
-
-```shell-session
-$ boundary auth-methods update password -id ampw_1234567890 \
-   -name "devops" \
-   -description "Password auth-method for DevOps"
-```
+- `-min-password-length` `(string: "")` - Specifies the minimum length of passwords.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
Edit the `auth-methods` options in the CLI draft doc #3411.