### PR TITLE
chore(e2e): Add GetUserPolicy permission to service user

### DIFF
--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -177,6 +177,7 @@ data "aws_iam_policy_document" "enos_policy_document" {
       "iam:GetRolePolicy",
       "iam:GetUser",
       "iam:GetUserId",
+      "iam:GetUserPolicy",
       "iam:ListAccessKeys",
       "iam:ListAttachedRolePolicies",
       "iam:ListGroupsForUser",


### PR DESCRIPTION
This PR updates the permissions for the AWS user used in CI to include `iam:GetUserPolicy`. We started seeing failures last night due to...
```
Error: waiting for IAM User Policy (boundary-e2e-EMvkM:boundary_e2e_EMvkM) create: AccessDenied: User: arn:aws:sts::173905499206:assumed-role/github_actions-boundary_enterprise_ci/GitHubActions is not authorized to perform: iam:GetUserPolicy on resource: user boundary-e2e-EMvkM because no identity-based policy allows the iam:GetUserPolicy action
	status code: 403, request id: 6b2f6782-c305-4d22-bdb4-f4bf8c0148e1

  with module.iam_setup.aws_iam_user_policy.boundary,
  on ../../modules/aws_iam_setup/main.tf line 20, in resource "aws_iam_user_policy" "boundary":
  20: resource "aws_iam_user_policy" "boundary" {
  Validate: success!
  Plan: success!
```

I've already applied the changes to the user and the failures have been resolved. This PR is just checking the terraform changes.