### PR TITLE
Fix dev key generation

### DIFF
--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -370,7 +370,7 @@ func DevKeyGeneration() string {
 	if n != numBytes {
 		panic(fmt.Errorf("expected to read 32 bytes, read %d", n))
 	}
-	devKey := base64.StdEncoding.EncodeToString(randBuf.Bytes())[:numBytes]
+	devKey := base64.StdEncoding.EncodeToString(randBuf.Bytes())
 	return devKey
 }
 

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"os"
@@ -628,8 +629,9 @@ func TestDevWorkerRecordingStoragePath(t *testing.T) {
 func TestDevKeyGeneration(t *testing.T) {
 	t.Parallel()
 	dk := DevKeyGeneration()
-	numBytes := 32
-	require.Equal(t, numBytes, len(dk))
+	buf, err := base64.StdEncoding.DecodeString(dk)
+	require.NoError(t, err)
+	require.Len(t, buf, 32)
 	require.NotEqual(t, dk, DevKeyGeneration())
 }
 


### PR DESCRIPTION
In #2076 the refactor changed the position of a parenthesis, causing the dev key to truncate the base64 representation instead of specifying which bytes to base64 encode.

We don't need this slicing anymore anyways since we now do individual key generation calls so just remove it.