### PR TITLE
docs: Cherry pick 0.14.0 docs changes to 0.14.1 branch

### DIFF
--- a/website/content/docs/commands/connect/ssh.mdx
+++ b/website/content/docs/commands/connect/ssh.mdx
@@ -88,3 +88,7 @@ This command performs a target authorization or consumes an existing authorizati
 -  `username` `(string: "")` - The username you want to pass through to the
    client.
    You can also specify a username using the **BOUNDARY_CONNECT_USERNAME** environment variable.
+
+- `remote-command` `(string: "")` - A command that you want to run on the remote host.
+You can specify a complete command line, or you may include additional arguments.
+If you include additional arguments, you must append them to the command and separate them using spaces.

--- a/website/content/docs/concepts/domain-model/accounts.mdx
+++ b/website/content/docs/concepts/domain-model/accounts.mdx
@@ -36,7 +36,7 @@ Password account types have the following additional attributes:
 - `password` - (optional)
   Not setting the `password` disables the account.
 
-### LDAP account attributes <sup>Beta</sup>
+### LDAP account attributes
 
 LDAP account types have the following additional attributes:
 

--- a/website/content/docs/concepts/domain-model/auth-methods.mdx
+++ b/website/content/docs/concepts/domain-model/auth-methods.mdx
@@ -45,7 +45,7 @@ The OIDC auth method has the following additional attributes:
   responses are allowed.
 
 - `api_url_prefix` (required) The API prefix to use when generating callback URLs
-  for the provider. You should set the value to an address that allows the provider to reach 
+  for the provider. You should set the value to an address that allows the provider to reach
   the controller.
 
 - `callback_url` (output read-only) The URL that should be provided to the IdP
@@ -58,7 +58,7 @@ The OIDC auth method has the following additional attributes:
   use with the provider.
 
 - `client-secret` (required) The corresponding client secret.
-  
+
 - `client_secret_hmac` (output read-only) The HMAC of the client secret that the Boundary controller
   returns. It is used for comparison to the value's initial setting.
 
@@ -83,8 +83,8 @@ The OIDC auth method has the following additional attributes:
 - `signing-algorithm` (required) The allowed signing algorithm. You can specify this attribute
   multiple times for multiple values.
 
-  
-### LDAP auth method attributes <sup>Beta</sup>
+
+### LDAP auth method attributes
 
 The ldap auth method has the following additional attributes:
 
@@ -179,7 +179,7 @@ The ldap auth method has the following additional attributes:
   - `maximum_page_size` - (optional) If set, it specifies a maximum ldap search
     result size to use when retrieving the authenticated user's group
     memberships. You can use this setting to avoid reaching the LDAP server's max result
-    size. 
+    size.
 
   - `dereference_aliases` - (optional) If set, it will control how aliases are
     dereferenced when you search.

--- a/website/content/docs/concepts/domain-model/managed-groups.mdx
+++ b/website/content/docs/concepts/domain-model/managed-groups.mdx
@@ -41,7 +41,7 @@ OIDC managed groups have the following additional attributes:
 [filtering concepts]: /boundary/docs/concepts/filtering
 [oidc managed groups filtering]: /boundary/docs/concepts/filtering/oidc-managed-groups
 
-### LDAP managed group information and attributes <sup>Beta</sup>
+### LDAP managed group information and attributes
 
 Membership in LDAP managed groups is evaluated when the auth method is used for
 authentication, based on information contained within the LDAP server. Every

--- a/website/content/docs/concepts/domain-model/storage-buckets.mdx
+++ b/website/content/docs/concepts/domain-model/storage-buckets.mdx
@@ -38,29 +38,48 @@ You must provide a name for the bucket in the external object store.
 - `secrets` - (Optional) A collection of sensitive fields, like [credentials][], which the plugin uses to interface with the backing service.
 These fields are write only.
 
-### AWS S3 attributes and secrets
+## AWS S3 attributes and secrets
 
 At this time, the only supported storage for storage buckets is AWS S3.
 In AWS S3, a storage bucket contains the bucket name, region, and optional prefix, as well as any credentials needed to access the bucket, such as the secret key.
 
-#### Attributes
+The AWS S3 storage bucket can use static or dynamic credentials.
+You can configure static credentials using an access key and secret key or dynamic credentials using the AWS [`AssumeRole` API](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole).
+
+### Attributes
 
 AWS S3 buckets have the following attributes:
 
 - `region` - (Required) The S3 region to configure the storage bucket in.
-- `disable_credential_rotation` - (Optional) If set to `true`, credential rotation is not performed.
+- `disable_credential_rotation` - (Optional for static credentials, Required for dynamic credentials) If set to `true`, credential rotation is not performed.
 By default, the AWS plugin [rotates credentials](https://github.com/hashicorp/boundary-plugin-aws/blob/main/README.md#credential-rotation).
+Note that this attribute is required, if you use dynamic credentials.
+- `role_arn` - (Optional) The ARN (Amazon Resource Name) role that is attached to the EC2 instance that the self-managed worker runs on.
+The Role ARN is required if the AWS S3 bucket is configured to use dynamic credentials using `AssumeRole`.
+- `role_external_id` - (Optional) A required value if you delegate third party access to your AWS resources.
+You can configure this value if your AWS S3 bucket is configured to use dynamic credentials.
+For more information, refer to the AWS documentation for [How to use an external ID when granting access to your AWS resources to a third party](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
+- `role_session_name`: (Optional) A unique identifier for the AWS session.
+You can use this value to control how IAM principals and applications name their role sesions when they assume an IAM role.
+By providing a session name, you enable tracking session actions in AWS CloudTrail logs.
+You can configure this value if your AWS S3 bucket is configured to use dynamic credentials.
+For more information, refer to the AWS documentation for [Logging IAM and AWS STS API calls with AWS CloudTrail](https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html).
+- `role_tags`: (Optional) An object with key-value pair attributes that is passed when you assume an IAM role.
+For more information, refer to the AWS documentation for [Passing session tags in AWS STS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html).
 
-#### Secrets
+### Secrets
 
-AWS S3 buckets have the following secrets:
+AWS S3 buckets can have the following secrets:
 
-- `access_key_id` - (Required) The access key ID for the IAM user to use with this storage bucket.
-- `secret_access_key` - (Required) The secret access key for the IAM user to use with this storage bucket.
+- `access_key_id` - (Optional) The access key ID for the IAM user to use with this storage bucket.
+Access keys are required if the AWS S3 bucket is configured to use static credentials.
+- `secret_access_key` - (Optional) The secret access key for the IAM user to use with this storage bucket.
+Secret access keys are required if the AWS S3 bucket is configured to use static credentials.
 
 ## Referenced by
 
 - [Session recordings](/boundary/docs/concepts/domain-model/session-recordings)
+- [Create a storage bucket](/boundary/docs/configuration/session-recording/create-storage-bucket)
 
 ## Service API docs
 

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -30,7 +30,10 @@ At this time, the only supported storage is AWS S3.
 - An AWS S3 storage bucket
 
    You must associate the Boundary storage bucket with an AWS S3 storage bucket.
-   An AWS S3 storage bucket contains the bucket name, region, and optional prefix, as well as any credentials needed to access the bucket, such as the access and secret key.
+   An AWS S3 storage bucket contains the bucket name, region, and optional prefix, as well as any credentials needed to access the bucket.
+
+   The AWS S3 storage bucket can use static or dynamic credentials.
+   You can configure static credentials using an access key and secret key or dynamic credentials using the AWS [`AssumeRole` API](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole).
 - An AWS IAM role policy with the following statement:
    ```json
     {
@@ -139,23 +142,75 @@ Complete the following steps to create a storage bucket in Boundary for session 
 <Tabs>
 <Tab heading="CLI">
 
+The required fields for creating a storage bucket vary depending on whether you configured the AWS S3 bucket with static or dynamic credentials:
+
+<Tabs>
+<Tab heading="Static credentials">
+
 1. Log in to Boundary.
 1. Use the following command to create a storage bucket in Boundary:
 
-    ```bash
-    boundary storage-buckets create -bucket-name mybucket1 -plugin-name aws -secrets ‘{“access_key_id”: “123456789” , “secret_access_key” : “123/456789/12345678”}’ -worker-filter ‘“dev” in “/tags/type”’ -attributes ‘{“region”:”us-east-1”,”disable_credential_rotation”:true}’ -scope-id o_1234567890
-    ```
+   ```shell-session
+   boundary storage-buckets create \
+      -bucket-name mybucket1 \
+      -plugin-name aws \
+      -secrets ‘{“access_key_id”: “123456789” , “secret_access_key” : “123/456789/12345678”}’ \
+      -worker-filter ‘“dev” in “/tags/type”’ \
+      -attributes ‘{“region”:”us-east-1”,”disable_credential_rotation”:true}’ \
+      -scope-id o_1234567890
+   ```
 
-    Replace the values above with the following required AWS secrets and any optional [attributes](/boundary/docs/concepts/domain-model/storage-buckets) you want to associate with the Boundary storage bucket:
+   Replace the values above with the following required AWS secrets and any optional [attributes](/boundary/docs/concepts/domain-model/storage-buckets) you want to associate with the Boundary storage bucket:
 
-    - `region`: (Required) The AWS region to use.
-    - `bucket-name`: (Required) Name of the AWS bucket you want to associate with the Boundary storage bucket.
-    - `access_key_id`: (Required) The AWS access key to use.
-    - `secret_access_key_id`: (Required) The AWS secret access key to use.
+   - `region`: (Required) The AWS region to use.
+   - `bucket-name`: (Required) Name of the AWS bucket you want to associate with the Boundary storage bucket.
+   - `access_key_id`: (Required) The AWS access key to use.
+   - `secret_access_key_id`: (Required) The AWS secret access key to use.
     This attribute contains the secret access key for static credentials.
-    - `worker-filter`: (Required) A filter that indicates which Boundary workers have access to the storage. The filter must match an existing worker in order to create a Boundary storage bucket.
-    - `shared_credentials_file`: (Optional) The shared credentials file to use.
-    - `shared_credentials_profile`: (Optional) The profile name to use in the shared credentials file.
+   - `worker-filter`: (Required) A filter that indicates which Boundary workers have access to the storage. The filter must match an existing worker in order to create a Boundary storage bucket.
+   - `shared_credentials_file`: (Optional) The shared credentials file to use.
+   - `shared_credentials_profile`: (Optional) The profile name to use in the shared credentials file.
+   - `disable_credential_rotation`: (Optional) Prevents the AWS plugin from automatically rotating credentials.
+
+     Although credentials are stored encrypted in Boundary, by default the [AWS plugin](https://github.com/hashicorp/boundary-plugin-aws) attempts to rotate the credentials you provide. The given credentials are used to create a new credential, and then the original credential is revoked. After rotation, only Boundary knows the client secret the plugin uses.
+
+</Tab>
+
+<Tab heading="Dynamic credentials">
+
+1. Log in to Boundary.
+1. Use the following command to create a storage bucket in Boundary:
+
+   ```shell-session
+   boundary storage-buckets create \
+      -bucket-name mybucket1 \
+      -plugin-name aws \
+      -worker-filter ‘“dev” in “/tags/type”’ \
+      -attributes ‘{“region”:”us-east-1”,”disable_credential_rotation”:true,"role_arn":"arn:aws:iam::123456789012:role/S3Access"}’ \
+      -scope-id o_1234567890
+   ```
+
+   Replace the values above with the following required AWS secrets and any optional [attributes](/boundary/docs/concepts/domain-model/storage-buckets) you want to associate with the Boundary storage bucket:
+
+   - `region`: (Required) The AWS region to use.
+   - `bucket-name`: (Required) Name of the AWS bucket you want to associate with the Boundary storage bucket.
+   - `role_arn`: (Required) The ARN (Amazon Resource Name) role that is attached to the EC2 instance that the self-managed worker runs on.
+   - `role_external_id`: (Optional) A required value if you delegate third party access to your AWS resources.
+   For more information, refer to the AWS documentation for [How to use an external ID when granting access to your AWS resources to a third party](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
+   - `role_session_name`: (Optional) A unique identifier for the AWS session.
+   You can use this value to control how IAM principals and applications name their role sesions when they assume an IAM role.
+   By providing a session name, you enable tracking session actions in AWS CloudTrail logs.
+   For more information, refer to the AWS documentation for [Logging IAM and AWS STS API calls with AWS CloudTrail](https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html).
+   - `role_tags`: (Optional) An object with key-value pair attributes that is passed when you assume an IAM role.
+   For more information, refer to the AWS documentation for [Passing session tags in AWS STS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html).
+   - `worker-filter`: (Required) A filter that indicates which Boundary workers have access to the storage. The filter must match an existing worker in order to create a Boundary storage bucket.
+   - `shared_credentials_file`: (Optional) The shared credentials file to use.
+   - `shared_credentials_profile`: (Optional) The profile name to use in the shared credentials file.
+   - `disable_credential_rotation`: (Required) Prevents the AWS plugin from automatically rotating credentials.
+   This option must be set to `true` if you use dynamic credentials.
+
+</Tab>
+</Tabs>
 
 </Tab>
 
@@ -172,12 +227,42 @@ Complete the following steps to create a storage bucket in Boundary for session 
    - **Bucket name**: (Required) Name of the AWS bucket you want to associate with the Boundary storage bucket.
    - **Bucket prefix**: (Optional) A base path where session recordings are stored.
    - **Region**: (Required) The AWS region to use.
+   - **Credential type**: (Required) The type of credential you want to use to authenticate to the external storage.
+   The required fields for creating a storage bucket vary depending on whether you configured the AWS S3 bucket with static or dynamic credentials:
+      - **Static**: Authenticates to the storage bucket using an access key that AWS generates.
+      - **Dynamic**: Authenticates to the storage bucket using credentials that were generated by AWS `AssumeRole`.
+
+   <Tabs>
+   <Tab heading="Static credentials">
+
    - **Access key ID**: (Required) The access key ID that AWS generates for the IAM user to use with the storage bucket.
    - **Secret access key**: (Required) The secret access key that AWS generates for the IAM user to use with this storage bucket.
-   - **Worker filter** (Required) A filter that indicates which Boundary workers have access to the storage. The filter must match an existing worker in order to create a Boundary storage bucket.
-   - **Disable credential rotation** (Optional) Although credentials are stored encrypted within Boundary, by default the [AWS plugin](https://github.com/hashicorp/boundary-plugin-aws) attempts to rotate the credentials you provide. The given credentials are used to create a new credential, and then the original credential is revoked. After rotation, only Boundary knows the client secret the plugin uses.
+   - **Worker filter**: (Required) A filter that indicates which Boundary workers have access to the storage. The filter must match an existing worker in order to create a Boundary storage bucket.
+   - **Disable credential rotation**: (Optional) Prevents the AWS plugin from automatically rotating credentials.
 
-      Select this option to disable this behavior and prevent the automatic rotation of credentials.
+      Although credentials are stored encrypted in Boundary, by default the [AWS plugin](https://github.com/hashicorp/boundary-plugin-aws) attempts to rotate the credentials you provide.
+      The given credentials are used to create a new credential, and then the original credential is revoked.
+      After rotation, only Boundary knows the client secret the plugin uses.
+
+   </Tab>
+
+   <Tab heading="Dynamic credentials">
+
+   - **Role ARN**: (Required) The ARN (Amazon Resource Name) role that is attached to the EC2 instance that the self-managed worker runs on.
+   - **Role external ID**: (Optional) A required value if you delegate third party access to your AWS resources.
+   For more information, refer to the AWS documentation for [How to use an external ID when granting access to your AWS resources to a third party](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
+   - **Role session name**: (Optional) A unique identifier for the AWS session.
+   You can use this value to control how IAM principals and applications name their role sesions when they assume an IAM role.
+   By providing a session name, you enable tracking session actions in AWS CloudTrail logs.
+   For more information, refer to the AWS documentation for [Logging IAM and AWS STS API calls with AWS CloudTrail](https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html).
+   - **Role tags**: An object with key-value pair attributes that is passed when you assume an IAM role.
+   For more information, refer to the AWS documentation for [Passing session tags in AWS STS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html).
+   - **Worker filter**: (Required) A filter that indicates which Boundary workers have access to the storage. The filter must match an existing worker in order to create a Boundary storage bucket.
+   - **Disable credential rotation**: (Required) Prevents the AWS plugin from automatically rotating credentials.
+   This option is required if you use dynamic credentials.
+
+   </Tab>
+   </Tabs>
 
 1. Select **Save**.
 
@@ -185,4 +270,7 @@ Complete the following steps to create a storage bucket in Boundary for session 
 </Tabs>
 
 Boundary creates the storage bucket resource and provides you with the bucket's ID.
-Once the storage bucket is created in Boundary, you can use the bucket's ID to [enable session recording on targets](/boundary/docs/configuration/session-recording/enable-session-recording).
+
+## Next steps
+
+After the storage bucket is created in Boundary, you can use the bucket's ID to [enable session recording on targets](/boundary/docs/configuration/session-recording/enable-session-recording).

--- a/website/content/docs/configuration/worker/pki-worker.mdx
+++ b/website/content/docs/configuration/worker/pki-worker.mdx
@@ -15,7 +15,7 @@ Example (not safe for production!):
 
 ```hcl
 worker {
-  auth_storage_path="/boundary/demo-worker-1"
+  auth_storage_path="/var/lib/boundary"
   initial_upstreams = ["10.0.0.1"]
 }
 ```
@@ -34,7 +34,7 @@ either directly or via an env var or file by using `env://` or `file://` syntax:
 
 ```hcl
 worker {
-  auth_storage_path="/boundary/demo-worker-1"
+  auth_storage_path="/var/lib/boundary"
   initial_upstreams = ["10.0.0.1"]
   controller_generated_activation_token = "neslat_........."
   # controller_generated_activation_token = "env://ACT_TOKEN"
@@ -88,7 +88,7 @@ Development example:
 
 ```hcl
 worker {
-  auth_storage_path="/boundary/demo-worker-1"
+  auth_storage_path="/var/lib/boundary"
   initial_upstreams = ["10.0.0.1"]
   recording_storage_path="/local/storage/directory"
 }

--- a/website/content/docs/install-boundary/configure-workers.mdx
+++ b/website/content/docs/install-boundary/configure-workers.mdx
@@ -98,7 +98,7 @@ listener "tcp" {
 worker {
   public_addr = "<worker_public_addr>"
   initial_upstreams = ["<controller_lb_address>:9201"]
-  auth_storage_path = "/etc/boundary.d/auth_storage/"
+  auth_storage_path = "/var/lib/boundary"
   tags {
     type = ["worker1", "upstream"]
   }
@@ -167,7 +167,7 @@ listener "tcp" {
 worker {
   public_addr = "<worker_public_addr>"
   initial_upstreams = ["<ingress_worker_address>:9202"]
-  auth_storage_path = "/etc/boundary.d/auth_storage/"
+  auth_storage_path = "/var/lib/boundary"
   tags {
     type = ["worker2", "intermediate"]
   }
@@ -236,7 +236,7 @@ listener "tcp" {
 worker {
   public_addr = "<worker_public_addr>"
   initial_upstreams = ["<intermediate_worker_address>:9202"]
-  auth_storage_path = "/etc/boundary.d/auth_storage/"
+  auth_storage_path = "/var/lib/boundary"
   tags {
     type = ["worker3", "egress"]
   }
@@ -350,7 +350,7 @@ listener "tcp" {
 worker {
   public_addr = "<worker_public_addr>"
   initial_upstreams = ["<controller_lb_address>:9201"]
-  auth_storage_path = "/etc/boundary.d/auth_storage/"
+  auth_storage_path = "/var/lib/boundary"
   tags {
     type = ["worker", "egress"]
   }

--- a/website/content/docs/operations/health.mdx
+++ b/website/content/docs/operations/health.mdx
@@ -45,7 +45,7 @@ a string that is parseable by
 
 ## API
 
-The new controller health service introduces a single read-only endpoint:
+The controller health service introduces a single read-only endpoint:
 
 | Status        | Description                                                    |
 |--------------|----------------------------------------------------------------|
@@ -54,6 +54,38 @@ The new controller health service introduces a single read-only endpoint:
 | `503`        | `GET /health` returns HTTP status `503 Service Unavailable` status if the controller is shutting down |
 
 All responses return empty bodies. `GET /health` does not support any input.
+
+## Example response
+
+When you check the health endpoint, Boundary returns a response with the following worker information:
+
+```json
+❯ curl "worker:9403/health?worker_info=1"
+
+{
+   "worker_process_info":{
+      "state":"active",
+      "active_session_count":0,
+      "upstream_connection_state":"READY"
+   }
+}
+```
+The response contains the following fields:
+
+- `state` - The operational state of the worker.
+Possible worker states include active, shutdown, and unknown.
+- `active_session_count` - The number of active sessions on the worker.
+- `upstream_connection_state` - The connection state of the worker.
+This value indicates whether the worker can connect to an upstream address or connection.
+It can be any of the following states:
+   - `CONNECTING` - The channel is trying to make a connection and is waiting for name resolution or the connection establishment.
+   - `READY` - The channel has successfully established a connection, and any attempts to communicate have succeeded.
+   - `TRANSIENT_FAILURE` - The channel suffered a transient failure such as a time out or socket error.
+   A channel in this state will switch to the `CONNECTING` state and try to establish a connection.
+   - `IDLE` - The channel is not attempting to create a connection because there are no calls.
+   - `SHUTDOWN` - The channel is shutting down.
+   Any new calls fail immediately.
+   Pending calls may continue running until Boundary cancels them.
 
 ## Example configuration
 

--- a/website/content/docs/operations/session-recordings/index.mdx
+++ b/website/content/docs/operations/session-recordings/index.mdx
@@ -17,6 +17,16 @@ Recorded sessions are stored in an external storage bucket that you create.
 Storing session recordings in a system external to Boundary means those recordings can be accessed, modified, deleted, and even restored independently of Boundary.
 You can view any sessions that Boundary recorded in your storage provider or via the CLI.
 
+When you view recorded sessions using the CLI or Admin UI, Boundary can convert the recording into other formats for playback.
+Currently Boundary supports converting the recording of an individual SSH channel into an [asciicast](https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md) format to play back an interactive SSH session.
+
+The asciicast format is well suited for the playback of interactive shell activity.
+However, some aspects of the recording cannot be translated into asciicast.
+For example, if an SSH session uses the `RemoteCommand` option, or is used to `exec` a command, the command is not displayed in the asciicast.
+The output of the command may be displayed, though.
+If you use SSH for something other than an interactive shell, such as for file transfer, X11 forwarding, or port forwarding, Boundary does not attempt to create an asciicast.
+In all cases, the SSH session is still recorded in the [BSR file](/boundary/docs/concepts/auditing/#bsr-directory-structure) and you can view the BSR file in the external storage bucket.
+
 For more information about working with recorded sessions, refer to the following topics:
 
 - [Find and view recorded sessions](/boundary/docs/operations/session-recordings/manage-recorded-sessions)

--- a/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
+++ b/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
@@ -9,6 +9,18 @@ description: |-
 
 You can view a list of all recorded sessions, or if you know the ID of a specific recorded session, you can find any channels associated with that recording.
 
+<Note>
+
+The asciicast format is well suited for the playback of interactive shell activity.
+However, some aspects of the recording cannot be translated into asciicast.
+For example, if an SSH session uses the `RemoteCommand` option, or is used to `exec` a command, the command is not displayed in the asciicast.
+The output of the command may be displayed, though.
+If you use SSH for something other than an interactive shell, such as for file transfer, X11 forwarding, or port forwarding, Boundary does not attempt to create an asciicast.
+
+In all cases, the SSH session is still recorded in the [BSR file](/boundary/docs/concepts/auditing/#bsr-directory-structure) and you can view the BSR file in the external storage bucket.
+
+</Note>
+
 <Tabs>
 <Tab heading="CLI">
 
@@ -72,7 +84,7 @@ You can find all recorded sessions in the UI from the global scope.
 1. Select **View** next to the session recording you want to view.
 
    The details page has information related to the session recording and
-   links to related inforation like user, target, and storage bucket.
+   links to related information like user, target, and storage bucket.
 
 ## Play back channel recording
 

--- a/website/content/docs/release-notes/v0_14_0.mdx
+++ b/website/content/docs/release-notes/v0_14_0.mdx
@@ -138,6 +138,24 @@ description: |-
     <a href="/boundary/docs/troubleshoot/troubleshoot-recorded-sessions#unsupported-recovery-workflow">Unsupported recovery workflow</a>
     </td>
   </tr>
+   <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.14.0
+    <br /><br />
+    (Fixed in 0.14.1)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Go CVE-2023-39325
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    The version of Go that was used in Boundary release 0.14.0 contained a CVE. The issue was fixed in Go versions 1.21.3 and 1.20. Boundary was updated to use the new Go versions in release 0.14.1, and the issue is resolved.
+    <br /><br />
+    Learn more:&nbsp;
+    <a href="https://github.com/advisories/GHSA-4374-p667-p6c8">HTTP/2 rapid reset can cause excessive work in net/http</a>
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
 
   </tbody>
 </table>

--- a/website/content/docs/release-notes/v0_14_0.mdx
+++ b/website/content/docs/release-notes/v0_14_0.mdx
@@ -1,0 +1,203 @@
+---
+layout: docs
+page_title: v0.14.0
+description: |-
+  Boundary release notes for v0.14.0
+---
+
+# Boundary 0.14.0 release notes
+
+**GA date:** October 11, 2023
+
+@include 'release-notes/intro.mdx'
+
+## New features
+
+<table>
+  <thead>
+    <tr>
+      <th style={{verticalAlign: 'middle'}}>Feature</th>
+      <th style={{verticalAlign: 'middle'}}>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      Boundary Desktop embedded terminal
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+     An embedded terminal has been added to the Boundary Desktop client for convenience. Now you can use the CLI directly from within Boundary Desktop.
+      <br /><br />
+      Learn more:&nbsp;
+      <a href="/boundary/tutorials/oss-getting-started/oss-getting-started-desktop-app">Install Boundary Desktop tutorial</a>
+    </td>
+  </tr>
+
+   <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      LDAP authorization method
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      The LDAP auth method is no longer in beta, it is now fully supported. Administrators can now create, manage, and delete LDAP auth methods along with managed groups and accounts using the admin console UI.
+      <br /><br />
+      Learn more:&nbsp;
+      <a href="/boundary/docs/concepts/domain-model/auth-methods">Auth methods</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      Dynamic credential support for storage buckets <sup>HCP/ENT</sup>
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      You can now configure dynamic credentials for AWS S3 storage buckets using the Amazon Web Services (AWS) <code>AssumeRole</code> API. We recommend that you configure credentials using <code>AssumeRole</code> instead of access keys when possible.
+      <br /><br />
+      Learn more:&nbsp;
+      <a href="/boundary/docs/configuration/session-recording/create-storage-bucket">Create a storage bucket</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      Remote pass-through commands for SSH
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      A new SSH flag, <code>remote-command</code> was introduced to the <a href="/boundary/docs/commands/connect/ssh">boundary connect ssh helper</a>. It lets you run the specified commands on the remote-machine using pass-through arguments.
+      <br /><br />
+      Learn more:&nbsp;
+      <a href="/boundary/docs/commands/connect/ssh">connect ssh command</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      New worker health metric
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      A new metric was added to the health endpoint to check the connection state of the worker and whether it can connect to an upstream controller. The result is automatically included in the response when you run the health endpoint.
+      <br /><br />
+      Learn more:&nbsp;
+      <a href="/boundary/docs/operations/health">Boundary health endpoints</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      Improved telemetry
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      Improved telemetry was added to Boundary. You can enable telemetry to gather information about your Boundary cluster.
+      <br /><br />
+      Learn more:&nbsp;
+      <a href="/boundary/docs/configuration/events">events stanza</a>
+    </td>
+  </tr>
+
+
+  </tbody>
+</table>
+
+## Known issues and breaking changes
+
+<table>
+  <thead>
+    <tr>
+      <th style={{verticalAlign: 'middle'}}>Version</th>
+      <th style={{verticalAlign: 'middle'}}>Issue</th>
+      <th style={{verticalAligh: 'middle'}}>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.13.0+
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Rotation of AWS access and secret keys during a session results in stale recordings
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    In Boundary version 0.13.0+, when you rotate a storage bucket's secrets, any new sessions use the new credentials. However, previously established sessions continue to use the old credentials.
+    <br /><br />
+    As a best practice, administrators should rotate credentials in a phased manner, ensuring that all previously established sessions are completed before revoking the stale credentials.
+    Otherwise, you may end up with recordings that aren't stored in the remote storage bucket, and are unable to be played back.
+    </td>
+  </tr>
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.13.0+
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Unsupported recovery workflow during worker failure
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    If a worker fails during a recording, there is no way to recover the recording. This could happen due to a network connectivity issue or because a worker is scaled down, for example.
+    <br /><br />
+    Learn more:&nbsp;
+    <a href="/boundary/docs/troubleshoot/troubleshoot-recorded-sessions#unsupported-recovery-workflow">Unsupported recovery workflow</a>
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+## Feature deprecations and EOL
+
+<table>
+  <thead>
+    <tr>
+      <th style={{verticalAlign: 'middle'}}>EOL</th>
+      <th style={{verticalAlign: 'middle'}}>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      <code>vault</code> credential library subtype
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+     As noted in the <a href="/boundary/docs/release-notes/v0_12_0#deprecations-and-changes">v0.12.0 release notes</a>, the <code>vault</code> credential library subtype was renamed to <code>vault-generic</code>. The <code>vault</code> subtype is removed in this release, you must use <code>vault-generic</code> now.
+      <br /><br />
+      Learn more:&nbsp;
+      <a href="/boundary/docs/concepts/domain-model/credential-libraries">Credential libraries</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      <code>status</code> field
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      As noted in the <a href="https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md#deprecationschanges-3">v0.12.0 changelog</a>, using the <code>-format=json</code> option with the CLI produced inconsistent results. The <code>status</code> field is removed in this release. The <code>status_code</code> field is now used for both successful requests and errors.
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      Default port value
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+     As noted in the <a href="/boundary/docs/release-notes/v0_12_0#deprecations-and-changes">v0.12.0 release notes</a>, targets now require a default port value. Previously, any ports that you defined as part of a host address were ignored, but allowed as part of the target definition. From this version on, if you define a port on a host address it results in an error.
+      <br /><br />
+      Learn more:&nbsp;
+      <a href="/boundary/docs/concepts/domain-model/targets">Targets</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      Application credentials parameter
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      As noted in the <a href="https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md#deprecationschanges-6">v0.10.0 changelog</a>, the <code>target</code> subcommands for application credentials were renamed to brokered credentials. The application credentials subcommands are removed in this release. You must use the brokered credential subcommands instead.
+      <br /><br />
+      Learn more:&nbsp;
+      <a href="/boundary/docs/commands/targets">targets</a>
+    </td>
+  </tr>
+
+
+  </tbody>
+</table>

--- a/website/content/docs/troubleshoot/troubleshoot-recorded-sessions.mdx
+++ b/website/content/docs/troubleshoot/troubleshoot-recorded-sessions.mdx
@@ -11,13 +11,29 @@ Refer to the following for information about how to troubleshoot recorded sessio
 
 ## Known bugs
 
-**Rotation of AWS access and secret keys during a session results in stale recordings**
+**Rotation of AWS access and secret keys during a session results in stale recordings:**
 
 In Boundary version 0.13.0, when you rotate a storage bucket's secrets, any new sessions use the new credentials.
 However, previously established sessions continue to use the old credentials.
 
 As a best practice, administrators should rotate credentials in a phased manner, ensuring that all previously established sessions are completed before revoking the stale credentials.
 Otherwise, you may end up with recordings that aren't stored in the remote storage bucket and are unable to be played back.
+
+
+<a id="unsupported-recovery-workflow"></a>
+
+**Unsupported recovery workflow during worker failure:**
+
+If a worker fails during a recording, there is no way to recover the recording.
+This could happen due to a network connectivity issue or because a worker is scaled down, for example.
+There are a number of currently unsupported failure cases, including when the worker:
+
+- Crashes and restarts while servicing connections and channels for session to an SSH target
+- Crashes and restarts while closing a channel, before all files are synced to remote storage
+- Crashes and restarts while closing a connection recorder, before all files are synced to remote storage
+- Crashes and restarts while closing a session recorder, before all files are synced to remote storage
+- Crashes and never restarts or is seen again while closing a channel/connection recorer/session recorder
+- Loses its connection to the controller and cancels sessions, it must resend the information when com
 
 ## Tips
 

--- a/website/content/partials/release-notes/intro.mdx
+++ b/website/content/partials/release-notes/intro.mdx
@@ -1,0 +1,4 @@
+Release notes provide an at-a-glance summary of key updates to new versions of Boundary.
+For a comprehensive list of product updates, improvements, and bug fixes refer to the [changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md) included with the Boundary code on GitHub.
+
+We encourage you to [upgrade to the latest release of Boundary](/boundary/tutorials/self-managed-deployment/upgrade-version) to take advantage of continuing improvements, critical fixes, and new features.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1415,6 +1415,10 @@
         "path": "release-notes"
       },
       {
+        "title": "v0.14.0",
+        "path": "release-notes/v0_14_0"
+      },
+      {
         "title": "v0.13.0",
         "path": "release-notes/v0_13_0"
       },


### PR DESCRIPTION
Several docs changes didn't make it from `main` to the `release/0.14.1` branch when it was created:

https://github.com/hashicorp/boundary/compare/release/0.14.1...main

These commits include all of the docs published for the 0.14.0 release:

- https://github.com/hashicorp/boundary/pull/3818
- https://github.com/hashicorp/boundary/pull/3759
- https://github.com/hashicorp/boundary/pull/3749
- https://github.com/hashicorp/boundary/pull/3852

This PR cherry-picks the missing docs changes above from `main` to `release/0.14.1`.