### PR TITLE
telemetry(observations): fix the details flag check

### DIFF
--- a/internal/auth/ldap/service_authenticate_test.go
+++ b/internal/auth/ldap/service_authenticate_test.go
@@ -40,6 +40,7 @@ func TestAuthenticate(t *testing.T) {
 		Mutex: testLock,
 		Name:  "test",
 	})
+	c.EventerConfig.TelemetryEnabled = true
 	require.NoError(t, event.InitSysEventer(testLogger, testLock, "use-Test_Authenticate", event.WithEventerConfig(&c.EventerConfig)))
 	// some standard factories for unit tests
 	authenticatorFn := func() (Authenticator, error) {

--- a/internal/auth/oidc/service_callback_test.go
+++ b/internal/auth/oidc/service_callback_test.go
@@ -52,6 +52,7 @@ func Test_Callback(t *testing.T) {
 		Mutex: testLock,
 		Name:  "test",
 	})
+	c.EventerConfig.TelemetryEnabled = true
 	require.NoError(t, event.InitSysEventer(testLogger, testLock, "use-Test_Callback", event.WithEventerConfig(&c.EventerConfig)))
 	// some standard factories for unit tests which
 	// are used in the Callback(...) call
@@ -666,6 +667,7 @@ func Test_ManagedGroupFiltering(t *testing.T) {
 		Mutex: testLock,
 		Name:  "test",
 	})
+	c.EventerConfig.TelemetryEnabled = true
 	require.NoError(t, event.InitSysEventer(testLogger, testLock, "use-Test_ManagedGroupFiltering", event.WithEventerConfig(&c.EventerConfig)))
 	// some standard factories for unit tests which
 	// are used in the Callback(...) call

--- a/internal/daemon/controller/handlers/authmethods/ldap_test.go
+++ b/internal/daemon/controller/handlers/authmethods/ldap_test.go
@@ -889,6 +889,7 @@ func TestAuthenticate_Ldap(t *testing.T) {
 		Mutex: testLock,
 		Name:  "test",
 	})
+	c.EventerConfig.TelemetryEnabled = true
 	require.NoError(t, event.InitSysEventer(testLogger, testLock, "use-Test_Authenticate", event.WithEventerConfig(&c.EventerConfig)))
 	iamRepoFn := func() (*iam.Repository, error) {
 		return iam.TestRepo(t, testConn, testRootWrapper), nil

--- a/internal/daemon/controller/handlers/authmethods/password_test.go
+++ b/internal/daemon/controller/handlers/authmethods/password_test.go
@@ -520,6 +520,7 @@ func TestAuthenticate_Password(t *testing.T) {
 		Mutex: testLock,
 		Name:  "test",
 	})
+	c.EventerConfig.TelemetryEnabled = true
 	require.NoError(t, event.InitSysEventer(testLogger, testLock, "use-Test_Authenticate", event.WithEventerConfig(&c.EventerConfig)))
 	sinkFileName := c.ObservationEvents.Name()
 	t.Cleanup(func() {

--- a/internal/event/context.go
+++ b/internal/event/context.go
@@ -110,7 +110,8 @@ func WriteObservation(ctx context.Context, caller Op, opt ...Option) error {
 			"%w", op, ErrInvalidParameter)
 	}
 	// For the case that the telemetry is not enabled, and we have events coming from interceptors.
-	if !eventer.conf.TelemetryEnabled && (opts.withRequest != nil || opts.withResponse != nil) {
+	// or the case that incoming call only has withDetails without enabling telemetry.
+	if !eventer.conf.TelemetryEnabled && (opts.withRequest != nil || opts.withResponse != nil || opts.withDetails != nil) {
 		return nil
 	}
 	// If telemetry is enabled, we add it to the options.

--- a/internal/event/context_test.go
+++ b/internal/event/context_test.go
@@ -440,14 +440,14 @@ func Test_WriteObservation(t *testing.T) {
 			cleanup: func() { event.TestResetSystEventer(t) },
 		},
 		{
-			name:               "simple",
+			name:               "simple-header",
 			ctx:                testCtx,
 			telemetryFlag:      true,
 			observationPayload: testPayloads,
 			header:             testWantHeader,
 		},
 		{
-			name:               "simple",
+			name:               "simple-details",
 			ctx:                testCtx,
 			telemetryFlag:      true,
 			observationPayload: testPayloads,

--- a/internal/event/context_test.go
+++ b/internal/event/context_test.go
@@ -440,13 +440,18 @@ func Test_WriteObservation(t *testing.T) {
 			cleanup: func() { event.TestResetSystEventer(t) },
 		},
 		{
-			name:                    "simple",
-			ctx:                     testCtx,
-			telemetryFlag:           true,
-			observationPayload:      testPayloads,
-			header:                  testWantHeader,
-			details:                 testWantDetails,
-			observationSinkFileName: c.AllEvents.Name(),
+			name:               "simple",
+			ctx:                testCtx,
+			telemetryFlag:      true,
+			observationPayload: testPayloads,
+			header:             testWantHeader,
+		},
+		{
+			name:               "simple",
+			ctx:                testCtx,
+			telemetryFlag:      true,
+			observationPayload: testPayloads,
+			details:            testWantDetails,
 		},
 	}
 	for _, tt := range tests {
@@ -483,6 +488,7 @@ func Test_WriteObservation(t *testing.T) {
 			if !tt.telemetryFlag {
 				require.Nil(event.WriteObservation(tt.ctx, event.Op(tt.name), event.WithRequest(tt.Request),
 					event.WithResponse(tt.Response)))
+				require.Nil(event.WriteObservation(tt.ctx, event.Op(tt.name), event.WithDetails(tt.details)))
 			}
 			if tt.observationSinkFileName != "" {
 				defer func() { _ = os.WriteFile(tt.observationSinkFileName, nil, 0o666) }()


### PR DESCRIPTION
This PR fix the telemetry checks, with this PR we only emit authenticate events if and only if the telemetry flag is turned on