### PR TITLE
test(e2e): Refactor vault setup method

### DIFF
--- a/testing/internal/e2e/tests/base_with_vault/credential_store_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/credential_store_test.go
@@ -45,7 +45,7 @@ func TestCliVaultCredentialStore(t *testing.T) {
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 
 	// Configure vault
-	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t, "testdata/boundary-controller-policy.hcl")
 	t.Cleanup(func() {
 		output := e2e.RunCommand(ctx, "vault",
 			e2e.WithArgs("policy", "delete", boundaryPolicyName),
@@ -209,7 +209,7 @@ func TestApiVaultCredentialStore(t *testing.T) {
 	boundary.AddHostSourceToTargetApi(t, ctx, client, newTargetId, newHostSetId)
 
 	// Configure vault
-	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t, "testdata/boundary-controller-policy.hcl")
 	output := e2e.RunCommand(ctx, "vault",
 		e2e.WithArgs("secrets", "enable", "-path="+c.VaultSecretPath, "kv-v2"),
 	)

--- a/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_connect_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_connect_test.go
@@ -47,7 +47,7 @@ func TestCliTcpTargetVaultConnectTarget(t *testing.T) {
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 
 	// Configure vault
-	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t, "testdata/boundary-controller-policy.hcl")
 	t.Cleanup(func() {
 		output := e2e.RunCommand(ctx, "vault",
 			e2e.WithArgs("policy", "delete", boundaryPolicyName),

--- a/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_authz_token_test.go
@@ -46,7 +46,7 @@ func TestCliTcpTargetVaultGenericConnectTargetWithAuthzToken(t *testing.T) {
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 
 	// Configure vault
-	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t, "testdata/boundary-controller-policy.hcl")
 	t.Cleanup(func() {
 		output := e2e.RunCommand(ctx, "vault",
 			e2e.WithArgs("policy", "delete", boundaryPolicyName),

--- a/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_ssh_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_ssh_test.go
@@ -46,7 +46,7 @@ func TestCliTcpTargetVaultGenericConnectTargetWithSsh(t *testing.T) {
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 
 	// Configure vault
-	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t, "testdata/boundary-controller-policy.hcl")
 	t.Cleanup(func() {
 		output := e2e.RunCommand(ctx, "vault",
 			e2e.WithArgs("policy", "delete", boundaryPolicyName),

--- a/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_test.go
@@ -47,7 +47,7 @@ func TestCliTcpTargetVaultGenericConnectTarget(t *testing.T) {
 	boundary.AddHostSourceToTargetCli(t, ctx, newTargetId, newHostSetId)
 
 	// Configure vault
-	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t, "testdata/boundary-controller-policy.hcl")
 	t.Cleanup(func() {
 		output := e2e.RunCommand(ctx, "vault",
 			e2e.WithArgs("policy", "delete", boundaryPolicyName),

--- a/testing/internal/e2e/tests/base_with_worker/target_tcp_worker_connect_ssh_test.go
+++ b/testing/internal/e2e/tests/base_with_worker/target_tcp_worker_connect_ssh_test.go
@@ -52,7 +52,7 @@ func TestCliTcpTargetWorkerConnectTarget(t *testing.T) {
 	)
 
 	// Configure vault
-	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t, "testdata/boundary-controller-policy.hcl")
 	t.Cleanup(func() {
 		output := e2e.RunCommand(ctx, "vault",
 			e2e.WithArgs("policy", "delete", boundaryPolicyName),

--- a/testing/internal/e2e/tests/base_with_worker/target_tcp_worker_connect_ssh_test.go
+++ b/testing/internal/e2e/tests/base_with_worker/target_tcp_worker_connect_ssh_test.go
@@ -166,7 +166,7 @@ func TestCliTcpTargetWorkerConnectTarget(t *testing.T) {
 		),
 	)
 	require.Error(t, output.Err)
-	require.Equal(t, output.ExitCode, 255)
+	require.Equal(t, 255, output.ExitCode)
 	t.Log("Successfully failed to connect to target with wrong worker filter")
 
 	// Try creating targets with an ingress worker filter. This should result in

--- a/testing/internal/e2e/tests/base_with_worker/target_tcp_worker_connect_ssh_test.go
+++ b/testing/internal/e2e/tests/base_with_worker/target_tcp_worker_connect_ssh_test.go
@@ -42,14 +42,6 @@ func TestCliTcpTargetWorkerConnectTarget(t *testing.T) {
 		require.NoError(t, output.Err, string(output.Stderr))
 	})
 	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
-	newTargetId := boundary.CreateNewTargetCli(
-		t,
-		ctx,
-		newProjectId,
-		c.TargetPort,
-		target.WithAddress("openssh-server"),
-		target.WithEgressWorkerFilter(fmt.Sprintf(`"%s" in "/tags/type"`, c.WorkerTagEgress)),
-	)
 
 	// Configure vault
 	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t, "testdata/boundary-controller-policy.hcl")
@@ -122,6 +114,16 @@ func TestCliTcpTargetWorkerConnectTarget(t *testing.T) {
 	require.NoError(t, err)
 	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
 	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
+
+	// Create a target
+	newTargetId := boundary.CreateNewTargetCli(
+		t,
+		ctx,
+		newProjectId,
+		c.TargetPort,
+		target.WithAddress("openssh-server"),
+		target.WithEgressWorkerFilter(fmt.Sprintf(`"%s" in "/tags/type"`, c.WorkerTagEgress)),
+	)
 
 	// Add brokered credentials to target
 	boundary.AddBrokeredCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialLibraryId)

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -235,7 +235,7 @@ func populateBoundaryDatabase(t testing.TB, ctx context.Context, c *config, te T
 	boundary.AddBrokeredCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialsId)
 
 	// Create vault credentials
-	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t)
+	boundaryPolicyName, kvPolicyFilePath := vault.Setup(t, "testdata/boundary-controller-policy.hcl")
 	output := e2e.RunCommand(ctx, "vault",
 		e2e.WithArgs("secrets", "enable", "-path="+c.VaultSecretPath, "kv-v2"),
 	)

--- a/testing/internal/e2e/vault/vault.go
+++ b/testing/internal/e2e/vault/vault.go
@@ -25,9 +25,9 @@ type CreateTokenResponse struct {
 
 // Setup verifies if appropriate credentials are set and adds the boundary controller
 // policy to vault. Returns the vault address.
-func Setup(t testing.TB) (boundaryPolicyName string, kvPolicyFilePath string) {
+func Setup(t testing.TB, boundaryControllerFilePath string) (boundaryPolicyName string, kvPolicyFilePath string) {
 	// Set up boundary policy
-	boundaryPolicyFilePath, err := filepath.Abs("testdata/boundary-controller-policy.hcl")
+	boundaryPolicyFilePath, err := filepath.Abs(boundaryControllerFilePath)
 	require.NoError(t, err)
 	boundaryPolicyName = WritePolicy(t, context.Background(), boundaryPolicyFilePath)
 


### PR DESCRIPTION
This PR makes an adjustment to the test suite to support tests for multihop.

The primary change is to the `vault.Setup` method, allowing it to pass in the desired `boundary-controller-policy` file. This enables test packages in `boundary-enterprise` to pass in their own file.