### PR TITLE
Telemetry(observations): add oidc and ldap observation events

### DIFF
--- a/internal/auth/ldap/service_authenticate.go
+++ b/internal/auth/ldap/service_authenticate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/event"
 	"github.com/hashicorp/boundary/internal/iam"
 )
 
@@ -82,7 +83,10 @@ func Authenticate(
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
-
+	if err := event.WriteObservation(ctx, op, event.WithDetails("user_id", user.GetPublicId(), "auth_token_start",
+		token.GetCreateTime(), "auth_token_end", token.GetExpirationTime())); err != nil {
+		return nil, errors.Wrap(ctx, err, op, errors.WithMsg("Unable to write observation event for authenticate method"))
+	}
 	return token, nil
 }
 

--- a/internal/auth/ldap/service_authenticate_test.go
+++ b/internal/auth/ldap/service_authenticate_test.go
@@ -5,7 +5,10 @@ package ldap
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"sync"
 	"testing"
 
@@ -15,6 +18,7 @@ import (
 	"github.com/hashicorp/boundary/internal/event"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/eventlogger/formatter_filters/cloudevents"
 	"github.com/hashicorp/go-hclog"
 	"github.com/jimlambrt/gldap"
 	"github.com/jimlambrt/gldap/testdirectory"
@@ -29,7 +33,14 @@ func TestAuthenticate(t *testing.T) {
 	testRw := db.New(testConn)
 	rootWrapper := db.TestWrapper(t)
 	testKms := kms.TestKms(t, testConn, rootWrapper)
-
+	opt := event.TestWithObservationSink(t)
+	c := event.TestEventerConfig(t, "Test_StartAuth_to_Callback", opt)
+	testLock := &sync.Mutex{}
+	testLogger := hclog.New(&hclog.LoggerOptions{
+		Mutex: testLock,
+		Name:  "test",
+	})
+	require.NoError(t, event.InitSysEventer(testLogger, testLock, "use-Test_Authenticate", event.WithEventerConfig(&c.EventerConfig)))
 	// some standard factories for unit tests
 	authenticatorFn := func() (Authenticator, error) {
 		return NewRepository(testCtx, testRw, testRw, testKms)
@@ -303,19 +314,7 @@ func TestAuthenticate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			require.Equal(tc.order, idx)
-			config := event.EventerConfig{
-				ObservationsEnabled: true,
-			}
-			testLock := &sync.Mutex{}
-			testLogger := hclog.New(&hclog.LoggerOptions{
-				Mutex: testLock,
-				Name:  "test",
-			})
-			e, err := event.NewEventer(testLogger, testLock, tc.name, config)
-			require.NoError(err)
-			eCtx, err := event.NewEventerContext(tc.ctx, e)
-			require.NoError(err)
-			got, err := Authenticate(eCtx, tc.authenticatorFn, tc.lookupUserWithLoginFn, tc.tokenCreatorFn, tc.authMethodId, tc.loginName, tc.password)
+			got, err := Authenticate(tc.ctx, tc.authenticatorFn, tc.lookupUserWithLoginFn, tc.tokenCreatorFn, tc.authMethodId, tc.loginName, tc.password)
 			if tc.wantErrMatch != nil {
 				require.Error(err)
 				assert.Empty(got)
@@ -327,6 +326,20 @@ func TestAuthenticate(t *testing.T) {
 			}
 			require.NoError(err)
 			assert.NotEmpty(got)
+			sinkFileName := c.ObservationEvents.Name()
+			defer func() { _ = os.WriteFile(sinkFileName, nil, 0o666) }()
+			b, err := ioutil.ReadFile(sinkFileName)
+			require.NoError(err)
+			gotRes := &cloudevents.Event{}
+			err = json.Unmarshal(b, gotRes)
+			require.NoErrorf(err, "json: %s", string(b))
+			details, ok := gotRes.Data.(map[string]any)["details"]
+			require.True(ok)
+			for _, key := range details.([]any) {
+				assert.Contains(key.(map[string]any)["payload"], "user_id")
+				assert.Contains(key.(map[string]any)["payload"], "auth_token_start")
+				assert.Contains(key.(map[string]any)["payload"], "auth_token_end")
+			}
 		})
 	}
 }

--- a/internal/daemon/controller/handlers/authmethods/ldap_test.go
+++ b/internal/daemon/controller/handlers/authmethods/ldap_test.go
@@ -5,8 +5,12 @@ package authmethods_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -20,12 +24,14 @@ import (
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/authmethods"
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/event"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/types/scope"
 	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/authmethods"
 	scopepb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/scopes"
+	"github.com/hashicorp/eventlogger/formatter_filters/cloudevents"
 	"github.com/hashicorp/go-hclog"
 	"github.com/jimlambrt/gldap"
 	"github.com/jimlambrt/gldap/testdirectory"
@@ -876,7 +882,14 @@ func TestAuthenticate_Ldap(t *testing.T) {
 	testRootWrapper := db.TestWrapper(t)
 	testKms := kms.TestKms(t, testConn, testRootWrapper)
 	o, _ := iam.TestScopes(t, iam.TestRepo(t, testConn, testRootWrapper))
-
+	opt := event.TestWithObservationSink(t)
+	c := event.TestEventerConfig(t, "Test_StartAuth_to_Callback", opt)
+	testLock := &sync.Mutex{}
+	testLogger := hclog.New(&hclog.LoggerOptions{
+		Mutex: testLock,
+		Name:  "test",
+	})
+	require.NoError(t, event.InitSysEventer(testLogger, testLock, "use-Test_Authenticate", event.WithEventerConfig(&c.EventerConfig)))
 	iamRepoFn := func() (*iam.Repository, error) {
 		return iam.TestRepo(t, testConn, testRootWrapper), nil
 	}
@@ -1094,7 +1107,20 @@ func TestAuthenticate_Ldap(t *testing.T) {
 			assert.Equal(aToken.GetCreatedTime(), aToken.GetApproximateLastUsedTime())
 			assert.Equal(testAm.GetPublicId(), aToken.GetAuthMethodId())
 			assert.Equal(tc.wantType, resp.GetType())
-
+			sinkFileName := c.ObservationEvents.Name()
+			defer func() { _ = os.WriteFile(sinkFileName, nil, 0o666) }()
+			b, err := ioutil.ReadFile(sinkFileName)
+			require.NoError(err)
+			gotRes := &cloudevents.Event{}
+			err = json.Unmarshal(b, gotRes)
+			require.NoErrorf(err, "json: %s", string(b))
+			details, ok := gotRes.Data.(map[string]any)["details"]
+			require.True(ok)
+			for _, key := range details.([]any) {
+				assert.Contains(key.(map[string]any)["payload"], "user_id")
+				assert.Contains(key.(map[string]any)["payload"], "auth_token_start")
+				assert.Contains(key.(map[string]any)["payload"], "auth_token_end")
+			}
 			// support testing for pre-provisioned accounts
 			if tc.acctId != "" {
 				assert.Equal(tc.acctId, aToken.GetAccountId())


### PR DESCRIPTION
This PR adds an observation event for OIDC and LDAP authentication methods. This observation event will include the user ID and auth token start and end time. This will be used for telemetry purposes
cc: @jimlambrt 