### PR TITLE
docs: Add enterprise badge

### DIFF
--- a/website/content/docs/commands/session-recordings/download.mdx
+++ b/website/content/docs/commands/session-recordings/download.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # session-recordings download
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Command: `boundary session-recordings download`
 
 The `boundary session-recordings download` command lets you download a Boundary session recording.

--- a/website/content/docs/commands/session-recordings/index.mdx
+++ b/website/content/docs/commands/session-recordings/index.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # session-recordings
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Command: `boundary session-recordings`
 
 The `session-recordings` command lets you perform operations on Boundary session recording resources.

--- a/website/content/docs/commands/session-recordings/list.mdx
+++ b/website/content/docs/commands/session-recordings/list.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # session-recordings list
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Command: `boundary session-recordings list`
 
 The `boundary session-recordings list` command lets you list the Boundary session recordings within a given scope or resource.

--- a/website/content/docs/commands/session-recordings/read.mdx
+++ b/website/content/docs/commands/session-recordings/read.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # session-recordings read
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Command: `boundary session-recordings read`
 
 The `boundary session-recordings read` command lets you read information about a Boundary session recording by providing the ID.

--- a/website/content/docs/commands/storage-buckets/create.mdx
+++ b/website/content/docs/commands/storage-buckets/create.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # storage-buckets create
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Command: `boundary storage-buckets create`
 
 The `boundary storage-buckets create` command lets you create Boundary storage buckets.

--- a/website/content/docs/commands/storage-buckets/delete.mdx
+++ b/website/content/docs/commands/storage-buckets/delete.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # storage-buckets delete
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Command: `boundary storage-buckets delete`
 
 The `boundary storage-buckets delete` command lets you delete Boundary storage buckets.

--- a/website/content/docs/commands/storage-buckets/index.mdx
+++ b/website/content/docs/commands/storage-buckets/index.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # storage-buckets
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Command: `boundary storage-buckets`
 
 The `storage-buckets` command lets you perform operations on Boundary storage bucket resources.

--- a/website/content/docs/commands/storage-buckets/list.mdx
+++ b/website/content/docs/commands/storage-buckets/list.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # storage-buckets list
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Command: `storage-buckets list`
 
 The `storage-buckets list` command lets you list the storage buckets within a given scope or resource.

--- a/website/content/docs/commands/storage-buckets/read.mdx
+++ b/website/content/docs/commands/storage-buckets/read.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # storage-buckets read
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Command: `boundary storage-buckets read`
 
 The `boundary storage-buckets read` command lets you read information about Boundary storage buckets.

--- a/website/content/docs/commands/storage-buckets/update.mdx
+++ b/website/content/docs/commands/storage-buckets/update.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # storage-buckets update
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Command: `boundary storage-buckets update`
 
 The `boundary storage-buckets update` command lets you update Boundary storage buckets by ID.

--- a/website/content/docs/concepts/auditing.mdx
+++ b/website/content/docs/concepts/auditing.mdx
@@ -25,6 +25,8 @@ Further, security teams seek to prevent incidents and proactively identify poten
 
 ## Session recording
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Boundary provides auditing capabilities via [session recording](/boundary/docs/concepts/domain-model/session-recordings).
 In Boundary, a session represents a set of connections between a user and a host from a target.
 The session begins when an authorized user requests access to a target, and it ends when that access is terminated.
@@ -72,6 +74,8 @@ Boundary emits audit events for actions performed by users. Here are **some** of
 
 ## Storage buckets
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 A resource known as a [storage bucket](/boundary/docs/concepts/domain-model/storage-buckets) is used to store the recorded sessions.
 The storage bucket represents a bucket in an external object store.
 At this time, the only supported storage for storage buckets is AWS S3.
@@ -91,6 +95,8 @@ The storage bucket's lifecycle does not affect the lifecycle of the bucket in th
 Any session recording metadata that is attached to the storage bucket is deleted when the storage bucket is deleted.
 
 ## BSR directory structure
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 The BSR (Boundary Session Recording) defines a hierarchical directory structure of files and a binary file format.
 It contains all the data transmitted between a user and a target during a single session.

--- a/website/content/docs/concepts/credential-management.mdx
+++ b/website/content/docs/concepts/credential-management.mdx
@@ -65,7 +65,9 @@ Learn more about [credential brokering](/boundary/tutorials/hcp-getting-started/
 
 Learn more about the [Vault dynamic secrets engine](/vault/docs/secrets).
 
-## Credential injection <sup>HCP/ENT</sup>
+## Credential injection
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 Credential injection is the process by which a credential is fetched from a credential store and then passed on to a worker for authentication to a remote machine.
 With credential injection, the user never sees the credential required to authenticate to the target.

--- a/website/content/docs/concepts/domain-model/credential-libraries.mdx
+++ b/website/content/docs/concepts/domain-model/credential-libraries.mdx
@@ -34,7 +34,9 @@ The default value is `GET`.
 - `vault-http-request-body` - (optional) The body of the HTTP request the library sends to Vault when it requests credentials.
 Only valid if `http_method` is set to `POST`.
 
-### Vault SSH certificate credential library attributes <sup>HCP/ENT</sup>
+### Vault SSH certificate credential library attributes
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 As of Boundary 0.12.0, you can configure SSH credential injection using [Vault's SSH secrets engine](/vault/docs/secrets/ssh) to create the SSH certificate credentials.
 SSH certificate-based authentication extends key-based authentication using digital signatures.

--- a/website/content/docs/concepts/domain-model/session-recordings.mdx
+++ b/website/content/docs/concepts/domain-model/session-recordings.mdx
@@ -5,8 +5,9 @@ description: |-
   The anatomy of a Boundary session recording
 ---
 
-# Session recordings <sup>HCP/ENT</sup>
+# Session recordings
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 A session recording represents a directory structure of
 files in an external object store that together are the

--- a/website/content/docs/concepts/domain-model/storage-buckets.mdx
+++ b/website/content/docs/concepts/domain-model/storage-buckets.mdx
@@ -5,8 +5,9 @@ description: |-
   The anatomy of a Boundary storage bucket
 ---
 
-# Storage buckets <sup>HCP/ENT</sup>
+# Storage buckets
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 A resource known as a storage bucket is used to store the [session recordings][].
 The storage bucket represents a bucket in an external object store.

--- a/website/content/docs/concepts/domain-model/targets.mdx
+++ b/website/content/docs/concepts/domain-model/targets.mdx
@@ -92,7 +92,9 @@ TCP targets have the following additional attribute:
 - `default_port` - (required)
   The default port to set on this target.
 
-### SSH target attributes <sup>HCP/ENT</sup>
+### SSH target attributes
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 SSH targets use injected application credentials to authenticate an SSH session between the client and end host.
 Injected credentials allow users to securely connect to remost hosts using SSH, while never being in the possession of a valid credential for that target host.

--- a/website/content/docs/concepts/filtering/worker-tags.mdx
+++ b/website/content/docs/concepts/filtering/worker-tags.mdx
@@ -148,7 +148,10 @@ The `ingress_worker_filter`<sup>HCP/ENT</sup> attribute controls which workers a
 This is the worker a client connects to when initiating a connection to a target.
 
 
-## Vault workers <sup>HCP/ENT</sup>
+## Vault workers
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Tags are used to control which [PKI workers] can manage Vault requests by specifying
 a `worker_filter`attribute when configuring [credential stores].
 

--- a/website/content/docs/concepts/security/data-encryption.mdx
+++ b/website/content/docs/concepts/security/data-encryption.mdx
@@ -105,7 +105,10 @@ $ boundary scopes list-key-version-destruction-jobs -scope-id p_A4jfDjZ9jf
 Once the job disappears from this list, the associated key version will have
 been destroyed and any existing data will have been re-encrypted.
 
-## The `bsr` KMS key <sup>HCP/ENT</sup>
+## The `bsr` KMS key
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 The `bsr` KMS key is required for [session recording](/boundary/docs/configuration/session-recording).
 If you do not add a `bsr` key to your controller configuration, you will receive an error when you attempt to enable session recording.
 The key is used for encrypting data and checking the integrity of recordings.

--- a/website/content/docs/concepts/workers.mdx
+++ b/website/content/docs/concepts/workers.mdx
@@ -52,7 +52,10 @@ with tag “A,” to connect to targets in “Network A.”
 
 ![Boundary architecture example showing workers with tags](/img/worker-tags.png)
 
-## Multi-hop sessions <sup>HCP/ENT</sup>
+## Multi-hop sessions
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Most organizations want to provide access to infrastructure without exposing private networks. Many organizations also have complex network topologies requiring
 inbound traffic to route through multiple network enclaves in order to reach the target system.
 [Multi-hop](/boundary/docs/configuration/worker#multi-hop-worker-capabilities-hcp-ent) sessions allow you to chain together two or more workers

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -5,7 +5,9 @@ description: |-
   How to create a storage bucket for session recording in Boundary
 ---
 
-# Create a storage bucket <sup>HCP/ENT</sup>
+# Create a storage bucket
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 As of Boundary 0.13.0, you can record and audit user sessions.
 A Boundary resource known as a [storage bucket](/boundary/docs/concepts/domain-model/storage-buckets) is used to store the recorded sessions.

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -5,7 +5,7 @@ description: |-
   How to create a storage bucket for session recording in Boundary
 ---
 
-# Create a storage bucket
+# Create a storage bucket <sup>HCP/ENT</sup>
 
 As of Boundary 0.13.0, you can record and audit user sessions.
 A Boundary resource known as a [storage bucket](/boundary/docs/concepts/domain-model/storage-buckets) is used to store the recorded sessions.

--- a/website/content/docs/configuration/session-recording/enable-session-recording.mdx
+++ b/website/content/docs/configuration/session-recording/enable-session-recording.mdx
@@ -5,7 +5,7 @@ description: |-
   How to enable session recording on a target in Boundary
 ---
 
-# Enable session recording on a target
+# Enable session recording on a target <sup>HCP/ENT</sup>
 
 You must enable session recording for any targets that you want to record sessions on.
 When you [create a storage bucket](/boundary/docs/configuration/session-recording/create-storage-bucket), Boundary provides you with an ID.

--- a/website/content/docs/configuration/session-recording/enable-session-recording.mdx
+++ b/website/content/docs/configuration/session-recording/enable-session-recording.mdx
@@ -5,7 +5,9 @@ description: |-
   How to enable session recording on a target in Boundary
 ---
 
-# Enable session recording on a target <sup>HCP/ENT</sup>
+# Enable session recording on a target
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 You must enable session recording for any targets that you want to record sessions on.
 When you [create a storage bucket](/boundary/docs/configuration/session-recording/create-storage-bucket), Boundary provides you with an ID.

--- a/website/content/docs/configuration/session-recording/index.mdx
+++ b/website/content/docs/configuration/session-recording/index.mdx
@@ -5,7 +5,9 @@ description: |-
   An overview of session recording in Boundary
 ---
 
-# Overview <sup>HCP/ENT</sup>
+# Overview
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 Boundary provides auditing capabilities via session recording.
 In Boundary, a session represents a set of connections between a user and a host from a target.

--- a/website/content/docs/configuration/session-recording/index.mdx
+++ b/website/content/docs/configuration/session-recording/index.mdx
@@ -5,7 +5,7 @@ description: |-
   An overview of session recording in Boundary
 ---
 
-# Overview
+# Overview <sup>HCP/ENT</sup>
 
 Boundary provides auditing capabilities via session recording.
 In Boundary, a session represents a set of connections between a user and a host from a target.

--- a/website/content/docs/configuration/worker/index.mdx
+++ b/website/content/docs/configuration/worker/index.mdx
@@ -104,7 +104,9 @@ Any other updated values are ignored.
 The `SIGTERM` and `SIGINT` signals initiate a graceful shutdown on a worker. The worker waits for any sessions to drain
 before shutting down. Workers in a graceful shutdown state do not receive any new work, including session proxying, from the control plane.
 
-## Multi-hop worker capabilities <sup>HCP/ENT</sup>
+## Multi-hop worker capabilities
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 Multi-hop capabilities, including multi-hop sessions and Vault private access,
 is when a session or Vault credential request goes through more than one worker.

--- a/website/content/docs/configuration/worker/pki-worker.mdx
+++ b/website/content/docs/configuration/worker/pki-worker.mdx
@@ -77,7 +77,9 @@ kms "aead" {
 }
 ```
 
-## Session recording <sup>(HCP/ENT)</sup>
+## Session recording
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 [Session recording](/boundary/docs/configuration/session-recording) requires at least one PKI worker with access to local and remote storage.
 PKI workers used for session recording require an accessible directory defined by `recording_storage_path` for

--- a/website/content/docs/operations/session-recordings/index.mdx
+++ b/website/content/docs/operations/session-recordings/index.mdx
@@ -5,7 +5,9 @@ description: |-
   How to work with Boundary's recorded sessions
 ---
 
-# Recorded sessions operations
+# Recorded sessions operations <sup>HCP/ENT</sup>
+
+<EnterpriseAlert product="boundary" />
 
 Boundary provides [auditing](/boundary/docs/concepts/auditing) capabilities via [session recording](/boundary/docs/configuration/session-recording).
 In Boundary, a session represents a set of connections between a user and a host from a target.

--- a/website/content/docs/operations/session-recordings/index.mdx
+++ b/website/content/docs/operations/session-recordings/index.mdx
@@ -5,9 +5,9 @@ description: |-
   How to work with Boundary's recorded sessions
 ---
 
-# Recorded sessions operations <sup>HCP/ENT</sup>
+# Recorded sessions operations
 
-<EnterpriseAlert product="boundary" />
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 Boundary provides [auditing](/boundary/docs/concepts/auditing) capabilities via [session recording](/boundary/docs/configuration/session-recording).
 In Boundary, a session represents a set of connections between a user and a host from a target.

--- a/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
+++ b/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
@@ -5,7 +5,7 @@ description: |-
   How to find, download, and view Boundary's recorded sessions
 ---
 
-# Find and view recorded sessions
+# Find and view recorded sessions <sup>HCP/ENT</sup>
 
 You can view a list of all recorded sessions, or if you know the ID of a specific recorded session, you can find any channels associated with that recording.
 

--- a/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
+++ b/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
@@ -5,7 +5,9 @@ description: |-
   How to find, download, and view Boundary's recorded sessions
 ---
 
-# Find and view recorded sessions <sup>HCP/ENT</sup>
+# Find and view recorded sessions
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 You can view a list of all recorded sessions, or if you know the ID of a specific recorded session, you can find any channels associated with that recording.
 

--- a/website/content/docs/operations/session-recordings/validate-data-store.mdx
+++ b/website/content/docs/operations/session-recordings/validate-data-store.mdx
@@ -4,7 +4,7 @@ page_title: Validate the data integrity in the external object store
 description: |-
   How Boundary validates the data integrity of recorded sessions in the external object store
 ---
-# How Boundary validates data integrity in the external object store
+# How Boundary validates data integrity in the external object store <sup>HCP/ENT</sup>
 
 When a Boundary worker uploads a BSR file to AWS S3 through the Boundary AWS plugin, the plugin calculates the SHA256 checksum of the contents of the BSR file and attaches this information to the object that is uploaded to S3.
 The SHA256 checksum value attached to the S3 object is returned to the Boundary worker.

--- a/website/content/docs/operations/session-recordings/validate-data-store.mdx
+++ b/website/content/docs/operations/session-recordings/validate-data-store.mdx
@@ -4,7 +4,9 @@ page_title: Validate the data integrity in the external object store
 description: |-
   How Boundary validates the data integrity of recorded sessions in the external object store
 ---
-# How Boundary validates data integrity in the external object store <sup>HCP/ENT</sup>
+# How Boundary validates data integrity in the external object store
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 When a Boundary worker uploads a BSR file to AWS S3 through the Boundary AWS plugin, the plugin calculates the SHA256 checksum of the contents of the BSR file and attaches this information to the object that is uploaded to S3.
 The SHA256 checksum value attached to the S3 object is returned to the Boundary worker.

--- a/website/content/docs/operations/session-recordings/validate-session-recordings.mdx
+++ b/website/content/docs/operations/session-recordings/validate-session-recordings.mdx
@@ -5,7 +5,7 @@ description: |-
   How to validate the integrity of Boundary's recorded sessions
 ---
 
-# Validate the integrity of session recordings
+# Validate the integrity of session recordings <sup>HCP/ENT</sup>
 
 BSR directories are validated based on the contents in the directory.
 Boundary cryptographically verifies each individual Boundary Session Recording (BSR) file.

--- a/website/content/docs/operations/session-recordings/validate-session-recordings.mdx
+++ b/website/content/docs/operations/session-recordings/validate-session-recordings.mdx
@@ -5,7 +5,9 @@ description: |-
   How to validate the integrity of Boundary's recorded sessions
 ---
 
-# Validate the integrity of session recordings <sup>HCP/ENT</sup>
+# Validate the integrity of session Recordings
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 BSR directories are validated based on the contents in the directory.
 Boundary cryptographically verifies each individual Boundary Session Recording (BSR) file.

--- a/website/content/docs/troubleshoot/troubleshoot-recorded-sessions.mdx
+++ b/website/content/docs/troubleshoot/troubleshoot-recorded-sessions.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # Troubleshoot session recordings
 
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 Refer to the following for information about how to troubleshoot recorded sessions.
 
 ## Known bugs

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -508,7 +508,12 @@
       },
       {
         "title": "Recorded sessions",
-        "path": "troubleshoot/troubleshoot-recorded-sessions"
+        "path": "troubleshoot/troubleshoot-recorded-sessions",
+        "badge": {
+          "text": "HCP/ENT",
+          "type": "outlined",
+          "color": "neutral"
+        }
       }
     ]
   },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -264,10 +264,20 @@
           },
           {
             "title": "Session recordings",
+            "badge": {
+              "text": "HCP/ENT",
+              "type": "outlined",
+              "color": "neutral"
+            },
             "path": "concepts/domain-model/session-recordings"
           },
           {
             "title": "Storage buckets",
+            "badge": {
+              "text": "HCP/ENT",
+              "type": "outlined",
+              "color": "neutral"
+            },
             "path": "concepts/domain-model/storage-buckets"
           },
           {
@@ -391,6 +401,11 @@
       },
       {
         "title": "Session recordings",
+        "badge": {
+          "text": "HCP/ENT",
+          "type": "outlined",
+          "color": "neutral"
+        },
         "routes": [
           {
             "title": "Overview",
@@ -454,6 +469,11 @@
       },
       {
         "title": "Session recordings",
+        "badge": {
+          "text": "HCP/ENT",
+          "type": "outlined",
+          "color": "neutral"
+        },
         "routes": [
           {
             "title": "Overview",
@@ -1084,6 +1104,11 @@
       },
       {
         "title": "session-recordings",
+        "badge": {
+          "text": "HCP/ENT",
+          "type": "outlined",
+          "color": "neutral"
+        },
         "routes": [
           {
             "title": "Overview",
@@ -1126,6 +1151,11 @@
       },
       {
         "title": "storage-buckets",
+        "badge": {
+          "text": "HCP/ENT",
+          "type": "outlined",
+          "color": "neutral"
+        },
         "routes": [
           {
             "title": "Overview",


### PR DESCRIPTION
This pull request adds enterprise badges/alerts to Boundary docs pages where it is appropriate to call out that a feature is supported only in Enterprise or HCP Boundary. The enterprise badge and enterprise alert are existing devdot web components.

I added an **HCP/ENT** badge to the table of contents for any topics that only apply to one of the Enterprise versions. If there are nested topics, I only applied the badge to the top level:

<img width="310" alt="image" src="https://github.com/hashicorp/boundary/assets/76443935/03caa212-2ad0-4892-bf18-25cc12370bbd">

For other examples in the TOC, view:

- Concepts > Domain model > Session recordings & Storage buckets
- Configuration > Session recordings
- Operations > Session recordings
- Commands (CLI) > session-recordings & storage-buckets

At the topic level, I added an alert to any topics or sections that only applied to one of the Enterprise versions. I added the alert directly under the level 1 heading, if the whole topic was targeted to the Ent versions:

<img width="638" alt="image" src="https://github.com/hashicorp/boundary/assets/76443935/a55fd99b-c12e-43d5-a301-952254fd6322">

I can't change the Boundary logo in the alert, but I did add the text "This feature requires HCP Boundary or Boundary Enterprise" and included a link to the product page (similar to Vault).

If only one section of a topic applies to the Enterprise versions, I added the alert directly underneath the relevant heading. See the example here for Credential injection in the Credential management topic:

<img width="637" alt="image" src="https://github.com/hashicorp/boundary/assets/76443935/e06d68cd-329b-46f4-a350-314903131abe">

I did a find/replace for any places where we were still using the HCP/ENT "sup" tag and replaced them with the alert. There are a couple exceptions where I left an inline "sup" tag, if we used it in a sentence in a field definition. It seemed disruptive to include the alert in the middle of a paragraph. But there aren't many instances like that.

This is a manual process, so we would have to remember to add the tag/alert for new features going forward.

[See the changes in the preview deployment](https://boundary-4epzqpxnx-hashicorp.vercel.app/boundary/docs)
