### PR TITLE
test(e2e): Add missing proxy listener to config file

### DIFF
--- a/enos/modules/docker_boundary/boundary-config-bsr.hcl
+++ b/enos/modules/docker_boundary/boundary-config-bsr.hcl
@@ -34,6 +34,12 @@ listener "tcp" {
 }
 
 listener "tcp" {
+  address     = "boundary:9202"
+  purpose     = "proxy"
+  tls_disable = true
+}
+
+listener "tcp" {
   address     = "boundary:9203"
   purpose     = "ops"
   tls_disable = true


### PR DESCRIPTION
While working on a multihop test, I discovered that I made an error in a boundary config file when I added a collocated worker back to the file. This PR adds the necessary proxy listener to the config file so that the worker can properly load.