### PR TITLE
test(e2e): Wait until target ec2 instance is ready to be used

### DIFF
--- a/enos/modules/aws_target/main.tf
+++ b/enos/modules/aws_target/main.tf
@@ -79,6 +79,20 @@ resource "aws_instance" "target" {
   })
 }
 
+resource "enos_remote_exec" "wait" {
+  for_each = {
+    for idx, instance in aws_instance.target : idx => instance
+  }
+
+  inline = ["cloud-init status --wait"]
+
+  transport = {
+    ssh = {
+      host = aws_instance.target[each.key].public_ip
+    }
+  }
+}
+
 output "target_ips" {
   value = aws_instance.target.*.private_ip
 }


### PR DESCRIPTION
This PR updates the e2e test suite to address some new flakiness we started seeing.

Tests would sometimes fail due to the following
```
worker_test.go:96: 
│         	Error Trace:	/home/runner/work/boundary/boundary/testing/internal/e2e/tests/aws/worker_test.go:96
│         	Error:      	Received unexpected error:
│         	            	exit status 255
│         	Test:       	TestCliWorker
│         	Messages:   	Warning: Permanently added '[127.0.0.1]:37479' (ED25519) to the list of known hosts.
│         	            	"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8)."
│         	            	Connection closed by 127.0.0.1 port 37479
```

Based on the error message, it seems like we're trying to access the target (ec2 instance) before it's ready to be used. This PR adds in a check to ensure that the instance has fully initialized.
```
ubuntu@ip-10-13-4-124:~$ cloud-init status --wait

status: done
```