### PR TITLE
docs: Edit multiple groups options

### DIFF
--- a/website/content/docs/api-clients/commands/groups/add-members.mdx
+++ b/website/content/docs/api-clients/commands/groups/add-members.mdx
@@ -2,24 +2,24 @@
 layout: docs
 page_title: groups add-members - Command
 description: |-
-  The "groups add-members" command allows Boundary admin to add members (users) to a group.
+  The "groups add-members" command lets Boundary admin add members (users) to a group.
 ---
 
 # groups add-members
 
 Command: `boundary groups add-members`
 
-The `groups add-members` command adds members (users) to a group given its ID.
+The `groups add-members` command lets you add users as members of a group.
 
 ## Examples
 
-Add a user with ID, "u_qboadM3Q25" to the group with ID, "g_XzlDiNLgoz".
+The following example adds a user with ID, `u_qboadM3Q25` to the group with ID, `g_XzlDiNLgoz`:
 
 ```shell-session
 $ boundary groups add-members -id g_XzlDiNLgoz -member u_qboadM3Q25
 ```
 
-**Example output:** 
+**Example output:**
 
 <CodeBlockConfig hideClipboard>
 
@@ -68,10 +68,8 @@ $  boundary groups add-members [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the group on which to operate.
-
-- `-member` `(string: "")` - ID of the user to be added to the group. The
-  `-member` flag can be specified multiple times.
-
+- `-id` `(string: "")` - Indicates the ID of the group you want to add a member to.
+- `-member` `(string: "")` - Indicates the ID of the user you want to add to the group.
+You can specify the `-member` flag multiple times.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/create.mdx
+++ b/website/content/docs/api-clients/commands/groups/create.mdx
@@ -2,18 +2,18 @@
 layout: docs
 page_title: groups create - Command
 description: |-
-  The "groups create" command allows Boundary admin to create a group.
+  The "groups create" command lets Boundary admin create a group.
 ---
 
 # groups create
 
 Command: `boundary groups create`
 
-The `groups create` command creates a new group.
+The `groups create` command lets you create a new group.
 
 ## Examples
 
-Create a group, "group01" under the "IT_Support" organization.
+The following example creates a group, `group01` in the scope `o_R0wbo0H6Zl`:
 
 ```shell-session
 $ boundary groups create -name "group01" \
@@ -66,13 +66,10 @@ $ boundary groups create [options] [args]
 
 ### Command options
 
-- `-description` `(string: "")` - Description to set on the group.
-
-- `-name` `(string: "")` - Name to set on the group.
-
-- `-scope-id` `(string: "")` - Scope in which to make the request. The default
-   is global. This can also be specified via the BOUNDARY_SCOPE_ID environment
-   variable.
-
+- `-description` `(string: "")` - Specifies a description to set on the new group.
+- `-name` `(string: "")` - Specifies a name to set on the new group.
+- `-scope-id` `(string: "")` - Indicates the scope in which to create the group.
+The default value is `global`.
+You can also specify a scope using the **BOUNDARY_SCOPE_ID** environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/delete.mdx
+++ b/website/content/docs/api-clients/commands/groups/delete.mdx
@@ -2,19 +2,19 @@
 layout: docs
 page_title: groups delete - Command
 description: |-
-  The "groups delete" command allows Boundary admin to delete a group resource.
+  The "groups delete" command lets Boundary admin delete a group resource.
 ---
 
 # groups delete
 
 Command: `boundary groups delete`
 
-The `groups delete` command deletes an existing group.
+The `groups delete` command lets you delete an existing group.
 
 
 ## Examples
 
-Delete a group with the given ID (`g_FNVVhAd0on`). 
+The following example deletes a group with the given ID, `g_FNVVhAd0on`.
 
 ```shell-session
 $ boundary groups delete -id g_FNVVhAd0on
@@ -34,6 +34,6 @@ $ boundary groups delete [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the groups to delete.
+- `-id` `(string: "")` - Indicates the ID of the group to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/index.mdx
+++ b/website/content/docs/api-clients/commands/groups/index.mdx
@@ -2,25 +2,23 @@
 layout: docs
 page_title: groups - Command
 description: |-
-  The "groups" command allows Boundary admin to create and manage the group resources.
+  The "groups" command lets Boundary admin create and manage group resources.
 ---
 
 # groups
 
 Command: `boundary groups`
 
-The `groups` command create and manage the group resource in Boundary.
+The `groups` command lets you create and manage group resources in Boundary.
 
-A group in Boundary is a resource that represents a collection of users that are
-treated equally for the purposes of access control. A group is a principal,
-which allows it to be assigned to roles. Roles assigned to a group are
-indirectly assigned to the users in the group, and users receive all permissions
-of the assigned roles. Groups can be defined at the global, organization, or
-project scope.
+A group in Boundary is a resource that represents a collection of users that are treated equally for the purposes of access control.
+A group is a principal, which means it can be assigned to roles.
+Roles assigned to a group are indirectly assigned to the users in the group, and users receive all permissions of the assigned roles.
+You can define groups at the global, organization, or project scope.
 
 ## Examples
 
-Create a group, "group01" under the "IT_Support" organization.
+The following example creates a group, `group01` in a scope with the id `o_R0wbo0H6Zl`:
 
 ```shell-session
 $ boundary groups create -name "group01" \
@@ -81,7 +79,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [add-members](/boundary/docs/api-clients/commands/groups/add-members)

--- a/website/content/docs/api-clients/commands/groups/list.mdx
+++ b/website/content/docs/api-clients/commands/groups/list.mdx
@@ -2,20 +2,18 @@
 layout: docs
 page_title: groups list - Command
 description: |-
-  The "groups list" command allows Boundary admin to list groups within an enclosing scope or resource.
+  The "groups list" command lets Boundary admin list groups within an enclosing scope or resource.
 ---
 
 # groups list
 
 Command: `boundary groups list`
 
-The `groups list` command lists all groups within an enclosing scope or
-resource.
+The `groups list` command lists all groups within an enclosing scope or resource.
 
 ## Examples
 
-List all groups defined within an organization where the org ID is
-"o_R0wbo0H6Zl". 
+The following example lists all groups defined within the scope `o_R0wbo0H6Zl`:
 
 ```shell-session
 $ boundary groups list -scope-id o_R0wbo0H6Zl
@@ -82,17 +80,14 @@ $ boundary groups list [options] [args]
 
 ### Command options
 
-- `-filter` `(string: "")` - If set, the list operation will be filtered before
-   being returned. The filter operates against each item in the list. Using
-   single quotes is recommended as filters contain double quotes. 
-
-- `-recursive`  - If set, the list operation will be applied
-   recursively into child scopes, if supported by the type. The default is
-   false.
-
-- `-scope-id ``(string: "")` - Scope in which to make the request. The default
-  is global. This can also be specified via the `BOUNDARY_SCOPE_ID` environment
-  variable.
-
+- `-filter` `(string: "")` - Indicates whether Boundary should filter the list operation before the results are returned.
+The filter operates against each item in the list.
+We recommend that you use single quotes, because the filters contain double quotes.
+Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
+- `-recursive`  - Runs the list operation recursively on any child scopes, if the type supports it.
+The default value is `false`.
+- `-scope-id ``(string: "")` - The scope from which to list the groups.
+The default value is `global`.
+You can also specify this value using the **BOUNDARY_SCOPE_ID** environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/read.mdx
+++ b/website/content/docs/api-clients/commands/groups/read.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: groups read - Command
 description: |-
-  The "groups read" command allows Boundary admin to read a group resource.
+  The "groups read" command lets Boundary admin read a group resource.
 ---
 
 # groups read
@@ -14,7 +14,7 @@ The `groups read` command retrieves the group details for a given ID.
 
 ## Examples
 
-Retrieves the group information for a group with ID, `g_XzlDiNLgoz`.
+The following example retrieves the group information for a group with the ID, `g_XzlDiNLgoz`:
 
 ```shell-session
 $ boundary groups read -id g_XzlDiNLgoz
@@ -68,6 +68,6 @@ $ boundary groups read [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the groups to operate.
+- `-id` `(string: "")` - Indicates the ID of the group to retrieve information for.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/remove-members.mdx
+++ b/website/content/docs/api-clients/commands/groups/remove-members.mdx
@@ -2,20 +2,18 @@
 layout: docs
 page_title: groups remove-members - Command
 description: |-
-  The "groups remove-members" command allows Boundary admin to remove members (users) from a group given its ID..
+  The "groups remove-members" command lets Boundary admin remove members (users) from a group given its ID.
 ---
 
 # groups remove-members
 
 Command: `boundary groups remove-members`
 
-The `groups remove-members` command removes members (users) from a group given
-its ID.
+The `groups remove-members` command removes users from a group, given its ID.
 
 ## Examples
 
-Remove a user with ID, `u_J5l9FWB7yq` from "webdev" group where its group ID is
-`g_FNVVhAd0on`.
+The following example removes a user with the ID `u_J5l9FWB7yq` from a group with the ID `g_FNVVhAd0on`:
 
 ```shell-session
 $ boundary groups remove-members -id g_FNVVhAd0on \
@@ -71,9 +69,9 @@ $ boundary groups remove-members [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the group on which to operate.
+- `-id` `(string: "")` - Indicates the ID of the group from which to remove a member.
 
-- `-member` `(string: "")` - ID of the user to be added to the group. The
-  `-member` flag can be specified multiple times.
+- `-member` `(string: "")` - Indicates the ID of the user to be removed from the group.
+You can specify the `-member` flag multiple times.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/set-members.mdx
+++ b/website/content/docs/api-clients/commands/groups/set-members.mdx
@@ -2,20 +2,18 @@
 layout: docs
 page_title: groups set-members - Command
 description: |-
-  The "groups set-members" command allows Boundary admin to set the complete set of members (users) on a group given its ID. 
+  The "groups set-members" command lets Boundary admin configure a complete set of members (users) on a group given its ID.
 ---
 
 # groups set-members
 
 Command: `boundary groups set-members`
 
-The `groups set-members` command sets the complete set of members (users) on a
-group given its ID. 
+The `groups set-members` command lets you configure the complete set of users in a group.
 
 ## Examples
 
-Set users with ID, "`u_ad8tbsXHJP`" and "`u_J5l9FWB7yq`" as group members to
-"webdev" group where its group ID is `g_FNVVhAd0on`.
+The following example set users with the IDs, "`u_ad8tbsXHJP`" and "`u_J5l9FWB7yq`" as group members in a group with the group ID `g_FNVVhAd0on`:
 
 ```shell-session
 $ boundary groups set-members -id g_FNVVhAd0on \
@@ -75,10 +73,9 @@ $ boundary groups set-members [options] [args]
 
 ### Command options
 
-- `-id` `(string: "")` - ID of the group on which to operate.
+- `-id` `(string: "")` - Indicates the ID of the group on which to set members.
 
-- `-member` `(string: "")` - ID of the user to be added to the group. The
-  `-member` flag can be specified multiple times.
-
+- `-member` `(string: "")` - Indicates the ID of the user or users you want to add to the group.
+You can specify the `-member` flag multiple times.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/groups/update.mdx
+++ b/website/content/docs/api-clients/commands/groups/update.mdx
@@ -2,18 +2,18 @@
 layout: docs
 page_title: groups update - Command
 description: |-
-  The "groups update" command allows Boundary admin to update a group resource.
+  The "groups update" command lets Boundary admin update a group resource.
 ---
 
 # groups update
 
 Command: `boundary groups update`
 
-The `groups update` command updates an existing group information.
+The `groups update` command lets you update an existing group's information.
 
 ## Examples
 
-An existing group (`g_9SpLKOoTse`) has the following detail. 
+In this example, an existing group (`g_9SpLKOoTse`) has the following details:
 
 <CodeBlockConfig hideClipboard>
 
@@ -31,12 +31,12 @@ Group information:
 
 </CodeBlockConfig>
 
-Update the name, login name, and description.
+The following command updates the group's `description` and `version`:
 
 ```shell-session
 $ boundary groups update -id g_9SpLKOoTse \
    -description "Customer support for product XXX" \
-   -version 3
+   -version 4
 ```
 
 **Example output:**
@@ -80,15 +80,12 @@ $ boundary groups update [options] [args]
 
 </CodeBlockConfig>
 
-The available types are: `ldap`, `oidc`, and `password`.
-
 ### Command options
 
-- `-description` `(string: "")` - Description to set on the groups.
-- `-id` `(string: "")` - ID of the groups on which to operate.
-- `-name` `(string: "")` - Name to set on the groups.
-- `-version` `(string: "")` - The version of the groups against which to
-   perform an update operation. If not specified, the command will perform a
-   check-and-set automatically.
+- `-description` `(string: "")` - Updates the description on the group.
+- `-id` `(string: "")` - Indicates the ID of the group to update.
+- `-name` `(string: "")` - Updates the name of the group.
+- `-version` `(string: "")` - Indicates the version of the group to update.
+If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/managed-groups/create.mdx
+++ b/website/content/docs/api-clients/commands/managed-groups/create.mdx
@@ -64,13 +64,13 @@ $ boundary managed-groups create ldap [options] [args]
 
 #### Command options
 
-- `-auth-method-id=<string>` - The auth-method resource to use for creating the managed group.
+- `-auth-method-id=<string>` - Specifies the auth-method resource to use for creating the managed group.
 You can also specify the auth-method resource using the BOUNDARY_AUTH_METHOD_ID environment variable.
-- `-description=<string>` - The description to set for the LDAP managed group.
-- `-group-names=<string>` - The LDAP group names against which an LDAP account's associated groups are evaluated to determine membership.
+- `-description=<string>` - Sets the description for the LDAP managed group.
+- `-group-names=<string>` - Indicates the LDAP group names against which an LDAP account's associated groups are evaluated to determine membership.
 Boundary evaluates managed group membership when you log in.
 You can specify multiple group names.
-- `-name=<string>` - The name to set for the LDAP managed group.
+- `-name=<string>` - Sets the name for the LDAP managed group.
 
 </Tab>
 <Tab heading="OIDC">
@@ -97,13 +97,12 @@ $ boundary managed-groups create oidc [options] [args]
 
 #### Command options
 
-- `-auth-method-id=<string>` - The auth-method resource to use for creating the managed group.
+- `-auth-method-id=<string>` - Indicates the auth-method resource to use for creating the managed group.
 You can also specify the auth-method resource using the BOUNDARY_AUTH_METHOD_ID environment variable.
-- `-description=<string>` - The description to set for the OIDC managed group.
-- `-filter=<string>` - The filter that defines the criteria against which an account's OIDC token and user info are evaluated to determine if it is a member of the OIDC managed group.
+- `-description=<string>` - Sets the description for the OIDC managed group.
+- `-filter=<string>` - Specifies the filter that defines the criteria against which an account's OIDC token and user info are evaluated to determine if it is a member of the OIDC managed group.
 Boundary evaluates managed group membership when you log in.
-- `-name=<string>` - The name to set for the OIDC managed group.
-
+- `-name=<string>` - Sets the name for the OIDC managed group.
 
 </Tab>
 </Tabs>

--- a/website/content/docs/api-clients/commands/managed-groups/delete.mdx
+++ b/website/content/docs/api-clients/commands/managed-groups/delete.mdx
@@ -31,6 +31,6 @@ $ boundary managed-groups delete [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the managed group to delete.
+- `-id=<string>` - Indicates the ID of the managed group you want to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/managed-groups/index.mdx
+++ b/website/content/docs/api-clients/commands/managed-groups/index.mdx
@@ -36,7 +36,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [create](/boundary/docs/api-clients/commands/managed-groups/create)

--- a/website/content/docs/api-clients/commands/managed-groups/list.mdx
+++ b/website/content/docs/api-clients/commands/managed-groups/list.mdx
@@ -31,9 +31,9 @@ $ boundary managed-groups list [options] [args]
 
 ### Command options
 
-- `auth-method-id=<string>` - The auth method resource to use for this operation.
+- `auth-method-id=<string>` - Indicates the auth method resource to use for this operation.
 You can also specify the auth method using the BOUNDARY_AUTH_METHOD_ID environment variable.
-- `-filter=<string>` - If you set this value, Boundary filters the list operation before the results are returned.
+- `-filter=<string>` - Determines whether Boundary filters the list operation before the results are returned.
 The filter operates against each item in the list.
 We recommend that you use single quotes, because the filters contain double quotes.
 Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.

--- a/website/content/docs/api-clients/commands/managed-groups/read.mdx
+++ b/website/content/docs/api-clients/commands/managed-groups/read.mdx
@@ -2,18 +2,18 @@
 layout: docs
 page_title: managed-groups read - Command
 description: |-
-  The "managed-groups read" command lets you read a managed group with a given ID.
+  The "managed-groups read" command lets you read the details of a managed group with a given ID.
 ---
 
 # managed-groups read
 
 Command: `boundary managed-groups read`
 
-The `boundary managed-groups read` command lets you read a Boundary managed group using its given ID.
+The `boundary managed-groups read` command lets you read the details of a Boundary managed group using its given ID.
 
 ## Example
 
-This example reads a managed group with the ID `_1234567890`:
+This example reads the details of a managed group with the ID `_1234567890`:
 
 ```shell-session
 $ boundary managed-groups read -id _1234567890
@@ -31,6 +31,6 @@ $ boundary managed-groups read [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the managed group to read.
+- `-id=<string>` - Indicates the ID of the managed group you want to read information for.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/managed-groups/update.mdx
+++ b/website/content/docs/api-clients/commands/managed-groups/update.mdx
@@ -64,13 +64,13 @@ $ boundary managed-groups update ldap [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the LDAP managed group.
-- `-group-names=<string>` - The LDAP group names against which an LDAP account's associated groups are evaluated to determine membership.
+- `-description=<string>` - Sets the description for the LDAP managed group.
+- `-group-names=<string>` - Indicates the LDAP group names against which an LDAP account's associated groups are evaluated to determine membership.
 Boundary evaluates managed group membership when you log in.
 You can specify multiple group names.
-- `-id=<string>` - ID of the LDAP managed group to update.
-- `-name=<string>` - The name to set for the LDAP managed group.
-- `-version=<int>` - The version of the LDAP managed group to update.
+- `-id=<string>` - Indicates the ID of the LDAP managed group to update.
+- `-name=<string>` - Sets the name for the LDAP managed group.
+- `-version=<int>` - Indicates the version of the LDAP managed group to update.
 If you do not specify a version, the command automatically performs a check-and-set.
 
 </Tab>
@@ -98,12 +98,12 @@ $ boundary managed-groups update oidc [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the OIDC managed group.
-- `-filter=<string>` - The filter that defines the criteria against which an account's OIDC token and user info are evaluated to determine if it is a member of the OIDC managed group.
+- `-description=<string>` - Sets the description for the OIDC managed group.
+- `-filter=<string>` - Specifies the filter that defines the criteria against which an account's OIDC token and user info are evaluated to determine if it is a member of the OIDC managed group.
 Boundary evaluates managed group membership when you log in.
-- `-id=<string>` - ID of the OIDC managed group you want to update.
-- `-name=<string>` - The name to set for the OIDC managed group.
-- `-version=<int>` - The version of the OIDC managed group to update.
+- `-id=<string>` - Indicates the ID of the OIDC managed group you want to update.
+- `-name=<string>` - Sets the name for the OIDC managed group.
+- `-version=<int>` - Indicates the version of the OIDC managed group to update.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 </Tab>

--- a/website/content/docs/api-clients/commands/storage-buckets/list.mdx
+++ b/website/content/docs/api-clients/commands/storage-buckets/list.mdx
@@ -40,6 +40,6 @@ Refer to the [Filter resource listings documentation](/boundary/docs/concepts/fi
 The default value is `false`.
 - `scope-id=<string>` - The scope from which to list the storage buckets.
 The default value is `global`.
-You can also specify this value using the BOUNDARY_SCOPE_ID environment variable.
+You can also specify this value using the **BOUNDARY_SCOPE_ID** environment variable.
 
 @include 'cmd-option-note.mdx'


### PR DESCRIPTION
Edits the `groups` and `managed-groups` options in the CLI draft doc #3411.