### PR TITLE
EOY license updates

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -2,7 +2,7 @@ schema_version = 1
 
 project {
   license        = "BUSL-1.1"
-  copyright_year = 2020
+  copyright_year = 2024
 
   header_ignore = [
     ".github/**",

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             HashiCorp, Inc.
-Licensed Work:        Boundary Version 0.14.0 or later. The Licensed Work is (c) 2023
+Licensed Work:        Boundary Version 0.14.0 or later. The Licensed Work is (c) 2024
                       HashiCorp, Inc.
 Additional Use Grant: You may make production use of the Licensed Work, provided
                       Your use does not include offering the Licensed Work to third

--- a/internal/proto/controller/api/.copywrite.hcl
+++ b/internal/proto/controller/api/.copywrite.hcl
@@ -2,7 +2,7 @@ schema_version = 1
 
 project {
   license        = "MPL-2.0"
-  copyright_year = 2020
+  copyright_year = 2024
 
   header_ignore = []
 }

--- a/internal/proto/controller/custom_options/.copywrite.hcl
+++ b/internal/proto/controller/custom_options/.copywrite.hcl
@@ -2,7 +2,7 @@ schema_version = 1
 
 project {
   license        = "MPL-2.0"
-  copyright_year = 2020
+  copyright_year = 2024
 
   header_ignore = []
 }

--- a/internal/proto/plugin/.copywrite.hcl
+++ b/internal/proto/plugin/.copywrite.hcl
@@ -2,7 +2,7 @@ schema_version = 1
 
 project {
   license        = "MPL-2.0"
-  copyright_year = 2020
+  copyright_year = 2024
 
   header_ignore = []
 }

--- a/internal/proto/worker/proxy/v1/.copywrite.hcl
+++ b/internal/proto/worker/proxy/v1/.copywrite.hcl
@@ -2,7 +2,7 @@ schema_version = 1
 
 project {
   license        = "MPL-2.0"
-  copyright_year = 2020
+  copyright_year = 2024
 
   header_ignore = []
 }


### PR DESCRIPTION
DO NOT MERGE UNTIL EOY 2023

Updates text in license and copywrite bot files for 2024.

Do not backport; release branches will be addressed individually.
