### PR TITLE
feat(github): Disable schema-diff for PRs in draft state

### DIFF
--- a/.github/workflows/schema-diff.yml
+++ b/.github/workflows/schema-diff.yml
@@ -2,6 +2,17 @@ name: schema-diff
 
 on:
   pull_request:
+    types:
+      # By default, a workflow only runs when a pull_request event's activity
+      # type is `opened`, `synchronize`, or `reopened`.
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+      # Since we care about the PR state, we also need to run when there is a PR
+      # state change: From "Draft" to "Ready for Review" and vice-versa.
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
+      - 'converted_to_draft'
+      - 'ready_for_review'
     paths:
       - 'internal/db/schema/migrations/**/*.sql'
       - 'scripts/schema-diff.sh'
@@ -16,6 +27,7 @@ permissions:
 jobs:
   schema-diff:
     name: "Schema Diff"
+    if: '! github.event.pull_request.draft'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
This commit disables `schema-diff` on PRs in the draft state. This is another layer of control to prevent `schema-diff` GitHub comments from polluting PRs that might not necessarily need `schema-diff` run against them