### PR TITLE
Revert "chore(deps): bump actions/setup-python from 4.7.1 to 4.8.0 (#…

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -31,7 +31,7 @@ jobs:
         cache: false
 
     - name: Set up Python
-      uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
+      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
       with:
         python-version: 3.x
 


### PR DESCRIPTION
…4098)"

This reverts commit 17e9edc07f7c268b1cf3567b7a0e5e1c6a3cf5eb.

Reverting since this action should/will be handled by TSCCR.