### PR TITLE
docs: Fix broken link

### DIFF
--- a/website/content/docs/concepts/host-discovery/index.mdx
+++ b/website/content/docs/concepts/host-discovery/index.mdx
@@ -37,7 +37,7 @@ infrastructure targets can be automated with
 This allows for dynamic configuration of a host and target without the need
 for prior knowledge of the target’s connection info.
 
-**[Runtime host discovery via dynamic host catalogs](/boundary/tutorials/access-management/aws-host-catalogs)**:
+**[Runtime host discovery via dynamic host catalogs](/boundary/tutorials/host-management/aws-host-catalogs)**:
 Boundary dynamic host catalogs automate the ingestion of resources from
 infrastructure providers into Boundary. Boundary hosts are automatically
 created, updated and added to host sets in order to reflect the connection

--- a/website/content/docs/concepts/host-discovery/index.mdx
+++ b/website/content/docs/concepts/host-discovery/index.mdx
@@ -58,5 +58,5 @@ Boundary currently supports dynamic host catalog for AWS and
 Azure and we will continue to grow this ecosystem to support additional providers.
 
 You can get started with dynamic host catalogs for AWS
-[here](/boundary/tutorials/access-management/aws-host-catalogs)
-and for Azure [here](/boundary/tutorials/access-management/azure-host-catalogs).
+[here](/boundary/tutorials/host-management/aws-host-catalogs)
+and for Azure [here](/boundary/tutorials/host-management/azure-host-catalogs).

--- a/website/content/docs/operations/session-recordings/validate-session-recordings.mdx
+++ b/website/content/docs/operations/session-recordings/validate-session-recordings.mdx
@@ -5,7 +5,7 @@ description: |-
   How to validate the integrity of Boundary's recorded sessions
 ---
 
-# Validate the integrity of session Recordings
+# Validate the integrity of session recordings
 
 <EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 


### PR DESCRIPTION
There is a broken link in the [Host discovery index page](https://developer.hashicorp.com/boundary/docs/concepts/host-discovery). It should go to the AWS host catalogs tutorial:

<img width="738" alt="image" src="https://github.com/hashicorp/boundary/assets/76443935/b8f52ef8-befd-451c-9bb2-1f79fbc27b02">

This PR updates the link. I also fixed a recently introduced typo on the [Validate the integrity of session recordings](https://developer.hashicorp.com/boundary/docs/operations/session-recordings/validate-session-recordings) page.

View the preview deployment:

- [Host discovery](https://boundary-pisnem33d-hashicorp.vercel.app/boundary/docs/concepts/host-discovery)
- [Validate the integrity of session recordings](https://boundary-pisnem33d-hashicorp.vercel.app/boundary/docs/operations/session-recordings/validate-session-recordings)

UPDATE: I found and fixed 2 more broken links in the same topic here:

<img width="732" alt="image" src="https://github.com/hashicorp/boundary/assets/76443935/73a8de09-6bd9-4c43-8433-0dc4472b0b71">
