### PR TITLE
pagination: assert we have enough after filtering

### DIFF
--- a/internal/pagination/pagination_test.go
+++ b/internal/pagination/pagination_test.go
@@ -1089,8 +1089,8 @@ func Test_fillPage(t *testing.T) {
 		pageSize := 2
 		listItemsFn := func(prevPageLast *testType, refreshToken *pbs.ListRefreshToken, limit int) ([]*testType, error) {
 			if prevPageLast != nil {
-				assert.Equal(t, 2, prevPageLast.I)
-				return []*testType{{3}, {4}, {5}}, nil
+				assert.Equal(t, 3, prevPageLast.I)
+				return []*testType{{4}, {5}, {6}}, nil
 			}
 			return []*testType{{1}, {2}, {3}}, nil
 		}
@@ -1112,8 +1112,8 @@ func Test_fillPage(t *testing.T) {
 		pageSize := 2
 		listItemsFn := func(prevPageLast *testType, refreshToken *pbs.ListRefreshToken, limit int) ([]*testType, error) {
 			if prevPageLast != nil {
-				assert.Equal(t, 2, prevPageLast.I)
-				return []*testType{{3}, {4}}, nil
+				assert.Equal(t, 3, prevPageLast.I)
+				return []*testType{{4}, {5}}, nil
 			}
 			return []*testType{{1}, {2}, {3}}, nil
 		}
@@ -1135,8 +1135,8 @@ func Test_fillPage(t *testing.T) {
 		pageSize := 2
 		listItemsFn := func(prevPageLast *testType, refreshToken *pbs.ListRefreshToken, limit int) ([]*testType, error) {
 			if prevPageLast != nil {
-				assert.Equal(t, 2, prevPageLast.I)
-				return []*testType{{3}}, nil
+				assert.Equal(t, 3, prevPageLast.I)
+				return []*testType{{4}}, nil
 			}
 			return []*testType{{1}, {2}, {3}}, nil
 		}
@@ -1158,8 +1158,8 @@ func Test_fillPage(t *testing.T) {
 		pageSize := 2
 		listItemsFn := func(prevPageLast *testType, refreshToken *pbs.ListRefreshToken, limit int) ([]*testType, error) {
 			if prevPageLast != nil {
-				assert.Equal(t, 2, prevPageLast.I)
-				return []*testType{{3}}, nil
+				assert.Equal(t, 3, prevPageLast.I)
+				return []*testType{{4}}, nil
 			}
 			return []*testType{{1}, {2}, {3}}, nil
 		}
@@ -1183,9 +1183,9 @@ func Test_fillPage(t *testing.T) {
 			switch {
 			case prevPageLast == nil:
 				return []*testType{{1}, {2}, {3}}, nil
-			case prevPageLast.I == 2:
-				return []*testType{{3}, {4}, {5}}, nil
-			case prevPageLast.I == 4:
+			case prevPageLast.I == 3:
+				return []*testType{{4}, {5}, {6}}, nil
+			case prevPageLast.I == 6:
 				return nil, nil
 			default:
 				t.Fatalf("unexpected call to listItemsFn with %#v", prevPageLast)
@@ -1210,8 +1210,8 @@ func Test_fillPage(t *testing.T) {
 		pageSize := 2
 		listItemsFn := func(prevPageLast *testType, refreshToken *pbs.ListRefreshToken, limit int) ([]*testType, error) {
 			if prevPageLast != nil {
-				assert.Equal(t, 2, prevPageLast.I)
-				return []*testType{{3}}, nil
+				assert.Equal(t, 3, prevPageLast.I)
+				return []*testType{{4}}, nil
 			}
 			return []*testType{{1}, {2}, {3}}, nil
 		}


### PR DESCRIPTION
The previous code had a bug whereby it assumed that as soon as there is at least one more element available from the list items function, we're not at the end. This is incorrect, as that element may be subject to the filter.

The new code asserts that we have at least one more element available after the filtering has been applied. This allows us to correctly determine when a listing is complete and not.

This also allowed us to significantly simplify the fillPage function.