### PR TITLE
feat(ratelimit): Expose metrics on quota usage

### DIFF
--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -1,0 +1,16 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ratelimit
+
+import "github.com/hashicorp/go-rate"
+
+// NewLimiter creates a rate.Limiter.
+func NewLimiter(limits []*rate.Limit, maxEntries int) (*rate.Limiter, error) {
+	return rate.NewLimiter(
+		limits,
+		maxEntries,
+		rate.WithQuotaStorageUsageMetric(rateLimitQuotaUsage),
+		rate.WithQuotaStorageCapacityMetric(rateLimitQuotaStorageCapacity),
+	)
+}

--- a/internal/ratelimit/metrics.go
+++ b/internal/ratelimit/metrics.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ratelimit
+
+import (
+	"github.com/hashicorp/boundary/globals"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	subsystem = "controller_api_ratelimiter"
+)
+
+var (
+	rateLimitQuotaStorageCapacity prometheus.Gauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: globals.MetricNamespace,
+			Subsystem: subsystem,
+			Name:      "quota_storage_capacity",
+			Help:      "Guague of the number if quotas that can be stored by the rate limiter",
+		},
+	)
+	rateLimitQuotaUsage prometheus.Gauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: globals.MetricNamespace,
+			Subsystem: subsystem,
+			Name:      "quota_storage_usage",
+			Help:      "Guague of the number if quotas that are currently being stored by the rate limiter",
+		},
+	)
+)
+
+// InitializeMetrics initializes the metrics for visibility into the rate limiter.
+func InitializeMetrics(r prometheus.Registerer) {
+	if r == nil {
+		return
+	}
+	r.MustRegister(
+		rateLimitQuotaStorageCapacity,
+		rateLimitQuotaUsage,
+	)
+}


### PR DESCRIPTION
This provides two prometheus metrics to monitor the rate limiter:

boundary_controller_api_ratelimiter_quota_storage_capacity:

This is a gague that shows the total number of quotas that can be stored
at a given moment by the rate limiter.

boundary_controller_api_ratelimiter_quota_storage_usage:

This is a gague that shows the number of quotas currently being stored
by the limiter. If this becomes equal to the capacity, requests that
would result in a new quota being created will get limited and receive a
429 status code.