### PR TITLE
Update Vault Credential Library Docs with additional options

### DIFF
--- a/website/content/docs/concepts/domain-model/credential-libraries.mdx
+++ b/website/content/docs/concepts/domain-model/credential-libraries.mdx
@@ -27,7 +27,7 @@ The generic Vault credential library has the following additional attributes:
 
 - `credential-mapping-override` - (optional) Override the field attributes in the credential retrieved from Vault. 
 
-- `vault-http_method` - (optional) The HTTP method the library uses when requesting credentials from Vault.
+- `vault-http-method` - (optional) The HTTP method the library uses when requesting credentials from Vault.
 Can be either `GET` or `POST`.
 The default value is `GET`.
 

--- a/website/content/docs/concepts/domain-model/credential-libraries.mdx
+++ b/website/content/docs/concepts/domain-model/credential-libraries.mdx
@@ -23,15 +23,15 @@ The generic Vault credential library has the following additional attributes:
 
 - `vault-path` - (required) The path in Vault to request credentials from.
 
-- `credential-type` - (optional) The type of credential this library will issue. Defaults to Unspecified. 
+- `credential-type` - (optional) The type of credential this library issues. The default value is `unspecified`.
 
-- `credential-mapping-override` - (optional) Override the field attributes in the credential retrieved from Vault. 
+- `credential-mapping-override` - (optional) If set, this value overrides the field attributes in the credential that is retrieved from Vault.
 
-- `vault-http-method` - (optional) The HTTP method the library uses when requesting credentials from Vault.
+- `vault-http-method` - (optional) The HTTP method the library uses when it requests credentials from Vault.
 Can be either `GET` or `POST`.
 The default value is `GET`.
 
-- `vault-http-request-body` - (optional) The body of the HTTP request the library sends to Vault when requesting credentials.
+- `vault-http-request-body` - (optional) The body of the HTTP request the library sends to Vault when it requests credentials.
 Only valid if `http_method` is set to `POST`.
 
 ### Vault SSH certificate credential library attributes <sup>HCP/ENT</sup>

--- a/website/content/docs/concepts/domain-model/credential-libraries.mdx
+++ b/website/content/docs/concepts/domain-model/credential-libraries.mdx
@@ -21,13 +21,17 @@ A credential library has the following configurable attributes:
 
 The generic Vault credential library has the following additional attributes:
 
-- `path` - (required) The path in Vault to request credentials from.
+- `vault-path` - (required) The path in Vault to request credentials from.
 
-- `http_method` - (optional) The HTTP method the library uses when requesting credentials from Vault.
+- `credential-type` - (optional) The type of credential this library will issue. Defaults to Unspecified. 
+
+- `credential-mapping-override` - (optional) Override the field attributes in the credential retrieved from Vault. 
+
+- `vault-http_method` - (optional) The HTTP method the library uses when requesting credentials from Vault.
 Can be either `GET` or `POST`.
 The default value is `GET`.
 
-- `http_request_body` - (optional) The body of the HTTP request the library sends to Vault when requesting credentials.
+- `vault-http-request-body` - (optional) The body of the HTTP request the library sends to Vault when requesting credentials.
 Only valid if `http_method` is set to `POST`.
 
 ### Vault SSH certificate credential library attributes <sup>HCP/ENT</sup>
@@ -50,7 +54,7 @@ Alternatively, you could set the `session_connection_limit` to `1` for any targe
 
 </Note>
 
-- `path` - (required) The path in Vault to request credentials from.
+- `vault-path` - (required) The path in Vault to request credentials from.
 
 - `username` - (required) The username to use with the SSH certificate.
 You can create a template for this value using [Vault credential library parameter templating](#vault-credential-library-parameter-templating).


### PR DESCRIPTION
Adding/updating pieces of the Credential Library domain docs that are missing currently:

Added Attributes:
* credential-type
* credential-mapping-override 

Modified Attributes
* path -> vault-path 
* http_method -> vault-http-method
* http_request_body -> vault-http-request-body