### PR TITLE
chore(e2e): Set terraform version to 1.5 until issue is addressed

### DIFF
--- a/.github/workflows/enos-fmt.yml
+++ b/.github/workflows/enos-fmt.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1    # TSCCR: loading action configs: failed to query HEAD reference: failed to get advertised references: authorization failed
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7 # QT-623: pin to terraform 1.5.x until a tfjson bug is resolved
       - uses: hashicorp/action-setup-enos@v1    # TSCCR: loading action configs: failed to query HEAD reference: failed to get advertised references: authorization failed
         with:
           github-token: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -125,6 +125,7 @@ jobs:
           # the terraform wrapper will break Terraform execution in enos because
           # it changes the output to text when we expect it to be JSON.
           terraform_wrapper: false
+          terraform_version: 1.5.7 # QT-623: pin to terraform 1.5.x until a tfjson bug is resolved
       - name: Import GPG key for Boundary pass keystore
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41 # v5.3.0


### PR DESCRIPTION
Terraform 1.6 was just released, and it may have caused some issues with `enos`. This PR will modify `enos` to pin it to use Terraform 1.5 until there's a fix.

```
Error: json: cannot unmarshal array into Go struct field rawState.checks of type tfjson.CheckResultStatic
```

Equivalent PR in vault: https://github.com/hashicorp/vault/pull/23508