### PR TITLE
test(e2e): Use docker mirror when pulling image

### DIFF
--- a/testing/internal/e2e/infra/docker.go
+++ b/testing/internal/e2e/infra/docker.go
@@ -34,7 +34,7 @@ func StartBoundaryDatabase(t testing.TB, pool *dockertest.Pool, network *dockert
 	require.NoError(t, err)
 
 	err = pool.Client.PullImage(docker.PullImageOptions{
-		Repository: repository,
+		Repository: fmt.Sprintf("%s/%s", c.DockerMirror, repository),
 		Tag:        tag,
 	}, docker.AuthConfiguration{})
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func InitBoundaryDatabase(t testing.TB, pool *dockertest.Pool, network *dockerte
 	require.NoError(t, err)
 
 	err = pool.Client.PullImage(docker.PullImageOptions{
-		Repository: repository,
+		Repository: fmt.Sprintf("%s/%s", c.DockerMirror, repository),
 		Tag:        tag,
 	}, docker.AuthConfiguration{})
 	require.NoError(t, err)


### PR DESCRIPTION
This PR makes a minor fix to the e2e migration test. There were a few spots where we're not pulling the docker image from the docker mirror even though we're specifying the mirror when calling `RunWithOptions`.