### PR TITLE
ci(schema-diff): Fix error with large diffs

### DIFF
--- a/.github/workflows/schema-diff.yml
+++ b/.github/workflows/schema-diff.yml
@@ -86,7 +86,7 @@ jobs:
 
           # Parse it through jq to build a valid json object.
           jq --null-input \
-            --arg comment "$(cat github-comment.txt)" \
+            --rawfile comment github-comment.txt \
             '{"body": $comment}' > body.json
 
           # Post comment on PR.


### PR DESCRIPTION
When generating the JSON for submitting the github comment, if the
message was too large, the workflow would fail with the following error:

    /usr/bin/jq: Argument list too long

This fix switches to using the `--rawfile`, which allows jq to process
the large comment.