### PR TITLE
test(e2e): Add support for `-additional-valid-principals` test

### DIFF
--- a/enos/modules/test_e2e_docker/test.sh
+++ b/enos/modules/test_e2e_docker/test.sh
@@ -13,7 +13,7 @@ apt update
 # unzip is used to unzip boundary.zip
 # pass is used to store the auth token from `boundary authenticate``
 # lsb-release is used for adding the hashicorp apt source
-# postgresql is used for postgres tests
+# postgresql-client is used for postgres tests
 apt install unzip pass lsb-release postgresql-client -y
 
 # Create a GPG key
@@ -79,7 +79,16 @@ do
 done <<< $lines
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
 apt update
-apt install vault
+apt install vault -y
+
+# Install the docker cli
+wget -O- https://download.docker.com/linux/debian/gpg | gpg --batch --yes --dearmor -o /etc/apt/keyrings/docker.gpg
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt update
+apt install docker-ce-cli -y
 
 # Run Tests
 unzip /boundary.zip -d /usr/local/bin/

--- a/enos/modules/test_e2e_docker/test_runner.sh
+++ b/enos/modules/test_e2e_docker/test_runner.sh
@@ -46,6 +46,7 @@ docker run \
     -v "$MODULE_DIR/test.sh:/scripts/test.sh" \
     -v "$E2E_SSH_KEY_PATH:/keys/target.pem" \
     -v "$BOUNDARY_CLI_DIR:/boundary.zip" \
+    -v "/var/run/docker.sock:/var/run/docker.sock" \
     --network $TEST_NETWORK_NAME \
     --cap-add=CAP_IPC_LOCK \
     $TEST_RUNNER_IMAGE \

--- a/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_test.go
+++ b/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_test.go
@@ -104,7 +104,6 @@ func TestCliCreateAwsDynamicHostCatalogWithHostSet(t *testing.T) {
 	)
 	require.NoError(t, err)
 	expectedHostCatalogCount := expectedHostSetCount1 + expectedHostSetCount2
-	require.NoError(t, err)
 	assert.Equal(t, expectedHostCatalogCount, actualHostCatalogCount, "Numbers of hosts in host catalog did not match expected amount")
 
 	// Create target
@@ -221,8 +220,8 @@ func TestApiCreateAwsDynamicHostCatalog(t *testing.T) {
 	t.Log("Successfully found items in the host set")
 	var targetIps []string
 	err = json.Unmarshal([]byte(c.AwsHostSetIps1), &targetIps)
-	expectedHostSetCount := len(targetIps)
 	require.NoError(t, err)
+	expectedHostSetCount := len(targetIps)
 	assert.Equal(t, expectedHostSetCount, actualHostSetCount, "Numbers of hosts in host set did not match expected amount")
 
 	// Get list of all hosts from host catalog
@@ -252,6 +251,5 @@ func TestApiCreateAwsDynamicHostCatalog(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Log("Successfully found items in the host catalog")
-	require.NoError(t, err)
 	assert.Equal(t, actualHostCatalogCount, expectedHostSetCount, "Numbers of hosts in host catalog did not match expected amount")
 }


### PR DESCRIPTION
This PR updates the e2e test suite in order to support a test for using the new `-additional-valid-principals` option in `vault-ssh-certificate credential libraries`. 

The primary change is to install the `docker` cli on the test runner so that it's able to restart a container during a test. This is needed because the test needs to modify the SSH config on the target host and reload the container to get those changes. 

There will be a follow-up PR in `boundary-enterprise` to add the test.