### PR TITLE
docs: Update `events` stanza for telemetry

### DIFF
--- a/website/content/docs/configuration/events/common.mdx
+++ b/website/content/docs/configuration/events/common.mdx
@@ -14,7 +14,7 @@ These parameters are shared across all sink types:
 - `description` - Specify a description for the sink.
 
 - `event_types` - Specifies a list of event types that will be sent to the sink.
-  Can be `*`, `error`, `system`, `observation` or `audit`.
+  Can be `*`, `audit`, `error`, `observation`, `system`, or `telemetry`.
 
 - `event_source_url` - Specifies an optional event source URL for the sink. If
   not specified, the default source will be composed of the

--- a/website/content/docs/configuration/events/index.mdx
+++ b/website/content/docs/configuration/events/index.mdx
@@ -58,6 +58,7 @@ events {
   audit_enabled = false
   observations_enabled = true
   sysevents_enabled = true
+  telemetry_enabled = false
   sink "stderr" {
     name = "default"
     event_types = ["*"]

--- a/website/content/docs/configuration/events/index.mdx
+++ b/website/content/docs/configuration/events/index.mdx
@@ -15,7 +15,7 @@ Example:
 events {
   observations_enabled = true
   sysevents_enabled = true
-  telemetry_enabled = true
+  telemetry_enabled = false
   sink "stderr" {
     name = "all-events"
     description = "All events sent to stderr"

--- a/website/content/docs/configuration/events/index.mdx
+++ b/website/content/docs/configuration/events/index.mdx
@@ -15,6 +15,7 @@ Example:
 events {
   observations_enabled = true
   sysevents_enabled = true
+  telemetry_enabled = true
   sink "stderr" {
     name = "all-events"
     description = "All events sent to stderr"
@@ -39,6 +40,9 @@ events {
 - `observations_enabled` - Specifies if observation events should be emitted.
 
 - `sysevents_enabled` - Specifies if system events should be emitted.
+
+- `telemetry_enabled` - Specifies if telemetry events should be emitted.
+To receive telemetry events, you must also set `observations_enabled` to `true`.
 
 - `sink` - Specifies the configuration of an event sink. Currently, two types of
   sink are supported: [file](/boundary/docs/configuration/events/file) and [stderr](/boundary/docs/configuration/events/stderr). If no sinks are configured then all


### PR DESCRIPTION
This pull request updates the `events` documentation to add the new telemetry attributes per [ICU-11049](https://hashicorp.atlassian.net/browse/ICU-11049).

View the updates in the preview deployment here:

- [events stanza](https://boundary-mzyri3g2f-hashicorp.vercel.app/boundary/docs/configuration/events)
- [Common sink parameters](https://boundary-mzyri3g2f-hashicorp.vercel.app/boundary/docs/configuration/events/common)

[ICU-11049]: https://hashicorp.atlassian.net/browse/ICU-11049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ