### PR TITLE
fix (events): convert multierror to stdlib error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/oligot/go-mod-upgrade v0.9.1
 	github.com/ory/dockertest/v3 v3.9.1
 	github.com/pires/go-proxyproto v0.7.0
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/posener/complete v1.2.3
 	github.com/prometheus/client_golang v1.12.1
 	github.com/ryanuber/go-glob v1.0.0

--- a/internal/auth/oidc/auth_method.go
+++ b/internal/auth/oidc/auth_method.go
@@ -5,6 +5,7 @@ package oidc
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/boundary/internal/oplog"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-kms-wrapping/v2/extras/structwrapping"
-	"github.com/hashicorp/go-multierror"
 	kvbuilder "github.com/hashicorp/go-secure-stdlib/kv-builder"
 	"google.golang.org/protobuf/proto"
 )
@@ -254,26 +254,26 @@ func (a *AuthMethod) hmacClientSecret(ctx context.Context, cipher wrapping.Wrapp
 // components of a complete/valid oidc auth method.
 func (am *AuthMethod) isComplete(ctx context.Context) error {
 	const op = "oidc.(AuthMethod).isComplete"
-	var result *multierror.Error
+	var result error
 	if err := am.validate(ctx, op); err != nil {
-		result = multierror.Append(result, errors.Wrap(ctx, err, op))
+		result = stderrors.Join(result, errors.Wrap(ctx, err, op))
 	}
 	if am.Issuer == "" {
-		result = multierror.Append(result, errors.New(ctx, errors.InvalidParameter, op, "missing issuer"))
+		result = stderrors.Join(result, errors.New(ctx, errors.InvalidParameter, op, "missing issuer"))
 	}
 	if am.ApiUrl == "" {
-		result = multierror.Append(result, errors.New(ctx, errors.InvalidParameter, op, "missing api url"))
+		result = stderrors.Join(result, errors.New(ctx, errors.InvalidParameter, op, "missing api url"))
 	}
 	if am.ClientId == "" {
-		result = multierror.Append(result, errors.New(ctx, errors.InvalidParameter, op, "missing client id"))
+		result = stderrors.Join(result, errors.New(ctx, errors.InvalidParameter, op, "missing client id"))
 	}
 	if am.ClientSecret == "" {
-		result = multierror.Append(result, errors.New(ctx, errors.InvalidParameter, op, "missing client secret"))
+		result = stderrors.Join(result, errors.New(ctx, errors.InvalidParameter, op, "missing client secret"))
 	}
 	if len(am.SigningAlgs) == 0 {
-		result = multierror.Append(result, errors.New(ctx, errors.InvalidParameter, op, "missing signing algorithms"))
+		result = stderrors.Join(result, errors.New(ctx, errors.InvalidParameter, op, "missing signing algorithms"))
 	}
-	return result.ErrorOrNil()
+	return result
 }
 
 type convertedValues struct {

--- a/internal/bsr/internal/checksum/checksum_test.go
+++ b/internal/bsr/internal/checksum/checksum_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/hashicorp/boundary/internal/bsr/internal/checksum"
 	"github.com/hashicorp/boundary/internal/bsr/internal/fstest"
-	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,11 +87,7 @@ func TestFile(t *testing.T) {
 			testString,
 			testSum + "  test\n",
 			nil,
-			func() error {
-				var wantErrors *multierror.Error
-				wantErrors = multierror.Append(wantErrors, errors.New("checksum.(File).Close: crypto.(Sha256SumWriter).Close: close error"))
-				return wantErrors.ErrorOrNil()
-			}(),
+			errors.New("checksum.(File).Close: crypto.(Sha256SumWriter).Close: close error"),
 			true,
 		},
 		{
@@ -102,11 +97,7 @@ func TestFile(t *testing.T) {
 			testString,
 			testSum + "  test\n",
 			nil,
-			func() error {
-				var wantErrors *multierror.Error
-				wantErrors = multierror.Append(wantErrors, errors.New("checksum.(File).Close: stat error"))
-				return wantErrors.ErrorOrNil()
-			}(),
+			errors.New("checksum.(File).Close: stat error"),
 			false,
 		},
 		{
@@ -116,11 +107,7 @@ func TestFile(t *testing.T) {
 			testString,
 			testSum + "  test\n",
 			nil,
-			func() error {
-				var wantErrors *multierror.Error
-				wantErrors = multierror.Append(wantErrors, errors.New("checksum.(File).Close: write failed"))
-				return wantErrors.ErrorOrNil()
-			}(),
+			errors.New("checksum.(File).Close: write failed"),
 			false,
 		},
 	}

--- a/internal/bsr/internal/sign/sign.go
+++ b/internal/bsr/internal/sign/sign.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/boundary/internal/bsr/internal/is"
 	"github.com/hashicorp/boundary/internal/bsr/kms"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
-	"github.com/hashicorp/go-multierror"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -142,28 +141,28 @@ func NewFile(ctx context.Context, f writerFile, w io.Writer, keys *kms.Keys) (*F
 func (f *File) Close() error {
 	const op = "sign.(File).Close"
 
-	var closeErrors *multierror.Error
+	var closeErrors error
 	if err := f.Writer.Close(); err != nil {
-		closeErrors = multierror.Append(closeErrors, fmt.Errorf("%s: %w", op, err))
+		closeErrors = errors.Join(closeErrors, fmt.Errorf("%s: %w", op, err))
 	}
 
 	sig, err := f.Writer.Sign(f.ctx)
 	if err != nil {
-		closeErrors = multierror.Append(closeErrors, fmt.Errorf("%s: %w", op, err))
-		return closeErrors.ErrorOrNil()
+		closeErrors = errors.Join(closeErrors, fmt.Errorf("%s: %w", op, err))
+		return closeErrors
 	}
 
 	b, err := proto.Marshal(sig)
 	if err != nil {
-		closeErrors = multierror.Append(closeErrors, fmt.Errorf("%s: %w", op, err))
-		return closeErrors.ErrorOrNil()
+		closeErrors = errors.Join(closeErrors, fmt.Errorf("%s: %w", op, err))
+		return closeErrors
 	}
 
 	if _, err := f.signatureWriter.Write(b); err != nil {
-		closeErrors = multierror.Append(closeErrors, fmt.Errorf("%s: %w", op, err))
+		closeErrors = errors.Join(closeErrors, fmt.Errorf("%s: %w", op, err))
 	}
 
-	return closeErrors.ErrorOrNil()
+	return closeErrors
 }
 
 var _ writerFile = (*File)(nil)

--- a/internal/bsr/internal/sign/sign_test.go
+++ b/internal/bsr/internal/sign/sign_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/boundary/internal/bsr/internal/sign"
 	"github.com/hashicorp/boundary/internal/bsr/kms"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
-	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -111,11 +110,7 @@ func TestFile(t *testing.T) {
 			testString,
 			testSig,
 			nil,
-			func() error {
-				var wantErrors *multierror.Error
-				wantErrors = multierror.Append(wantErrors, errors.New("sign.(File).Close: sign.(Writer).Close: close error"))
-				return wantErrors.ErrorOrNil()
-			}(),
+			errors.New("sign.(File).Close: sign.(Writer).Close: close error"),
 			true,
 		},
 		{
@@ -126,11 +121,7 @@ func TestFile(t *testing.T) {
 			testString,
 			testSig,
 			nil,
-			func() error {
-				var wantErrors *multierror.Error
-				wantErrors = multierror.Append(wantErrors, errors.New("sign.(File).Close: write failed"))
-				return wantErrors.ErrorOrNil()
-			}(),
+			errors.New("sign.(File).Close: write failed"),
 			false,
 		},
 	}

--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -6,6 +6,7 @@ package base
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -27,7 +28,6 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/pluginutil/v2"
 	"github.com/mitchellh/cli"
-	"github.com/pkg/errors"
 	"github.com/posener/complete"
 )
 
@@ -246,7 +246,7 @@ func (c *Command) Client(opt ...Option) (*api.Client, error) {
 	if modifiedTLS {
 		// Setup TLS config
 		if err := c.client.SetTLSConfig(tlsConfig); err != nil {
-			return nil, errors.Wrap(err, "failed to setup TLS config")
+			return nil, fmt.Errorf("failed to setup TLS config: %w", err)
 		}
 	}
 

--- a/internal/cmd/base/dev.go
+++ b/internal/cmd/base/dev.go
@@ -6,6 +6,7 @@ package base
 import (
 	"context"
 	"crypto/ed25519"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -24,7 +25,6 @@ import (
 	"github.com/hashicorp/boundary/internal/types/scope"
 	"github.com/hashicorp/boundary/testing/dbtest"
 	capoidc "github.com/hashicorp/cap/oidc"
-	"github.com/hashicorp/go-multierror"
 	"github.com/jimlambrt/gldap"
 	"github.com/jimlambrt/gldap/testdirectory"
 )
@@ -75,7 +75,7 @@ func (b *Server) CreateDevDatabase(ctx context.Context, opt ...Option) error {
 		if err != nil {
 			err = fmt.Errorf("unable to initialize dev database with dialect %s: %w", dialect, err)
 			if c != nil {
-				err = multierror.Append(err, c())
+				err = errors.Join(err, c())
 			}
 			return err
 		}
@@ -87,7 +87,7 @@ func (b *Server) CreateDevDatabase(ctx context.Context, opt ...Option) error {
 		if _, err := schema.MigrateStore(ctx, schema.Dialect(dialect), b.DatabaseUrl); err != nil {
 			err = fmt.Errorf("error initializing store: %w", err)
 			if c != nil {
-				err = multierror.Append(err, c())
+				err = errors.Join(err, c())
 			}
 			return err
 		}
@@ -102,21 +102,21 @@ func (b *Server) CreateDevDatabase(ctx context.Context, opt ...Option) error {
 
 	if err := b.OpenAndSetServerDatabase(ctx, dialect); err != nil {
 		if c != nil {
-			err = multierror.Append(err, c())
+			err = errors.Join(err, c())
 		}
 		return err
 	}
 
 	if err := b.CreateGlobalKmsKeys(ctx); err != nil {
 		if c != nil {
-			err = multierror.Append(err, c())
+			err = errors.Join(err, c())
 		}
 		return err
 	}
 
 	if _, err := b.CreateInitialLoginRole(ctx); err != nil {
 		if c != nil {
-			err = multierror.Append(err, c())
+			err = errors.Join(err, c())
 		}
 		return err
 	}

--- a/internal/cmd/base/format.go
+++ b/internal/cmd/base/format.go
@@ -5,6 +5,7 @@ package base
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/boundary/version"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/go-wordwrap"
-	"github.com/pkg/errors"
 )
 
 // This is adapted from the code in the strings package for TrimSpace

--- a/internal/cmd/base/keyring.go
+++ b/internal/cmd/base/keyring.go
@@ -6,6 +6,7 @@ package base
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/hashicorp/boundary/api/authtokens"
 	nkeyring "github.com/jefferai/keyring"
-	"github.com/pkg/errors"
 	zkeyring "github.com/zalando/go-keyring"
 )
 

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -38,7 +38,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-kms-wrapping/v2/extras/multi"
-	"github.com/hashicorp/go-multierror"
 	configutil "github.com/hashicorp/go-secure-stdlib/configutil/v2"
 	"github.com/hashicorp/go-secure-stdlib/gatedwriter"
 	"github.com/hashicorp/go-secure-stdlib/listenerutil"
@@ -722,13 +721,13 @@ func (b *Server) SetupKMSes(ctx context.Context, ui cli.Ui, config *config.Confi
 }
 
 func (b *Server) RunShutdownFuncs() error {
-	var mErr *multierror.Error
+	var mErr error
 	for _, f := range b.ShutdownFuncs {
 		if err := f(); err != nil {
-			mErr = multierror.Append(mErr, err)
+			mErr = errors.Join(mErr, err)
 		}
 	}
-	return mErr.ErrorOrNil()
+	return mErr
 }
 
 // OpenAndSetServerDatabase calls OpenDatabase and sets its result *db.DB to the Server's

--- a/internal/cmd/ops/server.go
+++ b/internal/cmd/ops/server.go
@@ -7,6 +7,7 @@ package ops
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -18,10 +19,8 @@ import (
 	"github.com/hashicorp/boundary/internal/daemon/worker"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/listenerutil"
 	"github.com/mitchellh/cli"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -89,7 +88,7 @@ func (s *Server) Start() {
 func (s *Server) Shutdown() error {
 	const op = "ops.(Server).Shutdown"
 
-	var closeErrors *multierror.Error
+	var closeErrors error
 	for _, b := range s.bundles {
 		if b == nil || b.ln == nil || b.ln.Config == nil || b.ln.OpsListener == nil || b.ln.HTTPServer == nil {
 			return fmt.Errorf("%s: missing bundle, listener or its fields", op)
@@ -100,17 +99,17 @@ func (s *Server) Shutdown() error {
 
 		err := b.ln.HTTPServer.Shutdown(ctx)
 		if err != nil {
-			multierror.Append(closeErrors, fmt.Errorf("%s: failed to shutdown http server: %w", op, err))
+			errors.Join(closeErrors, fmt.Errorf("%s: failed to shutdown http server: %w", op, err))
 		}
 
 		err = b.ln.OpsListener.Close()
 		err = listenerCloseErrorCheck(b.ln.Config.Type, err)
 		if err != nil {
-			multierror.Append(closeErrors, fmt.Errorf("%s: failed to close listener mux: %w", op, err))
+			errors.Join(closeErrors, fmt.Errorf("%s: failed to close listener mux: %w", op, err))
 		}
 	}
 
-	return closeErrors.ErrorOrNil()
+	return closeErrors
 }
 
 // WaitIfHealthExists waits for a configurable period of time `d` if the health endpoint has been

--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -42,7 +42,6 @@ import (
 	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/targets"
 	fm "github.com/hashicorp/boundary/version"
 	"github.com/hashicorp/go-bexpr"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/mr-tron/base58"
 	"google.golang.org/grpc/codes"
@@ -965,7 +964,7 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 			deleteCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			_, err := sessionRepo.DeleteSession(deleteCtx, sess.PublicId)
-			retErr = multierror.Append(retErr, err)
+			retErr = stderrors.Join(retErr, err)
 		}
 	}()
 
@@ -996,7 +995,7 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 				deleteCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 				defer cancel()
 				err := credRepo.Revoke(deleteCtx, sess.PublicId)
-				retErr = multierror.Append(retErr, err)
+				retErr = stderrors.Join(retErr, err)
 				// This leaves the credential in a state which will allow it to be cleaned up
 				// by the periodic credential cleanup job.
 			}

--- a/internal/daemon/worker/listeners.go
+++ b/internal/daemon/worker/listeners.go
@@ -309,13 +309,14 @@ func (w *Worker) stopServersAndListeners() error {
 	mg.Go(w.stopClusterGrpcServer)
 
 	stopErrors := mg.Wait()
+	convertedStopErrors := stopErrors.ErrorOrNil()
 
 	err := w.stopAnyListeners()
 	if err != nil {
-		stopErrors = multierror.Append(stopErrors, err)
+		convertedStopErrors = stderrors.Join(convertedStopErrors, err)
 	}
 
-	return stopErrors.ErrorOrNil()
+	return convertedStopErrors
 }
 
 func (w *Worker) stopHttpServer() error {

--- a/internal/db/read_writer.go
+++ b/internal/db/read_writer.go
@@ -6,6 +6,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	stderrors "errors"
 	"fmt"
 	"reflect"
 	"sync/atomic"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/boundary/internal/oplog/store"
 	"github.com/hashicorp/go-dbw"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
-	"github.com/hashicorp/go-multierror"
 )
 
 const (
@@ -442,14 +442,14 @@ func (rw *Db) DoTx(ctx context.Context, retries uint, backOff Backoff, handler T
 			return info, errors.Wrap(ctx, err, op, errors.WithoutEvent())
 		}
 
-		var txnErr *multierror.Error
+		var txnErr error
 		if commitErr := beginTx.Commit(ctx); commitErr != nil {
-			txnErr = multierror.Append(txnErr, errors.Wrap(ctx, commitErr, op, errors.WithMsg("commit error")))
+			txnErr = stderrors.Join(txnErr, errors.Wrap(ctx, commitErr, op, errors.WithMsg("commit error")))
 			// unsure if rolling back is required or possible, but including
 			// this attempt to rollback on a commit error just in case it's
 			// possible.
 			if err := beginTx.Rollback(ctx); err != nil {
-				return info, multierror.Append(txnErr, errors.Wrap(ctx, err, op, errors.WithMsg("rollback error")))
+				return info, stderrors.Join(txnErr, errors.Wrap(ctx, err, op, errors.WithMsg("rollback error")))
 			}
 			return info, txnErr
 		}

--- a/internal/db/schema/internal/postgres/postgres.go
+++ b/internal/db/schema/internal/postgres/postgres.go
@@ -40,7 +40,6 @@ import (
 	"github.com/hashicorp/boundary/internal/db/schema/migration"
 	"github.com/hashicorp/boundary/internal/db/schema/migrations"
 	"github.com/hashicorp/boundary/internal/errors"
-	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
@@ -197,7 +196,7 @@ func (p *Postgres) CommitRun(ctx context.Context) error {
 	}
 	if err := p.tx.Commit(); err != nil {
 		if errRollback := p.tx.Rollback(); errRollback != nil && errRollback != sql.ErrTxDone {
-			err = multierror.Append(err, errRollback)
+			err = stderrors.Join(err, errRollback)
 		}
 		return errors.Wrap(ctx, err, op)
 	}

--- a/internal/errors/match_test.go
+++ b/internal/errors/match_test.go
@@ -8,7 +8,6 @@ import (
 	stderrors "errors"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -303,13 +302,13 @@ func TestMatch(t *testing.T) {
 		{
 			name:     "match on hashicorp multi error",
 			template: T(errInvalidFieldMask),
-			err:      multierror.Append(stdErr, errInvalidFieldMask),
+			err:      stderrors.Join(stdErr, errInvalidFieldMask),
 			want:     true,
 		},
 		{
 			name:     "match on hashicorp multi error for specific code",
 			template: T(InvalidFieldMask),
-			err:      multierror.Append(stdErr, errInvalidFieldMask),
+			err:      stderrors.Join(stdErr, errInvalidFieldMask),
 			want:     true,
 		},
 		{

--- a/internal/event/cloudevents_formatter_node_test.go
+++ b/internal/event/cloudevents_formatter_node_test.go
@@ -312,10 +312,12 @@ func TestNode_Process(t *testing.T) {
 			tt.n.Predicate = tt.predicate
 
 			gotEvent, err := tt.n.Process(ctx, tt.e)
-			if tt.wantIsError != nil {
+			if tt.wantIsError != nil || tt.wantErrContains != "" {
 				require.Error(err)
 				assert.Nil(gotEvent)
-				assert.ErrorIs(err, tt.wantIsError)
+				if tt.wantIsError != nil {
+					assert.ErrorIs(err, tt.wantIsError)
+				}
 				if tt.wantErrContains != "" {
 					assert.Contains(err.Error(), tt.wantErrContains)
 				}

--- a/internal/event/context.go
+++ b/internal/event/context.go
@@ -130,7 +130,9 @@ func WriteObservation(ctx context.Context, caller Op, opt ...Option) error {
 
 // WriteError will write an error event.  It will first check the
 // ctx for an eventer, then try event.SysEventer() and if no eventer can be
-// found an hclog.Logger will be created and used.
+// found an hclog.Logger will be created and used.  Note: any multierror errors
+// will be converted to a stdlib error (because multierror doesn't support json
+// marshaling).
 //
 // The options WithInfoMsg, WithInfo, WithId and WithRequestInfo are supported
 // and all other options are ignored.

--- a/internal/event/event_error.go
+++ b/internal/event/event_error.go
@@ -4,7 +4,9 @@
 package event
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 )
 
 // errorVersion defines the version of error events
@@ -35,6 +37,12 @@ func newError(fromOperation Op, e error, opt ...Option) (*err, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", op, err)
 		}
+	}
+	// multierror doesn't support json Marshaling which will cause a problem
+	// when the event is formatted, so we're going to convert it here to a
+	// stdlib error
+	if reflect.TypeOf(e).String() == "*multierror.Error" {
+		e = errors.New(e.Error())
 	}
 	newErr := &err{
 		Id:          Id(opts.withId),

--- a/internal/event/event_error_test.go
+++ b/internal/event/event_error_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,6 +62,27 @@ func Test_newError(t *testing.T) {
 				Version:     errorVersion,
 				Op:          Op("valid-all-opts"),
 				Id:          "valid-all-opts",
+				RequestInfo: TestRequestInfo(t),
+				Info:        map[string]any{"msg": "hello"},
+			},
+		},
+		{
+			name:   "multierror-conversion",
+			fromOp: Op("multierror"),
+			e: func() error {
+				return multierror.Append(fmt.Errorf("%s: multierror all opts: %w", "multierror", ErrInvalidParameter))
+			}(),
+			opts: []Option{
+				WithId("multierror"),
+				WithRequestInfo(TestRequestInfo(t)),
+				WithInfo("msg", "hello"),
+			},
+			want: &err{
+				ErrorFields: fmt.Errorf("1 error occurred:\n\t* multierror: multierror all opts: invalid parameter\n\n"),
+				Error:       "1 error occurred:\n\t* multierror: multierror all opts: invalid parameter\n\n",
+				Version:     errorVersion,
+				Op:          Op("multierror"),
+				Id:          "multierror",
 				RequestInfo: TestRequestInfo(t),
 				Info:        map[string]any{"msg": "hello"},
 			},

--- a/internal/event/eventer_retry_test.go
+++ b/internal/event/eventer_retry_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/eventlogger"
-	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -113,24 +112,9 @@ func TestEventer_retrySend(t *testing.T) {
 			err := eventer.retrySend(tt.ctx, tt.retries, tt.backOff, tt.handler)
 			if tt.wantErrIs != nil {
 				require.Error(err)
-				multi, isMultiError := err.(*multierror.Error)
-				switch isMultiError {
-				case true:
-					matched := false
-					for _, e := range multi.WrappedErrors() {
-						if assert.ErrorIs(e, tt.wantErrIs) {
-							if tt.wantErrContain != "" {
-								assert.Contains(err.Error(), tt.wantErrContain)
-							}
-							matched = true
-						}
-					}
-					assert.True(matched)
-				default:
-					assert.ErrorIs(err, tt.wantErrIs)
-					if tt.wantErrContain != "" {
-						assert.Contains(err.Error(), tt.wantErrContain)
-					}
+				assert.ErrorIs(err, tt.wantErrIs)
+				if tt.wantErrContain != "" {
+					assert.Contains(err.Error(), tt.wantErrContain)
 				}
 				return
 			}

--- a/internal/session/service_worker_status_report.go
+++ b/internal/session/service_worker_status_report.go
@@ -5,11 +5,11 @@ package session
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/event"
-	"github.com/hashicorp/go-multierror"
 )
 
 // StateReport is used to report on the state of a Session.
@@ -44,27 +44,27 @@ func WorkerStatusReport(ctx context.Context, repo *Repository, connRepo *Connect
 		}
 	}
 
-	merr := new(multierror.Error)
+	var merr error
 	err := connRepo.updateBytesUpBytesDown(ctx, reportedConnections...)
 	if err != nil {
-		merr = multierror.Append(merr, errors.New(ctx, errors.Internal, op, fmt.Sprintf("failed to update bytes up and down for worker reported connections: %v", err)))
+		merr = stderrors.Join(merr, errors.New(ctx, errors.Internal, op, fmt.Sprintf("failed to update bytes up and down for worker reported connections: %v", err)))
 	}
 
 	notActive, err := repo.CheckIfNotActive(ctx, reportedSessions)
 	if err != nil {
-		merr = multierror.Append(merr, errors.New(ctx, errors.Internal, op, fmt.Sprintf("Error checking session state for worker %s: %v", workerId, err)))
+		merr = stderrors.Join(merr, errors.New(ctx, errors.Internal, op, fmt.Sprintf("Error checking session state for worker %s: %v", workerId, err)))
 	}
 
 	closed, err := connRepo.closeOrphanedConnections(ctx, workerId, reportedConnectionIds)
 	if err != nil {
-		merr = multierror.Append(merr, errors.New(ctx, errors.Internal, op, fmt.Sprintf("Error closing orphaned connections for worker %s: %v", workerId, err)))
+		merr = stderrors.Join(merr, errors.New(ctx, errors.Internal, op, fmt.Sprintf("Error closing orphaned connections for worker %s: %v", workerId, err)))
 	}
 	if len(closed) > 0 {
 		event.WriteSysEvent(ctx, op, "marked unclaimed connections as closed", "controller_id", workerId, "count", len(closed))
 	}
 
-	if merr.ErrorOrNil() != nil {
-		return nil, merr.ErrorOrNil()
+	if merr != nil {
+		return nil, merr
 	}
 	return notActive, nil
 }


### PR DESCRIPTION
multierror errors will be converted to a stdlib error (because multierror doesn't support json marshaling).

This PR also includes:
- [refact (errors): convert from multierror to stdlib errors.Join(...)](https://github.com/hashicorp/boundary/commit/53743de99d087fcbbbed33d608c811010b8b7007)
- [refact: convert from pkg/errors to stdlib error wrapping](https://github.com/hashicorp/boundary/commit/0ac4f65b40cd38bdf6f716322f2ecefca5350edb)