### PR TITLE
internal/perms: Fix grant parser bugs

### DIFF
--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -236,7 +236,7 @@ func (g *Grant) unmarshalJSON(ctx context.Context, data []byte) error {
 				return errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("unable to interpret %q element %q as string", "ids", id))
 			}
 			if idStr == "" {
-				return errors.New(ctx, errors.InvalidParameter, op, `segment "ids=" not formatted correctly, missing value`)
+				return errors.New(ctx, errors.InvalidParameter, op, "empty ID provided")
 			}
 			g.ids[i] = idStr
 		}
@@ -323,6 +323,11 @@ func (g *Grant) unmarshalText(ctx context.Context, grantString string) error {
 
 		case "ids":
 			g.ids = strings.Split(kv[1], ",")
+			for _, id := range g.ids {
+				if id == "" {
+					return errors.New(ctx, errors.InvalidParameter, op, "empty ID provided")
+				}
+			}
 
 		case "type":
 			typeString := strings.ToLower(kv[1])

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -235,6 +235,9 @@ func (g *Grant) unmarshalJSON(ctx context.Context, data []byte) error {
 			if !ok {
 				return errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("unable to interpret %q element %q as string", "ids", id))
 			}
+			if idStr == "" {
+				return errors.New(ctx, errors.InvalidParameter, op, `segment "ids=" not formatted correctly, missing value`)
+			}
 			g.ids[i] = idStr
 		}
 	}
@@ -286,6 +289,8 @@ func (g *Grant) unmarshalJSON(ctx context.Context, data []byte) error {
 				switch {
 				case !ok:
 					return errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("unable to interpret %v in output_fields array as string", v))
+				case field == ",":
+					return errors.New(ctx, errors.InvalidParameter, op, `"," is not a valid output field`)
 				default:
 					fields = append(fields, field)
 				}

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -232,11 +232,13 @@ func (g *Grant) unmarshalJSON(ctx context.Context, data []byte) error {
 		g.ids = make([]string, len(ids))
 		for i, id := range ids {
 			idStr, ok := id.(string)
-			if !ok {
+			switch {
+			case !ok:
 				return errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("unable to interpret %q element %q as string", "ids", id))
-			}
-			if idStr == "" {
+			case idStr == "":
 				return errors.New(ctx, errors.InvalidParameter, op, "empty ID provided")
+			case strings.Contains(idStr, ","):
+				return errors.New(ctx, errors.InvalidParameter, op, "ID cannot contain a comma")
 			}
 			g.ids[i] = idStr
 		}
@@ -289,8 +291,8 @@ func (g *Grant) unmarshalJSON(ctx context.Context, data []byte) error {
 				switch {
 				case !ok:
 					return errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("unable to interpret %v in output_fields array as string", v))
-				case field == ",":
-					return errors.New(ctx, errors.InvalidParameter, op, `"," is not a valid output field`)
+				case strings.Contains(field, ","):
+					return errors.New(ctx, errors.InvalidParameter, op, "output fields cannot contain a comma")
 				default:
 					fields = append(fields, field)
 				}

--- a/internal/perms/grants_test.go
+++ b/internal/perms/grants_test.go
@@ -322,6 +322,34 @@ func Test_Unmarshaling(t *testing.T) {
 			textErr:   `perms.(Grant).unmarshalText: segment "id=" not formatted correctly, missing value: parameter violation: error #100`,
 		},
 		{
+			name:      "bad segment id comma",
+			jsonInput: `{"id":","}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+			textInput: `id=,`,
+			textErr:   `perms.(Grant).unmarshalText: ID cannot contain a comma: parameter violation: error #100`,
+		},
+		{
+			name:      "bad segment id start with comma",
+			jsonInput: `{"id":",something"}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+			textInput: `id=,something`,
+			textErr:   `perms.(Grant).unmarshalText: ID cannot contain a comma: parameter violation: error #100`,
+		},
+		{
+			name:      "bad segment id with comma",
+			jsonInput: `{"id":"some,thing"}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+			textInput: `id=some,thing`,
+			textErr:   `perms.(Grant).unmarshalText: ID cannot contain a comma: parameter violation: error #100`,
+		},
+		{
+			name:      "bad segment id end with comma",
+			jsonInput: `{"id":"something,"}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+			textInput: `id=something,`,
+			textErr:   `perms.(Grant).unmarshalText: ID cannot contain a comma: parameter violation: error #100`,
+		},
+		{
 			name:      "bad segment ids",
 			jsonInput: `{"ids":true}`,
 			jsonErr:   `perms.(Grant).unmarshalJSON: unable to interpret "ids" as array: parameter violation: error #100`,
@@ -338,22 +366,62 @@ func Test_Unmarshaling(t *testing.T) {
 		{
 			name:      "segment ids comma",
 			jsonInput: `{"ids":[","]}`,
-			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma: parameter violation: error #100`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
 		},
 		{
 			name:      "segment ids starting with comma",
 			jsonInput: `{"ids":[",something"]}`,
-			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma: parameter violation: error #100`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
 		},
 		{
 			name:      "segment ids with comma",
 			jsonInput: `{"ids":["some,thing"]}`,
-			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma: parameter violation: error #100`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
 		},
 		{
 			name:      "segment ids ending with comma",
 			jsonInput: `{"ids":["something,"]}`,
-			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma: parameter violation: error #100`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids semicolon",
+			jsonInput: `{"ids":[","]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids starting with semicolon",
+			jsonInput: `{"ids":[";something"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids with semicolon",
+			jsonInput: `{"ids":["some;thing"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids ending with semicolon",
+			jsonInput: `{"ids":["something;"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids equals sign",
+			jsonInput: `{"ids":["="]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids starting with equals sign",
+			jsonInput: `{"ids":["=something"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids with equals sign",
+			jsonInput: `{"ids":["some=thing"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids ending with equals sign",
+			jsonInput: `{"ids":["something="]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
 		},
 		{
 			name: "good id",
@@ -445,22 +513,62 @@ func Test_Unmarshaling(t *testing.T) {
 		{
 			name:      "bad output fields comma",
 			jsonInput: `{"output_fields":[","]}`,
-			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma: parameter violation: error #100`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
 		},
 		{
 			name:      "output fields starting with comma",
 			jsonInput: `{"output_fields":[",something"]}`,
-			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma: parameter violation: error #100`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
 		},
 		{
 			name:      "output fields with comma",
 			jsonInput: `{"output_fields":["some,thing"]}`,
-			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma: parameter violation: error #100`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
 		},
 		{
 			name:      "output fields ending with comma",
 			jsonInput: `{"output_fields":["something,"]}`,
-			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma: parameter violation: error #100`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids semicolon",
+			jsonInput: `{"ids":[";"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids starting with semicolon",
+			jsonInput: `{"ids":[";something"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids with semicolon",
+			jsonInput: `{"ids":["some;thing"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids ending with semicolon",
+			jsonInput: `{"ids":["something;"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids equals sign",
+			jsonInput: `{"ids":["="]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids starting with equals sign",
+			jsonInput: `{"ids":["=something"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids with equals sign",
+			jsonInput: `{"ids":["some=thing"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids ending with equals sign",
+			jsonInput: `{"ids":["something="]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
 		},
 		{
 			name: "good actions",
@@ -488,6 +596,26 @@ func Test_Unmarshaling(t *testing.T) {
 			name:      "bad json action",
 			jsonInput: `{"actions":[1, true]}`,
 			jsonErr:   `perms.(Grant).unmarshalJSON: unable to interpret 1 in actions array as string: parameter violation: error #100`,
+		},
+		{
+			name:      "segment actions comma",
+			jsonInput: `{"actions":[","]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: action cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment actions starting with comma",
+			jsonInput: `{"actions":[",something"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: action cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment actions with comma",
+			jsonInput: `{"actions":["some,thing"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: action cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "segment actions ending with comma",
+			jsonInput: `{"actions":["something,"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: action cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
 		},
 	}
 
@@ -1196,6 +1324,7 @@ func FuzzParse(f *testing.F) {
 		"ids={{account.id}},{{user.id}};actions=update,read",
 		`{"id":"foobar","type":"host-catalog","actions":["create"]}`,
 		`{"ids":["foobar"],"type":"host-catalog","actions":["create"]}`,
+		`{"ids":["\""]}`,
 	}
 	for _, tc := range tc {
 		f.Add(tc)

--- a/internal/perms/grants_test.go
+++ b/internal/perms/grants_test.go
@@ -336,6 +336,26 @@ func Test_Unmarshaling(t *testing.T) {
 			textErr:   `perms.(Grant).unmarshalText: empty ID provided: parameter violation: error #100`,
 		},
 		{
+			name:      "segment ids comma",
+			jsonInput: `{"ids":[","]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids starting with comma",
+			jsonInput: `{"ids":[",something"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids with comma",
+			jsonInput: `{"ids":["some,thing"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma: parameter violation: error #100`,
+		},
+		{
+			name:      "segment ids ending with comma",
+			jsonInput: `{"ids":["something,"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: ID cannot contain a comma: parameter violation: error #100`,
+		},
+		{
 			name: "good id",
 			expected: Grant{
 				id: "foobar",
@@ -425,7 +445,22 @@ func Test_Unmarshaling(t *testing.T) {
 		{
 			name:      "bad output fields comma",
 			jsonInput: `{"output_fields":[","]}`,
-			jsonErr:   `perms.(Grant).unmarshalJSON: "," is not a valid output field: parameter violation: error #100`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma: parameter violation: error #100`,
+		},
+		{
+			name:      "output fields starting with comma",
+			jsonInput: `{"output_fields":[",something"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma: parameter violation: error #100`,
+		},
+		{
+			name:      "output fields with comma",
+			jsonInput: `{"output_fields":["some,thing"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma: parameter violation: error #100`,
+		},
+		{
+			name:      "output fields ending with comma",
+			jsonInput: `{"output_fields":["something,"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: output fields cannot contain a comma: parameter violation: error #100`,
 		},
 		{
 			name: "good actions",

--- a/internal/perms/grants_test.go
+++ b/internal/perms/grants_test.go
@@ -329,9 +329,11 @@ func Test_Unmarshaling(t *testing.T) {
 			textErr:   `perms.(Grant).unmarshalText: segment "ids=" not formatted correctly, missing value: parameter violation: error #100`,
 		},
 		{
-			name:      "bad json segment ids",
+			name:      "empty segment ids",
 			jsonInput: `{"ids":[""]}`,
-			jsonErr:   `perms.(Grant).unmarshalJSON: segment "ids=" not formatted correctly, missing value: parameter violation: error #100`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: empty ID provided: parameter violation: error #100`,
+			textInput: `ids=,`,
+			textErr:   `perms.(Grant).unmarshalText: empty ID provided: parameter violation: error #100`,
 		},
 		{
 			name: "good id",

--- a/internal/perms/grants_test.go
+++ b/internal/perms/grants_test.go
@@ -329,6 +329,11 @@ func Test_Unmarshaling(t *testing.T) {
 			textErr:   `perms.(Grant).unmarshalText: segment "ids=" not formatted correctly, missing value: parameter violation: error #100`,
 		},
 		{
+			name:      "bad json segment ids",
+			jsonInput: `{"ids":[""]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: segment "ids=" not formatted correctly, missing value: parameter violation: error #100`,
+		},
+		{
 			name: "good id",
 			expected: Grant{
 				id: "foobar",
@@ -414,6 +419,11 @@ func Test_Unmarshaling(t *testing.T) {
 			jsonErr:   `perms.(Grant).unmarshalJSON: unable to interpret "output_fields" as array: parameter violation: error #100`,
 			textInput: `output_fields=ids=version,name`,
 			textErr:   `perms.(Grant).unmarshalText: segment "output_fields=ids=version,name" not formatted correctly, wrong number of equal signs: parameter violation: error #100`,
+		},
+		{
+			name:      "bad output fields comma",
+			jsonInput: `{"output_fields":[","]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: "," is not a valid output field: parameter violation: error #100`,
 		},
 		{
 			name: "good actions",

--- a/internal/perms/testdata/fuzz/FuzzParse/3187a710d9bc1612
+++ b/internal/perms/testdata/fuzz/FuzzParse/3187a710d9bc1612
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("ids=,;actions=reAd")

--- a/internal/perms/testdata/fuzz/FuzzParse/4572b81e0281070d
+++ b/internal/perms/testdata/fuzz/FuzzParse/4572b81e0281070d
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("{\"output_fields\":[\",\"]}")

--- a/internal/perms/testdata/fuzz/FuzzParse/536fbfc4db40b83d
+++ b/internal/perms/testdata/fuzz/FuzzParse/536fbfc4db40b83d
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("{\"id\":\"=\",\"actions\":[\"reAd\"]}")

--- a/internal/perms/testdata/fuzz/FuzzParse/5d676d09fce49675
+++ b/internal/perms/testdata/fuzz/FuzzParse/5d676d09fce49675
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("{\"ids\":[\",00\"],\"actions\":[\"CreAte\"]}")

--- a/internal/perms/testdata/fuzz/FuzzParse/6bfe75c429073a6a
+++ b/internal/perms/testdata/fuzz/FuzzParse/6bfe75c429073a6a
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("id=,;output_fields=0")

--- a/internal/perms/testdata/fuzz/FuzzParse/9b33c3b84320755d
+++ b/internal/perms/testdata/fuzz/FuzzParse/9b33c3b84320755d
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("id=,0;output_fields=0")

--- a/internal/perms/testdata/fuzz/FuzzParse/c9a7351b4994e353
+++ b/internal/perms/testdata/fuzz/FuzzParse/c9a7351b4994e353
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("{\"ids\":[\"\"],\"actions\":[\"CreAte\"]}")


### PR DESCRIPTION
This fixes two bugs in the grant parser:

1. The parser would accept "," as an output field when parsing from JSON. This would then make it into the canonical string, which would make it look like we had a trailing comma. Disallow the use of a comma as an output field.
2. The parser would accept empty IDs when parsing from JSON. Make this behavior consistent with the text behavior.