### PR TITLE
chore(e2e): Continue if log renaming fails

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -250,6 +250,7 @@ jobs:
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           enos scenario launch --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
       - name: Rename e2e tests output
+        continue-on-error: true
         run : |
           pushd enos
           scenario="${{ matrix.filter }}"


### PR DESCRIPTION
This PR makes a small fix to the e2e test GitHub Actions workflow.

https://github.com/hashicorp/boundary/pull/3882/files introduced a modification that renamed log files to be based on scenario name rather than the test package name (some scenarios use the same test package, which would cause some overwrites).

A simplified form of the workflow goes like...
- run scenario
- rename log
- retry scenario if first run failed

If the first run failed, however, the `rename log` step would also fail due to not finding any `*.log` files (Example: https://github.com/hashicorp/boundary/actions/runs/6773821118/job/18410808033#step:28:32). This PR updates the step to ignore the error so that it can attempt the retry.