### PR TITLE
Observation(event): adding op instead of type details paylaod

### DIFF
--- a/internal/event/event_observation.go
+++ b/internal/event/event_observation.go
@@ -107,9 +107,6 @@ func (o *observation) ComposeFrom(events []*eventlogger.Event) (eventlogger.Even
 			if _, ok := payload[DetailsField]; !ok {
 				payload[DetailsField] = []gated.EventPayloadDetails{}
 			}
-			if g.Op == "" {
-				g.Op = "Unknown"
-			}
 			payload[DetailsField] = append(payload[DetailsField].([]gated.EventPayloadDetails), gated.EventPayloadDetails{
 				Type:      string(g.Op),
 				CreatedAt: v.CreatedAt.String(),

--- a/internal/event/event_observation.go
+++ b/internal/event/event_observation.go
@@ -107,8 +107,11 @@ func (o *observation) ComposeFrom(events []*eventlogger.Event) (eventlogger.Even
 			if _, ok := payload[DetailsField]; !ok {
 				payload[DetailsField] = []gated.EventPayloadDetails{}
 			}
+			if g.Op == "" {
+				g.Op = "Unknown"
+			}
 			payload[DetailsField] = append(payload[DetailsField].([]gated.EventPayloadDetails), gated.EventPayloadDetails{
-				Type:      string(v.Type),
+				Type:      string(g.Op),
 				CreatedAt: v.CreatedAt.String(),
 				Payload:   g.Detail,
 			})


### PR DESCRIPTION
This PR adds an `op` string instead of a `type` inside details payload in the observation event.
cc: @jimlambrt 