### PR TITLE
docs: Add OIDC prompt attribute

### DIFF
--- a/website/content/docs/commands/accounts/update.mdx
+++ b/website/content/docs/commands/accounts/update.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: accounts update - Command
 description: |-
-  The "accounts update" command lets Boundary admin update an account resource.
+  The "accounts update" command updates an existing account resource's LDAP, OIDC, or password authentication information.
 ---
 
 # accounts update
@@ -131,7 +131,7 @@ The `boundary accounts update oidc` command updates an OIDC account.
 
 #### Example
 
-The folloiwng example updates an OIDC account with the ID `acctoidc_1234567890` to add the name `devops` and the description `Oidc account for DevOps`:
+The following example updates an OIDC account with the ID `acctoidc_1234567890` to add the name `devops` and the description `Oidc account for DevOps`:
 
 ```shell-session
 $ boundary accounts update oidc -id acctoidc_1234567890 \

--- a/website/content/docs/commands/auth-methods/create.mdx
+++ b/website/content/docs/commands/auth-methods/create.mdx
@@ -239,7 +239,7 @@ The following are OIDC-specific options in addition to the command options:
 - `-max-age` `(string: "")` - Indicates the OIDC "max_age" parameter that is sent to the provider.
 
 - `prompts` `(string: "")` - Indicates whether the OIDC authorization server should display authentication or consent user interface prompts.
-You can use any of the following types of prompts to customize the behavior of the authentication process:
+You can optionally configure one or more of the following types of prompts to customize the behavior of the authentication process:
    - `none` - The authorization server does not display any authentication or consent prompts.
    - `login` - The authorization server prompts users for reauthentication before allowing them to log in.
    - `consent` - The authorization server prompts users for consent before returning any information to Boundary.

--- a/website/content/docs/commands/auth-methods/create.mdx
+++ b/website/content/docs/commands/auth-methods/create.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: auth-methods create - Command
 description: |-
-  The "auth-methods create" command lets Boundary admin create an auth method.
+  The "auth-methods create" command creates auth method resources in Boundary. You can create LDAP, OIDC, and password auth method types.
 ---
 
 # auth-methods create
@@ -237,6 +237,14 @@ The following are OIDC-specific options in addition to the command options:
 - `-issuer` `(string: "")` - Indicates the provider's issuer URL.
 
 - `-max-age` `(string: "")` - Indicates the OIDC "max_age" parameter that is sent to the provider.
+
+- `prompts` `(string: "")` - Indicates whether the OIDC authorization server should display authentication or consent user interface prompts.
+You can use any of the following types of prompts to customize the behavior of the authentication process:
+   - `none` - The authorization server does not display any authentication or consent prompts.
+   - `login` - The authorization server prompts users for reauthentication before allowing them to log in.
+   - `consent` - The authorization server prompts users for consent before returning any information to Boundary.
+   - `select_account` - The authorization server prompts users to select a user account.
+   The `select_account` option can be helpful if your users have multiple sets of login credentials.
 
 - `-signing-algorithm` `(string: "")` - Indicates the allowed signing algorithm. You may specify this multiple times for multiple values.
 

--- a/website/content/docs/commands/auth-methods/create.mdx
+++ b/website/content/docs/commands/auth-methods/create.mdx
@@ -246,6 +246,13 @@ You can optionally configure one or more of the following types of prompts to cu
    - `select_account` - The authorization server prompts users to select a user account.
    The `select_account` option can be helpful if your users have multiple sets of login credentials.
 
+<Note>
+
+Cloud providers implement `prompts` in different ways.
+You may notice differences in behavior if you configure OIDC authentication on multiple cloud providers.
+
+</Note>
+
 - `-signing-algorithm` `(string: "")` - Indicates the allowed signing algorithm. You may specify this multiple times for multiple values.
 
 

--- a/website/content/docs/commands/auth-methods/create.mdx
+++ b/website/content/docs/commands/auth-methods/create.mdx
@@ -238,13 +238,13 @@ The following are OIDC-specific options in addition to the command options:
 
 - `-max-age` `(string: "")` - Indicates the OIDC "max_age" parameter that is sent to the provider.
 
-- `prompts` `(string: "")` - Indicates whether the OIDC authorization server should display authentication or consent user interface prompts.
+- `prompts` `(string: "")` - Indicates whether the OIDC authorization server should display reauthentication, account selection, or consent user interface prompts.
 You can optionally configure one or more of the following types of prompts to customize the behavior of the authentication process:
    - `none` - The authorization server does not display any authentication or consent prompts.
    - `login` - The authorization server prompts users for reauthentication before allowing them to log in.
    - `consent` - The authorization server prompts users for consent before returning any information to Boundary.
    - `select_account` - The authorization server prompts users to select a user account.
-   The `select_account` option can be helpful if your users have multiple sets of login credentials.
+   The `select_account` option can be helpful if your users have multiple accounts.
 
 <Note>
 

--- a/website/content/docs/commands/auth-methods/update.mdx
+++ b/website/content/docs/commands/auth-methods/update.mdx
@@ -252,7 +252,7 @@ The following are options are specific to OIDC auth-methods in addition to the c
 - `-max-age` `(string: "")` - Indicates the OIDC "max_age" parameter sent to the provider.
 
 - `prompts` `(string: "")` - Indicates whether the OIDC authorization server should display authentication or consent user interface prompts.
-You can use any of the following types of prompts to customize the behavior of the authentication process:
+You can optionally configure one or more of the following types of prompts to customize the behavior of the authentication process:
    - `none` - The authorization server does not display any authentication or consent prompts.
    - `login` - The authorization server prompts users for reauthentication before allowing them to log in.
    - `consent` - The authorization server prompts users for consent before returning any information to Boundary.

--- a/website/content/docs/commands/auth-methods/update.mdx
+++ b/website/content/docs/commands/auth-methods/update.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: auth-methods update - Command
 description: |-
-  The "auth-methods update" command lets Boundary admin update an auth method.
+  The "auth-methods update" command updates existing auth method resources in Boundary. You can update LDAP, OIDC, and password auth method types.
 ---
 
 # auth-methods update
@@ -250,6 +250,14 @@ The following are options are specific to OIDC auth-methods in addition to the c
 - `-issuer` `(string: "")` - Indicates the provider's Issuer URL.
 
 - `-max-age` `(string: "")` - Indicates the OIDC "max_age" parameter sent to the provider.
+
+- `prompts` `(string: "")` - Indicates whether the OIDC authorization server should display authentication or consent user interface prompts.
+You can use any of the following types of prompts to customize the behavior of the authentication process:
+   - `none` - The authorization server does not display any authentication or consent prompts.
+   - `login` - The authorization server prompts users for reauthentication before allowing them to log in.
+   - `consent` - The authorization server prompts users for consent before returning any information to Boundary.
+   - `select_account` - The authorization server prompts users to select a user account.
+   The `select_account` option can be helpful if your users have multiple sets of login credentials.
 
 - `-signing-algorithm` `(string: "")` - Indicates the allowed signing algorithm. You may specify this value multiple times for multiple values.
 

--- a/website/content/docs/commands/auth-methods/update.mdx
+++ b/website/content/docs/commands/auth-methods/update.mdx
@@ -259,6 +259,13 @@ You can optionally configure one or more of the following types of prompts to cu
    - `select_account` - The authorization server prompts users to select a user account.
    The `select_account` option can be helpful if your users have multiple sets of login credentials.
 
+<Note>
+
+Cloud providers implement `prompts` in different ways.
+You may notice differences in behavior if you configure OIDC authentication on multiple cloud providers.
+
+</Note>
+
 - `-signing-algorithm` `(string: "")` - Indicates the allowed signing algorithm. You may specify this value multiple times for multiple values.
 
 

--- a/website/content/docs/commands/auth-methods/update.mdx
+++ b/website/content/docs/commands/auth-methods/update.mdx
@@ -251,13 +251,13 @@ The following are options are specific to OIDC auth-methods in addition to the c
 
 - `-max-age` `(string: "")` - Indicates the OIDC "max_age" parameter sent to the provider.
 
-- `prompts` `(string: "")` - Indicates whether the OIDC authorization server should display authentication or consent user interface prompts.
+- `prompts` `(string: "")` - Indicates whether the OIDC authorization server should display reauthentication, account selection, or consent user interface prompts.
 You can optionally configure one or more of the following types of prompts to customize the behavior of the authentication process:
    - `none` - The authorization server does not display any authentication or consent prompts.
    - `login` - The authorization server prompts users for reauthentication before allowing them to log in.
    - `consent` - The authorization server prompts users for consent before returning any information to Boundary.
    - `select_account` - The authorization server prompts users to select a user account.
-   The `select_account` option can be helpful if your users have multiple sets of login credentials.
+   The `select_account` option can be helpful if your users have multiple accounts.
 
 <Note>
 

--- a/website/content/docs/concepts/domain-model/auth-methods.mdx
+++ b/website/content/docs/concepts/domain-model/auth-methods.mdx
@@ -80,13 +80,13 @@ The OIDC auth method has the following additional attributes:
   users to reauthenticate, and an unset `maxAge` results in a Terraform value of
   -1 and the default TTL of the chosen OIDC is used.
 
-- `prompt` (optional) If you configure this attribute, the OIDC authorization server prompts users for reauthentication or consent when they log in.
+- `prompt` (optional) If you configure this attribute, the OIDC authorization server prompts users for reauthentication, account selection, or consent when they log in.
 You can optionally configure one or more of the following additional attributes to customize the behavior of the authentication process:
    - `none` (optional) The authorization server does not display any authentication or consent prompts.
    - `login` (optional) The authorization server prompts users for reauthentication before allowing them to log in.
    - `consent` (optional) The authorization server prompts users for consent before returning any information to Boundary.
    - `select_account` (optional) The authorization server prompts users to select a user account.
-   The `select_account` setting can be helpful if your users have multiple sets of login credentials.
+   The `select_account` setting can be helpful if your users have multiple accounts.
 
 <Note>
 

--- a/website/content/docs/concepts/domain-model/auth-methods.mdx
+++ b/website/content/docs/concepts/domain-model/auth-methods.mdx
@@ -88,6 +88,13 @@ You can optionally configure one or more of the following additional attributes 
    - `select_account` (optional) The authorization server prompts users to select a user account.
    The `select_account` setting can be helpful if your users have multiple sets of login credentials.
 
+<Note>
+
+Cloud providers implement `prompt` in different ways.
+You may notice differences in behavior if you configure OIDC authentication on multiple cloud providers.
+
+</Note>
+
 - `signing-algorithm` (required) The allowed signing algorithm. You can specify this attribute
   multiple times for multiple values.
 

--- a/website/content/docs/concepts/domain-model/auth-methods.mdx
+++ b/website/content/docs/concepts/domain-model/auth-methods.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Domain model - auth methods
 description: |-
-  The anatomy of a Boundary auth method
+  Use auth methods to authenticate users to Boundary. Learn which attributes you can configure for password, OIDC, and LDAP auth methods in Boundary.
 ---
 
 # Auth methods
@@ -79,6 +79,14 @@ The OIDC auth method has the following additional attributes:
   user is challenged again. A value of `0` sets an immediate requirement for all
   users to reauthenticate, and an unset `maxAge` results in a Terraform value of
   -1 and the default TTL of the chosen OIDC is used.
+
+- `prompt` (optional) If you configure this attribute, the OIDC authorization server prompts users for reauthentication or consent when they log in.
+You can configure the following additional attributes to customize the behavior of the authentication process:
+   - `none` (optional) The authorization server does not display any authentication or consent prompts.
+   - `login` (optional) The authorization server prompts users for reauthentication before allowing them to log in.
+   - `consent` (optional) The authorization server prompts users for consent before returning any information to Boundary.
+   - `select_account` (optional) The authorization server prompts users to select a user account.
+   The `select_account` setting can be helpful if your users have multiple sets of login credentials.
 
 - `signing-algorithm` (required) The allowed signing algorithm. You can specify this attribute
   multiple times for multiple values.

--- a/website/content/docs/concepts/domain-model/auth-methods.mdx
+++ b/website/content/docs/concepts/domain-model/auth-methods.mdx
@@ -81,7 +81,7 @@ The OIDC auth method has the following additional attributes:
   -1 and the default TTL of the chosen OIDC is used.
 
 - `prompt` (optional) If you configure this attribute, the OIDC authorization server prompts users for reauthentication or consent when they log in.
-You can configure the following additional attributes to customize the behavior of the authentication process:
+You can optionally configure one or more of the following additional attributes to customize the behavior of the authentication process:
    - `none` (optional) The authorization server does not display any authentication or consent prompts.
    - `login` (optional) The authorization server prompts users for reauthentication before allowing them to log in.
    - `consent` (optional) The authorization server prompts users for consent before returning any information to Boundary.


### PR DESCRIPTION
Per ICU-11466, we are adding the OIDC `prompts` attribute to support authentication prompts including account picker functionality. This PR updates the domain model and CLI documentation with the new options (https://hashicorp.atlassian.net/browse/ICU-11903).

View the updates in the preview deployment:

- [OIDC domain model auth method attributes](https://boundary-h766xzy27-hashicorp.vercel.app/boundary/docs/concepts/domain-model/auth-methods#oidc-auth-method-attributes)
- CLI
   - [auth method create](https://boundary-h766xzy27-hashicorp.vercel.app/boundary/docs/commands/auth-methods/create#usages-by-type) on the OIDC tab
   - [auth method update](https://boundary-h766xzy27-hashicorp.vercel.app/boundary/docs/commands/auth-methods/update#usages-by-type) on the OIDC tab