### PR TITLE
docs: Update session recording reqs for HCP

### DIFF
--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -123,21 +123,13 @@ At this time, the only supported storage is AWS S3.
 
 ### Boundary workers requirements
 
-[Session recording](/boundary/docs/configuration/session-recording) requires at least one PKI worker that:
+[Session recording](/boundary/docs/configuration/session-recording) requires at least one worker that:
 - Has access to the AWS S3 storage bucket
-- Has an accessible directory defined by `recording_storage_path` for storing session recordings while they are in progress. On session closure, Boundary moves the local session recording to remote storage and deletes the local copy. For more details, refer to the [PKI worker configuration](/boundary/docs/configuration/worker/pki-worker#session-recording) documentation.
+- Has an accessible directory defined by `recording_storage_path` for storing session recordings while they are in progress. On session closure, Boundary moves the local session recording to remote storage and deletes the local copy.
+   - For HCP Boundary, refer to the [Self-managed worker configuration](/hcp/docs/boundary/self-managed-workers) documentation.
+   - For Boundary Enterprise, refer to the refer to the [PKI worker configuration](/boundary/docs/configuration/worker/pki-worker#session-recording) documentation.
 - Has at least 1 MB of available disk space.
 - Runs Darwin, Windows, or Linux. The following binaries are not supported for session recording: NetBSD, OpenBSD, Solaris.
-
-Development example:
-
-```hcl
-worker {
-auth_storage_path="/boundary/demo-worker-1"
-initial_upstreams = ["10.0.0.1"]
-recording_storage_path="/local/storage/directory"
-}
-```
 
 Complete the following steps to create a storage bucket in Boundary for session recording:
 

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -123,13 +123,18 @@ At this time, the only supported storage is AWS S3.
 
 ### Boundary workers requirements
 
-[Session recording](/boundary/docs/configuration/session-recording) requires at least one worker that:
-- Has access to the AWS S3 storage bucket
-- Has an accessible directory defined by `recording_storage_path` for storing session recordings while they are in progress. On session closure, Boundary moves the local session recording to remote storage and deletes the local copy.
+[Session recording](/boundary/docs/configuration/session-recording) requires that you configure at least one worker for local storage.
+
+~> Note that you cannot use an HCP managed worker for the local storage. HCP Boundary users must configure a self-managed worker to enable session recording.
+
+The worker that you configure for storage must:
+
+- Have access to the AWS S3 storage bucket
+- Have an accessible directory defined by `recording_storage_path` for storing session recordings while they are in progress. On session closure, Boundary moves the local session recording to remote storage and deletes the local copy.
    - For HCP Boundary, refer to the [Self-managed worker configuration](/hcp/docs/boundary/self-managed-workers/session-recording) documentation.
    - For Boundary Enterprise, refer to the refer to the [PKI worker configuration](/boundary/docs/configuration/worker/pki-worker#session-recording) documentation.
-- Has at least 1 MB of available disk space.
-- Runs Darwin, Windows, or Linux. The following binaries are not supported for session recording: NetBSD, OpenBSD, Solaris.
+- Have at least 1 MB of available disk space.
+- Run Darwin, Windows, or Linux. The following binaries are not supported for session recording: NetBSD, OpenBSD, Solaris.
 
 Complete the following steps to create a storage bucket in Boundary for session recording:
 

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -125,7 +125,9 @@ At this time, the only supported storage is AWS S3.
 
 [Session recording](/boundary/docs/configuration/session-recording) requires that you configure at least one worker for local storage.
 
-~> Note that you cannot use an HCP managed worker for the local storage. HCP Boundary users must configure a self-managed worker to enable session recording.
+<Note>
+You cannot use an HCP managed worker for the local storage. HCP Boundary users must configure a self-managed worker to enable session recording.
+</Note>
 
 The worker that you configure for storage must:
 

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -126,7 +126,7 @@ At this time, the only supported storage is AWS S3.
 [Session recording](/boundary/docs/configuration/session-recording) requires at least one worker that:
 - Has access to the AWS S3 storage bucket
 - Has an accessible directory defined by `recording_storage_path` for storing session recordings while they are in progress. On session closure, Boundary moves the local session recording to remote storage and deletes the local copy.
-   - For HCP Boundary, refer to the [Self-managed worker configuration](/hcp/docs/boundary/self-managed-workers) documentation.
+   - For HCP Boundary, refer to the [Self-managed worker configuration](/hcp/docs/boundary/self-managed-workers/session-recording) documentation.
    - For Boundary Enterprise, refer to the refer to the [PKI worker configuration](/boundary/docs/configuration/worker/pki-worker#session-recording) documentation.
 - Has at least 1 MB of available disk space.
 - Runs Darwin, Windows, or Linux. The following binaries are not supported for session recording: NetBSD, OpenBSD, Solaris.

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -123,7 +123,7 @@ At this time, the only supported storage is AWS S3.
 
 ### Boundary workers requirements
 
-[Session recording](/boundary/docs/configuration/session-recording) requires that you configure at least one worker for local storage.
+[Session recording](/boundary/docs/configuration/session-recording) requires that you [configure at least one worker for local storage](/boundary/docs/configuration/session-recording/create-storage-bucket#boundary-workers-requirements).
 
 <Note>
 You cannot use an HCP managed worker for the local storage. HCP Boundary users must configure a self-managed worker to enable session recording.


### PR DESCRIPTION
The worker requirements in the **Create a storage bucket** topic do not mention the need for a self-managed worker in HCP environments. I added a new topic to the HCP docs that discusses the self-managed worker configuration in PR [#798](https://github.com/hashicorp/hcp-docs/pull/798). This pull request clarifies the difference between Enterprise and HCP configurations and links out to the new HCP topic.

[View the update in the preview deployment](https://boundary-7i46v0l7b-hashicorp.vercel.app/boundary/docs/configuration/session-recording/create-storage-bucket#boundary-workers-requirements).

** Note that the link in the preview environment will not work until PR [#798](https://github.com/hashicorp/hcp-docs/pull/798) is merged.