### PR TITLE
fix(db): make bucket_prefix column immutable for storage buckets

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/80/01_storage_bucket.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/80/01_storage_bucket.up.sql
@@ -1,0 +1,11 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+
+drop trigger immutable_columns on storage_plugin_storage_bucket;
+
+create trigger immutable_columns before update on storage_plugin_storage_bucket
+  for each row execute procedure immutable_columns('public_id', 'scope_id', 'create_time', 'bucket_name', 'bucket_prefix');
+
+commit;


### PR DESCRIPTION
# Summary

The storage domain does not allow the storage bucket prefix value to be mutated during an update action because it is not supported in the mask. However the column is mutable when directly interacting with the database table. This PR updates the `immutable_columns` trigger on the `storage_plugin_storage_bucket` table to include `bucket_prefix`.