### PR TITLE
docs: Fix broken subheading links

### DIFF
--- a/website/content/docs/concepts/domain-model/targets.mdx
+++ b/website/content/docs/concepts/domain-model/targets.mdx
@@ -50,7 +50,7 @@ A target has the following configurable attributes:
   A boolean expression to [filter][] which egress workers can handle sessions
   for this target.
   Egress worker filters determine which workers are used to access targets.
-  You can configure an egress filter to enable [multi-hop](/boundary/docs/configuration/worker#multi-hop-worker-capabilities-hcp-ent) connections.
+  You can configure an egress filter to enable [multi-hop](/boundary/docs/configuration/worker#multi-hop-worker-capabilities) connections.
   If you do not configure an egress filter, then Boundary uses a single worker to connect to the controller.
 
 - `ingress_worker_filter` - (optional) <sup>HCP/ENT</sup>

--- a/website/content/docs/concepts/workers.mdx
+++ b/website/content/docs/concepts/workers.mdx
@@ -26,7 +26,7 @@ You can use workers in various ways depending on your needs, as follows:
 ### Session proxying
 
 You can use workers to proxy sessions between clients and targets located in public or private networks. In addition, you can configure workers in
-[multi-hop](#multi-hop-sessions-hcp-ent) sessions and form a chain of proxies to reach deeper into protected networks.
+[multi-hop](#multi-hop-sessions) sessions and form a chain of proxies to reach deeper into protected networks.
 
 ### Worker authentication
 
@@ -40,7 +40,7 @@ environment.
 
 ### Protocol decryption
 
-Workers can perform SSH protocol decryption for [credential injection](/boundary/docs/concepts/credential-management#credential-injection-hcp-ent) and [session
+Workers can perform SSH protocol decryption for [credential injection](/boundary/docs/concepts/credential-management#credential-injection) and [session
 recording](/boundary/docs/concepts/domain-model/session-recordings). For session recording, workers also write the recorded session contents directly to the [storage
 bucket](/boundary/docs/concepts/domain-model/storage-buckets).
 
@@ -58,7 +58,7 @@ with tag “A,” to connect to targets in “Network A.”
 
 Most organizations want to provide access to infrastructure without exposing private networks. Many organizations also have complex network topologies requiring
 inbound traffic to route through multiple network enclaves in order to reach the target system.
-[Multi-hop](/boundary/docs/configuration/worker#multi-hop-worker-capabilities-hcp-ent) sessions allow you to chain together two or more workers
+[Multi-hop](/boundary/docs/configuration/worker#multi-hop-worker-capabilities) sessions allow you to chain together two or more workers
 across multiple networks to form reverse proxy connections between the user and the target, even in complex networks with strict outbound-only policies.
 
 In multi-hop scenarios, there are typically three types of workers:

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -125,7 +125,7 @@ At this time, the only supported storage is AWS S3.
 
 [Session recording](/boundary/docs/configuration/session-recording) requires at least one PKI worker that:
 - Has access to the AWS S3 storage bucket
-- Has an accessible directory defined by `recording_storage_path` for storing session recordings while they are in progress. On session closure, Boundary moves the local session recording to remote storage and deletes the local copy. For more details, refer to [PKI workers](/boundary/docs/configuration/worker/pki-worker#session-recording-hcp-ent).
+- Has an accessible directory defined by `recording_storage_path` for storing session recordings while they are in progress. On session closure, Boundary moves the local session recording to remote storage and deletes the local copy. For more details, refer to the [PKI worker configuration](/boundary/docs/configuration/worker/pki-worker#session-recording) documentation.
 - Has at least 1 MB of available disk space.
 - Runs Darwin, Windows, or Linux. The following binaries are not supported for session recording: NetBSD, OpenBSD, Solaris.
 

--- a/website/content/docs/configuration/session-recording/enable-session-recording.mdx
+++ b/website/content/docs/configuration/session-recording/enable-session-recording.mdx
@@ -19,9 +19,9 @@ You use the storage bucket's ID to associate a target with the storage bucket.
 - Session recording is only supported for SSH targets at this time.
 - A KMS key with the purpose `bsr` must be added to the controller configuration.
 The key is used for encrypting data and checking the integrity of recordings.
-Refer to [Create the controller configuration](/boundary/docs/install-boundary/configure-controllers#create-the-controller-configuration) and [the `bsr` KMS key](/boundary/docs/concepts/security/data-encryption#the-bsr-kms-key-hcp-ent) documentation for more information about configuring a KMS block.
+Refer to [Create the controller configuration](/boundary/docs/install-boundary/configure-controllers#create-the-controller-configuration) and [the `bsr` KMS key](/boundary/docs/concepts/security/data-encryption#the-bsr-kms-key) documentation for more information about configuring a KMS block.
 - The targets must be configured with an ingress or egress worker filter that includes a worker with access to the storage bucket you created.
-Refer to [SSH target attributes](/boundary/docs/concepts/domain-model/targets#ssh-target-attributes-hcp-ent) for more information.
+Refer to [SSH target attributes](/boundary/docs/concepts/domain-model/targets#ssh-target-attributes) for more information.
 - You must enable injected application credentials on any target that you want to use for session recording.
 
 Complete the following steps to enable session recording on a target.

--- a/website/content/docs/install-boundary/configure-workers.mdx
+++ b/website/content/docs/install-boundary/configure-workers.mdx
@@ -18,7 +18,7 @@ Before you configure workers, you should have completed the following steps:
 
 In the following configuration files, there are common configuration components as well as some unique components depending on the role the Boundary worker performs.
 There are three files, one for each worker in a unique network boundary.
-Additionally, Boundary Enterprise supports a [multi-hop configuration](/boundary/docs/configuration/worker#multi-hop-worker-capabilities-hcp-ent) in which the Boundary workers can serve one of three purposes: an ingress worker, an ingress/egress worker, or an egress worker.
+Additionally, Boundary Enterprise supports a [multi-hop configuration](/boundary/docs/configuration/worker#multi-hop-worker-capabilities) in which the Boundary workers can serve one of three purposes: an ingress worker, an ingress/egress worker, or an egress worker.
 
 ## Prepare the environment files
 
@@ -69,11 +69,11 @@ Select your Boundary edition, and complete the following steps to configure work
 <Tabs>
 <Tab heading="Enterprise">
 
-For Boundary Enterprise, you can configure ingress, intermediary, and egress workers to take advantage of [multi-hop worker capabilities](/boundary/docs/configuration/worker#multi-hop-worker-capabilities-hcp-ent).
+For Boundary Enterprise, you can configure ingress, intermediary, and egress workers to take advantage of [multi-hop worker capabilities](/boundary/docs/configuration/worker#multi-hop-worker-capabilities).
 
 Note that "ingress," "intermediary," and "egress" are general ways to describe how the respective worker interacts with resources.
 A worker can serve more than one of those roles at a time.
-Refer to [Multi-hop sessions](/boundary/docs/concepts/workers#multi-hop-sessions-hcp-ent) for more information.
+Refer to [Multi-hop sessions](/boundary/docs/concepts/workers#multi-hop-sessions) for more information.
 
 Complete the steps below to configure workers for Boundary Enterprise.
 


### PR DESCRIPTION
We renamed some subheadings to simplify how we call out enterprise features and inadvertently broke some anchor links. This PR fixes the links.