### PR TITLE
test(e2e): Add check for vault worker filters

### DIFF
--- a/testing/internal/e2e/tests/base_with_worker/target_tcp_worker_connect_ssh_test.go
+++ b/testing/internal/e2e/tests/base_with_worker/target_tcp_worker_connect_ssh_test.go
@@ -115,6 +115,17 @@ func TestCliTcpTargetWorkerConnectTarget(t *testing.T) {
 	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
 	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
 
+	// Try to set a worker filter on a vault credential-store
+	output = e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"credential-stores", "update", "vault",
+			"-id", newCredentialStoreId,
+			"worker-filter", fmt.Sprintf(`"%s" in "/tags/type"`, c.WorkerTagEgress),
+		),
+	)
+	require.Error(t, output.Err)
+	require.Equal(t, 1, output.ExitCode)
+
 	// Create a target
 	newTargetId := boundary.CreateNewTargetCli(
 		t,


### PR DESCRIPTION
This PR updates an e2e test to check that vault worker filters are not available in Boundary CE. There will be a follow-up PR in `boundary-enterprise` to add a test that uses vault worker filters.