### PR TITLE
chore(scripts): Check if UI artifact is expired

### DIFF
--- a/internal/ui/VERSION
+++ b/internal/ui/VERSION
@@ -1,4 +1,4 @@
-f4c153a1321281017cc22a3eea46e01ea5f876a9
+37c0c55a6033e552bc8f4d5b707db731fb618b87
 # This file determines the version of the UI to embed in the boundary binary.
 # Update this file by running 'make update-ui-version' from the root of this repo.
 # Set UI_COMMITISH when running the above target to update to a specific version.


### PR DESCRIPTION
This PR attempts to address an issue when building boundary locally, but the corresponding UI artifacts have expired in Github. Currently, when this occurs, the build script fails and you are blocked from building boundary
```
> make build-ui
 ./scripts/build-ui.sh
│ ==> Building default UI version from internal/ui/VERSION:
│ 37c0c55a6033e552bc8f4d5b707db731fb618b87
│ Found gh cli, attempting to download ui assets
│ Downloading artifact: 739929234 for admin-ui-oss
│ 37c0c55a6033e552bc8f4d5b707db731fb618b87
│ gh: Artifact has expired (HTTP 410)
│ make: *** [build-ui] Error 1
```

This change will verify if an artifact has expired and will fall back to building the UI assets locally.
```
❯ make build-ui
./scripts/build-ui.sh
==> Building default UI version from internal/ui/VERSION: 37c0c55a6033e552bc8f4d5b707db731fb618b87
Found gh cli, attempting to download ui assets
Artifact has expired. Falling back to building the UI locally...
Cloning into 'internal/ui/.tmp/boundary-ui'...
remote: Enumerating objects: 71106, done.
remote: Counting objects: 100% (9138/9138), done.
...
```

However, this change does NOT address failures in CI. CI uses a [Github Action artifact](https://github.com/hashicorp/boundary/blob/7c185dad9378cf145cc3a61bb9e50ede0158e210/.github/workflows/build.yml#L165-L172) instead of the script and will still fail if the artifact has expired.