### PR TITLE
Unauthenticated users don't recurse except for authmethods and scopes

### DIFF
--- a/internal/daemon/controller/handlers/authtokens/authtoken_service.go
+++ b/internal/daemon/controller/handlers/authtokens/authtoken_service.go
@@ -73,9 +73,8 @@ func (s Service) ListAuthTokens(ctx context.Context, req *pbs.ListAuthTokensRequ
 	if authResults.Error != nil {
 		// If it's forbidden, and it's a recursive request, and they're
 		// successfully authenticated but just not authorized, keep going as we
-		// may have authorization on downstream scopes. Or, if they've not
-		// authenticated, still process in case u_anon has permissions.
-		if (authResults.Error == handlers.ForbiddenError() || authResults.Error == handlers.UnauthenticatedError()) &&
+		// may have authorization on downstream scopes.
+		if authResults.Error == handlers.ForbiddenError() &&
 			req.GetRecursive() &&
 			authResults.AuthenticationFinished {
 		} else {

--- a/internal/daemon/controller/handlers/credentialstores/credentialstore_service.go
+++ b/internal/daemon/controller/handlers/credentialstores/credentialstore_service.go
@@ -128,9 +128,8 @@ func (s Service) ListCredentialStores(ctx context.Context, req *pbs.ListCredenti
 	if authResults.Error != nil {
 		// If it's forbidden, and it's a recursive request, and they're
 		// successfully authenticated but just not authorized, keep going as we
-		// may have authorization on downstream scopes. Or, if they've not
-		// authenticated, still process in case u_anon has permissions.
-		if (authResults.Error == handlers.ForbiddenError() || authResults.Error == handlers.UnauthenticatedError()) &&
+		// may have authorization on downstream scopes.
+		if authResults.Error == handlers.ForbiddenError() &&
 			req.GetRecursive() &&
 			authResults.AuthenticationFinished {
 		} else {

--- a/internal/daemon/controller/handlers/groups/group_service.go
+++ b/internal/daemon/controller/handlers/groups/group_service.go
@@ -88,9 +88,8 @@ func (s Service) ListGroups(ctx context.Context, req *pbs.ListGroupsRequest) (*p
 	if authResults.Error != nil {
 		// If it's forbidden, and it's a recursive request, and they're
 		// successfully authenticated but just not authorized, keep going as we
-		// may have authorization on downstream scopes. Or, if they've not
-		// authenticated, still process in case u_anon has permissions.
-		if (authResults.Error == handlers.ForbiddenError() || authResults.Error == handlers.UnauthenticatedError()) &&
+		// may have authorization on downstream scopes.
+		if authResults.Error == handlers.ForbiddenError() &&
 			req.GetRecursive() &&
 			authResults.AuthenticationFinished {
 		} else {

--- a/internal/daemon/controller/handlers/groups/group_service_test.go
+++ b/internal/daemon/controller/handlers/groups/group_service_test.go
@@ -12,12 +12,17 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/groups"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
+	authpb "github.com/hashicorp/boundary/internal/gen/controller/auth"
 	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/requests"
+	"github.com/hashicorp/boundary/internal/server"
 	"github.com/hashicorp/boundary/internal/types/scope"
 	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/groups"
 	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/scopes"
@@ -211,6 +216,69 @@ func TestGet(t *testing.T) {
 			assert.Empty(cmp.Diff(got, tc.res, protocmp.Transform()), "GetGroup(%q) got response\n%q, wanted\n%q", req, got, tc.res)
 		})
 	}
+}
+
+func TestAnonAuth(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kms := kms.TestKms(t, conn, wrapper)
+
+	rw := db.New(conn)
+
+	iamRepo := iam.TestRepo(t, conn, wrapper)
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	tokenRepoFn := func() (*authtoken.Repository, error) {
+		return authtoken.NewRepository(ctx, rw, rw, kms)
+	}
+	serversRepoFn := func() (*server.Repository, error) {
+		return server.NewRepository(ctx, rw, rw, kms)
+	}
+
+	org, proj := iam.TestScopes(t, iamRepo)
+	at := authtoken.TestAuthToken(t, conn, kms, org.GetPublicId())
+
+	r := iam.TestRole(t, conn, proj.GetPublicId())
+	_ = iam.TestUserRole(t, conn, r.GetPublicId(), at.GetIamUserId())
+	_ = iam.TestRoleGrant(t, conn, r.GetPublicId(), "id=*;type=*;actions=*")
+
+	ar := iam.TestRole(t, conn, proj.GetPublicId())
+	_ = iam.TestUserRole(t, conn, ar.GetPublicId(), globals.AnonymousUserId)
+	_ = iam.TestRoleGrant(t, conn, ar.GetPublicId(), "id=*;type=*;actions=*")
+
+	iam.TestGroup(t, conn, org.GetPublicId())
+
+	s, err := groups.NewService(ctx, iamRepoFn)
+	require.NoError(t, err)
+
+	authedReqInfo := authpb.RequestInfo{
+		TokenFormat: uint32(auth.AuthTokenTypeBearer),
+		PublicId:    at.GetPublicId(),
+		Token:       at.GetToken(),
+	}
+	authedReqCtx := context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+	authedCtx := auth.NewVerifierContext(authedReqCtx, iamRepoFn, tokenRepoFn, serversRepoFn, kms, &authedReqInfo)
+
+	anonReqInfo := authpb.RequestInfo{
+		TokenFormat: uint32(auth.AuthTokenTypeUnknown),
+	}
+	anonReqCtx := context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+	anonCtx := auth.NewVerifierContext(anonReqCtx, iamRepoFn, tokenRepoFn, serversRepoFn, kms, &anonReqInfo)
+
+	_, err = s.ListGroups(authedCtx, &pbs.ListGroupsRequest{
+		ScopeId:   "global",
+		Recursive: true,
+	})
+	require.NoError(t, err)
+
+	_, err = s.ListGroups(anonCtx, &pbs.ListGroupsRequest{
+		ScopeId:   "global",
+		Recursive: true,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, handlers.UnauthenticatedError())
 }
 
 func TestList(t *testing.T) {

--- a/internal/daemon/controller/handlers/host_catalogs/host_catalog_service.go
+++ b/internal/daemon/controller/handlers/host_catalogs/host_catalog_service.go
@@ -129,9 +129,8 @@ func (s Service) ListHostCatalogs(ctx context.Context, req *pbs.ListHostCatalogs
 	if authResults.Error != nil {
 		// If it's forbidden, and it's a recursive request, and they're
 		// successfully authenticated but just not authorized, keep going as we
-		// may have authorization on downstream projects. Or, if they've not
-		// authenticated, still process in case u_anon has permissions.
-		if (authResults.Error == handlers.ForbiddenError() || authResults.Error == handlers.UnauthenticatedError()) &&
+		// may have authorization on downstream projects.
+		if authResults.Error == handlers.ForbiddenError() &&
 			req.GetRecursive() &&
 			authResults.AuthenticationFinished {
 		} else {

--- a/internal/daemon/controller/handlers/roles/role_service.go
+++ b/internal/daemon/controller/handlers/roles/role_service.go
@@ -92,9 +92,8 @@ func (s Service) ListRoles(ctx context.Context, req *pbs.ListRolesRequest) (*pbs
 	if authResults.Error != nil {
 		// If it's forbidden, and it's a recursive request, and they're
 		// successfully authenticated but just not authorized, keep going as we
-		// may have authorization on downstream scopes. Or, if they've not
-		// authenticated, still process in case u_anon has permissions.
-		if (authResults.Error == handlers.ForbiddenError() || authResults.Error == handlers.UnauthenticatedError()) &&
+		// may have authorization on downstream scopes.
+		if authResults.Error == handlers.ForbiddenError() &&
 			req.GetRecursive() &&
 			authResults.AuthenticationFinished {
 		} else {

--- a/internal/daemon/controller/handlers/roles/role_service_test.go
+++ b/internal/daemon/controller/handlers/roles/role_service_test.go
@@ -14,14 +14,18 @@ import (
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/auth/ldap"
 	"github.com/hashicorp/boundary/internal/auth/oidc"
+	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/roles"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
+	authpb "github.com/hashicorp/boundary/internal/gen/controller/auth"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/perms"
+	"github.com/hashicorp/boundary/internal/requests"
+	"github.com/hashicorp/boundary/internal/server"
 	"github.com/hashicorp/boundary/internal/types/scope"
 	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/roles"
 	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/scopes"
@@ -188,6 +192,67 @@ func TestGet(t *testing.T) {
 			assert.Empty(cmp.Diff(got, tc.res, protocmp.Transform()), "GetRole(%q) got response\n%q, wanted\n%q", req, got, tc.res)
 		})
 	}
+}
+
+func TestAnonAuth(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kms := kms.TestKms(t, conn, wrapper)
+
+	rw := db.New(conn)
+
+	iamRepo := iam.TestRepo(t, conn, wrapper)
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	tokenRepoFn := func() (*authtoken.Repository, error) {
+		return authtoken.NewRepository(ctx, rw, rw, kms)
+	}
+	serversRepoFn := func() (*server.Repository, error) {
+		return server.NewRepository(ctx, rw, rw, kms)
+	}
+
+	org, proj := iam.TestScopes(t, iamRepo)
+	at := authtoken.TestAuthToken(t, conn, kms, org.GetPublicId())
+
+	r := iam.TestRole(t, conn, proj.GetPublicId())
+	_ = iam.TestUserRole(t, conn, r.GetPublicId(), at.GetIamUserId())
+	_ = iam.TestRoleGrant(t, conn, r.GetPublicId(), "id=*;type=*;actions=*")
+
+	ar := iam.TestRole(t, conn, proj.GetPublicId())
+	_ = iam.TestUserRole(t, conn, ar.GetPublicId(), globals.AnonymousUserId)
+	_ = iam.TestRoleGrant(t, conn, ar.GetPublicId(), "id=*;type=*;actions=*")
+
+	s, err := roles.NewService(ctx, iamRepoFn)
+	require.NoError(t, err)
+
+	authedReqInfo := authpb.RequestInfo{
+		TokenFormat: uint32(auth.AuthTokenTypeBearer),
+		PublicId:    at.GetPublicId(),
+		Token:       at.GetToken(),
+	}
+	authedReqCtx := context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+	authedCtx := auth.NewVerifierContext(authedReqCtx, iamRepoFn, tokenRepoFn, serversRepoFn, kms, &authedReqInfo)
+
+	anonReqInfo := authpb.RequestInfo{
+		TokenFormat: uint32(auth.AuthTokenTypeUnknown),
+	}
+	anonReqCtx := context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+	anonCtx := auth.NewVerifierContext(anonReqCtx, iamRepoFn, tokenRepoFn, serversRepoFn, kms, &anonReqInfo)
+
+	_, err = s.ListRoles(authedCtx, &pbs.ListRolesRequest{
+		ScopeId:   "global",
+		Recursive: true,
+	})
+	require.NoError(t, err)
+
+	_, err = s.ListRoles(anonCtx, &pbs.ListRolesRequest{
+		ScopeId:   "global",
+		Recursive: true,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, handlers.UnauthenticatedError())
 }
 
 func TestList(t *testing.T) {

--- a/internal/daemon/controller/handlers/sessions/session_service.go
+++ b/internal/daemon/controller/handlers/sessions/session_service.go
@@ -132,9 +132,8 @@ func (s Service) ListSessions(ctx context.Context, req *pbs.ListSessionsRequest)
 	if authResults.Error != nil {
 		// If it's forbidden, and it's a recursive request, and they're
 		// successfully authenticated but just not authorized, keep going as we
-		// may have authorization on downstream scopes. Or, if they've not
-		// authenticated, still process in case u_anon has permissions.
-		if (authResults.Error == handlers.ForbiddenError() || authResults.Error == handlers.UnauthenticatedError()) &&
+		// may have authorization on downstream scopes.
+		if authResults.Error == handlers.ForbiddenError() &&
 			req.GetRecursive() &&
 			authResults.AuthenticationFinished {
 		} else {

--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -197,9 +197,8 @@ func (s Service) ListTargets(ctx context.Context, req *pbs.ListTargetsRequest) (
 	if authResults.Error != nil {
 		// If it's forbidden, and it's a recursive request, and they're
 		// successfully authenticated but just not authorized, keep going as we
-		// may have authorization on downstream scopes. Or, if they've not
-		// authenticated, still process in case u_anon has permissions.
-		if (authResults.Error == handlers.ForbiddenError() || authResults.Error == handlers.UnauthenticatedError()) &&
+		// may have authorization on downstream scopes.
+		if authResults.Error == handlers.ForbiddenError() &&
 			req.GetRecursive() &&
 			authResults.AuthenticationFinished {
 		} else {

--- a/internal/daemon/controller/handlers/users/user_service.go
+++ b/internal/daemon/controller/handlers/users/user_service.go
@@ -88,9 +88,8 @@ func (s Service) ListUsers(ctx context.Context, req *pbs.ListUsersRequest) (*pbs
 	if authResults.Error != nil {
 		// If it's forbidden, and it's a recursive request, and they're
 		// successfully authenticated but just not authorized, keep going as we
-		// may have authorization on downstream scopes. Or, if they've not
-		// authenticated, still process in case u_anon has permissions.
-		if (authResults.Error == handlers.ForbiddenError() || authResults.Error == handlers.UnauthenticatedError()) &&
+		// may have authorization on downstream scopes.
+		if authResults.Error == handlers.ForbiddenError() &&
 			req.GetRecursive() &&
 			authResults.AuthenticationFinished {
 		} else {

--- a/internal/daemon/controller/handlers/workers/worker_service.go
+++ b/internal/daemon/controller/handlers/workers/worker_service.go
@@ -124,9 +124,8 @@ func (s Service) ListWorkers(ctx context.Context, req *pbs.ListWorkersRequest) (
 	if authResults.Error != nil {
 		// If it's forbidden, and it's a recursive request, and they're
 		// successfully authenticated but just not authorized, keep going as we
-		// may have authorization on downstream scopes. Or, if they've not
-		// authenticated, still process in case u_anon has permissions.
-		if (authResults.Error == handlers.ForbiddenError() || authResults.Error == handlers.UnauthenticatedError()) &&
+		// may have authorization on downstream scopes.
+		if authResults.Error == handlers.ForbiddenError() &&
 			req.GetRecursive() &&
 			authResults.AuthenticationFinished {
 		} else {


### PR DESCRIPTION
Recursive listing for an u_anon is disabled for all resources except for auth methods and scopes.  This PR removes an authResult exception added before that change was made that would allow u_anon requests to potentially recurse for other top level resources