### PR TITLE
Go SDK auto pagination tweaks

### DIFF
--- a/api/accounts/account.gen.go
+++ b/api/accounts/account.gen.go
@@ -345,6 +345,12 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "accounts", nil, apiOpts...)
 		if err != nil {
@@ -373,14 +379,34 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/accounts/account.gen.go
+++ b/api/accounts/account.gen.go
@@ -346,7 +346,8 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -380,8 +381,13 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/accounts/account.gen.go
+++ b/api/accounts/account.gen.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type Account struct {
@@ -410,8 +410,8 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *Account) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *Account) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/accounts/account.gen.go
+++ b/api/accounts/account.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -340,11 +341,10 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -398,21 +398,20 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *Account) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/accounts/option.gen.go
+++ b/api/accounts/option.gen.go
@@ -5,7 +5,6 @@
 package accounts
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -27,7 +26,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -53,9 +51,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	return opts, apiOpts
 }
@@ -83,14 +78,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/authmethods/authmethods.gen.go
+++ b/api/authmethods/authmethods.gen.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type AuthMethod struct {
@@ -416,8 +416,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *AuthMethod) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *AuthMethod) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/authmethods/authmethods.gen.go
+++ b/api/authmethods/authmethods.gen.go
@@ -352,7 +352,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -386,8 +387,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/authmethods/authmethods.gen.go
+++ b/api/authmethods/authmethods.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -346,11 +347,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -404,21 +404,20 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *AuthMethod) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/authmethods/authmethods.gen.go
+++ b/api/authmethods/authmethods.gen.go
@@ -351,6 +351,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "auth-methods", nil, apiOpts...)
 		if err != nil {
@@ -379,14 +385,34 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/authmethods/option.gen.go
+++ b/api/authmethods/option.gen.go
@@ -27,7 +27,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -54,9 +53,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -87,14 +83,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -231,11 +232,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -289,21 +289,20 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *AuthToken) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -8,11 +8,11 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type AuthToken struct {
@@ -301,8 +301,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *AuthToken) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *AuthToken) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -237,7 +237,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -271,8 +272,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -236,6 +236,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "auth-tokens", nil, apiOpts...)
 		if err != nil {
@@ -264,14 +270,34 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/authtokens/option.gen.go
+++ b/api/authtokens/option.gen.go
@@ -27,7 +27,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -55,9 +54,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
 	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
-	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -77,14 +73,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/credentiallibraries/credential_library.gen.go
+++ b/api/credentiallibraries/credential_library.gen.go
@@ -351,6 +351,12 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "credential-libraries", nil, apiOpts...)
 		if err != nil {
@@ -379,14 +385,34 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/credentiallibraries/credential_library.gen.go
+++ b/api/credentiallibraries/credential_library.gen.go
@@ -352,7 +352,8 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -386,8 +387,13 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/credentiallibraries/credential_library.gen.go
+++ b/api/credentiallibraries/credential_library.gen.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type CredentialLibrary struct {
@@ -416,8 +416,8 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *CredentialLibrary) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *CredentialLibrary) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/credentiallibraries/credential_library.gen.go
+++ b/api/credentiallibraries/credential_library.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -346,11 +347,10 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -404,21 +404,20 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *CredentialLibrary) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/credentiallibraries/option.gen.go
+++ b/api/credentiallibraries/option.gen.go
@@ -5,7 +5,6 @@
 package credentiallibraries
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -27,7 +26,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -53,9 +51,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	return opts, apiOpts
 }
@@ -83,14 +78,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/credentials/credential.gen.go
+++ b/api/credentials/credential.gen.go
@@ -350,7 +350,8 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -384,8 +385,13 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/credentials/credential.gen.go
+++ b/api/credentials/credential.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -344,11 +345,10 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -402,21 +402,20 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *Credential) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/credentials/credential.gen.go
+++ b/api/credentials/credential.gen.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type Credential struct {
@@ -414,8 +414,8 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *Credential) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *Credential) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/credentials/credential.gen.go
+++ b/api/credentials/credential.gen.go
@@ -349,6 +349,12 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "credentials", nil, apiOpts...)
 		if err != nil {
@@ -377,14 +383,34 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/credentials/option.gen.go
+++ b/api/credentials/option.gen.go
@@ -5,7 +5,6 @@
 package credentials
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -27,7 +26,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -53,9 +51,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	return opts, apiOpts
 }
@@ -83,14 +78,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/credentialstores/credential_store.gen.go
+++ b/api/credentialstores/credential_store.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -345,11 +346,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -403,21 +403,20 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *CredentialStore) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/credentialstores/credential_store.gen.go
+++ b/api/credentialstores/credential_store.gen.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type CredentialStore struct {
@@ -415,8 +415,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *CredentialStore) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *CredentialStore) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/credentialstores/credential_store.gen.go
+++ b/api/credentialstores/credential_store.gen.go
@@ -351,7 +351,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -385,8 +386,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/credentialstores/credential_store.gen.go
+++ b/api/credentialstores/credential_store.gen.go
@@ -350,6 +350,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "credential-stores", nil, apiOpts...)
 		if err != nil {
@@ -378,14 +384,34 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/credentialstores/option.gen.go
+++ b/api/credentialstores/option.gen.go
@@ -27,7 +27,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -54,9 +53,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -87,14 +83,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mr-tron/base58 v1.2.0
 	github.com/stretchr/testify v1.8.2
+	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 	golang.org/x/time v0.3.0
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.28.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -79,6 +79,8 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/api/groups/group.gen.go
+++ b/api/groups/group.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -339,11 +340,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -397,22 +397,21 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *Group) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }
 

--- a/api/groups/group.gen.go
+++ b/api/groups/group.gen.go
@@ -345,7 +345,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -379,8 +380,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/groups/group.gen.go
+++ b/api/groups/group.gen.go
@@ -344,6 +344,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "groups", nil, apiOpts...)
 		if err != nil {
@@ -372,16 +378,36 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }
 
 func (c *Client) AddMembers(ctx context.Context, id string, version uint32, memberIds []string, opt ...Option) (*GroupUpdateResult, error) {

--- a/api/groups/group.gen.go
+++ b/api/groups/group.gen.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type Group struct {
@@ -409,8 +409,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *Group) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *Group) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/groups/option.gen.go
+++ b/api/groups/option.gen.go
@@ -27,7 +27,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -54,9 +53,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -87,14 +83,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/hostcatalogs/host_catalog.gen.go
+++ b/api/hostcatalogs/host_catalog.gen.go
@@ -9,12 +9,12 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/plugins"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type HostCatalog struct {
@@ -420,8 +420,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *HostCatalog) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *HostCatalog) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/hostcatalogs/host_catalog.gen.go
+++ b/api/hostcatalogs/host_catalog.gen.go
@@ -355,6 +355,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "host-catalogs", nil, apiOpts...)
 		if err != nil {
@@ -383,14 +389,34 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/hostcatalogs/host_catalog.gen.go
+++ b/api/hostcatalogs/host_catalog.gen.go
@@ -356,7 +356,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -390,8 +391,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/hostcatalogs/host_catalog.gen.go
+++ b/api/hostcatalogs/host_catalog.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -350,11 +351,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -408,21 +408,20 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *HostCatalog) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/hostcatalogs/option.gen.go
+++ b/api/hostcatalogs/option.gen.go
@@ -28,7 +28,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -55,9 +54,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -88,14 +84,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/hosts/host.gen.go
+++ b/api/hosts/host.gen.go
@@ -352,7 +352,8 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -386,8 +387,13 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/hosts/host.gen.go
+++ b/api/hosts/host.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -346,11 +347,10 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -404,21 +404,20 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *Host) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/hosts/host.gen.go
+++ b/api/hosts/host.gen.go
@@ -351,6 +351,12 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "hosts", nil, apiOpts...)
 		if err != nil {
@@ -379,14 +385,34 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/hosts/host.gen.go
+++ b/api/hosts/host.gen.go
@@ -9,12 +9,12 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/plugins"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type Host struct {
@@ -416,8 +416,8 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *Host) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *Host) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/hosts/option.gen.go
+++ b/api/hosts/option.gen.go
@@ -5,7 +5,6 @@
 package hosts
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -27,7 +26,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -53,9 +51,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	return opts, apiOpts
 }
@@ -83,14 +78,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/hostsets/host_set.gen.go
+++ b/api/hostsets/host_set.gen.go
@@ -9,12 +9,12 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/plugins"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type HostSet struct {
@@ -414,8 +414,8 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *HostSet) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *HostSet) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/hostsets/host_set.gen.go
+++ b/api/hostsets/host_set.gen.go
@@ -350,7 +350,8 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -384,8 +385,13 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/hostsets/host_set.gen.go
+++ b/api/hostsets/host_set.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -344,11 +345,10 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -402,22 +402,21 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *HostSet) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }
 

--- a/api/hostsets/host_set.gen.go
+++ b/api/hostsets/host_set.gen.go
@@ -349,6 +349,12 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "host-sets", nil, apiOpts...)
 		if err != nil {
@@ -377,16 +383,36 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }
 
 func (c *Client) AddHosts(ctx context.Context, id string, version uint32, hostIds []string, opt ...Option) (*HostSetUpdateResult, error) {

--- a/api/hostsets/option.gen.go
+++ b/api/hostsets/option.gen.go
@@ -5,7 +5,6 @@
 package hostsets
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -27,7 +26,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -53,9 +51,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	return opts, apiOpts
 }
@@ -83,14 +78,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/managedgroups/managedgroups.gen.go
+++ b/api/managedgroups/managedgroups.gen.go
@@ -345,6 +345,12 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "managed-groups", nil, apiOpts...)
 		if err != nil {
@@ -373,14 +379,34 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/managedgroups/managedgroups.gen.go
+++ b/api/managedgroups/managedgroups.gen.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type ManagedGroup struct {
@@ -410,8 +410,8 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *ManagedGroup) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *ManagedGroup) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/managedgroups/managedgroups.gen.go
+++ b/api/managedgroups/managedgroups.gen.go
@@ -346,7 +346,8 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -380,8 +381,13 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/managedgroups/managedgroups.gen.go
+++ b/api/managedgroups/managedgroups.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -340,11 +341,10 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -398,21 +398,20 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *ManagedGroup) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/managedgroups/option.gen.go
+++ b/api/managedgroups/option.gen.go
@@ -5,7 +5,6 @@
 package managedgroups
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/api"
@@ -27,7 +26,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 }
 
 func getDefaultOptions() options {
@@ -53,9 +51,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	return opts, apiOpts
 }
@@ -83,14 +78,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/roles/option.gen.go
+++ b/api/roles/option.gen.go
@@ -27,7 +27,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -54,9 +53,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -87,14 +83,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/roles/role.gen.go
+++ b/api/roles/role.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -342,11 +343,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -400,22 +400,21 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *Role) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }
 

--- a/api/roles/role.gen.go
+++ b/api/roles/role.gen.go
@@ -347,6 +347,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "roles", nil, apiOpts...)
 		if err != nil {
@@ -375,16 +381,36 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }
 
 func (c *Client) AddGrants(ctx context.Context, id string, version uint32, grantStrings []string, opt ...Option) (*RoleUpdateResult, error) {

--- a/api/roles/role.gen.go
+++ b/api/roles/role.gen.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type Role struct {
@@ -412,8 +412,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *Role) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *Role) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/roles/role.gen.go
+++ b/api/roles/role.gen.go
@@ -348,7 +348,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -382,8 +383,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/scopes/option.gen.go
+++ b/api/scopes/option.gen.go
@@ -28,7 +28,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -55,9 +54,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -88,14 +84,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/scopes/scope.gen.go
+++ b/api/scopes/scope.gen.go
@@ -345,7 +345,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Scop
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -379,8 +380,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Scop
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/scopes/scope.gen.go
+++ b/api/scopes/scope.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -339,11 +340,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Scop
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -397,21 +397,20 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Scop
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *Scope) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/scopes/scope.gen.go
+++ b/api/scopes/scope.gen.go
@@ -9,10 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
+	"golang.org/x/exp/slices"
 )
 
 type Scope struct {
@@ -409,8 +409,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Scop
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *Scope) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *Scope) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/sessionrecordings/option.gen.go
+++ b/api/sessionrecordings/option.gen.go
@@ -26,7 +26,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -54,9 +53,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
 	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
-	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
 	}
@@ -76,14 +72,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/sessionrecordings/session_recording.gen.go
+++ b/api/sessionrecordings/session_recording.gen.go
@@ -187,7 +187,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -221,8 +222,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/sessionrecordings/session_recording.gen.go
+++ b/api/sessionrecordings/session_recording.gen.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -181,11 +182,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -239,21 +239,20 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *SessionRecording) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/sessionrecordings/session_recording.gen.go
+++ b/api/sessionrecordings/session_recording.gen.go
@@ -186,6 +186,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "session-recordings", nil, apiOpts...)
 		if err != nil {
@@ -214,14 +220,34 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/sessionrecordings/session_recording.gen.go
+++ b/api/sessionrecordings/session_recording.gen.go
@@ -8,11 +8,11 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type SessionRecording struct {
@@ -251,8 +251,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *SessionRecording) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *SessionRecording) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/sessions/option.gen.go
+++ b/api/sessions/option.gen.go
@@ -28,7 +28,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -55,9 +54,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -88,14 +84,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/sessions/session.gen.go
+++ b/api/sessions/session.gen.go
@@ -8,11 +8,11 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type Session struct {
@@ -268,8 +268,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *Session) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *Session) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/sessions/session.gen.go
+++ b/api/sessions/session.gen.go
@@ -203,6 +203,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "sessions", nil, apiOpts...)
 		if err != nil {
@@ -231,14 +237,34 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/sessions/session.gen.go
+++ b/api/sessions/session.gen.go
@@ -204,7 +204,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -238,8 +239,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/sessions/session.gen.go
+++ b/api/sessions/session.gen.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -198,11 +199,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -256,21 +256,20 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *Session) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }

--- a/api/storagebuckets/option.gen.go
+++ b/api/storagebuckets/option.gen.go
@@ -28,7 +28,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -55,9 +54,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -88,14 +84,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/storagebuckets/storage_bucket.gen.go
+++ b/api/storagebuckets/storage_bucket.gen.go
@@ -9,12 +9,12 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/plugins"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type StorageBucket struct {
@@ -417,8 +417,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Stor
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *StorageBucket) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *StorageBucket) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/storagebuckets/storage_bucket.gen.go
+++ b/api/storagebuckets/storage_bucket.gen.go
@@ -352,6 +352,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Stor
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "storage-buckets", nil, apiOpts...)
 		if err != nil {
@@ -380,14 +386,34 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Stor
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }

--- a/api/storagebuckets/storage_bucket.gen.go
+++ b/api/storagebuckets/storage_bucket.gen.go
@@ -353,7 +353,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Stor
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -387,8 +388,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Stor
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/targets/option.gen.go
+++ b/api/targets/option.gen.go
@@ -27,7 +27,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -54,9 +53,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -87,14 +83,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/targets/target.gen.go
+++ b/api/targets/target.gen.go
@@ -363,6 +363,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "targets", nil, apiOpts...)
 		if err != nil {
@@ -391,16 +397,36 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }
 
 func (c *Client) AddCredentialSources(ctx context.Context, id string, version uint32, opt ...Option) (*TargetUpdateResult, error) {

--- a/api/targets/target.gen.go
+++ b/api/targets/target.gen.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type Target struct {
@@ -428,8 +428,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *Target) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *Target) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/targets/target.gen.go
+++ b/api/targets/target.gen.go
@@ -364,7 +364,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -398,8 +399,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/api/targets/target.gen.go
+++ b/api/targets/target.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -358,11 +359,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -416,22 +416,21 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *Target) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }
 

--- a/api/users/option.gen.go
+++ b/api/users/option.gen.go
@@ -27,7 +27,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -54,9 +53,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -87,14 +83,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/users/user.gen.go
+++ b/api/users/user.gen.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type User struct {
@@ -413,8 +413,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*User
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *User) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *User) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/users/user.gen.go
+++ b/api/users/user.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -343,11 +344,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*User
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -401,22 +401,21 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*User
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *User) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }
 

--- a/api/users/user.gen.go
+++ b/api/users/user.gen.go
@@ -348,6 +348,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*User
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "users", nil, apiOpts...)
 		if err != nil {
@@ -376,16 +382,36 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*User
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }
 
 func (c *Client) AddAccounts(ctx context.Context, id string, version uint32, accountIds []string, opt ...Option) (*UserUpdateResult, error) {

--- a/api/workers/option.gen.go
+++ b/api/workers/option.gen.go
@@ -27,7 +27,6 @@ type options struct {
 	withSkipCurlOutput      bool
 	withFilter              string
 	withRefreshToken        string
-	withPageSize            uint
 	withRecursive           bool
 }
 
@@ -54,9 +53,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -87,14 +83,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 

--- a/api/workers/worker.gen.go
+++ b/api/workers/worker.gen.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type Worker struct {
@@ -467,8 +467,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Work
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *Worker) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *Worker) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }

--- a/api/workers/worker.gen.go
+++ b/api/workers/worker.gen.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/boundary/api"
@@ -397,11 +398,10 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Work
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -455,22 +455,21 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Work
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *Worker) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }
 

--- a/api/workers/worker.gen.go
+++ b/api/workers/worker.gen.go
@@ -402,6 +402,12 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Work
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "workers", nil, apiOpts...)
 		if err != nil {
@@ -430,16 +436,36 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Work
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items) - 1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }
 
 func (c *Client) AddWorkerTags(ctx context.Context, id string, version uint32, apiTags map[string][]string, opt ...Option) (*WorkerUpdateResult, error) {

--- a/api/workers/worker.gen.go
+++ b/api/workers/worker.gen.go
@@ -403,7 +403,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Work
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -437,8 +438,13 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Work
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items) - 1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items) - 1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -335,8 +335,8 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 	}
 	// Finally, sort the results again since in-place updates and deletes
 	// may have shuffled items.
-	slices.SortFunc(target.Items, func(i, j *{{ .Name }}) int {
-		return i.UpdatedTime.Compare(j.UpdatedTime)
+	slices.SortFunc(target.Items, func(i, j *{{ .Name }}) bool {
+		return i.UpdatedTime.Before(j.UpdatedTime)
 	})
 	return target, nil
 }
@@ -676,10 +676,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kr/pretty"
-
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
+	"golang.org/x/exp/slices"
 )
 
 type {{ .Name }} struct { {{ range .Fields }}

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -271,6 +271,12 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 	}
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
+	// idToIndex keeps a map from the ID of an item to its index in target.Items.
+	// This is used to remove deleted items from the result after pagination is done.
+	idToIndex := map[string]int{}
+	for i, item := range target.Items {
+		idToIndex[item.Id] = i
+	}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "{{ .CollectionPath }}", nil, apiOpts...)
 		if err != nil {
@@ -299,16 +305,36 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 		if apiErr != nil {
 			return nil, apiErr
 		}
-		target.Items = append(target.Items, page.Items...)
+		for _, item := range page.Items {
+			target.Items = append(target.Items, item)
+			idToIndex[item.Id] = len(target.Items)-1
+		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.RefreshToken = page.RefreshToken
 		target.ResponseType = page.ResponseType
 		target.response = resp
 		if target.ResponseType == "complete" {
-			return target, nil
+			break
 		}
 	}
+	// Remove any items deleted since the start of the iteration,
+	// and also remove those IDs from the RemovedIds slice.
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	removedIds := target.RemovedIds
+	target.RemovedIds = target.RemovedIds[:0]
+	for _, removedId := range removedIds {
+		if i, ok := idToIndex[removedId]; ok {
+			// Remove the item at index i.
+			// https://github.com/golang/go/wiki/SliceTricks#delete
+			copy(target.Items[i:], target.Items[i+1:])
+			target.Items[len(target.Items)-1] = nil
+			target.Items = target.Items[:len(target.Items)-1]
+		} else {
+			target.RemovedIds = append(target.RemovedIds, removedId)
+		}
+	}
+	return target, nil
 }
 `))
 

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -266,11 +266,10 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 		return nil, apiErr
 	}
 	target.response = resp
-	if opts.withRefreshToken != "" || target.ResponseType == "complete" || target.ResponseType == "" {
+	if target.ResponseType == "complete" || target.ResponseType == "" {
 		return target, nil
 	}
-	// if refresh token is not set explicitly and there are more results,
-	// automatically fetch the rest of the results.
+	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
 	// This is used to update updated items in-place and remove deleted items
 	// from the result after pagination is done.
@@ -324,22 +323,21 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 			break
 		}
 	}
-	// Remove any items deleted since the start of the iteration,
-	// and also remove those IDs from the RemovedIds slice.
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	removedIds := target.RemovedIds
-	target.RemovedIds = target.RemovedIds[:0]
-	for _, removedId := range removedIds {
+	for _, removedId := range  target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
-			// Remove the item at index i.
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			copy(target.Items[i:], target.Items[i+1:])
-			target.Items[len(target.Items)-1] = nil
+			// Remove the item at index i without preserving order
+			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
+			target.Items[i] = target.Items[len(target.Items)-1] 
 			target.Items = target.Items[:len(target.Items)-1]
-		} else {
-			target.RemovedIds = append(target.RemovedIds, removedId)
+			// Update the index of the last element
+			idToIndex[target.Items[i].Id] = i
 		}
 	}
+	// Finally, sort the results again since in-place updates and deletes
+	// may have shuffled items.
+	slices.SortFunc(target.Items, func(i, j *{{ .Name }}) int {
+		return i.UpdatedTime.Compare(j.UpdatedTime)
+	})
 	return target, nil
 }
 `))

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -272,7 +272,8 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 	// if refresh token is not set explicitly and there are more results,
 	// automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
-	// This is used to remove deleted items from the result after pagination is done.
+	// This is used to update updated items in-place and remove deleted items
+	// from the result after pagination is done.
 	idToIndex := map[string]int{}
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
@@ -306,8 +307,13 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 			return nil, apiErr
 		}
 		for _, item := range page.Items {
-			target.Items = append(target.Items, item)
-			idToIndex[item.Id] = len(target.Items)-1
+			if i, ok := idToIndex[item.Id]; ok {
+				// Item has already been seen at index i, update in-place
+				target.Items[i] = item
+			} else {
+				target.Items = append(target.Items, item)
+				idToIndex[item.Id] = len(target.Items)-1
+			}
 		}
 		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -811,7 +811,6 @@ type options struct {
 	withSkipCurlOutput bool
 	withFilter string
 	withRefreshToken string
-	withPageSize uint 
 	{{ if .RecursiveListing }} withRecursive bool {{ end }}
 }
 
@@ -838,9 +837,6 @@ func getOpts(opt ...Option) (options, []api.Option) {
 	}
 	if opts.withRefreshToken != "" {
 		opts.queryMap["refresh_token"] = opts.withRefreshToken
-	}
-	if opts.withPageSize != 0 {
-		opts.queryMap["page_size"] = strconv.FormatUint(uint64(opts.withPageSize), 10)
 	}{{ if .RecursiveListing }}
 	if opts.withRecursive {
 		opts.queryMap["recursive"] = strconv.FormatBool(opts.withRecursive)
@@ -873,14 +869,6 @@ func WithSkipCurlOutput(skip bool) Option {
 func WithRefreshToken(refreshToken string) Option {
 	return func(o *options) {
 		o.withRefreshToken = refreshToken
-	}
-}
-
-// WithPageSize tells the API use the provided page size for listing
-// opertaions on this resource.
-func WithPageSize(pageSize uint) Option {
-	return func(o *options) {
-		o.withPageSize = pageSize
 	}
 }
 


### PR DESCRIPTION
## [api: remove deleted items from list response](https://github.com/hashicorp/boundary/commit/8e63a08d80c494a66fd4df62bfbd7ea0d3647865)

When automatically paginating over the responses from our list endpoints, there is a chance that an item could be included both in the list of items and in the list of deleted IDs (if it was deleted while paginating). Perform a post-processing step to remove these items from the Items slice.

## [api: update previously seen items in-place](https://github.com/hashicorp/boundary/commit/bbf4962f56c0f6c37b7ec0594b371ffd8b135fd8)

When automatically paginating over the responses from our list endpoints, there is a chance that an item could be included twice (if it is updated during pagination). If an item is seen twice, update it in-place instead.