### PR TITLE
internal/host: fix inconsistent receiver

### DIFF
--- a/internal/host/plugin/immutable_fields_test.go
+++ b/internal/host/plugin/immutable_fields_test.go
@@ -166,8 +166,8 @@ func TestPluginSet_ImmutableFields(t *testing.T) {
 	}
 }
 
-func (c *HostSet) testCloneHostSet() *HostSet {
-	cp := proto.Clone(c.HostSet)
+func (s *HostSet) testCloneHostSet() *HostSet {
+	cp := proto.Clone(s.HostSet)
 	return &HostSet{
 		HostSet: cp.(*store.HostSet),
 	}


### PR DESCRIPTION
This is a lint error but wasn't caught because it was a historic problem. It's appearing again now because we're adding another method to this type as part of the pagination work.