### PR TITLE
docs: Edit `roles` and `scopes` options

### DIFF
--- a/website/content/docs/api-clients/commands/roles/add-grants.mdx
+++ b/website/content/docs/api-clients/commands/roles/add-grants.mdx
@@ -32,12 +32,12 @@ $ boundary roles add-grants [options] [args]
 
 ### Command options
 
-- `-grant=<string>` - The grants to add.
+- `-grant=<string>` - Indicates which grants to add.
 You can specify grants in compact string format or JSON.
 If you use JSON, be sure to escape it properly.
 You can optionally specify multiple grants.
-- `-id=<string>` - ID of the role to add grants to.
-- `-version=<int>` The version of the role to add grants to.
+- `-id=<string>` - Specifies the ID of the role to add grants to.
+- `-version=<int>` Specifies the version of the role to add grants to.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/roles/add-principals.mdx
+++ b/website/content/docs/api-clients/commands/roles/add-principals.mdx
@@ -33,11 +33,11 @@ $ boundary roles add-principals [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the role to add principals to.
-- `-principal=<string>` - The principals to add to the role.
+- `-id=<string>` - Indicates the ID of the role to add principals to.
+- `-principal=<string>` - Specifies the principals to add to the role.
 Principals can be users or groups.
 You can optionally specify multiple principals per role.
-- `-version=<int>` The version of the role to add principals to.
+- `-version=<int>` Indicates the version of the role to add principals to.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/roles/create.mdx
+++ b/website/content/docs/api-clients/commands/roles/create.mdx
@@ -31,11 +31,11 @@ $ boundary roles create [options] [args]
 
 ### Command options
 
-- `-description=<string>` - A description to assign to the role.
-- `-grant-scope-id=<string>` - The scope ID for any grants set on the role.
-- `-name=<string>` - The name you want to give the role.
-- `-scope-id=<string>` - The scope in which to create the role.
+- `-description=<string>` - Assigns a description to the role.
+- `-grant-scope-id=<string>` - Specifies the scope ID for any grants set on the role.
+- `-name=<string>` - Assigns a name to the role.
+- `-scope-id=<string>` - Indicates the scope in which to create the role.
 The default is `global`.
-You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
+You can also specify the scope using the **BOUNDARY_SCOPE_ID** environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/roles/delete.mdx
+++ b/website/content/docs/api-clients/commands/roles/delete.mdx
@@ -31,6 +31,6 @@ $ boundary roles delete [options] [args]
 
 ### Command options
 
-- `-id=<string>` - The ID of the role to delete.
+- `-id=<string>` - Indicates the ID of the role to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/roles/index.mdx
+++ b/website/content/docs/api-clients/commands/roles/index.mdx
@@ -42,7 +42,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [add-grants](/boundary/docs/api-clients/commands/roles/add-grants)

--- a/website/content/docs/api-clients/commands/roles/list.mdx
+++ b/website/content/docs/api-clients/commands/roles/list.mdx
@@ -32,14 +32,14 @@ $ boundary roles list [options] [args]
 
 ### Command options
 
-- `-filter=<string>` - If you set this value, Boundary filters the list operation before the results are returned.
+- `-filter=<string>` - Determines whether Boundary filters the list operation before the results are returned.
 The filter operates against each item in the list.
 We recommend that you use single quotes, because the filters contain double quotes.
 Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
-- `-recursive` - If you set this value, Boundary runs the list operation recursively on any child scopes, if the type supports it.
+- `-recursive` - Runs the list operation recursively on any child scopes, if the type supports it.
 The default value is `false`.
-- `-scope-id=<string>` - The enclosing scope from which to list the roles.
+- `-scope-id=<string>` - Specifies the enclosing scope from which to list the roles.
 The default value is `global`.
-You can also specify this value using the BOUNDARY_SCOPE_ID environment variable.
+You can also specify this value using the **BOUNDARY_SCOPE_ID** environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/roles/read.mdx
+++ b/website/content/docs/api-clients/commands/roles/read.mdx
@@ -2,18 +2,18 @@
 layout: docs
 page_title: roles read - Command
 description: |-
-  The "roles read" command lets you read a role with a given ID.
+  The "roles read" command lets you read the information about a role with a given ID.
 ---
 
 # roles read
 
 Command: `boundary roles read`
 
-The `boundary roles read` command lets you read a Boundary role using its given ID.
+The `boundary roles read` command lets you read the information about a Boundary role using its given ID.
 
 ## Example
 
-This example reads a role with the ID `r_1234567890`:
+This example reads the details of a role with the ID `r_1234567890`:
 
 ```shell-session
 $ boundary roles read -id r_1234567890
@@ -31,6 +31,6 @@ $ boundary roles read [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the role to read.
+- `-id=<string>` - Specifies the ID of the role to read.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/roles/remove-grants.mdx
+++ b/website/content/docs/api-clients/commands/roles/remove-grants.mdx
@@ -32,12 +32,12 @@ $ boundary roles remove-grants [options] [args]
 
 ### Command options
 
-- `-grant=<string>` - The grants to remove.
+- `-grant=<string>` - Specifies which grants you want to remove from the role.
 You can specify grants in compact string format or JSON.
 If you use JSON, be sure to escape it properly.
 You can optionally specify multiple grants.
-- `-id=<string>` - ID of the role to remove grants from.
-- `-version=<int>` The version of the role to remove grants from.
+- `-id=<string>` - Indicates the ID of the role to remove grants from.
+- `-version=<int>` - Indicates the version of the role to remove grants from.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/roles/remove-principals.mdx
+++ b/website/content/docs/api-clients/commands/roles/remove-principals.mdx
@@ -33,11 +33,11 @@ $ boundary roles remove-principals [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the role to remove principals from.
-- `-principal=<string>` - The principals to remove from the role.
+- `-id=<string>` - Indicates the ID of the role you want to remove principals from.
+- `-principal=<string>` - Indicates the principals you want to remove from the role.
 Principals can be users or groups.
 You can optionally specify multiple principals per role.
-- `-version=<int>` The version of the role to remove principals from.
+- `-version=<int>` Indicates the version of the role to remove principals from.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/roles/set-grants.mdx
+++ b/website/content/docs/api-clients/commands/roles/set-grants.mdx
@@ -14,7 +14,7 @@ You can specify multiple grants per role.
 
 ## Example
 
-This example sets multiple grants which permit read and list permissions on a role with the ID `r_1234567890`:
+This example sets multiple grants which allow read and list permissions for a role with the ID `r_1234567890`:
 
 ```shell-session
 $ boundary roles set-grants -id r_1234567890 -grant "id=*;type=*;actions=read" -grant
@@ -33,12 +33,12 @@ $ boundary roles set-grants [options] [args]
 
 ### Command options
 
-- `-grant=<string>` - The grants to set.
+- `-grant=<string>` - Specifies the grants you want to set on the role.
 You can specify grants in compact string format or JSON.
 If you use JSON, be sure to escape it properly.
 You can optionally specify multiple grants.
-- `-id=<string>` - ID of the role to set grants on.
-- `-version=<int>` The version of the role to set grants on.
+- `-id=<string>` - Indicates the ID of the role you want to set grants on.
+- `-version=<int>` Indicates the version of the role to set grants on.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/roles/set-principals.mdx
+++ b/website/content/docs/api-clients/commands/roles/set-principals.mdx
@@ -33,11 +33,11 @@ $ boundary roles set-principals [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the role to set principals on.
-- `-principal=<string>` - The principals to set on the role.
+- `-id=<string>` - Indicates the ID of the role you want to set principals on.
+- `-principal=<string>` - Specifies which principals you want to set on the role.
 Principals can be users or groups.
 You can optionally specify multiple principals per role.
-- `-version=<int>` The version of the role to set principals on.
+- `-version=<int>` Indicates the version of the role to set principals on.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/roles/update.mdx
+++ b/website/content/docs/api-clients/commands/roles/update.mdx
@@ -31,11 +31,11 @@ $ boundary roles update [options] [args]
 
 ### Command options
 
-- `-description=<string>` - A description to assign to the role.
-- `-grant-scope-id=<string>` - The scope ID for any grants set on the role.
-- `-id=<string>` - ID of the role to update.
-- `-name=<string>` - The name you want to give the role.
-- `-version=<int>` - The version of the role to update.
+- `-description=<string>` - Assigns a description to the role.
+- `-grant-scope-id=<string>` - Indicates the scope ID for any grants set on the role.
+- `-id=<string>` - Indicates the ID of the role you want to update.
+- `-name=<string>` - Assigns a name to the role.
+- `-version=<int>` - Indicates the version of the role you want to update.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/scopes/create.mdx
+++ b/website/content/docs/api-clients/commands/scopes/create.mdx
@@ -31,14 +31,14 @@ $ boundary scopes create [options] [args]
 
 ### Command options
 
-- `-description=<string>` - A description to assign to the scope.
-- `-name=<string>` - The name you want to give the scope.
-- `-scope-id=<string>` - The scope in which to create the scope.
+- `-description=<string>` - Assigns a description to the scope.
+- `-name=<string>` - Assigns a name to the scope.
+- `-scope-id=<string>` - Indicates the scope in which to create the scope.
 The default is `global`.
-You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
-- `-skip-admin-role-creation` - If you enable this option, Boundary does not create a role that grants the current user administrative access to the newly created scope.
+You can also specify the scope using the **BOUNDARY_SCOPE_ID** environment variable.
+- `-skip-admin-role-creation` - Indicates that Boundary should not create a role that grants the current user administrative access to the newly created scope.
 The default value is `false`.
-- `-skip-default-role-creation` - If you enable this option, Boundary does not create a role that grants the anonymous user access to log in to auth methods and other actions within the newly created scope.
+- `-skip-default-role-creation` - Indicates that Boundary should not create a role that grants the anonymous user access to log in to auth methods and other actions within the newly created scope.
 The default value is `false`.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/scopes/delete.mdx
+++ b/website/content/docs/api-clients/commands/scopes/delete.mdx
@@ -31,6 +31,6 @@ $ boundary scopes delete [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the scope to delete.
+- `-id=<string>` - Indicates the ID of the scope you want to delete.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/scopes/destroy-key-version.mdx
+++ b/website/content/docs/api-clients/commands/scopes/destroy-key-version.mdx
@@ -34,7 +34,7 @@ $ boundary scopes destroy-key-version [args]
 
 ### Command options
 
-- `-key-version-id=<string>` - The ID of the key version to destrooy.
-- `-scope-id=<string>` - The ID of the scope in which the key version you want to destroy exists.
+- `-key-version-id=<string>` - Indicates the ID of the key version you want to destroy.
+- `-scope-id=<string>` - Indicates the ID of the scope in which the key version you want to destroy exists.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/scopes/index.mdx
+++ b/website/content/docs/api-clients/commands/scopes/index.mdx
@@ -40,7 +40,7 @@ Subcommands:
 
 </CodeBlockConfig>
 
-For more information, examples, and usage about a subcommand, click on the name
+For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
 - [create](/boundary/docs/api-clients/commands/scopes/create)

--- a/website/content/docs/api-clients/commands/scopes/list-key-version-destruction-jobs.mdx
+++ b/website/content/docs/api-clients/commands/scopes/list-key-version-destruction-jobs.mdx
@@ -9,7 +9,7 @@ description: |-
 
 Command: `scopes list-key-version-destruction-jobs`
 
-When the [key version destruction job](/boundary/docs/api-clients/commands/scopes/destroy-key-version) runs, it asynchronously re-encrypts any existing data within the latest key version before it destroys the key version.
+When the [key version destruction job](/boundary/docs/api-clients/commands/scopes/destroy-key-version) runs, it asynchronously re-encrypts any existing data within the latest key version before it destroys the key version you selected for destruction.
 The `scopes list-key-version-destruction jobs` command lists all pending key version destruction jobs within a scope.
 
 ## Example
@@ -32,6 +32,6 @@ $ boundary scopes list-key-version-destruction-jobs [args]
 
 ### Command options
 
-- `-scope-id=<string>` - The ID of the scope in which to list key version destruction jobs.
+- `-scope-id=<string>` - Indicates the ID of the scope in which to list key version destruction jobs.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/scopes/list-keys.mdx
+++ b/website/content/docs/api-clients/commands/scopes/list-keys.mdx
@@ -13,7 +13,7 @@ The `boundary scopes list-keys` command lets you list the keys within a given sc
 
 ## Example
 
-This example lists all keys within the scope `s_1234567890`.
+This example lists all keys within the scope `s_1234567890`:
 
 ```shell-session
 $ boundary scopes list-keys -scope-id s_1234567890
@@ -31,6 +31,6 @@ $ boundary scopes list-keys [args]
 
 ### Command options
 
-- `-scope-id=<string>` - The enclosing scope from which to list the keys.
+- `-scope-id=<string>` - Specifies the ID of the enclosing scope from which to list the keys.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/scopes/list.mdx
+++ b/website/content/docs/api-clients/commands/scopes/list.mdx
@@ -32,14 +32,14 @@ $ boundary scopes list [options] [args]
 
 ### Command options
 
-- `-filter=<string>` - If you set this value, Boundary filters the list operation before the results are returned.
+- `-filter=<string>` - Determines whether Boundary filters the list operation before the results are returned.
 The filter operates against each item in the list.
 We recommend that you use single quotes, because the filters contain double quotes.
 Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
-- `-recursive` - If you set this value, Boundary runs the list operation recursively on any child scopes, if the type supports it.
+- `-recursive` - Runs the list operation recursively on any child scopes, if the type supports it.
 The default value is `false`.
-- `-scope-id=<string>` - The enclosing scope from which to list the scopes.
+- `-scope-id=<string>` - Indicates the enclosing scope from which to list the scopes.
 The default value is `global`.
-You can also specify this value using the BOUNDARY_SCOPE_ID environment variable.
+You can also specify this value using the **BOUNDARY_SCOPE_ID** environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/scopes/read.mdx
+++ b/website/content/docs/api-clients/commands/scopes/read.mdx
@@ -2,18 +2,18 @@
 layout: docs
 page_title: scopes read - Command
 description: |-
-  The "scopes read" command lets you read a scope with a given ID.
+  The "scopes read" command lets you read the details about a scope using its given ID.
 ---
 
 # scopes read
 
 Command: `boundary scopes read`
 
-The `boundary scopes read` command lets you read a Boundary scope using its given ID.
+The `boundary scopes read` command lets you read the details about a Boundary scope using its given ID.
 
 ## Example
 
-This example reads a scope with the ID `o_1234567890`:
+This example reads the details about a scope with the ID `o_1234567890`:
 
 ```shell-session
 $ boundary scopes read -id o_1234567890
@@ -31,6 +31,6 @@ $ boundary scopes read [options] [args]
 
 ### Command options
 
-- `-id=<string>` - ID of the scope to read.
+- `-id=<string>` - Indicates the ID of the scope to read.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/scopes/rotate-keys.mdx
+++ b/website/content/docs/api-clients/commands/scopes/rotate-keys.mdx
@@ -13,7 +13,7 @@ The `boundary scopes rotate-keys` command lets you replace a scope's current KEK
 
 ## Example
 
-This example rotates all keys within the scope `s_1234567890`.
+This example rotates all keys within the scope `s_1234567890`:
 
 ```shell-session
 $ boundary scopes rotate-keys -scope-id s_1234567890
@@ -31,8 +31,8 @@ $ boundary scopes rotate-keys [args]
 
 ### Command options
 
-- `-rewrap` - Whether to re-encrypt DEKs with the new KEK.
+- `-rewrap` - Indicates whether to re-encrypt DEKs with the new KEK.
 The default value is `false`.
-- `-scope-id=<string>` - The enclosing scope from which to rotate the keys.
+- `-scope-id=<string>` - Specifies the enclosing scope in which you want to rotate the keys.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/api-clients/commands/scopes/update.mdx
+++ b/website/content/docs/api-clients/commands/scopes/update.mdx
@@ -31,13 +31,13 @@ $ boundary scopes update [options] [args]
 
 ### Command options
 
-- `-description=<string>` - A description to assign to the scope.
-- `-id=<string>` - ID of the scope to update.
-- `-name=<string>` - The name you want to give the scope.
-- `-primary-auth-method-id=<string>` - The primary auth method ID for the scope.
+- `-description=<string>` - Assigns a description to the scope.
+- `-id=<string>` - Indicates the ID of the scope to update.
+- `-name=<string>` - Assigns a name to the scope.
+- `-primary-auth-method-id=<string>` - Specifies the primary auth method ID for the scope.
 The primary auth method is allowed to create users on the initial login.
 It is also used as a source for the account full name and email used for the scope's users.
-- `-version=<int>` - The version of the scope to update.
+- `-version=<int>` - Indicates the version of the scope to update.
 If you do not specify a version, the command performs a check-and-set automatically.
 
 @include 'cmd-option-note.mdx'


### PR DESCRIPTION
Edits the `roles` and `scopes` options in the CLI draft doc #3411.