### PR TITLE
chore(enos): Provide boundary edition when building UI

### DIFF
--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -57,7 +57,8 @@ scenario "e2e_aws_base_with_vault" {
     module = matrix.builder == "crt" ? module.build_crt : module.build_local
 
     variables {
-      path = local.build_path[matrix.builder]
+      path    = local.build_path[matrix.builder]
+      edition = var.boundary_edition
     }
   }
 

--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -57,7 +57,8 @@ scenario "e2e_aws_base" {
     module = matrix.builder == "crt" ? module.build_crt : module.build_local
 
     variables {
-      path = local.build_path[matrix.builder]
+      path    = local.build_path[matrix.builder]
+      edition = var.boundary_edition
     }
   }
 

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -58,7 +58,8 @@ scenario "e2e_aws" {
     module = matrix.builder == "crt" ? module.build_crt : module.build_local
 
     variables {
-      path = local.build_path[matrix.builder]
+      path    = local.build_path[matrix.builder]
+      edition = var.boundary_edition
     }
   }
 

--- a/enos/enos-scenario-e2e-docker-base-with-postgres.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-postgres.hcl
@@ -41,6 +41,7 @@ scenario "e2e_docker_base_with_postgres" {
     variables {
       path           = matrix.builder == "crt" ? local.boundary_docker_image_file : ""
       cli_build_path = local.build_path[matrix.builder]
+      edition        = var.boundary_edition
     }
   }
 

--- a/enos/enos-scenario-e2e-docker-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-vault.hcl
@@ -41,6 +41,7 @@ scenario "e2e_docker_base_with_vault" {
     variables {
       path           = matrix.builder == "crt" ? local.boundary_docker_image_file : ""
       cli_build_path = local.build_path[matrix.builder]
+      edition        = var.boundary_edition
     }
   }
 

--- a/enos/enos-scenario-e2e-docker-base-with-worker.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-worker.hcl
@@ -44,6 +44,7 @@ scenario "e2e_docker_base_with_worker" {
     variables {
       path           = matrix.builder == "crt" ? local.boundary_docker_image_file : ""
       cli_build_path = local.build_path[matrix.builder]
+      edition        = var.boundary_edition
     }
   }
 

--- a/enos/enos-scenario-e2e-docker-base.hcl
+++ b/enos/enos-scenario-e2e-docker-base.hcl
@@ -41,6 +41,7 @@ scenario "e2e_docker_base" {
     variables {
       path           = matrix.builder == "crt" ? local.boundary_docker_image_file : ""
       cli_build_path = local.build_path[matrix.builder]
+      edition        = var.boundary_edition
     }
   }
 

--- a/enos/enos-scenario-e2e-ui.hcl
+++ b/enos/enos-scenario-e2e-ui.hcl
@@ -58,7 +58,8 @@ scenario "e2e_ui" {
     module = matrix.builder == "crt" ? module.build_crt : module.build_local
 
     variables {
-      path = local.build_path[matrix.builder]
+      path    = local.build_path[matrix.builder]
+      edition = var.boundary_edition
     }
   }
 

--- a/enos/modules/build_boundary_docker_crt/main.tf
+++ b/enos/modules/build_boundary_docker_crt/main.tf
@@ -19,6 +19,10 @@ variable "cli_build_path" {
   type        = string
 }
 
+variable "edition" {
+  default = "oss"
+}
+
 resource "enos_local_exec" "load_docker_image" {
   inline = ["docker load -i ${var.path}"]
 }

--- a/enos/modules/build_boundary_docker_local/main.tf
+++ b/enos/modules/build_boundary_docker_local/main.tf
@@ -20,6 +20,10 @@ variable "cli_build_path" {
   type        = string
 }
 
+variable "edition" {
+  default = "oss"
+}
+
 resource "enos_local_exec" "get_git_sha" {
   inline = ["git rev-parse --short HEAD"]
 }
@@ -32,6 +36,7 @@ resource "enos_local_exec" "build_docker_image" {
   environment = {
     "IMAGE_NAME"    = local.image_name
     "ARTIFACT_PATH" = var.cli_build_path
+    "EDITION"       = var.edition
   }
   scripts = ["${path.module}/build.sh"]
 }

--- a/enos/modules/build_crt/main.tf
+++ b/enos/modules/build_crt/main.tf
@@ -6,6 +6,10 @@ variable "path" {
   default = "/tmp"
 }
 
+variable "edition" {
+  default = "oss"
+}
+
 output "artifact_path" {
   value = var.path
 }


### PR DESCRIPTION
This PR updates the e2e test suite to ensure that the appropriate version of the UI is built into the boundary binary. This addresses an issue where elements like the Session Recording UI were not being visible when spinning up boundary through enos.