### PR TITLE
test(server): Fix flakiness in TestServer_ReloadWorkerTags

### DIFF
--- a/internal/cmd/commands/server/worker_initial_upstreams_reload_test.go
+++ b/internal/cmd/commands/server/worker_initial_upstreams_reload_test.go
@@ -97,7 +97,7 @@ pollFirstController:
 	for {
 		select {
 		case <-timeout.C:
-			t.Fatalf("timeout wait for worker to connect to first controller")
+			t.Fatalf("timeout waiting for worker to connect to first controller")
 		case <-poll.C:
 			w, err = serversRepo.LookupWorkerByName(testController.Context(), "test")
 			require.NoError(err)
@@ -168,7 +168,7 @@ pollSecondController:
 	for {
 		select {
 		case <-timeout.C:
-			t.Fatalf("timeout wait for worker to connect to second controller")
+			t.Fatalf("timeout waiting for worker to connect to second controller")
 		case <-poll.C:
 			w, err = serversRepo.LookupWorkerByName(testController2.Context(), "test")
 			require.NoError(err)

--- a/internal/cmd/commands/server/worker_tags_reload_test.go
+++ b/internal/cmd/commands/server/worker_tags_reload_test.go
@@ -80,6 +80,7 @@ func TestServer_ReloadWorkerTags(t *testing.T) {
 		controller.WithWorkerAuthKms(workerAuthWrapper),
 		controller.WithRootKms(rootWrapper),
 		controller.WithRecoveryKms(recoveryWrapper),
+		controller.WithEnableEventing(),
 	)
 	t.Cleanup(testController.Shutdown)
 
@@ -154,6 +155,7 @@ pollController:
 	// Set new tags on worker
 	t.Log("Restart worker with new tags...")
 	cmd.presetConfig.Store(fmt.Sprintf(workerBaseConfig+tag2Config, key, testController.ClusterAddrs()[0]))
+	t.Logf("%s", workerBaseConfig+tag2Config)
 	cmd.SighupCh <- struct{}{}
 	select {
 	case <-cmd.reloadedCh:

--- a/internal/cmd/commands/server/worker_tags_reload_test.go
+++ b/internal/cmd/commands/server/worker_tags_reload_test.go
@@ -176,13 +176,11 @@ pollControllerAgain:
 			w, err = serversRepo.LookupWorkerByName(testController.Context(), "test")
 			require.NoError(err)
 			if w != nil {
+				t.Logf("%s, %+v", w.GetLastStatusTime().AsTime().Round(time.Second), w.GetConfigTags())
 				switch {
 				case lastStatusTime.IsZero():
 					lastStatusTime = w.GetLastStatusTime().AsTime().Round(time.Second)
-					t.Log(lastStatusTime)
 				default:
-					t.Log(w.GetLastStatusTime().AsTime().Round(time.Second))
-
 					if !lastStatusTime.Round(time.Second).Equal(w.GetLastStatusTime().AsTime().Round(time.Second)) {
 						if i == 3 {
 							timeout.Stop()

--- a/testing/controller/controller.go
+++ b/testing/controller/controller.go
@@ -124,8 +124,8 @@ func DisableDatabaseCreation() Option {
 	}
 }
 
-// DisableDatabaseCreation skips creating a database in docker and allows one to
-// be provided through a tcOptions.
+// DisableDatabaseDestruction skips destoying the database in docker and allows
+// it to be examined after-the-fact
 func DisableDatabaseDestruction() Option {
 	return func(c *option) error {
 		c.setDisableDatabaseDestruction = true


### PR DESCRIPTION
This PR attempts to address flakiness in `TestServer_ReloadWorkerTags` by replacing hard-coded sleeps with some smarter polling similarly used in `TestServer_ReloadInitialUpstreams`. This test would occasionally fail for the following reason...
```
--- FAIL: TestServer_ReloadWorkerTags (121.34s)
                                               
    worker_tags_reload_test.go:126: 
        	Error Trace:	/home/runner/actions-runner/_work/boundary-enterprise/boundary-enterprise/internal/cmd/commands/server/worker_tags_reload_test.go:108
        	            				/home/runner/actions-runner/_work/boundary-enterprise/boundary-enterprise/internal/cmd/commands/server/worker_tags_reload_test.go:126
        	Error:      	Should be true
        	Test:       	TestServer_ReloadWorkerTags
```

The test is expecting the controller to get updated worker tags, but sometimes, it's not getting the expected values. The initial theory is that the hard-coded sleeps didn't wait long enough for the changes to propagate to the controller. 