### PR TITLE
docs: Edit multiple credentials options

### DIFF
--- a/website/content/docs/api-clients/commands/accounts/update.mdx
+++ b/website/content/docs/api-clients/commands/accounts/update.mdx
@@ -87,8 +87,6 @@ $ boundary accounts update [type] [options] [args]
 
 </CodeBlockConfig>
 
-The available types are: `ldap`, `oidc`, and `password`.
-
 ### Command options
 
 - `-description` `(string: "")` - Specifies the description to set on the account.
@@ -99,6 +97,8 @@ The available types are: `ldap`, `oidc`, and `password`.
    check-and-set automatically.
 
 ### Usages by type
+
+The available types are: `ldap`, `oidc`, and `password`.
 
 <Tabs>
 <Tab heading="LDAP">

--- a/website/content/docs/api-clients/commands/auth-methods/create.mdx
+++ b/website/content/docs/api-clients/commands/auth-methods/create.mdx
@@ -80,8 +80,6 @@ $ boundary auth-methods create [type] [sub command] [options] [args]
 
 </CodeBlockConfig>
 
-The available types are: `ldap`, `oidc`, and `password`.
-
 ### Command options:
 
 - `-description` `(string: "")` - Specifies the description to set on the auth method.
@@ -92,6 +90,8 @@ The available types are: `ldap`, `oidc`, and `password`.
 @include 'cmd-option-note.mdx'
 
 ### Usages by type
+
+The available types are: `ldap`, `oidc`, and `password`.
 
 <Tabs>
 <Tab heading="LDAP">

--- a/website/content/docs/api-clients/commands/credential-libraries/create.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/create.mdx
@@ -2,20 +2,18 @@
 layout: docs
 page_title: credential-libraries create - Command
 description: |-
-  The "credential-libraries create" command allows create operations on Boundary credential library resources.
+  The "credential-libraries create" command lets you create Boundary credential library resources.
 ---
 
 # credential-libraries create
 
 Command: `boundary credential-libraries create`
 
-The `credential-libraries create` command creates a credential library resource
-in Boundary.
+The `credential-libraries create` command lets you create a credential library resource in Boundary.
 
 ## Examples
 
-Create a credential library for database credentials where Vault's database
-secrets engine provide dynamic credentials.
+The following example creates a credential library for database credentials where Vault's database secrets engine provides dynamic credentials:
 
 ```shell-session
 $ boundary credential-libraries create vault-generic \
@@ -68,32 +66,42 @@ $ boundary credential-libraries create [type] [sub command] [options] [args]
 
 </CodeBlockConfig>
 
+### Command options
+
+- `-credential-store-id` `(string: "")` - Indicates the credential store resource to use
+      for the operation. You can also specify the credential store using the
+      **BOUNDARY_CREDENTIAL_STORE_ID** environment variable.
+- `-description` `(string: "")` - Specifies a description of the credential library.
+- `-name` `(string: "")` - Specifies the name of the credential library.
+
+
+### Usages by type
+
 The available types are `vault-generic` and `vault-ssh-certificate`.
 
 <Note>
 
-A credential library type, `vault` is deprecated, so use `vault-generic` type
-instead.
+A credential library type, `vault` is deprecated, so use `vault-generic` type instead.
 
 </Note>
 
-### Command options
-
-- `-credential-store-id` `(string: "")` - The credential-store resource to use
-      for the operation. This can also be specified via the
-      `BOUNDARY_CREDENTIAL_STORE_ID` environment variable.
-
-- `-description` `(string: "")` - Description to set on the credential library.
-
-- `-name` `(string: "")` - Name to set on the credential library.
-
-
-#### Usages by type
 
 <Tabs>
 <Tab heading="Vault">
 
-Create a credential library of `vault-generic` type.
+The `credential-libraries create vault-generic` command lets you create a generic Vault credential library.
+
+#### Example
+
+The following example creates a generic Vault credential library using a credential store with the ID `csvlt_1234567890`:
+
+```shell-session
+$ boundary credential-libraries create vault-generic \
+   -credential-store-id csvlt_1234567890 \
+   -vault-path "database/creds/dba"
+```
+
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -103,40 +111,36 @@ $ boundary credential-libraries create vault-generic [options] [args]
 
 </CodeBlockConfig>
 
-### Vault credential library options
+#### Vault credential library options
 
-The following are Vault credential library specific options in addition to the
-command options.
+The following are specific Vault credential library options in addition to the command options:
 
-- `-credential-mapping-override`  - The credential mapping
-  override.
+- `-credential-mapping-override`  - Indicates an override for credential mapping.
+- `-credential-type` `(string: "")` - Determines the type of credential this library issues.
+The default value is `Unspecified`.
+- `-vault-http-method` `(string: "")` - Determines the HTTP method the library should use when it communicates with Vault.
+- `-vault-http-request-body` `(string: "")` - Indicates the HTTP request body the credential library uses to communicate with Vault.
+This value can be the HTTP request body value itself, it can refer to a file on disk (`file://`) from which the value is read, or it can refer to an environment variable (`env://`) from which the value is read.
+- `-vault-path` `(string: "")` - Indicates the path in Vault to request credentials from.
 
-- `-credential-type` `(string: "")` - The type of credential this library will
-  issue, defaults to Unspecified.
+</Tab>
 
-- `-vault-http-method` `(string: "")` - The http method the library should use
-  when communicating with vault.
+<Tab heading="Vault SSH certificate">
 
-- `-vault-http-request-body` `(string: "")` - The http request body the library
-   uses to communicate with Vault. This can be the value itself, refer to a file
-   on disk (`file://`) from which the value will be read, or an env var
-   (`env://`) from which the value will be read.
-
-- `-vault-path` `(string: "")` - The path in vault to request credentials from.
-
+The `credential-libraries create vault-ssh-certificate` command lets you create a Vault SSH certificate credential library.
 
 #### Example
 
+The following example creates a Vault SSH certificate credential library with the ID `csvlt_1234567890`:
+
 ```shell-session
-$ boundary credential-libraries create vault-generic \
-   -credential-store-id csvlt_1234567890 \
-   -vault-path "database/creds/dba"
+$ boundary credential-libraries create vault-ssh-certificate \
+   -credential-store-id  csvlt_1234567890 \
+   -vault-path "/ssh/sign/role" \
+   -username user
 ```
 
-</Tab>
-<Tab heading="Vault SSH certificate">
-
-Create a credential library of `vault-ssh-certificate` type.
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -146,62 +150,43 @@ $ boundary credential-libraries create vault-ssh-certificate [options] [args]
 
 </CodeBlockConfig>
 
-### Vault SSH certificate credential library options
+#### Vault SSH certificate credential library options
 
-The following are Vault SSH certificate credential library specific options in
-addition to the command options.
+The following are options are specific to the Vault SSH certificate credential library, in addition to the command options:
 
-- `-critical-option`  - A key=value pair to add to the request's
-   critical-options map. This can also be a key value only which will set a JSON
-   null as the value. If a value is provided, the type is automatically
-   inferred. Use `-string-critical-option`, `-bool-critical-option`, or
-   `-num-critical-option` if the type needs to be overridden. Can be specified
-   multiple times. Supports sourcing values from files via "file://" and env
-   vars via "env://".
-
-- `-critical-options` `(string: "")` - A JSON  map value to use as the entirety
-   of the request's critical-options map. Usually this will be sourced from a
-   file via "file://" syntax. Is exclusive with the other critical-option flags.
-
-- `-extension`  - A key=value pair to add to the request's
-   extensions map. This can also be a key value only which will set a JSON null
-   as the value. If a value is provided, the type is automatically inferred. Use
-   `-string-extension`, `-bool-extension`, or `-num-extension` if the type needs to be
-   overridden. Can be specified multiple times. Supports sourcing values from
-   files via "file://" and env vars via "env://".
-
-- `-extensions` `(string: "")` - A JSON map value to use as the entirety of
-   the request's extensions map. Usually this will be sourced from a file via
-   "file://" syntax. Is exclusive with the other extension flags.
-
-- `-key-bits` `(string: "")` - The number of bits when generating the ssh
-   private key. Depends on key_type. If ed25519 this should not be set, or set
-   to 0, if ecdsa one of 256, 384, 521, if rsa one of 2048, 3072, 4096.
-
-- `-key-id` `(string: "")` - The key id that the created certificate should
-  have.
-
-- `-key-type` `(string: "")` - The key type for the generated ssh private key.
-   One of: ed25519, ecdsa, rsa.
-
-- `-ttl` `(string: "")` - The time-to-live for the generated certificate.
-
-- `-username` `(string: "")` - The username to use with the ssh certificate.
-
-- `-vault-path` `(string: "")` - The path in vault to request credentials from.
-
-
-#### Example
-
-```shell-session
-$ boundary credential-libraries create vault-ssh-certificate \
-   -credential-store-id  csvlt_1234567890 \
-   -vault-path "/ssh/sign/role" \
-   -username user
-```
+- `-critical-option`  - Specifies a key=value pair to add to the request's
+   critical-options map.
+   It can also be a key value only which sets a JSON null as the value.
+   If you provide a value, Boundary infers the type automatically.
+   You can use `-string-critical-option`, `-bool-critical-option`, or `-num-critical-option` to override the type.
+   You can specify values for this option multiple times.
+   This option supports sourcing values from files using "file://" and environment variables using "env://".
+- `-critical-options` `(string: "")` - Indicates a JSON  map value to use as the entirety of the request's critical-options map.
+Usually this value is sourced from a file using "file://" syntax.
+This value is exclusive with the other critical-option flags.
+- `-extension`  - Specifies a key=value pair to add to the request's extensions map.
+It can also be a key value only which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+You can use `-string-extension`, `-bool-extension`, or `-num-extension` to override the type.
+You can specify values for this option multiple times.
+This option supports sourcing values from files using "file://" and environment variables using "env://".
+- `-extensions` `(string: "")` - Specifies a JSON map value to use as the entirety of
+   the request's extensions map.
+   Usually this value is sourced from a file using "file://" syntax.
+   This option is exclusive with the other extension flags.
+- `-key-bits` `(string: "")` - Specifies the number of bits to use when the SSH private key is generated.
+The value depends on the `key_type`.
+If you use a `ed25519` key, you should not set a value or set the value to `0`.
+If you use a `ecdsa` key, you should set the value to `256`, `384`, or `521`.
+If you use an `rsa` key, you should set the value to `2048`, `3072`, or `4096`.
+- `-key-id` `(string: "")` - Specifies the created certificate's key id.
+- `-key-type` `(string: "")` - Specifies the key type for the generated ssh private key.
+Supported values include `ed25519`, `ecdsa`, and `rsa`.
+- `-ttl` `(string: "")` - Indicates the generated certificate's time-to-live.
+- `-username` `(string: "")` - Specifies the username to use with the SSH certificate.
+- `-vault-path` `(string: "")` - Specifies the path in Vault to request credentials from.
 
 </Tab>
 </Tabs>
-
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-libraries/create.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/create.mdx
@@ -160,19 +160,19 @@ The following are options are specific to the Vault SSH certificate credential l
    If you provide a value, Boundary infers the type automatically.
    You can use `-string-critical-option`, `-bool-critical-option`, or `-num-critical-option` to override the type.
    You can specify values for this option multiple times.
-   This option supports sourcing values from files using "file://" and environment variables using "env://".
+   This option supports sourcing values from files using `file://` and environment variables using `env://`.
 - `-critical-options` `(string: "")` - Indicates a JSON  map value to use as the entirety of the request's critical-options map.
-Usually this value is sourced from a file using "file://" syntax.
+Usually this value is sourced from a file using the `file://` syntax.
 This value is exclusive with the other critical-option flags.
 - `-extension`  - Specifies a key=value pair to add to the request's extensions map.
 It can also be a key value only which will set a JSON null as the value.
 If you provide a value, Boundary automatically infers the type.
 You can use `-string-extension`, `-bool-extension`, or `-num-extension` to override the type.
 You can specify values for this option multiple times.
-This option supports sourcing values from files using "file://" and environment variables using "env://".
+This option supports sourcing values from files using `file://` and environment variables using `env://`.
 - `-extensions` `(string: "")` - Specifies a JSON map value to use as the entirety of
    the request's extensions map.
-   Usually this value is sourced from a file using "file://" syntax.
+   Usually this value is sourced from a file using the `file://` syntax.
    This option is exclusive with the other extension flags.
 - `-key-bits` `(string: "")` - Specifies the number of bits to use when the SSH private key is generated.
 The value depends on the `key_type`.

--- a/website/content/docs/api-clients/commands/credential-libraries/delete.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/delete.mdx
@@ -13,7 +13,7 @@ The `credential-libraries delete` command lets you delete an existing credential
 
 ## Example
 
-The following example deletes a credential library with the ID `csvlt_5fvkRjCjou`.
+The following example deletes a credential library with the ID `csvlt_5fvkRjCjou`:
 
 ```shell-session
 $ boundary credential-libraries delete -id csvlt_5fvkRjCjou

--- a/website/content/docs/api-clients/commands/credential-libraries/delete.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/delete.mdx
@@ -2,19 +2,18 @@
 layout: docs
 page_title: credential-libraries delete - Command
 description: |-
-  The "credential-libraries delete" command allows Boundary admin to delete a credential library resource.
+  The "credential-libraries delete" command lets Boundary admin delete a credential library resource.
 ---
 
 # credential-libraries delete
 
 Command: `boundary credential-libraries delete`
 
-The `credential-libraries delete` command deletes an existing credential library
-resource.
+The `credential-libraries delete` command lets you delete an existing credential library resource.
 
-## Examples
+## Example
 
-Delete a credential library with the given ID. 
+The following example deletes a credential library with the ID `csvlt_5fvkRjCjou`.
 
 ```shell-session
 $ boundary credential-libraries delete -id csvlt_5fvkRjCjou
@@ -33,6 +32,6 @@ $ boundary credential-libraries delete [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the credential library on which to operate.
+- `-id` `(string: "")` - Indicates the ID of the credential library to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-libraries/index.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/index.mdx
@@ -84,6 +84,6 @@ of the subcommand in the sidebar or one of the links below:
 
 - [create](/boundary/docs/api-clients/commands/credential-libraries/create)
 - [delete](/boundary/docs/api-clients/commands/credential-libraries/delete)
+- [list](/boundary/docs/api-clients/commands/credential-libraries/list)
 - [read](/boundary/docs/api-clients/commands/credential-libraries/read)
 - [update](/boundary/docs/api-clients/commands/credential-libraries/update)
-- [list](/boundary/docs/api-clients/commands/credential-libraries/list)

--- a/website/content/docs/api-clients/commands/credential-libraries/index.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/index.mdx
@@ -2,26 +2,26 @@
 layout: docs
 page_title: credential-libraries - Command
 description: |-
-  The "credential-libraries" command allows Boundary admin to create and manage the credential libraries.
+  The "credential-libraries" command lets Boundary admin create and manage credential libraries.
 ---
 
 # credential-libraries
 
 Command: `boundary credential-libraries`
 
-The `credential-libraries` command allows operations on Boundary credential
-library resources. A credential library provides credentials for sessions. All
-credentials returned by a library must be equivalent from an access control
-perspective. A credential library is responsible for managing the lifecycle of
-the credentials it returns. For dynamic secrets, this includes creation,
-renewal, and revocation. For rotating credentials, this includes check-out,
-check-in, and rotation of secrets. The system retrieves credentials from a
-library for a session and notifies the library when the session has been
-terminated. A credential library belongs to a single credential store.
+The `credential-libraries` command lets you perform operations on Boundary credential library resources.
+A credential library provides credentials for sessions.
+All credentials returned by a library must be equivalent from an access control perspective.
+
+A credential library is responsible for managing the lifecycle of the credentials it returns.
+For dynamic secrets, this includes creation, renewal, and revocation.
+For rotating credentials, this includes check-out, check-in, and rotation of secrets.
+The system retrieves credentials from a library for a session and notifies the library when the session has been terminated.
+A credential library belongs to a single credential store.
 
 ## Examples
 
-Retrieve a credential library information for a given ID, `clvlt_QYnQPAjA24`.
+The following example retrieves information for a credential library with the ID, `clvlt_QYnQPAjA24`:
 
 ```shell-session
 $ boundary credential-libraries read -id clvlt_QYnQPAjA24
@@ -79,7 +79,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [create](/boundary/docs/api-clients/commands/credential-libraries/create)

--- a/website/content/docs/api-clients/commands/credential-libraries/list.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/list.mdx
@@ -9,16 +9,15 @@ description: |-
 
 Command: `boundary credential-libraries list`
 
-The `credential-libraries list` command lists credential libraries within an
-enclosing scope or resource.
+The `credential-libraries list` command lists credential libraries within an enclosing scope or resource.
 
 ## Examples
 
-List all credential libraries for a given credential store.
+The following example lists all credential libraries for a credential store with the ID `clvlt_QYnQPAjA24`:
 
 ```shell-session
 $ boundary credential-libraries list \
-   -credential-store-id clvlt_QYnQPAjA24
+   -credential-store-id
 ```
 
 **Example output:**
@@ -53,13 +52,11 @@ $ boundary credential-libraries list [options] [args]
 
 ### Command options
 
-- `-credential-store-id` `(string: "")` - The credential-store resource to use
-  for the operation. This can also be specified via the
-  `BOUNDARY_CREDENTIAL_STORE_ID` environment variable.
-
-- `-filter` `(string: "")` - If set, the list operation will be filtered before
-   being returned. The filter operates against each item in the list. Using
-   single quotes is recommended as filters contain double quotes. 
-
+- `-credential-store-id` `(string: "")` - Indicates the credential store resource to list credential libraries for.
+You can also specify the credential store using the **BOUNDARY_CREDENTIAL_STORE_ID** environment variable.
+- `-filter` `(string: "")` - Indicates whether Boundary filters the list operation before the results are returned.
+The filter operates against each item in the list.
+We recommend that you use single quotes, because the filters contain double quotes.
+Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-libraries/read.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/read.mdx
@@ -2,20 +2,19 @@
 layout: docs
 page_title: credential-libraries read - Command
 description: |-
-  The "credential-libraries read" command allows Boundary admin to read a credential library information.
+  The "credential-libraries read" command lets Boundary admin read credential library information.
 ---
 
 # credential-libraries read
 
 Command: `boundary credential-libraries read`
 
-The `credential-libraries read` command reads a credential library information
-of a specific ID.
+The `credential-libraries read` command reads the credential library information for a specific credential library ID.
 
 
 ## Examples
 
-Retrieve a credential library information for a given ID, `clvlt_QYnQPAjA24`.
+The following example retrieves credential library information for a credential library with the ID `clvlt_QYnQPAjA24`:
 
 ```shell-session
 $ boundary credential-libraries read -id clvlt_QYnQPAjA24
@@ -67,6 +66,6 @@ $ boundary credential-libraries read [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the credential library on which to operate.
+- `-id` `(string: "")` - Indicates the ID of the credential library from which to read information.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-libraries/update.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/update.mdx
@@ -157,19 +157,19 @@ The following are options specific to the Vault SSH certificate credential libra
    If you provide a value, Boundary infers the type automatically.
    You can use `-string-critical-option`, `-bool-critical-option`, or `-num-critical-option` to override the type.
    You can specify values for this option multiple times.
-   This option supports sourcing values from files using "file://" and environment variables using "env://".
+   This option supports sourcing values from files using `file://` and environment variables using `env://`.
 - `-critical-options` `(string: "")` Indicates a JSON  map value to use as the entirety of the request's critical-options map.
-Usually this value is sourced from a file using "file://" syntax.
+Usually this value is sourced from a file using the `file://` syntax.
 This value is exclusive with the other critical-option flags.
 - `-extension`  - Specifies a key=value pair to add to the request's extensions map.
 It can also be a key value only which will set a JSON null as the value.
 If you provide a value, Boundary automatically infers the type.
 You can use `-string-extension`, `-bool-extension`, or `-num-extension` to override the type.
 You can specify values for this option multiple times.
-This option supports sourcing values from files using "file://" and environment variables using "env://".
+This option supports sourcing values from files using `file://` and environment variables using `env://`.
 - `-extensions` `(string: "")` - Specifies a JSON map value to use as the entirety of
    the request's extensions map.
-   Usually this value is sourced from a file using "file://" syntax.
+   Usually this value is sourced from a file using the `file://` syntax.
    This option is exclusive with the other extension flags.
 - `-key-bits` `(string: "")` - Specifies the number of bits to use when the SSH private key is generated.
 The value depends on the `key_type`.

--- a/website/content/docs/api-clients/commands/credential-libraries/update.mdx
+++ b/website/content/docs/api-clients/commands/credential-libraries/update.mdx
@@ -2,20 +2,18 @@
 layout: doc
 page_title: credential-libraries update - Command
 description: |-
-  The "credential-libraries update" command allows Boundary admin to update a credential library resource.
+  The "credential-libraries update" command lets Boundary admin update a credential library resource.
 ---
 
 # credential-libraries update
 
 Command: `boundary credential-libraries update`
 
-The `credential-libraries update` command performs update operations on Boundary
-credential library resources. 
+The `credential-libraries update` command lets you update Boundary credential library resources.
 
 ## Examples
 
-Update an existing Vault credential library to point to a new Vault secrets
-engine path.
+The following example updates an existing Vault credential library with the ID `csvlt_5fvkRjCjou` to point to a new Vault secrets engine path:
 
 ```shell-session
 $ boundary credential-libraries update vault-generic \
@@ -67,6 +65,16 @@ $ boundary credential-libraries update vault [options] [args]
 
 </CodeBlockConfig>
 
+### Command options
+
+- `-description` `(string: "")` - Specifies a description to set on the credential library.
+- `-id` `(string: "")` - Indicates the ID of the credential library to update.
+- `-name` `(string: "")` - Specifies a name to set on the credential library.
+- `-version` `(int: 0)` - The version of the credential library against which to perform the update operation.
+If you don't specify a version, the command performs a check-and-set automatically.
+
+#### Usages by type
+
 The available types are `vault-generic` and `vault-ssh-certificate`.
 
 <Note>
@@ -76,24 +84,23 @@ instead.
 
 </Note>
 
-### Command options
-
-- `-description` `(string: "")` - Description to set on the credential library.
-
-- `-id` `(string: "")` - ID of the credential library on which to operate.
-
-- `-name` `(string: "")` - Name to set on the credential library.
-
-- `-version` `(int: 0)` - The version of the credential library against which to
-   perform an update operation. If not specified, the command will perform a
-   check-and-set automatically.
-
-#### Usages by type
-
 <Tabs>
 <Tab heading="Vault">
 
-Update a credential library of `vault-generic` type.
+The `credential-libraries update vault-generic` command lets you update a generic Vault credential library.
+
+#### Example
+
+The following example updates a generic Vault credential library with the ID `clvlt_1234567890` to add the name `devops` and the description `For DevOps usage`:
+
+```shell-session
+$ boundary credential-libraries update vault-generic \
+   -id clvlt_1234567890 \
+   -name devops \
+   -description "For DevOps usage"
+```
+
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -103,38 +110,34 @@ $ boundary credential-libraries create vault-generic [options] [args]
 
 </CodeBlockConfig>
 
-### Vault credential library options
+#### Vault credential library options
 
-The following are Vault credential library specific options in addition to the
-command options.
+The following are specific Vault credential library options in addition to the command options:
 
-- `-credential-mapping-override`  - The credential mapping
-  override.
+- `-credential-mapping-override`  - Indicates an override for credential mapping.
+- `-vault-http-method` `(string: "")` - Determines the HTTP method the library should use when it communicates with Vault.
+- `-vault-http-request-body` `(strinboundary credential-libraries update vault-ssh-certificate -id clvsclt_1234567890 -name devops -description "For DevOps usage": "")` - Indicates the HTTP request body the credential library uses to communicate with Vault.
+This value can be the HTTP request body itself, it can refer to a file on disk (`file://`) from which the value is read, or it can refer to an environment variable (`env://`) from which the value is read.
+- `-vault-path` `(string: "")` - Indicates the path in Vault to request credentials from.
 
-- `-vault-http-method` `(string: "")` - The http method the library should use
-  when communicating with Vault.
+</Tab>
 
-- `-vault-http-request-body` `(strinboundary credential-libraries update vault-ssh-certificate -id clvsclt_1234567890 -name devops -description "For DevOps usage": "")` - The http request body the library
-   uses to communicate with vault. This can be the value itself, refer to a file
-   on disk (`file://`) from which the value will be read, or an env var
-   (`env://`) from which the value will be read.
+<Tab heading="Vault SSH certificate">
 
-- `-vault-path` `(string: "")` - The path in vault to request credentials from.
-
+The `credential-libraries update vault-ssh-certificate` command lets you update a Vault SSH certificate credential library.
 
 #### Example
 
+The following example updates a Vault SSH certificate credential library with the ID `clvsclt_1234567890` to add the name `devops` and the description `For DevOps usage`:
+
 ```shell-session
-$ boundary credential-libraries update vault-generic \
-   -id clvlt_1234567890 \
+$ boundary credential-libraries update vault-ssh-certificate \
+   -id clvsclt_1234567890 \
    -name devops \
    -description "For DevOps usage"
 ```
 
-</Tab>
-<Tab heading="Vault SSH certificate">
-
-Update a credential library of `vault-ssh-certificate` type.
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -144,59 +147,41 @@ $ boundary credential-libraries update vault-ssh-certificate [options] [args]
 
 </CodeBlockConfig>
 
-### Vault SSH certificate credential library options
+#### Vault SSH certificate credential library options
 
-The following are Vault SSH certificate credential library specific options in
-addition to the command options.
+The following are options specific to the Vault SSH certificate credential library, in addition to the command options:
 
-- `-critical-option`  - A key=value pair to add to the request's
-   critical-options map. This can also be a key value only which will set a JSON
-   null as the value. If a value is provided, the type is automatically
-   inferred. Use `-string-critical-option`, `-bool-critical-option`, or
-   `-num-critical-option` if the type needs to be overridden. Can be specified
-   multiple times. Supports sourcing values from files via "file://" and env
-   vars via "env://".
-
-- `-critical-options` `(string: "")` - A JSON map value to use as the entirety
-   of the request's critical-options map. Usually this will be sourced from a
-   file via "file://" syntax. Is exclusive with the other critical-option flags.
-
-- `-extension`  - A key=value pair to add to the request's
-   extensions map. This can also be a key value only which will set a JSON null
-   as the value. If a value is provided, the type is automatically inferred. Use
-   `-string-extension`, `-bool-extension`, or `-num-extension` if the type needs to be
-   overridden. Can be specified multiple times. Supports sourcing values from
-   files via "file://" and env vars via "env://".
-
-- `-extensions` `(string: "")` - A JSON map value to use as the entirety of
-   the request's extensions map. Usually this will be sourced from a file via
-   "file://" syntax. Is exclusive with the other extension flags.
-
-- `-key-bits` `(string: "")` - The number of bits when generating the ssh
-   private key. Depends on key_type. If ed25519 this should not be set, or set
-   to 0, if ecdsa one of 256, 384, 521, if rsa one of 2048, 3072, 4096.
-
-- `-key-id` `(string: "")` - The key id that the created certificate should
-  have.
-
-- `-key-type` `(string: "")` - The key type for the generated ssh private key.
-   One of: ed25519, ecdsa, rsa.
-
-- `-ttl` `(string: "")` - The time-to-live for the generated certificate.
-
-- `-username` `(string: "")` - The username to use with the ssh certificate.
-
-- `-vault-path` `(string: "")` - The path in vault to request credentials from.
-
-
-#### Example
-
-```shell-session
-$ boundary credential-libraries update vault-ssh-certificate \
-   -id clvsclt_1234567890 \
-   -name devops \
-   -description "For DevOps usage"
-```
+- `-critical-option`  - Specifies a key=value pair to add to the request's
+   critical-options map.
+   It can also be a key value only which sets a JSON null as the value.
+   If you provide a value, Boundary infers the type automatically.
+   You can use `-string-critical-option`, `-bool-critical-option`, or `-num-critical-option` to override the type.
+   You can specify values for this option multiple times.
+   This option supports sourcing values from files using "file://" and environment variables using "env://".
+- `-critical-options` `(string: "")` Indicates a JSON  map value to use as the entirety of the request's critical-options map.
+Usually this value is sourced from a file using "file://" syntax.
+This value is exclusive with the other critical-option flags.
+- `-extension`  - Specifies a key=value pair to add to the request's extensions map.
+It can also be a key value only which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+You can use `-string-extension`, `-bool-extension`, or `-num-extension` to override the type.
+You can specify values for this option multiple times.
+This option supports sourcing values from files using "file://" and environment variables using "env://".
+- `-extensions` `(string: "")` - Specifies a JSON map value to use as the entirety of
+   the request's extensions map.
+   Usually this value is sourced from a file using "file://" syntax.
+   This option is exclusive with the other extension flags.
+- `-key-bits` `(string: "")` - Specifies the number of bits to use when the SSH private key is generated.
+The value depends on the `key_type`.
+If you use a `ed25519` key, you should not set a value or set the value to `0`.
+If you use a `ecdsa` key, you should set the value to `256`, `384`, or `521`.
+If you use an `rsa` key, you should set the value to `2048`, `3072`, or `4096`.
+- `-key-id` `(string: "")` - Specifies the certificate's key id.
+- `-key-type` `(string: "")` - Specifies the key type for the ssh private key.
+Supported values include `ed25519`, `ecdsa`, and `rsa`.
+- `-ttl` `(string: "")` - Indicates the generated certificate's time-to-live.
+- `-username` `(string: "")` - Specifies the username to use with the SSH certificate.
+- `-vault-path` `(string: "")` - Specifies the path in Vault to request credentials from.
 
 </Tab>
 </Tabs>

--- a/website/content/docs/api-clients/commands/credential-stores/create.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/create.mdx
@@ -2,19 +2,18 @@
 layout: docs
 page_title: credential-stores create - Command
 description: |-
-  The "credential-stores create" command create operations on Boundary credential store resources.
+  The "credential-stores create" command lets you create Boundary credential store resources.
 ---
 
 # credential-stores create
 
 Command: `boundary credential-stores create`
 
-The `credential-stores create` command creates a credential store resource
-in Boundary.
+The `credential-stores create` command lets you create a Boundary credential store resource.
 
 ## Examples
 
-Create a credential store resource in a project scope. 
+The following example creates a credential store resource in a project scope with the ID `p_tnqESc86qE`:
 
 ```shell-session
 $ boundary credential-stores create vault -scope-id p_tnqESc86qE \
@@ -70,24 +69,32 @@ $ boundary credential-stores create [type] [sub command] [options] [args]
 
 </CodeBlockConfig>
 
-The available types are `static` and `vault`.
-
 ### Command options
 
-- `-description` `(string: "")` - Description to set on the credential store.
+- `-description` `(string: "")` - Specifies the description to set on the credential store.
+- `-name` `(string: "")` - Specifies the name to set on the credential store.
+- `-scope-id` `(string: "")` - Indicates the scope in which to make the request.
+The default scope is `global`.
+You can also indicate the scope using the **BOUNDARY_SCOPE_ID** environment variable.
 
-- `-name` `(string: "")` - Name to set on the credential store.
+### Usages by type
 
-- `-scope-id` `(string: "")` - Scope in which to make the request. The default
-  is global. This can also be specified via the `BOUNDARY_SCOPE_ID` environment
-  variable.
-
-#### Usages by type
+The available types are `static` and `vault`.
 
 <Tabs>
 <Tab heading="Static">
 
-Create a static-type credential store.
+The `credential-stores create static` command lets you create a static-type credential store.
+
+#### Example
+
+The following example creates a static credential score in a scope with the ID `p_1234567890`:
+
+```shell-session
+$ boundary credential-stores create static -scope-id p_1234567890
+```
+
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -97,16 +104,23 @@ $ boundary credential-stores create static [options] [args]
 
 </CodeBlockConfig>
 
-#### Example
-
-```shell-session
-$ boundary credential-stores create static -scope-id p_1234567890
-```
 
 </Tab>
 <Tab heading="Vault">
 
-Create a credential stores of `vault` type.
+The `credential-stores create vault` command lets you create a Vault credential store.
+
+#### Example
+
+The following example creates a Vault credential store:
+
+```shell-session
+$ boundary credential-stores create vault \
+   -vault-address "http://127.0.0.1:8200" \
+   -vault-token "<new-token-value>"
+```
+
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -116,50 +130,24 @@ $ boundary credential-stores create vault [options] [args]
 
 </CodeBlockConfig>
 
-### Vault credential stores options
+#### Vault credential stores options
 
-The following are Vault credential stores specific options in addition to the
-command options.
+The following options are specific to Vault credential stores in addition to the command options:
 
-- `-vault-address` `(string: "")` - The address of the Vault server. This should
-  be a complete URL such as https://127.0.0.1:8200
-
-- `-vault-ca-cert` `(string: "")` - The CA Cert to use when connecting to vault.
-  This can be the value itself, refer to a file on disk (`file://`) from which the
-   value will be read, or an env var (env://) from which the value will be read.
-
-- `-vault-client-certificate` `(string: "")` - The client certificate to use
-  when boundary connects to vault for this store. This can be the value itself,
-  refer to a file on disk (`file://`) from which the value will be read, or an env
-  var (`env://`) from which the value will be read.
-
-- `-vault-client-certificate-key` `(string: "")` - The client certificate's
-  private key to use when boundary connects to vault for this store. This can be
-  the value itself, refer to a file on disk (`file://`) from which the value will
-  be read, or an env var (`env://`) from which the value will be read.
-
-- `-vault-namespace` `(string: "")` - The vault namespace the store should use.
-
-- `-vault-tls-server-name` `(string: "")` - Name to use as the SNI host when
-  connecting via TLS.
-
-- `-vault-tls-skip-verify`  - Whether to skip tls verification.
-The default is false.
-
-- `-vault-token` `(string: "")` - The vault token to use when boundary connects
-  to vault for this store.
-
-- `-worker-filter` `(string: "")` - A boolean expression to filter which workers
-  can handle Vault commands for this credential store.
-
-
-#### Example
-
-```shell-session
-$ boundary credential-stores create vault \
-   -vault-address "http://127.0.0.1:8200" \
-   -vault-token "<new-token-value>"
-```
+- `-vault-address` `(string: "")` - Indicates the address of the Vault server.
+The address should be a complete URL such as https://127.0.0.1:8200.
+- `-vault-ca-cert` `(string: "")` - Indicates the CA certificate to use when you connect to Vault.
+This value can be the CA certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-vault-client-certificate` `(string: "")` - Indicates the client certificate to use when Boundary connects to Vault for this credential store.
+This value can be the client certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-vault-client-certificate-key` `(string: "")` - Specifies which private key the client certificate should use when Boundary connects to Vault for this store.
+This value can be the private key itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-vault-namespace` `(string: "")` - Indicates which Vault namespace the credential store should use.
+- `-vault-tls-server-name` `(string: "")` - Indicates the name to use as the SNI host when you connect using TLS.
+- `-vault-tls-skip-verify`  - Indicates whether to skip TLS verification.
+The default value is `false`.
+- `-vault-token` `(string: "")` - Specifies which Vault token to use when Boundary connects to Vault for this credential store.
+- `-worker-filter` `(string: "")` - Specifies a Boolean expression to filter which workers can process Vault commands for this credential store.
 
 </Tab>
 </Tabs>

--- a/website/content/docs/api-clients/commands/credential-stores/create.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/create.mdx
@@ -137,11 +137,11 @@ The following options are specific to Vault credential stores in addition to the
 - `-vault-address` `(string: "")` - Indicates the address of the Vault server.
 The address should be a complete URL such as https://127.0.0.1:8200.
 - `-vault-ca-cert` `(string: "")` - Indicates the CA certificate to use when you connect to Vault.
-This value can be the CA certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be the CA certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-vault-client-certificate` `(string: "")` - Indicates the client certificate to use when Boundary connects to Vault for this credential store.
-This value can be the client certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be the client certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-vault-client-certificate-key` `(string: "")` - Specifies which private key the client certificate should use when Boundary connects to Vault for this store.
-This value can be the private key itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be the private key itself, or it can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-vault-namespace` `(string: "")` - Indicates which Vault namespace the credential store should use.
 - `-vault-tls-server-name` `(string: "")` - Indicates the name to use as the SNI host when you connect using TLS.
 - `-vault-tls-skip-verify`  - Indicates whether to skip TLS verification.

--- a/website/content/docs/api-clients/commands/credential-stores/delete.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/delete.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: credential-stores delete - Command
 description: |-
-  The "credential-stores delete" command allows Boundary admin to delete a credential store resource.
+  The "credential-stores delete" command lets Boundary admin delete a credential store resource.
 ---
 
 # credential-stores delete
@@ -13,7 +13,7 @@ The `credential-stores delete` command deletes a credential store given its ID.
 
 ## Examples
 
-Delete a credential store of the given ID. 
+The following example deletes a credential store with the ID `csvlt_5fvkRjCjou`:
 
 ```shell-session
 $ boundary credential-stores delete -id csvlt_5fvkRjCjou
@@ -33,6 +33,6 @@ $ boundary credential-stores delete [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the credential store on which to operate.
+- `-id` `(string: "")` - Indicates the ID of the credential store to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-stores/index.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/index.mdx
@@ -2,24 +2,22 @@
 layout: docs
 page_title: credential-stores - Command
 description: |-
-  The "credential-stores" command allows Boundary admin to create and manage the credential libraries.
+  The "credential-stores" command lets Boundary admin create and manage credential stores.
 ---
 
 # credential-stores
 
 Command: `boundary credential-stores`
 
-The `credential-stores` command allows operations on Boundary credential
-library resources. 
+The `credential-stores` command lets you manage Boundary credential store resources.
 
-A credential store belongs to a scope and must support the principle of least
-privilege by providing mechanisms to limit the credentials it can access to the
-minimum necessary for the scope it is in.
-
+A credential store is a resource that can retrieve, store, and potentially generate credentials of differing types and differing access levels.
+They belong to projects and support the principle of least privilege by limiting the credentials that can be accessed to the minimum necessary for the project.
+A credential store can also contain credential libraries.
 
 ## Examples
 
-List all credential stores for a given scope ID.
+The following example lists all credential stores for a scope with the ID `p_tnqESc86qE`:
 
 ```shell-session
 $ boundary credential-stores list -scope-id p_tnqESc86qE
@@ -62,7 +60,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [create](/boundary/docs/api-clients/commands/credential-stores/create)

--- a/website/content/docs/api-clients/commands/credential-stores/index.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/index.mdx
@@ -65,6 +65,6 @@ of the subcommand in the sidebar or one of the links below:
 
 - [create](/boundary/docs/api-clients/commands/credential-stores/create)
 - [delete](/boundary/docs/api-clients/commands/credential-stores/delete)
+- [list](/boundary/docs/api-clients/commands/credential-stores/list)
 - [read](/boundary/docs/api-clients/commands/credential-stores/read)
 - [update](/boundary/docs/api-clients/commands/credential-stores/update)
-- [list](/boundary/docs/api-clients/commands/credential-stores/list)

--- a/website/content/docs/api-clients/commands/credential-stores/list.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/list.mdx
@@ -9,12 +9,11 @@ description: |-
 
 Command: `boundary credential-stores list`
 
-The `credential-stores list` command lists credential stores within an enclosing
-scope or resource.
+The `credential-stores list` command lists any credential stores within an enclosing scope or resource.
 
 ## Examples
 
-List all credential stores for a given scope ID.
+The following example lists all credential stores for a scope with the ID `p_tnqESc86qE`:
 
 ```shell-session
 $ boundary credential-stores list -scope-id p_tnqESc86qE
@@ -51,17 +50,14 @@ $ boundary credential-stores list [options] [args]
 
 ### Command options
 
-- `-filter` `(string: "")` - If set, the list operation will be filtered before
-   being returned. The filter operates against each item in the list. Using
-   single quotes is recommended as filters contain double quotes. 
-
-- `-recursive`  - If set, the list operation will be applied
-   recursively into child scopes, if supported by the type. The default is
-   false.
-
-- `-scope-id ``(string: "")` - Scope in which to make the request. The default
-  is global. This can also be specified via the `BOUNDARY_SCOPE_ID` environment
-  variable.
-
+- `-filter` `(string: "")` - Determines whether Boundary filters the list operation before the results are returned.
+The filter operates against each item in the list.
+We recommend that you use single quotes, because the filters contain double quotes.
+Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
+- `-recursive`  - Indicates whether the list operation should be applied recursively into child scopes, if supported by the type.
+The default value is `false`.
+- `-scope-id ``(string: "")` - Indicates the scope in which to make the request.
+The default value is `global`.
+You can also specify the scope using the **BOUNDARY_SCOPE_ID** environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-stores/read.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/read.mdx
@@ -2,20 +2,18 @@
 layout: docs
 page_title: credential-stores read - Command
 description: |-
-  The "credential-stores read" command allows Boundary admin to read a credential store information.
+  The "credential-stores read" command lets Boundary admin read credential store information.
 ---
 
 # credential-stores read
 
 Command: `boundary credential-stores read`
 
-The `credential-stores read` command reads a credential store information
-of a specific ID.
-
+The `credential-stores read` command reads credential store information for a credential store with a specific ID.
 
 ## Examples
 
-Retrieve a credential store information for a given ID, `clvlt_QYnQPAjA24`.
+The following example retrieves credential store information for a credential store with the ID `csvlt_5fvkRjCjou`:
 
 ```shell-session
 $ boundary credential-stores read -id csvlt_5fvkRjCjou
@@ -68,9 +66,8 @@ $ boundary credential-stores read [options] [args]
 
 </CodeBlockConfig>
 
-
 ### Command options
 
-- `-id` `(string: "")` - ID of the credential stores on which to operate.
+- `-id` `(string: "")` - Indicates the ID of the credential store for which to read information.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-stores/update.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/update.mdx
@@ -2,19 +2,18 @@
 layout: doc
 page_title: credential-stores update - Command
 description: |-
-  The "credential-stores update" command allows Boundary admin to update a credential store resource.
+  The "credential-stores update" command lets Boundary admin update a credential store resource.
 ---
 
 # credential-stores update
 
 Command: `boundary credential-stores update`
 
-The `credential-stores update` command performs update operations on Boundary
-credential store resources.
+The `credential-stores update` command lets you update Boundary credential store resources.
 
 ## Examples
 
-Update an existing Vault credential store.
+The following example updates an existing Vault credential store with the ID `csvlt_5fvkRjCjou` to add the description `For DevOps usage`, and the Vault namespace `devops`:
 
 ```shell-session
 $ boundary credential-stores update vault -id csvlt_5fvkRjCjou \
@@ -74,23 +73,32 @@ $ boundary credential-stores update vault [options] [args]
 
 ### Command options
 
-- `-description` `(string: "")` - Description to set on the credential store.
-
-- `-id` `(string: "")` - ID of the credential store on which to operate.
-
-- `-name` `(string: "")` - Name to set on the credential store.
-
-- `-version` `(int: 0)` - The version of the credential store against which to
-   perform an update operation. If not specified, the command will perform a
-   check-and-set automatically.
-
+- `-description` `(string: "")` - Specifies the description to set on the credential store.
+- `-id` `(string: "")` - Indicates the ID of the credential store to update.
+- `-name` `(string: "")` - Specifies the name to set on the credential store.
+- `-version` `(int: 0)` - Indicates the version of the credential store against which to perform an update operation.
+If you do not specify a version, the command performs a check-and-set automatically.
 
 #### Usages by type
+
+The available types are `static` and `vault`.
 
 <Tabs>
 <Tab heading="Static">
 
-Update a credential store of `static` type.
+The `credential-stores update static` command lets you update information for a static credential store.
+
+#### Example
+
+The following example updates a static credential store with the name `devops` and the description `For DevOps usage`:
+
+```shell-session
+$ boundary credential-stores update static \
+   -name devops \
+   -description "For DevOps usage"
+```
+
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -100,18 +108,23 @@ $ boundary credential-stores update static [options] [args]
 
 </CodeBlockConfig>
 
+</Tab>
+<Tab heading="Vault">
+
+The `credential-stores update vault` command lets you update a Vault credential store.
+
 #### Example
 
+The following example updates a Vault credential store with the ID `csvlt_1234567890` to add the name `devops` and the description `For DevOps usage`:
+
 ```shell-session
-$ boundary credential-stores update static \
+$ boundary credential-stores update vault \
+   -id csvlt_1234567890 \
    -name devops \
    -description "For DevOps usage"
 ```
 
-</Tab>
-<Tab heading="Vault">
-
-Update a credential store of `vault` type.
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -121,54 +134,26 @@ $ boundary credential-stores update vault [options] [args]
 
 </CodeBlockConfig>
 
-### Vault credential store options
+#### Vault credential store options
 
-The following are Vault credential store specific options in addition to the
-command options.
+The following options are specific to Vault credential stores in addition to the command options:
 
-- `-vault-address` `(string: "")` - The address of the Vault server. This should
-  be a complete URL such as https://127.0.0.1:8200
-
-- `-vault-ca-cert` `(string: "")` - The CA Cert to use when connecting to vault.
-  This can be the value itself, refer to a file on disk (`file://`) from which the
-   value will be read, or an env var (env://) from which the value will be read.
-
-- `-vault-client-certificate` `(string: "")` - The client certificate to use
-  when boundary connects to vault for this store. This can be the value itself,
-  refer to a file on disk (`file://`) from which the value will be read, or an env
-  var (`env://`) from which the value will be read.
-
-- `-vault-client-certificate-key` `(string: "")` - The client certificate's
-  private key to use when boundary connects to vault for this store. This can be
-  the value itself, refer to a file on disk (`file://`) from which the value will
-  be read, or an env var (`env://`) from which the value will be read.
-
-- `-vault-namespace` `(string: "")` - The vault namespace the store should use.
-
-- `-vault-tls-server-name` `(string: "")` - Name to use as the SNI host when
-  connecting via TLS.
-
-- `-vault-tls-skip-verify`  - Whether to skip tls verification.
-The default is false.
-
-- `-vault-token` `(string: "")` - The vault token to use when boundary connects
-  to vault for this store.
-
-- `-worker-filter` `(string: "")` - A boolean expression to filter which workers
-  can handle Vault commands for this credential store.
-
-
-#### Example
-
-```shell-session
-$ boundary credential-stores update vault \
-   -id csvlt_1234567890 \
-   -name devops \
-   -description "For DevOps usage"
-```
+- `-vault-address` `(string: "")` - Indicates the address of the Vault server.
+The address should be a complete URL such as https://127.0.0.1:8200.
+- `-vault-ca-cert` `(string: "")` - Indicates the CA certificate to use when you connect to Vault.
+This value can be the CA certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-vault-client-certificate` `(string: "")` - Indicates the client certificate to use when Boundary connects to Vault for this credential store.
+This value can be the client certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-vault-client-certificate-key` `(string: "")` - Specifies which private key the client certificate should use when Boundary connects to Vault for this store.
+This value can be the private key itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-vault-namespace` `(string: "")` - Indicates which Vault namespace the credential store should use.
+- `-vault-tls-server-name` `(string: "")` - Indicates the name to use as the SNI host when you connect using TLS.
+- `-vault-tls-skip-verify`  - Indicates whether to skip TLS verification.
+The default value is `false`.
+- `-vault-token` `(string: "")` - Specifies which Vault token to use when Boundary connects to Vault for this credential store.
+- `-worker-filter` `(string: "")` - Specifies a Boolean expression to filter which workers can process Vault commands for this credential store.
 
 </Tab>
 </Tabs>
-
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credential-stores/update.mdx
+++ b/website/content/docs/api-clients/commands/credential-stores/update.mdx
@@ -141,11 +141,11 @@ The following options are specific to Vault credential stores in addition to the
 - `-vault-address` `(string: "")` - Indicates the address of the Vault server.
 The address should be a complete URL such as https://127.0.0.1:8200.
 - `-vault-ca-cert` `(string: "")` - Indicates the CA certificate to use when you connect to Vault.
-This value can be the CA certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be the CA certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-vault-client-certificate` `(string: "")` - Indicates the client certificate to use when Boundary connects to Vault for this credential store.
-This value can be the client certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be the client certificate itself, or it can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-vault-client-certificate-key` `(string: "")` - Specifies which private key the client certificate should use when Boundary connects to Vault for this store.
-This value can be the private key itself, or it can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be the private key itself, or it can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-vault-namespace` `(string: "")` - Indicates which Vault namespace the credential store should use.
 - `-vault-tls-server-name` `(string: "")` - Indicates the name to use as the SNI host when you connect using TLS.
 - `-vault-tls-skip-verify`  - Indicates whether to skip TLS verification.

--- a/website/content/docs/api-clients/commands/credentials/create.mdx
+++ b/website/content/docs/api-clients/commands/credentials/create.mdx
@@ -2,20 +2,18 @@
 layout: docs
 page_title: credentials create - Command
 description: |-
-  The "credentials create" command allows create operations on Boundary credential resources.
+  The "credentials create" command lets you create Boundary credential resources.
 ---
 
 # credentials create
 
 Command: `boundary credentials create`
 
-The `credentials create` command allows create operations on Boundary credential
-resources.
-
+The `credentials create` command lets you create Boundary credential resources.
 
 ## Examples
 
-Define a new `username_password` credential within a static credential store.
+The following example defines a new username password credential within a static credential store with the ID `credup_J15mtU4qmy`:
 
 ```shell-session
 $ boundary credentials create username-password \
@@ -69,26 +67,32 @@ $ boundary credentials create [type] [sub command] [options] [args]
 
 </CodeBlockConfig>
 
-The available types are `json`, `ssh-private-key`, and `username-password`.
-
-
 ### Command options
 
-- `-credential-store-id` `(string: "")` - The credential-store resource to use
-   for the operation. This can also be specified via the
-   `BOUNDARY_CREDENTIAL_STORE_ID` environment variable.
-
-- `-description` `(string: "")` - Description to set on the credential.
-
-- `-name` `(string: "")` - Name to set on the credential.
-
+- `-credential-store-id` `(string: "")` - Indicates the credential-store resource in which to create the credential.
+You can also specify the credential store using the **BOUNDARY_CREDENTIAL_STORE_ID** environment variable.
+- `-description` `(string: "")` - Specifies a description to set on the credential.
+- `-name` `(string: "")` - Specifies a name to set on the credential.
 
 #### Usages by type
+
+The available types are `json`, `ssh-private-key`, and `username-password`.
 
 <Tabs>
 <Tab heading="JSON">
 
-Create a credential of `json` type.
+The `credentials create json` command lets you create a JSON type credential.
+
+#### Example
+
+The following example creates a JSON credential in a credential store with the ID `csst_1234567890`:
+
+```shell-session
+$ boundary credentials create json \
+   -credential-store-id csst_1234567890 \
+   -object file:///home/user/secret
+```
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -98,47 +102,46 @@ $ boundary credentials create json [options] [args]
 
 </CodeBlockConfig>
 
-### JSON object credential options:
+#### JSON object credential options
 
-The following are object (JSON) credential specific options in addition to the
-command options.
+The following options are specific to JSON credentials in addition to the command options:
 
-
-- `-bool-kv` `(map: {})` – A key=value bool value to add to the request's object
-   map. Can be specified multiple times. Supports sourcing values from files via
-   "file://" and env vars via "env://".
-
-- `-kv` `(map: {})` – A key=value pair to add to the request's object map. This
-   can also be a key value only which will set a JSON null as the value. If a
-   value is provided, the type is automatically inferred. Use `-string-kv`,
-   `-bool-kv`, or `-num-kv` if the type needs to be overridden. Can be specified
-   multiple times. Supports sourcing values from files via "file://" and env
-   vars via "env://".
-
-- `-num-kv` `(map: {})` – A key=value numeric value to add to the request's
-   object map. Can be specified multiple times. Supports sourcing values from
-   files via "file://" and env vars via "env://".
-
-- `-object` `(string: "")` - A JSON map value to use as the entirety of the
-   request's object map. Usually this will be sourced from a file via "file://"
-   syntax. Is exclusive with the other kv flags.
-
-- `-string-kv` `(map: {})` – A key=value string value to add to the request's
-   object map. Can be specified multiple times. Supports sourcing values from
-   files via "file://" and env vars via "env://".
-
-#### Example
-
-```shell-session
-$ boundary credentials create json \
-   -credential-store-id csst_1234567890 \
-   -object file:///home/user/secret
-```
+- `-bool-kv` `(map: {})` – Specifies a key=value Boolean value to add to the request's object map.
+You can specify this option multiple times.
+This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-kv` `(map: {})` – Specifies a key=value pair to add to the request's object map.
+This option can also be a key value only which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+Use `-string-kv`,`-bool-kv`, or `-num-kv` to override the type.
+You can specify this option multiple times.
+This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-num-kv` `(map: {})` – Specifies a key=value numeric value to add to the request's object map.
+You can specify this option multiple times.
+This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-object` `(string: "")` - Specifies a JSON map value to use as the entirety of the request's object map.
+Usually this is sourced from a file using `file://` syntax.
+This option is exclusive with the other kv flags.
+- `-string-kv` `(map: {})` – Specifies a key=value string value to add to the request's object map.
+You can specify this option multiple times.
+This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
 
 </Tab>
 <Tab heading="SSH private key">
 
-Create a credential of `ssh-private-key` type.
+The `credentials create ssh-private-key` command lets you create an SSH private key credential type.
+
+#### Example
+
+The following example creates an SSH private key credential in a credential store with the ID `csvlt_1234567890`:
+
+```shell-session
+$ boundary credentials create ssh-private-key \
+   -credential-store-id csvlt_1234567890 \
+   -username user \
+   -private-key file:///home/user/.ssh/id_ed25519
+```
+
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -148,39 +151,36 @@ $ boundary credentials create ssh-private-key [options] [args]
 
 </CodeBlockConfig>
 
+#### SSH private key credential options
 
-### SSH private key credential options:
+The following options are specific to SSH private key credentials in addition to the command options:
 
-The following are SSH private key credentials specific options in addition to
-the command options.
+- `-private-key` `(string: "")` - Specifies the SSH private key associated with the
+   credential.
+   This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-private-key-passphrase` `(string: "")` - Specifies the passphrase associated with the
+   SSH private key.
+   Boundary ingores this value if the private key does not require a passphrase or if you do not supply a private key.
+   This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+   If you leave this option empty, and the key requires a passphrase, you can enter it manually.
+- `-username` `(string: "")` - Specifies the username associated with the credential.
 
-- `-private-key` `(string: "")` - The SSH private key associated with the
-   credential. This can refer to a file on disk (file://) from which the value
-   will be read or an env var (env://) from which the value will be read.
+</Tab>
+<Tab heading="Username password">
 
-- `-private-key-passphrase` `(string: "")` - The passphrase associated with the
-   SSH private key. This value is ignored if the private key does not require a
-   passphrase or if no private key is supplied. This can refer to a file on disk
-   (file://) from which the value will be read, or an env var (env://) from
-   which the value will be read. Or, if left empty, if the key requires a
-   passphrase it can be entered manually.
-
-- `-username` `(string: "")` - The username associated with the credential.
-
+The `credentials create username-password` command lets you create a username password type credential.
 
 #### Example
 
+The following example creates a username password credential in a credential store with the ID `csvlt_1234567890`:
+
 ```shell-session
-$ boundary credentials create ssh-private-key \
+$ boundary credentials create username-password \
    -credential-store-id csvlt_1234567890 \
-   -username user \
-   -private-key file:///home/user/.ssh/id_ed25519
+   -username user -password pass
 ```
 
-</Tab>
-<Tab heading="Username/password">
-
-Create a credential of `username-password` type.
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -191,27 +191,15 @@ $ boundary credentials create username-password -credential-store-id [options] [
 </CodeBlockConfig>
 
 
-### Username/password credential options:
+#### Username password credential options
 
-The following are username/password credentials specific options in addition to
-the command options.
+The following options are specific to username password credentials in addition to the command options:
 
-- `-password` `(string: "")` - The password associated with the credential. This
-   can be a file on disk (`file://`) from which the value will be read, or an
-   env var (`env://`) from which the value will be read.
-
-- `-username` `(string: "")` - The username associated with the credential.
-
-#### Example
-
-```shell-session
-$ boundary credentials create username-password \
-   -credential-store-id csvlt_1234567890 \
-   -username user -password pass
-```
+- `-password` `(string: "")` - Indicates the password associated with the credential.
+This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-username` `(string: "")` - Indicates the username associated with the credential.
 
 </Tab>
 </Tabs>
-
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credentials/create.mdx
+++ b/website/content/docs/api-clients/commands/credentials/create.mdx
@@ -108,22 +108,22 @@ The following options are specific to JSON credentials in addition to the comman
 
 - `-bool-kv` `(map: {})` – Specifies a key=value Boolean value to add to the request's object map.
 You can specify this option multiple times.
-This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-kv` `(map: {})` – Specifies a key=value pair to add to the request's object map.
 This option can also be a key value only which will set a JSON null as the value.
 If you provide a value, Boundary automatically infers the type.
 Use `-string-kv`,`-bool-kv`, or `-num-kv` to override the type.
 You can specify this option multiple times.
-This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-num-kv` `(map: {})` – Specifies a key=value numeric value to add to the request's object map.
 You can specify this option multiple times.
-This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-object` `(string: "")` - Specifies a JSON map value to use as the entirety of the request's object map.
 Usually this is sourced from a file using `file://` syntax.
 This option is exclusive with the other kv flags.
 - `-string-kv` `(map: {})` – Specifies a key=value string value to add to the request's object map.
 You can specify this option multiple times.
-This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 
 </Tab>
 <Tab heading="SSH private key">
@@ -157,11 +157,11 @@ The following options are specific to SSH private key credentials in addition to
 
 - `-private-key` `(string: "")` - Specifies the SSH private key associated with the
    credential.
-   This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+   This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-private-key-passphrase` `(string: "")` - Specifies the passphrase associated with the
    SSH private key.
    Boundary ingores this value if the private key does not require a passphrase or if you do not supply a private key.
-   This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+   This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
    If you leave this option empty, and the key requires a passphrase, you can enter it manually.
 - `-username` `(string: "")` - Specifies the username associated with the credential.
 
@@ -196,7 +196,7 @@ $ boundary credentials create username-password -credential-store-id [options] [
 The following options are specific to username password credentials in addition to the command options:
 
 - `-password` `(string: "")` - Indicates the password associated with the credential.
-This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-username` `(string: "")` - Indicates the username associated with the credential.
 
 </Tab>

--- a/website/content/docs/api-clients/commands/credentials/delete.mdx
+++ b/website/content/docs/api-clients/commands/credentials/delete.mdx
@@ -2,18 +2,18 @@
 layout: docs
 page_title: credentials delete - Command
 description: |-
-  The "credentials delete" command allows Boundary admin to delete a credential resource.
+  The "credentials delete" command lets Boundary admin delete a credential resource.
 ---
 
 # credentials delete
 
 Command: `boundary credentials delete`
 
-The `credentials delete` command deletes a credential given its ID.
+The `credentials delete` command lets you delete a credential given its ID.
 
 ## Examples
 
-Delete a credential of the given ID. 
+The following example deletes a credential with the ID `credup_6zHHwQWvUS`:
 
 ```shell-session
 $ boundary credentials delete -id credup_6zHHwQWvUS
@@ -30,9 +30,8 @@ $ boundary credentials delete [options] [args]
 
 </CodeBlockConfig>
 
-
 ### Command options
 
-- `-id` `(string: "")` - ID of the credential on which to operate.
+- `-id` `(string: "")` - Indicates the ID of the credential to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credentials/index.mdx
+++ b/website/content/docs/api-clients/commands/credentials/index.mdx
@@ -78,6 +78,6 @@ of the subcommand in the sidebar or one of the links below:
 
 - [create](/boundary/docs/api-clients/commands/credentials/create)
 - [delete](/boundary/docs/api-clients/commands/credentials/delete)
+- [list](/boundary/docs/api-clients/commands/credentials/list)
 - [read](/boundary/docs/api-clients/commands/credentials/read)
 - [update](/boundary/docs/api-clients/commands/credentials/update)
-- [list](/boundary/docs/api-clients/commands/credentials/list)

--- a/website/content/docs/api-clients/commands/credentials/index.mdx
+++ b/website/content/docs/api-clients/commands/credentials/index.mdx
@@ -2,21 +2,20 @@
 layout: docs
 page_title: credentials - Command
 description: |-
-  The "credentials" command allows operations on Boundary credential resources.
+  The "credentials" command lets you create and manage Boundary credential resources.
 ---
 
 # credentials
 
 Command: `boundary credentials`
 
-The `credentials` command allows operations on Boundary credential resources.
+The `credentials` command lets you create and manage Boundary credential resources.
 
-A credential is a data structure containing one or more secrets that binds an
-identity to a set of permissions or capabilities on a host for a session.
+A credential is a data structure containing one or more secrets that bind an identity to a set of permissions or capabilities on a host for a session.
 
 ## Examples
 
-Retrieve the information about the credential with ID, "credup_J15mtU4qmy".
+The following example retrieves information about a credential with the ID `credup_J15mtU4qmy`:
 
 ```shell-session
 $ boundary credentials read -id credup_J15mtU4qmy
@@ -74,7 +73,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [create](/boundary/docs/api-clients/commands/credentials/create)

--- a/website/content/docs/api-clients/commands/credentials/list.mdx
+++ b/website/content/docs/api-clients/commands/credentials/list.mdx
@@ -9,12 +9,11 @@ description: |-
 
 Command: `boundary credentials list`
 
-The `credentials list` command lists credentials within an enclosing
-scope or resource.
+The `credentials list` command lists credentials within an enclosing scope or resource.
 
 ## Examples
 
-List all credentials for a given credential store ID.
+The following example lists all credentials for a credential store with the ID `csst_5GGWwRngd7`:
 
 ```shell-session
 $ credentials list -credential-store-id csst_5GGWwRngd7
@@ -72,13 +71,11 @@ $ boundary credentials list [options] [args]
 
 ### Command options
 
-- `-credential-store-id` `(string: "")` - The credential-store resource to use
-   for the operation. This can also be specified via the
-   `BOUNDARY_CREDENTIAL_STORE_ID` environment variable.
-
-- `-filter` `(string: "")` - If set, the list operation will be filtered before
-   being returned. The filter operates against each item in the list. Using
-   single quotes is recommended as filters contain double quotes. 
-
+- `-credential-store-id` `(string: "")` - Indicates the credential store resource that contains the credentials you want to list.
+You can also specify the credential store using the **BOUNDARY_CREDENTIAL_STORE_ID** environment variable.
+- `-filter` `(string: "")` - Indicates whether Boundary should filter the list operation before the results are returned.
+The filter operates against each item in the list.
+We recommend that you use single quotes, because the filters contain double quotes.
+Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credentials/read.mdx
+++ b/website/content/docs/api-clients/commands/credentials/read.mdx
@@ -2,20 +2,18 @@
 layout: docs
 page_title: credentials read - Command
 description: |-
-  The "credentials read" command reads a credential given its ID.
+  The "credentials read" command reads information for a credential given its ID.
 ---
 
 # credentials read
 
 Command: `boundary credentials read`
 
-The `credentials read` command retrieves a credential information
-of a specified ID.
-
+The `credentials read` command retrieves information about a credential with a specified ID.
 
 ## Examples
 
-Retrieve a credential information for a given ID, `clvlt_QYnQPAjA24`.
+The following example retrieves credential information for a credential with the ID `credup_29IUJANN59`:
 
 ```shell-session
 $ boundary credentials read -id credup_29IUJANN59
@@ -67,6 +65,6 @@ $ boundary credentials read [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the credential on which to operate.
+- `-id` `(string: "")` - Specifies the ID of the credential for which you want to retrieve information.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credentials/update.mdx
+++ b/website/content/docs/api-clients/commands/credentials/update.mdx
@@ -2,19 +2,18 @@
 layout: doc
 page_title: credentials update - Command
 description: |-
-  The "credentials update" command allows Boundary admin to update a credential resource.
+  The "credentials update" command lets Boundary admin update a credential resource.
 ---
 
 # credentials update
 
 Command: `boundary credentials update`
 
-The `credentials update` command performs update operations on Boundary
-credential resources.
+The `credentials update` command lets you update Boundary credential resources.
 
 ## Examples
 
-Update an existing user/password credential with new password.
+The following example updates an existing user password credential with a new password:
 
 ```shell-session
 $ export NEW_SSH_USER_PASSWORD="my-new-long-password"
@@ -68,28 +67,35 @@ $ boundary credentials update [type] [sub command] [options] [args]
 
 </CodeBlockConfig>
 
-The available types are `json`, `ssh-private-key`, and `username-password`.
-
-
 ### Command options
 
-- `-description` `(string: "")` - Description to set on the credential.
-
-- `-id` `(string: "")` - ID of the credential on which to operate.
-
-- `-name` `(string: "")` - Name to set on the credential.
-
-- `-version` `(int: 0)` - The version of the credential against which to perform
-   an update operation. If not specified, the command will perform a
-   check-and-set automatically.
-
+- `-description` `(string: "")` - Specifies a description to set on the credential.
+- `-id` `(string: "")` - Indicates the ID of the credential to update.
+- `-name` `(string: "")` - Specifies a name to set on the credential.
+- `-version` `(int: 0)` - Indicates the version of the credential to update.
+If you don't specify a version, the command performs a check-and-set automatically.
 
 #### Usages by type
+
+The available types are `json`, `ssh-private-key`, and `username-password`.
 
 <Tabs>
 <Tab heading="JSON">
 
-Update a credential of `json` type.
+The `credentials update json` command lets you update a JSON credential.
+
+#### Example
+
+The following example updates a JSON credential with the ID `csst_1234567890`:
+
+```shell-session
+$ boundary credentials update json \
+   -id csst_1234567890 \
+   -name devops \
+   -description "For DevOps usage"
+```
+
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -99,48 +105,46 @@ $ boundary credentials update json [options] [args]
 
 </CodeBlockConfig>
 
-### JSON object credential options:
+#### JSON object credential options
 
-The following are object (JSON) credential specific options in addition to the
-command options.
+The following options are specific to JSON credentials in addition to the command options:
 
-
-- `-bool-kv` `(map: {})` – A key=value bool value to add to the request's object
-   map. Can be specified multiple times. Supports sourcing values from files via
-   "file://" and env vars via "env://".
-
-- `-kv` `(map: {})` – A key=value pair to add to the request's object map. This
-   can also be a key value only which will set a JSON null as the value. If a
-   value is provided, the type is automatically inferred. Use `-string-kv`,
-   `-bool-kv`, or `-num-kv` if the type needs to be overridden. Can be specified
-   multiple times. Supports sourcing values from files via "file://" and env
-   vars via "env://".
-
-- `-num-kv` `(map: {})` – A key=value numeric value to add to the request's
-   object map. Can be specified multiple times. Supports sourcing values from
-   files via "file://" and env vars via "env://".
-
-- `-object` `(string: "")` - A JSON map value to use as the entirety of the
-   request's object map. Usually this will be sourced from a file via "file://"
-   syntax. Is exclusive with the other kv flags.
-
-- `-string-kv` `(map: {})` – A key=value string value to add to the request's
-   object map. Can be specified multiple times. Supports sourcing values from
-   files via "file://" and env vars via "env://".
-
-#### Example
-
-```shell-session
-$ boundary credentials update json \
-   -id csst_1234567890 \
-   -name devops \
-   -description "For DevOps usage"
-```
+- `-bool-kv` `(map: {})` – Specifies a key=value Boolean value to add to the request's object map.
+You can specify this option multiple times.
+This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-kv` `(map: {})` – Specifies a key=value pair to add to the request's object map.
+This option can also be a key value only which will set a JSON null as the value.
+If you provide a value, Boundary automatically infers the type.
+Use `-string-kv`,`-bool-kv`, or `-num-kv` to override the type.
+You can specify this option multiple times.
+This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-num-kv` `(map: {})` – Specifies a key=value numeric value to add to the request's object map.
+You can specify this option multiple times.
+This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-object` `(string: "")` - Specifies a JSON map value to use as the entirety of the request's object map.
+Usually this is sourced from a file using `file://` syntax.
+This option is exclusive with the other kv flags.
+- `-string-kv` `(map: {})` – Specifies a key=value string value to add to the request's object map.
+You can specify this option multiple times.
+This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
 
 </Tab>
 <Tab heading="SSH private key">
 
-Update a credential of `ssh-private-key` type.
+The `credentials update ssh-private-key` lets you update an SSH private key credential.
+
+#### Example
+
+The following example updates an SSH private key with the ID `clvlt_1234567890`:
+
+```shell-session
+$ boundary credentials update ssh-private-key \
+   -id clvlt_1234567890 \
+   -name devops \
+   -description "For DevOps usage"
+```
+
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -150,39 +154,37 @@ $ boundary credentials update ssh-private-key [options] [args]
 
 </CodeBlockConfig>
 
+#### SSH private key credential options
 
-### SSH private key credential options:
+The following options are specific to SSH private key credentials in addition to the command options:
 
-The following are SSH private key credentials specific options in addition to
-the command options.
+- `-private-key` `(string: "")` - Specifies the SSH private key associated with the
+   credential.
+   This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-private-key-passphrase` `(string: "")` - Specifies the passphrase associated with the
+   SSH private key.
+   Boundary ingores this value if the private key does not require a passphrase or if you do not supply a private key.
+   This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+   If you leave this option empty, and the key requires a passphrase, you can enter it manually.
+- `-username` `(string: "")` - Specifies the username associated with the credential.
 
-- `-private-key` `(string: "")` - The SSH private key associated with the
-   credential. This can refer to a file on disk (file://) from which the value
-   will be read or an env var (env://) from which the value will be read.
+</Tab>
+<Tab heading="Username password">
 
-- `-private-key-passphrase` `(string: "")` - The passphrase associated with the
-   SSH private key. This value is ignored if the private key does not require a
-   passphrase or if no private key is supplied. This can refer to a file on disk
-   (file://) from which the value will be read, or an env var (env://) from
-   which the value will be read. Or, if left empty, if the key requires a
-   passphrase it can be entered manually.
-
-- `-username` `(string: "")` - The username associated with the credential.
-
+The `credentials update username-password` command lets you update a username password type.
 
 #### Example
 
+The following example updates a username password credential with the ID `clvlt_1234567890`:
+
 ```shell-session
-$ boundary credentials update ssh-private-key \
+$ boundary credentials update username-password \
    -id clvlt_1234567890 \
    -name devops \
    -description "For DevOps usage"
 ```
 
-</Tab>
-<Tab heading="Username/password">
-
-Update a credential of `username-password` type.
+#### Usage
 
 <CodeBlockConfig hideClipboard>
 
@@ -192,29 +194,15 @@ $ boundary credentials update username-password [options] [args]
 
 </CodeBlockConfig>
 
+#### Username password credential options
 
-### Username/password credential options:
+The following options are specific to username password credentials in addition to the command options:
 
-The following are username/password credentials specific options in addition to
-the command options.
-
-- `-password` `(string: "")` - The password associated with the credential. This
-   can be a file on disk (`file://`) from which the value will be read, or an
-   env var (`env://`) from which the value will be read.
-
-- `-username` `(string: "")` - The username associated with the credential.
-
-#### Example
-
-```shell-session
-$ boundary credentials update username-password \
-   -id clvlt_1234567890 \
-   -name devops \
-   -description "For DevOps usage"
-```
+- `-password` `(string: "")` - Indicates the password associated with the credential.
+This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+- `-username` `(string: "")` - Indicates the username associated with the credential.
 
 </Tab>
 </Tabs>
-
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/credentials/update.mdx
+++ b/website/content/docs/api-clients/commands/credentials/update.mdx
@@ -111,22 +111,22 @@ The following options are specific to JSON credentials in addition to the comman
 
 - `-bool-kv` `(map: {})` – Specifies a key=value Boolean value to add to the request's object map.
 You can specify this option multiple times.
-This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-kv` `(map: {})` – Specifies a key=value pair to add to the request's object map.
 This option can also be a key value only which will set a JSON null as the value.
 If you provide a value, Boundary automatically infers the type.
 Use `-string-kv`,`-bool-kv`, or `-num-kv` to override the type.
 You can specify this option multiple times.
-This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-num-kv` `(map: {})` – Specifies a key=value numeric value to add to the request's object map.
 You can specify this option multiple times.
-This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-object` `(string: "")` - Specifies a JSON map value to use as the entirety of the request's object map.
 Usually this is sourced from a file using `file://` syntax.
 This option is exclusive with the other kv flags.
 - `-string-kv` `(map: {})` – Specifies a key=value string value to add to the request's object map.
 You can specify this option multiple times.
-This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 
 </Tab>
 <Tab heading="SSH private key">
@@ -160,11 +160,11 @@ The following options are specific to SSH private key credentials in addition to
 
 - `-private-key` `(string: "")` - Specifies the SSH private key associated with the
    credential.
-   This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+   This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-private-key-passphrase` `(string: "")` - Specifies the passphrase associated with the
    SSH private key.
    Boundary ingores this value if the private key does not require a passphrase or if you do not supply a private key.
-   This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+   This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
    If you leave this option empty, and the key requires a passphrase, you can enter it manually.
 - `-username` `(string: "")` - Specifies the username associated with the credential.
 
@@ -199,7 +199,7 @@ $ boundary credentials update username-password [options] [args]
 The following options are specific to username password credentials in addition to the command options:
 
 - `-password` `(string: "")` - Indicates the password associated with the credential.
-This value can be a reference to a file on disk (`file://`) or an environment variable (env://) from which Boundary reads the value.
+This value can be a reference to a file on disk (`file://`) or an environment variable (`env://`) from which Boundary reads the value.
 - `-username` `(string: "")` - Indicates the username associated with the credential.
 
 </Tab>


### PR DESCRIPTION
Edits the `credential-libraries`, `credential-stores`, and `credentials` options in the CLI draft doc #3411.