### PR TITLE
Minor test fixes

### DIFF
--- a/internal/tests/api/credentials/credentials_test.go
+++ b/internal/tests/api/credentials/credentials_test.go
@@ -468,7 +468,7 @@ func TestUpdateAfterKeyRotation(t *testing.T) {
 
 	// Update JSON credential, will re-encrypt with new key versions
 	obj["password"] = "password"
-	cred, err = credsClient.Update(ctx, cred.Item.Id, 1, credentials.WithJsonCredentialObject(obj))
+	_, err = credsClient.Update(ctx, cred.Item.Id, 1, credentials.WithJsonCredentialObject(obj))
 	require.NoError(err)
 
 	// Create new key versions again
@@ -500,7 +500,7 @@ func TestUpdateAfterKeyRotation(t *testing.T) {
 	for {
 		jobs, err := scopesClient.ListKeyVersionDestructionJobs(ctx, proj.PublicId)
 		require.NoError(err)
-		if len(jobs.Items) == 1 {
+		if len(jobs.Items) >= 1 {
 			break
 		}
 		select {


### PR DESCRIPTION
The auth rotation test fix allows us to keep checking if we did not yet see the expected bytes in case the call to lookup succeeds but we are late in rotating due to parallelism.

The api credentials test fix allows us to check if at _least_ one rotation has happened. That way if two rotations happen before we check again due to parallelism, this is deemed a successful result.