### PR TITLE
tests: Set a default job run interval based on the test deadline

### DIFF
--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -474,8 +474,19 @@ type TestControllerOpts struct {
 	// database
 	LivenessTimeToStaleDuration time.Duration
 
-	// The amount of time between the scheduler waking up to run it's registered
-	// jobs.
+	// The amount of time between the scheduler waking up to run it's
+	// registered jobs.
+	//
+	// If t.Deadline() has a value and the value is under 1 minute, the
+	// default value is set to half the value of t.Deadline(). If
+	// t.Deadline() has a value and the value is 1 minute or more, the
+	// default value is set to 1 minute.
+	//
+	// Tests using the Vault test server should be aware that Vault
+	// Credential Stores only accept Vault tokens that have a TTL greater
+	// than the SchedulerRunJobInterval. The Vault test server, by default,
+	// creates Vault tokens with a TTL equal to the duration of time
+	// remaining until t.Deadline() is reached.
 	SchedulerRunJobInterval time.Duration
 
 	// The time to use for CA certificate lifetime for worker auth
@@ -631,6 +642,18 @@ func TestControllerConfig(t testing.TB, ctx context.Context, tc *TestController,
 	}
 	if opts.Config.Controller.Name == "" {
 		require.NoError(t, opts.Config.Controller.InitNameIfEmpty(ctxTest))
+	}
+
+	if opts.SchedulerRunJobInterval == 0 {
+		if t, ok := t.(*testing.T); ok {
+			if deadline, ok := t.Deadline(); ok {
+				opts.SchedulerRunJobInterval = 1 * time.Minute
+				if time.Until(deadline) < opts.SchedulerRunJobInterval {
+					half := int64(time.Until(deadline) / 2)
+					opts.SchedulerRunJobInterval = time.Duration(half)
+				}
+			}
+		}
 	}
 	opts.Config.Controller.Scheduler.JobRunIntervalDuration = opts.SchedulerRunJobInterval
 


### PR DESCRIPTION
The Vault Credential Store only accepts Vault tokens that have a TTL greater than the internal job scheduler's run frequency. This prevents a Vault Credential Store from being created with a Vault token that will expire before Boundary can renew it.

The Vault test server, by default, creates Vault tokens with a TTL equal to the duration of time remaining until `t.Deadline()` is reached.

This change sets the test controller's default job scheduler duration to be half of time remaining until `t.Deadline()`. The default job scheduler duration can still be overridden by setting a duration on `TestConrollerOpts.SchedulerRunJobInterval`.

This change fixes the error received when running:

    go test -timeout 30s \
      -tags devlicense \
      -run '^TestList$' \
      github.com/hashicorp/boundary/internal/tests/api/credentialstores

Which returned this error:

    {"kind":"Internal",
    "message":"credentialstores.(Service).createInRepo: unable to create
    credential store: vault.(Repository).CreateCredentialStore: unknown,
    unknown: error #0: scheduler interval must be greater than token
    ttl. scheduler jobs interval value: 1m0s"}