### PR TITLE
feat(oidc-prompt): repository changes for OIDC Prompt

### DIFF
--- a/internal/auth/oidc/auth_method.go
+++ b/internal/auth/oidc/auth_method.go
@@ -471,7 +471,7 @@ func ParseAccountClaimMaps(ctx context.Context, m ...string) ([]ClaimMap, error)
 }
 
 // convertPrompts converts the embedded prompts from []string
-// to []interface{} where each slice element is a *SigningAlg. It will return an
+// to []interface{} where each slice element is a *Prompt. It will return an
 // error if the AuthMethod's public id is not set.
 func (am *AuthMethod) convertPrompts(ctx context.Context) ([]any, error) {
 	const op = "oidc.(AuthMethod).convertPrompts"

--- a/internal/auth/oidc/repository_auth_method_create.go
+++ b/internal/auth/oidc/repository_auth_method_create.go
@@ -16,7 +16,7 @@ import (
 
 // CreateAuthMethod creates am (*AuthMethod) in the repo along with its
 // associated embedded optional value objects of SigningAlgs, AudClaims,
-// and Certificates and returns the newly created AuthMethod
+// Prompts, and Certificates and returns the newly created AuthMethod
 // (with its PublicId set)
 //
 // The AuthMethod's public id and version must be empty (zero values).
@@ -122,6 +122,13 @@ func (r *Repository) CreateAuthMethod(ctx context.Context, am *AuthMethod, opt .
 					return err
 				}
 				msgs = append(msgs, accountClaimMapsOplogMsgs...)
+			}
+			if len(vo.Prompts) > 0 {
+				promptOplogMsgs := make([]*oplog.Message, 0, len(vo.Prompts))
+				if err := w.CreateItems(ctx, vo.Prompts, db.NewOplogMsgs(&promptOplogMsgs)); err != nil {
+					return err
+				}
+				msgs = append(msgs, promptOplogMsgs...)
 			}
 			metadata := am.oplog(oplog.OpType_OP_TYPE_CREATE)
 			if err := w.WriteOplogEntryWith(ctx, oplogWrapper, ticket, metadata, msgs); err != nil {

--- a/internal/auth/oidc/repository_auth_method_create_test.go
+++ b/internal/auth/oidc/repository_auth_method_create_test.go
@@ -36,6 +36,14 @@ func TestRepository_CreateAuthMethod(t *testing.T) {
 		}
 		return s
 	}
+
+	convertPrompts := func(prompts ...PromptParam) []string {
+		s := make([]string, 0, len(prompts))
+		for _, a := range prompts {
+			s = append(s, string(a))
+		}
+		return s
+	}
 	tests := []struct {
 		name         string
 		am           func(*testing.T) *AuthMethod
@@ -48,6 +56,7 @@ func TestRepository_CreateAuthMethod(t *testing.T) {
 				algs := []Alg{RS256, ES256}
 				cbs := TestConvertToUrls(t, "https://www.alice.com/callback")[0]
 				auds := []string{"alice-rp", "bob-rp"}
+				prompts := []PromptParam{"consent", "select_account"}
 				cert1, pem1 := testGenerateCA(t, "localhost")
 				cert2, pem2 := testGenerateCA(t, "localhost")
 				certs := []*x509.Certificate{cert1, cert2}
@@ -65,6 +74,7 @@ func TestRepository_CreateAuthMethod(t *testing.T) {
 					WithName("alice's restaurant"),
 					WithDescription("it's a good place to eat"),
 					WithClaimsScopes("email", "profile"),
+					WithPrompts(prompts...),
 					WithAccountClaimMap(map[string]AccountToClaim{"display_name": ToNameClaim, "oid": ToSubClaim}),
 				)
 				require.NoError(t, err)
@@ -74,6 +84,7 @@ func TestRepository_CreateAuthMethod(t *testing.T) {
 				require.Equal(t, am.AudClaims, auds)
 				require.Equal(t, am.Certificates, pems)
 				require.Equal(t, am.OperationalState, string(InactiveState))
+				require.Equal(t, am.Prompts, convertPrompts(prompts...))
 				return am
 			},
 		},
@@ -83,6 +94,7 @@ func TestRepository_CreateAuthMethod(t *testing.T) {
 				algs := []Alg{RS256, ES256}
 				cbs := TestConvertToUrls(t, "https://www.alice.com/callback")[0]
 				auds := []string{"alice-rp-custom", "bob-rp-custom"}
+				prompts := []PromptParam{"consent", "select_account"}
 				cert1, pem1 := testGenerateCA(t, "localhost")
 				cert2, pem2 := testGenerateCA(t, "localhost")
 				certs := []*x509.Certificate{cert1, cert2}
@@ -97,6 +109,7 @@ func TestRepository_CreateAuthMethod(t *testing.T) {
 					WithApiUrl(cbs),
 					WithSigningAlgs(algs...),
 					WithCertificates(certs...),
+					WithPrompts(prompts...),
 					WithName("alice's restaurant with a twist"),
 					WithDescription("it's an okay but kinda weird place to eat"),
 					WithClaimsScopes("email", "profile"),
@@ -109,6 +122,7 @@ func TestRepository_CreateAuthMethod(t *testing.T) {
 				require.Equal(t, am.AudClaims, auds)
 				require.Equal(t, am.Certificates, pems)
 				require.Equal(t, am.OperationalState, string(InactiveState))
+				require.Equal(t, am.Prompts, convertPrompts(prompts...))
 				return am
 			},
 			opt: []Option{WithPublicId("amoidc_1234567890")},

--- a/internal/auth/oidc/repository_auth_method_delete_test.go
+++ b/internal/auth/oidc/repository_auth_method_delete_test.go
@@ -42,6 +42,27 @@ func TestRepository_DeleteAuthMethod(t *testing.T) {
 			wantRowsDeleted: 1,
 		},
 		{
+			name: "valid-with-prompts",
+			authMethod: func() *AuthMethod {
+				org, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+				databaseWrapper, err := kmsCache.GetWrapper(context.Background(), org.PublicId, kms.KeyPurposeDatabase)
+				require.NoError(t, err)
+				return TestAuthMethod(
+					t,
+					conn,
+					databaseWrapper,
+					org.PublicId,
+					InactiveState,
+					"alice_rp",
+					"alices-dogs-name",
+					WithIssuer(TestConvertToUrls(t, "https://alice.com")[0]),
+					WithApiUrl(TestConvertToUrls(t, "https://api.com")[0]),
+					WithPrompts(SelectAccount),
+				)
+			}(),
+			wantRowsDeleted: 1,
+		},
+		{
 			name:         "no-public-id",
 			authMethod:   func() *AuthMethod { am := AllocAuthMethod(); return &am }(),
 			wantErrMatch: errors.T(errors.InvalidPublicId),

--- a/internal/auth/oidc/repository_auth_method_read.go
+++ b/internal/auth/oidc/repository_auth_method_read.go
@@ -167,6 +167,9 @@ func (r *Repository) getAuthMethods(ctx context.Context, authMethodId string, sc
 		if agg.AccountClaimMaps != "" {
 			am.AccountClaimMaps = strings.Split(agg.AccountClaimMaps, aggregateDelimiter)
 		}
+		if agg.Prompts != "" {
+			am.Prompts = strings.Split(agg.Prompts, aggregateDelimiter)
+		}
 		authMethods = append(authMethods, &am)
 	}
 	return authMethods, nil
@@ -198,6 +201,7 @@ type authMethodAgg struct {
 	Certs                             string
 	ClaimsScopes                      string
 	AccountClaimMaps                  string
+	Prompts                           string
 }
 
 // TableName returns the table name for gorm

--- a/internal/auth/oidc/repository_auth_method_read_test.go
+++ b/internal/auth/oidc/repository_auth_method_read_test.go
@@ -33,7 +33,8 @@ func TestRepository_LookupAuthMethod(t *testing.T) {
 		"alice_rp", "alices-dogs-name",
 		WithAccountClaimMap(map[string]AccountToClaim{"oid": ToSubClaim, "display_name": ToNameClaim}),
 		WithApiUrl(TestConvertToUrls(t, "https://alice-active-priv.com/callback")[0]),
-		WithSigningAlgs(RS256))
+		WithSigningAlgs(RS256),
+		WithPrompts(Consent, SelectAccount))
 	amActivePub := TestAuthMethod(
 		t,
 		conn, databaseWrapper, org.PublicId, ActivePublicState,
@@ -151,6 +152,32 @@ func TestRepository_ListAuthMethods(t *testing.T) {
 				return []string{am1a.ScopeId}, []*AuthMethod{am1a}, am1a.PublicId
 			},
 			opt: []Option{WithLimit(1), WithOrderByCreateTime(true)},
+		},
+		{
+			name: "with-prompts",
+			setupFn: func() ([]string, []*AuthMethod, string) {
+				org, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+				databaseWrapper, err := kmsCache.GetWrapper(context.Background(), org.PublicId, kms.KeyPurposeDatabase)
+				require.NoError(t, err)
+
+				am1a := TestAuthMethod(
+					t,
+					conn,
+					databaseWrapper,
+					org.PublicId,
+					InactiveState,
+					"alice_rp",
+					"alices-dogs-name",
+					WithIssuer(TestConvertToUrls(t, "https://alice.com")[0]),
+					WithApiUrl(TestConvertToUrls(t, "https://api.com")[0]),
+					WithClaimsScopes("email", "profile"),
+					WithPrompts(Consent, SelectAccount),
+				)
+				iam.TestSetPrimaryAuthMethod(t, iamRepo, org, am1a.PublicId)
+				am1a.IsPrimaryAuthMethod = true
+
+				return []string{am1a.ScopeId}, []*AuthMethod{am1a}, am1a.PublicId
+			},
 		},
 		{
 			name: "no-search-criteria",

--- a/internal/auth/oidc/testing.go
+++ b/internal/auth/oidc/testing.go
@@ -39,8 +39,8 @@ import (
 const TestFakeManagedGroupFilter = `"/foo" == "bar"`
 
 // TestAuthMethod creates a test oidc auth method.  WithName, WithDescription,
-// WithMaxAge, WithApiUrl, WithIssuer, WithCertificates, WithAudClaims, and
-// WithSigningAlgs options are supported.
+// WithMaxAge, WithApiUrl, WithIssuer, WithCertificates, WithAudClaims,
+// WithSigningAlgs and WithPrompts options are supported.
 func TestAuthMethod(
 	t testing.TB,
 	conn *db.DB,
@@ -122,6 +122,17 @@ func TestAuthMethod(
 		}
 		require.NoError(rw.CreateItems(ctx, newAccountClaimMaps))
 		require.Equal(len(opts.withAccountClaimMap), len(authMethod.AccountClaimMaps))
+	}
+	if len(opts.withPrompts) > 0 {
+		newPrompts := make([]any, 0, len(opts.withPrompts))
+		for _, p := range opts.withPrompts {
+			prompt, err := NewPrompt(ctx, authMethod.PublicId, p)
+			require.NoError(err)
+			newPrompts = append(newPrompts, prompt)
+		}
+		err := rw.CreateItems(ctx, newPrompts)
+		require.NoError(err)
+		require.Equal(len(opts.withPrompts), len(authMethod.Prompts))
 	}
 	authMethod.OperationalState = string(state)
 	rowsUpdated, err := rw.Update(ctx, authMethod, []string{OperationalStateField}, nil)


### PR DESCRIPTION
Boundary OIDC method does not currently support passing in prompts during authentication. This change adds the capability of passing OIDC prompts. Prompts are optional OIDC parameters that determine the behaviour of the authentication server: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest

### Changes

- Update create, read, write and delete  repository changes to support new `Prompt` option for OIDC auth method
- Update test helper functions to support creating a test auth method with prompts