### PR TITLE
docs: Edit multiple hosts options

### DIFF
--- a/website/content/docs/api-clients/commands/host-catalogs/create.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/create.mdx
@@ -40,7 +40,7 @@ Subcommands:
 You can create plugin or static host catalog types.
 
 <Tabs>
-<Tab heading="plugin">
+<Tab heading="Plugin">
 
 The `boundary host-catalogs create plugin` command lets you create a plugin type host catalog.
 
@@ -64,59 +64,59 @@ $ boundary host-catalogs create plugin [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the plugin host catalog.
-- `-name=<string>` - The name to set for the plugin host catalog.
-- `-plugin-id=<string>` - The ID of the plugin associated with the host catalog you are creating.
-- `-plugin-name=<string>` - The name of the plugin associated with the host catalog you are creating.
-- `-scope-id=<string>` - The scope in which you want to create the host catalog.
+- `-description=<string>` - Sets the description for the plugin host catalog.
+- `-name=<string>` - Sets the name for the plugin host catalog.
+- `-plugin-id=<string>` - Specifies the ID of the plugin associated with the host catalog you want to create.
+- `-plugin-name=<string>` - Specifies the name of the plugin associated with the host catalog you want to create.
+- `-scope-id=<string>` - Indicates the scope in which you want to create the host catalog.
 The default scope is `global`.
-You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
+You can also specify the scope using the **BOUNDARY_SCOPE_ID** environment variable.
 
 #### Attribute options
 
-- `-attr` - A key=value pair to add to the request's attribute map.
-This option can also be a key value only, which will set a JSON null as the value.
+- `-attr` - Specifies a key=value pair to add to the request's attribute map.
+This option can also be a key value only, which sets a JSON null as the value.
 If you provide a value, Boundary automatically infers the type.
 You can override the type using `-string-attr`, `-bool-attr`, or `-num-attr`.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-attributes=<string>` - A JSON map value that you can use as the entirety of the request's attributes map.
-Usually this value is sourced from file using "file://" syntax.
-This option is exclusive with other attr flags.
-- `-bool-attr` - A key=value Boolean value that you can add to the request's attributes map.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-attributes=<string>` - Specifies a JSON map value that you can use as the entirety of the request's attributes map.
+Usually this value is sourced from a file using the `file://` syntax.
+This option is exclusive with other `attr` flags.
+- `-bool-attr` - Specifies a key=value Boolean value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-num-attr` - A key=value numeric value that you can add to the request's attributes map.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-num-attr` - Specifies a key=value numeric value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This attribute supports values from files using "file://" and environment variables using "env://".
-- `-string-attr` - A key=value string value that you can add to the request's attributes map.
+This attribute supports referencing values from files using `file://` and environment variables using `env://`.
+- `-string-attr` - Specifies a key=value string value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
+This option supports referencing values from files using `file://` and environment variables using `env://`.
 
 #### Secrets options
 
-- `-bool-secret` - A key=value Boolean value that you can add to the request's secrets map.
+- `-bool-secret` - Specifies a key=value Boolean value that you can add to the request's secrets map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-num-secret` - A key=value numeric value that you can add to the request's secrets map.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-num-secret` - Specifies a key=value numeric value that you can add to the request's secrets map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-secret` - A key=value pair that you can add to the request's secrets map.
-This option can also be a key value only, which will set a JSON null as the value.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-secret` - Specifies a key=value pair that you can add to the request's secrets map.
+This option can also be a key value only, which sets a JSON null as the value.
 If you provide a value, Boundary automatically infers the type.
 You can override the type using `-string-secret`, `-bool-secret`, or `-num-secret`.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-secrets=<string>` - A JSON map value that you can use as the entirety of the request's secrets map.
-Usually this value is sourced from file using "file://" syntax.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-secrets=<string>` - Specifies a JSON map value that you can use as the entirety of the request's secrets map.
+Usually this value is sourced from file using `file://` syntax.
 This option is exclusive with other secret flags.
-- `-string-secret` - A key=value string value that you can add to the request's attributes map.
+- `-string-secret` - Specifies a key=value string value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
+This option supports referencing values from files using `file://` and environment variables using `env://`.
 
 </Tab>
 
-<Tab heading="static">
+<Tab heading="Static">
 
 The `boundary host-catalogs create static` command lets you create a static type host catalog.
 
@@ -140,11 +140,11 @@ $ boundary host-catalogs create static [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the static host catalog.
-- `-name=<string>` - The name to set for the static host catalog.
-- `-scope-id=<string>` - The scope in which to create the static host catalog.
+- `-description=<string>` - Sets the description for the static host catalog.
+- `-name=<string>` - Sets the name for the static host catalog.
+- `-scope-id=<string>` - Indicates the scope in which to create the static host catalog.
 The default scope is `global`.
-You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable,
+You can also specify the scope using the **BOUNDARY_SCOPE_ID** environment variable,
 
 </Tab>
 </Tabs>

--- a/website/content/docs/api-clients/commands/host-catalogs/delete.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/delete.mdx
@@ -31,6 +31,6 @@ $ boundary host-catalogs delete [options] [args]
 
 ### Command options
 
-- `-id=<string>` - The ID of the host catalog to delete.
+- `-id=<string>` - Indicates the ID of the host catalog to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-catalogs/index.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/index.mdx
@@ -13,7 +13,7 @@ The `host-catalogs` command lets you perform operations on Boundary host catalog
 
 ## Example
 
-The following command reads a host catalog with the ID `hcst_1234567890`:
+The following example reads the information from a host catalog with the ID `hcst_1234567890`:
 
 ```shell-session
 $ boundary host-catalogs read -id hcst_1234567890
@@ -36,7 +36,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [create](/boundary/docs/api-clients/commands/host-catalogs/create)

--- a/website/content/docs/api-clients/commands/host-catalogs/list.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/list.mdx
@@ -32,13 +32,13 @@ $ boundary host-catalogs list [options] [args]
 
 ### Command options
 
-- `-filter=<string>` - If you set this value, Boundary filters the list operation before the results are returned.
+- `-filter=<string>` - Indicates whether Boundary should filter the list operation before the results are returned.
 The filter operates against each item in the list.
 We recommend that you use single quotes, because the filters contain double quotes.
 Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
-- `-recursive` - If you set this value, Boundary runs the list operation recursively on any child scopes, if the type supports it.
-- `-scope-id=<string>` - The scope from which you want to list host catalogs.
+- `-recursive` - Runs the list operation recursively on any child scopes, if the type supports it.
+- `-scope-id=<string>` - Indicates the scope from which you want to list host catalogs.
 The default scope is `global`.
-You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
+You can also specify the scope using the **BOUNDARY_SCOPE_ID** environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-catalogs/read.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/read.mdx
@@ -2,18 +2,18 @@
 layout: docs
 page_title: host-catalogs read - Command
 description: |-
-  The "host-catalogs read" command lets you read a host catalog with a given ID.
+  The "host-catalogs read" command lets you read host catalog information with a given host catalog ID.
 ---
 
 # host-catalogs read
 
 Command: `boundary host-catalogs read`
 
-The `boundary host-catalogs read` command lets you read a Boundary host catalog using its given ID.
+The `boundary host-catalogs read` command lets you read information about a Boundary host catalog using its given ID.
 
 ## Example
 
-This example reads a host catalog with the ID `_1234567890`:
+This example reads the details for a host catalog with the ID `_1234567890`:
 
 ```shell-session
 $ boundary host-catalogs read -id _1234567890
@@ -31,6 +31,6 @@ $ boundary host-catalogs read [options] [args]
 
 ### Command options
 
-- `-id=<string>` - The ID of the host catalog to read.
+- `-id=<string>` - Indicates the ID of the host catalog whose information you want to read.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-catalogs/update.mdx
+++ b/website/content/docs/api-clients/commands/host-catalogs/update.mdx
@@ -40,7 +40,7 @@ Subcommands:
 You can update plugin or static host set types.
 
 <Tabs>
-<Tab heading="plugin">
+<Tab heading="Plugin">
 
 The `boundary host-catalogs update plugin` command lets you update a plugin type host catalog.
 
@@ -64,57 +64,57 @@ $ boundary host-catalogs update plugin [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the plugin host catalog.
-- `-id=<string>` - The ID of the plugin type host catalog to update.
-- `-name=<string>` - The name to set for the plugin host catalog.
-- `-version=<int>` - The version of the plugin host catalog to update.
+- `-description=<string>` - Sets the description for the plugin host catalog.
+- `-id=<string>` - Specifies the ID of the plugin type host catalog to update.
+- `-name=<string>` - Sets the name for the plugin host catalog.
+- `-version=<int>` - Indicates the version of the plugin host catalog to update.
 If you do not specify a version, the command automatically performs a check-and-set.
 
 #### Attribute options
 
-- `-attr` - A key=value pair to add to the request's attribute map.
-This option can also be a key value only, which will set a JSON null as the value.
+- `-attr` - Specifies a key=value pair to add to the request's attribute map.
+This option can also be a key value only, which sets a JSON null as the value.
 If you provide a value, Boundary automatically infers the type.
 You can override the type using `-string-attr`, `-bool-attr`, or `-num-attr`.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-attributes=<string>` - A JSON map value that you can use as the entirety of the request's attributes map.
-Usually this value is sourced from file using "file://" syntax.
-This option is exclusive with other attr flags.
-- `-bool-attr` - A key=value Boolean value that you can add to the request's attributes map.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-attributes=<string>` - Specifies a JSON map value that you can use as the entirety of the request's attributes map.
+Usually this value is sourced from a file using the `file://` syntax.
+This option is exclusive with other `attr` flags.
+- `-bool-attr` - Specifies a key=value Boolean value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-num-attr` - A key=value numeric value that you can add to the request's attributes map.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-num-attr` - Specifies a key=value numeric value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This attribute supports values from files using "file://" and environment variables using "env://".
-- `-string-attr` - A key=value string value that you can add to the request's attributes map.
+This attribute supports referencing values from files using `file://` and environment variables using `env://`.
+- `-string-attr` - Specifies a key=value string value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
+This option supports referencing values from files using `file://` and environment variables using `env://`.
 
 ### Secrets options
 
-- `-bool-secret` - A key=value Boolean value that you can add to the request's secrets map.
+- `-bool-secret` - Specifies a key=value Boolean value that you can add to the request's secrets map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-num-secret` - A key=value numeric value that you can add to the request's secrets map.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-num-secret` - Specifies a key=value numeric value that you can add to the request's secrets map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-secret` - A key=value pair that you can add to the request's secrets map.
-This option can also be a key value only, which will set a JSON null as the value.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-secret` - Specifies a key=value pair that you can add to the request's secrets map.
+This option can also be a key value only, which sets a JSON null as the value.
 If you provide a value, Boundary automatically infers the type.
 You can override the type using `-string-secret`, `-bool-secret`, or `-num-secret`.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-secrets=<string>` - A JSON map value that you can use as the entirety of the request's secrets map.
-Usually this value is sourced from file using "file://" syntax.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-secrets=<string>` - Specifies a JSON map value that you can use as the entirety of the request's secrets map.
+Usually this value is sourced from file using `file://` syntax.
 This option is exclusive with other secret flags.
-- `-string-secret` - A key=value string value that you can add to the request's attributes map.
+- `-string-secret` - Specifies key=value string value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
+This option supports referencing values from files using `file://` and environment variables using `env://`.
 
 </Tab>
 
-<Tab heading="static">
+<Tab heading="Static">
 
 The `boundary host-catalogs update static` command lets you update a static type host catalog.
 
@@ -138,10 +138,10 @@ $ boundary host-catalogs update static [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the static host catalog.
-- `-id=<string>` - The ID of the static type host catalog to update.
-- `-name=<string>` - The name to set for the static host catalog.
-- `-version=<int>` - The version of the static type host catalog to update.
+- `-description=<string>` - Sets the description for the static host catalog.
+- `-id=<string>` - Indicates the ID of the static type host catalog you want to update.
+- `-name=<string>` - Sets the name for the static host catalog.
+- `-version=<int>` - Indicates the version of the static type host catalog you want to update.
 If you do not specify a version, the command automatically performs a check-and-set.
 
 </Tab>

--- a/website/content/docs/api-clients/commands/host-sets/add-hosts.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/add-hosts.mdx
@@ -31,10 +31,10 @@ $ boundary host-sets add-hosts <subcommand> [options] [args]
 
 ### Command options
 
-- `-host=<string>` - The hosts to add to the host set.
+- `-host=<string>` - Specifies the hosts you want to add to the host set.
 You can specify multiple hosts.
-- `-id=<string>` - The ID of the host set to add hosts to.
-- `-version=<int>` The version of the host set.
+- `-id=<string>` - Indicates the ID of the host set you want to add hosts to.
+- `-version=<int>` Indicates the version of the host set you want to add hosts to.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/create.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/create.mdx
@@ -37,10 +37,10 @@ Subcommands:
 
 ### Usages by type
 
-You can create plugin or static host set types.
+You can create plugin or static type host sets.
 
 <Tabs>
-<Tab heading="plugin">
+<Tab heading="Plugin">
 
 The `boundary host-sets create plugin` command lets you create a plugin type host set.
 
@@ -64,40 +64,41 @@ $ boundary host-sets create plugin [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the plugin host set.
-- `-host-catalog-id=<string>` - The host catalog resource to use for the operation.
-You can also specify the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
-- `-name=<string>` - The name to set for the plugin host set.
+- `-description=<string>` - Sets the description for the plugin host set.
+- `-host-catalog-id=<string>` - Indicates the host catalog resource to use for the operation.
+You can also specify the host catalog using the **BOUNDARY_HOST_CATALOG_ID** environment variable.
+- `-name=<string>` - Sets the name for the plugin host set.
 
 #### Attribute options
 
-- `-attr` - A key=value pair to add to the request's attribute map.
-This option can also be a key value only, which will set a JSON null as the value.
+- `-attr` - Specifies a key=value pair to add to the request's attribute map.
+This option can also be a key value only, which sets a JSON null as the value.
 If you provide a value, Boundary automatically infers the type.
 You can override the type using `-string-attr`, `-bool-attr`, or `-num-attr`.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-attributes=<string>` - A JSON map value that you can use as the entirety of the request's attributes map.
-Usually this value is sourced from file using "file://" syntax.
-This option is exclusive with other attr flags.
-- `-bool-attr` - A key=value Boolean value that you can add to the request's attributes map.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-attributes=<string>` - Specifies a JSON map value that you can use as the entirety of the request's attributes map.
+Usually this value is sourced from a file using the `file://` syntax.
+This option is exclusive with other `attr` flags.
+- `-bool-attr` - Specifies a key=value Boolean value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-num-attr` - A key=value numeric value that you can add to the request's attributes map.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-num-attr` - Specifies a key=value numeric value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This attribute supports values from files using "file://" and environment variables using "env://".
-- `-string-attr` - A key=value string value that you can add to the request's attributes map.
+This attribute supports referencing values from files using `file://` and environment variables using `env://`.
+- `-string-attr` - Specifies a key=value string value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
+This option supports referencing values from files using `file://` and environment variables using `env://`.
 
 #### Plugin host-set options
 
-- `-preferred-endpoint=<string>` - An endpoint preference that specifies which IP address or DNS name out of a host's available options is preferred.
-You can specify the preference using `cidr:<valid IPv4/6 CIDR>` or `dns:<globbed name>`.
-You can specify multiple preferences which create an order of preferences.
+- `-preferred-endpoint=<string>` - Specifies which IP address or DNS name out of a host's available options is preferred as an endpoint.
+You can specify your preference using `cidr:<valid IPv4/6 CIDR>` or `dns:<globbed name>`.
+You can specify multiple preferences to create an order of preferences.
 If you do not specify a preference, Boundary chooses a value from all available values using a built-in priority order.
 The endpoint preference option may not be valid for all plugin types.
-- `-sync-interval=<string>` - An integer number of a seconds or a string such as `400s`, `5m`, or `6h` that indicates the interval of time between sync operations on the host set.
+- `-sync-interval=<string>` - Indicates the interval of time between sync operations on the host set.
+You can enter an integer number of seconds or a string such as `400s`, `5m`, or `6h`.
 The interval is applied to the end of the previous sync operation, not the beginning.
 If you set the interval to a negative value, it disables synchronization for that host set.
 If you set the interval to null, Boundary uses the default value.
@@ -105,7 +106,7 @@ The default value may change between releases.
 
 </Tab>
 
-<Tab heading="static">
+<Tab heading="Static">
 
 The `boundary host-sets create static` command lets you create a static type host set.
 
@@ -129,10 +130,10 @@ $ boundary host-sets create static [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the static host set.
-- `-host-catalog-id=<string>` - The host catalog resource to use for the operation.
-You can also specify the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
-- `-name=<string>` - The name to set for the static host set.
+- `-description=<string>` - Sets the description for the static host set.
+- `-host-catalog-id=<string>` - Indicates the host catalog resource to use for the operation.
+You can also specify the host catalog using the **BOUNDARY_HOST_CATALOG_ID** environment variable.
+- `-name=<string>` - Sets the name for the static host set.
 
 </Tab>
 </Tabs>

--- a/website/content/docs/api-clients/commands/host-sets/delete.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/delete.mdx
@@ -31,6 +31,6 @@ $ boundary host-sets delete [options] [args]
 
 ### Command options
 
-- `-id=<string>` - The ID of the host set to delete.
+- `-id=<string>` - Indicates the ID of the host set you want to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/index.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/index.mdx
@@ -13,7 +13,7 @@ The `host-sets` command lets you perform operations on Boundary host set resourc
 
 ## Example
 
-The following command reads a host set with the ID `hsst_1234567890`:
+The following command reads the details of a host set with the ID `hsst_1234567890`:
 
 ```shell-session
 $ boundary host-sets read -id hsst_1234567890
@@ -39,7 +39,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [add-hosts](/boundary/docs/api-clients/commands/host-sets/add-hosts)

--- a/website/content/docs/api-clients/commands/host-sets/list.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/list.mdx
@@ -31,11 +31,11 @@ $ boundary host-sets list [options] [args]
 
 ### Command options
 
-- `-filter=<string>` - If you set this value, Boundary filters the list operation before the results are returned.
+- `-filter=<string>` - Indicates whether Boundary should filter the list operation before the results are returned.
 The filter operates against each item in the list.
 We recommend that you use single quotes, because the filters contain double quotes.
 Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
-- `-host-catalog-id=<string>` - The host catalog resource to use to produce the list.
-You can also specify the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
+- `-host-catalog-id=<string>` - Indicates the host catalog resource to use to produce the list.
+You can also specify the host catalog using the **BOUNDARY_HOST_CATALOG_ID** environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/read.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/read.mdx
@@ -2,18 +2,18 @@
 layout: docs
 page_title: host-sets read - Command
 description: |-
-  The "host-sets read" command lets you read a host set with a given ID.
+  The "host-sets read" command lets you read the details of a host set resource using its given ID.
 ---
 
 # host-sets read
 
 Command: `boundary host-sets read`
 
-The `boundary host-sets read` command lets you read a Boundary host set using its given ID.
+The `boundary host-sets read` command lets you read the details of a Boundary host set using its given ID.
 
 ## Example
 
-This example reads a host set with the ID `_1234567890`:
+This example reads host set details for a host set with the ID `_1234567890`:
 
 ```shell-session
 $ boundary host-sets read -id _1234567890
@@ -31,6 +31,6 @@ $ boundary host-sets read [options] [args]
 
 ### Command options
 
-- `-id=<string>` - The ID of the host set to read.
+- `-id=<string>` - Indicates the ID of the host set whose information you want to read.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/remove-hosts.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/remove-hosts.mdx
@@ -31,10 +31,10 @@ $ boundary host-sets remove-hosts <subcommand> [options] [args]
 
 ### Command options
 
-- `-host=<string>` - The hosts to remove from the host set.
+- `-host=<string>` - Specifies the hosts you want to remove from the host set.
 You can specify multiple hosts.
-- `-id=<string>` - The ID of the host set to remove hosts from.
-- `-version=<int>` The version of the host set.
+- `-id=<string>` - Indicates the ID of the containing host set you want to remove hosts from.
+- `-version=<int>` Specifies the version of the host set you want to remove hosts from.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/set-hosts.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/set-hosts.mdx
@@ -2,14 +2,14 @@
 layout: docs
 page_title: host-sets set-hosts - Command
 description: |-
-  The "host-sets set-hosts" command lets you set the complete set of hosts on host source resources, if the types match and the operation is allowed by the host set type.
+  The "host-sets set-hosts" command lets you configure the complete set of hosts on host source resources, if the types match and the operation is allowed by the host set type.
 ---
 
 # host-sets set-hosts
 
 Command: `host-sets set-hosts`
 
-The `host-sets set-hosts` command lets you set the complete set of hosts on a host set resource, if the types match and it is allowed by the host set type.
+The `host-sets set-hosts` command lets you configure the complete set of hosts on a host set resource, if the types match and it is allowed by the host set type.
 
 ## Example
 
@@ -31,10 +31,10 @@ $ boundary host-sets set-hosts <subcommand> [options] [args]
 
 ### Command options
 
-- `-host=<string>` - The hosts to set on the host set.
+- `-host=<string>` - Specifies the hosts to configure on the host set.
 You can specify multiple hosts.
-- `-id=<string>` - The ID of the host set to set hosts on.
-- `-version=<int>` The version of the host set.
+- `-id=<string>` - Indicates the ID of the host set to set hosts on.
+- `-version=<int>` Specifies the version of the host set you want to set hosts on.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/host-sets/update.mdx
+++ b/website/content/docs/api-clients/commands/host-sets/update.mdx
@@ -40,7 +40,7 @@ Subcommands:
 You can update plugin or static host set types.
 
 <Tabs>
-<Tab heading="plugin">
+<Tab heading="Plugin">
 
 The `boundary host-sets update plugin` command lets you update a plugin type host set.
 
@@ -64,41 +64,42 @@ $ boundary host-sets update plugin [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the plugin host set.
-- `-id=<string>` - The ID of the plugin type host set to update.
-- `-name=<string>` - The name to set for the plugin host set.
-- `-version=<int>` - The version of the plugin host set to update.
+- `-description=<string>` - Sets the description for the plugin host set.
+- `-id=<string>` - Indicates the ID of the plugin type host set to update.
+- `-name=<string>` - Sets the name for the plugin host set.
+- `-version=<int>` - Indicates the version of the plugin host set to update.
 If you do not specify a version, the command automatically performs a check-and-set.
 
 #### Attribute options
 
-- `-attr` - A key=value pair to add to the request's attribute map.
-This option can also be a key value only, which will set a JSON null as the value.
+- `-attr` - Specifies a key=value pair to add to the request's attribute map.
+This option can also be a key value only, which sets a JSON null as the value.
 If you provide a value, Boundary automatically infers the type.
 You can override the type using `-string-attr`, `-bool-attr`, or `-num-attr`.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-attributes=<string>` - A JSON map value that you can use as the entirety of the request's attributes map.
-Usually this value is sourced from file using "file://" syntax.
-This option is exclusive with other attr flags.
-- `-bool-attr` - A key=value Boolean value that you can add to the request's attributes map.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-attributes=<string>` - Specifies a JSON map value that you can use as the entirety of the request's attributes map.
+Usually this value is sourced from a file using the `file://` syntax.
+This option is exclusive with other `attr` flags.
+- `-bool-attr` - Specifies a key=value Boolean value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
-- `-num-attr` - A key=value numeric value that you can add to the request's attributes map.
+This option supports referencing values from files using `file://` and environment variables using `env://`.
+- `-num-attr` - Specifies a key=value numeric value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This attribute supports values from files using "file://" and environment variables using "env://".
-- `-string-attr` - A key=value string value that you can add to the request's attributes map.
+This attribute supports referencing values from files using `file://` and environment variables using `env://`.
+- `-string-attr` - Specifies a key=value string value that you can add to the request's attributes map.
 You can specify this value multiple times.
-This option supports values from files using "file://" and environment variables using "env://".
+This option supports referencing values from files using `file://` and environment variables using `env://`.
 
 #### Plugin host-set options
 
-- `-preferred-endpoint=<string>` - An endpoint preference that specifies which IP address or DNS name out of a host's available options is preferred.
-You can specify the preference using `cidr:<valid IPv4/6 CIDR>` or `dns:<globbed name>`.
-You can specify multiple preferences which create an order of preferences.
+- `-preferred-endpoint=<string>` - Specifies which IP address or DNS name out of a host's available options is preferred as an endpoint.
+You can specify your preference using `cidr:<valid IPv4/6 CIDR>` or `dns:<globbed name>`.
+You can specify multiple preferences to create an order of preferences.
 If you do not specify a preference, Boundary chooses a value from all available values using a built-in priority order.
 The endpoint preference option may not be valid for all plugin types.
-- `-sync-interval=<string>` - An integer number of a seconds or a string such as `400s`, `5m`, or `6h` that indicates the interval of time between sync operations on the host set.
+- `-sync-interval=<string>` - Indicates the interval of time between sync operations on the host set.
+You can enter an integer number of seconds or a string such as `400s`, `5m`, or `6h`.
 The interval is applied to the end of the previous sync operation, not the beginning.
 If you set the interval to a negative value, it disables synchronization for that host set.
 If you set the interval to null, Boundary uses the default value.
@@ -106,7 +107,7 @@ The default value may change between releases.
 
 </Tab>
 
-<Tab heading="static">
+<Tab heading="Static">
 
 The `boundary host-sets update static` command lets you update a static type host set.
 
@@ -130,10 +131,10 @@ $ boundary host-sets update static [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the static host set.
-- `-id=<string>` - The ID of the static type host set to update.
-- `-name=<string>` - The name to set for the static host set.
-- `-version=<int>` - The version of the static type host set to update.
+- `-description=<string>` - Sets the description for the static host set.
+- `-id=<string>` - Indicates the ID of the static type host set to update.
+- `-name=<string>` - Sets the name for the static host set.
+- `-version=<int>` - Specifies the version of the static type host set to update.
 If you do not specify a version, the command automatically performs a check-and-set.
 
 </Tab>

--- a/website/content/docs/api-clients/commands/hosts/create.mdx
+++ b/website/content/docs/api-clients/commands/hosts/create.mdx
@@ -58,13 +58,13 @@ $ boundary hosts create static [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the static host.
-- `-host-catalog-id=<string>` - The host catalog resource to use for the operation.
-You can also specfiy the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
-- `-name=<string>` - The name to set for the static host.
+- `-description=<string>` - Sets the description for the host.
+- `-host-catalog-id=<string>` - Indicates the host catalog resource to use for the operation.
+You can also specify the host catalog using the **BOUNDARY_HOST_CATALOG_ID** environment variable.
+- `-name=<string>` - Sets the name for the host.
 
 #### Static host options
 
-- `-address=<string>` - The address of the host.
+- `-address=<string>` - Specifies the address of the static host.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/hosts/delete.mdx
+++ b/website/content/docs/api-clients/commands/hosts/delete.mdx
@@ -31,6 +31,6 @@ $ boundary hosts delete [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the host to delete.
+- `-id=<string>` - Specifies the ID of the host you want to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/hosts/index.mdx
+++ b/website/content/docs/api-clients/commands/hosts/index.mdx
@@ -13,7 +13,7 @@ The `hosts` command lets you perform operations on Boundary host resources.
 
 ## Example
 
-The following command reads a host with the ID `hst_1234567890`:
+The following command reads the details of a host with the ID `hst_1234567890`:
 
 ```shell-session
 $ boundary hosts read -id hst_1234567890
@@ -36,7 +36,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [create](/boundary/docs/api-clients/commands/hosts/create)

--- a/website/content/docs/api-clients/commands/hosts/list.mdx
+++ b/website/content/docs/api-clients/commands/hosts/list.mdx
@@ -31,11 +31,11 @@ $ boundary hosts list [options] [args]
 
 ### Command options
 
-- `-filter=<string>` - If you set this value, Boundary filters the list operation before the results are returned.
+- `-filter=<string>` - Indicates whether Boundary should filter the list operation before the results are returned.
 The filter operates against each item in the list.
 We recommend that you use single quotes, because the filters contain double quotes.
 Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
-- `-host-catalog-id=<string>` - The host catalog resource to use to produce the list.
-You can also specify the host catalog using the BOUNDARY_HOST_CATALOG_ID environment variable.
+- `-host-catalog-id=<string>` - Indicates which host catalog resource to use to produce the list.
+You can also specify the host catalog using the **BOUNDARY_HOST_CATALOG_ID** environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/hosts/read.mdx
+++ b/website/content/docs/api-clients/commands/hosts/read.mdx
@@ -2,18 +2,18 @@
 layout: docs
 page_title: hosts read - Command
 description: |-
-  The "hosts read" command lets you read a host with a given ID.
+  The "hosts read" command lets you read information about a host with a given ID.
 ---
 
 # hosts read
 
 Command: `boundary hosts read`
 
-The `boundary hosts read` command lets you read a Boundary host using its given ID.
+The `boundary hosts read` command lets you read information about a Boundary host using its given ID.
 
 ## Example
 
-This example reads a host with the ID `h_1234567890`:
+This example reads the information about a host with the ID `h_1234567890`:
 
 ```shell-session
 $ boundary hosts read -id h_1234567890
@@ -31,6 +31,6 @@ $ boundary hosts read [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the host to read.
+- `-id=<string>` - Indicates the ID of the host whose information you want to read.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/hosts/update.mdx
+++ b/website/content/docs/api-clients/commands/hosts/update.mdx
@@ -58,14 +58,14 @@ $ boundary hosts update static [options] [args]
 
 #### Command options
 
-- `-description=<string>` - The description to set for the static host.
-- `-id=<string>` - The ID of the static host to update
-- `-name=<string>` - The name to set for the static host.
-- `-version=<int>` - The version of the static host to update.
+- `-description=<string>` - Sets the description for the static host.
+- `-id=<string>` - Indicates the ID of the static host you want to update.
+- `-name=<string>` - Sets the name for the static host.
+- `-version=<int>` - Specifies the version of the static host to update.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 #### Static host options
 
-- `-address=<string>` - The address of the host.
+- `-address=<string>` - Indicates the address of the static host.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/hosts/update.mdx
+++ b/website/content/docs/api-clients/commands/hosts/update.mdx
@@ -58,10 +58,10 @@ $ boundary hosts update static [options] [args]
 
 #### Command options
 
-- `-description=<string>` - Sets the description for the static host.
-- `-id=<string>` - Indicates the ID of the static host you want to update.
-- `-name=<string>` - Sets the name for the static host.
-- `-version=<int>` - Specifies the version of the static host to update.
+- `-description=<string>` - Sets the description for the host.
+- `-id=<string>` - Indicates the ID of the host you want to update.
+- `-name=<string>` - Sets the name for the host.
+- `-version=<int>` - Specifies the version of the host to update.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 #### Static host options


### PR DESCRIPTION
Edits the `host-catalogs`, `host-sets`, and `hosts` options in the CLI draft doc #3411.