### PR TITLE
fix: monitorUpstreamConnectionState CPU consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## Next
 
+### Bug Fixes
+* monitorUpstreamConnectionState CPU consumption: `monitorUpstreamConnectionState()` is a goroutine that listens for GRPC client connection changes using GRPC's `WaitForStateChange` method. `monitorUpstreamConnectionState()` was consuming the a lot of CPU. It was continuously running and not actually waiting for state changes. The `state` for `monitorUpstreamConnectionState()` was not getting correctly updated which caused the loop to continuously run instead of waiting for new state changes.
+
 ## 0.14.1 (2023/10/17)
 
 ### Security

--- a/internal/daemon/worker/controller_connection.go
+++ b/internal/daemon/worker/controller_connection.go
@@ -434,7 +434,7 @@ func monitorUpstreamConnectionState(ctx context.Context, cc *grpc.ClientConn, co
 	}
 
 	for cc.WaitForStateChange(ctx, state) {
-		state := cc.GetState()
+		state = cc.GetState()
 
 		// if the client is shutdown, exit function
 		if state == connectivity.Shutdown {
@@ -442,7 +442,5 @@ func monitorUpstreamConnectionState(ctx context.Context, cc *grpc.ClientConn, co
 		}
 
 		connectionState.Store(state)
-
-		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/internal/daemon/worker/controller_connection.go
+++ b/internal/daemon/worker/controller_connection.go
@@ -442,5 +442,7 @@ func monitorUpstreamConnectionState(ctx context.Context, cc *grpc.ClientConn, co
 		}
 
 		connectionState.Store(newState)
+
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/internal/daemon/worker/controller_connection.go
+++ b/internal/daemon/worker/controller_connection.go
@@ -434,14 +434,14 @@ func monitorUpstreamConnectionState(ctx context.Context, cc *grpc.ClientConn, co
 	}
 
 	for cc.WaitForStateChange(ctx, state) {
-		newState := cc.GetState()
+		state := cc.GetState()
 
 		// if the client is shutdown, exit function
-		if newState == connectivity.Shutdown {
+		if state == connectivity.Shutdown {
 			return
 		}
 
-		connectionState.Store(newState)
+		connectionState.Store(state)
 
 		time.Sleep(10 * time.Millisecond)
 	}


### PR DESCRIPTION
Bug found in https://github.com/hashicorp/boundary/issues/3881

`monitorUpstreamConnectionState()` is a goroutine that listens for GRPC client connection changes using GRPC's `WaitForStateChange` method. 

`monitorUpstreamConnectionState()` is currently consuming the a lot of CPU. It seems to be continuously running and not actually waiting for state changes.

Reference for GRPC Connection State Transitions: https://grpc.github.io/grpc/core/md_doc_connectivity-semantics-and-api.html

`state` was never getting updated so the default state was never getting updated which was causing the loop not to wait for new state chanegs

**Before Fix**

<img width="896" alt="image" src="https://github.com/hashicorp/boundary/assets/9772116/8baba176-0ecf-43bb-a258-1703ab656efd">


**After Fix**

<img width="929" alt="image" src="https://github.com/hashicorp/boundary/assets/9772116/952e729a-8062-44f2-bac6-fdd5b15f3174">
