### PR TITLE
credential: fix lint errors

### DIFF
--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -136,7 +136,7 @@ type PrivateKey []byte
 
 // JsonObject represents a JSON object that is serialized.
 type JsonObject struct {
-	structpb.Struct
+	*structpb.Struct
 }
 
 // UsernamePassword is a credential containing a username and a password.

--- a/internal/credential/redact_test.go
+++ b/internal/credential/redact_test.go
@@ -177,7 +177,7 @@ func TestJsonObject_MarshalJSON(t *testing.T) {
 	t.Run("within-struct", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
 		secret := JsonObject{
-			structpb.Struct{
+			Struct: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"secret": structpb.NewStringValue("password"),
 				},

--- a/internal/credential/static/repository_credentials_test.go
+++ b/internal/credential/static/repository_credentials_test.go
@@ -47,7 +47,7 @@ func TestRepository_Retrieve(t *testing.T) {
 	assert.NoError(err)
 
 	secondObj := credential.JsonObject{
-		structpb.Struct{
+		Struct: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"username": structpb.NewStringValue("new-user"),
 				"password": structpb.NewStringValue("new-password"),

--- a/internal/credential/static/testing.go
+++ b/internal/credential/static/testing.go
@@ -72,7 +72,7 @@ do/lpv8N1+5Eb3lOB3DrqcEqRwXzSQcO2QcpikNSHyPquGR689I3xUm6kWmpKs49aacTUx
 // TestJsonObject returns a json object and it's marshalled format to be used for testing
 func TestJsonObject() (credential.JsonObject, []byte, error) {
 	object := credential.JsonObject{
-		structpb.Struct{
+		Struct: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"username": structpb.NewStringValue("user"),
 				"password": structpb.NewStringValue("password"),

--- a/internal/daemon/controller/handlers/credentials/credential_service.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service.go
@@ -718,7 +718,7 @@ func toJsonStorageCredential(ctx context.Context, storeId string, in *pb.Credent
 		ctx,
 		storeId,
 		credential.JsonObject{
-			*object,
+			Struct: object,
 		},
 		opts...)
 	if err != nil {

--- a/internal/daemon/controller/handlers/credentials/credential_service_test.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service_test.go
@@ -727,7 +727,7 @@ func TestCreate(t *testing.T) {
 				Type:              credential.JsonSubtype.String(),
 				Attrs: &pb.Credential_JsonAttributes{
 					JsonAttributes: &pb.JsonAttributes{
-						Object: &obj.Struct,
+						Object: obj.Struct,
 					},
 				},
 			}},


### PR DESCRIPTION
The existing pattern was subject to a bug whereby a lock value was copied every time the value was passed around. This was happening because of the use of an embedded protobuf type. To avoid copying a mutex, use a pointer type in the embedding.

Also fixes a few linter warnings complaining about the use of unkeyed literals.