### PR TITLE
docs: Backport fix for broken link

### DIFF
--- a/website/content/docs/install-boundary/index.mdx
+++ b/website/content/docs/install-boundary/index.mdx
@@ -11,4 +11,4 @@ This section details installing Boundary in a self-managed environment.
 You can use the topics in this section to install the Community Edition or the Enterprise version of Boundary.
 The section also includes reference architecture, system requirement recommendations, and best practices.
 
-To deploy HCP Boundary instead, refer to the [HCP Boundary Get Started section](/hcp/docs/get-started/deploy-and-login).
+To deploy HCP Boundary instead, refer to the [HCP Boundary Get Started section](/boundary/docs/hcp/get-started/deploy-and-login).


### PR DESCRIPTION
This pull request backports the fix from #4081 to the `stable-website` branch.