### PR TITLE
test(e2e): Change postgres deadlock timeout to default

### DIFF
--- a/enos/modules/docker_postgres/postgresql.conf
+++ b/enos/modules/docker_postgres/postgresql.conf
@@ -3,7 +3,6 @@ max_connections            = 100
 work_mem                   = 50000kB
 shared_buffers             = 64MB
 log_destination            = 'stderr'
-deadlock_timeout           = 100
 log_min_messages           = info
 log_min_error_statement    = error
 log_error_verbosity        = verbose


### PR DESCRIPTION
This PR updates the postgres docker container in the e2e test suite to use the default deadlock timeout. The current setting was occasionally causing some flaky tests, like the following...
```
Error from controller when performing delete on scope
            	
Error information:
  Kind:                Internal
  Message:             scope.(Service).deleteFromRepo: unable to delete scope:
  iam.(Repository).DeleteScope: failed for o_TG0TF3JWcq:
  iam.(Repository).delete: db.DoTx: iam.(Repository).delete: db.Delete: unknown,
  unknown: error #0: dbw.Delete: ERROR: deadlock detected (SQLSTATE 40P01)
  Status:              500
  context:             Error from controller when performing delete on scope
```

This PR removes the current override so it uses the default value instead. The override was carried over from some prior testing. 