### PR TITLE
chore(e2e): Fix trigger to get debug logs

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -298,7 +298,7 @@ jobs:
           enos scenario destroy --timeout 60m0s --chdir ./enos ${{ matrix.filter }}
       - name: Get logs for aws dependencies error
         # Retrieve logs from the terraform to help diagnose some aws cleanup issues
-        if: always() && (contains(matrix.filter, 'e2e_aws') || matrix.filter == 'e2e_database') && steps.destroy.outcome == 'failure'
+        if: ${{ always() && steps.destroy.outcome == 'failure' }}
         continue-on-error: true
         run: |
           enos scenario exec --cmd graph --chdir ./enos ${{ matrix.filter }}


### PR DESCRIPTION
Observed another instance where the step to get debug logs for the "Delete AWS dependencies" issue isn't triggering: https://github.com/hashicorp/boundary/actions/runs/6778925990/job/18425552648

This PR attempts to modify the `if` condition again to get it to trigger. This update makes it match the condition in the step below (`Destroy Enos scenario (Retry)`), so it SHOULD work.