### PR TITLE
test: Add option for logging in test controller

### DIFF
--- a/testing/controller/controller.go
+++ b/testing/controller/controller.go
@@ -32,6 +32,7 @@ type option struct {
 	setRecoveryKms                 bool
 	setDatabaseUrl                 bool
 	setEnableTemplatedDatabase     bool
+	setEnableEventing              bool
 }
 
 type Option func(*option) error
@@ -211,6 +212,14 @@ func WithDatabaseUrl(url string) Option {
 func WithEnableTemplatedDatabase(enable bool) Option {
 	return func(c *option) error {
 		c.setEnableTemplatedDatabase = enable
+		return nil
+	}
+}
+
+func WithEnableEventing() Option {
+	return func(c *option) error {
+		c.setEnableEventing = true
+		c.tcOptions.EnableEventing = true
 		return nil
 	}
 }


### PR DESCRIPTION
This PR adds an option to the test controller to enable logging (Related: https://github.com/hashicorp/boundary/pull/3163)

Example:
```
testController := controller.NewTestController(
	t,
	controller.WithWorkerAuthKms(workerAuthWrapper),
	controller.WithRootKms(rootWrapper),
	controller.WithRecoveryKms(recoveryWrapper),
	controller.WithEnableEventing(),
)
```