### PR TITLE
New generic pagination

### DIFF
--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/boundary/internal/host/plugin"
 	"github.com/hashicorp/boundary/internal/host/static"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/pagination"
 	"github.com/hashicorp/boundary/internal/perms"
 	"github.com/hashicorp/boundary/internal/refreshtoken"
 	"github.com/hashicorp/boundary/internal/requests"
@@ -249,7 +250,7 @@ func (s Service) ListTargets(ctx context.Context, req *pbs.ListTargetsRequest) (
 	if err != nil {
 		return nil, err
 	}
-	filterItemFn := func(item target.Target) (bool, error) {
+	filterItemFn := func(ctx context.Context, item target.Target) (bool, error) {
 		pbItem, err := toProto(ctx, item, newOutputOpts(ctx, item, authResults, authzScopes)...)
 		if err != nil {
 			return false, err
@@ -266,7 +267,7 @@ func (s Service) ListTargets(ctx context.Context, req *pbs.ListTargetsRequest) (
 		return nil, err
 	}
 
-	var listResp *target.ListResponse
+	var listResp *pagination.ListResponse2[target.Target]
 	if req.GetRefreshToken() == "" {
 		listResp, err = target.List(ctx, repo, grantsHash, pageSize, filterItemFn)
 		if err != nil {
@@ -315,7 +316,7 @@ func (s Service) ListTargets(ctx context.Context, req *pbs.ListTargetsRequest) (
 	}
 	resp := &pbs.ListTargetsResponse{
 		Items:        finalItems,
-		EstItemCount: uint32(listResp.EstimatedTotalItems),
+		EstItemCount: uint32(listResp.EstimatedItemCount),
 		RemovedIds:   listResp.DeletedIds,
 		ResponseType: respType,
 		SortBy:       "updated_time",

--- a/internal/pagination/doc.go
+++ b/internal/pagination/doc.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package pagination implements generic functions for paginating
+// through a collection using callbacks. The functions will automatically
+// request additional items to match the input page size even when
+// some items may be filtered out.
+// See example_test.go for examples of using the library.
+package pagination

--- a/internal/pagination/example_test.go
+++ b/internal/pagination/example_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package pagination_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/boundary/internal/boundary"
+	"github.com/hashicorp/boundary/internal/db/timestamp"
+	"github.com/hashicorp/boundary/internal/pagination"
+	"github.com/hashicorp/boundary/internal/refreshtoken"
+	"github.com/hashicorp/boundary/internal/types/resource"
+)
+
+// An example resource. In a real example, this would
+// be a Target or Session or similar.
+type ExampleResource struct {
+	boundary.Resource
+	Value int
+}
+
+func (e *ExampleResource) GetPublicId() string {
+	return "er_1234567890"
+}
+
+func (e *ExampleResource) GetUpdateTime() *timestamp.Timestamp {
+	return timestamp.New(time.Now().Add(-10 * time.Hour))
+}
+
+func (e *ExampleResource) GetResourceType() resource.Type {
+	return resource.Unknown
+}
+
+func ExampleList() {
+	grantsHash := []byte("hash-of-grants") // Acquired from authorization logic
+	pageSize := 10                         // From request or service default
+	filterItemFunc := func(ctx context.Context, item *ExampleResource) (bool, error) {
+		// Inspect item to determine whether we want to
+		// include it in the final list.
+		return item.Value < 5, nil
+	}
+	listItemsFunc := func(ctx context.Context, prevPageLast *ExampleResource, limit int) ([]*ExampleResource, error) {
+		// Do the listing of the resource, generally using a
+		// repository method such as target.(*Repository).listTargets.
+		// Use the input to set up any options, for example a limit
+		// or a starting point.
+		if prevPageLast == nil {
+			// No previous page item means this is the first list request.
+			// List using limit.
+			// opts := target.Option{
+			//	target.WithLimit(limit),
+			// }
+		} else {
+			// Use the previous page last item to start pagination from the
+			// next page.
+			// opts := target.Option{
+			//	target.WithLimit(limit),
+			//	target.WithStartPageAfterItem(prevPageLast.GetPublicId(), prevPageLast.GetUpdateTime()),
+			// }
+		}
+		// Example result from the repository
+		return []*ExampleResource{
+			{nil, 0},
+			{nil, 1},
+			{nil, 2},
+			{nil, 3},
+			{nil, 4},
+			{nil, 5},
+			{nil, 6},
+			{nil, 7},
+			{nil, 8},
+			{nil, 9},
+			{nil, 10},
+		}, nil
+	}
+	estimatedCountFunc := func(ctx context.Context) (int, error) {
+		// Get an estimate from the database of the total number
+		// of entries for this resource, usually using some
+		// repository method.
+		return 1000, nil
+	}
+	resp, err := pagination.List(context.Background(), grantsHash, pageSize, filterItemFunc, listItemsFunc, estimatedCountFunc)
+	if err != nil {
+		fmt.Println("failed to paginate", err)
+		return
+	}
+	fmt.Println("Got results:")
+	for _, item := range resp.Items {
+		fmt.Printf("\tValue: %d\n", item.Value)
+	}
+	if resp.CompleteListing {
+		fmt.Println("Listing was complete")
+	} else {
+		fmt.Println("Listing was not complete")
+	}
+	fmt.Println("There are an estimated", resp.EstimatedItemCount, "total items available")
+	// Output: Got results:
+	//	Value: 0
+	//	Value: 1
+	//	Value: 2
+	//	Value: 3
+	//	Value: 4
+	//	Value: 0
+	//	Value: 1
+	//	Value: 2
+	//	Value: 3
+	//	Value: 4
+	// Listing was not complete
+	// There are an estimated 1000 total items available
+}
+
+func ExampleListRefresh() {
+	grantsHash := []byte("hash-of-grants") // Acquired from authorization logic
+	pageSize := 10                         // From request or service default
+	refreshToken, err := refreshtoken.New( // Normally from incoming request
+		context.Background(),
+		time.Now(),
+		time.Now(),
+		resource.Unknown,
+		grantsHash,
+		"er_1234567890",
+		time.Now().Add(-time.Hour),
+	)
+	if err != nil {
+		fmt.Println("failed to paginate", err)
+		return
+	}
+	filterItemFunc := func(ctx context.Context, item *ExampleResource) (bool, error) {
+		// Inspect item to determine whether we want to
+		// include it in the final list.
+		return item.Value < 5, nil
+	}
+	listItemsFunc := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *ExampleResource, limit int) ([]*ExampleResource, error) {
+		// Do the listing of the resource, generally using a
+		// repository method such as target.(*Repository).listTargets.
+		// Use the input to set up any options, for example a limit
+		// or a starting point.
+		if prevPageLast == nil {
+			// No previous page item means use the values from the refresh token.
+			// opts := target.Option{
+			//	target.WithLimit(limit),
+			//	target.WithStartPageAfterItem(tok.GetPublicId(), tok.GetUpdateTime()),
+			// }
+		} else {
+			// Use the previous page last item to start pagination from the next page.
+			// opts := target.Option{
+			//	target.WithLimit(limit),
+			//	target.WithStartPageAfterItem(prevPageLast.GetPublicId(), prevPageLast.GetUpdateTime()),
+			// }
+		}
+		// Example result from the repository
+		return []*ExampleResource{
+			{nil, 0},
+			{nil, 1},
+			{nil, 2},
+			{nil, 3},
+			{nil, 4},
+			{nil, 5},
+			{nil, 6},
+			{nil, 7},
+			{nil, 8},
+			{nil, 9},
+			{nil, 10},
+		}, nil
+	}
+	estimatedCountFunc := func(ctx context.Context) (int, error) {
+		// Get an estimate from the database of the total number
+		// of entries for this resource, usually using some
+		// repository method.
+		return 1000, nil
+	}
+	deletedIdsFunc := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+		// Return IDs of resources that have been deleted since the provided timestamp.
+		// Also return a timestamp for which this list was created, allowing the next
+		// invocation to start from the point where this invocation left off.
+		return []string{"er_0123456789"}, time.Now(), nil
+	}
+	resp, err := pagination.ListRefresh(context.Background(), refreshToken, grantsHash, pageSize, filterItemFunc, listItemsFunc, estimatedCountFunc, deletedIdsFunc)
+	if err != nil {
+		fmt.Println("failed to paginate", err)
+		return
+	}
+	fmt.Println("Got results:")
+	for _, item := range resp.Items {
+		fmt.Printf("\tValue: %d\n", item.Value)
+	}
+	if resp.CompleteListing {
+		fmt.Println("Listing was complete")
+	} else {
+		fmt.Println("Listing was not complete")
+	}
+	fmt.Println("There are an estimated", resp.EstimatedItemCount, "total items available")
+	fmt.Println("The following resources have been deleted since we last saw them:")
+	for _, id := range resp.DeletedIds {
+		fmt.Println("\t" + id)
+	}
+	// Output: Got results:
+	//	Value: 0
+	//	Value: 1
+	//	Value: 2
+	//	Value: 3
+	//	Value: 4
+	//	Value: 0
+	//	Value: 1
+	//	Value: 2
+	//	Value: 3
+	//	Value: 4
+	// Listing was not complete
+	// There are an estimated 1000 total items available
+	// The following resources have been deleted since we last saw them:
+	//	er_0123456789
+}

--- a/internal/pagination/example_test.go
+++ b/internal/pagination/example_test.go
@@ -178,7 +178,7 @@ func ExampleListRefresh() {
 		// invocation to start from the point where this invocation left off.
 		return []string{"er_0123456789"}, time.Now(), nil
 	}
-	resp, err := pagination.ListRefresh(context.Background(), refreshToken, grantsHash, pageSize, filterItemFunc, listItemsFunc, estimatedCountFunc, deletedIdsFunc)
+	resp, err := pagination.ListRefresh(context.Background(), grantsHash, pageSize, filterItemFunc, listItemsFunc, estimatedCountFunc, deletedIdsFunc, refreshToken)
 	if err != nil {
 		fmt.Println("failed to paginate", err)
 		return

--- a/internal/pagination/pagination2.go
+++ b/internal/pagination/pagination2.go
@@ -127,13 +127,13 @@ func List[T boundary.Resource](
 // resources that have been deleted since the refresh token was last used.
 func ListRefresh[T boundary.Resource](
 	ctx context.Context,
-	tok *refreshtoken.Token,
 	grantsHash []byte,
 	pageSize int,
 	filterItemFn ListFilterFunc[T],
 	listRefreshItemsFn ListRefreshItemsFunc[T],
 	estimatedCountFn EstimatedCountFunc,
 	listDeletedIDsFn ListDeletedIDsFunc,
+	tok *refreshtoken.Token,
 ) (*ListResponse2[T], error) {
 	const op = "pagination.ListRefresh"
 

--- a/internal/pagination/pagination2.go
+++ b/internal/pagination/pagination2.go
@@ -1,0 +1,223 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package pagination
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/boundary/internal/boundary"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/refreshtoken"
+)
+
+// ListResponse2 represents the response from the paginated list operation.
+type ListResponse2[T boundary.Resource] struct {
+	// Items contains the page of items. They have
+	// been filtered according to the behaviour of
+	// the filter item func, and will always have as
+	// many items as requested in the page size, unless
+	// there were not enough elements available, in
+	// which case it will contain all elements that
+	// were available.
+	Items []T
+	// CompleteListing signifies whether this page contains
+	// the final item currently available. This indicates
+	// that it may be appropriate to wait some time before
+	// requesting additional pages.
+	CompleteListing bool
+	// RefreshToken is the token that the caller can use
+	// to request a new page of items. The items in the
+	// new page will have been updated more recently
+	// than all the items in the previous page. This
+	// field may be empty if there were no results for a
+	// List call.
+	RefreshToken *refreshtoken.Token
+	// DeletedIds contains a list of item IDs that have been
+	// deleted since the last request for items. This can happen
+	// both during the initial pagination or when requesting a
+	// refresh. This is always empty for the initial List call.
+	DeletedIds []string
+	// EstimatedItemCount is an estimate on exactly how many
+	// items matching the filter function are available. If
+	// a List call is complete, this number is equal to
+	// the number of items returned. Otherwise, the
+	// estimated count function is consulted for an estimate.
+	EstimatedItemCount int
+}
+
+// ListFilterFunc is a callback used to filter out resources that don't match
+// some criteria. The function must return true for items that should be included in the final
+// result. Returning an error results in an error being returned from the pagination.
+type ListFilterFunc[T boundary.Resource] func(ctx context.Context, item T) (bool, error)
+
+// ListItemsFunc2 returns a slice of T that have been updated since prevPageLastItem.
+// If prevPageLastItem is empty, it returns a slice of T starting with the least recently updated.
+type ListItemsFunc2[T boundary.Resource] func(ctx context.Context, prevPageLastItem T, limit int) ([]T, error)
+
+// ListRefreshItemsFunc returns a slice of T that have been updated since prevPageLastItem.
+// If prevPageLastItem is empty, it returns a slice of T that have been updated since the
+// item in the refresh token.
+type ListRefreshItemsFunc[T boundary.Resource] func(ctx context.Context, tok *refreshtoken.Token, prevPageLastItem T, limit int) ([]T, error)
+
+// EstimatedCountFunc is used to estimate the total number of items
+// available for the resource that is being listed.
+type EstimatedCountFunc func(ctx context.Context) (int, error)
+
+// ListDeletedIDsFunc is used to list the IDs of the resources deleted since
+// the given timestamp. It returns a slice of IDs and the timestamp of the
+// instant in which the slice was created.
+type ListDeletedIDsFunc func(ctx context.Context, since time.Time) ([]string, time.Time, error)
+
+// List returns a ListResponse. The response will contain at most a
+// number of items equal to the pageSize. Items are fetched using the
+// listItemsFn and then items are checked using the filterItemFn
+// to determine if they should be included in the response.
+// The response includes a new refresh token based on the grants and items.
+// The estimatedCountFn is used to provide an estimated total number of
+// items that can be returned by making additional requests using the provided
+// refresh token.
+func List[T boundary.Resource](
+	ctx context.Context,
+	grantsHash []byte,
+	pageSize int,
+	filterItemFn ListFilterFunc[T],
+	listItemsFn ListItemsFunc2[T],
+	estimatedCountFn EstimatedCountFunc,
+) (*ListResponse2[T], error) {
+	const op = "pagination.List"
+
+	items, completeListing, err := list(ctx, grantsHash, pageSize, filterItemFn, listItemsFn)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
+
+	resp := &ListResponse2[T]{
+		Items:              items,
+		CompleteListing:    completeListing,
+		EstimatedItemCount: len(items),
+	}
+
+	if !completeListing {
+		// If this was not a complete listing, get an estimate
+		// of the total items from the DB.
+		var err error
+		resp.EstimatedItemCount, err = estimatedCountFn(ctx)
+		if err != nil {
+			return nil, errors.Wrap(ctx, err, op)
+		}
+	}
+
+	if len(items) > 0 {
+		resp.RefreshToken = refreshtoken.FromResource(items[len(items)-1], grantsHash)
+	}
+
+	return resp, nil
+}
+
+// ListRefresh returns a ListResponse. The response will contain at most a
+// number of items equal to the pageSize. Items are fetched using the
+// listRefreshItemsFn and then items are checked using the filterItemFn
+// to determine if they should be included in the response.
+// The response includes a new refresh token based on the grants and items.
+// The estimatedCountFn is used to provide an estimated total number of
+// items that can be returned by making additional requests using the provided
+// refresh token. The listDeletedIDsFn is used to list the IDs of any
+// resources that have been deleted since the refresh token was last used.
+func ListRefresh[T boundary.Resource](
+	ctx context.Context,
+	tok *refreshtoken.Token,
+	grantsHash []byte,
+	pageSize int,
+	filterItemFn ListFilterFunc[T],
+	listRefreshItemsFn ListRefreshItemsFunc[T],
+	estimatedCountFn EstimatedCountFunc,
+	listDeletedIDsFn ListDeletedIDsFunc,
+) (*ListResponse2[T], error) {
+	const op = "pagination.ListRefresh"
+
+	deletedIds, transactionTimestamp, err := listDeletedIDsFn(ctx, tok.UpdatedTime)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
+
+	listItemsFn := func(ctx context.Context, prevPageLast T, limit int) ([]T, error) {
+		return listRefreshItemsFn(ctx, tok, prevPageLast, limit)
+	}
+
+	items, completeListing, err := list(ctx, grantsHash, pageSize, filterItemFn, listItemsFn)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
+
+	resp := &ListResponse2[T]{
+		Items:           items,
+		CompleteListing: completeListing,
+		DeletedIds:      deletedIds,
+	}
+
+	resp.EstimatedItemCount, err = estimatedCountFn(ctx)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
+
+	if len(items) > 0 {
+		resp.RefreshToken = tok.RefreshLastItem(items[len(items)-1], transactionTimestamp)
+	} else {
+		resp.RefreshToken = tok.Refresh(transactionTimestamp)
+	}
+
+	return resp, nil
+}
+
+func list[T boundary.Resource](
+	ctx context.Context,
+	grantsHash []byte,
+	pageSize int,
+	filterItemFn ListFilterFunc[T],
+	listItemsFn ListItemsFunc2[T],
+) ([]T, bool, error) {
+	const op = "pagination.list"
+
+	var lastItem T
+	limit := pageSize + 1
+	items := make([]T, 0, limit)
+dbLoop:
+	for {
+		// Request another page from the DB until we fill the final items
+		page, err := listItemsFn(ctx, lastItem, limit)
+		if err != nil {
+			return nil, false, errors.Wrap(ctx, err, op)
+		}
+		for _, item := range page {
+			ok, err := filterItemFn(ctx, item)
+			if err != nil {
+				return nil, false, errors.Wrap(ctx, err, op)
+			}
+			if ok {
+				items = append(items, item)
+				// If we filled the items after filtering,
+				// we're done.
+				if len(items) == cap(items) {
+					break dbLoop
+				}
+			}
+		}
+		// If the current page was shorter than the limit, stop iterating
+		if len(page) < limit {
+			break dbLoop
+		}
+
+		lastItem = page[len(page)-1]
+	}
+	// If we couldn't fill the items, it was a complete listing.
+	completeListing := len(items) < cap(items)
+	if !completeListing {
+		// Items is of size pageSize+1, so
+		// truncate if it was filled.
+		items = items[:pageSize]
+	}
+
+	return items, completeListing, nil
+}

--- a/internal/pagination/pagination2_test.go
+++ b/internal/pagination/pagination2_test.go
@@ -1,0 +1,1186 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package pagination
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/boundary/internal/boundary"
+	"github.com/hashicorp/boundary/internal/db/timestamp"
+	"github.com/hashicorp/boundary/internal/refreshtoken"
+	"github.com/hashicorp/boundary/internal/types/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testType2 struct {
+	boundary.Resource
+	ID string
+}
+
+func (t *testType2) GetResourceType() resource.Type {
+	return resource.Unknown
+}
+
+func (t *testType2) GetUpdateTime() *timestamp.Timestamp {
+	return timestamp.Now()
+}
+
+func (t *testType2) GetPublicId() string {
+	return t.ID
+}
+
+func Test_List(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("no-rows", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return nil, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Items)
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 0)
+		// No response token expected when there were no results
+		assert.Nil(t, resp.RefreshToken)
+	})
+	t.Run("fill-on-first-with-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "2"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "2")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-first-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "2"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 2)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "2")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent-with-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}, {nil, "5"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 2)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("dont-fill-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 1)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("dont-fill-with-full-last-page", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			switch {
+			case prevPageLast == nil:
+				return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+			case prevPageLast.ID == "3":
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			case prevPageLast.ID == "6":
+				return nil, nil
+			default:
+				t.Fatalf("unexpected call to listItemsFn with %#v", prevPageLast)
+				return nil, nil
+			}
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 1)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("filter-everything", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			switch {
+			case prevPageLast == nil:
+				return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+			case prevPageLast.ID == "3":
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			case prevPageLast.ID == "6":
+				return nil, nil
+			default:
+				t.Fatalf("unexpected call to listItemsFn with %#v", prevPageLast)
+				return nil, nil
+			}
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			// Filter every item
+			return false, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Items)
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 0)
+		assert.Nil(t, resp.RefreshToken)
+	})
+	t.Run("errors-when-list-errors-immediately", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			return nil, errors.New("failed to list")
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.ErrorContains(t, err, "failed to list")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-list-errors-subsequently", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				return nil, errors.New("failed to list")
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.ErrorContains(t, err, "failed to list")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-filter-errors", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return false, errors.New("failed to filter")
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.ErrorContains(t, err, "failed to filter")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-estimated-count-errors", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 0, errors.New("failed to estimate count")
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.ErrorContains(t, err, "failed to estimate count")
+		assert.Empty(t, resp)
+	})
+}
+
+func Test_ListRefresh(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("no-rows", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return nil, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Items)
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-first-with-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "2"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "2")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-first-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "2"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "2")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent-with-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}, {nil, "5"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("dont-fill-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("dont-fill-with-full-last-page", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			switch {
+			case prevPageLast == nil:
+				return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+			case prevPageLast.ID == "3":
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			case prevPageLast.ID == "6":
+				return nil, nil
+			default:
+				t.Fatalf("unexpected call to listRefreshItemsFn with %#v", prevPageLast)
+				return nil, nil
+			}
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("filter-everything", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			switch {
+			case prevPageLast == nil:
+				return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+			case prevPageLast.ID == "3":
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			case prevPageLast.ID == "6":
+				return nil, nil
+			default:
+				t.Fatalf("unexpected call to listRefreshItemsFn with %#v", prevPageLast)
+				return nil, nil
+			}
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			// Filter every item
+			return false, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Items)
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("errors-when-list-errors-immediately", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			return nil, errors.New("failed to list")
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.ErrorContains(t, err, "failed to list")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-list-errors-subsequently", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				return nil, errors.New("failed to list")
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.ErrorContains(t, err, "failed to list")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-filter-errors", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return false, errors.New("failed to filter")
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.ErrorContains(t, err, "failed to filter")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-estimated-count-errors", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 0, errors.New("failed to estimate count")
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.ErrorContains(t, err, "failed to estimate count")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-listing-deleted-ids-errors", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, errors.New("failed to list deleted ids")
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			refreshToken,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+		)
+		require.ErrorContains(t, err, "failed to list deleted ids")
+		assert.Empty(t, resp)
+	})
+}

--- a/internal/pagination/pagination2_test.go
+++ b/internal/pagination/pagination2_test.go
@@ -471,13 +471,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.NoError(t, err)
 		assert.Empty(t, resp.Items)
@@ -524,13 +524,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.NoError(t, err)
 		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "2"}}))
@@ -578,13 +578,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.NoError(t, err)
 		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "2"}}))
@@ -639,13 +639,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.NoError(t, err)
 		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
@@ -700,13 +700,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.NoError(t, err)
 		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
@@ -761,13 +761,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.NoError(t, err)
 		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
@@ -822,13 +822,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.NoError(t, err)
 		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}}))
@@ -889,13 +889,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.NoError(t, err)
 		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}}))
@@ -953,13 +953,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.NoError(t, err)
 		assert.Empty(t, resp.Items)
@@ -1006,13 +1006,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.ErrorContains(t, err, "failed to list")
 		assert.Empty(t, resp)
@@ -1052,13 +1052,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.ErrorContains(t, err, "failed to list")
 		assert.Empty(t, resp)
@@ -1092,13 +1092,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.ErrorContains(t, err, "failed to filter")
 		assert.Empty(t, resp)
@@ -1132,13 +1132,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.ErrorContains(t, err, "failed to estimate count")
 		assert.Empty(t, resp)
@@ -1172,13 +1172,13 @@ func Test_ListRefresh(t *testing.T) {
 		grantsHash := []byte("some hash")
 		resp, err := ListRefresh(
 			ctx,
-			refreshToken,
 			grantsHash,
 			pageSize,
 			filterItemFn,
 			listRefreshItemsFn,
 			estimatedItemCountFn,
 			deletedIDsFn,
+			refreshToken,
 		)
 		require.ErrorContains(t, err, "failed to list deleted ids")
 		assert.Empty(t, resp)

--- a/internal/target/service_list.go
+++ b/internal/target/service_list.go
@@ -6,89 +6,31 @@ package target
 import (
 	"context"
 
-	"github.com/hashicorp/boundary/internal/errors"
-	"github.com/hashicorp/boundary/internal/refreshtoken"
+	"github.com/hashicorp/boundary/internal/pagination"
 )
-
-// This function is a callback passed down from the application service layer
-// used to filter out protobuf targets that don't match any user-supplied filter.
-type ListFilterFunc func(Target) (bool, error)
 
 // List lists targets according to the page size,
 // filtering out entries that do not
-// pass the filter item fn. It returns a new refresh token
+// pass the filter item function. It returns a new refresh token
 // based on the grants hash and the returned targets.
 func List(
 	ctx context.Context,
 	repo *Repository,
 	grantsHash []byte,
 	pageSize int,
-	filterItemFn ListFilterFunc,
-) (*ListResponse, error) {
-	const op = "target.List"
-
-	limit := pageSize + 1
-	opts := []Option{
-		WithLimit(limit),
-	}
-
-	targets := make([]Target, 0, limit)
-dbLoop:
-	for {
-		// Request another page from the DB until we fill the final items
-		page, err := repo.listTargets(ctx, opts...)
-		if err != nil {
-			return nil, errors.Wrap(ctx, err, op)
-		}
-		for _, item := range page {
-			ok, err := filterItemFn(item)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				targets = append(targets, item)
-				// If we filled the items after filtering,
-				// we're done.
-				if len(targets) == cap(targets) {
-					break dbLoop
-				}
-			}
-		}
-		// If the current page was shorter than the limit, stop iterating
-		if len(page) < limit {
-			break dbLoop
-		}
-
-		opts = []Option{
+	filterItemFn pagination.ListFilterFunc[Target],
+) (*pagination.ListResponse2[Target], error) {
+	listItemsFn := func(ctx context.Context, lastPageItem Target, limit int) ([]Target, error) {
+		opts := []Option{
 			WithLimit(limit),
-			WithStartPageAfterItem(page[len(page)-1].GetPublicId(), page[len(page)-1].GetUpdateTime().AsTime()),
 		}
-	}
-	// If we couldn't fill the items, it was a complete listing.
-	completeListing := len(targets) < cap(targets)
-	totalItems := len(targets)
-	if !completeListing {
-		// Items is of size pageSize+1, so
-		// truncate if it was filled.
-		targets = targets[:pageSize]
-		// If this was not a complete listing, get an estimate
-		// of the total items from the DB.
-		var err error
-		totalItems, err = repo.estimatedCount(ctx)
-		if err != nil {
-			return nil, errors.Wrap(ctx, err, op)
+		if lastPageItem != nil {
+			opts = append(opts,
+				WithStartPageAfterItem(lastPageItem.GetPublicId(), lastPageItem.GetUpdateTime().AsTime()),
+			)
 		}
+		return repo.listTargets(ctx, opts...)
 	}
 
-	resp := &ListResponse{
-		Items:               targets,
-		EstimatedTotalItems: totalItems,
-		CompleteListing:     completeListing,
-	}
-
-	if len(targets) > 0 {
-		resp.RefreshToken = refreshtoken.FromResource(targets[len(targets)-1], grantsHash)
-	}
-
-	return resp, nil
+	return pagination.List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, repo.estimatedCount)
 }

--- a/internal/target/service_list_ext_test.go
+++ b/internal/target/service_list_ext_test.go
@@ -62,7 +62,7 @@ func TestService_List(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("simple pagination", func(t *testing.T) {
-		filterFunc := func(t target.Target) (bool, error) {
+		filterFunc := func(_ context.Context, t target.Target) (bool, error) {
 			return true, nil
 		}
 		resp, err := target.List(ctx, repo, []byte("some hash"), 1, filterFunc)
@@ -70,7 +70,7 @@ func TestService_List(t *testing.T) {
 		require.NotNil(t, resp.RefreshToken)
 		require.Equal(t, resp.RefreshToken.GrantsHash, []byte("some hash"))
 		require.False(t, resp.CompleteListing)
-		require.Equal(t, resp.EstimatedTotalItems, 5)
+		require.Equal(t, resp.EstimatedItemCount, 5)
 		require.Empty(t, resp.DeletedIds)
 		require.Len(t, resp.Items, 1)
 		require.Empty(t, cmp.Diff(resp.Items[0], targets[0], cmpopts.IgnoreUnexported(targettest.Target{}, store.Target{}, timestamp.Timestamp{}, timestamppb.Timestamp{})))
@@ -79,7 +79,7 @@ func TestService_List(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, resp2.RefreshToken.GrantsHash, []byte("some hash"))
 		require.False(t, resp2.CompleteListing)
-		require.Equal(t, resp2.EstimatedTotalItems, 5)
+		require.Equal(t, resp2.EstimatedItemCount, 5)
 		require.Empty(t, resp2.DeletedIds)
 		require.Len(t, resp2.Items, 1)
 		require.Empty(t, cmp.Diff(resp2.Items[0], targets[1], cmpopts.IgnoreUnexported(targettest.Target{}, store.Target{}, timestamp.Timestamp{}, timestamppb.Timestamp{})))
@@ -88,7 +88,7 @@ func TestService_List(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, resp3.RefreshToken.GrantsHash, []byte("some hash"))
 		require.False(t, resp3.CompleteListing)
-		require.Equal(t, resp3.EstimatedTotalItems, 5)
+		require.Equal(t, resp3.EstimatedItemCount, 5)
 		require.Empty(t, resp3.DeletedIds)
 		require.Len(t, resp3.Items, 1)
 		require.Empty(t, cmp.Diff(resp3.Items[0], targets[2], cmpopts.IgnoreUnexported(targettest.Target{}, store.Target{}, timestamp.Timestamp{}, timestamppb.Timestamp{})))
@@ -97,7 +97,7 @@ func TestService_List(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, resp4.RefreshToken.GrantsHash, []byte("some hash"))
 		require.False(t, resp4.CompleteListing)
-		require.Equal(t, resp4.EstimatedTotalItems, 5)
+		require.Equal(t, resp4.EstimatedItemCount, 5)
 		require.Empty(t, resp4.DeletedIds)
 		require.Len(t, resp4.Items, 1)
 		require.Empty(t, cmp.Diff(resp4.Items[0], targets[3], cmpopts.IgnoreUnexported(targettest.Target{}, store.Target{}, timestamp.Timestamp{}, timestamppb.Timestamp{})))
@@ -106,7 +106,7 @@ func TestService_List(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, resp5.RefreshToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp5.CompleteListing)
-		require.Equal(t, resp5.EstimatedTotalItems, 5)
+		require.Equal(t, resp5.EstimatedItemCount, 5)
 		require.Empty(t, resp5.DeletedIds)
 		require.Len(t, resp5.Items, 1)
 		require.Empty(t, cmp.Diff(resp5.Items[0], targets[4], cmpopts.IgnoreUnexported(targettest.Target{}, store.Target{}, timestamp.Timestamp{}, timestamppb.Timestamp{})))
@@ -115,13 +115,13 @@ func TestService_List(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, resp6.RefreshToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp6.CompleteListing)
-		require.Equal(t, resp6.EstimatedTotalItems, 5)
+		require.Equal(t, resp6.EstimatedItemCount, 5)
 		require.Empty(t, resp6.DeletedIds)
 		require.Empty(t, resp6.Items)
 	})
 
 	t.Run("simple pagination with aggressive filtering", func(t *testing.T) {
-		filterFunc := func(t target.Target) (bool, error) {
+		filterFunc := func(_ context.Context, t target.Target) (bool, error) {
 			return t.GetPublicId() == targets[len(targets)-1].GetPublicId(), nil
 		}
 		resp, err := target.List(ctx, repo, []byte("some hash"), 1, filterFunc)
@@ -129,7 +129,7 @@ func TestService_List(t *testing.T) {
 		require.NotNil(t, resp.RefreshToken)
 		require.Equal(t, resp.RefreshToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp.CompleteListing)
-		require.Equal(t, resp.EstimatedTotalItems, 1)
+		require.Equal(t, resp.EstimatedItemCount, 1)
 		require.Empty(t, resp.DeletedIds)
 		require.Len(t, resp.Items, 1)
 		require.Empty(t, cmp.Diff(resp.Items[0], targets[4], cmpopts.IgnoreUnexported(targettest.Target{}, store.Target{}, timestamp.Timestamp{}, timestamppb.Timestamp{})))
@@ -140,13 +140,13 @@ func TestService_List(t *testing.T) {
 		require.True(t, resp2.CompleteListing)
 		// Note: this might be surprising, but there isn't any way for the refresh
 		// call to know that the last call got a different number.
-		require.Equal(t, resp2.EstimatedTotalItems, 5)
+		require.Equal(t, resp2.EstimatedItemCount, 5)
 		require.Empty(t, resp2.DeletedIds)
 		require.Empty(t, resp2.Items)
 	})
 
 	t.Run("simple pagination with deletion", func(t *testing.T) {
-		filterFunc := func(t target.Target) (bool, error) {
+		filterFunc := func(_ context.Context, t target.Target) (bool, error) {
 			return true, nil
 		}
 		deletedTargetId := targets[0].GetPublicId()
@@ -163,7 +163,7 @@ func TestService_List(t *testing.T) {
 		require.NotNil(t, resp.RefreshToken)
 		require.Equal(t, resp.RefreshToken.GrantsHash, []byte("some hash"))
 		require.False(t, resp.CompleteListing)
-		require.Equal(t, resp.EstimatedTotalItems, 4)
+		require.Equal(t, resp.EstimatedItemCount, 4)
 		require.Empty(t, resp.DeletedIds)
 		require.Len(t, resp.Items, 1)
 		require.Empty(t, cmp.Diff(resp.Items[0], targets[0], cmpopts.IgnoreUnexported(targettest.Target{}, store.Target{}, timestamp.Timestamp{}, timestamppb.Timestamp{})))
@@ -172,7 +172,7 @@ func TestService_List(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, resp2.RefreshToken.GrantsHash, []byte("some hash"))
 		require.False(t, resp2.CompleteListing)
-		require.Equal(t, resp2.EstimatedTotalItems, 4)
+		require.Equal(t, resp2.EstimatedItemCount, 4)
 		require.Empty(t, resp2.DeletedIds)
 		require.Len(t, resp2.Items, 1)
 		require.Empty(t, cmp.Diff(resp2.Items[0], targets[1], cmpopts.IgnoreUnexported(targettest.Target{}, store.Target{}, timestamp.Timestamp{}, timestamppb.Timestamp{})))
@@ -190,7 +190,7 @@ func TestService_List(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, resp3.RefreshToken.GrantsHash, []byte("some hash"))
 		require.False(t, resp3.CompleteListing)
-		require.Equal(t, resp3.EstimatedTotalItems, 3)
+		require.Equal(t, resp3.EstimatedItemCount, 3)
 		require.Contains(t, resp3.DeletedIds, deletedTargetId)
 		require.Len(t, resp3.Items, 1)
 		require.Empty(t, cmp.Diff(resp3.Items[0], targets[1], cmpopts.IgnoreUnexported(targettest.Target{}, store.Target{}, timestamp.Timestamp{}, timestamppb.Timestamp{})))
@@ -199,7 +199,7 @@ func TestService_List(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, resp4.RefreshToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp4.CompleteListing)
-		require.Equal(t, resp4.EstimatedTotalItems, 3)
+		require.Equal(t, resp4.EstimatedItemCount, 3)
 		require.Len(t, resp4.Items, 1)
 		require.Empty(t, cmp.Diff(resp4.Items[0], targets[2], cmpopts.IgnoreUnexported(targettest.Target{}, store.Target{}, timestamp.Timestamp{}, timestamppb.Timestamp{})))
 
@@ -207,7 +207,7 @@ func TestService_List(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, resp5.RefreshToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp5.CompleteListing)
-		require.Equal(t, resp5.EstimatedTotalItems, 3)
+		require.Equal(t, resp5.EstimatedItemCount, 3)
 		require.Empty(t, resp5.Items)
 	})
 }

--- a/internal/target/service_list_refresh.go
+++ b/internal/target/service_list_refresh.go
@@ -6,7 +6,7 @@ package target
 import (
 	"context"
 
-	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/pagination"
 	"github.com/hashicorp/boundary/internal/refreshtoken"
 )
 
@@ -21,78 +21,23 @@ func ListRefresh(
 	repo *Repository,
 	grantsHash []byte,
 	pageSize int,
-	filterItemFn func(Target) (bool, error),
-) (*ListResponse, error) {
-	const op = "target.ListRefresh"
-
-	deletedIds, transactionTimestamp, err := repo.listDeletedIds(ctx, tok.UpdatedTime)
-	if err != nil {
-		return nil, errors.Wrap(ctx, err, op)
-	}
-
-	limit := pageSize + 1
-	opts := []Option{
-		WithLimit(limit),
-		WithStartPageAfterItem(tok.LastItemId, tok.LastItemUpdatedTime),
-	}
-
-	targets := make([]Target, 0, pageSize+1)
-dbLoop:
-	for {
-		// Request another page from the DB until we fill the final items
-		page, err := repo.listTargets(ctx, opts...)
-		if err != nil {
-			return nil, errors.Wrap(ctx, err, op)
-		}
-		for _, item := range page {
-			ok, err := filterItemFn(item)
-			if err != nil {
-				return nil, errors.Wrap(ctx, err, op)
-			}
-			if ok {
-				targets = append(targets, item)
-				// If we filled the items after filtering,
-				// we're done.
-				if len(targets) == cap(targets) {
-					break dbLoop
-				}
-			}
-		}
-		// If the current page was shorter than the limit, stop iterating
-		if len(page) < limit {
-			break dbLoop
-		}
-
-		opts = []Option{
+	filterItemFn pagination.ListFilterFunc[Target],
+) (*pagination.ListResponse2[Target], error) {
+	listItemsFn := func(ctx context.Context, tok *refreshtoken.Token, lastPageItem Target, limit int) ([]Target, error) {
+		opts := []Option{
 			WithLimit(limit),
-			WithStartPageAfterItem(page[len(page)-1].GetPublicId(), page[len(page)-1].GetUpdateTime().AsTime()),
 		}
-	}
-	// If we couldn't fill the items, it was a complete listing.
-	completeListing := len(targets) < cap(targets)
-	if !completeListing {
-		// Items is of size pageSize+1, so
-		// truncate if it was filled.
-		targets = targets[:pageSize]
-	}
-
-	totalItems, err := repo.estimatedCount(ctx)
-	if err != nil {
-		return nil, errors.Wrap(ctx, err, op)
+		if lastPageItem != nil {
+			opts = append(opts,
+				WithStartPageAfterItem(lastPageItem.GetPublicId(), lastPageItem.GetUpdateTime().AsTime()),
+			)
+		} else {
+			opts = append(opts,
+				WithStartPageAfterItem(tok.LastItemId, tok.LastItemUpdatedTime),
+			)
+		}
+		return repo.listTargets(ctx, opts...)
 	}
 
-	resp := &ListResponse{
-		Items:               targets,
-		DeletedIds:          deletedIds,
-		EstimatedTotalItems: totalItems,
-		CompleteListing:     completeListing,
-	}
-
-	if len(targets) > 0 {
-		resp.RefreshToken = tok.RefreshLastItem(targets[len(targets)-1], transactionTimestamp)
-	} else {
-		resp.RefreshToken = tok.Refresh(transactionTimestamp)
-	}
-
-	return resp, nil
+	return pagination.ListRefresh(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, repo.estimatedCount, repo.listDeletedIds, tok)
 }


### PR DESCRIPTION
## [internal/pagination: add new pagination logic](https://github.com/hashicorp/boundary/commit/0f56a6a7ee1a8b9797a0bb663f92f39c35d6c2b9)

This unifies the core of the pagination logic in
the new pattern, significantly simplifying the
domain logic and removing repetition. This also
makes it easier to test the generic logic in
isolation.

I've established that this pattern can be applied
both to the simpler pagination in the target
domain and the more complicated logic in
the auth domain.

## [internal/target: migrate to generic pagination](https://github.com/hashicorp/boundary/commit/1f0e86fa497d0020c76a8ce68562543d880918d5)

Jim, I hope this doesn't add too much indirection to the domain logic. I'm open to suggestion to improve it in any way, but I found that implementing the pagination logic through copy-paste-edit was error prone and this significantly reduces the burden when implementing a new resource.