### PR TITLE
docs: Clarify SSH options and session recording

### DIFF
--- a/website/content/docs/operations/session-recordings/index.mdx
+++ b/website/content/docs/operations/session-recordings/index.mdx
@@ -16,12 +16,16 @@ An administrator can later view the recordings to investigate security issues, r
 Recorded sessions are stored in an external storage bucket that you create.
 Storing session recordings in a system external to Boundary means those recordings can be accessed, modified, deleted, and even restored independently of Boundary.
 You can view any sessions that Boundary recorded in your storage provider or via the CLI.
-By default, Boundary converts recorded sessions to an asciicast format for playback.
 
-Some SSH connection options are not captured by the asciicast playback format.
-If you use remote commands or an interactive shell, for example, these might not be viewable in the asciicast recorded output.
-Boundary does capture all user inputs, however, and you can view a complete audit trail of remote commands and interactive shell input in the [BSR file](/boundary/docs/concepts/auditing/#bsr-directory-structure).
-You can view the BSR file in the external storage bucket.
+When you view recorded sessions using the CLI or Admin UI, Boundary can convert the recording into other formats for playback.
+Currently Boundary supports converting the recording of an individual SSH channel into an [asciicast](https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md) format to play back an interactive SSH session.
+
+The asciicast format is well suited for the playback of interactive shell activity.
+However, some aspects of the recording cannot be translated into asciicast.
+For example, if an SSH session uses the `RemoteCommand` option, or is used to `exec` a command, the command is not displayed in the asciicast.
+The output of the command may be displayed, however.
+If you use SSH for something other than an interactive shell, such as for file transfer, X11 forwarding, or port forwarding, Boundary does not attempt to create an asciicast.
+In all cases, the SSH session is still recorded in the [BSR file](/boundary/docs/concepts/auditing/#bsr-directory-structure) and you can view the BSR file in the external storage bucket.
 
 For more information about working with recorded sessions, refer to the following topics:
 

--- a/website/content/docs/operations/session-recordings/index.mdx
+++ b/website/content/docs/operations/session-recordings/index.mdx
@@ -16,6 +16,12 @@ An administrator can later view the recordings to investigate security issues, r
 Recorded sessions are stored in an external storage bucket that you create.
 Storing session recordings in a system external to Boundary means those recordings can be accessed, modified, deleted, and even restored independently of Boundary.
 You can view any sessions that Boundary recorded in your storage provider or via the CLI.
+By default, Boundary converts recorded sessions to an asciicast format for playback.
+
+Some SSH connection options are not captured by the asciicast playback format.
+If you use remote commands or an interactive shell, for example, these might not be viewable in the asciicast recorded output.
+Boundary does capture all user inputs, however, and you can view a complete audit trail of remote commands and interactive shell input in the [BSR file](/boundary/docs/concepts/auditing/#bsr-directory-structure).
+You can view the BSR file in the external storage bucket.
 
 For more information about working with recorded sessions, refer to the following topics:
 

--- a/website/content/docs/operations/session-recordings/index.mdx
+++ b/website/content/docs/operations/session-recordings/index.mdx
@@ -23,7 +23,7 @@ Currently Boundary supports converting the recording of an individual SSH channe
 The asciicast format is well suited for the playback of interactive shell activity.
 However, some aspects of the recording cannot be translated into asciicast.
 For example, if an SSH session uses the `RemoteCommand` option, or is used to `exec` a command, the command is not displayed in the asciicast.
-The output of the command may be displayed, however.
+The output of the command may be displayed, though.
 If you use SSH for something other than an interactive shell, such as for file transfer, X11 forwarding, or port forwarding, Boundary does not attempt to create an asciicast.
 In all cases, the SSH session is still recorded in the [BSR file](/boundary/docs/concepts/auditing/#bsr-directory-structure) and you can view the BSR file in the external storage bucket.
 

--- a/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
+++ b/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
@@ -11,10 +11,13 @@ You can view a list of all recorded sessions, or if you know the ID of a specifi
 
 <Note>
 
-Some SSH connection options are not captured by the asciicast playback format.
-If you use remote commands or an interactive shell, for example, these might not be viewable in the asciicast recorded output.
-Boundary does capture all user inputs, however, and you can view a complete audit trail of remote commands and interactive shell input in the [BSR file](/boundary/docs/concepts/auditing/#bsr-directory-structure).
-You can view the BSR file in the external storage bucket.
+The asciicast format is well suited for the playback of interactive shell activity.
+However, some aspects of the recording cannot be translated into asciicast.
+For example, if an SSH session uses the `RemoteCommand` option, or is used to `exec` a command, the command is not displayed in the asciicast.
+The output of the command may be displayed, though.
+If you use SSH for something other than an interactive shell, such as for file transfer, X11 forwarding, or port forwarding, Boundary does not attempt to create an asciicast.
+
+In all cases, the SSH session is still recorded in the [BSR file](/boundary/docs/concepts/auditing/#bsr-directory-structure) and you can view the BSR file in the external storage bucket.
 
 </Note>
 

--- a/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
+++ b/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
@@ -9,6 +9,15 @@ description: |-
 
 You can view a list of all recorded sessions, or if you know the ID of a specific recorded session, you can find any channels associated with that recording.
 
+<Note>
+
+Some SSH connection options are not captured by the asciicast playback format.
+If you use remote commands or an interactive shell, for example, these might not be viewable in the asciicast recorded output.
+Boundary does capture all user inputs, however, and you can view a complete audit trail of remote commands and interactive shell input in the [BSR file](/boundary/docs/concepts/auditing/#bsr-directory-structure).
+You can view the BSR file in the external storage bucket.
+
+</Note>
+
 <Tabs>
 <Tab heading="CLI">
 
@@ -72,7 +81,7 @@ You can find all recorded sessions in the UI from the global scope.
 1. Select **View** next to the session recording you want to view.
 
    The details page has information related to the session recording and
-   links to related inforation like user, target, and storage bucket.
+   links to related information like user, target, and storage bucket.
 
 ## Play back channel recording
 


### PR DESCRIPTION
This PR seeks to clarify the way session recording handles some SSH connection options per issue number 344 and slack conversation (https://hashicorp.slack.com/archives/C014AHXUL3G/p1695043488542069).

View the update in the preview deployment:

- [Recorded sessions operations](https://boundary-ekdxl1ko7-hashicorp.vercel.app/boundary/docs/operations/session-recordings)
- [Manage recorded sessions](https://boundary-ekdxl1ko7-hashicorp.vercel.app/boundary/docs/operations/session-recordings/manage-recorded-sessions)

Jira: https://hashicorp.atlassian.net/browse/SPE-433