### PR TITLE
feat(oidc-prompt): OIDC Prompt API & CLI

### DIFF
--- a/internal/auth/oidc/prompt.go
+++ b/internal/auth/oidc/prompt.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/boundary/internal/auth/oidc/store"
 	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/cap/oidc"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -29,6 +30,12 @@ var supportedPrompts = map[PromptParam]bool{
 	Login:         true,
 	Consent:       true,
 	SelectAccount: true,
+}
+
+// SupportedPrompt returns true if the provided prompt is supported
+// by boundary.
+func SupportedPrompt(p PromptParam) bool {
+	return supportedPrompts[p]
 }
 
 // defaultPromptTableName defines the default table name for a Prompt
@@ -69,6 +76,16 @@ func (s *Prompt) validate(ctx context.Context, caller errors.Op) error {
 		return errors.New(ctx, errors.InvalidParameter, caller, fmt.Sprintf("unsupported prompt: %s", s.Prompt))
 	}
 	return nil
+}
+
+func convertToOIDCPrompts(ctx context.Context, p []string) []oidc.Prompt {
+	prompts := make([]oidc.Prompt, 0, len(p))
+	for _, a := range p {
+		prompt := oidc.Prompt(a)
+		prompts = append(prompts, prompt)
+	}
+
+	return prompts
 }
 
 // AllocPrompt makes an empty one in memory

--- a/internal/auth/oidc/prompt_test.go
+++ b/internal/auth/oidc/prompt_test.go
@@ -1,0 +1,286 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package oidc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestPrompts_Create(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	org, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	rw := db.New(conn)
+
+	databaseWrapper, err := kmsCache.GetWrapper(context.Background(), org.PublicId, kms.KeyPurposeDatabase)
+	require.NoError(t, err)
+
+	testAuthMethod := TestAuthMethod(t, conn, databaseWrapper, org.PublicId, InactiveState, "alice_rp", "my-dogs-name",
+		WithIssuer(TestConvertToUrls(t, "https://alice.com")[0]), WithApiUrl(TestConvertToUrls(t, "https://api.com")[0]))
+
+	type args struct {
+		authMethodId string
+		prompt       PromptParam
+	}
+	tests := []struct {
+		name            string
+		args            args
+		want            *Prompt
+		wantErr         bool
+		wantIsErr       errors.Code
+		create          bool
+		wantCreateErr   bool
+		wantCreateIsErr errors.Code
+	}{
+		{
+			name: "valid",
+			args: args{
+				authMethodId: testAuthMethod.PublicId,
+				prompt:       SelectAccount,
+			},
+			create: true,
+			want: func() *Prompt {
+				want := AllocPrompt()
+				want.OidcMethodId = testAuthMethod.PublicId
+				want.PromptParam = string(SelectAccount)
+				return &want
+			}(),
+		},
+		{
+			name: "dup", // must follow "valid" test. Prompt must be be unique for an OidcMethodId
+			args: args{
+				authMethodId: testAuthMethod.PublicId,
+				prompt:       SelectAccount,
+			},
+			create: true,
+			want: func() *Prompt {
+				want := AllocPrompt()
+				want.OidcMethodId = testAuthMethod.PublicId
+				want.PromptParam = string(SelectAccount)
+				return &want
+			}(),
+			wantCreateErr:   true,
+			wantCreateIsErr: errors.NotUnique,
+		},
+		{
+			name: "empty-auth-method",
+			args: args{
+				authMethodId: "",
+				prompt:       Consent,
+			},
+			wantErr:   true,
+			wantIsErr: errors.InvalidParameter,
+		},
+		{
+			name: "empty-prompt",
+			args: args{
+				authMethodId: testAuthMethod.PublicId,
+				prompt:       "",
+			},
+			wantErr:   true,
+			wantIsErr: errors.InvalidParameter,
+		},
+		{
+			name: "supported-prompt",
+			args: args{
+				authMethodId: testAuthMethod.PublicId,
+				prompt:       PromptParam("EVE256"), // The unsupported evesdropper 256 curve
+			},
+			wantErr:   true,
+			wantIsErr: errors.InvalidParameter,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := NewPrompt(ctx, tt.args.authMethodId, tt.args.prompt)
+			if tt.wantErr {
+				require.Error(err)
+				assert.True(errors.Match(errors.T(tt.wantIsErr), err))
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tt.want, got)
+			if tt.create {
+				ctx := context.Background()
+				err = rw.Create(ctx, got)
+				if tt.wantCreateErr {
+					assert.Error(err)
+					assert.True(errors.Match(errors.T(tt.wantCreateIsErr), err))
+					return
+				} else {
+					assert.NoError(err)
+				}
+				found := AllocPrompt()
+				require.NoError(rw.LookupWhere(ctx, &found, "oidc_method_id = ? and prompt = ?", []any{tt.args.authMethodId, string(tt.args.prompt)}))
+				assert.Equal(got, &found)
+			}
+		})
+	}
+}
+
+func TestPrompt_Delete(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+	org, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	rw := db.New(conn)
+
+	databaseWrapper, err := kmsCache.GetWrapper(context.Background(), org.PublicId, kms.KeyPurposeDatabase)
+	require.NoError(t, err)
+
+	testAuthMethod := TestAuthMethod(
+		t,
+		conn,
+		databaseWrapper,
+		org.PublicId,
+		InactiveState,
+		"alice_rp",
+		"my-dogs-name",
+		WithIssuer(TestConvertToUrls(t, "https://alice.com")[0]),
+		WithApiUrl(TestConvertToUrls(t, "https://api.com")[0]),
+		WithPrompts(Consent))
+
+	testResource := func(authMethodId string, prompt PromptParam) *Prompt {
+		c, err := NewPrompt(ctx, authMethodId, prompt)
+		require.NoError(t, err)
+		return c
+	}
+	tests := []struct {
+		name            string
+		Prompt          *Prompt
+		wantRowsDeleted int
+		overrides       func(*Prompt)
+		wantErr         bool
+		wantErrMsg      string
+	}{
+		{
+			name:            "valid",
+			Prompt:          testResource(testAuthMethod.PublicId, SelectAccount),
+			wantErr:         false,
+			wantRowsDeleted: 1,
+		},
+		{
+			name:            "bad-OidcMethodId",
+			Prompt:          testResource(testAuthMethod.PublicId, Login),
+			overrides:       func(c *Prompt) { c.OidcMethodId = "bad-id" },
+			wantErr:         false,
+			wantRowsDeleted: 0,
+		},
+		{
+			name:            "bad-prompt",
+			Prompt:          testResource(testAuthMethod.PublicId, None),
+			overrides:       func(c *Prompt) { c.PromptParam = "bad-prompt" },
+			wantErr:         false,
+			wantRowsDeleted: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			ctx := context.Background()
+			cp := tt.Prompt.Clone()
+			require.NoError(rw.Create(ctx, &cp))
+
+			if tt.overrides != nil {
+				tt.overrides(cp)
+			}
+			deletedRows, err := rw.Delete(ctx, &cp)
+			if tt.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+			if tt.wantRowsDeleted == 0 {
+				assert.Equal(tt.wantRowsDeleted, deletedRows)
+				return
+			}
+			assert.Equal(tt.wantRowsDeleted, deletedRows)
+			found := AllocPrompt()
+			err = rw.LookupWhere(ctx, &found, "oidc_method_id = ? and prompt = ?", []any{tt.Prompt.OidcMethodId, tt.Prompt.String()})
+			assert.Truef(errors.IsNotFoundError(err), "unexpected error: %s", err.Error())
+		})
+	}
+}
+
+func TestPrompt_Clone(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrapper)
+
+	t.Run("valid", func(t *testing.T) {
+		assert, require := assert.New(t), require.New(t)
+		org, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+		databaseWrapper, err := kmsCache.GetWrapper(context.Background(), org.PublicId, kms.KeyPurposeDatabase)
+		require.NoError(err)
+		m := TestAuthMethod(t, conn, databaseWrapper, org.PublicId, InactiveState, "alice_rp", "my-dogs-name",
+			WithIssuer(TestConvertToUrls(t, "https://alice.com")[0]), WithApiUrl(TestConvertToUrls(t, "https://api.com")[0]))
+		orig, err := NewPrompt(ctx, m.PublicId, Consent)
+		require.NoError(err)
+		cp := orig.Clone()
+		assert.True(proto.Equal(cp.Prompt, orig.Prompt))
+	})
+	t.Run("not-equal", func(t *testing.T) {
+		assert, require := assert.New(t), require.New(t)
+		org, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+		databaseWrapper, err := kmsCache.GetWrapper(context.Background(), org.PublicId, kms.KeyPurposeDatabase)
+		require.NoError(err)
+		m := TestAuthMethod(t, conn, databaseWrapper, org.PublicId, InactiveState, "alice_rp", "my-dogs-name",
+			WithIssuer(TestConvertToUrls(t, "https://alice.com")[0]), WithApiUrl(TestConvertToUrls(t, "https://api.com")[0]))
+		orig, err := NewPrompt(ctx, m.PublicId, Consent)
+		require.NoError(err)
+		orig2, err := NewPrompt(ctx, m.PublicId, SelectAccount)
+		require.NoError(err)
+
+		cp := orig.Clone()
+		assert.True(!proto.Equal(cp.Prompt, orig2.Prompt))
+	})
+}
+
+func TestPrompt_SetTableName(t *testing.T) {
+	t.Parallel()
+	defaultTableName := defaultPromptTableName
+	tests := []struct {
+		name      string
+		setNameTo string
+		want      string
+	}{
+		{
+			name:      "new-name",
+			setNameTo: "new-name",
+			want:      "new-name",
+		},
+		{
+			name:      "reset to default",
+			setNameTo: "",
+			want:      defaultTableName,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			def := AllocPrompt()
+			require.Equal(defaultTableName, def.TableName())
+			m := AllocPrompt()
+			m.SetTableName(tt.setNameTo)
+			assert.Equal(tt.want, m.TableName())
+		})
+	}
+}

--- a/internal/auth/oidc/prompt_test.go
+++ b/internal/auth/oidc/prompt_test.go
@@ -284,3 +284,47 @@ func TestPrompt_SetTableName(t *testing.T) {
 		})
 	}
 }
+
+func TestPrompt_SupportedPrompt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		prompt PromptParam
+		want   bool
+	}{
+		{
+			name:   "none-prompt",
+			prompt: None,
+			want:   true,
+		},
+		{
+			name:   "login-prompt",
+			prompt: Login,
+			want:   true,
+		},
+		{
+			name:   "consent-prompt",
+			prompt: Consent,
+			want:   true,
+		},
+		{
+			name:   "select-account-prompt",
+			prompt: SelectAccount,
+			want:   true,
+		},
+		{
+			name:   "invalid-prompt",
+			prompt: "invalid",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got := SupportedPrompt(tt.prompt)
+			assert.Equal(tt.want, got)
+		})
+	}
+}

--- a/internal/auth/oidc/service_start_auth.go
+++ b/internal/auth/oidc/service_start_auth.go
@@ -118,6 +118,11 @@ func StartAuth(ctx context.Context, oidcRepoFn OidcRepoFactory, authMethodId str
 		oidcOpts = append(oidcOpts, oidc.WithScopes(am.ClaimsScopes...))
 	}
 
+	if len(am.Prompts) > 0 {
+		prompts := convertToOIDCPrompts(ctx, am.Prompts)
+		oidcOpts = append(oidcOpts, oidc.WithPrompts(prompts...))
+	}
+
 	// a bare min oidc.Request needed for the provider.AuthURL(...) call.  We've intentionally not populated
 	// things like Audiences, because this oidc.Request isn't cached and not intended for use in future legs
 	// of the authen flow.

--- a/internal/cmd/commands/authmethodscmd/oidc_funcs.go
+++ b/internal/cmd/commands/authmethodscmd/oidc_funcs.go
@@ -33,6 +33,7 @@ type extraOidcCmdVars struct {
 	flagAccountClaimMaps                  []string
 	flagDisableDiscoveredConfigValidation bool
 	flagDryRun                            bool
+	flagPrompts                           []string
 }
 
 const (
@@ -50,6 +51,7 @@ const (
 	stateFlagName                             = "state"
 	disableDiscoveredConfigValidationFlagName = "disable-discovered-config-validation"
 	dryRunFlagName                            = "dry-run"
+	promptsFlagName                           = "prompts"
 )
 
 func extraOidcActionsFlagsMapFuncImpl() map[string][]string {
@@ -65,6 +67,7 @@ func extraOidcActionsFlagsMapFuncImpl() map[string][]string {
 			allowedAudienceFlagName,
 			claimsScopes,
 			accountClaimMaps,
+			promptsFlagName,
 		},
 		"change-state": {
 			idFlagName,
@@ -158,6 +161,12 @@ func extraOidcFlagsFuncImpl(c *OidcCommand, set *base.FlagSets, _ *base.FlagSet)
 				Name:   dryRunFlagName,
 				Target: &c.flagDryRun,
 				Usage:  "Performs all completeness and validation checks with any newly-provided values without persisting the changes.",
+			})
+		case promptsFlagName:
+			f.StringSliceVar(&base.StringSliceVar{
+				Name:   promptsFlagName,
+				Target: &c.flagPrompts,
+				Usage:  "The optional prompt parameter that can be included in the authentication request to control the behavior of the authentication flow.",
 			})
 		}
 	}
@@ -282,6 +291,13 @@ func extraOidcFlagHandlingFuncImpl(c *OidcCommand, f *base.FlagSets, opts *[]aut
 	}
 	if c.flagDryRun {
 		*opts = append(*opts, authmethods.WithOidcAuthMethodDryRun(c.flagDryRun))
+	}
+	switch {
+	case len(c.flagPrompts) == 0:
+	case len(c.flagPrompts) == 1 && c.flagPrompts[0] == "null":
+		*opts = append(*opts, authmethods.DefaultOidcAuthMethodPrompts())
+	default:
+		*opts = append(*opts, authmethods.WithOidcAuthMethodPrompts(c.flagPrompts))
 	}
 
 	return true

--- a/internal/daemon/controller/handlers/authmethods/authmethod_service.go
+++ b/internal/daemon/controller/handlers/authmethods/authmethod_service.go
@@ -862,6 +862,7 @@ func toAuthMethodProto(ctx context.Context, in auth.AuthMethod, opt ...handlers.
 			AllowedAudiences:  i.GetAudClaims(),
 			ClaimsScopes:      i.GetClaimsScopes(),
 			AccountClaimMaps:  i.GetAccountClaimMaps(),
+			Prompts:           i.GetPrompts(),
 		}
 		if i.DisableDiscoveredConfigValidation {
 			attrs.DisableDiscoveredConfigValidation = true
@@ -1031,6 +1032,14 @@ func validateCreateRequest(ctx context.Context, req *pbs.CreateAuthMethodRequest
 						}
 					}
 				}
+				if len(attrs.GetPrompts()) > 0 {
+					for _, p := range attrs.GetPrompts() {
+						if !oidc.SupportedPrompt(oidc.PromptParam(p)) {
+							badFields[promptsField] = fmt.Sprintf("Contains unsupported prompt %q", p)
+							break
+						}
+					}
+				}
 				if strings.TrimSpace(attrs.GetApiUrlPrefix().GetValue()) == "" {
 					// TODO: When we start accepting the address used in the request make this an optional field.
 					badFields[apiUrlPrefixField] = "This field is required."
@@ -1155,6 +1164,14 @@ func validateUpdateRequest(ctx context.Context, req *pbs.UpdateAuthMethodRequest
 					for _, sa := range attrs.GetSigningAlgorithms() {
 						if !oidc.SupportedAlgorithm(oidc.Alg(sa)) {
 							badFields[signingAlgorithmField] = fmt.Sprintf("Contains unsupported algorithm %q", sa)
+							break
+						}
+					}
+				}
+				if len(attrs.GetPrompts()) > 0 {
+					for _, p := range attrs.GetPrompts() {
+						if !oidc.SupportedPrompt(oidc.PromptParam(p)) {
+							badFields[promptsField] = fmt.Sprintf("Contains unsupported prompt %q", p)
 							break
 						}
 					}

--- a/internal/daemon/controller/handlers/authmethods/authmethod_service_test.go
+++ b/internal/daemon/controller/handlers/authmethods/authmethod_service_test.go
@@ -143,7 +143,8 @@ func TestGet(t *testing.T) {
 	databaseWrapper, err := kmsCache.GetWrapper(context.Background(), o.GetPublicId(), kms.KeyPurposeDatabase)
 	require.NoError(t, err)
 	oidcam := oidc.TestAuthMethod(t, conn, databaseWrapper, o.GetPublicId(), oidc.InactiveState, "alice_rp", "secret",
-		oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://alice.com")[0]), oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://api.com")[0]))
+		oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://alice.com")[0]), oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://api.com")[0]),
+		oidc.WithPrompts(oidc.SelectAccount))
 
 	wantOidc := &pb.AuthMethod{
 		Id:          oidcam.GetPublicId(),
@@ -159,6 +160,7 @@ func TestGet(t *testing.T) {
 				State:            string(oidc.InactiveState),
 				ApiUrlPrefix:     wrapperspb.String("https://api.com"),
 				CallbackUrl:      fmt.Sprintf(oidc.CallbackEndpoint, "https://api.com"),
+				Prompts:          []string{string(oidc.SelectAccount)},
 			},
 		},
 		Version: 1,
@@ -303,7 +305,8 @@ func TestList(t *testing.T) {
 	databaseWrapper, err := kmsCache.GetWrapper(context.Background(), oWithAuthMethods.GetPublicId(), kms.KeyPurposeDatabase)
 	require.NoError(t, err)
 	oidcam := oidc.TestAuthMethod(t, conn, databaseWrapper, oWithAuthMethods.GetPublicId(), oidc.ActivePublicState, "alice_rp", "secret",
-		oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://alice.com")[0]), oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://api.com")[0]), oidc.WithSigningAlgs(oidc.EdDSA))
+		oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://alice.com")[0]), oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://api.com")[0]), oidc.WithSigningAlgs(oidc.EdDSA),
+		oidc.WithPrompts(oidc.Consent))
 	iam.TestSetPrimaryAuthMethod(t, iamRepo, oWithAuthMethods, oidcam.GetPublicId())
 
 	wantSomeAuthMethods = append(wantSomeAuthMethods, &pb.AuthMethod{
@@ -325,6 +328,7 @@ func TestList(t *testing.T) {
 				SigningAlgorithms: []string{
 					string(oidc.EdDSA),
 				},
+				Prompts: []string{string(oidc.Consent)},
 			},
 		},
 		IsPrimary:                   true,
@@ -533,7 +537,8 @@ func TestDelete(t *testing.T) {
 	databaseWrapper, err := kmsCache.GetWrapper(context.Background(), o.GetPublicId(), kms.KeyPurposeDatabase)
 	require.NoError(t, err)
 	oidcam := oidc.TestAuthMethod(t, conn, databaseWrapper, o.GetPublicId(), oidc.InactiveState, "alice_rp", "my-dogs-name",
-		oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://alice.com")[0]), oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://api.com")[0]))
+		oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://alice.com")[0]), oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://api.com")[0]),
+		oidc.WithPrompts(oidc.SelectAccount))
 
 	ldapAm := ldap.TestAuthMethod(t, conn, databaseWrapper, o.GetPublicId(), []string{"ldaps://ldap1"})
 
@@ -1367,6 +1372,66 @@ func TestCreate(t *testing.T) {
 			}},
 			err:         handlers.ApiErrorWithCode(codes.InvalidArgument),
 			errContains: "invalid attributes.account_attribute_maps (unable to parse)",
+		},
+		{
+			name: "OIDC AuthMethod With Unsupported Prompt",
+			req: &pbs.CreateAuthMethodRequest{Item: &pb.AuthMethod{
+				ScopeId: o.GetPublicId(),
+				Type:    oidc.Subtype.String(),
+				Attrs: &pb.AuthMethod_OidcAuthMethodsAttributes{
+					OidcAuthMethodsAttributes: &pb.OidcAuthMethodAttributes{
+						ApiUrlPrefix: wrapperspb.String("https://api.com"),
+						Issuer:       wrapperspb.String("https://example2.discovery.url:4821"),
+						ClientId:     wrapperspb.String("someclientid"),
+						ClientSecret: wrapperspb.String("secret"),
+						Prompts:      []string{string(oidc.SelectAccount), "invalid"},
+					},
+				},
+			}},
+			err:         handlers.ApiErrorWithCode(codes.InvalidArgument),
+			errContains: "Contains unsupported prompt",
+		},
+		{
+			name: "Create OIDC AuthMethod With Supported Prompt",
+			req: &pbs.CreateAuthMethodRequest{Item: &pb.AuthMethod{
+				ScopeId: o.GetPublicId(),
+				Type:    oidc.Subtype.String(),
+				Attrs: &pb.AuthMethod_OidcAuthMethodsAttributes{
+					OidcAuthMethodsAttributes: &pb.OidcAuthMethodAttributes{
+						Issuer:       wrapperspb.String("https://example.discovery.url:4821/.well-known/openid-configuration/"),
+						ClientId:     wrapperspb.String("exampleclientid"),
+						ClientSecret: wrapperspb.String("secret"),
+						ApiUrlPrefix: wrapperspb.String("https://callback.prefix:9281/path"),
+						Prompts:      []string{string(oidc.SelectAccount)},
+					},
+				},
+			}},
+			idPrefix: globals.OidcAuthMethodPrefix + "_",
+			res: &pbs.CreateAuthMethodResponse{
+				Uri: fmt.Sprintf("auth-methods/%s_", globals.OidcAuthMethodPrefix),
+				Item: &pb.AuthMethod{
+					Id:          defaultAm.GetPublicId(),
+					ScopeId:     o.GetPublicId(),
+					CreatedTime: defaultAm.GetCreateTime().GetTimestamp(),
+					UpdatedTime: defaultAm.GetUpdateTime().GetTimestamp(),
+					Scope:       &scopepb.ScopeInfo{Id: o.GetPublicId(), Type: o.GetType(), ParentScopeId: scope.Global.String()},
+					Version:     1,
+					Type:        oidc.Subtype.String(),
+					Attrs: &pb.AuthMethod_OidcAuthMethodsAttributes{
+						OidcAuthMethodsAttributes: &pb.OidcAuthMethodAttributes{
+							Issuer:           wrapperspb.String("https://example.discovery.url:4821/"),
+							ClientId:         wrapperspb.String("exampleclientid"),
+							ClientSecretHmac: "<hmac>",
+							State:            string(oidc.InactiveState),
+							ApiUrlPrefix:     wrapperspb.String("https://callback.prefix:9281/path"),
+							CallbackUrl:      "https://callback.prefix:9281/path/v1/auth-methods/oidc:authenticate:callback",
+							Prompts:          []string{string(oidc.SelectAccount)},
+						},
+					},
+					AuthorizedActions:           oidcAuthorizedActions,
+					AuthorizedCollectionActions: authorizedCollectionActions,
+				},
+			},
 		},
 	}
 	for _, tc := range cases {

--- a/internal/daemon/controller/handlers/authmethods/oidc.go
+++ b/internal/daemon/controller/handlers/authmethods/oidc.go
@@ -46,7 +46,7 @@ const (
 	codeField                              = "attributes.code"
 	claimsScopesField                      = "attributes.claims_scopes"
 	accountClaimMapsField                  = "attributes.account_claim_maps"
-	PromptsField                           = "attributes.prompts"
+	promptsField                           = "attributes.prompts"
 )
 
 var oidcMaskManager handlers.MaskManager


### PR DESCRIPTION
Boundary OIDC method does not currently support passing in prompts during authentication. This change adds the capability of passing OIDC prompts. Prompts are optional OIDC parameters that determine the behaviour of the authentication server: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest

# Changes

- Add `prompt` option for OIDC auth method CLI create and update
- Pass configured prompt during OIDC authentication
- Add `prompt` API validation for create and update
- Add missed tests for prompt, immutable fields test, handler test

## API
1. Create OIDC auth method with `select_account` prompt
```
curl --location 'http://127.0.0.1:9200/v1/auth-methods' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer $TOKEN' \
--data '{
    "type": "oidc",
    "name": "OIDC Name",
    "description": "OIDC Description",
    "scope_id": "global",
    "attributes": {
        "issuer": "https://sts.windows.net/TENANT_ID/",
        "client_id": "$CLIENT_ID",
        "client_secret": "$CLIENT_SECRET",
        "api_url_prefix": "http://localhost:9200",
        "disable_discovered_config_validation": false,
        "dry_run": false,
        "signing_algorithms": ["RS256"],
        "prompts": ["select_account"]
    }
}'
```
2. Update OIDC auth method with multiple prompts
```
curl --location --request PATCH 'http://127.0.0.1:9200/v1/auth-methods/{id}' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer $TOKEN' \
--data '{
    "version": 1,
    "attributes": {
        "prompts": ["select_account", "consent"]
    }
}'
```
## CLI
1. Create OIDC auth method with `select_account` prompt
```
boundary auth-methods create oidc \                                         
  -issuer "https://sts.windows.net/TENANT_ID/" \
  -client-id "$CLIENT_ID" \
  -client-secret "$CLIENT_SECRET" \
  -signing-algorithm RS256 \
  -api-url-prefix "$API_URL_PREFIX" \
  -name "azure" \
  -prompts "select_account"
  
Auth Method information:
  Created Time:         Thu, 16 Nov 2023 16:35:09 EST
  ID:                   amoidc_CFZkkKFTct
  Name:                 azure
  Type:                 oidc
  Updated Time:         Thu, 16 Nov 2023 16:35:09 EST
  Version:              1

  Scope:
    ID:                 global
    Name:               global
    Type:               global

  Authorized Actions:
    no-op
    read
    update
    delete
    change-state
    authenticate

  Authorized Actions on Auth Method's Collections:
    accounts:
      create
      list
    managed-groups:
      create
      list

  Attributes:
    api_url_prefix:     http://localhost:9200
    callback_url:       http://localhost:9200/v1/auth-methods/oidc:authenticate:callback
    client_id:         <CLIENT_ID>
    client_secret_hmac: <HMAC>
    issuer:             https://sts.windows.net/TENANT_ID/
    prompts:            [select_account]
    signing_algorithms: [RS256]
    state:              inactive  
```

2. Update OIDC auth method with multiple prompts
```
boundary auth-methods update oidc -id amoidc_CFZkkKFTct -prompts 'select_account' -prompt 'consent'

Auth Method information:
  Created Time:           Thu, 16 Nov 2023 16:35:09 EST
  ID:                     amoidc_CFZkkKFTct
  Is Primary For Scope:   true
  Name:                   azure
  Type:                   oidc
  Updated Time:           Thu, 16 Nov 2023 16:37:52 EST
  Version:                3

  Scope:
    ID:                   global
    Name:                 global
    Type:                 global

  Authorized Actions:
    no-op
    read
    update
    delete
    change-state
    authenticate

  Authorized Actions on Auth Method's Collections:
    accounts:
      create
      list
    managed-groups:
      create
      list

  Attributes:
    api_url_prefix:       http://localhost:9200
    callback_url:         http://localhost:9200/v1/auth-methods/oidc:authenticate:callback
    client_id:            <CLIENT_ID>
    client_secret_hmac:   <HMAC>
    issuer:               https://sts.windows.net/TENANT_ID/
    prompts:              [consent select_account]
    signing_algorithms:   [RS256]
    state:                active-public
```