### PR TITLE
test(bats): Use correct attribute for the `vault-ssh-certificate critical-options` test

### DIFF
--- a/internal/tests/cli/boundary/credential_libraries.bats
+++ b/internal/tests/cli/boundary/credential_libraries.bats
@@ -493,7 +493,7 @@ export NEW_VAULT_LIB="test_vault"
   [ "$status" -eq 0 ]
 
   # can unset it
-  run update_vault_ssh_certificate_library -id $clid -extensions null
+  run update_vault_ssh_certificate_library -id $clid -critical-options null
   echo "$output"
   [ "$status" -eq 0 ]
 
@@ -502,7 +502,7 @@ export NEW_VAULT_LIB="test_vault"
   [ "$status" -eq 0 ]
   got=$(echo "$output")
 
-  run field_eq "$got" ".item.attributes.extensions" "null"
+  run field_eq "$got" ".item.attributes.critical_options" "null"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
This PR fixes a bats test to check for the correct attribute. This particular test is validating `vault-ssh-certificate library critical-options`, but there were a few checks using the wrong attribute.