### PR TITLE
internal/credential: simplify TestObject test helper

### DIFF
--- a/internal/credential/static/json_credential_test.go
+++ b/internal/credential/static/json_credential_test.go
@@ -26,8 +26,7 @@ func TestJsonCredential_New(t *testing.T) {
 	kkms := kms.TestKms(t, conn, wrapper)
 	rw := db.New(conn)
 
-	obj, objBytes, err := TestJsonObject()
-	assert.NoError(t, err)
+	obj, objBytes := TestJsonObject(t)
 
 	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
 	cs := TestCredentialStore(t, conn, wrapper, prj.PublicId)

--- a/internal/credential/static/repository_credential_test.go
+++ b/internal/credential/static/repository_credential_test.go
@@ -411,8 +411,7 @@ func TestRepository_CreateJsonCredential(t *testing.T) {
 	wrapper := db.TestWrapper(t)
 	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
 
-	obj, objBytes, err := TestJsonObject()
-	assert.NoError(t, err)
+	obj, objBytes := TestJsonObject(t)
 
 	cs := TestCredentialStore(t, conn, wrapper, prj.PublicId)
 
@@ -576,8 +575,7 @@ func TestRepository_LookupCredential(t *testing.T) {
 	spkCredWithPass := TestSshPrivateKeyCredential(t, conn, wrapper, "username", string(testdata.PEMEncryptedKeys[0].PEMBytes),
 		store.PublicId, prj.PublicId, WithPrivateKeyPassphrase([]byte(testdata.PEMEncryptedKeys[0].EncryptionKey)))
 
-	obj, _, err := TestJsonObject()
-	assert.NoError(t, err)
+	obj, _ := TestJsonObject(t)
 
 	jsonCred := TestJsonCredential(t, conn, wrapper, store.PublicId, prj.PublicId, obj)
 
@@ -683,8 +681,7 @@ func TestRepository_ListCredentials(t *testing.T) {
 	TestUsernamePasswordCredentials(t, conn, wrapper, "user", "pass", store.GetPublicId(), prj.GetPublicId(), total/3)
 	TestSshPrivateKeyCredentials(t, conn, wrapper, "user", TestSshPrivateKeyPem, store.GetPublicId(), prj.GetPublicId(), total/3)
 
-	obj, _, err := TestJsonObject()
-	assert.NoError(t, err)
+	obj, _ := TestJsonObject(t)
 
 	TestJsonCredentials(t, conn, wrapper, store.GetPublicId(), prj.GetPublicId(), obj, total/3)
 
@@ -776,8 +773,7 @@ func TestRepository_DeleteCredential(t *testing.T) {
 	upCred := TestUsernamePasswordCredential(t, conn, wrapper, "user", "pass", store.GetPublicId(), prj.GetPublicId())
 	spkCred := TestSshPrivateKeyCredential(t, conn, wrapper, "user", TestSshPrivateKeyPem, store.GetPublicId(), prj.GetPublicId())
 
-	obj, _, err := TestJsonObject()
-	assert.NoError(t, err)
+	obj, _ := TestJsonObject(t)
 
 	jsonCred := TestJsonCredential(t, conn, wrapper, store.PublicId, prj.PublicId, obj)
 
@@ -2016,8 +2012,7 @@ func TestRepository_UpdateJsonCredential(t *testing.T) {
 	rw := db.New(conn)
 	wrapper := db.TestWrapper(t)
 
-	_, objBytes, err := TestJsonObject()
-	assert.NoError(t, err)
+	_, objBytes := TestJsonObject(t)
 
 	secondJsonSecret := &structpb.Struct{
 		Fields: map[string]*structpb.Value{

--- a/internal/credential/static/repository_credentials_test.go
+++ b/internal/credential/static/repository_credentials_test.go
@@ -43,8 +43,7 @@ func TestRepository_Retrieve(t *testing.T) {
 		string(testdata.PEMEncryptedKeys[0].PEMBytes), staticStore.GetPublicId(), prj.GetPublicId(),
 		WithPrivateKeyPassphrase([]byte(testdata.PEMEncryptedKeys[0].EncryptionKey)))
 
-	obj, _, err := TestJsonObject()
-	assert.NoError(err)
+	obj, _ := TestJsonObject(t)
 
 	secondObj := credential.JsonObject{
 		Struct: &structpb.Struct{

--- a/internal/credential/static/rewrapping_test.go
+++ b/internal/credential/static/rewrapping_test.go
@@ -219,8 +219,7 @@ func TestRewrap_credStaticJsonRewrapFn(t *testing.T) {
 
 		_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
 		cs := TestCredentialStore(t, conn, wrapper, prj.PublicId)
-		obj, objBytes, err := TestJsonObject()
-		assert.NoError(t, err)
+		obj, objBytes := TestJsonObject(t)
 		cred, err := NewJsonCredential(ctx, cs.GetPublicId(), obj)
 		assert.NoError(t, err)
 

--- a/internal/credential/static/testing.go
+++ b/internal/credential/static/testing.go
@@ -70,7 +70,7 @@ do/lpv8N1+5Eb3lOB3DrqcEqRwXzSQcO2QcpikNSHyPquGR689I3xUm6kWmpKs49aacTUx
 )
 
 // TestJsonObject returns a json object and it's marshalled format to be used for testing
-func TestJsonObject() (credential.JsonObject, []byte, error) {
+func TestJsonObject(t testing.TB) (credential.JsonObject, []byte) {
 	object := credential.JsonObject{
 		Struct: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
@@ -81,7 +81,8 @@ func TestJsonObject() (credential.JsonObject, []byte, error) {
 		},
 	}
 	b, err := json.Marshal(object.AsMap())
-	return object, b, err
+	require.NoError(t, err)
+	return object, b
 }
 
 // TestCredentialStore creates a static credential store in the provided DB with

--- a/internal/credential/static/testing_test.go
+++ b/internal/credential/static/testing_test.go
@@ -101,8 +101,7 @@ func Test_TestJsonCredential(t *testing.T) {
 
 	store := TestCredentialStore(t, conn, wrapper, prj.GetPublicId())
 
-	obj, objBytes, err := TestJsonObject()
-	assert.NoError(err)
+	obj, objBytes := TestJsonObject(t)
 
 	cred := TestJsonCredential(t, conn, wrapper, store.GetPublicId(), prj.GetPublicId(), obj, WithName("my-name"), WithDescription("my-description"))
 	require.NotNil(cred)
@@ -130,8 +129,7 @@ func Test_TestJsonCredentials(t *testing.T) {
 
 	store := TestCredentialStore(t, conn, wrapper, prj.GetPublicId())
 
-	obj, _, err := TestJsonObject()
-	assert.NoError(err)
+	obj, _ := TestJsonObject(t)
 
 	count := 3
 	creds := TestJsonCredentials(t, conn, wrapper, store.GetPublicId(), prj.GetPublicId(), obj, count)

--- a/internal/daemon/controller/handlers/credentials/credential_service_test.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service_test.go
@@ -108,8 +108,7 @@ func TestList(t *testing.T) {
 			},
 		})
 
-		obj, objBytes, err := static.TestJsonObject()
-		assert.NoError(t, err)
+		obj, objBytes := static.TestJsonObject(t)
 
 		credJson := static.TestJsonCredential(t, conn, wrapper, store.GetPublicId(), prj.GetPublicId(), obj)
 		hm, err = crypto.HmacSha256(ctx, objBytes, databaseWrapper, []byte(store.GetPublicId()), nil)
@@ -244,7 +243,7 @@ func TestGet(t *testing.T) {
 	require.NoError(t, err)
 	passHm, err := crypto.HmacSha256(context.Background(), []byte(testdata.PEMEncryptedKeys[0].EncryptionKey), databaseWrapper, []byte(store.GetPublicId()), nil)
 
-	obj, objBytes, err := static.TestJsonObject()
+	obj, objBytes := static.TestJsonObject(t)
 	assert.NoError(t, err)
 
 	jsonCred := static.TestJsonCredential(t, conn, wrapper, store.GetPublicId(), prj.GetPublicId(), obj)
@@ -428,7 +427,7 @@ func TestDelete(t *testing.T) {
 	upCred := static.TestUsernamePasswordCredential(t, conn, wrapper, "user", "pass", store.GetPublicId(), prj.GetPublicId())
 	spkCred := static.TestSshPrivateKeyCredential(t, conn, wrapper, "user", static.TestSshPrivateKeyPem, store.GetPublicId(), prj.GetPublicId())
 
-	obj, _, err := static.TestJsonObject()
+	obj, _ := static.TestJsonObject(t)
 	assert.NoError(t, err)
 
 	jsonCred := static.TestJsonCredential(t, conn, wrapper, store.GetPublicId(), prj.GetPublicId(), obj)
@@ -497,8 +496,7 @@ func TestCreate(t *testing.T) {
 	_, prj := iam.TestScopes(t, iamRepo)
 	store := static.TestCredentialStore(t, conn, wrapper, prj.GetPublicId())
 
-	obj, objBytes, err := static.TestJsonObject()
-	assert.NoError(t, err)
+	obj, objBytes := static.TestJsonObject(t)
 
 	cases := []struct {
 		name     string
@@ -894,8 +892,7 @@ func TestUpdate(t *testing.T) {
 
 	freshCredJson := func() (*static.JsonCredential, func()) {
 		t.Helper()
-		obj, _, err := static.TestJsonObject()
-		assert.NoError(t, err)
+		obj, _ := static.TestJsonObject(t)
 		cred := static.TestJsonCredential(t, conn, wrapper, store.GetPublicId(), prj.GetPublicId(), obj)
 		clean := func() {
 			_, err := s.DeleteCredential(ctx, &pbs.DeleteCredentialRequest{Id: cred.GetPublicId()})


### PR DESCRIPTION
The TestObject test helper previously returned an error, but it's easier to have it perform the error check itself, as it conventionally done with test helpers.