### PR TITLE
Add TransactionTimestamp, use for listing deleted IDs

### DIFF
--- a/internal/auth/ldap/repository_account.go
+++ b/internal/auth/ldap/repository_account.go
@@ -148,17 +148,19 @@ func (r *Repository) ListAccounts(ctx context.Context, withAuthMethodId string, 
 	return accts, nil
 }
 
-// ListDeletedIds lists the public IDs of any accounts deleted since the timestamp provided.
+// ListDeletedIds lists the public IDs of any accounts deleted since the timestamp provided,
+// and returns the timestamp of the transaction, to be used in other ListDeletedIds transactions.
+// This should ensure the correct list of deleted IDs is always returned.
 func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]string, time.Time, error) {
 	const op = "account.(Repository).ListDeletedIds"
 	var deletedAccounts []*deletedAccount
-	var transactionTimestamp time.Time
+	var now time.Time
 	if _, err := r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{}, func(r db.Reader, w db.Writer) error {
 		if err := r.SearchWhere(ctx, &deletedAccounts, "delete_time >= ?", []any{since}); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query deleted accounts"))
 		}
 		var err error
-		transactionTimestamp, err = r.TransactionTimestamp(ctx)
+		now, err = r.Now(ctx)
 		if err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query transaction timestamp"))
 		}
@@ -170,7 +172,7 @@ func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]str
 	for _, acct := range deletedAccounts {
 		accountIds = append(accountIds, acct.PublicId)
 	}
-	return accountIds, transactionTimestamp, nil
+	return accountIds, now, nil
 }
 
 // EstimatedCount returns an estimate ofthe total number of items in the accounts table.

--- a/internal/auth/ldap/repository_account.go
+++ b/internal/auth/ldap/repository_account.go
@@ -149,17 +149,28 @@ func (r *Repository) ListAccounts(ctx context.Context, withAuthMethodId string, 
 }
 
 // ListDeletedIds lists the public IDs of any accounts deleted since the timestamp provided.
-func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]string, error) {
+func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]string, time.Time, error) {
 	const op = "account.(Repository).ListDeletedIds"
 	var deletedAccounts []*deletedAccount
-	if err := r.reader.SearchWhere(ctx, &deletedAccounts, "delete_time >= ?", []any{since}); err != nil {
-		return nil, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query deleted accounts"))
+	var transactionTimestamp time.Time
+	if _, err := r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{}, func(r db.Reader, w db.Writer) error {
+		if err := r.SearchWhere(ctx, &deletedAccounts, "delete_time >= ?", []any{since}); err != nil {
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query deleted accounts"))
+		}
+		var err error
+		transactionTimestamp, err = r.TransactionTimestamp(ctx)
+		if err != nil {
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query transaction timestamp"))
+		}
+		return nil
+	}); err != nil {
+		return nil, time.Time{}, err
 	}
 	var accountIds []string
 	for _, acct := range deletedAccounts {
 		accountIds = append(accountIds, acct.PublicId)
 	}
-	return accountIds, nil
+	return accountIds, transactionTimestamp, nil
 }
 
 // EstimatedCount returns an estimate ofthe total number of items in the accounts table.

--- a/internal/auth/ldap/repository_account_test.go
+++ b/internal/auth/ldap/repository_account_test.go
@@ -1414,9 +1414,13 @@ func TestListDeletedIds(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Expect no entries at the start
-	deletedIds, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(t, err)
 	require.Empty(t, deletedIds)
+	// Transaction time should be within ~10 seconds of now
+	now := time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Create and delete account
 	authMethod := TestAuthMethod(t, testConn, databaseWrapper, org.PublicId, []string{"ldaps://ldap1"})
@@ -1425,14 +1429,20 @@ func TestListDeletedIds(t *testing.T) {
 	require.NoError(t, err)
 
 	// Expect a single entry
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(t, err)
 	require.Equal(t, []string{account.PublicId}, deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Try again with the time set to now, expect no entries
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now())
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now())
 	require.NoError(t, err)
 	require.Empty(t, deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 }
 
 func TestEstimatedCount(t *testing.T) {

--- a/internal/auth/oidc/repository_account.go
+++ b/internal/auth/oidc/repository_account.go
@@ -182,17 +182,19 @@ func (r *Repository) ListAccounts(ctx context.Context, withAuthMethodId string, 
 	return accts, nil
 }
 
-// ListDeletedIds lists the public IDs of any accounts deleted since the timestamp provided.
+// ListDeletedIds lists the public IDs of any accounts deleted since the timestamp provided,
+// and returns the timestamp of the transaction, to be used in other ListDeletedIds transactions.
+// This should ensure the correct list of deleted IDs is always returned.
 func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]string, time.Time, error) {
 	const op = "account.(Repository).ListDeletedIds"
 	var deletedAccounts []*deletedAccount
-	var transactionTimestamp time.Time
+	var now time.Time
 	if _, err := r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{}, func(r db.Reader, w db.Writer) error {
 		if err := r.SearchWhere(ctx, &deletedAccounts, "delete_time >= ?", []any{since}); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query deleted accounts"))
 		}
 		var err error
-		transactionTimestamp, err = r.TransactionTimestamp(ctx)
+		now, err = r.Now(ctx)
 		if err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query transaction timestamp"))
 		}
@@ -204,7 +206,7 @@ func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]str
 	for _, acct := range deletedAccounts {
 		accountIds = append(accountIds, acct.PublicId)
 	}
-	return accountIds, transactionTimestamp, nil
+	return accountIds, now, nil
 }
 
 // EstimatedCount returns an estimate of the total number of items in the accounts table.

--- a/internal/auth/oidc/repository_account_test.go
+++ b/internal/auth/oidc/repository_account_test.go
@@ -1402,9 +1402,13 @@ func TestListDeletedIds(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Expect no entries at the start
-	deletedIds, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(t, err)
 	require.Empty(t, deletedIds)
+	// Transaction time should be within ~10 seconds of now
+	now := time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Create and delete account
 	authMethod := TestAuthMethod(
@@ -1419,14 +1423,20 @@ func TestListDeletedIds(t *testing.T) {
 	require.NoError(t, err)
 
 	// Expect a single entry
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(t, err)
 	require.Equal(t, []string{account.PublicId}, deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Try again with the time set to now, expect no entries
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now())
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now())
 	require.NoError(t, err)
 	require.Empty(t, deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 }
 
 func TestEstimatedCount(t *testing.T) {

--- a/internal/auth/password/repository_account.go
+++ b/internal/auth/password/repository_account.go
@@ -195,17 +195,28 @@ func (r *Repository) ListAccounts(ctx context.Context, withAuthMethodId string, 
 }
 
 // ListDeletedIds lists the public IDs of any accounts deleted since the timestamp provided.
-func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]string, error) {
+func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]string, time.Time, error) {
 	const op = "account.(Repository).ListDeletedIds"
 	var deletedAccounts []*deletedAccount
-	if err := r.reader.SearchWhere(ctx, &deletedAccounts, "delete_time >= ?", []any{since}); err != nil {
-		return nil, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query deleted accounts"))
+	var transactionTimestamp time.Time
+	if _, err := r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{}, func(r db.Reader, w db.Writer) error {
+		if err := r.SearchWhere(ctx, &deletedAccounts, "delete_time >= ?", []any{since}); err != nil {
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query deleted accounts"))
+		}
+		var err error
+		transactionTimestamp, err = r.TransactionTimestamp(ctx)
+		if err != nil {
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query transaction timestamp"))
+		}
+		return nil
+	}); err != nil {
+		return nil, time.Time{}, err
 	}
 	var accountIds []string
 	for _, acct := range deletedAccounts {
 		accountIds = append(accountIds, acct.PublicId)
 	}
-	return accountIds, nil
+	return accountIds, transactionTimestamp, nil
 }
 
 // EstimatedCount returns an estimate of the total number of items in the accounts table.

--- a/internal/auth/password/repository_account_test.go
+++ b/internal/auth/password/repository_account_test.go
@@ -1219,9 +1219,13 @@ func TestListDeletedIds(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Expect no entries at the start
-	deletedIds, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(t, err)
 	require.Empty(t, deletedIds)
+	// Transaction time should be within ~10 seconds of now
+	now := time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Create and delete account
 	authMethods := TestAuthMethods(t, conn, org.GetPublicId(), 1)
@@ -1230,14 +1234,20 @@ func TestListDeletedIds(t *testing.T) {
 	require.NoError(t, err)
 
 	// Expect a single entry
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(t, err)
 	require.Equal(t, []string{account.PublicId}, deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Try again with the time set to now, expect no entries
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now())
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now())
 	require.NoError(t, err)
 	require.Empty(t, deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 }
 
 func TestEstimatedCount(t *testing.T) {

--- a/internal/authtoken/repository_test.go
+++ b/internal/authtoken/repository_test.go
@@ -937,23 +937,33 @@ func TestListDeletedIds(t *testing.T) {
 	require.NotNil(repo)
 
 	// Expect no entries at the start
-	deletedIds, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(err)
 	require.Empty(deletedIds)
+	// Transaction time should be within ~10 seconds of now
+	now := time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Delete token
 	_, err = repo.DeleteAuthToken(ctx, at.PublicId)
 	require.NoError(err)
 
 	// Expect a single entry
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(err)
 	require.Equal([]string{at.PublicId}, deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Try again with the time set to now, expect no entries
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now())
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now())
 	require.NoError(err)
 	require.Empty(deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 }
 
 func TestEstimatedCount(t *testing.T) {

--- a/internal/credential/service_credential_test.go
+++ b/internal/credential/service_credential_test.go
@@ -109,7 +109,7 @@ func TestCredentialService_ListDeletedIds(t *testing.T) {
 		writer := &fakeWriter{
 			DoTxFn: func(ctx context.Context, retries uint, backoff db.Backoff, handler db.TxHandler) (db.RetryInfo, error) {
 				r := &fakeReader{
-					TransactionTimestampFn: func(ctx context.Context) (time.Time, error) {
+					NowFn: func(ctx context.Context) (time.Time, error) {
 						return time.Now(), nil
 					},
 				}
@@ -165,7 +165,7 @@ func TestCredentialService_ListDeletedIds(t *testing.T) {
 		writer := &fakeWriter{
 			DoTxFn: func(ctx context.Context, retries uint, backoff db.Backoff, handler db.TxHandler) (db.RetryInfo, error) {
 				r := &fakeReader{
-					TransactionTimestampFn: func(ctx context.Context) (time.Time, error) {
+					NowFn: func(ctx context.Context) (time.Time, error) {
 						return time.Now(), nil
 					},
 				}

--- a/internal/credential/service_library_test.go
+++ b/internal/credential/service_library_test.go
@@ -52,11 +52,11 @@ func (f *fakeWriter) DoTx(ctx context.Context, retries uint, backOff db.Backoff,
 
 type fakeReader struct {
 	db.Reader
-	TransactionTimestampFn func(context.Context) (time.Time, error)
+	NowFn func(context.Context) (time.Time, error)
 }
 
-func (f *fakeReader) TransactionTimestamp(ctx context.Context) (time.Time, error) {
-	return f.TransactionTimestampFn(ctx)
+func (f *fakeReader) Now(ctx context.Context) (time.Time, error) {
+	return f.NowFn(ctx)
 }
 
 func TestNewLibraryService(t *testing.T) {
@@ -166,7 +166,7 @@ func TestLibraryService_ListDeletedIds(t *testing.T) {
 		writer := &fakeWriter{
 			DoTxFn: func(ctx context.Context, retries uint, backoff db.Backoff, handler db.TxHandler) (db.RetryInfo, error) {
 				r := &fakeReader{
-					TransactionTimestampFn: func(ctx context.Context) (time.Time, error) {
+					NowFn: func(ctx context.Context) (time.Time, error) {
 						return time.Now(), nil
 					},
 				}
@@ -236,7 +236,7 @@ func TestLibraryService_ListDeletedIds(t *testing.T) {
 		writer := &fakeWriter{
 			DoTxFn: func(ctx context.Context, retries uint, backoff db.Backoff, handler db.TxHandler) (db.RetryInfo, error) {
 				r := &fakeReader{
-					TransactionTimestampFn: func(ctx context.Context) (time.Time, error) {
+					NowFn: func(ctx context.Context) (time.Time, error) {
 						return time.Now(), nil
 					},
 				}
@@ -267,7 +267,7 @@ func TestLibraryService_ListDeletedIds(t *testing.T) {
 		writer := &fakeWriter{
 			DoTxFn: func(ctx context.Context, retries uint, backoff db.Backoff, handler db.TxHandler) (db.RetryInfo, error) {
 				r := &fakeReader{
-					TransactionTimestampFn: func(ctx context.Context) (time.Time, error) {
+					NowFn: func(ctx context.Context) (time.Time, error) {
 						return time.Now(), nil
 					},
 				}

--- a/internal/credential/service_store_test.go
+++ b/internal/credential/service_store_test.go
@@ -119,7 +119,7 @@ func TestStoreService_ListDeletedIds(t *testing.T) {
 		writer := &fakeWriter{
 			DoTxFn: func(ctx context.Context, retries uint, backoff db.Backoff, handler db.TxHandler) (db.RetryInfo, error) {
 				r := &fakeReader{
-					TransactionTimestampFn: func(ctx context.Context) (time.Time, error) {
+					NowFn: func(ctx context.Context) (time.Time, error) {
 						return time.Now(), nil
 					},
 				}
@@ -175,7 +175,7 @@ func TestStoreService_ListDeletedIds(t *testing.T) {
 		writer := &fakeWriter{
 			DoTxFn: func(ctx context.Context, retries uint, backoff db.Backoff, handler db.TxHandler) (db.RetryInfo, error) {
 				r := &fakeReader{
-					TransactionTimestampFn: func(ctx context.Context) (time.Time, error) {
+					NowFn: func(ctx context.Context) (time.Time, error) {
 						return time.Now(), nil
 					},
 				}

--- a/internal/db/read_writer.go
+++ b/internal/db/read_writer.go
@@ -70,6 +70,9 @@ type Reader interface {
 
 	// ScanRows will scan sql rows into the interface provided
 	ScanRows(ctx context.Context, rows *sql.Rows, result any) error
+
+	// TransactionTimestamp returns the current transaction timestamp.
+	TransactionTimestamp(ctx context.Context) (time.Time, error)
 }
 
 // Writer interface defines create, update and retryable transaction handlers
@@ -523,6 +526,22 @@ func (rw *Db) SearchWhere(ctx context.Context, resources any, where string, args
 		return wrapError(ctx, err, op)
 	}
 	return nil
+}
+
+// TransactionTimestamp returns the current transaction timestamp.
+func (rw *Db) TransactionTimestamp(ctx context.Context) (time.Time, error) {
+	const op = "db.(*Db).TransactionTimestamp"
+	rows, err := rw.Query(ctx, "select current_timestamp", nil)
+	if err != nil {
+		return time.Time{}, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query current timestamp"))
+	}
+	var now time.Time
+	for rows.Next() {
+		if err := rw.ScanRows(ctx, rows, &now); err != nil {
+			return time.Time{}, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query current timestamp"))
+		}
+	}
+	return now, nil
 }
 
 func isNil(i any) bool {

--- a/internal/db/read_writer.go
+++ b/internal/db/read_writer.go
@@ -71,8 +71,8 @@ type Reader interface {
 	// ScanRows will scan sql rows into the interface provided
 	ScanRows(ctx context.Context, rows *sql.Rows, result any) error
 
-	// TransactionTimestamp returns the current transaction timestamp.
-	TransactionTimestamp(ctx context.Context) (time.Time, error)
+	// Now returns the current transaction timestamp.
+	Now(ctx context.Context) (time.Time, error)
 }
 
 // Writer interface defines create, update and retryable transaction handlers
@@ -528,9 +528,9 @@ func (rw *Db) SearchWhere(ctx context.Context, resources any, where string, args
 	return nil
 }
 
-// TransactionTimestamp returns the current transaction timestamp.
-func (rw *Db) TransactionTimestamp(ctx context.Context) (time.Time, error) {
-	const op = "db.(*Db).TransactionTimestamp"
+// Now returns the current transaction timestamp.
+func (rw *Db) Now(ctx context.Context) (time.Time, error) {
+	const op = "db.(*Db).Now"
 	rows, err := rw.Query(ctx, "select current_timestamp", nil)
 	if err != nil {
 		return time.Time{}, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query current timestamp"))

--- a/internal/db/read_writer_test.go
+++ b/internal/db/read_writer_test.go
@@ -3193,3 +3193,16 @@ func TestDb_oplogMsgsForItems(t *testing.T) {
 // 		})
 // 	}
 // }
+
+func TestDb_TransactionTimestamp(t *testing.T) {
+	t.Parallel()
+	conn, _ := TestSetup(t, "postgres")
+	rw := New(conn)
+	ctx := context.Background()
+	now, err := rw.TransactionTimestamp(ctx)
+	require.NoError(t, err)
+	// Check that it's within 1 second of now according to the system
+	// If this is flaky... just increase the limit 😬.
+	assert.True(t, now.Before(time.Now().Add(time.Second)))
+	assert.True(t, now.After(time.Now().Add(-time.Second)))
+}

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -352,17 +352,28 @@ func (r *Repository) ListSessions(ctx context.Context, opt ...Option) ([]*Sessio
 }
 
 // ListDeletedIds lists the public IDs of any sessions deleted since the timestamp provided.
-func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]string, error) {
+func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]string, time.Time, error) {
 	const op = "session.(Repository).ListDeletedIds"
 	var deletedSessions []*deletedSession
-	if err := r.reader.SearchWhere(ctx, &deletedSessions, "delete_time >= ?", []any{since}); err != nil {
-		return nil, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query deleted sessions"))
+	var transactionTimestamp time.Time
+	if _, err := r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{}, func(r db.Reader, w db.Writer) error {
+		if err := r.SearchWhere(ctx, &deletedSessions, "delete_time >= ?", []any{since}); err != nil {
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query deleted sessions"))
+		}
+		var err error
+		transactionTimestamp, err = r.TransactionTimestamp(ctx)
+		if err != nil {
+			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query transaction timestamp"))
+		}
+		return nil
+	}); err != nil {
+		return nil, time.Time{}, err
 	}
 	var sessionIds []string
 	for _, sess := range deletedSessions {
 		sessionIds = append(sessionIds, sess.PublicId)
 	}
-	return sessionIds, nil
+	return sessionIds, transactionTimestamp, nil
 }
 
 // EstimatedCount returns an estimate of the total number of items in the session table.

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -351,17 +351,19 @@ func (r *Repository) ListSessions(ctx context.Context, opt ...Option) ([]*Sessio
 	return sessions, nil
 }
 
-// ListDeletedIds lists the public IDs of any sessions deleted since the timestamp provided.
+// ListDeletedIds lists the public IDs of any sessions deleted since the timestamp provided,
+// and returns the timestamp of the transaction, to be used in other ListDeletedIds transactions.
+// This should ensure the correct list of deleted IDs is always returned.
 func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]string, time.Time, error) {
 	const op = "session.(Repository).ListDeletedIds"
 	var deletedSessions []*deletedSession
-	var transactionTimestamp time.Time
+	var now time.Time
 	if _, err := r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{}, func(r db.Reader, w db.Writer) error {
 		if err := r.SearchWhere(ctx, &deletedSessions, "delete_time >= ?", []any{since}); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query deleted sessions"))
 		}
 		var err error
-		transactionTimestamp, err = r.TransactionTimestamp(ctx)
+		now, err = r.Now(ctx)
 		if err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to query transaction timestamp"))
 		}
@@ -373,7 +375,7 @@ func (r *Repository) ListDeletedIds(ctx context.Context, since time.Time) ([]str
 	for _, sess := range deletedSessions {
 		sessionIds = append(sessionIds, sess.PublicId)
 	}
-	return sessionIds, transactionTimestamp, nil
+	return sessionIds, now, nil
 }
 
 // EstimatedCount returns an estimate of the total number of items in the session table.

--- a/internal/session/repository_session_test.go
+++ b/internal/session/repository_session_test.go
@@ -1884,9 +1884,13 @@ func TestListDeletedIds(t *testing.T) {
 	require.NoError(t, err)
 
 	// Expect no entries at the start
-	deletedIds, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(t, err)
 	require.Empty(t, deletedIds)
+	// Transaction time should be within ~10 seconds of now
+	now := time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Delete a session
 	s := TestDefaultSession(t, conn, wrapper, iamRepo)
@@ -1894,14 +1898,20 @@ func TestListDeletedIds(t *testing.T) {
 	require.NoError(t, err)
 
 	// Expect a single entry
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(t, err)
 	require.Equal(t, []string{s.PublicId}, deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Try again with the time set to now, expect no entries
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now())
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now())
 	require.NoError(t, err)
 	require.Empty(t, deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 }
 
 func TestEstimatedCount(t *testing.T) {

--- a/internal/target/tcp/repository_test.go
+++ b/internal/target/tcp/repository_test.go
@@ -411,9 +411,13 @@ func TestListDeletedIds(t *testing.T) {
 	require.NoError(t, err)
 
 	// Expect no entries at the start
-	deletedIds, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err := repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(t, err)
 	require.Empty(t, deletedIds)
+	// Transaction time should be within ~10 seconds of now
+	now := time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Delete a session
 	tg := tcp.TestTarget(ctx, t, conn, proj1.GetPublicId(), "deleteme")
@@ -421,14 +425,20 @@ func TestListDeletedIds(t *testing.T) {
 	require.NoError(t, err)
 
 	// Expect a single entry
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now().AddDate(-1, 0, 0))
 	require.NoError(t, err)
 	require.Equal(t, []string{tg.GetPublicId()}, deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 
 	// Try again with the time set to now, expect no entries
-	deletedIds, err = repo.ListDeletedIds(ctx, time.Now())
+	deletedIds, ttime, err = repo.ListDeletedIds(ctx, time.Now())
 	require.NoError(t, err)
 	require.Empty(t, deletedIds)
+	now = time.Now()
+	assert.True(t, ttime.Add(-10*time.Second).Before(now))
+	assert.True(t, ttime.Add(10*time.Second).After(now))
 }
 
 func TestEstimatedCount(t *testing.T) {


### PR DESCRIPTION
## [db: add TransactionTimestamp](https://github.com/hashicorp/boundary/commit/17c52eda89a1be17b5d04a3f92d87eca59a5399a)

The TransactionTimestamp method returns the timestamp
of the current transaction.

## [all: source deleted ID timestamp from transaction](https://github.com/hashicorp/boundary/commit/ed8471ea127a2eebabad0d7a13368f4319a11021)

Removes the Now() function and replaces it with a timestamp
sourced from the same transaction within which the list
call is made. This should ensure we always get the correct
list of deleted IDs and simplifies the repositories.