### PR TITLE
docs: Edit `config` options

### DIFF
--- a/website/content/docs/api-clients/commands/config/autocomplete.mdx
+++ b/website/content/docs/api-clients/commands/config/autocomplete.mdx
@@ -9,19 +9,19 @@ description: |-
 
 Command: `boundary config autocomplete`
 
-The `config autocomplete` command installs or uninstalls autocompletion support
+The `config autocomplete` command lets you install or uninstall autocompletion support
 for Boundary's CLI.
 
 
 ## Examples
 
-Installs autocompletion support for Boundary's CLI.
+The following command installs autocompletion support for Boundary's CLI:
 
 ```shell-session
 $ boundary config autocomplete install
 ```
 
-Uninstalls autocompletion support for Boundary's CLI.
+The following command uninstalls autocompletion support from Boundary's CLI:
 
 ```shell-session
 $ boundary config autocomplete uninstall
@@ -39,7 +39,7 @@ $ boundary config autocomplete install [options] [args]
 
 </CodeBlockConfig>
 
-**Uninstsall:**
+**Uninstall:**
 
 <CodeBlockConfig hideClipboard>
 
@@ -51,4 +51,3 @@ $ boundary config autocomplete uninstall [options] [args]
 
 
 @include 'cmd-option-note.mdx'
-

--- a/website/content/docs/api-clients/commands/config/decrypt.mdx
+++ b/website/content/docs/api-clients/commands/config/decrypt.mdx
@@ -9,20 +9,19 @@ description: |-
 
 Command: `boundary config decrypt`
 
-The `config decrypt` command decrypts sensitive values in a Boundary's
-configuration file. These values must be marked with `{{decrypt()}}` as
-appropriate. For example, `key = {{decrypt(encrypted_value)}}`.
+The `config decrypt` command decrypts sensitive values in a Boundary
+configuration file. You must mark these values with `{{decrypt()}}` as
+appropriate, for example: `key = {{decrypt(encrypted_value)}}`.
 
 ## Examples
 
-Overwrite into the existing config file use the `-overwrite` flag.
+The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
 $ boundary config decrypt -overwrite config.hcl
 ```
 
-In order for this command to perform its task, a "kms" block must be defined
-within a configuration file. 
+In order for this command to perform its task, you must define a "kms" block within the configuration file:
 
 ```hcl
 kms "aead" {
@@ -32,11 +31,11 @@ kms "aead" {
 }
 ```
 
-The "kms" block can be defined in the configuration file or via the `-config`
-flag. If defined in the configuration file, only string parameters are
-supported, and the markers must be inside the quote marks delimiting the string.
-Additionally, if the block is defined inline, do not use an "aead" block with
-the key defined in the configuration file as it provides no protection.
+You can define the "kms" block in the configuration file or using the `-config`
+flag. If you define it in the configuration file, only string parameters are
+supported, and the markers must be inside the quotation marks that delimit the string.
+Additionally, if you define the block inline, do not use an "aead" block with
+the key defined in the configuration file, as it provides no protection.
 
 ## Usage
 
@@ -51,18 +50,16 @@ $ boundary config decrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file upon which to perform
-  encryption or decryption
+- `-config` `(string: "")` - Indicates the configuration file to decrypt.
 
-- `-config-kms` `(string: "")` - If specified, the given file will be parsed for
-   a "kms" block with purpose "config" and will use it to perform the command.
-   If not set, the command will expect a block inline with the configuration
-   file, and will only be able to support quoted string parameters.
+- `-config-kms` `(string: "")` - Specifies whether the given file is parsed for
+   a "kms" block with purpose `config`, and whether it should be used to perform the command.
+   If you do not configure this value, the command expects a block to be defined inline with the configuration file, and will only be able to support quoted string parameters.
 
-- `-overwrite`  - Overwrite the existing file. The default is
-  false.
+- `-overwrite`  - Overwrites the existing file. The default value is
+  `false`.
 
-- `-strip`  - Strip the declarations from the file afterwards.
-  The default is false.
+- `-strip`  - Strips the declarations from the file afterwards.
+  The default value is `false`.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/config/encrypt.mdx
+++ b/website/content/docs/api-clients/commands/config/encrypt.mdx
@@ -9,21 +9,20 @@ description: |-
 
 Command: `boundary config encrypt`
 
-The `config encrypt` command encrypts sensitive values in a Boundary's
-configuration file. These values must be marked with `{{encrypt()}}` as
-appropriate. For example, `key = {{encrypt(key_value)}}`.
+The `config encrypt` command encrypts sensitive values in a Boundary
+configuration file. You must mark these values with `{{encrypt()}}` as
+appropriate, for example: `key = {{encrypt(key_value)}}`.
 
 
 ## Examples
 
-Overwrite into the existing config file use the `-overwrite` flag.
+The following command overwrites the existing configuration file use the `-overwrite` flag:
 
 ```shell-session
 $ boundary config encrypt -overwrite config.hcl
 ```
 
-In order for this command to perform its task, a "kms" block must be defined
-within a configuration file. 
+In order for this command to perform its task, you must define a "kms" block within a configuration file:
 
 ```hcl
 kms "aead" {
@@ -33,10 +32,10 @@ kms "aead" {
 }
 ```
 
-The "kms" block can be defined in the configuration file or via the -config
-flag. If defined in the configuration file, only string parameters are
-supported, and the markers must be inside the quote marks delimiting the string.
-Additionally, if the block is defined inline, do not use an "aead" block with
+You can define the "kms" block in the configuration file or using the `-config`
+flag. If you define it in in the configuration file, only string parameters are
+supported, and the markers must be inside the quotation marks that delimit the string.
+Additionally, if you define the block inline, do not use an "aead" block with
 the key defined in the configuration file as it provides no protection.
 
 ## Usage
@@ -52,18 +51,16 @@ $ boundary config encrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file upon which to perform
-  encryption or encryption
+- `-config` `(string: "")` - Indicates the configuration file to encrypt.
 
-- `-config-kms` `(string: "")` - If specified, the given file will be parsed for
-   a "kms" block with purpose "config" and will use it to perform the command.
-   If not set, the command will expect a block inline with the configuration
-   file, and will only be able to support quoted string parameters.
+- `-config-kms` `(string: "")` - Specifies whether the given file is parsed for
+   a "kms" block with purpose `config`, and whether it should be used to perform the command.
+   If you do not configure this value, the command expects a block to be defined inline with the configuration file, and will only be able to support quoted string parameters.
 
-- `-overwrite`  - Overwrite the existing file. The default is
-  false.
+- `-overwrite`  - Overwrites the existing file. The default value is
+  `false`.
 
-- `-strip`  - Strip the declarations from the file afterwards.
-  The default is false.
+- `-strip`  - Strips the declarations from the file afterwards.
+  The default value is `false`.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/config/get-token.mdx
+++ b/website/content/docs/api-clients/commands/config/get-token.mdx
@@ -13,7 +13,7 @@ The `config get-token` command fetches a token stored by the Boundary CLI.
 
 ## Examples
 
-Get the token stored by the Boundary CLI.
+The following command gets the token stored by the Boundary CLI:
 
 ```shell-session
 $ boundary config get-token
@@ -29,9 +29,8 @@ at_yczA5UPS7Y_s13B5PWh7KENvtKQKgDxaEvP682FMfq5eXrpzKNTpmaHgLS2ucRexrTQ7ueMhDFY5M
 
 </CodeBlockConfig>
 
-This can be useful in various situations. For example, a line such as the
-following could be in a shell script shared by developers, such that each
-developer on their own machine executing the script ends up using their own
+This command can be useful in various situations. For example, developers could share a line such as the following in a shell script, such that each
+developer on their own machine executes the script using their own
 Boundary token:
 
 <CodeBlockConfig hideClipboard>
@@ -44,11 +43,11 @@ $ curl --header "Authorization: Bearer $(boundary config get-token)" \
 
 </CodeBlockConfig>
 
-This command keeps parity with the behavior of other Boundary commands; if the
-`BOUNDARY_TOKEN` environment variable it set, it will override the value loaded
+This command keeps parity with the behavior of other Boundary commands; if you set the
+`BOUNDARY_TOKEN` environment variable, it overrides the value loaded
 from the system store. Not only does this keep parity, but it also allows
-examples such as the one above to work even if there is no stored token but if
-an environment variable is specified.
+examples such as the one above to work even if there is no stored token, but you specified
+an environment variable.
 
 ## Usage
 
@@ -62,27 +61,32 @@ $ boundary config get-token [options] [args]
 
 ### Command options
 
-- `-account-id`  - If specified, print out the account ID
-      associated with the token instead of the token itself. The default is
-      false.
+- `-account-id`  - Prints out the account ID
+      associated with the token instead of the token itself, if specified. The default value is
+      `false`.
 
-- `-auth-method-id`  - If specified, print out the auth method ID
-   associated with the token instead of the token itself. The default is false.
+- `-auth-method-id`  - Prints out the auth method ID
+   associated with the token instead of the token itself, if specified. The default value is `false`.
 
-- `-keyring-type` `(string: "")` - The type of keyring to use. Defaults to
-   "auto" which will use the Windows credential manager, OSX keychain, or
-   cross-platform password store depending on platform. Set to "none" to disable
-   keyring functionality. Available types, depending on platform, are:
-   "wincred", "keychain", "pass", and "secret-service". The default is auto.
-   This can also be specified via the BOUNDARY_KEYRING_TYPE environment
+- `-keyring-type` `(string: "")` - Indicates the type of keyring to use. This value defaults to
+   `auto` which uses the Windows credential manager, OSX keychain, or
+   cross-platform password store depending on the platform. Set this value to `none` to disable
+   keyring functionality. The following keyring types are available, depending on platform:
+
+   - `wincred`
+   - `keychain`
+   - `pass`
+   - `secret-service`
+
+  You can also specify the keyring type using the **BOUNDARY_KEYRING_TYPE** environment
    variable.
 
-- `-token-name` `(string: "")` - If specified, the given value will be used as
-   the name when loading the token from the system credential store. This must
-   correspond to a name used when authenticating. This can also be specified via
-   the BOUNDARY_TOKEN_NAME environment variable.
+- `-token-name` `(string: "")` - Indicates whether the given value should be used as
+   the name when loading the token from the system credential store. This value must
+   correspond to a name used when authenticating. You can also specify the token name using
+   the **BOUNDARY_TOKEN_NAME** environment variable.
 
-- `-user-id`  - If specified, print out the user ID associated
-   with the token instead of the token itself. The default is false.
+- `-user-id`  - Prints out the user ID associated
+   with the token instead of the token itself, if specified. The default value is `false`.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/config/index.mdx
+++ b/website/content/docs/api-clients/commands/config/index.mdx
@@ -2,31 +2,31 @@
 layout: docs
 page_title: config - Command
 description: |-
-  The "config" command groups subcommands for operators interacting with Boundary's config files.
+  The "config" command groups subcommands for operators to interact with Boundary's configuration files.
 ---
 
 # config
 
 Command: `boundary config`
 
-The `config` command groups subcommands for operators interacting with
-Boundary's config files.
+The `config` command groups subcommands for operators to interact with
+Boundary's configuration files.
 
 ## Examples
 
-Encrypt sensitive values in a config file
+The following command encrypts sensitive values in a configuration file:
 
 ```shell-session
 $ boundary config encrypt config.hcl
 ```
 
-Decrypt sensitive values in a config file.
+The following command decrypts sensitive values in a configuration file:
 
 ```shell-session
 $ boundary config decrypt config.hcl
 ```
 
-Read a stored token out.
+The following comand reads a stored token's output.
 
 ```shell-session
 $ boundary config get-token
@@ -51,7 +51,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [autocomplete](/boundary/docs/api-clients/commands/config/autocomplete)


### PR DESCRIPTION
Edits the `config` options in the CLI draft doc #3411.