### PR TITLE
docs: Edit `auth-tokens` & `authenticate` options

### DIFF
--- a/website/content/docs/api-clients/commands/auth-tokens/delete.mdx
+++ b/website/content/docs/api-clients/commands/auth-tokens/delete.mdx
@@ -11,9 +11,9 @@ Command: `boundary auth-tokens delete`
 
 The `auth-tokens delete` command deletes an auth token given its ID.
 
-## Examples
+## Example
 
-Delete an auth token with ID, "at_LvUqeYz80B".
+The following command deletes an auth token with the ID `at_LvUqeYz80B`:
 
 ```shell-session
 $ boundary auth-tokens delete -id at_LvUqeYz80B
@@ -33,6 +33,6 @@ $ boundary auth-tokens delete [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the auth token on which to operate.
+- `-id` `(string: "")` - Specifies the ID of the auth token to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/auth-tokens/index.mdx
+++ b/website/content/docs/api-clients/commands/auth-tokens/index.mdx
@@ -9,11 +9,11 @@ description: |-
 
 Command: `boundary auth-tokens`
 
-The `auth-tokens` command manages the auth token resource in Boundary. 
+The `auth-tokens` command lets you manage auth token resources in Boundary.
 
-## Examples
+## Example
 
-The following command list existing auth tokens recursively.
+The following example command lists existing auth tokens recursively:
 
 ```shell-session
 $ boundary auth-tokens list -recursive
@@ -67,7 +67,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [delete](/boundary/docs/api-clients/commands/auth-tokens/delete)

--- a/website/content/docs/api-clients/commands/auth-tokens/list.mdx
+++ b/website/content/docs/api-clients/commands/auth-tokens/list.mdx
@@ -9,13 +9,13 @@ description: |-
 
 Command: `boundary auth-tokens list`
 
-The `auth-tokens list` command lists auth tokens within an enclosing scope or
+The `auth-tokens list` command lists all auth tokens within an enclosing scope or
 resource.
 
 
 ## Examples
 
-List auth tokens recursively into child scopes if applicable.
+The following command lists all auth tokens recursively from any child scopes, if applicable:
 
 ```shell-session
 $ boundary auth-tokens list
@@ -72,16 +72,16 @@ $ boundary auth-tokens list [options] [args]
 
 ### Command options
 
-- `-filter` `(string: "")` - If set, the list operation will be filtered before
-   being returned. The filter operates against each item in the list. Using
-   single quotes is recommended as filters contain double quotes. 
+- `-filter` `(string: "")` - Determines whether the list operation is filtered before it is returned.
+The filter operates against each item in the list.
+We recommend that you use single quotes, as filters contain double quotes.
+Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
 
-- `-recursive`  - If set, the list operation will be applied
-   recursively into child scopes, if supported by the type. The default is
-   false.
+- `-recursive`  - Determines whether the list operation is applied recursively into child scopes, if the type supports it.
+The default value is `false`.
 
-- `-scope-id` `(string: "")` - Scope in which to make the request. The default
-   is global. This can also be specified via the BOUNDARY_SCOPE_ID environment
-   variable.
+- `-scope-id` `(string: "")` - Designates the scope from which to list the auth tokens.
+The default value is `global`.
+You can also specify this value using the BOUNDARY_SCOPE_ID environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/auth-tokens/read.mdx
+++ b/website/content/docs/api-clients/commands/auth-tokens/read.mdx
@@ -13,7 +13,7 @@ The `auth-tokens read` command reads an auth token given its ID.
 
 ## Examples
 
-Read the auth token details where its ID is "at_Gvd3jsqSO2".
+The following example reads the auth token details for an auth token with the ID `at_Gvd3jsqSO2`:
 
 ```shell-session
 $ boundary auth-tokens read -id at_Gvd3jsqSO2
@@ -60,6 +60,6 @@ $ boundary auth-tokens read [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the auth token on which to operate.
+- `-id` `(string: "")` - Specifies the ID of the auth token to read.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/authenticate/index.mdx
+++ b/website/content/docs/api-clients/commands/authenticate/index.mdx
@@ -2,21 +2,19 @@
 layout: docs
 page_title: authenticate - Command
 description: |-
-  The "authenticate" command authenticates the Boundary commandline client using a specified auth method.
+  The "authenticate" command authenticates the Boundary command line client using a specified auth method.
 ---
 
 # authenticate
 
 Command: `boundary authenticate`
 
-The `authenticate` command authenticates the Boundary commandline client using a
-specified auth method.
+The `authenticate` command authenticates the Boundary command line client using the auth method that you specify.
 
 
 ## Examples
 
-Authenticating with Boundary using the configured OIDC auth method where auth
-method ID is "amoidc_q7jAdI1QgA".
+The following example authenticates the Boundary CLI using a configured OIDC auth method where the auth method ID is `amoidc_q7jAdI1QgA`:
 
 
 ```shell-session
@@ -58,7 +56,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [ldap](/boundary/docs/api-clients/commands/authenticate/ldap)

--- a/website/content/docs/api-clients/commands/authenticate/ldap.mdx
+++ b/website/content/docs/api-clients/commands/authenticate/ldap.mdx
@@ -9,19 +9,16 @@ description: |-
 
 Command: `boundary authenticate ldap`
 
-The `authenticate ldap` command invokes the ldap auth method to authenticate the
+The `authenticate ldap` command lets you invokes the LDAP auth method to authenticate the
 Boundary CLI.
 
+## Example
 
-## Examples
-
-ldap an OIDC auth method by passing the OIDC provider's domain (`-issuer`),
-client ID, and client secret.
+The following example uses an LDAP auth method with the ID `amldap_1234567890` and the login name `foo` to authenticate the Boundary CLI:
 
 ```shell-session
 $ boundary authenticate ldap -auth-method-id amldap_1234567890 -login-name foo
 ```
-
 
 ## Usage
 
@@ -35,23 +32,17 @@ $ boundary authenticate ldap [options] [args]
 
 ### Command options
 
-- `-auth-method-id` `(string: "")` - The auth-method resource to use for the
-   operation. This can also be specified via the `BOUNDARY_AUTH_METHOD_ID`
-   environment variable.
+- `-auth-method-id` `(string: "")` - Specifies the auth-method resource you want to use for authentication.
+You can also specify the auth method resource using the `BOUNDARY_AUTH_METHOD_ID` environment variable.
 
-- `-login-name` `(string: "")` - The login name corresponding to an account
-   within the given auth method. This can also be specified via the
-   `BOUNDARY_AUTHENTICATE_PASSWORD_LOGIN_NAME` environment variable.
+- `-login-name` `(string: "")` - Specifies a login name that corresponds to an account within the given auth method.
+You can also specify a login name using the `BOUNDARY_AUTHENTICATE_PASSWORD_LOGIN_NAME` environment variable.
 
-- `-password` `(string: "")` - The password associated with the login name. If
-   blank, the command will prompt for the password to be entered interactively
-   in a non-echoing way. Otherwise, this can refer to a file on disk (`file://`)
-   from which a password will be read or an env var (`env://`) from which the
-   password will be read. This can also be specified via the
-   `BOUNDARY_AUTHENTICATE_PASSWORD_PASSWORD` environment variable.
+- `-password` `(string: "")` - Indicates the password that is associated with the login name.
+If this value is blank, the command prompts you to enter the password interactively in a non-echoing way.
+Otherwise, this value can refer to a file on disk (`file://`) from which a password is read or an environment variable (`env://`) from which the password is read. You can also specify the password using the `BOUNDARY_AUTHENTICATE_PASSWORD_PASSWORD` environment variable.
 
-- `-scope-id` `(string: "")` - The scope ID to use for the operation. This can
-   also be specified via the `BOUNDARY_SCOPE_ID` environment variable.
+- `-scope-id` `(string: "")` - Indicates the scope ID to use for the operation.
+You can also specify the scope ID using the `BOUNDARY_SCOPE_ID` environment variable.
 
 @include 'cmd-option-note.mdx'
-

--- a/website/content/docs/api-clients/commands/authenticate/oidc.mdx
+++ b/website/content/docs/api-clients/commands/authenticate/oidc.mdx
@@ -9,24 +9,24 @@ description: |-
 
 Command: `boundary authenticate oidc`
 
-The `authenticate oidc` command invokes the OIDC auth method to authenticate the
+The `authenticate oidc` command lets you invoke the OIDC auth method to authenticate the
 Boundary CLI.
 
-The OIDC authentication method allows Boundary users to delegate authentication
-to an OIDC provider. This feature allows Boundary to integrate with widely
+The OIDC authentication method lets Boundary users delegate authentication
+to an OIDC provider. OIDC authentication allows Boundary to integrate with widely
 adopted identity providers like Okta, cloud-hosted active directory services
 with an OIDC frontend, and cloud identity management systems such as AWS IAM.
 
 ## Examples
 
-Authenticate with Boundary using an oidc auth method with ID, "amoidc_q7jAdI1QgA".
+The following command authenticates the Boundary CLI using an OIDC auth method with the ID `amoidc_q7jAdI1QgA`:
 
 ```shell-session
 $ boundary authenticate oidc -auth-method-id amoidc_q7jAdI1QgA
 Opening returned authentication URL in your browser...
 ```
 
-**Example output:** 
+**Example output:**
 
 <CodeBlockConfig hideClipboard>
 
@@ -52,14 +52,12 @@ $ boundary authenticate oidc [options] [args]
 
 </CodeBlockConfig>
 
-
 ### Command options
 
-- `-auth-method-id` `(string: "")` - The auth-method resource to use for the
-      operation This can also be specified via the `BOUNDARY_AUTH_METHOD_ID`
-      environment variable.
+- `-auth-method-id` `(string: "")` - Specifies the auth method resource you want to use for the authentication.
+You can also specify the auth method resource using the `BOUNDARY_AUTH_METHOD_ID` environment variable.
 
-- `-scope-id` `(string: "")` - The scope ID to use for the operation. This can
-      also be specified via the `BOUNDARY_SCOPE_ID` environment variable.
+- `-scope-id` `(string: "")` - Indicates the scope ID to use for the operation.
+You can also specify the scope ID using the `BOUNDARY_SCOPE_ID` environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/authenticate/password.mdx
+++ b/website/content/docs/api-clients/commands/authenticate/password.mdx
@@ -15,7 +15,7 @@ authenticate the Boundary CLI.
 
 ## Examples
 
-The following example authenticates the Boundary CLI using the password auth methods by specifying the username:
+The following example authenticates the Boundary CLI using the password auth method and specifying the username:
 
 ```shell-session
 $ boundary authenticate password -login-name user1

--- a/website/content/docs/api-clients/commands/authenticate/password.mdx
+++ b/website/content/docs/api-clients/commands/authenticate/password.mdx
@@ -9,13 +9,13 @@ description: |-
 
 Command: `boundary authenticate password`
 
-The `authenticate password` command invokes the password auth method to
+The `authenticate password` command lets you invoke the password auth method to
 authenticate the Boundary CLI.
 
 
 ## Examples
 
-Authenticate using the password auth methods by specifying the username.
+The following example authenticates the Boundary CLI using the password auth methods by specifying the username:
 
 ```shell-session
 $ boundary authenticate password -login-name user1
@@ -43,23 +43,22 @@ $ boundary authenticate password [options] [args]
 
 ### Command options
 
-- `-auth-method-id` `(string: "")` - The auth-method resource to use for the
-   operation. This can also be specified via the `BOUNDARY_AUTH_METHOD_ID`
-   environment variable.
+- `-auth-method-id` `(string: "")` - Specifies the auth-method resource you want to use for the
+   authentication.
+   You can also specify the auth method resource using the `BOUNDARY_AUTH_METHOD_ID` environment variable.
 
-- `-login-name` `(string: "")` - The login name corresponding to an account
-   within the given auth method. This can also be specified via the
-   `BOUNDARY_AUTHENTICATE_PASSWORD_LOGIN_NAME` environment variable.
+- `-login-name` `(string: "")` - Specifies a login name that corresponds to an account
+   within the given auth method.
+   You can also specify a login name using the `BOUNDARY_AUTHENTICATE_PASSWORD_LOGIN_NAME` environment variable.
 
-- `-password` `(string: "")` - The password associated with the login name. If
-   blank, the command will prompt for the password to be entered interactively
-   in a non-echoing way. Otherwise, this can refer to a file on disk (`file://`)
-   from which a password will be read or an env var (`env://`) from which the
-   password will be read. This can also be specified via the
+- `-password` `(string: "")` - Indicates the password that is associated with the login name.
+   If this value is blank, the command prompts you to enter the password interactively
+   in a non-echoing way. Otherwise, this value can refer to a file on disk (`file://`)
+   from which a password is read or an environment variable (`env://`) from which the
+   password is read. You can also specify the password using the
    `BOUNDARY_AUTHENTICATE_PASSWORD_PASSWORD` environment variable.
 
-- `-scope-id` `(string: "")` - The scope ID to use for the operation. This can
-   also be specified via the `BOUNDARY_SCOPE_ID` environment variable.
+- `-scope-id` `(string: "")` - Indicates the scope ID to use for the operation. You can also specify the scope ID using the `BOUNDARY_SCOPE_ID` environment variable.
 
 
 @include 'cmd-option-note.mdx'


### PR DESCRIPTION
Edits the `auth-tokens` and `authenticate` options in the CLI draft doc #3411.