### PR TITLE
internal/tests: fix vault token with short TTL

### DIFF
--- a/internal/tests/api/credentialstores/credentialstore_test.go
+++ b/internal/tests/api/credentialstores/credentialstore_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/credentialstores"
@@ -21,7 +22,12 @@ import (
 
 func TestList(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
-	tc := controller.NewTestController(t, nil)
+	tc := controller.NewTestController(t, &controller.TestControllerOpts{
+		// Set a lower scheduler run job interval to avoid
+		// an error when the renewed Vault tokens TTL is lower
+		// than the scheduler run job interval.
+		SchedulerRunJobInterval: time.Second * 10,
+	})
 	defer tc.Shutdown()
 
 	vaultServ := vault.NewTestVaultServer(t, vault.WithTestVaultTLS(vault.TestNoTLS))


### PR DESCRIPTION
This fails locally for me without this change. The error message is
```
{"kind":"Internal", "message":"credentialstores.(Service).createInRepo: unable to create credential store: vault.(Repository).CreateCredentialStore: unknown, unknown: error #0: scheduler interval must be greater than token ttl. scheduler jobs interval value: 1m0s"}
```
Not sure if it's something about my local setup (vault version??) but it might affect others so I thought I'd submit this fix.