### PR TITLE
chore(plugins/aws): Bump to v0.2.1

### DIFF
--- a/plugins/boundary/mains/aws/go.mod
+++ b/plugins/boundary/mains/aws/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/boundary/plugins/boundary/mains/aws
 go 1.20
 
 require (
-	github.com/hashicorp/boundary-plugin-aws v0.2.0
+	github.com/hashicorp/boundary-plugin-aws v0.2.1
 	github.com/hashicorp/boundary/sdk v0.0.33
 )
 

--- a/plugins/boundary/mains/aws/go.sum
+++ b/plugins/boundary/mains/aws/go.sum
@@ -68,8 +68,8 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hashicorp/boundary-plugin-aws v0.2.0 h1:zzmOrDFRL+mSQZ2kGF/bsqB6NMj127SrD7qJGJsGIq8=
-github.com/hashicorp/boundary-plugin-aws v0.2.0/go.mod h1:3uJfacGCZ0uE/DMs83VuyWJ34DnwkDx5+3cLYhe+I18=
+github.com/hashicorp/boundary-plugin-aws v0.2.1 h1:pWOLo8U21WElJZ9+p2xQwLsX9KgfF1eJ/N6KcpXR9DE=
+github.com/hashicorp/boundary-plugin-aws v0.2.1/go.mod h1:3uJfacGCZ0uE/DMs83VuyWJ34DnwkDx5+3cLYhe+I18=
 github.com/hashicorp/boundary/sdk v0.0.33 h1:kHaVZ3b9j1QvYlG+vhAgrbXh8/+Rq2qlUIs8fKMQH7k=
 github.com/hashicorp/boundary/sdk v0.0.33/go.mod h1:jn9j5mM8v2pOk8aLeJNIszdm7WBf4gRSP68iy8Iu5Q0=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
This new version fixes a problem with static credentials set as environment variables.