### PR TITLE
Replace count(*) with meta estimate

### DIFF
--- a/internal/authtoken/query.go
+++ b/internal/authtoken/query.go
@@ -1,0 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package authtoken
+
+const (
+	estimateCountAuthTokens = `
+  select reltuples::bigint as estimate from pg_class where oid = (current_schema() || '.auth_token')::regclass
+`
+)

--- a/internal/authtoken/repository.go
+++ b/internal/authtoken/repository.go
@@ -362,10 +362,10 @@ func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]str
 	return authtokenIds, nil
 }
 
-// GetTotalItems returns the total number of items in the authtoken table.
+// GetTotalItems returns an estimate of the total number of items in the authtoken table.
 func (r *Repository) GetTotalItems(ctx context.Context) (int, error) {
 	const op = "authtoken.(Repository).GetTotalItems"
-	rows, err := r.reader.Query(ctx, "select count(*) from auth_token", nil)
+	rows, err := r.reader.Query(ctx, estimateCountAuthTokens, nil)
 	if err != nil {
 		return 0, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query total auth tokens"))
 	}

--- a/internal/daemon/controller/auth/auth.go
+++ b/internal/daemon/controller/auth/auth.go
@@ -11,6 +11,7 @@ import (
 	"hash"
 	"hash/fnv"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -948,6 +949,8 @@ func (r *VerifyResults) GrantsHash(ctx context.Context) ([]byte, error) {
 	for _, grant := range r.grants {
 		values = append(values, grant.Grant, grant.RoleId, grant.ScopeId)
 	}
+	// Sort for deterministic output
+	slices.Sort(values)
 	hashVal, err := hashStrings(values...)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)

--- a/internal/daemon/controller/handlers/accounts/account_service_test.go
+++ b/internal/daemon/controller/handlers/accounts/account_service_test.go
@@ -3501,6 +3501,10 @@ func TestListPagination(t *testing.T) {
 	deletedAccount := accounts[0]
 	accounts = accounts[1:]
 
+	// Run analyze to update postgres estimates
+	_, err = sqlDB.ExecContext(ctx, "analyze")
+	require.NoError(t, err)
+
 	// request updated results
 	req.RefreshToken = got.RefreshToken
 	got, err = s.ListAccounts(ctx, req)

--- a/internal/daemon/controller/handlers/credentiallibraries/credentiallibrary_service_test.go
+++ b/internal/daemon/controller/handlers/credentiallibraries/credentiallibrary_service_test.go
@@ -2679,7 +2679,7 @@ func TestListPagination(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 	ctx := context.Background()
 	conn, _ := db.TestSetup(t, "postgres")
-	sqlDb, err := conn.SqlDB(ctx)
+	sqlDB, err := conn.SqlDB(ctx)
 	require.NoError(err)
 	wrapper := db.TestWrapper(t)
 	kms := kms.TestKms(t, conn, wrapper)
@@ -2718,7 +2718,7 @@ func TestListPagination(t *testing.T) {
 	}
 
 	// Run analyze to update postgres meta tables
-	_, err = sqlDb.ExecContext(ctx, "analyze")
+	_, err = sqlDB.ExecContext(ctx, "analyze")
 	require.NoError(err)
 
 	authMethod := password.TestAuthMethods(t, conn, o.GetPublicId(), 1)[0]
@@ -2831,6 +2831,10 @@ func TestListPagination(t *testing.T) {
 	allCredentialLibraries = allCredentialLibraries[1:]
 	pbNewCredLib := vaultCredentialLibraryToProto(newCredLib, prj)
 	allCredentialLibraries = append(allCredentialLibraries, pbNewCredLib)
+
+	// Run analyze to update postgres meta tables
+	_, err = sqlDB.ExecContext(ctx, "analyze")
+	require.NoError(err)
 
 	// Request updated results
 	req.RefreshToken = got.RefreshToken

--- a/internal/daemon/controller/handlers/targets/tcp/target_service_test.go
+++ b/internal/daemon/controller/handlers/targets/tcp/target_service_test.go
@@ -422,6 +422,8 @@ func TestListPagination(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	conn, _ := db.TestSetup(t, "postgres")
+	sqlDB, err := conn.SqlDB(ctx)
+	require.NoError(t, err)
 	wrapper := db.TestWrapper(t)
 	kms := kms.TestKms(t, conn, wrapper)
 
@@ -469,6 +471,10 @@ func TestListPagination(t *testing.T) {
 			Address:                &wrapperspb.StringValue{},
 		})
 	}
+
+	// Run analyze to update postgres estimates
+	_, err = sqlDB.ExecContext(ctx, "analyze")
+	require.NoError(t, err)
 
 	// Test without anon user
 	requestInfo := authpb.RequestInfo{
@@ -579,6 +585,10 @@ func TestListPagination(t *testing.T) {
 	require.NoError(t, err)
 	deletedTarget := allTargets[0]
 	allTargets = allTargets[1:]
+
+	// Run analyze to update postgres estimates
+	_, err = sqlDB.ExecContext(ctx, "analyze")
+	require.NoError(t, err)
 
 	// Request updated results
 	req.RefreshToken = got.RefreshToken

--- a/internal/session/query.go
+++ b/internal/session/query.go
@@ -423,6 +423,10 @@ update session_credential
 where session_id = ?
 	and credential_sha256 = ?;
 `
+
+	estimateCountSessions = `
+select reltuples::bigint as estimate from pg_class where oid = (current_schema() || '.session')::regclass
+`
 )
 
 const (

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -365,10 +365,10 @@ func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]str
 	return sessionIds, nil
 }
 
-// GetTotalItems returns the total number of items in the session table.
+// GetTotalItems returns an estimate of the total number of items in the session table.
 func (r *Repository) GetTotalItems(ctx context.Context) (int, error) {
 	const op = "session.(Repository).GetTotalItems"
-	rows, err := r.reader.Query(ctx, "select count(*) from session", nil)
+	rows, err := r.reader.Query(ctx, estimateCountSessions, nil)
 	if err != nil {
 		return 0, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query total sessions"))
 	}

--- a/internal/target/query.go
+++ b/internal/target/query.go
@@ -58,4 +58,9 @@ select public_id, project_id from target
 %s
 ;
 `
+
+	// Note that targets don't have a root aggregate table, so we list each target table explicitly
+	estimateCountTargets = `
+select sum(reltuples::bigint) as estimate from pg_class where (oid = (current_schema() || '.target_tcp')::regclass or oid = (current_schema() || '.target_ssh')::regclass)
+`
 )

--- a/internal/target/repository.go
+++ b/internal/target/repository.go
@@ -365,10 +365,10 @@ func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]str
 	return targetIds, nil
 }
 
-// GetTotalItems returns the total number of items across all targets.
+// GetTotalItems returns an estimate of the total number of items across all targets.
 func (r *Repository) GetTotalItems(ctx context.Context) (int, error) {
 	const op = "target.(Repository).GetTotalItems"
-	rows, err := r.reader.Query(ctx, "select count(*) from "+targetsViewDefaultTable, nil)
+	rows, err := r.reader.Query(ctx, estimateCountTargets, nil)
 	if err != nil {
 		return 0, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query total targets"))
 	}


### PR DESCRIPTION
Replace the use of the expensive count(*) function with an estimate maintained by the Postgres query planner.