### PR TITLE
test(e2e): Run additional commands over localhost and validate exit codes

### DIFF
--- a/testing/internal/e2e/tests/base/target_tcp_connect_localhost_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_localhost_test.go
@@ -74,6 +74,56 @@ func TestCliTcpTargetConnectTargetWithLocalhost(t *testing.T) {
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
 	require.Equal(t, c.TargetAddress, strings.TrimSpace(string(output.Stdout)))
+	require.Equal(t, 0, output.ExitCode)
+
+	// Run a bash command
+	output = e2e.RunCommand(ctx, "ssh",
+		e2e.WithArgs(
+			"localhost",
+			"-p", port,
+			"-l", c.TargetSshUser,
+			"-i", c.TargetSshKeyPath,
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "IdentitiesOnly=yes", // forces the use of the provided key
+			"bash -c 'mkdir /tmp/hello && rmdir /tmp/hello'",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	require.Equal(t, 0, output.ExitCode)
+
+	// Run another bash command
+	output = e2e.RunCommand(ctx, "ssh",
+		e2e.WithArgs(
+			"localhost",
+			"-p", port,
+			"-l", c.TargetSshUser,
+			"-i", c.TargetSshKeyPath,
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "IdentitiesOnly=yes", // forces the use of the provided key
+			"bash -c 'echo hello'",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+	require.Equal(t, "hello", strings.TrimSpace(string(output.Stdout)))
+	require.Equal(t, 0, output.ExitCode)
+
+	// Run a command with exit code of 1
+	output = e2e.RunCommand(ctx, "ssh",
+		e2e.WithArgs(
+			"localhost",
+			"-p", port,
+			"-l", c.TargetSshUser,
+			"-i", c.TargetSshKeyPath,
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "IdentitiesOnly=yes", // forces the use of the provided key
+			"rm test.txt",
+		),
+	)
+	require.Error(t, output.Err, string(output.Stderr))
+	require.Equal(t, 1, output.ExitCode) // rm: cannot remove 'test.txt': No such file or directory
 
 	// Cancel session
 	cancel()


### PR DESCRIPTION
This PR updates an existing e2e test to run some additional commands over a session and confirm that the appropriate exit code is returned. This was inspired by the issue outlined in this ticket: https://hashicorp.atlassian.net/browse/ICU-11267.

There will be a follow-up PR in `boundary-enterprise` to add the same commands to a test for SSH targets.