### PR TITLE
pagination: use size of items when possible

### DIFF
--- a/internal/daemon/controller/handlers/authtokens/authtoken_service_test.go
+++ b/internal/daemon/controller/handlers/authtokens/authtoken_service_test.go
@@ -335,7 +335,7 @@ func TestList(t *testing.T) {
 			req:  &pbs.ListAuthTokensRequest{ScopeId: orgWithSomeTokens.GetPublicId()},
 			res: &pbs.ListAuthTokensResponse{
 				Items:        wantSomeTokens,
-				EstItemCount: 9,
+				EstItemCount: 3,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",
@@ -346,7 +346,7 @@ func TestList(t *testing.T) {
 			req:  &pbs.ListAuthTokensRequest{ScopeId: orgWithOtherTokens.GetPublicId()},
 			res: &pbs.ListAuthTokensResponse{
 				Items:        wantOtherTokens,
-				EstItemCount: 9,
+				EstItemCount: 3,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",
@@ -356,7 +356,6 @@ func TestList(t *testing.T) {
 			name: "List No Token",
 			req:  &pbs.ListAuthTokensRequest{ScopeId: orgNoTokens.GetPublicId()},
 			res: &pbs.ListAuthTokensResponse{
-				EstItemCount: 9,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",
@@ -398,7 +397,7 @@ func TestList(t *testing.T) {
 			},
 			res: &pbs.ListAuthTokensResponse{
 				Items:        wantSomeTokens,
-				EstItemCount: 9,
+				EstItemCount: 3,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",
@@ -408,7 +407,6 @@ func TestList(t *testing.T) {
 			name: "Filter All Tokens",
 			req:  &pbs.ListAuthTokensRequest{ScopeId: orgWithOtherTokens.GetPublicId(), Filter: `"/item/scope/id"=="thisdoesntmatch"`},
 			res: &pbs.ListAuthTokensResponse{
-				EstItemCount: 9,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",

--- a/internal/daemon/controller/handlers/sessions/session_service_test.go
+++ b/internal/daemon/controller/handlers/sessions/session_service_test.go
@@ -453,7 +453,7 @@ func TestList(t *testing.T) {
 			req:  &pbs.ListSessionsRequest{ScopeId: pWithSessions.GetPublicId()},
 			res: &pbs.ListSessionsResponse{
 				Items:        wantSession,
-				EstItemCount: 21,
+				EstItemCount: 10,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",
@@ -466,7 +466,7 @@ func TestList(t *testing.T) {
 			req:  &pbs.ListSessionsRequest{ScopeId: pWithSessions.GetPublicId(), IncludeTerminated: true},
 			res: &pbs.ListSessionsResponse{
 				Items:        wantIncludeTerminatedSessions,
-				EstItemCount: 21,
+				EstItemCount: 11,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",
@@ -478,7 +478,7 @@ func TestList(t *testing.T) {
 			name: "List No Sessions",
 			req:  &pbs.ListSessionsRequest{ScopeId: pNoSessions.GetPublicId()},
 			res: &pbs.ListSessionsResponse{
-				EstItemCount: 21,
+				EstItemCount: 0,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",
@@ -491,7 +491,7 @@ func TestList(t *testing.T) {
 			req:  &pbs.ListSessionsRequest{ScopeId: scope.Global.String(), Recursive: true},
 			res: &pbs.ListSessionsResponse{
 				Items:        wantSession,
-				EstItemCount: 21,
+				EstItemCount: 10,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",
@@ -504,7 +504,7 @@ func TestList(t *testing.T) {
 			req:  &pbs.ListSessionsRequest{ScopeId: pWithSessions.GetPublicId(), Filter: fmt.Sprintf(`"/item/id"==%q`, wantSession[4].Id)},
 			res: &pbs.ListSessionsResponse{
 				Items:        wantSession[4:5],
-				EstItemCount: 21,
+				EstItemCount: 1,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",
@@ -520,7 +520,7 @@ func TestList(t *testing.T) {
 			},
 			res: &pbs.ListSessionsResponse{
 				Items:        wantSession,
-				EstItemCount: 21,
+				EstItemCount: 10,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",
@@ -532,7 +532,6 @@ func TestList(t *testing.T) {
 			name: "Filter To Nothing",
 			req:  &pbs.ListSessionsRequest{ScopeId: pWithSessions.GetPublicId(), Filter: `"/item/id" == ""`},
 			res: &pbs.ListSessionsResponse{
-				EstItemCount: 21,
 				ResponseType: "complete",
 				SortBy:       "updated_time",
 				SortDir:      "asc",

--- a/internal/pagination/pagination.go
+++ b/internal/pagination/pagination.go
@@ -170,9 +170,16 @@ func PaginateRequest[T any, PbT ResponseItem](
 		}
 	}
 
-	resp.EstimatedItemCount, err = repo.GetTotalItems(ctx)
-	if err != nil {
-		return nil, errors.Wrap(ctx, err, op)
+	if refreshToken == nil && resp.CompleteListing {
+		// This single page contains all visible items, set
+		// estimated item count based on length of the items
+		// slice directly
+		resp.EstimatedItemCount = len(resp.Items)
+	} else {
+		resp.EstimatedItemCount, err = repo.GetTotalItems(ctx)
+		if err != nil {
+			return nil, errors.Wrap(ctx, err, op)
+		}
 	}
 
 	return resp, nil


### PR DESCRIPTION
When we have a request without a request token and all results fit within the page size, we can set the estimated item count directly from the size of the items, since it contains all visible items.