### PR TITLE
Add GetResourceType to boundary.Resource

### DIFF
--- a/internal/auth/ldap/account.go
+++ b/internal/auth/ldap/account.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/boundary/internal/auth/ldap/store"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -118,6 +119,11 @@ func (a *Account) SetTableName(n string) {
 // doesn't currently support subject.
 func (a *Account) GetSubject() string {
 	return ""
+}
+
+// GetResourceType returns the resource type of the Account
+func (a *Account) GetResourceType() resource.Type {
+	return resource.Account
 }
 
 // oplog will create oplog metadata for the Account.

--- a/internal/auth/ldap/auth_method.go
+++ b/internal/auth/ldap/auth_method.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/boundary/internal/auth/ldap/store"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -110,6 +111,11 @@ func (am *AuthMethod) TableName() string {
 // SetTableName sets the table name (func is required by oplog)
 func (am *AuthMethod) SetTableName(n string) {
 	am.tableName = n
+}
+
+// GetResourceType returns the resource type of the AuthMethod
+func (am *AuthMethod) GetResourceType() resource.Type {
+	return resource.AuthMethod
 }
 
 // oplog will create oplog metadata for the AuthMethod.

--- a/internal/auth/ldap/managed_group.go
+++ b/internal/auth/ldap/managed_group.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/boundary/internal/auth/ldap/store"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -78,6 +79,11 @@ func (mg *ManagedGroup) TableName() string {
 // SetTableName sets the table name.
 func (mg *ManagedGroup) SetTableName(n string) {
 	mg.tableName = n
+}
+
+// GetResourceType returns the resource type of the ManagedGroup
+func (mg *ManagedGroup) GetResourceType() resource.Type {
+	return resource.ManagedGroup
 }
 
 // oplog will create oplog metadata for the ManagedGroup.

--- a/internal/auth/oidc/account.go
+++ b/internal/auth/oidc/account.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/boundary/internal/auth/oidc/store"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -113,6 +114,11 @@ func (a *Account) TableName() string {
 // SetTableName sets the table name.
 func (a *Account) SetTableName(n string) {
 	a.tableName = n
+}
+
+// GetResourceType returns the resource type of the Account
+func (a *Account) GetResourceType() resource.Type {
+	return resource.Account
 }
 
 // GetLoginName returns the login name, which will always be empty as this type

--- a/internal/auth/oidc/auth_method.go
+++ b/internal/auth/oidc/auth_method.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/libs/crypto"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-kms-wrapping/v2/extras/structwrapping"
 	kvbuilder "github.com/hashicorp/go-secure-stdlib/kv-builder"
@@ -188,6 +189,11 @@ func (a *AuthMethod) TableName() string {
 // SetTableName sets the table name.
 func (a *AuthMethod) SetTableName(n string) {
 	a.tableName = n
+}
+
+// GetResourceType returns the resource type of the AuthMethod
+func (a *AuthMethod) GetResourceType() resource.Type {
+	return resource.AuthMethod
 }
 
 // oplog will create oplog metadata for the AuthMethod.

--- a/internal/auth/oidc/managed_group.go
+++ b/internal/auth/oidc/managed_group.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/boundary/internal/auth/oidc/store"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/go-bexpr"
 	"google.golang.org/protobuf/proto"
 )
@@ -84,6 +85,11 @@ func (mg *ManagedGroup) TableName() string {
 // SetTableName sets the table name.
 func (mg *ManagedGroup) SetTableName(n string) {
 	mg.tableName = n
+}
+
+// GetResourceType returns the resource type of the ManagedGroup
+func (mg *ManagedGroup) GetResourceType() resource.Type {
+	return resource.ManagedGroup
 }
 
 // oplog will create oplog metadata for the ManagedGroup.

--- a/internal/auth/password/account.go
+++ b/internal/auth/password/account.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/boundary/internal/auth/password/store"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -68,6 +69,11 @@ func (a *Account) TableName() string {
 // SetTableName sets the table name.
 func (a *Account) SetTableName(n string) {
 	a.tableName = n
+}
+
+// GetResourceType returns the resource type of the Account
+func (a *Account) GetResourceType() resource.Type {
+	return resource.Account
 }
 
 // GetEmail returns the email, which will always be empty as this type doesn't

--- a/internal/auth/password/authmethod.go
+++ b/internal/auth/password/authmethod.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/boundary/internal/auth/password/store"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -67,6 +68,11 @@ func (a *AuthMethod) TableName() string {
 // SetTableName sets the table name.
 func (a *AuthMethod) SetTableName(n string) {
 	a.tableName = n
+}
+
+// GetResourceType returns the resource type of the AuthMethod
+func (a *AuthMethod) GetResourceType() resource.Type {
+	return resource.AuthMethod
 }
 
 func (a *AuthMethod) oplog(op oplog.OpType) oplog.Metadata {

--- a/internal/boundary/boundary.go
+++ b/internal/boundary/boundary.go
@@ -7,6 +7,7 @@ package boundary
 
 import (
 	"github.com/hashicorp/boundary/internal/db/timestamp"
+	"github.com/hashicorp/boundary/internal/types/resource"
 )
 
 // An Entity is an object distinguished by its identity, rather than its
@@ -24,11 +25,12 @@ type Aggregate interface {
 	GetUpdateTime() *timestamp.Timestamp
 }
 
-// A Resource is an aggregate with a name and description.
+// A Resource is an aggregate with a name, description, and resource type.
 type Resource interface {
 	Aggregate
 	GetName() string
 	GetDescription() string
+	GetResourceType() resource.Type
 }
 
 // AuthzProtectedEntity is used by some functions (primarily

--- a/internal/credential/static/credential_store.go
+++ b/internal/credential/static/credential_store.go
@@ -6,6 +6,7 @@ package static
 import (
 	"github.com/hashicorp/boundary/internal/credential/static/store"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -53,6 +54,11 @@ func (cs *CredentialStore) TableName() string {
 // SetTableName sets the table name.
 func (cs *CredentialStore) SetTableName(n string) {
 	cs.tableName = n
+}
+
+// GetResourceType returns the resource type of the CredentialStore
+func (cs *CredentialStore) GetResourceType() resource.Type {
+	return resource.CredentialStore
 }
 
 func (cs *CredentialStore) oplog(op oplog.OpType) oplog.Metadata {

--- a/internal/credential/static/json_credential.go
+++ b/internal/credential/static/json_credential.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/libs/crypto"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-kms-wrapping/v2/extras/structwrapping"
 	"google.golang.org/protobuf/proto"
@@ -86,6 +87,11 @@ func (c *JsonCredential) TableName() string {
 // SetTableName sets the table name.
 func (c *JsonCredential) SetTableName(n string) {
 	c.tableName = n
+}
+
+// GetResourceType returns the resource type of the Credential
+func (c *JsonCredential) GetResourceType() resource.Type {
+	return resource.Credential
 }
 
 func (c *JsonCredential) oplog(op oplog.OpType) oplog.Metadata {

--- a/internal/credential/static/ssh_private_key_credential.go
+++ b/internal/credential/static/ssh_private_key_credential.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/libs/crypto"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/protobuf/proto"
@@ -103,6 +104,11 @@ func (c *SshPrivateKeyCredential) TableName() string {
 // SetTableName sets the table name.
 func (c *SshPrivateKeyCredential) SetTableName(n string) {
 	c.tableName = n
+}
+
+// GetResourceType returns the resource type of the Credential
+func (c *SshPrivateKeyCredential) GetResourceType() resource.Type {
+	return resource.Credential
 }
 
 func (c *SshPrivateKeyCredential) oplog(op oplog.OpType) oplog.Metadata {

--- a/internal/credential/static/usernamepassword_credential.go
+++ b/internal/credential/static/usernamepassword_credential.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/libs/crypto"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-kms-wrapping/v2/extras/structwrapping"
 	"google.golang.org/protobuf/proto"
@@ -71,6 +72,11 @@ func (c *UsernamePasswordCredential) TableName() string {
 // SetTableName sets the table name.
 func (c *UsernamePasswordCredential) SetTableName(n string) {
 	c.tableName = n
+}
+
+// GetResourceType returns the resource type of the Credential
+func (c *UsernamePasswordCredential) GetResourceType() resource.Type {
+	return resource.Credential
 }
 
 func (c *UsernamePasswordCredential) oplog(op oplog.OpType) oplog.Metadata {

--- a/internal/credential/vault/credential_library.go
+++ b/internal/credential/vault/credential_library.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/boundary/internal/credential/vault/store"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -101,6 +102,11 @@ func (l *CredentialLibrary) TableName() string {
 // SetTableName sets the table name.
 func (l *CredentialLibrary) SetTableName(n string) {
 	l.tableName = n
+}
+
+// GetResourceType returns the resource type of the CredentialLibrary
+func (l *CredentialLibrary) GetResourceType() resource.Type {
+	return resource.CredentialLibrary
 }
 
 func (l *CredentialLibrary) oplog(op oplog.OpType) oplog.Metadata {

--- a/internal/credential/vault/credential_store.go
+++ b/internal/credential/vault/credential_store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -132,6 +133,11 @@ func (cs *CredentialStore) TableName() string {
 // SetTableName sets the table name.
 func (cs *CredentialStore) SetTableName(n string) {
 	cs.tableName = n
+}
+
+// GetResourceType returns the resource type of the CredentialStore
+func (cs *CredentialStore) GetResourceType() resource.Type {
+	return resource.CredentialStore
 }
 
 func (cs *CredentialStore) oplog(op oplog.OpType) oplog.Metadata {

--- a/internal/credential/vault/private_library.go
+++ b/internal/credential/vault/private_library.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/boundary/internal/db/timestamp"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/boundary/internal/util/template"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-kms-wrapping/v2/extras/structwrapping"
@@ -268,6 +269,11 @@ func (pl *genericIssuingCredentialLibrary) CredentialType() globals.CredentialTy
 	}
 }
 
+// GetResourceType returns the resource type of the CredentialLibrary
+func (pl *genericIssuingCredentialLibrary) GetResourceType() resource.Type {
+	return resource.CredentialLibrary
+}
+
 func (pl *genericIssuingCredentialLibrary) client(ctx context.Context) (vaultClient, error) {
 	const op = "vault.(genericIssuingCredentialLibrary).client"
 	clientConfig := &clientConfig{
@@ -493,6 +499,11 @@ type privateCredentialLibraryAllTypes struct {
 }
 
 func (pl *privateCredentialLibraryAllTypes) GetPublicId() string { return pl.PublicId }
+
+// GetResourceType returns the resource type of the CredentialLibrary
+func (pl *privateCredentialLibraryAllTypes) GetResourceType() resource.Type {
+	return resource.CredentialLibrary
+}
 
 func (pl *privateCredentialLibraryAllTypes) decrypt(ctx context.Context, cipher wrapping.Wrapper) error {
 	const op = "vault.(privateCredentialLibraryAllTypes).decrypt"
@@ -746,6 +757,11 @@ func (lib *sshCertIssuingCredentialLibrary) CredentialType() globals.CredentialT
 	default:
 		return globals.CredentialType(ct)
 	}
+}
+
+// GetResourceType returns the resource type of the CredentialLibrary
+func (lib *sshCertIssuingCredentialLibrary) GetResourceType() resource.Type {
+	return resource.CredentialLibrary
 }
 
 func (lib *sshCertIssuingCredentialLibrary) client(ctx context.Context) (vaultClient, error) {

--- a/internal/credential/vault/ssh_certificate_credential_library.go
+++ b/internal/credential/vault/ssh_certificate_credential_library.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/boundary/internal/credential"
 	"github.com/hashicorp/boundary/internal/credential/vault/store"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -91,6 +92,11 @@ func (l *SSHCertificateCredentialLibrary) TableName() string {
 // SetTableName sets the table name.
 func (l *SSHCertificateCredentialLibrary) SetTableName(n string) {
 	l.tableName = n
+}
+
+// GetResourceType returns the resource type of the CredentialLibrary
+func (l *SSHCertificateCredentialLibrary) GetResourceType() resource.Type {
+	return resource.CredentialLibrary
 }
 
 func (l *SSHCertificateCredentialLibrary) oplog(op oplog.OpType) oplog.Metadata {

--- a/internal/host/plugin/host.go
+++ b/internal/host/plugin/host.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/boundary/internal/event"
 	"github.com/hashicorp/boundary/internal/host/plugin/store"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"google.golang.org/protobuf/proto"
 )
@@ -88,6 +89,11 @@ func (s *Host) TableName() string {
 // set the name to "" the name will be reset to the default name.
 func (s *Host) SetTableName(n string) {
 	s.tableName = n
+}
+
+// GetResourceType returns the resource type of the Host
+func (s *Host) GetResourceType() resource.Type {
+	return resource.Host
 }
 
 func allocHost() *Host {

--- a/internal/host/plugin/host_catalog.go
+++ b/internal/host/plugin/host_catalog.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/boundary/internal/host/plugin/store"
 	"github.com/hashicorp/boundary/internal/libs/crypto"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -122,14 +123,19 @@ func (c *HostCatalog) SetTableName(n string) {
 	c.tableName = n
 }
 
-func (s *HostCatalog) oplog(op oplog.OpType) oplog.Metadata {
+// GetResourceType returns the resource type of the HostCatalog
+func (c *HostCatalog) GetResourceType() resource.Type {
+	return resource.HostCatalog
+}
+
+func (c *HostCatalog) oplog(op oplog.OpType) oplog.Metadata {
 	metadata := oplog.Metadata{
-		"resource-public-id": []string{s.PublicId},
+		"resource-public-id": []string{c.PublicId},
 		"resource-type":      []string{"plugin-host-catalog"},
 		"op-type":            []string{op.String()},
 	}
-	if s.ProjectId != "" {
-		metadata["project-id"] = []string{s.ProjectId}
+	if c.ProjectId != "" {
+		metadata["project-id"] = []string{c.ProjectId}
 	}
 	return metadata
 }

--- a/internal/host/plugin/host_set.go
+++ b/internal/host/plugin/host_set.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/host/plugin/store"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -63,6 +64,11 @@ func (s *HostSet) TableName() string {
 // set the name to "" the name will be reset to the default name.
 func (s *HostSet) SetTableName(n string) {
 	s.tableName = n
+}
+
+// GetResourceType returns the resource type of the HostSet
+func (s *HostSet) GetResourceType() resource.Type {
+	return resource.HostSet
 }
 
 func allocHostSet() *HostSet {

--- a/internal/host/static/host.go
+++ b/internal/host/static/host.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/host/static/store"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -69,6 +70,11 @@ func (h *Host) TableName() string {
 // set the name to "" the name will be reset to the default name.
 func (h *Host) SetTableName(n string) {
 	h.tableName = n
+}
+
+// GetResourceType returns the resource type of the Host
+func (h *Host) GetResourceType() resource.Type {
+	return resource.Host
 }
 
 func allocHost() *Host {

--- a/internal/host/static/host_catalog.go
+++ b/internal/host/static/host_catalog.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/host/static/store"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -57,6 +58,11 @@ func (c *HostCatalog) TableName() string {
 // set the name to "" the name will be reset to the default name.
 func (c *HostCatalog) SetTableName(n string) {
 	c.tableName = n
+}
+
+// GetResourceType returns the resource type of the HostCatalog
+func (c *HostCatalog) GetResourceType() resource.Type {
+	return resource.HostCatalog
 }
 
 func allocCatalog() *HostCatalog {

--- a/internal/host/static/host_set.go
+++ b/internal/host/static/host_set.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/host/static/store"
 	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -49,6 +50,11 @@ func (s *HostSet) TableName() string {
 // set the name to "" the name will be reset to the default name.
 func (s *HostSet) SetTableName(n string) {
 	s.tableName = n
+}
+
+// GetResourceType returns the resource type of the HostSet
+func (s *HostSet) GetResourceType() resource.Type {
+	return resource.HostSet
 }
 
 func allocHostSet() *HostSet {

--- a/internal/iam/group.go
+++ b/internal/iam/group.go
@@ -86,8 +86,8 @@ func (g *Group) GetScope(ctx context.Context, r db.Reader) (*Scope, error) {
 	return LookupScope(ctx, r, g)
 }
 
-// ResourceType returns the type of the Group.
-func (*Group) ResourceType() resource.Type { return resource.Group }
+// GetResourceType returns the type of the Group.
+func (*Group) GetResourceType() resource.Type { return resource.Group }
 
 // Actions returns the  available actions for Group
 func (*Group) Actions() map[string]action.Type {

--- a/internal/iam/group_test.go
+++ b/internal/iam/group_test.go
@@ -453,7 +453,7 @@ func TestGroup_Actions(t *testing.T) {
 func TestGroup_ResourceType(t *testing.T) {
 	assert := assert.New(t)
 	r := &Group{}
-	ty := r.ResourceType()
+	ty := r.GetResourceType()
 	assert.Equal(ty, resource.Group)
 }
 

--- a/internal/iam/repository.go
+++ b/internal/iam/repository.go
@@ -259,14 +259,14 @@ func (r *Repository) stdMetadata(ctx context.Context, resource Resource) (oplog.
 				"resource-public-id": []string{resource.GetPublicId()},
 				"scope-id":           []string{newScope.PublicId},
 				"scope-type":         []string{newScope.Type},
-				"resource-type":      []string{resource.ResourceType().String()},
+				"resource-type":      []string{resource.GetResourceType().String()},
 			}, nil
 		case scope.Project.String():
 			return oplog.Metadata{
 				"resource-public-id": []string{resource.GetPublicId()},
 				"scope-id":           []string{newScope.ParentId},
 				"scope-type":         []string{newScope.Type},
-				"resource-type":      []string{resource.ResourceType().String()},
+				"resource-type":      []string{resource.GetResourceType().String()},
 			}, nil
 		default:
 			return nil, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("not a supported scope for metadata: %s", s.Type))
@@ -284,7 +284,7 @@ func (r *Repository) stdMetadata(ctx context.Context, resource Resource) (oplog.
 		"resource-public-id": []string{resource.GetPublicId()},
 		"scope-id":           []string{scope.PublicId},
 		"scope-type":         []string{scope.Type},
-		"resource-type":      []string{resource.ResourceType().String()},
+		"resource-type":      []string{resource.GetResourceType().String()},
 	}, nil
 }
 

--- a/internal/iam/resource.go
+++ b/internal/iam/resource.go
@@ -33,7 +33,7 @@ type Resource interface {
 	GetScope(ctx context.Context, r db.Reader) (*Scope, error)
 
 	// Type of Resource (Target, Policy, User, Group, etc)
-	ResourceType() resource.Type
+	GetResourceType() resource.Type
 
 	// Actions that can be assigned permissions for
 	// the Resource in Policies. Action String() is key for

--- a/internal/iam/role.go
+++ b/internal/iam/role.go
@@ -86,8 +86,8 @@ func (role *Role) GetScope(ctx context.Context, r db.Reader) (*Scope, error) {
 	return LookupScope(ctx, r, role)
 }
 
-// ResourceType returns the type of the Role.
-func (*Role) ResourceType() resource.Type { return resource.Role }
+// GetResourceType returns the type of the Role.
+func (*Role) GetResourceType() resource.Type { return resource.Role }
 
 // Actions returns the available actions for Role.
 func (*Role) Actions() map[string]action.Type {

--- a/internal/iam/role_test.go
+++ b/internal/iam/role_test.go
@@ -558,7 +558,7 @@ func TestRole_Actions(t *testing.T) {
 func TestRole_ResourceType(t *testing.T) {
 	assert := assert.New(t)
 	r := &Role{}
-	ty := r.ResourceType()
+	ty := r.GetResourceType()
 	assert.Equal(ty, resource.Role)
 }
 

--- a/internal/iam/scope.go
+++ b/internal/iam/scope.go
@@ -150,8 +150,8 @@ func (s *Scope) VetForWrite(ctx context.Context, r db.Reader, opType db.OpType, 
 	return nil
 }
 
-// ResourceType returns the type of scope
-func (s *Scope) ResourceType() resource.Type {
+// GetResourceType returns the type of scope
+func (s *Scope) GetResourceType() resource.Type {
 	return resource.Scope
 }
 

--- a/internal/iam/scope_test.go
+++ b/internal/iam/scope_test.go
@@ -175,7 +175,7 @@ func TestScope_Actions(t *testing.T) {
 func TestScope_ResourceType(t *testing.T) {
 	o, err := NewOrg(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, o.ResourceType(), resource.Scope)
+	assert.Equal(t, o.GetResourceType(), resource.Scope)
 	assert.Equal(t, o.GetParentId(), scope.Global.String())
 }
 

--- a/internal/iam/user.go
+++ b/internal/iam/user.go
@@ -89,8 +89,8 @@ func (u *User) GetScope(ctx context.Context, r db.Reader) (*Scope, error) {
 	return LookupScope(ctx, r, u)
 }
 
-// ResourceType returns the type of the User
-func (*User) ResourceType() resource.Type { return resource.User }
+// GetResourceType returns the type of the User
+func (*User) GetResourceType() resource.Type { return resource.User }
 
 // Actions returns the  available actions for Users
 func (*User) Actions() map[string]action.Type {

--- a/internal/iam/user_test.go
+++ b/internal/iam/user_test.go
@@ -389,7 +389,7 @@ func TestUser_Actions(t *testing.T) {
 func TestUser_ResourceType(t *testing.T) {
 	t.Parallel()
 	u := AllocUser()
-	assert.Equal(t, resource.User, u.ResourceType())
+	assert.Equal(t, resource.User, u.GetResourceType())
 }
 
 func TestUser_SetTableName(t *testing.T) {

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/oplog"
 	"github.com/hashicorp/boundary/internal/target/store"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/boundary/internal/types/subtypes"
 )
 
@@ -26,6 +27,7 @@ type Target interface {
 	GetDescription() string
 	GetVersion() uint32
 	GetType() subtypes.Subtype
+	GetResourceType() resource.Type
 	GetCreateTime() *timestamp.Timestamp
 	GetUpdateTime() *timestamp.Timestamp
 	GetSessionMaxSeconds() uint32
@@ -106,6 +108,11 @@ func (t *targetView) SetTableName(n string) {
 	default:
 		t.tableName = n
 	}
+}
+
+// GetResourceType returns the resource type of the Target
+func (t *targetView) GetResourceType() resource.Type {
+	return resource.Target
 }
 
 func (t *targetView) SetHostSources(hs []HostSource) {

--- a/internal/target/targettest/target.go
+++ b/internal/target/targettest/target.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/boundary/internal/oplog"
 	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/internal/target/targettest/store"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/boundary/internal/types/subtypes"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -180,6 +181,11 @@ func (t *Target) SetName(name string) {
 
 func (t *Target) SetDescription(description string) {
 	t.Description = description
+}
+
+// GetResourceType returns the resource type of the Target
+func (t *Target) GetResourceType() resource.Type {
+	return resource.Target
 }
 
 func (t *Target) SetVersion(v uint32) {

--- a/internal/target/tcp/target.go
+++ b/internal/target/tcp/target.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/boundary/internal/oplog"
 	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/internal/target/tcp/store"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/boundary/internal/types/subtypes"
 	"google.golang.org/protobuf/proto"
 )
@@ -176,6 +177,11 @@ func (t *Target) SetName(name string) {
 
 func (t *Target) SetDescription(description string) {
 	t.Description = description
+}
+
+// GetResourceType returns the resource type of the Target
+func (t *Target) GetResourceType() resource.Type {
+	return resource.Target
 }
 
 func (t *Target) SetVersion(v uint32) {


### PR DESCRIPTION
## [internal/boundary: add GetResourceType to Resource](https://github.com/hashicorp/boundary/pull/3888/commits/38ca39f0a59ba24ef355e1204b48c7fb61a1be75)

The resource type method is used to automatically create refresh tokens from a resource when that resource is the last item returned in a page.