### PR TITLE
docs: Fix typo in command

### DIFF
--- a/website/content/docs/commands/credential-libraries/create.mdx
+++ b/website/content/docs/commands/credential-libraries/create.mdx
@@ -154,7 +154,7 @@ $ boundary credential-libraries create vault-ssh-certificate [options] [args]
 
 The following are options are specific to the Vault SSH certificate credential library, in addition to the command options:
 
-- `-additional-valid-principal` - Any additional users or groups that you want to configure as valid principals.
+- `-additional-valid-principals` - Any additional users or groups that you want to configure as valid principals.
 By default, Boundary only passes the username to Vault to sign as a valid principal.
 Use this option when you want to configure additional users or groups as valid principals that the certificate should be signed for in Vault.
 

--- a/website/content/docs/commands/credential-libraries/update.mdx
+++ b/website/content/docs/commands/credential-libraries/update.mdx
@@ -151,7 +151,7 @@ $ boundary credential-libraries update vault-ssh-certificate [options] [args]
 
 The following are options specific to the Vault SSH certificate credential library, in addition to the command options:
 
-- `-additional-valid-principal` - Any additional users or groups that you want to configure as valid principals.
+- `-additional-valid-principals` - Any additional users or groups that you want to configure as valid principals.
 By default, Boundary only passes the username to Vault as a valid principal.
 Use this option when you want to configure additional users or groups as valid principals that the certificate should be signed for in Vault.
 


### PR DESCRIPTION
There is a typo in the commands. This PR fixes it.