### PR TITLE
event(observation): Add request / response observation and add telemetry filter

### DIFF
--- a/internal/observability/event/event_observation.go
+++ b/internal/observability/event/event_observation.go
@@ -112,7 +112,7 @@ func (o *observation) ComposeFrom(events []*eventlogger.Event) (eventlogger.Even
 		}
 		if g.Request != nil {
 			msgReq := &Request{}
-			if v, ok := payload["request"]; ok {
+			if v, ok := payload[RequestField]; ok {
 				msgReq, ok = v.(*Request)
 				if !ok {
 					return "", nil, fmt.Errorf("%s: request %d is not an observation request: %w", op, i, eventlogger.ErrInvalidParameter)
@@ -134,11 +134,11 @@ func (o *observation) ComposeFrom(events []*eventlogger.Event) (eventlogger.Even
 			if g.Request.DetailsUpstreamMessage != nil {
 				msgReq.DetailsUpstreamMessage = g.Request.DetailsUpstreamMessage
 			}
-			payload["request"] = msgReq
+			payload[RequestField] = msgReq
 		}
 		if g.Response != nil {
 			msgRes := &Response{}
-			if v, ok := payload["response"]; ok {
+			if v, ok := payload[ResponseField]; ok {
 				msgRes, ok = v.(*Response)
 				if !ok {
 					return "", nil, fmt.Errorf("%s: response %d is not an observation response: %w", op, i, eventlogger.ErrInvalidParameter)
@@ -157,7 +157,7 @@ func (o *observation) ComposeFrom(events []*eventlogger.Event) (eventlogger.Even
 			if g.Response.DetailsUpstreamMessage != nil {
 				msgRes.DetailsUpstreamMessage = g.Response.DetailsUpstreamMessage
 			}
-			payload["response"] = msgRes
+			payload[ResponseField] = msgRes
 		}
 	}
 	return events[0].Type, payload, nil

--- a/internal/observability/event/event_observation.go
+++ b/internal/observability/event/event_observation.go
@@ -5,6 +5,7 @@ package event
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/eventlogger/filters/gated"
 	"github.com/hashicorp/go-secure-stdlib/strutil"

--- a/internal/observability/event/event_observation_test.go
+++ b/internal/observability/event/event_observation_test.go
@@ -4,12 +4,9 @@
 package event
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/boundary/internal/gen/controller/servers"
-	"github.com/hashicorp/boundary/internal/gen/controller/servers/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,50 +138,4 @@ func Test_observationEventType(t *testing.T) {
 	t.Parallel()
 	e := &observation{}
 	assert.Equal(t, string(ObservationType), e.EventType())
-}
-
-func Test_iterateProto(t *testing.T) {
-	assert, _ := assert.New(t), require.New(t)
-	input := Request{
-		Operation: "",
-		Endpoint:  "",
-		Details: &services.StatusRequest{
-			Jobs: []*services.JobStatus{
-				{Job: &services.Job{
-					Type:    1,
-					JobInfo: nil,
-				}},
-			},
-			UpdateTags: false,
-			WorkerStatus: &servers.ServerWorkerStatus{
-				PublicId:    "testID",
-				Name:        "w_1234567890",
-				Description: "A default worker created in",
-				Address:     "127.0.0.1:9202",
-				Tags: []*servers.TagPair{
-					{
-						Key:   "type",
-						Value: "dev",
-					},
-				},
-				KeyId:            "ovary-valid-curler-scrambled-glutinous-alias-rework-debit",
-				ReleaseVersion:   "Boundary v0.13.1",
-				OperationalState: "active",
-			},
-			ConnectedWorkerKeyIdentifiers:         nil,
-			ConnectedUnmappedWorkerKeyIdentifiers: nil,
-			ConnectedWorkerPublicIds:              nil,
-		},
-		DetailsUpstreamMessage: nil,
-	}
-
-	res := recurseStructureWithTagFilter(
-		input.Details,
-		map[string]string{
-			"eventstream": "observation",
-		},
-		false,
-	)
-	data, _ := json.Marshal(res)
-	assert.NotNil(data)
 }

--- a/internal/observability/event/event_observation_test.go
+++ b/internal/observability/event/event_observation_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/eventlogger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func Test_newObservation(t *testing.T) {
@@ -59,78 +61,6 @@ func Test_newObservation(t *testing.T) {
 				Version:     errorVersion,
 				Op:          Op("valid-all-opts"),
 				RequestInfo: TestRequestInfo(t),
-			},
-		},
-		{
-			name:   "with-request-no-telemetry",
-			fromOp: Op("with-request-no-telemetry"),
-			opts: []Option{
-				WithId("with-request-no-telemetry"),
-				WithRequestInfo(TestRequestInfo(t)),
-				WithFlush(),
-				WithRequest(TestWorkerRequest(t)),
-			},
-			want: &observation{
-				ID:          "with-request-no-telemetry",
-				Flush:       true,
-				Version:     errorVersion,
-				Op:          Op("with-request-no-telemetry"),
-				RequestInfo: TestRequestInfo(t),
-			},
-		},
-		{
-			name:   "with-response-no-telemetry",
-			fromOp: Op("with-response-no-telemetry"),
-			opts: []Option{
-				WithId("with-response-no-telemetry"),
-				WithRequestInfo(TestRequestInfo(t)),
-				WithFlush(),
-				WithResponse(TestWorkerResponse(t)),
-			},
-			want: &observation{
-				ID:          "with-response-no-telemetry",
-				Flush:       true,
-				Version:     errorVersion,
-				Op:          Op("with-response-no-telemetry"),
-				RequestInfo: TestRequestInfo(t),
-			},
-		},
-		{
-			name:   "with-request-with-telemetry",
-			fromOp: Op("with-request-with-telemetry"),
-			opts: []Option{
-				WithId("with-request-with-telemetry"),
-				WithRequestInfo(TestRequestInfo(t)),
-				WithFlush(),
-				WithRequest(TestWorkerRequest(t)),
-				WithTelemetry(),
-			},
-			want: &observation{
-				ID:          "with-request-with-telemetry",
-				Flush:       true,
-				Version:     errorVersion,
-				Op:          Op("with-request-with-telemetry"),
-				RequestInfo: TestRequestInfo(t),
-				Request:     TestWorkerRequest(t),
-			},
-		},
-		{
-			name:   "with-response-with-telemetry",
-			fromOp: Op("with-response-with-telemetry"),
-			opts: []Option{
-				WithId("with-response-with-telemetry"),
-				WithRequestInfo(TestRequestInfo(t)),
-				WithFlush(),
-				WithResponse(TestWorkerResponse(t)),
-				WithTelemetry(),
-			},
-			want: &observation{
-				ID:          "with-response-with-telemetry",
-				Flush:       true,
-				Version:     errorVersion,
-				Op:          Op("with-response-with-telemetry"),
-				RequestInfo: TestRequestInfo(t),
-				Response:    TestWorkerResponse(t),
 			},
 		},
 	}
@@ -210,4 +140,238 @@ func Test_observationEventType(t *testing.T) {
 	t.Parallel()
 	e := &observation{}
 	assert.Equal(t, string(ObservationType), e.EventType())
+}
+
+func Test_composeFromTelemetryFiltering(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	tests := []struct {
+		name                 string
+		fromOp               Op
+		opts                 []Option
+		wantObservation      *observation
+		wantErrIs            error
+		wantErrContains      string
+		wantFilteredRequest  *Request
+		wantFilteredResponse *Response
+	}{
+		{
+			name:   "with-request-no-telemetry",
+			fromOp: Op("with-request-no-telemetry"),
+			opts: []Option{
+				WithId("with-request-no-telemetry"),
+				WithRequestInfo(TestRequestInfo(t)),
+				WithFlush(),
+				WithRequest(&Request{
+					Operation: "op",
+					Endpoint:  "/worker-status/<id>",
+					Details:   testWorkerStatus(t),
+				}),
+			},
+			wantObservation: &observation{
+				ID:          "with-request-no-telemetry",
+				Flush:       true,
+				Version:     errorVersion,
+				Op:          Op("with-request-no-telemetry"),
+				RequestInfo: TestRequestInfo(t),
+			},
+		},
+		{
+			name:   "with-response-no-telemetry",
+			fromOp: Op("with-response-no-telemetry"),
+			opts: []Option{
+				WithId("with-response-no-telemetry"),
+				WithRequestInfo(TestRequestInfo(t)),
+				WithFlush(),
+				WithResponse(&Response{
+					StatusCode: 200,
+					Details:    testWorkerStatus(t),
+				}),
+			},
+			wantObservation: &observation{
+				ID:          "with-response-no-telemetry",
+				Flush:       true,
+				Version:     errorVersion,
+				Op:          Op("with-response-no-telemetry"),
+				RequestInfo: TestRequestInfo(t),
+			},
+		},
+		{
+			name:   "with-request-with-telemetry",
+			fromOp: Op("with-request-with-telemetry"),
+			opts: []Option{
+				WithId("with-request-with-telemetry"),
+				WithRequestInfo(TestRequestInfo(t)),
+				WithFlush(),
+				WithRequest(&Request{
+					Operation: "op",
+					Endpoint:  "/worker-status/<id>",
+					Details:   testWorkerStatus(t),
+				}),
+				WithTelemetry(),
+			},
+			wantObservation: &observation{
+				ID:          "with-request-with-telemetry",
+				Flush:       true,
+				Version:     errorVersion,
+				Op:          Op("with-request-with-telemetry"),
+				RequestInfo: TestRequestInfo(t),
+				Request: &Request{
+					Operation: "op",
+					Endpoint:  "/worker-status/<id>",
+					Details:   testWorkerStatus(t),
+				},
+			},
+			wantFilteredRequest: &Request{
+				Operation: "op",
+				Endpoint:  "/worker-status/<id>",
+				Details:   testWorkerStatusObservable(t),
+			},
+		},
+		{
+			name:   "with-response-with-telemetry",
+			fromOp: Op("with-response-with-telemetry"),
+			opts: []Option{
+				WithId("with-response-with-telemetry"),
+				WithRequestInfo(TestRequestInfo(t)),
+				WithFlush(),
+				WithResponse(&Response{
+					StatusCode: 200,
+					Details:    testWorkerStatus(t),
+				}),
+				WithTelemetry(),
+			},
+			wantObservation: &observation{
+				ID:          "with-response-with-telemetry",
+				Flush:       true,
+				Version:     errorVersion,
+				Op:          Op("with-response-with-telemetry"),
+				RequestInfo: TestRequestInfo(t),
+				Response: &Response{
+					StatusCode: 200,
+					Details:    testWorkerStatus(t),
+				},
+			},
+			wantFilteredResponse: &Response{
+				StatusCode: 200,
+				Details:    testWorkerStatusObservable(t),
+			},
+		},
+		{
+			name:   "nil-request-details-with-telemetry",
+			fromOp: Op("nil-request-details-with-telemetry"),
+			opts: []Option{
+				WithId("nil-request-details-with-telemetry"),
+				WithRequestInfo(TestRequestInfo(t)),
+				WithFlush(),
+				WithRequest(&Request{
+					Operation: "op",
+					Endpoint:  "/worker-status/<id>",
+					Details:   nil,
+				}),
+				WithTelemetry(),
+			},
+			wantObservation: &observation{
+				ID:          "nil-request-details-with-telemetry",
+				Flush:       true,
+				Version:     errorVersion,
+				Op:          Op("nil-request-details-with-telemetry"),
+				RequestInfo: TestRequestInfo(t),
+				Request: &Request{
+					Operation: "op",
+					Endpoint:  "/worker-status/<id>",
+					Details:   nil,
+				},
+			},
+			wantFilteredRequest: &Request{
+				Operation: "op",
+				Endpoint:  "/worker-status/<id>",
+				Details:   nil,
+			},
+		},
+		{
+			name:   "nil-response-details-with-telemetry",
+			fromOp: Op("nil-response-details-with-telemetry"),
+			opts: []Option{
+				WithId("nil-response-details-with-telemetry"),
+				WithRequestInfo(TestRequestInfo(t)),
+				WithFlush(),
+				WithResponse(&Response{
+					StatusCode: 200,
+					Details:    nil,
+				}),
+				WithTelemetry(),
+			},
+			wantObservation: &observation{
+				ID:          "nil-response-details-with-telemetry",
+				Flush:       true,
+				Version:     errorVersion,
+				Op:          Op("nil-response-details-with-telemetry"),
+				RequestInfo: TestRequestInfo(t),
+				Response: &Response{
+					StatusCode: 200,
+					Details:    nil,
+				},
+			},
+			wantFilteredResponse: &Response{
+				StatusCode: 200,
+				Details:    nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := newObservation(tt.fromOp, tt.opts...)
+			require.NoError(err)
+			require.NotNil(got)
+			opts := getOpts(tt.opts...)
+			if opts.withId == "" {
+				tt.wantObservation.ID = got.ID
+			}
+			assert.Equal(tt.wantObservation, got)
+			// feed the event through ComposeFrom which will filter any request/response data
+			_, ev, err := got.ComposeFrom(
+				[]*eventlogger.Event{
+					{
+						Type:      "observation",
+						CreatedAt: now,
+						Payload:   got,
+					},
+				},
+			)
+			if tt.wantErrIs != nil {
+				require.Error(err)
+				assert.Nil(got)
+				assert.ErrorIs(err, tt.wantErrIs)
+				if tt.wantErrContains != "" {
+					assert.Contains(err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			payload, ok := ev.(map[string]any)
+			assert.True(ok)
+			assert.NotNil(payload)
+			if tt.wantFilteredRequest != nil {
+				req, ok := payload["request"]
+				assert.True(ok)
+				assert.NotNil(req)
+				pmsg, ok := req.(*Request)
+				assert.True(ok)
+				assert.NotNil(pmsg)
+				assert.True(proto.Equal(tt.wantFilteredRequest.Details, pmsg.Details))
+			}
+			if tt.wantFilteredResponse != nil {
+				req, ok := payload["response"]
+				assert.True(ok)
+				assert.NotNil(req)
+				pmsg, ok := req.(*Response)
+				assert.True(ok)
+				assert.NotNil(pmsg)
+				assert.True(proto.Equal(tt.wantFilteredResponse.Details, pmsg.Details))
+			}
+		})
+	}
 }

--- a/internal/observability/event/event_observation_test.go
+++ b/internal/observability/event/event_observation_test.go
@@ -61,6 +61,78 @@ func Test_newObservation(t *testing.T) {
 				RequestInfo: TestRequestInfo(t),
 			},
 		},
+		{
+			name:   "with-request-no-telemetry",
+			fromOp: Op("with-request-no-telemetry"),
+			opts: []Option{
+				WithId("with-request-no-telemetry"),
+				WithRequestInfo(TestRequestInfo(t)),
+				WithFlush(),
+				WithRequest(TestWorkerRequest(t)),
+			},
+			want: &observation{
+				ID:          "with-request-no-telemetry",
+				Flush:       true,
+				Version:     errorVersion,
+				Op:          Op("with-request-no-telemetry"),
+				RequestInfo: TestRequestInfo(t),
+			},
+		},
+		{
+			name:   "with-response-no-telemetry",
+			fromOp: Op("with-response-no-telemetry"),
+			opts: []Option{
+				WithId("with-response-no-telemetry"),
+				WithRequestInfo(TestRequestInfo(t)),
+				WithFlush(),
+				WithResponse(TestWorkerResponse(t)),
+			},
+			want: &observation{
+				ID:          "with-response-no-telemetry",
+				Flush:       true,
+				Version:     errorVersion,
+				Op:          Op("with-response-no-telemetry"),
+				RequestInfo: TestRequestInfo(t),
+			},
+		},
+		{
+			name:   "with-request-with-telemetry",
+			fromOp: Op("with-request-with-telemetry"),
+			opts: []Option{
+				WithId("with-request-with-telemetry"),
+				WithRequestInfo(TestRequestInfo(t)),
+				WithFlush(),
+				WithRequest(TestWorkerRequest(t)),
+				WithTelemetry(),
+			},
+			want: &observation{
+				ID:          "with-request-with-telemetry",
+				Flush:       true,
+				Version:     errorVersion,
+				Op:          Op("with-request-with-telemetry"),
+				RequestInfo: TestRequestInfo(t),
+				Request:     TestWorkerRequest(t),
+			},
+		},
+		{
+			name:   "with-response-with-telemetry",
+			fromOp: Op("with-response-with-telemetry"),
+			opts: []Option{
+				WithId("with-response-with-telemetry"),
+				WithRequestInfo(TestRequestInfo(t)),
+				WithFlush(),
+				WithResponse(TestWorkerResponse(t)),
+				WithTelemetry(),
+			},
+			want: &observation{
+				ID:          "with-response-with-telemetry",
+				Flush:       true,
+				Version:     errorVersion,
+				Op:          Op("with-response-with-telemetry"),
+				RequestInfo: TestRequestInfo(t),
+				Response:    TestWorkerResponse(t),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/observability/event/event_observation_test.go
+++ b/internal/observability/event/event_observation_test.go
@@ -516,12 +516,8 @@ func Test_composeFromTelemetryFiltering(t *testing.T) {
 				pmsg, ok := req.(*Response)
 				assert.True(ok)
 				assert.NotNil(pmsg)
-				// fmt.Printf("ACTUAL %+v \n", pmsg.Details)
-				// j, err := json.Marshal(pmsg)
-				// assert.NotNil(err)
-				// fmt.Printf("ACTUAL JSON %s \n", string(j))
-				// fmt.Printf("RESPONSE %+v \n", tt.wantFilteredResponse.Details)
-				// assert.True(proto.Equal(tt.wantFilteredResponse.Details, pmsg.Details))
+				assert.True(proto.Equal(tt.wantFilteredResponse.Details, pmsg.Details), "protos differ:\nexpected: %+v\nactual: %+v", tt.wantFilteredResponse.Details, pmsg.Details)
+
 			}
 		})
 	}

--- a/internal/observability/event/eventer.go
+++ b/internal/observability/event/eventer.go
@@ -39,6 +39,8 @@ const (
 	IdField          = "id"           // IdField in an event.
 	CreatedAtField   = "created_at"   // CreatedAtField in an event.
 	TypeField        = "type"         // TypeField in an event.
+	RequestField     = "request"      // Request field in an event.
+	ResponseField    = "response"     // Response field in an event.
 
 	auditPipeline       = "audit-pipeline"       // auditPipeline is a pipeline for audit events
 	observationPipeline = "observation-pipeline" // observationPipeline is a pipeline for observation events

--- a/internal/observability/event/options.go
+++ b/internal/observability/event/options.go
@@ -48,6 +48,7 @@ type options struct {
 	withFilterOperations AuditFilterOperations
 	withGating           bool
 	withNoGateLocking    bool
+	withTelemetry        bool
 
 	// These options are related to the hclog adapter
 	withHclogLevel hclog.Level
@@ -226,5 +227,12 @@ func WithGating(with bool) Option {
 func WithNoGateLocking(with bool) Option {
 	return func(o *options) {
 		o.withNoGateLocking = with
+	}
+}
+
+// WithTelemetry allows an optional telemetry option.
+func WithTelemetry() Option {
+	return func(o *options) {
+		o.withTelemetry = true
 	}
 }

--- a/internal/observability/event/options_test.go
+++ b/internal/observability/event/options_test.go
@@ -196,6 +196,13 @@ func Test_GetOpts(t *testing.T) {
 		opts := getOpts(WithNoGateLocking(true))
 		assert.True(opts.withNoGateLocking)
 	})
+	t.Run("WithTelemetry", func(t *testing.T) {
+		assert := assert.New(t)
+		opts := getOpts(WithTelemetry())
+		testOpts := getDefaultOptions()
+		testOpts.withTelemetry = true
+		assert.Equal(opts, testOpts)
+	})
 }
 
 // testWrapper initializes an AEAD wrapping.Wrapper for testing.  Note: this

--- a/internal/observability/event/telemetry_filter.go
+++ b/internal/observability/event/telemetry_filter.go
@@ -23,14 +23,14 @@ func telemetryFilter(field reflect.StructField) bool {
 }
 
 // filterValue will preserve or zero a value based on if it is classed as observable
-func filterValue(fv reflect.Value, isObservable bool) error {
+func filterValue(fv reflect.Value, isObservable bool) {
 	if isObservable {
-		return nil // let data persist to telemetry
+		return // let data persist to telemetry
 	}
 
 	// check for nil value (prevent panics)
 	if fv == reflect.ValueOf(nil) {
-		return nil
+		return
 	}
 
 	if fv.Kind() == reflect.Ptr {
@@ -39,12 +39,12 @@ func filterValue(fv reflect.Value, isObservable bool) error {
 
 	// check to see if it's an exported struct field
 	if !fv.CanSet() {
-		return nil
+		return
 	}
 
 	fv.SetZero()
 
-	return nil
+	return
 }
 
 func recurseStructureWithProtoFilter(value reflect.Value, filterFunc protoFilter, isObservable bool) error {
@@ -101,7 +101,8 @@ func recurseStructureWithProtoFilter(value reflect.Value, filterFunc protoFilter
 		return nil
 	default:
 		// any other non structured type, we will output or not via filterValue
-		return filterValue(value, isObservable)
+		filterValue(value, isObservable)
+		return nil
 	}
 
 	return nil

--- a/internal/observability/event/telemetry_filter.go
+++ b/internal/observability/event/telemetry_filter.go
@@ -1,0 +1,115 @@
+package event
+
+import (
+	"errors"
+	"google.golang.org/protobuf/proto"
+	"reflect"
+)
+
+// protoFilter is a signature for a struct field validation test
+type protoFilter func(field reflect.StructField) bool
+
+// telemetryFilter checks a struct field should be included in observation telemetry data
+func telemetryFilter(field reflect.StructField) bool {
+	if field.Tag.Get("eventstream") == "observation" {
+		// log.Printf("%s is allowed by Tags (%s:\"%s\")", name, tag, tagValue)
+		return true
+	}
+	return false
+}
+
+// filterValue will preserve or zero a value based on if it is classed as observable
+func filterValue(fv reflect.Value, isObservable bool) error {
+	if isObservable {
+		return nil // let data persist to telemetry
+	}
+
+	// check for nil value (prevent panics)
+	if fv == reflect.ValueOf(nil) {
+		return nil
+	}
+
+	if fv.Kind() == reflect.Ptr {
+		fv = fv.Elem()
+	}
+
+	// check to see if it's an exported struct field
+	if !fv.CanSet() {
+		return nil
+	}
+
+	fv.SetZero()
+
+	return nil
+}
+
+func recurseStructureWithProtoFilter(value reflect.Value, filterFunc protoFilter, isObservable bool) error {
+
+	kind := value.Kind()
+
+	switch kind {
+	case reflect.Interface, reflect.Ptr:
+		value = value.Elem()
+		return recurseStructureWithProtoFilter(value, filterFunc, isObservable)
+	case reflect.Map:
+		m := reflect.ValueOf(value)
+		for _, k := range m.MapKeys() {
+			mVal := m.MapIndex(k)
+			if err := recurseStructureWithProtoFilter(mVal, filterFunc, isObservable); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Array, reflect.Slice:
+		if isObservable {
+			for i := 0; i < value.Len(); i++ {
+				sVal := value.Index(i)
+				if err := recurseStructureWithProtoFilter(sVal, filterFunc, isObservable); err != nil {
+					return err
+				}
+			}
+		} else {
+			if kind == reflect.Slice {
+				value.SetLen(0) // truncate
+			} else {
+				// fixed size, so we zero
+				for i := 0; i < value.Len(); i++ {
+					value.Index(i).SetZero()
+				}
+			}
+		}
+	case reflect.Struct:
+		fields := value.Type()
+		num := fields.NumField()
+		for i := 0; i < num; i++ {
+			field := fields.Field(i)
+			v := value.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			isObservable := true
+			if filterFunc != nil {
+				isObservable = filterFunc(field)
+			}
+			if err := recurseStructureWithProtoFilter(v, filterFunc, isObservable); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		// any other non structured type, we will output or not via filterValue
+		return filterValue(value, isObservable)
+	}
+
+	return nil
+}
+
+func filterProtoMessage(msg proto.Message, filterFunc protoFilter) (proto.Message, error) {
+	if msg == nil {
+		return nil, errors.New("nil message")
+	}
+
+	cloneMsg := proto.Clone(msg)
+	err := recurseStructureWithProtoFilter(reflect.ValueOf(cloneMsg), filterFunc, false)
+	return cloneMsg, err
+}

--- a/internal/observability/event/telemetry_filter.go
+++ b/internal/observability/event/telemetry_filter.go
@@ -31,7 +31,6 @@ type protoFilter func(field reflect.StructField) bool
 // telemetryFilter checks a struct field should be included in observation telemetry data
 func telemetryFilter(field reflect.StructField) bool {
 	if field.Tag.Get("eventstream") == "observation" {
-		// log.Printf("%s is allowed by Tags (%s:\"%s\")", name, tag, tagValue)
 		return true
 	}
 	return false

--- a/internal/observability/event/telemetry_filter.go
+++ b/internal/observability/event/telemetry_filter.go
@@ -55,32 +55,40 @@ func recurseStructureWithProtoFilter(value reflect.Value, filterFunc protoFilter
 		value = value.Elem()
 		return recurseStructureWithProtoFilter(value, filterFunc, isObservable)
 	case reflect.Map:
-		m := reflect.ValueOf(value)
-		for _, k := range m.MapKeys() {
-			mVal := m.MapIndex(k)
+		// m := reflect.ValueOf(value)
+		// fmt.Printf("type of m %+v \n", reflect.TypeOf(value))
+		for _, k := range value.MapKeys() {
+			mVal := value.MapIndex(k)
 			if err := recurseStructureWithProtoFilter(mVal, filterFunc, isObservable); err != nil {
 				return err
 			}
 		}
 		return nil
 	case reflect.Array, reflect.Slice:
-		if isObservable {
-			for i := 0; i < value.Len(); i++ {
-				sVal := value.Index(i)
-				if err := recurseStructureWithProtoFilter(sVal, filterFunc, isObservable); err != nil {
-					return err
-				}
-			}
-		} else {
-			if kind == reflect.Slice {
-				value.SetLen(0) // truncate
-			} else {
-				// fixed size, so we zero
-				for i := 0; i < value.Len(); i++ {
-					value.Index(i).SetZero()
-				}
+		for i := 0; i < value.Len(); i++ {
+			sVal := value.Index(i)
+			// fmt.Printf("Array: sval %+v, is observable %+v \n", sVal, isObservable)
+			if err := recurseStructureWithProtoFilter(sVal, filterFunc, isObservable); err != nil {
+				return err
 			}
 		}
+		//if isObservable {
+		//	for i := 0; i < value.Len(); i++ {
+		//		sVal := value.Index(i)
+		//		if err := recurseStructureWithProtoFilter(sVal, filterFunc, isObservable); err != nil {
+		//			return err
+		//		}
+		//	}
+		//} else {
+		//	if kind == reflect.Slice {
+		//		value.SetLen(0) // truncate
+		//	} else {
+		//		// fixed size, so we zero
+		//		for i := 0; i < value.Len(); i++ {
+		//			value.Index(i).SetZero()
+		//		}
+		//	}
+		//}
 	case reflect.Struct:
 		fields := value.Type()
 		num := fields.NumField()
@@ -94,6 +102,7 @@ func recurseStructureWithProtoFilter(value reflect.Value, filterFunc protoFilter
 			if filterFunc != nil {
 				isObservable = filterFunc(field)
 			}
+			// fmt.Printf("field name %+v, is observable %+v \n", field.Name, isObservable)
 			if err := recurseStructureWithProtoFilter(v, filterFunc, isObservable); err != nil {
 				return err
 			}

--- a/internal/observability/event/telemetry_filter.go
+++ b/internal/observability/event/telemetry_filter.go
@@ -1,9 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package event
 
 import (
 	"errors"
-	"google.golang.org/protobuf/proto"
 	"reflect"
+
+	"google.golang.org/protobuf/proto"
 )
 
 // protoFilter is a signature for a struct field validation test
@@ -44,7 +48,6 @@ func filterValue(fv reflect.Value, isObservable bool) error {
 }
 
 func recurseStructureWithProtoFilter(value reflect.Value, filterFunc protoFilter, isObservable bool) error {
-
 	kind := value.Kind()
 
 	switch kind {

--- a/internal/observability/event/telemetry_filter_test.go
+++ b/internal/observability/event/telemetry_filter_test.go
@@ -1,10 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package event
 
 import (
+	"testing"
+
 	"github.com/hashicorp/boundary/internal/gen/controller/servers"
 	"github.com/hashicorp/boundary/internal/gen/controller/servers/services"
 	tassert "github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_OnlyObservationTaggedFieldsPopulated(t *testing.T) {

--- a/internal/observability/event/telemetry_filter_test.go
+++ b/internal/observability/event/telemetry_filter_test.go
@@ -1,0 +1,101 @@
+package event
+
+import (
+	"github.com/hashicorp/boundary/internal/gen/controller/servers"
+	"github.com/hashicorp/boundary/internal/gen/controller/servers/services"
+	tassert "github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_OnlyObservationTaggedFieldsPopulated(t *testing.T) {
+	assert := tassert.New(t)
+
+	input := &services.StatusRequest{
+		Jobs: []*services.JobStatus{
+			{Job: &services.Job{
+				Type:    1,
+				JobInfo: nil,
+			}},
+		},
+		UpdateTags: false,
+		WorkerStatus: &servers.ServerWorkerStatus{
+			PublicId:    "testID",
+			Name:        "w_1234567890",
+			Description: "A default worker created in",
+			Address:     "127.0.0.1:9202",
+			Tags: []*servers.TagPair{
+				{
+					Key:   "type",
+					Value: "dev",
+				},
+			},
+			KeyId:            "ovary-valid-curler-scrambled-glutinous-alias-rework-debit",
+			ReleaseVersion:   "Boundary v0.13.1",
+			OperationalState: "active",
+		},
+	}
+
+	filtered, err := filterProtoMessage(input, telemetryFilter)
+	assert.NoError(err)
+
+	output, ok := filtered.(*services.StatusRequest)
+	assert.True(ok)
+
+	// expected content
+	assert.NotNil(output.WorkerStatus)
+	assert.Equal(input.WorkerStatus.PublicId, output.WorkerStatus.PublicId)
+	assert.Equal(input.WorkerStatus.ReleaseVersion, output.WorkerStatus.ReleaseVersion)
+	assert.Equal(input.WorkerStatus.OperationalState, output.WorkerStatus.OperationalState)
+
+	// non expected content
+	assert.Zero(output.WorkerStatus.Name)
+	assert.Zero(output.WorkerStatus.Address)
+	assert.Zero(output.WorkerStatus.Description)
+	assert.Zero(output.WorkerStatus.KeyId)
+	assert.Len(output.WorkerStatus.Tags, 0)
+	assert.Len(output.Jobs, 0)
+}
+
+func Test_AllFieldsPopulatedWithoutFilter(t *testing.T) {
+	assert := tassert.New(t)
+	input := &services.StatusRequest{
+		Jobs: []*services.JobStatus{
+			{Job: &services.Job{
+				Type:    1,
+				JobInfo: nil,
+			}},
+		},
+		UpdateTags: false,
+		WorkerStatus: &servers.ServerWorkerStatus{
+			PublicId:    "testID",
+			Name:        "w_1234567890",
+			Description: "A default worker created in",
+			Address:     "127.0.0.1:9202",
+			Tags: []*servers.TagPair{
+				{
+					Key:   "type",
+					Value: "dev",
+				},
+			},
+			KeyId:            "ovary-valid-curler-scrambled-glutinous-alias-rework-debit",
+			ReleaseVersion:   "Boundary v0.13.1",
+			OperationalState: "active",
+		},
+	}
+
+	filtered, err := filterProtoMessage(input, nil)
+	assert.NoError(err)
+
+	output, ok := filtered.(*services.StatusRequest)
+	assert.True(ok)
+
+	// expected content
+	assert.Equal(input, output)
+}
+
+func Test_NilMessageWillError(t *testing.T) {
+	assert := tassert.New(t)
+
+	_, err := filterProtoMessage(nil, nil)
+	assert.Error(err)
+}

--- a/internal/observability/event/telemetry_filter_test.go
+++ b/internal/observability/event/telemetry_filter_test.go
@@ -4,6 +4,10 @@
 package event
 
 import (
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/boundary/internal/gen/controller/servers"
@@ -102,4 +106,95 @@ func Test_NilMessageWillError(t *testing.T) {
 
 	_, err := filterProtoMessage(nil, nil)
 	assert.Error(err)
+}
+
+func Test_scalarSliceFilterAllZeroVals(t *testing.T) {
+	assert := tassert.New(t)
+	type testType struct {
+		NonObservableStrings []string
+		ObservableInts       []int `eventstream:"observation"`
+	}
+	data := &testType{
+		NonObservableStrings: []string{"a", "b", "c"},
+		ObservableInts:       []int{1, 2, 3, 4},
+	}
+	err := recurseStructureWithProtoFilter(reflect.ValueOf(data), telemetryFilter, false)
+	assert.NoError(err)
+	assert.Len(data.NonObservableStrings, 0)
+	assert.Len(data.ObservableInts, 4)
+}
+
+func Test_mapFilter(t *testing.T) {
+	assert := tassert.New(t)
+	type testType struct {
+		NonObservableMap map[string]int
+		ObservableMap    map[string]int `eventstream:"observation"`
+	}
+	data := &testType{
+		NonObservableMap: map[string]int{
+			"a": 1,
+			"b": 2,
+			"c": 3,
+		},
+		ObservableMap: map[string]int{
+			"d": 4,
+			"e": 5,
+			"f": 6,
+		},
+	}
+	err := recurseStructureWithProtoFilter(reflect.ValueOf(data), telemetryFilter, false)
+	assert.NoError(err)
+	assert.Len(data.NonObservableMap, 0)
+	assert.Len(data.ObservableMap, 3)
+	assert.Equal(data.ObservableMap, map[string]int{
+		"d": 4,
+		"e": 5,
+		"f": 6,
+	})
+}
+
+func Test_coreProtoTypes(t *testing.T) {
+	assert := tassert.New(t)
+	type testType struct {
+		Timestamp        *timestamppb.Timestamp
+		TimestampObs     *timestamppb.Timestamp `eventstream:"observation"`
+		WrappedString    *wrapperspb.StringValue
+		WrappedStringObs *wrapperspb.StringValue `eventstream:"observation"`
+		Fieldmask        *fieldmaskpb.FieldMask
+		FieldmaskObs     *fieldmaskpb.FieldMask `eventstream:"observation"`
+	}
+	data := &testType{
+		Timestamp: &timestamppb.Timestamp{
+			Seconds: 1694589179,
+			Nanos:   812910000,
+		},
+		TimestampObs: &timestamppb.Timestamp{
+			Seconds: 1694589179,
+			Nanos:   812910000,
+		},
+		WrappedString:    &wrapperspb.StringValue{Value: "[REDACTED]"},
+		WrappedStringObs: &wrapperspb.StringValue{Value: "[REDACTED]"},
+		Fieldmask: &fieldmaskpb.FieldMask{
+			Paths: []string{"a", "b"},
+		},
+		FieldmaskObs: &fieldmaskpb.FieldMask{
+			Paths: []string{"a", "b"},
+		},
+	}
+	err := recurseStructureWithProtoFilter(reflect.ValueOf(data), telemetryFilter, false)
+	assert.NoError(err)
+	assert.Nil(data.WrappedString)
+	assert.Nil(data.Timestamp)
+	assert.Nil(data.Fieldmask)
+	assert.NotNil(data.TimestampObs)
+	assert.NotNil(data.WrappedStringObs)
+	assert.NotNil(data.FieldmaskObs)
+	assert.Equal(data.TimestampObs, &timestamppb.Timestamp{
+		Seconds: 1694589179,
+		Nanos:   812910000,
+	})
+	assert.Equal(data.WrappedStringObs, &wrapperspb.StringValue{Value: "[REDACTED]"})
+	assert.Equal(data.FieldmaskObs, &fieldmaskpb.FieldMask{
+		Paths: []string{"a", "b"},
+	})
 }

--- a/internal/observability/event/telemetry_filter_test.go
+++ b/internal/observability/event/telemetry_filter_test.go
@@ -56,8 +56,8 @@ func Test_OnlyObservationTaggedFieldsPopulated(t *testing.T) {
 	assert.Zero(output.WorkerStatus.Address)
 	assert.Zero(output.WorkerStatus.Description)
 	assert.Zero(output.WorkerStatus.KeyId)
-	assert.Len(output.WorkerStatus.Tags, 0)
-	assert.Len(output.Jobs, 0)
+	assert.Len(output.WorkerStatus.Tags, 1)
+	assert.Len(output.Jobs, 1)
 }
 
 func Test_AllFieldsPopulatedWithoutFilter(t *testing.T) {

--- a/internal/observability/event/telemetry_filter_test.go
+++ b/internal/observability/event/telemetry_filter_test.go
@@ -4,13 +4,14 @@
 package event
 
 import (
+	"reflect"
+	"testing"
+
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
-	"reflect"
-	"testing"
 
 	"github.com/hashicorp/boundary/internal/gen/controller/servers"
 	"github.com/hashicorp/boundary/internal/gen/controller/servers/services"

--- a/internal/observability/event/telemetry_filter_test.go
+++ b/internal/observability/event/telemetry_filter_test.go
@@ -4,7 +4,9 @@
 package event
 
 import (
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"reflect"
@@ -60,7 +62,7 @@ func Test_OnlyObservationTaggedFieldsPopulated(t *testing.T) {
 	assert.Zero(output.WorkerStatus.Address)
 	assert.Zero(output.WorkerStatus.Description)
 	assert.Zero(output.WorkerStatus.KeyId)
-	assert.Len(output.WorkerStatus.Tags, 1)
+	assert.Len(output.WorkerStatus.Tags, 0)
 	assert.Len(output.Jobs, 1)
 }
 
@@ -197,4 +199,116 @@ func Test_coreProtoTypes(t *testing.T) {
 	assert.Equal(data.FieldmaskObs, &fieldmaskpb.FieldMask{
 		Paths: []string{"a", "b"},
 	})
+}
+
+func Test_mapStructPBValues(t *testing.T) {
+	assert := tassert.New(t)
+	type testType struct {
+		ListValueMap    map[string]*structpb.ListValue
+		ListValueMapObs map[string]*structpb.ListValue `eventstream:"observation"`
+	}
+	data := &testType{
+		ListValueMap: map[string]*structpb.ListValue{
+			"one": {Values: []*structpb.Value{
+				structpb.NewStringValue("one"),
+			}},
+			"two": {Values: []*structpb.Value{
+				structpb.NewStringValue("two"),
+			}},
+		},
+		ListValueMapObs: map[string]*structpb.ListValue{
+			"three": {Values: []*structpb.Value{
+				structpb.NewStringValue("three"),
+			}},
+			"four": {Values: []*structpb.Value{
+				structpb.NewStringValue("four"),
+			}},
+		},
+	}
+	err := recurseStructureWithProtoFilter(reflect.ValueOf(data), telemetryFilter, false)
+	assert.NoError(err)
+	assert.Len(data.ListValueMapObs, 2)
+	assert.True(
+		proto.Equal(
+			data.ListValueMapObs["three"],
+			&structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("three"),
+				},
+			},
+		),
+	)
+	assert.True(
+		proto.Equal(
+			data.ListValueMapObs["four"],
+			&structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("four"),
+				},
+			},
+		),
+	)
+	assert.Len(data.ListValueMap, 0)
+}
+
+func Test_sliceStructPBValues(t *testing.T) {
+	assert := tassert.New(t)
+	type testType struct {
+		ListValueSlice    []*structpb.ListValue
+		ListValueSliceObs []*structpb.ListValue `eventstream:"observation"`
+		ListValueArray    [2]*structpb.ListValue
+	}
+	data := &testType{
+		ListValueSlice: []*structpb.ListValue{
+			{Values: []*structpb.Value{
+				structpb.NewStringValue("one"),
+			}},
+			{Values: []*structpb.Value{
+				structpb.NewStringValue("two"),
+			}},
+		},
+		ListValueSliceObs: []*structpb.ListValue{
+			{Values: []*structpb.Value{
+				structpb.NewStringValue("three"),
+			}},
+			{Values: []*structpb.Value{
+				structpb.NewStringValue("four"),
+			}},
+		},
+		ListValueArray: [2]*structpb.ListValue{
+			{Values: []*structpb.Value{
+				structpb.NewStringValue("five"),
+			}},
+			{Values: []*structpb.Value{
+				structpb.NewStringValue("six"),
+			}},
+		},
+	}
+	err := recurseStructureWithProtoFilter(reflect.ValueOf(data), telemetryFilter, false)
+	assert.NoError(err)
+	assert.Len(data.ListValueSliceObs, 2)
+	assert.True(
+		proto.Equal(
+			data.ListValueSliceObs[0],
+			&structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("three"),
+				},
+			},
+		),
+	)
+	assert.True(
+		proto.Equal(
+			data.ListValueSliceObs[1],
+			&structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("four"),
+				},
+			},
+		),
+	)
+	assert.Len(data.ListValueSlice, 0)
+	assert.Len(data.ListValueArray, 2)
+	assert.Nil(data.ListValueArray[0])
+	assert.Nil(data.ListValueArray[1])
 }

--- a/internal/observability/event/testing.go
+++ b/internal/observability/event/testing.go
@@ -14,6 +14,7 @@ import (
 
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/gen/controller/servers"
+	"github.com/hashicorp/boundary/internal/gen/controller/servers/services"
 	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/groups"
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/eventlogger/formatter_filters/cloudevents"
@@ -364,27 +365,43 @@ func testLogger(t *testing.T, testLock hclog.Locker) hclog.Logger {
 	})
 }
 
-func TestWorkerRequest(t testing.TB) *Request {
+func testWorkerStatus(t testing.TB) *services.StatusRequest {
 	t.Helper()
-	return &Request{
-		Operation: "op",
-		Endpoint:  "/worker-status/<id>",
-		Details: &servers.ServerWorkerStatus{
-			PublicId: "worker-public-id",
-			Name:     "worker-name",
-			Address:  "worker-address",
+	return &services.StatusRequest{
+		Jobs: []*services.JobStatus{
+			{Job: &services.Job{
+				Type:    1,
+				JobInfo: nil,
+			}},
+		},
+		UpdateTags: false,
+		WorkerStatus: &servers.ServerWorkerStatus{
+			PublicId:    "testID",
+			Name:        "w_1234567890",
+			Description: "A default worker created in",
+			Address:     "127.0.0.1:9202",
+			Tags: []*servers.TagPair{
+				{
+					Key:   "type",
+					Value: "dev",
+				},
+			},
+			KeyId:            "ovary-valid-curler-scrambled-glutinous-alias-rework-debit",
+			ReleaseVersion:   "Boundary v0.13.1",
+			OperationalState: "active",
 		},
 	}
 }
 
-func TestWorkerResponse(t testing.TB) *Response {
+func testWorkerStatusObservable(t testing.TB) *services.StatusRequest {
 	t.Helper()
-	return &Response{
-		StatusCode: 200,
-		Details: &servers.ServerWorkerStatus{
-			PublicId: "worker-public-id",
-			Name:     "worker-name",
-			Address:  "worker-address",
+	return &services.StatusRequest{
+		Jobs: []*services.JobStatus{},
+		WorkerStatus: &servers.ServerWorkerStatus{
+			PublicId:         "testID",
+			Tags:             []*servers.TagPair{},
+			ReleaseVersion:   "Boundary v0.13.1",
+			OperationalState: "active",
 		},
 	}
 }

--- a/internal/observability/event/testing.go
+++ b/internal/observability/event/testing.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
+	"github.com/hashicorp/boundary/internal/gen/controller/servers"
 	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/groups"
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/eventlogger/formatter_filters/cloudevents"
@@ -361,4 +362,29 @@ func testLogger(t *testing.T, testLock hclog.Locker) hclog.Logger {
 		Name:       "test",
 		JSONFormat: true,
 	})
+}
+
+func TestWorkerRequest(t testing.TB) *Request {
+	t.Helper()
+	return &Request{
+		Operation: "op",
+		Endpoint:  "/worker-status/<id>",
+		Details: &servers.ServerWorkerStatus{
+			PublicId: "worker-public-id",
+			Name:     "worker-name",
+			Address:  "worker-address",
+		},
+	}
+}
+
+func TestWorkerResponse(t testing.TB) *Response {
+	t.Helper()
+	return &Response{
+		StatusCode: 200,
+		Details: &servers.ServerWorkerStatus{
+			PublicId: "worker-public-id",
+			Name:     "worker-name",
+			Address:  "worker-address",
+		},
+	}
 }

--- a/internal/observability/event/testing.go
+++ b/internal/observability/event/testing.go
@@ -401,7 +401,6 @@ func testWorkerStatusObservable(t testing.TB) *services.StatusRequest {
 		},
 		WorkerStatus: &servers.ServerWorkerStatus{
 			PublicId:         "testID",
-			Tags:             []*servers.TagPair{{}},
 			ReleaseVersion:   "Boundary v0.13.1",
 			OperationalState: "active",
 		},

--- a/internal/observability/event/testing.go
+++ b/internal/observability/event/testing.go
@@ -396,10 +396,12 @@ func testWorkerStatus(t testing.TB) *services.StatusRequest {
 func testWorkerStatusObservable(t testing.TB) *services.StatusRequest {
 	t.Helper()
 	return &services.StatusRequest{
-		Jobs: []*services.JobStatus{},
+		Jobs: []*services.JobStatus{
+			{Job: &services.Job{}},
+		},
 		WorkerStatus: &servers.ServerWorkerStatus{
 			PublicId:         "testID",
-			Tags:             []*servers.TagPair{},
+			Tags:             []*servers.TagPair{{}},
 			ReleaseVersion:   "Boundary v0.13.1",
 			OperationalState: "active",
 		},


### PR DESCRIPTION
Changes:
* Define option: `WithTelemetry()` (to specify if telemetry events are enabled)
* Create new `filterProtoMessage` function to sanitise proto messages based on a filter.
* Add `Request` and `Response` to `observation` type.
* Add `Request` / `Response` handling to `ComposeFrom` to included filtered telemetry data.
* Unit tests for `filterProtoMessage` and `ComposeFrom`.

