### PR TITLE
Add generic pagination package

### DIFF
--- a/internal/daemon/controller/controller.go
+++ b/internal/daemon/controller/controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	kmsjob "github.com/hashicorp/boundary/internal/kms/job"
+	"github.com/hashicorp/boundary/internal/pagination/purge"
 	"github.com/hashicorp/boundary/internal/plugin"
 	"github.com/hashicorp/boundary/internal/plugin/loopback"
 	"github.com/hashicorp/boundary/internal/scheduler"
@@ -585,6 +586,9 @@ func (c *Controller) registerJobs() error {
 		return err
 	}
 	if err := census.RegisterJob(c.baseContext, c.scheduler, c.conf.RawConfig.Reporting.License.Enabled, rw, rw); err != nil {
+		return err
+	}
+	if err := purge.RegisterJobs(c.baseContext, c.scheduler, rw, rw); err != nil {
 		return err
 	}
 

--- a/internal/pagination/doc.go
+++ b/internal/pagination/doc.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package pagination implements generic functions for paginating
+// through a collection using callbacks. The functions will automatically
+// request additional items to match the input page size even when
+// some items may be filtered out.
+// See example_test.go for examples of using the library.
+package pagination

--- a/internal/pagination/example_test.go
+++ b/internal/pagination/example_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package pagination_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/boundary/internal/boundary"
+	"github.com/hashicorp/boundary/internal/db/timestamp"
+	"github.com/hashicorp/boundary/internal/pagination"
+	"github.com/hashicorp/boundary/internal/refreshtoken"
+	"github.com/hashicorp/boundary/internal/types/resource"
+)
+
+// An example resource. In a real example, this would
+// be a Target or Session or similar.
+type ExampleResource struct {
+	boundary.Resource
+	Value int
+}
+
+func (e *ExampleResource) GetPublicId() string {
+	return "er_1234567890"
+}
+
+func (e *ExampleResource) GetUpdateTime() *timestamp.Timestamp {
+	return timestamp.New(time.Now().Add(-10 * time.Hour))
+}
+
+func (e *ExampleResource) GetResourceType() resource.Type {
+	return resource.Unknown
+}
+
+func ExampleList() {
+	grantsHash := []byte("hash-of-grants") // Acquired from authorization logic
+	pageSize := 10                         // From request or service default
+	filterItemFunc := func(ctx context.Context, item *ExampleResource) (bool, error) {
+		// Inspect item to determine whether we want to
+		// include it in the final list.
+		return item.Value < 5, nil
+	}
+	listItemsFunc := func(ctx context.Context, prevPageLast *ExampleResource, limit int) ([]*ExampleResource, error) {
+		// Do the listing of the resource, generally using a
+		// repository method such as target.(*Repository).listTargets.
+		// Use the input to set up any options, for example a limit
+		// or a starting point.
+		if prevPageLast == nil {
+			// No previous page item means this is the first list request.
+			// List using limit.
+			// opts := target.Option{
+			//	target.WithLimit(limit),
+			// }
+		} else {
+			// Use the previous page last item to start pagination from the
+			// next page.
+			// opts := target.Option{
+			//	target.WithLimit(limit),
+			//	target.WithStartPageAfterItem(prevPageLast.GetPublicId(), prevPageLast.GetUpdateTime()),
+			// }
+		}
+		// Example result from the repository
+		return []*ExampleResource{
+			{nil, 0},
+			{nil, 1},
+			{nil, 2},
+			{nil, 3},
+			{nil, 4},
+			{nil, 5},
+			{nil, 6},
+			{nil, 7},
+			{nil, 8},
+			{nil, 9},
+			{nil, 10},
+		}, nil
+	}
+	estimatedCountFunc := func(ctx context.Context) (int, error) {
+		// Get an estimate from the database of the total number
+		// of entries for this resource, usually using some
+		// repository method.
+		return 1000, nil
+	}
+	resp, err := pagination.List(context.Background(), grantsHash, pageSize, filterItemFunc, listItemsFunc, estimatedCountFunc)
+	if err != nil {
+		fmt.Println("failed to paginate", err)
+		return
+	}
+	fmt.Println("Got results:")
+	for _, item := range resp.Items {
+		fmt.Printf("\tValue: %d\n", item.Value)
+	}
+	if resp.CompleteListing {
+		fmt.Println("Listing was complete")
+	} else {
+		fmt.Println("Listing was not complete")
+	}
+	fmt.Println("There are an estimated", resp.EstimatedItemCount, "total items available")
+	// Output: Got results:
+	//	Value: 0
+	//	Value: 1
+	//	Value: 2
+	//	Value: 3
+	//	Value: 4
+	//	Value: 0
+	//	Value: 1
+	//	Value: 2
+	//	Value: 3
+	//	Value: 4
+	// Listing was not complete
+	// There are an estimated 1000 total items available
+}
+
+func ExampleListRefresh() {
+	grantsHash := []byte("hash-of-grants") // Acquired from authorization logic
+	pageSize := 10                         // From request or service default
+	refreshToken, err := refreshtoken.New( // Normally from incoming request
+		context.Background(),
+		time.Now(),
+		time.Now(),
+		resource.Unknown,
+		grantsHash,
+		"er_1234567890",
+		time.Now().Add(-time.Hour),
+	)
+	if err != nil {
+		fmt.Println("failed to paginate", err)
+		return
+	}
+	filterItemFunc := func(ctx context.Context, item *ExampleResource) (bool, error) {
+		// Inspect item to determine whether we want to
+		// include it in the final list.
+		return item.Value < 5, nil
+	}
+	listItemsFunc := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *ExampleResource, limit int) ([]*ExampleResource, error) {
+		// Do the listing of the resource, generally using a
+		// repository method such as target.(*Repository).listTargets.
+		// Use the input to set up any options, for example a limit
+		// or a starting point.
+		if prevPageLast == nil {
+			// No previous page item means use the values from the refresh token.
+			// opts := target.Option{
+			//	target.WithLimit(limit),
+			//	target.WithStartPageAfterItem(tok.GetPublicId(), tok.GetUpdateTime()),
+			// }
+		} else {
+			// Use the previous page last item to start pagination from the next page.
+			// opts := target.Option{
+			//	target.WithLimit(limit),
+			//	target.WithStartPageAfterItem(prevPageLast.GetPublicId(), prevPageLast.GetUpdateTime()),
+			// }
+		}
+		// Example result from the repository
+		return []*ExampleResource{
+			{nil, 0},
+			{nil, 1},
+			{nil, 2},
+			{nil, 3},
+			{nil, 4},
+			{nil, 5},
+			{nil, 6},
+			{nil, 7},
+			{nil, 8},
+			{nil, 9},
+			{nil, 10},
+		}, nil
+	}
+	estimatedCountFunc := func(ctx context.Context) (int, error) {
+		// Get an estimate from the database of the total number
+		// of entries for this resource, usually using some
+		// repository method.
+		return 1000, nil
+	}
+	deletedIdsFunc := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+		// Return IDs of resources that have been deleted since the provided timestamp.
+		// Also return a timestamp for which this list was created, allowing the next
+		// invocation to start from the point where this invocation left off.
+		return []string{"er_0123456789"}, time.Now(), nil
+	}
+	resp, err := pagination.ListRefresh(context.Background(), grantsHash, pageSize, filterItemFunc, listItemsFunc, estimatedCountFunc, deletedIdsFunc, refreshToken)
+	if err != nil {
+		fmt.Println("failed to paginate", err)
+		return
+	}
+	fmt.Println("Got results:")
+	for _, item := range resp.Items {
+		fmt.Printf("\tValue: %d\n", item.Value)
+	}
+	if resp.CompleteListing {
+		fmt.Println("Listing was complete")
+	} else {
+		fmt.Println("Listing was not complete")
+	}
+	fmt.Println("There are an estimated", resp.EstimatedItemCount, "total items available")
+	fmt.Println("The following resources have been deleted since we last saw them:")
+	for _, id := range resp.DeletedIds {
+		fmt.Println("\t" + id)
+	}
+	// Output: Got results:
+	//	Value: 0
+	//	Value: 1
+	//	Value: 2
+	//	Value: 3
+	//	Value: 4
+	//	Value: 0
+	//	Value: 1
+	//	Value: 2
+	//	Value: 3
+	//	Value: 4
+	// Listing was not complete
+	// There are an estimated 1000 total items available
+	// The following resources have been deleted since we last saw them:
+	//	er_0123456789
+}

--- a/internal/pagination/item.go
+++ b/internal/pagination/item.go
@@ -1,0 +1,18 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package pagination
+
+import (
+	"github.com/hashicorp/boundary/internal/db/timestamp"
+	"github.com/hashicorp/boundary/internal/types/resource"
+)
+
+// Item defines a subset of a boundary.Resource that can
+// be used as an input to a DB operation for the purposes
+// of pagination and sorting.
+type Item interface {
+	GetPublicId() string
+	GetUpdateTime() *timestamp.Timestamp
+	GetResourceType() resource.Type
+}

--- a/internal/pagination/pagination.go
+++ b/internal/pagination/pagination.go
@@ -1,0 +1,223 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package pagination
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/boundary/internal/boundary"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/refreshtoken"
+)
+
+// ListResponse represents the response from the paginated list operation.
+type ListResponse[T boundary.Resource] struct {
+	// Items contains the page of items. They have
+	// been filtered according to the behaviour of
+	// the filter item func, and will always have as
+	// many items as requested in the page size, unless
+	// there were not enough elements available, in
+	// which case it will contain all elements that
+	// were available.
+	Items []T
+	// CompleteListing signifies whether this page contains
+	// the final item currently available. This indicates
+	// that it may be appropriate to wait some time before
+	// requesting additional pages.
+	CompleteListing bool
+	// RefreshToken is the token that the caller can use
+	// to request a new page of items. The items in the
+	// new page will have been updated more recently
+	// than all the items in the previous page. This
+	// field may be empty if there were no results for a
+	// List call.
+	RefreshToken *refreshtoken.Token
+	// DeletedIds contains a list of item IDs that have been
+	// deleted since the last request for items. This can happen
+	// both during the initial pagination or when requesting a
+	// refresh. This is always empty for the initial List call.
+	DeletedIds []string
+	// EstimatedItemCount is an estimate on exactly how many
+	// items matching the filter function are available. If
+	// a List call is complete, this number is equal to
+	// the number of items returned. Otherwise, the
+	// estimated count function is consulted for an estimate.
+	EstimatedItemCount int
+}
+
+// ListFilterFunc is a callback used to filter out resources that don't match
+// some criteria. The function must return true for items that should be included in the final
+// result. Returning an error results in an error being returned from the pagination.
+type ListFilterFunc[T boundary.Resource] func(ctx context.Context, item T) (bool, error)
+
+// ListItemsFunc returns a slice of T that have been updated since prevPageLastItem.
+// If prevPageLastItem is empty, it returns a slice of T starting with the least recently updated.
+type ListItemsFunc[T boundary.Resource] func(ctx context.Context, prevPageLastItem T, limit int) ([]T, error)
+
+// ListRefreshItemsFunc returns a slice of T that have been updated since prevPageLastItem.
+// If prevPageLastItem is empty, it returns a slice of T that have been updated since the
+// item in the refresh token.
+type ListRefreshItemsFunc[T boundary.Resource] func(ctx context.Context, tok *refreshtoken.Token, prevPageLastItem T, limit int) ([]T, error)
+
+// EstimatedCountFunc is used to estimate the total number of items
+// available for the resource that is being listed.
+type EstimatedCountFunc func(ctx context.Context) (int, error)
+
+// ListDeletedIDsFunc is used to list the IDs of the resources deleted since
+// the given timestamp. It returns a slice of IDs and the timestamp of the
+// instant in which the slice was created.
+type ListDeletedIDsFunc func(ctx context.Context, since time.Time) ([]string, time.Time, error)
+
+// List returns a ListResponse. The response will contain at most a
+// number of items equal to the pageSize. Items are fetched using the
+// listItemsFn and then items are checked using the filterItemFn
+// to determine if they should be included in the response.
+// The response includes a new refresh token based on the grants and items.
+// The estimatedCountFn is used to provide an estimated total number of
+// items that can be returned by making additional requests using the provided
+// refresh token.
+func List[T boundary.Resource](
+	ctx context.Context,
+	grantsHash []byte,
+	pageSize int,
+	filterItemFn ListFilterFunc[T],
+	listItemsFn ListItemsFunc[T],
+	estimatedCountFn EstimatedCountFunc,
+) (*ListResponse[T], error) {
+	const op = "pagination.List"
+
+	items, completeListing, err := list(ctx, grantsHash, pageSize, filterItemFn, listItemsFn)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
+
+	resp := &ListResponse[T]{
+		Items:              items,
+		CompleteListing:    completeListing,
+		EstimatedItemCount: len(items),
+	}
+
+	if !completeListing {
+		// If this was not a complete listing, get an estimate
+		// of the total items from the DB.
+		var err error
+		resp.EstimatedItemCount, err = estimatedCountFn(ctx)
+		if err != nil {
+			return nil, errors.Wrap(ctx, err, op)
+		}
+	}
+
+	if len(items) > 0 {
+		resp.RefreshToken = refreshtoken.FromResource(items[len(items)-1], grantsHash)
+	}
+
+	return resp, nil
+}
+
+// ListRefresh returns a ListResponse. The response will contain at most a
+// number of items equal to the pageSize. Items are fetched using the
+// listRefreshItemsFn and then items are checked using the filterItemFn
+// to determine if they should be included in the response.
+// The response includes a new refresh token based on the grants and items.
+// The estimatedCountFn is used to provide an estimated total number of
+// items that can be returned by making additional requests using the provided
+// refresh token. The listDeletedIDsFn is used to list the IDs of any
+// resources that have been deleted since the refresh token was last used.
+func ListRefresh[T boundary.Resource](
+	ctx context.Context,
+	grantsHash []byte,
+	pageSize int,
+	filterItemFn ListFilterFunc[T],
+	listRefreshItemsFn ListRefreshItemsFunc[T],
+	estimatedCountFn EstimatedCountFunc,
+	listDeletedIDsFn ListDeletedIDsFunc,
+	tok *refreshtoken.Token,
+) (*ListResponse[T], error) {
+	const op = "pagination.ListRefresh"
+
+	deletedIds, transactionTimestamp, err := listDeletedIDsFn(ctx, tok.UpdatedTime)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
+
+	listItemsFn := func(ctx context.Context, prevPageLast T, limit int) ([]T, error) {
+		return listRefreshItemsFn(ctx, tok, prevPageLast, limit)
+	}
+
+	items, completeListing, err := list(ctx, grantsHash, pageSize, filterItemFn, listItemsFn)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
+
+	resp := &ListResponse[T]{
+		Items:           items,
+		CompleteListing: completeListing,
+		DeletedIds:      deletedIds,
+	}
+
+	resp.EstimatedItemCount, err = estimatedCountFn(ctx)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
+
+	if len(items) > 0 {
+		resp.RefreshToken = tok.RefreshLastItem(items[len(items)-1], transactionTimestamp)
+	} else {
+		resp.RefreshToken = tok.Refresh(transactionTimestamp)
+	}
+
+	return resp, nil
+}
+
+func list[T boundary.Resource](
+	ctx context.Context,
+	grantsHash []byte,
+	pageSize int,
+	filterItemFn ListFilterFunc[T],
+	listItemsFn ListItemsFunc[T],
+) ([]T, bool, error) {
+	const op = "pagination.list"
+
+	var lastItem T
+	limit := pageSize + 1
+	items := make([]T, 0, limit)
+dbLoop:
+	for {
+		// Request another page from the DB until we fill the final items
+		page, err := listItemsFn(ctx, lastItem, limit)
+		if err != nil {
+			return nil, false, errors.Wrap(ctx, err, op)
+		}
+		for _, item := range page {
+			ok, err := filterItemFn(ctx, item)
+			if err != nil {
+				return nil, false, errors.Wrap(ctx, err, op)
+			}
+			if ok {
+				items = append(items, item)
+				// If we filled the items after filtering,
+				// we're done.
+				if len(items) == cap(items) {
+					break dbLoop
+				}
+			}
+		}
+		// If the current page was shorter than the limit, stop iterating
+		if len(page) < limit {
+			break dbLoop
+		}
+
+		lastItem = page[len(page)-1]
+	}
+	// If we couldn't fill the items, it was a complete listing.
+	completeListing := len(items) < cap(items)
+	if !completeListing {
+		// Items is of size pageSize+1, so
+		// truncate if it was filled.
+		items = items[:pageSize]
+	}
+
+	return items, completeListing, nil
+}

--- a/internal/pagination/pagination_test.go
+++ b/internal/pagination/pagination_test.go
@@ -1,0 +1,1186 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package pagination
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/boundary/internal/boundary"
+	"github.com/hashicorp/boundary/internal/db/timestamp"
+	"github.com/hashicorp/boundary/internal/refreshtoken"
+	"github.com/hashicorp/boundary/internal/types/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testType2 struct {
+	boundary.Resource
+	ID string
+}
+
+func (t *testType2) GetResourceType() resource.Type {
+	return resource.Unknown
+}
+
+func (t *testType2) GetUpdateTime() *timestamp.Timestamp {
+	return timestamp.Now()
+}
+
+func (t *testType2) GetPublicId() string {
+	return t.ID
+}
+
+func Test_List(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("no-rows", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return nil, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Items)
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 0)
+		// No response token expected when there were no results
+		assert.Nil(t, resp.RefreshToken)
+	})
+	t.Run("fill-on-first-with-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "2"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "2")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-first-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "2"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 2)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "2")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent-with-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}, {nil, "5"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 2)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("dont-fill-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 1)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("dont-fill-with-full-last-page", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			switch {
+			case prevPageLast == nil:
+				return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+			case prevPageLast.ID == "3":
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			case prevPageLast.ID == "6":
+				return nil, nil
+			default:
+				t.Fatalf("unexpected call to listItemsFn with %#v", prevPageLast)
+				return nil, nil
+			}
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 1)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("filter-everything", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			switch {
+			case prevPageLast == nil:
+				return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+			case prevPageLast.ID == "3":
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			case prevPageLast.ID == "6":
+				return nil, nil
+			default:
+				t.Fatalf("unexpected call to listItemsFn with %#v", prevPageLast)
+				return nil, nil
+			}
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			// Filter every item
+			return false, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Items)
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 0)
+		assert.Nil(t, resp.RefreshToken)
+	})
+	t.Run("errors-when-list-errors-immediately", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			return nil, errors.New("failed to list")
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.ErrorContains(t, err, "failed to list")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-list-errors-subsequently", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				return nil, errors.New("failed to list")
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.ErrorContains(t, err, "failed to list")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-filter-errors", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return false, errors.New("failed to filter")
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.ErrorContains(t, err, "failed to filter")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-estimated-count-errors", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		listItemsFn := func(ctx context.Context, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 0, errors.New("failed to estimate count")
+		}
+		grantsHash := []byte("some hash")
+		resp, err := List(ctx, grantsHash, pageSize, filterItemFn, listItemsFn, estimatedItemCountFn)
+		require.ErrorContains(t, err, "failed to estimate count")
+		assert.Empty(t, resp)
+	})
+}
+
+func Test_ListRefresh(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("no-rows", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return nil, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Items)
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-first-with-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "2"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "2")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-first-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "2"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "2")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent-with-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}, {nil, "5"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.False(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("fill-on-subsequent", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID == "2" || item.ID == "4" || item.ID == "6" {
+				// Filter every other item
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}, {nil, "3"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "3")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("dont-fill-without-remaining", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				assert.Equal(t, "3", prevPageLast.ID)
+				return []*testType2{{nil, "4"}}, nil
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("dont-fill-with-full-last-page", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			switch {
+			case prevPageLast == nil:
+				return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+			case prevPageLast.ID == "3":
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			case prevPageLast.ID == "6":
+				return nil, nil
+			default:
+				t.Fatalf("unexpected call to listRefreshItemsFn with %#v", prevPageLast)
+				return nil, nil
+			}
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(resp.Items, []*testType2{{nil, "1"}}))
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("filter-everything", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			switch {
+			case prevPageLast == nil:
+				return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+			case prevPageLast.ID == "3":
+				return []*testType2{{nil, "4"}, {nil, "5"}, {nil, "6"}}, nil
+			case prevPageLast.ID == "6":
+				return nil, nil
+			default:
+				t.Fatalf("unexpected call to listRefreshItemsFn with %#v", prevPageLast)
+				return nil, nil
+			}
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			// Filter every item
+			return false, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Items)
+		assert.True(t, resp.CompleteListing)
+		assert.Empty(t, resp.DeletedIds)
+		assert.Equal(t, resp.EstimatedItemCount, 10)
+		require.NotNil(t, resp.RefreshToken)
+		// Times should be within ~10 seconds of now
+		assert.True(t, resp.RefreshToken.CreatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.CreatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Before(time.Now().Add(10*time.Second)))
+		assert.True(t, resp.RefreshToken.UpdatedTime.Equal(resp.RefreshToken.CreatedTime))
+		assert.Equal(t, resp.RefreshToken.GrantsHash, grantsHash)
+		assert.Equal(t, resp.RefreshToken.LastItemId, "1")
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.After(time.Now().Add(-10*time.Second)))
+		assert.True(t, resp.RefreshToken.LastItemUpdatedTime.Before(time.Now().Add(10*time.Second)))
+	})
+	t.Run("errors-when-list-errors-immediately", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			return nil, errors.New("failed to list")
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.ErrorContains(t, err, "failed to list")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-list-errors-subsequently", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			if prevPageLast != nil {
+				return nil, errors.New("failed to list")
+			}
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			if item.ID != "1" {
+				// Filter every item except the first
+				return false, nil
+			}
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.ErrorContains(t, err, "failed to list")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-filter-errors", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return false, errors.New("failed to filter")
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.ErrorContains(t, err, "failed to filter")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-estimated-count-errors", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 0, errors.New("failed to estimate count")
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, nil
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.ErrorContains(t, err, "failed to estimate count")
+		assert.Empty(t, resp)
+	})
+	t.Run("errors-when-listing-deleted-ids-errors", func(t *testing.T) {
+		t.Parallel()
+		pageSize := 2
+		refreshToken, err := refreshtoken.New(
+			ctx,
+			time.Now(),
+			time.Now(),
+			resource.Unknown,
+			[]byte("some hash"),
+			"1",
+			time.Now(),
+		)
+		require.NoError(t, err)
+		listRefreshItemsFn := func(ctx context.Context, tok *refreshtoken.Token, prevPageLast *testType2, limit int) ([]*testType2, error) {
+			assert.Nil(t, prevPageLast)
+			return []*testType2{{nil, "1"}, {nil, "2"}, {nil, "3"}}, nil
+		}
+		filterItemFn := func(ctx context.Context, item *testType2) (bool, error) {
+			return true, nil
+		}
+		estimatedItemCountFn := func(ctx context.Context) (int, error) {
+			return 10, nil
+		}
+		deletedIDsFn := func(ctx context.Context, since time.Time) ([]string, time.Time, error) {
+			return nil, time.Time{}, errors.New("failed to list deleted ids")
+		}
+		grantsHash := []byte("some hash")
+		resp, err := ListRefresh(
+			ctx,
+			grantsHash,
+			pageSize,
+			filterItemFn,
+			listRefreshItemsFn,
+			estimatedItemCountFn,
+			deletedIDsFn,
+			refreshToken,
+		)
+		require.ErrorContains(t, err, "failed to list deleted ids")
+		assert.Empty(t, resp)
+	})
+}

--- a/internal/pagination/purge/purge.go
+++ b/internal/pagination/purge/purge.go
@@ -1,0 +1,51 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package purge
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/scheduler"
+	"github.com/hashicorp/boundary/internal/util"
+)
+
+// RegisterJobs registers the purge job for each deletion table with the provided scheduler.
+func RegisterJobs(ctx context.Context, s *scheduler.Scheduler, r db.Reader, w db.Writer) error {
+	const op = "purge.RegisterJobs"
+	if s == nil {
+		return errors.New(ctx, errors.InvalidParameter, "nil scheduler", op, errors.WithoutEvent())
+	}
+	if util.IsNil(r) {
+		return errors.New(ctx, errors.Internal, "nil DB reader", op, errors.WithoutEvent())
+	}
+	if util.IsNil(w) {
+		return errors.New(ctx, errors.Internal, "nil DB writer", op, errors.WithoutEvent())
+	}
+
+	rows, err := r.Query(ctx, "select get_deletion_tables()", nil)
+	if err != nil {
+		return errors.Wrap(ctx, err, op, errors.WithMsg("unable to query for deletion tables"))
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var table string
+		err = rows.Scan(&table)
+		if err != nil {
+			return errors.Wrap(ctx, err, op, errors.WithMsg("unable to scan rows for deletion tables"))
+		}
+
+		purgeJob, err := newPurgeJob(ctx, w, table)
+		if err != nil {
+			return fmt.Errorf("error creating purge job: %w", err)
+		}
+		if err := s.RegisterJob(ctx, purgeJob); err != nil {
+			return errors.Wrap(ctx, err, op)
+		}
+	}
+	return nil
+}

--- a/internal/pagination/purge/purge_job.go
+++ b/internal/pagination/purge/purge_job.go
@@ -1,0 +1,69 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package purge
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/scheduler"
+)
+
+type purgeJob struct {
+	w     db.Writer
+	table string
+	query string
+}
+
+func newPurgeJob(ctx context.Context, w db.Writer, table string) (*purgeJob, error) {
+	const op = "purgeJob.newPurgeJob"
+	switch {
+	case w == nil:
+		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing db.Writer")
+	case table == "":
+		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing table")
+	}
+
+	query := fmt.Sprintf("delete from %s where delete_time < now() - interval '30 days'", table)
+	return &purgeJob{
+		w:     w,
+		table: table,
+		query: query,
+	}, nil
+}
+
+// Status reports the job’s current status.
+func (c *purgeJob) Status() scheduler.JobStatus {
+	return scheduler.JobStatus{}
+}
+
+// Run performs the required work depending on the implementation.
+// The context is used to notify the job that it should exit early.
+func (c *purgeJob) Run(ctx context.Context) error {
+	const op = "purge.(purgeJob).Run"
+	_, err := c.w.Exec(ctx, c.query, nil)
+	if err != nil {
+		return errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("unable to prune table %s", c.query)))
+	}
+	return nil
+}
+
+// NextRunIn returns the duration until the next job run should be scheduled.
+// This job runs about once a day.
+func (c *purgeJob) NextRunIn(_ context.Context) (time.Duration, error) {
+	return 24 * time.Hour, nil
+}
+
+// Name is the unique name of the job.
+func (c *purgeJob) Name() string {
+	return fmt.Sprintf("%s_items_table_purge", c.table)
+}
+
+// Description is the human-readable description of the job.
+func (c *purgeJob) Description() string {
+	return "Automatically deletes rows from the deleted items DB tables after 30 days, to ensure the tables don’t build up forever"
+}

--- a/internal/pagination/purge/purge_test.go
+++ b/internal/pagination/purge/purge_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package purge
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPurgeTables(t *testing.T) {
+	ctx := context.Background()
+
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+
+	db, err := conn.SqlDB(ctx)
+	if err != nil {
+		t.Errorf("error getting db connection %s", err)
+	}
+
+	rows, err := db.Query("select get_deletion_tables()")
+	if err != nil {
+		t.Errorf("unable to query for deletion tables %s", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var table string
+		err = rows.Scan(&table)
+		if err != nil {
+			t.Errorf("unable to scan rows for deletion tables %s", err)
+		}
+		_, err = db.Exec(fmt.Sprintf("insert into %s (public_id, delete_time) values ('p1234567890', $1)", table), time.Now())
+		if err != nil {
+			t.Errorf("error updating %s %s", table, err)
+		}
+		_, err = db.Exec(fmt.Sprintf("insert into %s (public_id, delete_time) values ('p9876543210', $1)", table), time.Now().AddDate(0, -2, 0))
+		if err != nil {
+			t.Errorf("error updating %s %s", table, err)
+		}
+
+		query := fmt.Sprintf("delete from %s where delete_time < now() - interval '30 days'", table)
+		sJob := purgeJob{
+			w:     rw,
+			table: table,
+			query: query,
+		}
+
+		err = sJob.Run(ctx)
+		require.NoError(t, err)
+
+		var count int
+		err = db.QueryRowContext(ctx, fmt.Sprintf("select count(public_id) from %s", table)).Scan(&count)
+		if err != nil {
+			t.Errorf("error checking %s table %s", table, err)
+		}
+		require.Equal(t, 1, count)
+	}
+}
+
+func TestNewPurgeJob(t *testing.T) {
+	ctx := context.Background()
+
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+
+	type args struct {
+		w     db.Writer
+		table string
+	}
+
+	tests := []struct {
+		name       string
+		args       args
+		wantIsErr  errors.Code
+		wantErrMsg string
+	}{
+		{
+			name: "valid",
+			args: args{
+				w:     rw,
+				table: "valid-table",
+			},
+		},
+		{
+			name: "nil-writer",
+			args: args{
+				w:     nil,
+				table: "valid-table",
+			},
+			wantIsErr:  errors.InvalidParameter,
+			wantErrMsg: "purgeJob.newPurgeJob: missing db.Writer: parameter violation: error #100",
+		},
+		{
+			name: "no table",
+			args: args{
+				w:     rw,
+				table: "",
+			},
+			wantIsErr:  errors.InvalidParameter,
+			wantErrMsg: "purgeJob.newPurgeJob: missing table: parameter violation: error #100",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := newPurgeJob(ctx, tt.args.w, tt.args.table)
+			if tt.wantIsErr != 0 {
+				assert.Truef(errors.Match(errors.T(tt.wantIsErr), err), "Unexpected error %s", err)
+				assert.Equal(tt.wantErrMsg, err.Error())
+				return
+			}
+			assert.NoError(err)
+			require.NotNil(got)
+		})
+	}
+}


### PR DESCRIPTION
## [internal/pagination: add new pagination package](https://github.com/hashicorp/boundary/commit/d1912b0cd46fe243ee9c34dee30ae294c3a99178)

The pagination package provides generic functions for iterating over a collection of items such that each incoming request is filled even after filtering is applied.

## [internal/pagination: add new purge package](https://github.com/hashicorp/boundary/commit/229c590a014eaf473ce9da74573ff0ab98a49906)

The purge package contains a job that is used to purge records from the foo_deleted tables when they become older than 30 days.

This PR depends on #3889 and all preceding PRs.