### PR TITLE
Decrease full fetch rate to ~1/hr

### DIFF
--- a/internal/clientcache/cmd/daemon/start.go
+++ b/internal/clientcache/cmd/daemon/start.go
@@ -107,7 +107,7 @@ func (c *StartCommand) Flags() *base.FlagSets {
 	f.DurationVar(&base.DurationVar{
 		Name:    "full-fetch-interval-seconds",
 		Target:  &c.flagFullFetchInterval,
-		Usage:   `If set, specifies the number of seconds between full cache refresh for boundary instances which do not support refresh tokens. Default: 5 minutes`,
+		Usage:   `If set, specifies the number of seconds between full cache refresh for boundary instances which do not support refresh tokens. Default: 60 minutes`,
 		Default: daemon.DefaultFullFetchIntervalSeconds * time.Second,
 	})
 	f.BoolVar(&base.BoolVar{
@@ -121,7 +121,7 @@ func (c *StartCommand) Flags() *base.FlagSets {
 		Name:    "background",
 		Target:  &c.flagBackground,
 		Default: false,
-		Usage:   `Turn on store debugging`,
+		Usage:   `Run the client cache daemon in the background.`,
 	})
 
 	return set

--- a/internal/clientcache/internal/daemon/ticker.go
+++ b/internal/clientcache/internal/daemon/ticker.go
@@ -18,7 +18,10 @@ const (
 	DefaultRefreshIntervalSeconds = 60
 	defaultRefreshInterval        = DefaultRefreshIntervalSeconds * time.Second
 
-	DefaultFullFetchIntervalSeconds = 60 * 5
+	// Since old versions of boundary controllers do not use refresh tokens,
+	// querying frequently from them can put too much load on them so we use a
+	// low rate of query.
+	DefaultFullFetchIntervalSeconds = 60 * 60
 	defaultFullFetchInterval        = DefaultFullFetchIntervalSeconds * time.Second
 
 	defaultRandomizationFactor float64 = 0.2


### PR DESCRIPTION
As a reminder, full fetch only comes into play when there is at least 1 resource already synced, but no refresh token is in storage.  If a user was just added, or if and old controller returns no targets or sessions, full fetch will not be used, and refresh will be used instead.