### PR TITLE
all: fix pagination where clause

### DIFF
--- a/internal/auth/ldap/repository_account.go
+++ b/internal/auth/ldap/repository_account.go
@@ -137,7 +137,7 @@ func (r *Repository) ListAccounts(ctx context.Context, withAuthMethodId string, 
 			sql.Named("after_item_update_time", opts.withStartPageAfterItem.updateTime),
 			sql.Named("after_item_id", opts.withStartPageAfterItem.publicId),
 		)
-		whereClause += " and update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id)"
+		whereClause += " and (update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id))"
 	}
 
 	var accts []*Account

--- a/internal/auth/oidc/repository_account.go
+++ b/internal/auth/oidc/repository_account.go
@@ -171,7 +171,7 @@ func (r *Repository) ListAccounts(ctx context.Context, withAuthMethodId string, 
 			sql.Named("after_item_update_time", opts.withStartPageAfterItem.updateTime),
 			sql.Named("after_item_id", opts.withStartPageAfterItem.publicId),
 		)
-		whereClause += " and update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id)"
+		whereClause += " and (update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id))"
 	}
 
 	var accts []*Account

--- a/internal/auth/password/repository_account.go
+++ b/internal/auth/password/repository_account.go
@@ -183,7 +183,7 @@ func (r *Repository) ListAccounts(ctx context.Context, withAuthMethodId string, 
 			sql.Named("after_item_update_time", opts.withStartPageAfterItem.updateTime),
 			sql.Named("after_item_id", opts.withStartPageAfterItem.publicId),
 		)
-		whereClause += " and update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id)"
+		whereClause += " and (update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id))"
 	}
 
 	var accts []*Account

--- a/internal/authtoken/repository.go
+++ b/internal/authtoken/repository.go
@@ -329,7 +329,7 @@ func (r *Repository) ListAuthTokens(ctx context.Context, withScopeIds []string, 
 			sql.Named("after_item_update_time", opts.withStartPageAfterItem.updateTime),
 			sql.Named("after_item_id", opts.withStartPageAfterItem.publicId),
 		)
-		whereClause += " and update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id)"
+		whereClause += " and (update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id))"
 	}
 
 	// use the view, to bring in the required account columns. Just don't forget

--- a/internal/credential/vault/repository_credential_library.go
+++ b/internal/credential/vault/repository_credential_library.go
@@ -487,7 +487,7 @@ func (r *Repository) ListCredentialLibraries(ctx context.Context, storeId string
 			sql.Named("after_item_update_time", opts.withStartPageAfterItem.updateTime),
 			sql.Named("after_item_id", opts.withStartPageAfterItem.publicId),
 		)
-		whereClause += " and update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id)"
+		whereClause += " and (update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id))"
 	}
 	var libs []*CredentialLibrary
 	err := r.reader.SearchWhere(ctx, &libs, whereClause, args, db.WithLimit(limit), db.WithOrder(withOrder))

--- a/internal/credential/vault/repository_ssh_certificate_credential_library.go
+++ b/internal/credential/vault/repository_ssh_certificate_credential_library.go
@@ -339,7 +339,7 @@ func (r *Repository) ListSSHCertificateCredentialLibraries(ctx context.Context, 
 			sql.Named("after_item_update_time", opts.withStartPageAfterItem.updateTime),
 			sql.Named("after_item_id", opts.withStartPageAfterItem.publicId),
 		)
-		whereClause += " and update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id)"
+		whereClause += " and (update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id))"
 	}
 	var libs []*SSHCertificateCredentialLibrary
 	err := r.reader.SearchWhere(ctx, &libs, whereClause, args, db.WithLimit(limit), db.WithOrder(withOrder))

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -314,7 +314,7 @@ func (r *Repository) ListSessions(ctx context.Context, opt ...Option) ([]*Sessio
 			sql.Named("after_item_update_time", opts.withStartPageAfterItem.UpdateTime),
 			sql.Named("after_item_id", opts.withStartPageAfterItem.PublicId),
 		)
-		whereClause += " and update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id)"
+		whereClause += " and (update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id))"
 	}
 
 	var limit string

--- a/internal/target/repository.go
+++ b/internal/target/repository.go
@@ -267,7 +267,7 @@ func (r *Repository) ListTargets(ctx context.Context, opt ...Option) ([]Target, 
 			sql.Named("after_item_update_time", opts.WithStartPageAfterItem.updateTime),
 			sql.Named("after_item_id", opts.WithStartPageAfterItem.publicId),
 		)
-		whereClause += "and update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id)"
+		whereClause += "and (update_time > @after_item_update_time or (update_time = @after_item_update_time and public_id > @after_item_id))"
 	}
 
 	var foundTargets []*targetView


### PR DESCRIPTION
The old clause would be read as

```
(original_where_clause AND update_time > last_item_update_time) OR (foo)
```

Add explicit parantheses to avoid this. It would have been extremely unlikely to be hit, as it requires two elements to have identical update times, but this is correct now.