### PR TITLE
chore(enos): Move `terraform-enos-aws-infra` to `boundary`

### DIFF
--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -80,6 +80,7 @@ data "aws_iam_policy_document" "enos_policy_document" {
       "ec2:CreateVPC",
       "ec2:DeleteInternetGateway",
       "ec2:DeleteKeyPair",
+      "ec2:DeleteRoute",
       "ec2:DeleteRouteTable",
       "ec2:DeleteSecurityGroup",
       "ec2:DeleteSubnet",
@@ -280,7 +281,7 @@ data "aws_iam_policy_document" "demo_user_policy_document" {
   }
 
   statement {
-    sid = "BoundarySessionS3OnlyMyAccount"
+    sid    = "BoundarySessionS3OnlyMyAccount"
     effect = "Allow"
     actions = [
       "s3:DeleteObject",
@@ -290,9 +291,9 @@ data "aws_iam_policy_document" "demo_user_policy_document" {
     ]
 
     condition {
-      test = "StringEquals"
+      test     = "StringEquals"
       variable = "s3:ResourceAccount"
-      values = [data.aws_caller_identity.current.account_id]
+      values   = [data.aws_caller_identity.current.account_id]
     }
 
     resources = ["*"]
@@ -324,6 +325,6 @@ data "aws_iam_policy_document" "demo_user_policy_document" {
       "s3:GetObject",
       "s3:GetObjectAttributes",
       "s3:PutObject",
-     ]
+    ]
   }
 }

--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -71,12 +71,10 @@ module "iam_setup" {
   source = "./modules/iam_setup"
 }
 
-module "infra" {
-  source  = "app.terraform.io/hashicorp-qti/aws-infra/enos"
-  version = ">= 0.3.1"
+module "aws_vpc" {
+  source = "./modules/aws_vpc"
 
-  project_name = "qti-enos-boundary"
-  environment  = var.environment
+  environment = var.environment
   common_tags = {
     "Project" : "Enos",
     "Project Name" : "qti-enos-boundary",

--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -62,7 +62,7 @@ scenario "e2e_aws_base_with_vault" {
   }
 
   step "create_base_infra" {
-    module = module.infra
+    module = module.aws_vpc
     depends_on = [
       step.find_azs,
     ]

--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -62,7 +62,7 @@ scenario "e2e_aws_base" {
   }
 
   step "create_base_infra" {
-    module = module.infra
+    module = module.aws_vpc
     depends_on = [
       step.find_azs,
     ]

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -187,7 +187,7 @@ scenario "e2e_aws" {
     module     = module.worker
     depends_on = [step.create_boundary_cluster]
     variables {
-      vpc_name                  = step.create_base_infra.vpc_id
+      vpc_id                    = step.create_base_infra.vpc_id
       availability_zones        = step.create_base_infra.availability_zone_names
       kms_key_arn               = step.create_base_infra.kms_key_arn
       ubuntu_ami_id             = step.create_base_infra.ami_ids["ubuntu"]["amd64"]

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -63,7 +63,7 @@ scenario "e2e_aws" {
   }
 
   step "create_base_infra" {
-    module = module.infra
+    module = module.aws_vpc
     depends_on = [
       step.find_azs,
     ]

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -42,7 +42,7 @@ scenario "e2e_database" {
   }
 
   step "create_base_infra" {
-    module = module.infra
+    module = module.aws_vpc
     depends_on = [
       step.find_azs,
     ]

--- a/enos/enos-scenario-e2e-ui.hcl
+++ b/enos/enos-scenario-e2e-ui.hcl
@@ -63,7 +63,7 @@ scenario "e2e_ui" {
   }
 
   step "create_base_infra" {
-    module = module.infra
+    module = module.aws_vpc
     depends_on = [
       step.find_azs,
     ]

--- a/enos/modules/aws_vpc/main.tf
+++ b/enos/modules/aws_vpc/main.tf
@@ -1,0 +1,239 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+variable "name" {
+  type        = string
+  default     = "enos-vpc"
+  description = "The name of the VPC"
+}
+
+variable "availability_zones" {
+  description = "List of AWS availability zones to use (or * for all available)"
+  type        = list(string)
+  default     = ["*"]
+}
+
+variable "cidr" {
+  type        = string
+  default     = "10.13.0.0/16"
+  description = "CIDR block for the VPC"
+}
+
+variable "environment" {
+  description = "Name of the environment."
+  type        = string
+  default     = "enos-environment"
+}
+
+variable "common_tags" {
+  description = "Tags to set for all resources"
+  type        = map(string)
+  default     = { "Project" : "enos" }
+}
+
+variable "create_kms_key" {
+  description = "Whether or not to create an key management service key"
+  type        = bool
+  default     = true
+}
+
+variable "ami_architectures" {
+  type        = list(string)
+  description = "The AMI architectures to fetch AMI IDs for."
+  default     = ["amd64", "arm64"]
+}
+
+locals {
+  // AWS AMIs standardized on the x86_64 label for 64bit x86 architectures, therefore amd64 should be rather x86_64.
+  architecture_filters = [for arch in var.ami_architectures : (arch == "amd64" ? "x86_64" : arch)]
+  common_tags = merge(
+    var.common_tags,
+    {
+      "Module" = "terraform-enos-aws-infra" // TODO:  Rename this once terraform-enos-aws-boundary is moved
+    },
+  )
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "zone-name"
+    values = var.availability_zones
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  count       = length(local.architecture_filters)
+
+  # Currently latest LTS-1
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [local.architecture_filters[count.index]]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+data "aws_ami" "rhel" {
+  most_recent = true
+  count       = length(local.architecture_filters)
+
+  filter {
+    name   = "name"
+    values = ["RHEL-8.8*HVM-20*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [local.architecture_filters[count.index]]
+  }
+
+  owners = ["309956199498"] # Redhat
+}
+
+resource "random_string" "cluster_id" {
+  length  = 8
+  lower   = true
+  upper   = false
+  numeric = false
+  special = false
+}
+
+resource "aws_kms_key" "key" {
+  count                   = var.create_kms_key ? 1 : 0
+  description             = "enos-kms-key"
+  deletion_window_in_days = 7 // 7 is the shortest allowed window
+}
+
+resource "aws_kms_alias" "alias" {
+  count         = var.create_kms_key ? 1 : 0
+  name          = "alias/enos_key-${random_string.cluster_id.result}"
+  target_key_id = aws_kms_key.key[0].key_id
+}
+
+resource "aws_vpc" "vpc" {
+  cidr_block           = var.cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = var.name
+    },
+  )
+}
+
+resource "aws_subnet" "subnet" {
+  count                   = length(data.aws_availability_zones.available.names)
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = cidrsubnet(var.cidr, 8, count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "${var.name}-subnet-${data.aws_availability_zones.available.names[count.index]}"
+    },
+  )
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "${var.name}-igw"
+    },
+  )
+}
+
+resource "aws_route" "igw" {
+  route_table_id         = aws_vpc.vpc.default_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+}
+
+resource "aws_security_group" "default" {
+  vpc_id = aws_vpc.vpc.id
+
+  ingress {
+    description = "allow_ingress_from_all"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "allow_egress_from_all"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "${var.name}-default"
+    },
+  )
+}
+
+output "vpc_id" {
+  description = "Created VPC ID"
+  value       = aws_vpc.vpc.id
+}
+
+output "vpc_cidr" {
+  description = "CIDR for whole VPC"
+  value       = var.cidr
+}
+
+output "vpc_subnets" {
+  description = "Generated subnet IDs and CIDRs"
+  value       = { for s in aws_subnet.subnet : s.id => s.cidr_block }
+}
+
+output "kms_key_arn" {
+  description = "ARN of the generated KMS key"
+  value       = try(aws_kms_key.key[0].arn, null)
+}
+
+output "kms_key_alias" {
+  description = "Alias of the generated KMS key"
+  value       = try(aws_kms_alias.alias[0].name, null)
+}
+
+output "availability_zone_names" {
+  description = "All availability zones with resources"
+  value       = data.aws_availability_zones.available.names
+}
+
+output "ami_ids" {
+  description = "The AWS AMI IDs for to use for ubuntu and rhel based instance for the amd64 and arm64 architectures."
+  value = {
+    ubuntu = { for idx, arch in var.ami_architectures : arch => data.aws_ami.ubuntu[idx].id }
+    rhel   = { for idx, arch in var.ami_architectures : arch => data.aws_ami.rhel[idx].id }
+  }
+}

--- a/enos/modules/worker/main.tf
+++ b/enos/modules/worker/main.tf
@@ -55,14 +55,14 @@ resource "random_integer" "az" {
 
 # Create a subnet so that the worker doesn't share one with a controller
 resource "aws_subnet" "default" {
-  vpc_id                  = var.vpc_name
+  vpc_id                  = var.vpc_id
   cidr_block              = "10.13.9.0/24"
   map_public_ip_on_launch = true
   availability_zone       = local.selected_az
   tags = merge(
     local.common_tags,
     {
-      "Name" = "${var.vpc_name}_worker_${random_pet.worker.id}_subnet"
+      "Name" = "${var.vpc_id}_worker_${random_pet.worker.id}_subnet"
     },
   )
 }
@@ -71,7 +71,7 @@ resource "aws_subnet" "default" {
 resource "aws_security_group" "default" {
   name        = "boundary-sg-worker-${random_pet.worker.id}"
   description = "SSH to worker to KMS and controllers"
-  vpc_id      = var.vpc_name
+  vpc_id      = var.vpc_id
 
   ingress {
     description = "SSH to the worker instance"
@@ -99,7 +99,7 @@ resource "aws_security_group" "default" {
   tags = merge(
     local.common_tags,
     {
-      "Name" = "${var.vpc_name}_worker_sg"
+      "Name" = "${var.vpc_id}_worker_sg"
     },
   )
 }
@@ -116,7 +116,7 @@ resource "aws_vpc_security_group_ingress_rule" "worker_to_controller" {
 }
 
 data "aws_vpc" "vpc" {
-  id = var.vpc_name
+  id = var.vpc_id
 }
 
 resource "aws_route_table_association" "worker_rta" {

--- a/enos/modules/worker/main.tf
+++ b/enos/modules/worker/main.tf
@@ -115,18 +115,13 @@ resource "aws_vpc_security_group_ingress_rule" "worker_to_controller" {
   ip_protocol       = "tcp"
 }
 
-data "aws_route_table" "default" {
-  vpc_id = var.vpc_name
-
-  filter {
-    name   = "tag:Name"
-    values = ["enos-vpc_route"]
-  }
+data "aws_vpc" "vpc" {
+  id = var.vpc_name
 }
 
 resource "aws_route_table_association" "worker_rta" {
   subnet_id      = aws_subnet.default.id
-  route_table_id = data.aws_route_table.default.id
+  route_table_id = data.aws_vpc.vpc.main_route_table_id
 }
 
 resource "aws_instance" "worker" {

--- a/enos/modules/worker/variables.tf
+++ b/enos/modules/worker/variables.tf
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-variable "vpc_name" {
-  description = "The name of the existing VPC to be used for this module"
+variable "vpc_id" {
+  description = "The id of the existing VPC to be used for this module"
   type        = string
 }
 


### PR DESCRIPTION
The terraform-enos-aws-infra repo was a terraform module to set up the base aws infrastructure. Vault made some local updates that might mitigate flakiness we've been seeing ("can't delete due to dependencies" error). We are replacing our usage of that module with Vault's local copy.