### PR TITLE
chore(e2e): Get logs to debug aws dependencies error 

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -289,6 +289,17 @@ jobs:
         run: |
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario destroy --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
+      - name: Get logs for aws dependencies error
+        # Retrieve logs from the terraform to help diagnose some aws cleanup issues
+        if: (contains(matrix.filter, 'e2e_aws') || matrix.filter == 'e2e_database') && steps.destroy.outcome == 'failure'
+        continue-on-error: true
+        run: |
+          enos scenario exec --cmd graph --chdir ./enos ${{ matrix.filter }}
+          TF_DIR=$(find ./enos/.enos/ -type d -mindepth 1 -maxdepth 1  | tail -1)
+          pushd "${TF_DIR}"
+          terraform state list
+          terraform state show module.create_base_infra.aws_route.igw
+          popd
       - name: Destroy Enos scenario (Retry)
         if: ${{ always() && steps.destroy.outcome == 'failure' }}
         run: |


### PR DESCRIPTION
This PR updates the GitHub Action workflow that runs the e2e tests to grab logs from the enos/terraform in order to shed some light on a flaky cleanup error we've been seeing.

```
Error: deleting EC2 Internet Gateway (igw-06f8eaf99d9358a07): DependencyViolation: The internetGateway 'igw-06f8eaf99d9358a07' has dependencies and cannot be deleted.
	status code: 400, request id: 5dcfda59-d43d-4ed6-a7ed-ccf0bed47b42
```