### PR TITLE
test(bats): Add `list` tests for other resource types

### DIFF
--- a/internal/tests/cli/boundary/_auth_methods.bash
+++ b/internal/tests/cli/boundary/_auth_methods.bash
@@ -1,0 +1,35 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+function create_password_auth_method() {
+  local name=$1
+  boundary auth-methods create password -name $name -format json
+}
+
+function read_auth_method() {
+  local amid=$1
+  boundary auth-methods read -id $amid -format json
+}
+
+function list_auth_methods() {
+  boundary auth-methods list -format json
+}
+
+function delete_auth_method() {
+  local amid=$1
+  boundary auth-methods delete -id $amid -format json
+}
+
+function update_password_auth_method() {
+  local amid=$1
+  boundary auth-methods update password -id $amid -description "TEST"
+}
+
+function auth_method_id() {
+  local name=$1
+  strip $(list_auth_methods | jq -c ".items[] | select(.name != null) | select(.name | contains(\"$name\")) | .[\"id\"]")
+}
+
+function get_default_ldap_auth_method_id() {
+  strip $(list_auth_methods | jq -c ".items[] | select(.type | contains(\"ldap\")) | .[\"id\"]")
+}

--- a/internal/tests/cli/boundary/_auth_tokens.bash
+++ b/internal/tests/cli/boundary/_auth_tokens.bash
@@ -21,7 +21,7 @@ function delete_token() {
 
 function token_id() {
   local tid=$1
-  strip $(read_token $tid | jq '.item.id') 
+  strip $(read_token $tid | jq '.item.id')
 }
 
 function logout_cmd() {
@@ -34,4 +34,8 @@ function get_token() {
 
 function read_token_no_keyring() {
   boundary auth-tokens read -keyring-type=none -id $1
+}
+
+function list_tokens() {
+  boundary auth-tokens list -format json
 }

--- a/internal/tests/cli/boundary/_managed_groups.bash
+++ b/internal/tests/cli/boundary/_managed_groups.bash
@@ -1,0 +1,35 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+function create_ldap_managed_group() {
+  local amid=$1
+  local name=$2
+  local gnames=$3
+  boundary managed-groups create ldap -auth-method-id $amid -name $name -group-names $gnames -format json
+}
+
+function read_managed_group() {
+  local mgid=$1
+  boundary managed-groups read -id $mgid -format json
+}
+
+function list_managed_groups() {
+  local amid=$1
+  boundary managed-groups list -auth-method-id $amid -format json
+}
+
+function update_ldap_managed_group() {
+  local $mgid=$1
+  boundary managed-groups update ldap -id $mgid -description "TEST"
+}
+
+function delete_managed_group() {
+  local mgid=$1
+  boundary managed-groups delete -id $mgid -format json
+}
+
+function managed_group_id() {
+  local amid=$1
+  local name=$2
+  strip $(list_managed_groups $amid | jq -c ".items[] | select(.name != null) | select(.name | contains(\"$name\")) | .[\"id\"]")
+}

--- a/internal/tests/cli/boundary/auth_methods.bats
+++ b/internal/tests/cli/boundary/auth_methods.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+load _auth
+load _auth_methods
+load _helpers
+
+export NEW_AUTH_METHOD='test_auth_method'
+
+@test "boundary/auth_method: can log in as unpriv user" {
+  run login $DEFAULT_UNPRIVILEGED_LOGIN
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/auth_method: unpriv user can list auth methods" {
+  run list_auth_methods
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/auth_method: log in as default user" {
+  run login $DEFAULT_LOGIN
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/auth_method: can list auth methods" {
+  run list_auth_methods
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/auth_method: can create a password auth method" {
+  run create_password_auth_method $NEW_AUTH_METHOD
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/auth_method: can read an auth method" {
+  local amid=$(auth_method_id $NEW_AUTH_METHOD)
+  run read_auth_method $amid
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/auth_method: can update an auth method" {
+  local amid=$(auth_method_id $NEW_AUTH_METHOD)
+  run update_password_auth_method $amid
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/auth_method: can delete an auth method" {
+  local amid=$(auth_method_id $NEW_AUTH_METHOD)
+  run delete_auth_method $amid
+  echo "$output"
+  [ "$status" -eq 0 ]
+}

--- a/internal/tests/cli/boundary/auth_token.bats
+++ b/internal/tests/cli/boundary/auth_token.bats
@@ -27,6 +27,12 @@ export NEW_USER='test'
   [ "$status" -eq 0 ]
 }
 
+@test "boundary/token: can list tokens" {
+  run list_tokens
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
 @test "boundary/token: can delete own token with no id given" {
   run login $DEFAULT_UNPRIVILEGED_LOGIN
   [ "$status" -eq 0 ]

--- a/internal/tests/cli/boundary/managed_groups.bats
+++ b/internal/tests/cli/boundary/managed_groups.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load _auth
+load _auth_methods
+load _helpers
+load _managed_groups
+
+export NEW_MANAGED_GROUP='test_managed_group'
+export NEW_GROUP_NAMES='test_group_names'
+
+@test "boundary/managed_group: log in as default user" {
+  run login $DEFAULT_LOGIN
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/managed_group: can create a managed group" {
+  local amid=$(get_default_ldap_auth_method_id)
+  run create_ldap_managed_group $amid $NEW_MANAGED_GROUP $NEW_GROUP_NAMES
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/managed_group: can update a managed group" {
+  local amid=$(get_default_ldap_auth_method_id)
+  local mgid=$(managed_group_id $amid $NEW_MANAGED_GROUP)
+  run update_ldap_managed_group $amid
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/managed_group: can delete a managed group" {
+  local amid=$(get_default_ldap_auth_method_id)
+  local mgid=$(managed_group_id $amid $NEW_MANAGED_GROUP)
+  run delete_managed_group $mgid
+  echo "$output"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
This PR adds bats tests to cover `list` functionality for the remaining resource types
- auth methods
- auth tokens
- managed groups

There are still two resource types outstanding: `storage-buckets` and `session-recordings`. Those will either be covered in boundary-enterprise `bats` or `e2e` tests.