### PR TITLE
docs: Update worker auth storage path

### DIFF
--- a/website/content/docs/configuration/worker/pki-worker.mdx
+++ b/website/content/docs/configuration/worker/pki-worker.mdx
@@ -15,7 +15,7 @@ Example (not safe for production!):
 
 ```hcl
 worker {
-  auth_storage_path="/boundary/demo-worker-1"
+  auth_storage_path="/var/lib/boundary"
   initial_upstreams = ["10.0.0.1"]
 }
 ```
@@ -34,7 +34,7 @@ either directly or via an env var or file by using `env://` or `file://` syntax:
 
 ```hcl
 worker {
-  auth_storage_path="/boundary/demo-worker-1"
+  auth_storage_path="/var/lib/boundary"
   initial_upstreams = ["10.0.0.1"]
   controller_generated_activation_token = "neslat_........."
   # controller_generated_activation_token = "env://ACT_TOKEN"
@@ -88,7 +88,7 @@ Development example:
 
 ```hcl
 worker {
-  auth_storage_path="/boundary/demo-worker-1"
+  auth_storage_path="/var/lib/boundary"
   initial_upstreams = ["10.0.0.1"]
   recording_storage_path="/local/storage/directory"
 }

--- a/website/content/docs/install-boundary/configure-workers.mdx
+++ b/website/content/docs/install-boundary/configure-workers.mdx
@@ -98,7 +98,7 @@ listener "tcp" {
 worker {
   public_addr = "<worker_public_addr>"
   initial_upstreams = ["<controller_lb_address>:9201"]
-  auth_storage_path = "/etc/boundary.d/auth_storage/"
+  auth_storage_path = "/var/lib/boundary"
   tags {
     type = ["worker1", "upstream"]
   }
@@ -167,7 +167,7 @@ listener "tcp" {
 worker {
   public_addr = "<worker_public_addr>"
   initial_upstreams = ["<ingress_worker_address>:9202"]
-  auth_storage_path = "/etc/boundary.d/auth_storage/"
+  auth_storage_path = "/var/lib/boundary"
   tags {
     type = ["worker2", "intermediate"]
   }
@@ -236,7 +236,7 @@ listener "tcp" {
 worker {
   public_addr = "<worker_public_addr>"
   initial_upstreams = ["<intermediate_worker_address>:9202"]
-  auth_storage_path = "/etc/boundary.d/auth_storage/"
+  auth_storage_path = "/var/lib/boundary"
   tags {
     type = ["worker3", "egress"]
   }
@@ -350,7 +350,7 @@ listener "tcp" {
 worker {
   public_addr = "<worker_public_addr>"
   initial_upstreams = ["<controller_lb_address>:9201"]
-  auth_storage_path = "/etc/boundary.d/auth_storage/"
+  auth_storage_path = "/var/lib/boundary"
   tags {
     type = ["worker", "egress"]
   }


### PR DESCRIPTION
From a Slack conversation: https://hashicorp.slack.com/archives/C01AQDJF3SA/p1694709178068199

The example we use for the `auth_storage_path` is `/boundary/demo-worker-1`. However, this assumes the Boundary user has access to create a directory in the root file system. This seems unlikely.

A better example would be to use `/var/lib/boundary`. 

This PR updates the `auth_storage_path` to reflect the best practice.

View the updates in the preview deployment:

- [PKI worker configuration](https://boundary-8cdbn42ol-hashicorp.vercel.app/boundary/docs/configuration/worker/pki-worker)
- [Configure workers](https://boundary-8cdbn42ol-hashicorp.vercel.app/boundary/docs/install-boundary/configure-workers)

Jira: https://hashicorp.atlassian.net/browse/SPE-432