### PR TITLE
chore(e2e): Fix logs to debug aws dependencies error

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -290,7 +290,7 @@ jobs:
           enos scenario destroy --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
       - name: Get logs for aws dependencies error
         # Retrieve logs from the terraform to help diagnose some aws cleanup issues
-        if: (contains(matrix.filter, 'e2e_aws') || matrix.filter == 'e2e_database') && steps.destroy.outcome == 'failure'
+        if: always() && (contains(matrix.filter, 'e2e_aws') || matrix.filter == 'e2e_database') && steps.destroy.outcome == 'failure'
         continue-on-error: true
         run: |
           enos scenario exec --cmd graph --chdir ./enos ${{ matrix.filter }}


### PR DESCRIPTION
This PR is a fix for https://github.com/hashicorp/boundary/pull/3796, which attempts to add logs to help debug an aws dependencies error on resource teardown.

I noticed a run where I expected to get these logs, but the action did not trigger. This PR adds an `always()` condition to the step, which is needed since a prior step is marked failure.
![Screenshot 2023-10-19 at 10 14 53 AM](https://github.com/hashicorp/boundary/assets/2474253/032b542d-ccca-4734-801a-de2c2d665d29)
