### PR TITLE
Telemetry: Adding telemetry flag and and telemetry sink event type

### DIFF
--- a/internal/cmd/base/event_flags.go
+++ b/internal/cmd/base/event_flags.go
@@ -18,6 +18,7 @@ type EventFlags struct {
 	AuditEnabled        *bool
 	ObservationsEnabled *bool
 	SysEventsEnabled    *bool
+	TelemetryEnabled    *bool
 	AllowFilters        []string
 	DenyFilters         []string
 }
@@ -50,6 +51,7 @@ type ComposedOfEventArgs struct {
 	Observations string
 	Audit        string
 	SysEvents    string
+	Telemetry    string
 	Allow        []string
 	Deny         []string
 }
@@ -74,6 +76,12 @@ func NewEventFlags(defaultFormat event.SinkFormat, c ComposedOfEventArgs) (*Even
 		f.ObservationsEnabled = &setTrue
 	case "false":
 		f.ObservationsEnabled = &setFalse
+	}
+	switch strings.ToLower(c.Telemetry) {
+	case "true":
+		f.TelemetryEnabled = &setTrue
+	case "false":
+		f.TelemetryEnabled = &setFalse
 	}
 	switch strings.ToLower(c.Audit) {
 	case "true":

--- a/internal/cmd/base/event_flags_test.go
+++ b/internal/cmd/base/event_flags_test.go
@@ -161,6 +161,24 @@ func Test_NewEventFlags(t *testing.T) {
 			},
 		},
 		{
+			name:          "telemetry-true",
+			defaultFormat: "cloudevents-json",
+			composedOf:    ComposedOfEventArgs{Format: "cloudevents-json", Telemetry: "true"},
+			wantFlags: &EventFlags{
+				Format:           "cloudevents-json",
+				TelemetryEnabled: &setTrue,
+			},
+		},
+		{
+			name:          "telemetry-false",
+			defaultFormat: "cloudevents-json",
+			composedOf:    ComposedOfEventArgs{Format: "cloudevents-json", Telemetry: "false"},
+			wantFlags: &EventFlags{
+				Format:           "cloudevents-json",
+				TelemetryEnabled: &setFalse,
+			},
+		},
+		{
 			name:          "valid-allow",
 			defaultFormat: "cloudevents-json",
 			composedOf:    ComposedOfEventArgs{Format: "cloudevents-json", Allow: []string{`"/Data/Header/status" == 401`}},

--- a/internal/cmd/base/server_test.go
+++ b/internal/cmd/base/server_test.go
@@ -301,12 +301,14 @@ func TestServer_SetupEventing(t *testing.T) {
 				AuditEnabled:        &setTrue,
 				ObservationsEnabled: &setFalse,
 				SysEventsEnabled:    &setFalse,
+				TelemetryEnabled:    &setFalse,
 			})},
 			want: func() event.EventerConfig {
 				c := event.DefaultEventerConfig()
 				c.AuditEnabled = true
 				c.ObservationsEnabled = false
 				c.SysEventsEnabled = false
+				c.TelemetryEnabled = false
 				return *c
 			}(),
 		},
@@ -330,12 +332,14 @@ func TestServer_SetupEventing(t *testing.T) {
 				ObservationsEnabled: false,
 				SysEventsEnabled:    false,
 				AuditEnabled:        true,
+				TelemetryEnabled:    false,
 			})},
 			want: func() event.EventerConfig {
 				c := event.DefaultEventerConfig()
 				c.AuditEnabled = true
 				c.ObservationsEnabled = false
 				c.SysEventsEnabled = false
+				c.TelemetryEnabled = false
 				return *c
 			}(),
 		},
@@ -353,6 +357,42 @@ func TestServer_SetupEventing(t *testing.T) {
 			})},
 			wantErrIs:       event.ErrInvalidParameter,
 			wantErrContains: "sink 0 is invalid",
+		},
+		{
+			name:   "opts-eventer-config-observation-telemetry-invalid",
+			s:      &Server{},
+			logger: testLogger,
+			lock:   testLock,
+			opt: []Option{WithEventFlags(&EventFlags{
+				Format:              event.JSONSinkFormat,
+				AuditEnabled:        &setTrue,
+				ObservationsEnabled: &setFalse,
+				SysEventsEnabled:    &setFalse,
+				TelemetryEnabled:    &setTrue,
+			})},
+			wantErrIs:       event.ErrInvalidParameter,
+			wantErrContains: "telemetry events require observation event to be enabled",
+		},
+		{
+			name:   "opts-eventer-config-observation-on-telemetry-off",
+			s:      &Server{},
+			logger: testLogger,
+			lock:   testLock,
+			opt: []Option{WithEventFlags(&EventFlags{
+				Format:              event.JSONSinkFormat,
+				AuditEnabled:        &setFalse,
+				ObservationsEnabled: &setTrue,
+				SysEventsEnabled:    &setFalse,
+				TelemetryEnabled:    &setFalse,
+			})},
+			want: func() event.EventerConfig {
+				c := event.DefaultEventerConfig()
+				c.AuditEnabled = false
+				c.ObservationsEnabled = true
+				c.SysEventsEnabled = false
+				c.TelemetryEnabled = false
+				return *c
+			}(),
 		},
 	}
 

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -201,6 +201,9 @@ func (b *Server) SetupEventing(ctx context.Context, logger hclog.Logger, seriali
 		if opts.withEventFlags.SysEventsEnabled != nil {
 			opts.withEventerConfig.SysEventsEnabled = *opts.withEventFlags.SysEventsEnabled
 		}
+		if opts.withEventFlags.TelemetryEnabled != nil {
+			opts.withEventerConfig.TelemetryEnabled = *opts.withEventFlags.TelemetryEnabled
+		}
 		if len(opts.withEventFlags.AllowFilters) > 0 {
 			for i := 0; i < len(opts.withEventerConfig.Sinks); i++ {
 				opts.withEventerConfig.Sinks[i].AllowFilters = opts.withEventFlags.AllowFilters

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -95,6 +95,7 @@ type Command struct {
 	flagEventFormat                      string
 	flagAudit                            string
 	flagObservations                     string
+	flagTelemetry                        string
 	flagSysEvents                        string
 	flagEveryEventAllowFilters           []string
 	flagEveryEventDenyFilters            []string
@@ -336,6 +337,12 @@ func (c *Command) Flags() *base.FlagSets {
 		Target:     &c.flagObservations,
 		Completion: complete.PredictSet("true", "false"),
 		Usage:      `Emit observation events. Supported values are "true" and "false".`,
+	})
+	f.StringVar(&base.StringVar{
+		Name:       "telemetry-events",
+		Target:     &c.flagTelemetry,
+		Completion: complete.PredictSet("true", "false"),
+		Usage:      `Emit telemetry events. Supported values are "true" and "false".`,
 	})
 	f.StringVar(&base.StringVar{
 		Name:       "audit-events",
@@ -646,6 +653,7 @@ func (c *Command) Run(args []string) int {
 		Format:       c.flagEventFormat,
 		Audit:        c.flagAudit,
 		Observations: c.flagObservations,
+		Telemetry:    c.flagTelemetry,
 		SysEvents:    c.flagSysEvents,
 		Allow:        c.flagEveryEventAllowFilters,
 		Deny:         c.flagEveryEventDenyFilters,

--- a/internal/cmd/commands/dev/flags_test.go
+++ b/internal/cmd/commands/dev/flags_test.go
@@ -61,6 +61,7 @@ func TestCommand_Flags(t *testing.T) {
 	assert.Contains(completions, "-container-image")
 	assert.Contains(completions, "-event-format")
 	assert.Contains(completions, "-observation-events")
+	assert.Contains(completions, "-telemetry-events")
 	assert.Contains(completions, "-audit-events")
 	assert.Contains(completions, "-system-events")
 	assert.Contains(completions, "-audit-events")

--- a/internal/observability/event/event_type.go
+++ b/internal/observability/event/event_type.go
@@ -16,12 +16,13 @@ const (
 	AuditType       Type = "audit"       // AuditType represents audit events
 	ErrorType       Type = "error"       // ErrorType represents error events
 	SystemType      Type = "system"      // SysType represents system events
+	TelemetryType   Type = "telemetry"   // TelemetryType represents telemetry events
 )
 
 func (et Type) Validate() error {
 	const op = "event.(Type).Validate"
 	switch et {
-	case EveryType, ObservationType, AuditType, ErrorType, SystemType:
+	case EveryType, ObservationType, AuditType, ErrorType, SystemType, TelemetryType:
 		return nil
 	default:
 		return fmt.Errorf("%s: '%s' is not a valid event type: %w", op, et, ErrInvalidParameter)

--- a/internal/observability/event/eventer.go
+++ b/internal/observability/event/eventer.go
@@ -593,6 +593,7 @@ func newFmtFilterNode(serverName string, c SinkConfig, opt ...Option) (eventlogg
 func DefaultEventerConfig() *EventerConfig {
 	return &EventerConfig{
 		AuditEnabled:        false,
+		TelemetryEnabled:    false,
 		ObservationsEnabled: true,
 		SysEventsEnabled:    true,
 		Sinks:               []*SinkConfig{DefaultSink()},

--- a/internal/observability/event/eventer_config.go
+++ b/internal/observability/event/eventer_config.go
@@ -12,6 +12,7 @@ type EventerConfig struct {
 	AuditEnabled        bool          `hcl:"audit_enabled"`        // AuditEnabled specifies if audit events should be emitted.
 	ObservationsEnabled bool          `hcl:"observations_enabled"` // ObservationsEnabled specifies if observation events should be emitted.
 	SysEventsEnabled    bool          `hcl:"sysevents_enabled"`    // SysEventsEnabled specifies if sysevents should be emitted.
+	TelemetryEnabled    bool          `hcl:"telemetry_enabled"`    // TelemetryEnabled specifies if telemetry events should be emitted.
 	Sinks               []*SinkConfig `hcl:"-"`                    // Sinks are all the configured sinks
 	ErrorEventsDisabled bool          `hcl:"-"`                    // ErrorEventsDisabled will disable error events from being emitted.  This should only be used to turn off error events in tests.
 }
@@ -24,6 +25,9 @@ func (c *EventerConfig) Validate() error {
 		if err := s.Validate(); err != nil {
 			return fmt.Errorf("%s: sink %d is invalid: %w", op, i, err)
 		}
+	}
+	if !c.ObservationsEnabled && c.TelemetryEnabled {
+		return fmt.Errorf("%s: telemetry events require observation event to be enabled: %w", op, ErrInvalidParameter)
 	}
 	return nil
 }

--- a/internal/observability/event/eventer_config_test.go
+++ b/internal/observability/event/eventer_config_test.go
@@ -33,6 +33,26 @@ func TestEventerConfig_Validate(t *testing.T) {
 			name: "valid-with-all-defaults",
 			c:    EventerConfig{},
 		},
+		{
+			name: "valid-observation-telemetry-flag",
+			c: EventerConfig{
+				AuditEnabled:        false,
+				ObservationsEnabled: true,
+				SysEventsEnabled:    false,
+				TelemetryEnabled:    true,
+			},
+		},
+		{
+			name: "invalid-observation-telemetry-flag",
+			c: EventerConfig{
+				AuditEnabled:        false,
+				ObservationsEnabled: false,
+				SysEventsEnabled:    false,
+				TelemetryEnabled:    true,
+			},
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "telemetry events require observation event to be enabled",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/observability/event/sink_config.go
+++ b/internal/observability/event/sink_config.go
@@ -6,6 +6,7 @@ package event
 import (
 	"fmt"
 	"io"
+	"slices"
 	"time"
 )
 
@@ -77,6 +78,11 @@ func (sc *SinkConfig) Validate() error {
 	}
 	if len(sc.EventTypes) == 0 {
 		return fmt.Errorf("%s: missing event types: %w", op, ErrInvalidParameter)
+	}
+
+	// This checks if the telemetry event is specified in the sink but the observation event is not specified.
+	if !slices.Contains(sc.EventTypes, ObservationType) && slices.Contains(sc.EventTypes, TelemetryType) {
+		return fmt.Errorf("%s: telemetry event type requires observation event type to be specified: %w", op, ErrInvalidParameter)
 	}
 
 	for _, et := range sc.EventTypes {

--- a/internal/observability/event/sink_config_test.go
+++ b/internal/observability/event/sink_config_test.go
@@ -208,6 +208,32 @@ func TestSinkConfig_Validate(t *testing.T) {
 			wantErrContains: `too many sink type config blocks`,
 		},
 		{
+			name: "invalid observation, telemetry type",
+			sc: SinkConfig{
+				Name:       "invalid observation, telemetry type",
+				EventTypes: []Type{TelemetryType, AuditType},
+				Type:       FileSink,
+				Format:     JSONSinkFormat,
+				FileConfig: &FileSinkTypeConfig{
+					FileName: "tmp.file",
+				},
+			},
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: `telemetry event type requires observation event type to be specified`,
+		},
+		{
+			name: "valid-observation-telemetry-type",
+			sc: SinkConfig{
+				Name:       "valid",
+				EventTypes: []Type{ObservationType, TelemetryType, AuditType},
+				Type:       FileSink,
+				FileConfig: &FileSinkTypeConfig{
+					FileName: "tmp.file",
+				},
+				Format: JSONSinkFormat,
+			},
+		},
+		{
 			name: "valid",
 			sc: SinkConfig{
 				Name:       "valid",


### PR DESCRIPTION
In this PR, we are adding a new event type called telemetry to both flag and sink types.
Telemetry event is associated with observation events and the following logic must be applied 

- Case 1: `Observation` flag is true, `Telemetry` flag is false -> This is a current and default behavior and we should just get the observation events without telemetry events

- Case 2: `Observation` flag is false, `Telemetry` flag is true -> In this situation, we throw an error saying that the Observation flag should be set to true if you want to receive telemetry events

     - From CLI if the flag is set with `--observation-events false --telemetry-events true` user will receive the following error message: ` event.(EventerConfig).Validate: telemetry events require observation event to be enabled: invalid parameter`
     - From sink event config if the user `event_types` specifies `telemetry` without specifying the `observation`
It will receive the following error message: 
`event.(SinkConfig).Validate: telemetry event type requires observation event type to be specified: invalid parameter`

- Case 3: `Observation` flag is true, `Telemetry` flag is true -> In this situation, the user will receive an observation event including telemetry events