### PR TITLE
Add target type and session user_id as searchable

### DIFF
--- a/internal/clientcache/internal/cache/repository_sessions_test.go
+++ b/internal/clientcache/internal/cache/repository_sessions_test.go
@@ -85,15 +85,15 @@ func TestRepository_refreshSessions(t *testing.T) {
 		si, err := json.Marshal(sess)
 		require.NoError(t, err)
 		want = append(want, &Session{
-			OwnerUserId: u.Id,
-			Id:          sess.Id,
-			Type:        sess.Type,
-			Status:      sess.Status,
-			Endpoint:    sess.Endpoint,
-			ScopeId:     sess.ScopeId,
-			TargetId:    sess.TargetId,
-			UserId:      sess.UserId,
-			Item:        string(si),
+			FkUserId: u.Id,
+			Id:       sess.Id,
+			Type:     sess.Type,
+			Status:   sess.Status,
+			Endpoint: sess.Endpoint,
+			ScopeId:  sess.ScopeId,
+			TargetId: sess.TargetId,
+			UserId:   sess.UserId,
+			Item:     string(si),
 		})
 	}
 	cases := []struct {
@@ -123,10 +123,10 @@ func TestRepository_refreshSessions(t *testing.T) {
 				Status: "a different status",
 			}),
 			want: append(want[1:], &Session{
-				OwnerUserId: want[0].OwnerUserId,
-				Id:          want[0].Id,
-				Status:      "a different status",
-				Item:        `{"id":"ttcp_1","created_time":"0001-01-01T00:00:00Z","updated_time":"0001-01-01T00:00:00Z","expiration_time":"0001-01-01T00:00:00Z","status":"a different status"}`,
+				FkUserId: want[0].FkUserId,
+				Id:       want[0].Id,
+				Status:   "a different status",
+				Item:     `{"id":"ttcp_1","created_time":"0001-01-01T00:00:00Z","updated_time":"0001-01-01T00:00:00Z","expiration_time":"0001-01-01T00:00:00Z","status":"a different status"}`,
 			}),
 		},
 		{

--- a/internal/clientcache/internal/cache/repository_targets_test.go
+++ b/internal/clientcache/internal/cache/repository_targets_test.go
@@ -75,7 +75,7 @@ func TestRepository_refreshTargets(t *testing.T) {
 		ti, err := json.Marshal(tar)
 		require.NoError(t, err)
 		want = append(want, &Target{
-			OwnerUserId: u.Id,
+			FkUserId:    u.Id,
 			Id:          tar.Id,
 			Name:        tar.Name,
 			Description: tar.Description,
@@ -115,10 +115,10 @@ func TestRepository_refreshTargets(t *testing.T) {
 			}),
 			want: append(want[1:],
 				&Target{
-					OwnerUserId: want[0].OwnerUserId,
-					Id:          want[0].Id,
-					Name:        "a different name",
-					Item:        `{"id":"ttcp_1","name":"a different name","created_time":"0001-01-01T00:00:00Z","updated_time":"0001-01-01T00:00:00Z"}`,
+					FkUserId: want[0].FkUserId,
+					Id:       want[0].Id,
+					Name:     "a different name",
+					Item:     `{"id":"ttcp_1","name":"a different name","created_time":"0001-01-01T00:00:00Z","updated_time":"0001-01-01T00:00:00Z"}`,
 				}),
 		},
 		{

--- a/internal/clientcache/internal/cache/search_test.go
+++ b/internal/clientcache/internal/cache/search_test.go
@@ -119,14 +119,14 @@ func TestSearch(t *testing.T) {
 		require.NoError(t, rw.Create(ctx, at))
 
 		targets := []any{
-			&Target{OwnerUserId: u.Id, Id: "t_1", Name: "one", Type: "tcp", Item: `{"id": "t_1", "name": "one", "type": "tcp"}`},
-			&Target{OwnerUserId: u.Id, Id: "t_2", Name: "two", Type: "tcp", Item: `{"id": "t_2", "name": "two", "type": "tcp"}`},
+			&Target{FkUserId: u.Id, Id: "t_1", Name: "one", Type: "tcp", Item: `{"id": "t_1", "name": "one", "type": "tcp"}`},
+			&Target{FkUserId: u.Id, Id: "t_2", Name: "two", Type: "tcp", Item: `{"id": "t_2", "name": "two", "type": "tcp"}`},
 		}
 		require.NoError(t, rw.CreateItems(ctx, targets))
 
 		sessions := []any{
-			&Session{OwnerUserId: u.Id, Id: "s_1", Endpoint: "one", Type: "tcp", UserId: "u123", Item: `{"id": "s_1", "endpoint": "one", "type": "tcp", "user_id": "u123"}`},
-			&Session{OwnerUserId: u.Id, Id: "s_2", Endpoint: "two", Type: "ssh", UserId: "u321", Item: `{"id": "s_2", "endpoint": "two", "type": "ssh", "user_id": "u321"}`},
+			&Session{FkUserId: u.Id, Id: "s_1", Endpoint: "one", Type: "tcp", UserId: "u123", Item: `{"id": "s_1", "endpoint": "one", "type": "tcp", "user_id": "u123"}`},
+			&Session{FkUserId: u.Id, Id: "s_2", Endpoint: "two", Type: "ssh", UserId: "u321", Item: `{"id": "s_2", "endpoint": "two", "type": "ssh", "user_id": "u321"}`},
 		}
 		require.NoError(t, rw.CreateItems(ctx, sessions))
 	}
@@ -192,10 +192,10 @@ func TestSearch(t *testing.T) {
 		got, err := ss.Search(ctx, SearchParams{
 			Resource:    "targets",
 			AuthTokenId: at.Id,
-			Query:       `owner_user_id % "u"`,
+			Query:       `fk_user_id % "u"`,
 		})
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, `invalid column "owner_user_id"`)
+		assert.ErrorContains(t, err, `invalid column "fk_user_id"`)
 		assert.Nil(t, got)
 	})
 
@@ -251,10 +251,10 @@ func TestSearch(t *testing.T) {
 		got, err := ss.Search(ctx, SearchParams{
 			Resource:    "sessions",
 			AuthTokenId: at.Id,
-			Query:       `owner_user_id % "u"`,
+			Query:       `fk_user_id % "u"`,
 		})
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, `invalid column "owner_user_id"`)
+		assert.ErrorContains(t, err, `invalid column "fk_user_id"`)
 		assert.Nil(t, got)
 	})
 

--- a/internal/clientcache/internal/cache/status.go
+++ b/internal/clientcache/internal/cache/status.go
@@ -149,7 +149,7 @@ func (s *StatusService) resourceStatus(ctx context.Context, u *user, rt resource
 	ret.LastError = errStatus
 
 	err = func() error {
-		query := fmt.Sprintf("select count(*) from %s where owner_user_id = @user_id", rt)
+		query := fmt.Sprintf("select count(*) from %s where fk_user_id = @user_id", rt)
 		r, err := s.repo.rw.Query(ctx, query, []any{sql.Named("user_id", u.Id)})
 		if err != nil {
 			return errors.Wrap(ctx, err, op)

--- a/internal/clientcache/internal/cache/store_test.go
+++ b/internal/clientcache/internal/cache/store_test.go
@@ -452,7 +452,7 @@ func TestTarget(t *testing.T) {
 
 	t.Run("target actions", func(t *testing.T) {
 		target := &Target{
-			OwnerUserId: u.Id,
+			FkUserId:    u.Id,
 			Id:          "tssh_1234567890",
 			Name:        "target",
 			Description: "target desc",
@@ -473,15 +473,15 @@ func TestTarget(t *testing.T) {
 
 		// TODO: Once the sqlite driver properly builds the delete query call
 		// n, err = rw.Delete(ctx, target) instead of the Exec call
-		n, err = rw.Exec(ctx, "delete from target where (owner_user_id, id) IN (values (?, ?))",
-			[]any{target.OwnerUserId, target.Id})
+		n, err = rw.Exec(ctx, "delete from target where (fk_user_id, id) IN (values (?, ?))",
+			[]any{target.FkUserId, target.Id})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, n)
 	})
 
 	t.Run("lookup a target", func(t *testing.T) {
 		target := &Target{
-			OwnerUserId: u.Id,
+			FkUserId:    u.Id,
 			Id:          "tssh_1234567890",
 			Name:        "target",
 			Description: "target desc",
@@ -493,8 +493,8 @@ func TestTarget(t *testing.T) {
 		require.NoError(t, rw.Create(ctx, target))
 
 		lookTar := &Target{
-			OwnerUserId: target.OwnerUserId,
-			Id:          target.Id,
+			FkUserId: target.FkUserId,
+			Id:       target.Id,
 		}
 		assert.NoError(t, rw.LookupById(ctx, lookTar))
 		assert.NotNil(t, lookTar)
@@ -506,7 +506,7 @@ func TestTarget(t *testing.T) {
 
 	t.Run("deleting the user deletes the target", func(t *testing.T) {
 		target := &Target{
-			OwnerUserId: u.Id,
+			FkUserId:    u.Id,
 			Id:          "tssh_1234567890",
 			Name:        "target",
 			Description: "target desc",
@@ -525,8 +525,8 @@ func TestTarget(t *testing.T) {
 		require.Equal(t, 1, n)
 
 		lookTar := &Target{
-			OwnerUserId: target.OwnerUserId,
-			Id:          target.Id,
+			FkUserId: target.FkUserId,
+			Id:       target.Id,
 		}
 		assert.ErrorContains(t, rw.LookupById(ctx, lookTar), "not found")
 	})
@@ -556,13 +556,13 @@ func TestSession(t *testing.T) {
 	})
 	t.Run("session actions", func(t *testing.T) {
 		session := &Session{
-			OwnerUserId: u.Id,
-			Id:          "s_1234567890",
-			Endpoint:    "endpoint",
-			ScopeId:     "p_123",
-			TargetId:    "ttcp_123",
-			UserId:      "u_123",
-			Item:        "{id:'s_1234567890'}",
+			FkUserId: u.Id,
+			Id:       "s_1234567890",
+			Endpoint: "endpoint",
+			ScopeId:  "p_123",
+			TargetId: "ttcp_123",
+			UserId:   "u_123",
+			Item:     "{id:'s_1234567890'}",
 		}
 
 		require.NoError(t, rw.Create(ctx, session))
@@ -576,27 +576,27 @@ func TestSession(t *testing.T) {
 
 		// TODO: Once the sqlite driver properly builds the delete query call
 		// n, err = rw.Delete(ctx, session) instead of the Exec call
-		n, err = rw.Exec(ctx, "delete from session where (owner_user_id, id) IN (values (?, ?))",
-			[]any{session.OwnerUserId, session.Id})
+		n, err = rw.Exec(ctx, "delete from session where (fk_user_id, id) IN (values (?, ?))",
+			[]any{session.FkUserId, session.Id})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, n)
 	})
 
 	t.Run("lookup a session", func(t *testing.T) {
 		session := &Session{
-			OwnerUserId: u.Id,
-			Id:          "s_1234567890",
-			Endpoint:    "endpoint",
-			ScopeId:     "p_123",
-			TargetId:    "ttcp_123",
-			UserId:      "u_123",
-			Item:        "{id:'s_1234567890'}",
+			FkUserId: u.Id,
+			Id:       "s_1234567890",
+			Endpoint: "endpoint",
+			ScopeId:  "p_123",
+			TargetId: "ttcp_123",
+			UserId:   "u_123",
+			Item:     "{id:'s_1234567890'}",
 		}
 		require.NoError(t, rw.Create(ctx, session))
 
 		lookSess := &Session{
-			OwnerUserId: u.Id,
-			Id:          session.Id,
+			FkUserId: u.Id,
+			Id:       session.Id,
 		}
 		assert.NoError(t, rw.LookupById(ctx, lookSess))
 		assert.NotNil(t, lookSess)
@@ -608,13 +608,13 @@ func TestSession(t *testing.T) {
 
 	t.Run("deleting the user deletes the session", func(t *testing.T) {
 		session := &Session{
-			OwnerUserId: u.Id,
-			Id:          "s_1234567890",
-			Endpoint:    "endpoint",
-			ScopeId:     "p_123",
-			TargetId:    "ttcp_123",
-			UserId:      "u_123",
-			Item:        "{id:'s_1234567890'}",
+			FkUserId: u.Id,
+			Id:       "s_1234567890",
+			Endpoint: "endpoint",
+			ScopeId:  "p_123",
+			TargetId: "ttcp_123",
+			UserId:   "u_123",
+			Item:     "{id:'s_1234567890'}",
 		}
 		require.NoError(t, rw.Create(ctx, session))
 		// Deleting the user deletes the session
@@ -626,8 +626,8 @@ func TestSession(t *testing.T) {
 		require.Equal(t, 1, n)
 
 		lookSess := &Session{
-			OwnerUserId: session.OwnerUserId,
-			Id:          session.Id,
+			FkUserId: session.FkUserId,
+			Id:       session.Id,
 		}
 		assert.ErrorContains(t, rw.LookupById(ctx, lookSess), "not found")
 	})

--- a/internal/clientcache/internal/daemon/token_handler.go
+++ b/internal/clientcache/internal/daemon/token_handler.go
@@ -114,7 +114,7 @@ func newTokenHandlerFunc(ctx context.Context, repo *cache.Repository, refresher 
 				AuthTokenId: perReq.AuthTokenId,
 			}
 			if err = repo.AddKeyringToken(ctx, perReq.BoundaryAddr, kt); err != nil {
-				writeError(w, "Failed to add a keyring stored token", http.StatusInternalServerError)
+				writeError(w, fmt.Sprintf("Failed to add a keyring stored token: %v", err), http.StatusInternalServerError)
 				return
 			}
 		case perReq.AuthToken != "":

--- a/internal/clientcache/internal/db/schema.sql
+++ b/internal/clientcache/internal/db/schema.sql
@@ -109,7 +109,7 @@ create table if not exists keyring_token (
 -- specific fields extracted to facilitate searching over those fields
 create table if not exists target (
   -- the boundary user id of the user who has was able to read/list this target
-  owner_user_id text not null
+  fk_user_id text not null
     references user(id)
     on delete cascade,
   -- the boundary id of the target
@@ -125,14 +125,14 @@ create table if not exists target (
   -- item is the json representation of this resource from the perspective of
   -- the the requesting user.
   item text,
-  primary key (owner_user_id, id)
+  primary key (fk_user_id, id)
 );
 
 -- session contains cached boundary session resource for a specific user and
 -- with specific fields extracted to facilitate searching over those fields
 create table if not exists session (
   -- the boundary user id of the user who has was able to read/list this resource
-  owner_user_id text not null
+  fk_user_id text not null
     references user(id)
     on delete cascade,
   -- the resource id from boundary of this session
@@ -146,13 +146,13 @@ create table if not exists session (
   scope_id text,
   target_id text,
   -- The user_id is the the id of the user that created this session. This can
-  -- be different from the owner_user_id which is the id of the boundary user
+  -- be different from the fk_user_id which is the id of the boundary user
   -- which synced this record into the cache.
   user_id text,
   -- item is the json representation of this resource from the perspective of
-  -- of the user whose id is set in owner_user_id
+  -- of the user whose id is set in fk_user_id
   item text,
-  primary key (owner_user_id, id)
+  primary key (fk_user_id, id)
 );
 
 -- contains errors from the last attempt to sync data from boundary for a


### PR DESCRIPTION
Since user_id in the session table conflicted with the existing column name rerferencing the owner of the synced data, I renamed that column to `owner_user_id`.  LMK what you thnk about that name.

Also note that a bug was uncovered in this PR which when creating with an OnConflict.   Using db.UpdateAll did not update any columns that the new resource being inserted didn't have a non-zero value for.  This would have resulted in addresses remaining in the cache if a target was updated to use host sets instead of addresses for example, or a description being removed in the controller but not getting removed from the cache.