### PR TITLE
pagination: list deleted Ids before items

### DIFF
--- a/internal/authtoken/repository.go
+++ b/internal/authtoken/repository.go
@@ -378,6 +378,22 @@ func (r *Repository) GetTotalItems(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+// Now returns the current timestamp in the DB.
+func (r *Repository) Now(ctx context.Context) (time.Time, error) {
+	const op = "authtoken.(Repository).Now"
+	rows, err := r.reader.Query(ctx, "select current_timestamp", nil)
+	if err != nil {
+		return time.Time{}, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query current timestamp"))
+	}
+	var now time.Time
+	for rows.Next() {
+		if err := r.reader.ScanRows(ctx, rows, &now); err != nil {
+			return time.Time{}, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query current timestamp"))
+		}
+	}
+	return now, nil
+}
+
 // DeleteAuthToken deletes the token with the provided id from the repository returning a count of the
 // number of records deleted.  All options are ignored.
 func (r *Repository) DeleteAuthToken(ctx context.Context, id string, opt ...Option) (int, error) {

--- a/internal/authtoken/repository_test.go
+++ b/internal/authtoken/repository_test.go
@@ -989,3 +989,23 @@ func TestGetTotalItems(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(0, numItems)
 }
+
+func TestNow(t *testing.T) {
+	t.Parallel()
+	assert, require := assert.New(t), require.New(t)
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	kms := kms.TestKms(t, conn, wrapper)
+
+	repo, err := NewRepository(ctx, rw, rw, kms)
+	require.NoError(err)
+
+	now, err := repo.Now(ctx)
+	require.NoError(err)
+	// Check that it's within 1 second of now according to the system
+	// If this is flaky... just increase the limit 😬.
+	assert.True(now.Before(time.Now().Add(time.Second)))
+	assert.True(now.After(time.Now().Add(-time.Second)))
+}

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -381,6 +381,22 @@ func (r *Repository) GetTotalItems(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+// Now returns the current timestamp in the DB.
+func (r *Repository) Now(ctx context.Context) (time.Time, error) {
+	const op = "session.(Repository).Now"
+	rows, err := r.reader.Query(ctx, "select current_timestamp", nil)
+	if err != nil {
+		return time.Time{}, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query current timestamp"))
+	}
+	var now time.Time
+	for rows.Next() {
+		if err := r.reader.ScanRows(ctx, rows, &now); err != nil {
+			return time.Time{}, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query current timestamp"))
+		}
+	}
+	return now, nil
+}
+
 // DeleteSession will delete a session from the repository.
 func (r *Repository) DeleteSession(ctx context.Context, publicId string, _ ...Option) (int, error) {
 	const op = "session.(Repository).DeleteSession"

--- a/internal/session/repository_session_test.go
+++ b/internal/session/repository_session_test.go
@@ -1933,3 +1933,21 @@ func TestGetTotalItems(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, numItems)
 }
+
+func TestNow(t *testing.T) {
+	t.Parallel()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrapper := db.TestWrapper(t)
+	kmsRepo := kms.TestKms(t, conn, wrapper)
+	ctx := context.Background()
+	repo, err := NewRepository(ctx, rw, rw, kmsRepo)
+	require.NoError(t, err)
+
+	now, err := repo.Now(ctx)
+	require.NoError(t, err)
+	// Check that it's within 1 second of now according to the system
+	// If this is flaky... just increase the limit 😬.
+	assert.True(t, now.Before(time.Now().Add(time.Second)))
+	assert.True(t, now.After(time.Now().Add(-time.Second)))
+}

--- a/internal/target/repository.go
+++ b/internal/target/repository.go
@@ -381,6 +381,22 @@ func (r *Repository) GetTotalItems(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+// Now returns the current timestamp in the DB.
+func (r *Repository) Now(ctx context.Context) (time.Time, error) {
+	const op = "target.(Repository).Now"
+	rows, err := r.reader.Query(ctx, "select current_timestamp", nil)
+	if err != nil {
+		return time.Time{}, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query current timestamp"))
+	}
+	var now time.Time
+	for rows.Next() {
+		if err := r.reader.ScanRows(ctx, rows, &now); err != nil {
+			return time.Time{}, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query current timestamp"))
+		}
+	}
+	return now, nil
+}
+
 // DeleteTarget will delete a target from the repository.
 func (r *Repository) DeleteTarget(ctx context.Context, publicId string, _ ...Option) (int, error) {
 	const op = "target.(Repository).DeleteTarget"

--- a/internal/target/tcp/repository_test.go
+++ b/internal/target/tcp/repository_test.go
@@ -462,3 +462,22 @@ func TestGetTotalItems(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, numItems)
 }
+
+func TestNow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	testKms := kms.TestKms(t, conn, wrapper)
+
+	rw := db.New(conn)
+	repo, err := target.NewRepository(ctx, rw, rw, testKms)
+	require.NoError(t, err)
+
+	now, err := repo.Now(ctx)
+	require.NoError(t, err)
+	// Check that it's within 1 second of now according to the system
+	// If this is flaky... just increase the limit 😬.
+	assert.True(t, now.Before(time.Now().Add(time.Second)))
+	assert.True(t, now.After(time.Now().Add(-time.Second)))
+}


### PR DESCRIPTION
If an item was deleted between us listing items and us listing deleted Ids, it could appear in both. This change changes the order of operations to make this impossible.

Also always include a refresh token in the response when one is provided in the request.