### PR TITLE
test(e2e): Add worker health check when setting up infra

### DIFF
--- a/enos/modules/docker_postgres/main.tf
+++ b/enos/modules/docker_postgres/main.tf
@@ -63,6 +63,8 @@ resource "docker_container" "postgres" {
     "POSTGRES_USER=${var.user}",
     "POSTGRES_PASSWORD=${var.password}",
   ]
+  cpu_set = "1-2"
+  memory  = 2000
   volumes {
     host_path      = abspath(path.module)
     container_path = "/etc/postgresql/"

--- a/enos/modules/docker_worker/worker-config-bsr-downstream.hcl
+++ b/enos/modules/docker_worker/worker-config-bsr-downstream.hcl
@@ -14,6 +14,12 @@ listener "tcp" {
   tls_disable = true
 }
 
+listener "tcp" {
+  address = "0.0.0.0:${port_ops}"
+  purpose = "ops"
+  tls_disable = true
+}
+
 worker {
   name = "${worker_name}"
   public_addr = "${worker_name}:${port}"

--- a/enos/modules/docker_worker/worker-config-bsr.hcl
+++ b/enos/modules/docker_worker/worker-config-bsr.hcl
@@ -14,6 +14,12 @@ listener "tcp" {
   tls_disable = true
 }
 
+listener "tcp" {
+  address = "0.0.0.0:${port_ops}"
+  purpose = "ops"
+  tls_disable = true
+}
+
 worker {
   name = "${worker_name}"
   public_addr = "${worker_name}:${port}"

--- a/enos/modules/docker_worker/worker-config-downstream.hcl
+++ b/enos/modules/docker_worker/worker-config-downstream.hcl
@@ -14,6 +14,12 @@ listener "tcp" {
   tls_disable = true
 }
 
+listener "tcp" {
+  address = "0.0.0.0:${port_ops}"
+  purpose = "ops"
+  tls_disable = true
+}
+
 worker {
   name = "${worker_name}"
   public_addr = "${worker_name}:${port}"

--- a/enos/modules/docker_worker/worker-config.hcl
+++ b/enos/modules/docker_worker/worker-config.hcl
@@ -14,6 +14,12 @@ listener "tcp" {
   tls_disable = true
 }
 
+listener "tcp" {
+  address = "0.0.0.0:${port_ops}"
+  purpose = "ops"
+  tls_disable = true
+}
+
 worker {
   name = "${worker_name}"
   public_addr = "${worker_name}:${port}"


### PR DESCRIPTION
This PR updates the e2e test suite to add a worker health check when setting up a docker worker container. This adds testing coverage on the `health` endpoint as well as ensures that the container is ready to use before running tests.