### PR TITLE
chore(e2e): Get logs from postgres container to debug deadlock errors

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -254,6 +254,12 @@ jobs:
           name: test-e2e-output
           path: enos/test*.log
           retention-days: 5
+      - name: Get logs from postgres container
+        # Retrieve logs from the postgres container on a failed
+        # run to help diagnose a deadlock issue
+        if: contains(matrix.filter, 'e2e_docker') && steps.run.outcome == 'failure'
+        run: |
+          docker logs database
       - name: Upload e2e UI tests debug info
         if: matrix.filter == 'e2e_ui builder:crt' && steps.run.outcome == 'failure'
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2


### PR DESCRIPTION
This PR updates the GitHub Action workflow that runs the e2e tests to grab logs from the postgres container. Hopefully, this will shed some light on a flaky deadlock error we've been seeing.
```
Messages:   	Error from controller when performing delete on scope
        	            	
        	            	Error information:
        	            	  Kind:                Internal
        	            	  Message:             scope.(Service).deleteFromRepo: unable to delete scope:
        	            	  iam.(Repository).DeleteScope: failed for o_TG0TF3JWcq:
        	            	  iam.(Repository).delete: db.DoTx: iam.(Repository).delete: db.Delete: unknown,
        	            	  unknown: error #0: dbw.Delete: ERROR: deadlock detected (SQLSTATE 40P01)
        	            	  Status:              500
        	            	  context:             Error from controller when performing delete on scope
```