### PR TITLE
[DO NOT MERGE UNTIL EOY] EOY license updates v.0.13.x

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,8 +1,8 @@
 schema_version = 1
 
 project {
-  license        = "MPL-2.0"
-  copyright_year = 2020
+  license        = "BUSL-1.1"
+  copyright_year = 2024
 
   header_ignore = [
     ".github/**",
@@ -14,5 +14,14 @@ project {
     "website/prettier.config.js",
     "**/*_ent.*",
     "**/*_ent_test.*",
+
+    # licensed under MPL - ignoring for now until the copywrite tool can support
+    # multiple licenses per repo.
+    "api/**",
+    "sdk/**",
+    "internal/proto/plugin/**",
+    "internal/proto/controller/custom_options/**", 
+    "internal/proto/controller/api/**",
+    "internal/proto/worker/proxy/v1/**",
   ]
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,365 +1,92 @@
-Copyright (c) 2020 HashiCorp, Inc.
-
-Mozilla Public License, version 2.0
-
-1. Definitions
-
-1.1. "Contributor"
-
-     means each individual or legal entity that creates, contributes to the
-     creation of, or owns Covered Software.
-
-1.2. "Contributor Version"
-
-     means the combination of the Contributions of others (if any) used by a
-     Contributor and that particular Contributor's Contribution.
-
-1.3. "Contribution"
-
-     means Covered Software of a particular Contributor.
-
-1.4. "Covered Software"
-
-     means Source Code Form to which the initial Contributor has attached the
-     notice in Exhibit A, the Executable Form of such Source Code Form, and
-     Modifications of such Source Code Form, in each case including portions
-     thereof.
-
-1.5. "Incompatible With Secondary Licenses"
-     means
-
-     a. that the initial Contributor has attached the notice described in
-        Exhibit B to the Covered Software; or
-
-     b. that the Covered Software was made available under the terms of
-        version 1.1 or earlier of the License, but not also under the terms of
-        a Secondary License.
-
-1.6. "Executable Form"
-
-     means any form of the work other than Source Code Form.
-
-1.7. "Larger Work"
-
-     means a work that combines Covered Software with other material, in a
-     separate file or files, that is not Covered Software.
-
-1.8. "License"
-
-     means this document.
-
-1.9. "Licensable"
-
-     means having the right to grant, to the maximum extent possible, whether
-     at the time of the initial grant or subsequently, any and all of the
-     rights conveyed by this License.
-
-1.10. "Modifications"
-
-     means any of the following:
-
-     a. any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of Covered Software; or
-
-     b. any new file in Source Code Form that contains any Covered Software.
-
-1.11. "Patent Claims" of a Contributor
-
-      means any patent claim(s), including without limitation, method,
-      process, and apparatus claims, in any patent Licensable by such
-      Contributor that would be infringed, but for the grant of the License,
-      by the making, using, selling, offering for sale, having made, import,
-      or transfer of either its Contributions or its Contributor Version.
-
-1.12. "Secondary License"
-
-      means either the GNU General Public License, Version 2.0, the GNU Lesser
-      General Public License, Version 2.1, the GNU Affero General Public
-      License, Version 3.0, or any later versions of those licenses.
-
-1.13. "Source Code Form"
-
-      means the form of the work preferred for making modifications.
-
-1.14. "You" (or "Your")
-
-      means an individual or a legal entity exercising rights under this
-      License. For legal entities, "You" includes any entity that controls, is
-      controlled by, or is under common control with You. For purposes of this
-      definition, "control" means (a) the power, direct or indirect, to cause
-      the direction or management of such entity, whether by contract or
-      otherwise, or (b) ownership of more than fifty percent (50%) of the
-      outstanding shares or beneficial ownership of such entity.
-
-
-2. License Grants and Conditions
-
-2.1. Grants
-
-     Each Contributor hereby grants You a world-wide, royalty-free,
-     non-exclusive license:
-
-     a. under intellectual property rights (other than patent or trademark)
-        Licensable by such Contributor to use, reproduce, make available,
-        modify, display, perform, distribute, and otherwise exploit its
-        Contributions, either on an unmodified basis, with Modifications, or
-        as part of a Larger Work; and
-
-     b. under Patent Claims of such Contributor to make, use, sell, offer for
-        sale, have made, import, and otherwise transfer either its
-        Contributions or its Contributor Version.
-
-2.2. Effective Date
-
-     The licenses granted in Section 2.1 with respect to any Contribution
-     become effective for each Contribution on the date the Contributor first
-     distributes such Contribution.
-
-2.3. Limitations on Grant Scope
-
-     The licenses granted in this Section 2 are the only rights granted under
-     this License. No additional rights or licenses will be implied from the
-     distribution or licensing of Covered Software under this License.
-     Notwithstanding Section 2.1(b) above, no patent license is granted by a
-     Contributor:
-
-     a. for any code that a Contributor has removed from Covered Software; or
-
-     b. for infringements caused by: (i) Your and any other third party's
-        modifications of Covered Software, or (ii) the combination of its
-        Contributions with other software (except as part of its Contributor
-        Version); or
-
-     c. under Patent Claims infringed by Covered Software in the absence of
-        its Contributions.
-
-     This License does not grant any rights in the trademarks, service marks,
-     or logos of any Contributor (except as may be necessary to comply with
-     the notice requirements in Section 3.4).
-
-2.4. Subsequent Licenses
-
-     No Contributor makes additional grants as a result of Your choice to
-     distribute the Covered Software under a subsequent version of this
-     License (see Section 10.2) or under the terms of a Secondary License (if
-     permitted under the terms of Section 3.3).
-
-2.5. Representation
-
-     Each Contributor represents that the Contributor believes its
-     Contributions are its original creation(s) or it has sufficient rights to
-     grant the rights to its Contributions conveyed by this License.
-
-2.6. Fair Use
-
-     This License is not intended to limit any rights You have under
-     applicable copyright doctrines of fair use, fair dealing, or other
-     equivalents.
-
-2.7. Conditions
-
-     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
-     Section 2.1.
-
-
-3. Responsibilities
-
-3.1. Distribution of Source Form
-
-     All distribution of Covered Software in Source Code Form, including any
-     Modifications that You create or to which You contribute, must be under
-     the terms of this License. You must inform recipients that the Source
-     Code Form of the Covered Software is governed by the terms of this
-     License, and how they can obtain a copy of this License. You may not
-     attempt to alter or restrict the recipients' rights in the Source Code
-     Form.
-
-3.2. Distribution of Executable Form
-
-     If You distribute Covered Software in Executable Form then:
-
-     a. such Covered Software must also be made available in Source Code Form,
-        as described in Section 3.1, and You must inform recipients of the
-        Executable Form how they can obtain a copy of such Source Code Form by
-        reasonable means in a timely manner, at a charge no more than the cost
-        of distribution to the recipient; and
-
-     b. You may distribute such Executable Form under the terms of this
-        License, or sublicense it under different terms, provided that the
-        license for the Executable Form does not attempt to limit or alter the
-        recipients' rights in the Source Code Form under this License.
-
-3.3. Distribution of a Larger Work
-
-     You may create and distribute a Larger Work under terms of Your choice,
-     provided that You also comply with the requirements of this License for
-     the Covered Software. If the Larger Work is a combination of Covered
-     Software with a work governed by one or more Secondary Licenses, and the
-     Covered Software is not Incompatible With Secondary Licenses, this
-     License permits You to additionally distribute such Covered Software
-     under the terms of such Secondary License(s), so that the recipient of
-     the Larger Work may, at their option, further distribute the Covered
-     Software under the terms of either this License or such Secondary
-     License(s).
-
-3.4. Notices
-
-     You may not remove or alter the substance of any license notices
-     (including copyright notices, patent notices, disclaimers of warranty, or
-     limitations of liability) contained within the Source Code Form of the
-     Covered Software, except that You may alter any license notices to the
-     extent required to remedy known factual inaccuracies.
-
-3.5. Application of Additional Terms
-
-     You may choose to offer, and to charge a fee for, warranty, support,
-     indemnity or liability obligations to one or more recipients of Covered
-     Software. However, You may do so only on Your own behalf, and not on
-     behalf of any Contributor. You must make it absolutely clear that any
-     such warranty, support, indemnity, or liability obligation is offered by
-     You alone, and You hereby agree to indemnify every Contributor for any
-     liability incurred by such Contributor as a result of warranty, support,
-     indemnity or liability terms You offer. You may include additional
-     disclaimers of warranty and limitations of liability specific to any
-     jurisdiction.
-
-4. Inability to Comply Due to Statute or Regulation
-
-   If it is impossible for You to comply with any of the terms of this License
-   with respect to some or all of the Covered Software due to statute,
-   judicial order, or regulation then You must: (a) comply with the terms of
-   this License to the maximum extent possible; and (b) describe the
-   limitations and the code they affect. Such description must be placed in a
-   text file included with all distributions of the Covered Software under
-   this License. Except to the extent prohibited by statute or regulation,
-   such description must be sufficiently detailed for a recipient of ordinary
-   skill to be able to understand it.
-
-5. Termination
-
-5.1. The rights granted under this License will terminate automatically if You
-     fail to comply with any of its terms. However, if You become compliant,
-     then the rights granted under this License from a particular Contributor
-     are reinstated (a) provisionally, unless and until such Contributor
-     explicitly and finally terminates Your grants, and (b) on an ongoing
-     basis, if such Contributor fails to notify You of the non-compliance by
-     some reasonable means prior to 60 days after You have come back into
-     compliance. Moreover, Your grants from a particular Contributor are
-     reinstated on an ongoing basis if such Contributor notifies You of the
-     non-compliance by some reasonable means, this is the first time You have
-     received notice of non-compliance with this License from such
-     Contributor, and You become compliant prior to 30 days after Your receipt
-     of the notice.
-
-5.2. If You initiate litigation against any entity by asserting a patent
-     infringement claim (excluding declaratory judgment actions,
-     counter-claims, and cross-claims) alleging that a Contributor Version
-     directly or indirectly infringes any patent, then the rights granted to
-     You by any and all Contributors for the Covered Software under Section
-     2.1 of this License shall terminate.
-
-5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
-     license agreements (excluding distributors and resellers) which have been
-     validly granted by You or Your distributors under this License prior to
-     termination shall survive termination.
-
-6. Disclaimer of Warranty
-
-   Covered Software is provided under this License on an "as is" basis,
-   without warranty of any kind, either expressed, implied, or statutory,
-   including, without limitation, warranties that the Covered Software is free
-   of defects, merchantable, fit for a particular purpose or non-infringing.
-   The entire risk as to the quality and performance of the Covered Software
-   is with You. Should any Covered Software prove defective in any respect,
-   You (not any Contributor) assume the cost of any necessary servicing,
-   repair, or correction. This disclaimer of warranty constitutes an essential
-   part of this License. No use of  any Covered Software is authorized under
-   this License except under this disclaimer.
-
-7. Limitation of Liability
-
-   Under no circumstances and under no legal theory, whether tort (including
-   negligence), contract, or otherwise, shall any Contributor, or anyone who
-   distributes Covered Software as permitted above, be liable to You for any
-   direct, indirect, special, incidental, or consequential damages of any
-   character including, without limitation, damages for lost profits, loss of
-   goodwill, work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses, even if such party shall have been
-   informed of the possibility of such damages. This limitation of liability
-   shall not apply to liability for death or personal injury resulting from
-   such party's negligence to the extent applicable law prohibits such
-   limitation. Some jurisdictions do not allow the exclusion or limitation of
-   incidental or consequential damages, so this exclusion and limitation may
-   not apply to You.
-
-8. Litigation
-
-   Any litigation relating to this License may be brought only in the courts
-   of a jurisdiction where the defendant maintains its principal place of
-   business and such litigation shall be governed by laws of that
-   jurisdiction, without reference to its conflict-of-law provisions. Nothing
-   in this Section shall prevent a party's ability to bring cross-claims or
-   counter-claims.
-
-9. Miscellaneous
-
-   This License represents the complete agreement concerning the subject
-   matter hereof. If any provision of this License is held to be
-   unenforceable, such provision shall be reformed only to the extent
-   necessary to make it enforceable. Any law or regulation which provides that
-   the language of a contract shall be construed against the drafter shall not
-   be used to construe this License against a Contributor.
-
-
-10. Versions of the License
-
-10.1. New Versions
-
-      Mozilla Foundation is the license steward. Except as provided in Section
-      10.3, no one other than the license steward has the right to modify or
-      publish new versions of this License. Each version will be given a
-      distinguishing version number.
-
-10.2. Effect of New Versions
-
-      You may distribute the Covered Software under the terms of the version
-      of the License under which You originally received the Covered Software,
-      or under the terms of any subsequent version published by the license
-      steward.
-
-10.3. Modified Versions
-
-      If you create software not governed by this License, and you want to
-      create a new license for such software, you may create and use a
-      modified version of this License if you rename the license and remove
-      any references to the name of the license steward (except to note that
-      such modified license differs from this License).
-
-10.4. Distributing Source Code Form that is Incompatible With Secondary
-      Licenses If You choose to distribute Source Code Form that is
-      Incompatible With Secondary Licenses under the terms of this version of
-      the License, the notice described in Exhibit B of this License must be
-      attached.
-
-Exhibit A - Source Code Form License Notice
-
-      This Source Code Form is subject to the
-      terms of the Mozilla Public License, v.
-      2.0. If a copy of the MPL was not
-      distributed with this file, You can
-      obtain one at
-      http://mozilla.org/MPL/2.0/.
-
-If it is not possible or desirable to put the notice in a particular file,
-then You may include the notice in a location (such as a LICENSE file in a
-relevant directory) where a recipient would be likely to look for such a
-notice.
-
-You may add additional accurate notices of copyright ownership.
-
-Exhibit B - "Incompatible With Secondary Licenses" Notice
-
-      This Source Code Form is "Incompatible
-      With Secondary Licenses", as defined by
-      the Mozilla Public License, v. 2.0.
-
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+Parameters
+
+Licensor:             HashiCorp, Inc.
+Licensed Work:        Boundary Version 0.13.2 or later. The Licensed Work is (c) 2024
+                      HashiCorp, Inc.
+Additional Use Grant: You may make production use of the Licensed Work, provided
+                      Your use does not include offering the Licensed Work to third
+                      parties on a hosted or embedded basis in order to compete with 
+                      HashiCorp's paid version(s) of the Licensed Work. For purposes 
+                      of this license:
+
+                      A "competitive offering" is a Product that is offered to third
+                      parties on a paid basis, including through paid support 
+                      arrangements, that significantly overlaps with the capabilities 
+                      of HashiCorp's paid version(s) of the Licensed Work. If Your 
+                      Product is not a competitive offering when You first make it 
+                      generally available, it will not become a competitive offering
+                      later due to HashiCorp releasing a new version of the Licensed 
+                      Work with additional capabilities. In addition, Products that 
+                      are not provided on a paid basis are not competitive.
+
+                      "Product" means software that is offered to end users to manage 
+                      in their own environments or offered as a service on a hosted 
+                      basis.
+
+                      "Embedded" means including the source code or executable code 
+                      from the Licensed Work in a competitive offering. "Embedded" 
+                      also means packaging the competitive offering in such a way 
+                      that the Licensed Work must be accessed or downloaded for the 
+                      competitive offering to operate.
+
+                      Hosting or using the Licensed Work(s) for internal purposes 
+                      within an organization is not considered a competitive 
+                      offering. HashiCorp considers your organization to include all 
+                      of your affiliates under common control.
+
+                      For binding interpretive guidance on using HashiCorp products 
+                      under the Business Source License, please visit our FAQ. 
+                      (https://www.hashicorp.com/license-faq)
+Change Date:          Four years from the date the Licensed Work is published.
+Change License:       MPL 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact licensing@hashicorp.com.
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,11 @@ protolint:
 .PHONY: copywrite
 copywrite:
 	copywrite headers
+	# In the protobuf API directories, remove the BUSL headers
+	# and rerun copywrite with the directory specific configuration.
+	cd internal/proto/controller/api && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + &&  copywrite headers
+	cd internal/proto/controller/custom_options && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + &&  copywrite headers
+	cd internal/proto/plugin && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + && copywrite headers
 
 .PHONY: website
 # must have nodejs and npm installed

--- a/cmd/boundary/main.go
+++ b/cmd/boundary/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/cmd/boundary/package_registry_oss.go
+++ b/cmd/boundary/package_registry_oss.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/globals/boundary_developer_env.go
+++ b/globals/boundary_developer_env.go
@@ -1,4 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package globals

--- a/globals/doc.go
+++ b/globals/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 /*
 Globals, in the traditional sense, are usually bad. But there are some

--- a/globals/errors.go
+++ b/globals/errors.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package globals
 

--- a/globals/fields.go
+++ b/globals/fields.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package globals
 

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package globals
 

--- a/globals/kms.go
+++ b/globals/kms.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package globals
 

--- a/globals/prefixes.go
+++ b/globals/prefixes.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package globals
 

--- a/globals/prefixes_test.go
+++ b/globals/prefixes_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package globals
 

--- a/internal/api/genapi/input.go
+++ b/internal/api/genapi/input.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/internal/api/genapi/main.go
+++ b/internal/api/genapi/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/internal/api/genapi/parse.go
+++ b/internal/api/genapi/parse.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/internal/auth/additional_verification_test.go
+++ b/internal/auth/additional_verification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package auth_test
 

--- a/internal/auth/db_test.go
+++ b/internal/auth/db_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package auth
 

--- a/internal/auth/ldap/account.go
+++ b/internal/auth/ldap/account.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/account_attribute_map.go
+++ b/internal/auth/ldap/account_attribute_map.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/account_attribute_map_test.go
+++ b/internal/auth/ldap/account_attribute_map_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/account_test.go
+++ b/internal/auth/ldap/account_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/auth_method.go
+++ b/internal/auth/ldap/auth_method.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/auth_method_test.go
+++ b/internal/auth/ldap/auth_method_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/bind_credential.go
+++ b/internal/auth/ldap/bind_credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/bind_credential_test.go
+++ b/internal/auth/ldap/bind_credential_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/certificate.go
+++ b/internal/auth/ldap/certificate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/certificate_test.go
+++ b/internal/auth/ldap/certificate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/certificate_utils.go
+++ b/internal/auth/ldap/certificate_utils.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/certificate_utils_test.go
+++ b/internal/auth/ldap/certificate_utils_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/client_certificate.go
+++ b/internal/auth/ldap/client_certificate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/client_certificate_test.go
+++ b/internal/auth/ldap/client_certificate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/group_entry_search_conf.go
+++ b/internal/auth/ldap/group_entry_search_conf.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/group_entry_search_conf_test.go
+++ b/internal/auth/ldap/group_entry_search_conf_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/ids.go
+++ b/internal/auth/ldap/ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/managed_group.go
+++ b/internal/auth/ldap/managed_group.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/managed_group_test.go
+++ b/internal/auth/ldap/managed_group_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/options.go
+++ b/internal/auth/ldap/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/options_test.go
+++ b/internal/auth/ldap/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository.go
+++ b/internal/auth/ldap/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_account.go
+++ b/internal/auth/ldap/repository_account.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_account_test.go
+++ b/internal/auth/ldap/repository_account_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_auth_method_create.go
+++ b/internal/auth/ldap/repository_auth_method_create.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_auth_method_create_test.go
+++ b/internal/auth/ldap/repository_auth_method_create_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_auth_method_delete.go
+++ b/internal/auth/ldap/repository_auth_method_delete.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_auth_method_delete_test.go
+++ b/internal/auth/ldap/repository_auth_method_delete_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_auth_method_read.go
+++ b/internal/auth/ldap/repository_auth_method_read.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_auth_method_read_test.go
+++ b/internal/auth/ldap/repository_auth_method_read_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_auth_method_update.go
+++ b/internal/auth/ldap/repository_auth_method_update.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_auth_method_update_test.go
+++ b/internal/auth/ldap/repository_auth_method_update_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_authenticate.go
+++ b/internal/auth/ldap/repository_authenticate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_authenticate_test.go
+++ b/internal/auth/ldap/repository_authenticate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_managed_group.go
+++ b/internal/auth/ldap/repository_managed_group.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_managed_group_members.go
+++ b/internal/auth/ldap/repository_managed_group_members.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_managed_group_members_test.go
+++ b/internal/auth/ldap/repository_managed_group_members_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap_test
 

--- a/internal/auth/ldap/repository_managed_group_test.go
+++ b/internal/auth/ldap/repository_managed_group_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/repository_test.go
+++ b/internal/auth/ldap/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/rewrapping.go
+++ b/internal/auth/ldap/rewrapping.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/rewrapping_test.go
+++ b/internal/auth/ldap/rewrapping_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/service_authenticate.go
+++ b/internal/auth/ldap/service_authenticate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/service_authenticate_test.go
+++ b/internal/auth/ldap/service_authenticate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/state.go
+++ b/internal/auth/ldap/state.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/state_test.go
+++ b/internal/auth/ldap/state_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/testing.go
+++ b/internal/auth/ldap/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/testing_test.go
+++ b/internal/auth/ldap/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/url.go
+++ b/internal/auth/ldap/url.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/url_test.go
+++ b/internal/auth/ldap/url_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/user_entry_search_conf.go
+++ b/internal/auth/ldap/user_entry_search_conf.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/ldap/user_entry_search_conf_test.go
+++ b/internal/auth/ldap/user_entry_search_conf_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ldap
 

--- a/internal/auth/oidc/account.go
+++ b/internal/auth/oidc/account.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/account_claim_map.go
+++ b/internal/auth/oidc/account_claim_map.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/account_claim_map_test.go
+++ b/internal/auth/oidc/account_claim_map_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/account_test.go
+++ b/internal/auth/oidc/account_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/aud_claim.go
+++ b/internal/auth/oidc/aud_claim.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/aud_claim_test.go
+++ b/internal/auth/oidc/aud_claim_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/auth_method.go
+++ b/internal/auth/oidc/auth_method.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/auth_method_test.go
+++ b/internal/auth/oidc/auth_method_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/certificate.go
+++ b/internal/auth/oidc/certificate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/certificate_test.go
+++ b/internal/auth/oidc/certificate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/certificate_utils.go
+++ b/internal/auth/oidc/certificate_utils.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/certificate_utils_test.go
+++ b/internal/auth/oidc/certificate_utils_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/claims_scope.go
+++ b/internal/auth/oidc/claims_scope.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/claims_scope_test.go
+++ b/internal/auth/oidc/claims_scope_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/client_secret.go
+++ b/internal/auth/oidc/client_secret.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/client_secret_test.go
+++ b/internal/auth/oidc/client_secret_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/ids.go
+++ b/internal/auth/oidc/ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/ids_test.go
+++ b/internal/auth/oidc/ids_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/immutable_fields_test.go
+++ b/internal/auth/oidc/immutable_fields_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/managed_group.go
+++ b/internal/auth/oidc/managed_group.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/managed_group_member_account.go
+++ b/internal/auth/oidc/managed_group_member_account.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/managed_group_test.go
+++ b/internal/auth/oidc/managed_group_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/options.go
+++ b/internal/auth/oidc/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/options_test.go
+++ b/internal/auth/oidc/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/provider.go
+++ b/internal/auth/oidc/provider.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/query.go
+++ b/internal/auth/oidc/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository.go
+++ b/internal/auth/oidc/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_account.go
+++ b/internal/auth/oidc/repository_account.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_account_test.go
+++ b/internal/auth/oidc/repository_account_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method.go
+++ b/internal/auth/oidc/repository_auth_method.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method_create.go
+++ b/internal/auth/oidc/repository_auth_method_create.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method_create_test.go
+++ b/internal/auth/oidc/repository_auth_method_create_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method_delete.go
+++ b/internal/auth/oidc/repository_auth_method_delete.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method_delete_test.go
+++ b/internal/auth/oidc/repository_auth_method_delete_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method_operational_state.go
+++ b/internal/auth/oidc/repository_auth_method_operational_state.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method_operational_state_test.go
+++ b/internal/auth/oidc/repository_auth_method_operational_state_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method_read.go
+++ b/internal/auth/oidc/repository_auth_method_read.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method_read_test.go
+++ b/internal/auth/oidc/repository_auth_method_read_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method_test.go
+++ b/internal/auth/oidc/repository_auth_method_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method_update.go
+++ b/internal/auth/oidc/repository_auth_method_update.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_auth_method_update_test.go
+++ b/internal/auth/oidc/repository_auth_method_update_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_managed_group.go
+++ b/internal/auth/oidc/repository_managed_group.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_managed_group_members.go
+++ b/internal/auth/oidc/repository_managed_group_members.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_managed_group_members_test.go
+++ b/internal/auth/oidc/repository_managed_group_members_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc_test
 

--- a/internal/auth/oidc/repository_managed_group_test.go
+++ b/internal/auth/oidc/repository_managed_group_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/repository_test.go
+++ b/internal/auth/oidc/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/request/validate.go
+++ b/internal/auth/oidc/request/validate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package request
 

--- a/internal/auth/oidc/rewrapping.go
+++ b/internal/auth/oidc/rewrapping.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/rewrapping_test.go
+++ b/internal/auth/oidc/rewrapping_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/service.go
+++ b/internal/auth/oidc/service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/service_callback.go
+++ b/internal/auth/oidc/service_callback.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/service_callback_test.go
+++ b/internal/auth/oidc/service_callback_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/service_start_auth.go
+++ b/internal/auth/oidc/service_start_auth.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/service_start_auth_test.go
+++ b/internal/auth/oidc/service_start_auth_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/service_test.go
+++ b/internal/auth/oidc/service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/service_token_request.go
+++ b/internal/auth/oidc/service_token_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/service_token_request_test.go
+++ b/internal/auth/oidc/service_token_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/signing_alg.go
+++ b/internal/auth/oidc/signing_alg.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/signing_alg_test.go
+++ b/internal/auth/oidc/signing_alg_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/state.go
+++ b/internal/auth/oidc/state.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/state_test.go
+++ b/internal/auth/oidc/state_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/oidc/testing.go
+++ b/internal/auth/oidc/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oidc
 

--- a/internal/auth/password/account.go
+++ b/internal/auth/password/account.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/account_test.go
+++ b/internal/auth/password/account_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/argon2.go
+++ b/internal/auth/password/argon2.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/argon2_test.go
+++ b/internal/auth/password/argon2_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/authmethod.go
+++ b/internal/auth/password/authmethod.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/authmethod_test.go
+++ b/internal/auth/password/authmethod_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/credential.go
+++ b/internal/auth/password/credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/options.go
+++ b/internal/auth/password/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/options_test.go
+++ b/internal/auth/password/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/private_ids.go
+++ b/internal/auth/password/private_ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/private_ids_test.go
+++ b/internal/auth/password/private_ids_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/public_ids.go
+++ b/internal/auth/password/public_ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/public_ids_test.go
+++ b/internal/auth/password/public_ids_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/query.go
+++ b/internal/auth/password/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/repository.go
+++ b/internal/auth/password/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/repository_account.go
+++ b/internal/auth/password/repository_account.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/repository_account_test.go
+++ b/internal/auth/password/repository_account_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/repository_authmethod.go
+++ b/internal/auth/password/repository_authmethod.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/repository_authmethod_test.go
+++ b/internal/auth/password/repository_authmethod_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/repository_configuration.go
+++ b/internal/auth/password/repository_configuration.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/repository_configuration_test.go
+++ b/internal/auth/password/repository_configuration_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/repository_password.go
+++ b/internal/auth/password/repository_password.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/repository_password_test.go
+++ b/internal/auth/password/repository_password_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/repository_test.go
+++ b/internal/auth/password/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/rewrapping.go
+++ b/internal/auth/password/rewrapping.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/rewrapping_test.go
+++ b/internal/auth/password/rewrapping_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/testing.go
+++ b/internal/auth/password/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/password/testing_test.go
+++ b/internal/auth/password/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package password
 

--- a/internal/auth/subtype.go
+++ b/internal/auth/subtype.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package auth
 

--- a/internal/auth/testing.go
+++ b/internal/auth/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package auth
 

--- a/internal/authtoken/account.go
+++ b/internal/authtoken/account.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/authtoken.go
+++ b/internal/authtoken/authtoken.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/authtoken_test.go
+++ b/internal/authtoken/authtoken_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/doc.go
+++ b/internal/authtoken/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package authtoken provides an authtoken with an encrypted value and
 // an associated expiration time.  It also provides a repository which

--- a/internal/authtoken/gorm.go
+++ b/internal/authtoken/gorm.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/gorm_test.go
+++ b/internal/authtoken/gorm_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/immutable_fields_test.go
+++ b/internal/authtoken/immutable_fields_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/options.go
+++ b/internal/authtoken/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/options_test.go
+++ b/internal/authtoken/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/repository.go
+++ b/internal/authtoken/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/repository_test.go
+++ b/internal/authtoken/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/rewrapping.go
+++ b/internal/authtoken/rewrapping.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/rewrapping_test.go
+++ b/internal/authtoken/rewrapping_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/status.go
+++ b/internal/authtoken/status.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/authtoken/testing.go
+++ b/internal/authtoken/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtoken
 

--- a/internal/boundary/boundary.go
+++ b/internal/boundary/boundary.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package boundary contains global interfaces and other definitions that
 // define the Boundary domain.

--- a/internal/bsr/bsr.go
+++ b/internal/bsr/bsr.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/bsr_open_test.go
+++ b/internal/bsr/bsr_open_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/bsr_test.go
+++ b/internal/bsr/bsr_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/byte_source.go
+++ b/internal/bsr/byte_source.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/byte_source_test.go
+++ b/internal/bsr/byte_source_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/chunk.go
+++ b/internal/bsr/chunk.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/chunk_end.go
+++ b/internal/bsr/chunk_end.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/chunk_end_test.go
+++ b/internal/bsr/chunk_end_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/chunk_header.go
+++ b/internal/bsr/chunk_header.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/chunk_header_test.go
+++ b/internal/bsr/chunk_header_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/chunk_scanner.go
+++ b/internal/bsr/chunk_scanner.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/chunk_scanner_test.go
+++ b/internal/bsr/chunk_scanner_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/chunk_test.go
+++ b/internal/bsr/chunk_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/compression.go
+++ b/internal/bsr/compression.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/compression_null_compression_test.go
+++ b/internal/bsr/compression_null_compression_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/compression_test.go
+++ b/internal/bsr/compression_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/container.go
+++ b/internal/bsr/container.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/container_test.go
+++ b/internal/bsr/container_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/convert/convert.go
+++ b/internal/bsr/convert/convert.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package convert
 

--- a/internal/bsr/convert/doc.go
+++ b/internal/bsr/convert/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package convert provides functions for converting BSR data into other formats.
 package convert

--- a/internal/bsr/convert/errors.go
+++ b/internal/bsr/convert/errors.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package convert
 

--- a/internal/bsr/convert/internal/asciicast/asciicast.go
+++ b/internal/bsr/convert/internal/asciicast/asciicast.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package asciicast defines structs to ease the creation of asciicast files.
 // See: https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md

--- a/internal/bsr/convert/internal/asciicast/asciicast_test.go
+++ b/internal/bsr/convert/internal/asciicast/asciicast_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package asciicast_test
 

--- a/internal/bsr/convert/options.go
+++ b/internal/bsr/convert/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package convert
 

--- a/internal/bsr/convert/options_test.go
+++ b/internal/bsr/convert/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package convert
 

--- a/internal/bsr/convert/ssh.go
+++ b/internal/bsr/convert/ssh.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package convert
 

--- a/internal/bsr/convert/ssh_test.go
+++ b/internal/bsr/convert/ssh_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package convert
 

--- a/internal/bsr/decode.go
+++ b/internal/bsr/decode.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/decode_test.go
+++ b/internal/bsr/decode_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/direction.go
+++ b/internal/bsr/direction.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/direction_test.go
+++ b/internal/bsr/direction_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/doc.go
+++ b/internal/bsr/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 /*
 Package bsr is used to read and write boundary session recordings.

--- a/internal/bsr/encode.go
+++ b/internal/bsr/encode.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/encode_test.go
+++ b/internal/bsr/encode_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/encryption.go
+++ b/internal/bsr/encryption.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/encryption_test.go
+++ b/internal/bsr/encryption_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/errors.go
+++ b/internal/bsr/errors.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/id.go
+++ b/internal/bsr/id.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/internal/checksum/checksum.go
+++ b/internal/bsr/internal/checksum/checksum.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package checksum provides a wrapper to compute a checksum on a writable file
 // while it is being written to, and record the final checksum when the file is

--- a/internal/bsr/internal/checksum/checksum_test.go
+++ b/internal/bsr/internal/checksum/checksum_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package checksum_test
 

--- a/internal/bsr/internal/checksum/sha256sums.go
+++ b/internal/bsr/internal/checksum/sha256sums.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package checksum
 

--- a/internal/bsr/internal/checksum/sha256sums_test.go
+++ b/internal/bsr/internal/checksum/sha256sums_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package checksum_test
 

--- a/internal/bsr/internal/fstest/fs.go
+++ b/internal/bsr/internal/fstest/fs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package fstest provides test implementations of the fs interfaces.
 package fstest

--- a/internal/bsr/internal/fstest/fs_test.go
+++ b/internal/bsr/internal/fstest/fs_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package fstest_test
 

--- a/internal/bsr/internal/fstest/local.go
+++ b/internal/bsr/internal/fstest/local.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package fstest
 

--- a/internal/bsr/internal/fstest/options.go
+++ b/internal/bsr/internal/fstest/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package fstest
 

--- a/internal/bsr/internal/fstest/space.go
+++ b/internal/bsr/internal/fstest/space.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package fstest provides test implementations of the fs interfaces.
 package fstest

--- a/internal/bsr/internal/is/nil.go
+++ b/internal/bsr/internal/is/nil.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package is
 

--- a/internal/bsr/internal/journal/journal.go
+++ b/internal/bsr/internal/journal/journal.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package journal provides a writer that uses a journal file to aide in recovery.
 package journal

--- a/internal/bsr/internal/journal/journal_test.go
+++ b/internal/bsr/internal/journal/journal_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package journal_test
 

--- a/internal/bsr/internal/sign/sign.go
+++ b/internal/bsr/internal/sign/sign.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package sign provides wrappers to compute a signature of data written to an
 // io.Writer

--- a/internal/bsr/internal/sign/sign_test.go
+++ b/internal/bsr/internal/sign/sign_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sign_test
 

--- a/internal/bsr/kms/errors.go
+++ b/internal/bsr/kms/errors.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/bsr/kms/keys.go
+++ b/internal/bsr/kms/keys.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/bsr/kms/keys_test.go
+++ b/internal/bsr/kms/keys_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms_test
 

--- a/internal/bsr/kms/option_test.go
+++ b/internal/bsr/kms/option_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/bsr/kms/options.go
+++ b/internal/bsr/kms/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/bsr/kms/testing.go
+++ b/internal/bsr/kms/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/bsr/magic.go
+++ b/internal/bsr/magic.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/magic_test.go
+++ b/internal/bsr/magic_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/meta_recording.go
+++ b/internal/bsr/meta_recording.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/meta_session.go
+++ b/internal/bsr/meta_session.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/options.go
+++ b/internal/bsr/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/options_test.go
+++ b/internal/bsr/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/protocol.go
+++ b/internal/bsr/protocol.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/protocol_test.go
+++ b/internal/bsr/protocol_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr_test
 

--- a/internal/bsr/ssh/chunk.go
+++ b/internal/bsr/ssh/chunk.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_break_request.go
+++ b/internal/bsr/ssh/chunk_break_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_break_request_test.go
+++ b/internal/bsr/ssh/chunk_break_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_cancel_tcpip_forward_request.go
+++ b/internal/bsr/ssh/chunk_cancel_tcpip_forward_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_cancel_tcpip_forward_request_test.go
+++ b/internal/bsr/ssh/chunk_cancel_tcpip_forward_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_decode_test.go
+++ b/internal/bsr/ssh/chunk_decode_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh_test
 

--- a/internal/bsr/ssh/chunk_direct_tcpip_request.go
+++ b/internal/bsr/ssh/chunk_direct_tcpip_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_direct_tcpip_request_test.go
+++ b/internal/bsr/ssh/chunk_direct_tcpip_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_env_request.go
+++ b/internal/bsr/ssh/chunk_env_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_env_request_test.go
+++ b/internal/bsr/ssh/chunk_env_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_exec_request.go
+++ b/internal/bsr/ssh/chunk_exec_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_exec_request_test.go
+++ b/internal/bsr/ssh/chunk_exec_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_exit_signal_request.go
+++ b/internal/bsr/ssh/chunk_exit_signal_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_exit_signal_request_test.go
+++ b/internal/bsr/ssh/chunk_exit_signal_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_exit_status_request.go
+++ b/internal/bsr/ssh/chunk_exit_status_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_exit_status_request_test.go
+++ b/internal/bsr/ssh/chunk_exit_status_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_forwarded_tcpip_request.go
+++ b/internal/bsr/ssh/chunk_forwarded_tcpip_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_forwarded_tcpip_request_test.go
+++ b/internal/bsr/ssh/chunk_forwarded_tcpip_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_pty_request.go
+++ b/internal/bsr/ssh/chunk_pty_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_pty_request_test.go
+++ b/internal/bsr/ssh/chunk_pty_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_session_request.go
+++ b/internal/bsr/ssh/chunk_session_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_session_request_test.go
+++ b/internal/bsr/ssh/chunk_session_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_shell_request.go
+++ b/internal/bsr/ssh/chunk_shell_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_shell_request_test.go
+++ b/internal/bsr/ssh/chunk_shell_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_signal_request.go
+++ b/internal/bsr/ssh/chunk_signal_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_signal_request_test.go
+++ b/internal/bsr/ssh/chunk_signal_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_subsystem_request.go
+++ b/internal/bsr/ssh/chunk_subsystem_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_subsystem_request_test.go
+++ b/internal/bsr/ssh/chunk_subsystem_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_tcpip_forward_request.go
+++ b/internal/bsr/ssh/chunk_tcpip_forward_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_tcpip_forward_request_test.go
+++ b/internal/bsr/ssh/chunk_tcpip_forward_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_unknown_request.go
+++ b/internal/bsr/ssh/chunk_unknown_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_unknown_request_test.go
+++ b/internal/bsr/ssh/chunk_unknown_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_window_change_request.go
+++ b/internal/bsr/ssh/chunk_window_change_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_window_change_request_test.go
+++ b/internal/bsr/ssh/chunk_window_change_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_x11_forwarding_request.go
+++ b/internal/bsr/ssh/chunk_x11_forwarding_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_x11_forwarding_request_test.go
+++ b/internal/bsr/ssh/chunk_x11_forwarding_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_x11_request.go
+++ b/internal/bsr/ssh/chunk_x11_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_x11_request_test.go
+++ b/internal/bsr/ssh/chunk_x11_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_xonn_xoff_request.go
+++ b/internal/bsr/ssh/chunk_xonn_xoff_request.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/chunk_xonn_xoff_request_test.go
+++ b/internal/bsr/ssh/chunk_xonn_xoff_request_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/ssh/doc.go
+++ b/internal/bsr/ssh/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 /*
 Package ssh defines chunk types for recordings of the ssh protocol.

--- a/internal/bsr/ssh/types.go
+++ b/internal/bsr/ssh/types.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ssh
 

--- a/internal/bsr/testing.go
+++ b/internal/bsr/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/timestamp.go
+++ b/internal/bsr/timestamp.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/timestamp_test.go
+++ b/internal/bsr/timestamp_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/bsr/types.go
+++ b/internal/bsr/types.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package bsr
 

--- a/internal/census/census.go
+++ b/internal/census/census.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package census
 

--- a/internal/census/census_job.go
+++ b/internal/census/census_job.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package census
 

--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/const.go
+++ b/internal/cmd/base/const.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/dev.go
+++ b/internal/cmd/base/dev.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/dev_test.go
+++ b/internal/cmd/base/dev_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/event_flags.go
+++ b/internal/cmd/base/event_flags.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/event_flags_test.go
+++ b/internal/cmd/base/event_flags_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/flags.go
+++ b/internal/cmd/base/flags.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/flags_test.go
+++ b/internal/cmd/base/flags_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/format.go
+++ b/internal/cmd/base/format.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/helpers.go
+++ b/internal/cmd/base/helpers.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/initial_resources.go
+++ b/internal/cmd/base/initial_resources.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/internal/docker/docker.go
+++ b/internal/cmd/base/internal/docker/docker.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package docker
 

--- a/internal/cmd/base/internal/docker/option.go
+++ b/internal/cmd/base/internal/docker/option.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package docker
 

--- a/internal/cmd/base/internal/docker/supported.go
+++ b/internal/cmd/base/internal/docker/supported.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build linux || darwin || windows
 // +build linux darwin windows

--- a/internal/cmd/base/internal/metric/build_info.go
+++ b/internal/cmd/base/internal/metric/build_info.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package metric provides functions to initialize a prometheus metric
 // detailing build info

--- a/internal/cmd/base/keyring.go
+++ b/internal/cmd/base/keyring.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/listener.go
+++ b/internal/cmd/base/listener.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/logging.go
+++ b/internal/cmd/base/logging.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/logging/logging.go
+++ b/internal/cmd/base/logging/logging.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package logging
 

--- a/internal/cmd/base/option.go
+++ b/internal/cmd/base/option.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/option_test.go
+++ b/internal/cmd/base/option_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/profiling_off.go
+++ b/internal/cmd/base/profiling_off.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build !memprofiler
 // +build !memprofiler

--- a/internal/cmd/base/profiling_on.go
+++ b/internal/cmd/base/profiling_on.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build memprofiler
 // +build memprofiler

--- a/internal/cmd/base/server_test.go
+++ b/internal/cmd/base/server_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/base/ui.go
+++ b/internal/cmd/base/ui.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cmd
 

--- a/internal/cmd/commands/accountscmd/funcs.go
+++ b/internal/cmd/commands/accountscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package accountscmd
 

--- a/internal/cmd/commands/accountscmd/ldap_funcs.go
+++ b/internal/cmd/commands/accountscmd/ldap_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package accountscmd
 

--- a/internal/cmd/commands/accountscmd/oidc_funcs.go
+++ b/internal/cmd/commands/accountscmd/oidc_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package accountscmd
 

--- a/internal/cmd/commands/accountscmd/password_funcs.go
+++ b/internal/cmd/commands/accountscmd/password_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package accountscmd
 

--- a/internal/cmd/commands/authenticate/authenticate.go
+++ b/internal/cmd/commands/authenticate/authenticate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authenticate
 

--- a/internal/cmd/commands/authenticate/funcs.go
+++ b/internal/cmd/commands/authenticate/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authenticate
 

--- a/internal/cmd/commands/authenticate/ldap.go
+++ b/internal/cmd/commands/authenticate/ldap.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authenticate
 

--- a/internal/cmd/commands/authenticate/oidc.go
+++ b/internal/cmd/commands/authenticate/oidc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authenticate
 

--- a/internal/cmd/commands/authenticate/password.go
+++ b/internal/cmd/commands/authenticate/password.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authenticate
 

--- a/internal/cmd/commands/authmethodscmd/funcs.go
+++ b/internal/cmd/commands/authmethodscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethodscmd
 

--- a/internal/cmd/commands/authmethodscmd/ldap_funcs.go
+++ b/internal/cmd/commands/authmethodscmd/ldap_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethodscmd
 

--- a/internal/cmd/commands/authmethodscmd/oidc_funcs.go
+++ b/internal/cmd/commands/authmethodscmd/oidc_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethodscmd
 

--- a/internal/cmd/commands/authmethodscmd/password_funcs.go
+++ b/internal/cmd/commands/authmethodscmd/password_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethodscmd
 

--- a/internal/cmd/commands/authtokenscmd/authtokens.go
+++ b/internal/cmd/commands/authtokenscmd/authtokens.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtokenscmd
 

--- a/internal/cmd/commands/authtokenscmd/funcs.go
+++ b/internal/cmd/commands/authtokenscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtokenscmd
 

--- a/internal/cmd/commands/config/autocomplete.go
+++ b/internal/cmd/commands/config/autocomplete.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package config
 

--- a/internal/cmd/commands/config/config.go
+++ b/internal/cmd/commands/config/config.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package config
 

--- a/internal/cmd/commands/config/encryptdecrypt.go
+++ b/internal/cmd/commands/config/encryptdecrypt.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package config
 

--- a/internal/cmd/commands/config/encryptdecrypt_test.go
+++ b/internal/cmd/commands/config/encryptdecrypt_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package config
 

--- a/internal/cmd/commands/config/token.go
+++ b/internal/cmd/commands/config/token.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package config
 

--- a/internal/cmd/commands/connect/client_tls_config.go
+++ b/internal/cmd/commands/connect/client_tls_config.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package connect
 

--- a/internal/cmd/commands/connect/connect.go
+++ b/internal/cmd/commands/connect/connect.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package connect
 

--- a/internal/cmd/commands/connect/credentials.go
+++ b/internal/cmd/commands/connect/credentials.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package connect
 

--- a/internal/cmd/commands/connect/credentials_test.go
+++ b/internal/cmd/commands/connect/credentials_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package connect
 

--- a/internal/cmd/commands/connect/funcs.go
+++ b/internal/cmd/commands/connect/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package connect
 

--- a/internal/cmd/commands/connect/http.go
+++ b/internal/cmd/commands/connect/http.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package connect
 

--- a/internal/cmd/commands/connect/kube.go
+++ b/internal/cmd/commands/connect/kube.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package connect
 

--- a/internal/cmd/commands/connect/postgres.go
+++ b/internal/cmd/commands/connect/postgres.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package connect
 

--- a/internal/cmd/commands/connect/rdp.go
+++ b/internal/cmd/commands/connect/rdp.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package connect
 

--- a/internal/cmd/commands/connect/ssh.go
+++ b/internal/cmd/commands/connect/ssh.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package connect
 

--- a/internal/cmd/commands/credentiallibrariescmd/funcs.go
+++ b/internal/cmd/commands/credentiallibrariescmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentiallibrariescmd
 

--- a/internal/cmd/commands/credentiallibrariescmd/vault-generic_funcs.go
+++ b/internal/cmd/commands/credentiallibrariescmd/vault-generic_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentiallibrariescmd
 

--- a/internal/cmd/commands/credentiallibrariescmd/vault-ssh-certificate_funcs.go
+++ b/internal/cmd/commands/credentiallibrariescmd/vault-ssh-certificate_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentiallibrariescmd
 

--- a/internal/cmd/commands/credentiallibrariescmd/vault_funcs.go
+++ b/internal/cmd/commands/credentiallibrariescmd/vault_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentiallibrariescmd
 

--- a/internal/cmd/commands/credentialscmd/funcs.go
+++ b/internal/cmd/commands/credentialscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialscmd
 

--- a/internal/cmd/commands/credentialscmd/json_credentials_funcs.go
+++ b/internal/cmd/commands/credentialscmd/json_credentials_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialscmd
 

--- a/internal/cmd/commands/credentialscmd/ssh-private-key_funcs.go
+++ b/internal/cmd/commands/credentialscmd/ssh-private-key_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialscmd
 

--- a/internal/cmd/commands/credentialscmd/username-password_funcs.go
+++ b/internal/cmd/commands/credentialscmd/username-password_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialscmd
 

--- a/internal/cmd/commands/credentialstorescmd/funcs.go
+++ b/internal/cmd/commands/credentialstorescmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialstorescmd
 

--- a/internal/cmd/commands/credentialstorescmd/static_funcs.go
+++ b/internal/cmd/commands/credentialstorescmd/static_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialstorescmd
 

--- a/internal/cmd/commands/credentialstorescmd/vault_funcs.go
+++ b/internal/cmd/commands/credentialstorescmd/vault_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialstorescmd
 

--- a/internal/cmd/commands/database/database.go
+++ b/internal/cmd/commands/database/database.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package database
 

--- a/internal/cmd/commands/database/funcs.go
+++ b/internal/cmd/commands/database/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package database
 

--- a/internal/cmd/commands/database/funcs_test.go
+++ b/internal/cmd/commands/database/funcs_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package database
 

--- a/internal/cmd/commands/database/init.go
+++ b/internal/cmd/commands/database/init.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package database
 

--- a/internal/cmd/commands/database/migrate.go
+++ b/internal/cmd/commands/database/migrate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package database
 

--- a/internal/cmd/commands/dev/dev.go
+++ b/internal/cmd/commands/dev/dev.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package dev
 

--- a/internal/cmd/commands/dev/flags_test.go
+++ b/internal/cmd/commands/dev/flags_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package dev
 

--- a/internal/cmd/commands/groupscmd/funcs.go
+++ b/internal/cmd/commands/groupscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package groupscmd
 

--- a/internal/cmd/commands/hostcatalogscmd/funcs.go
+++ b/internal/cmd/commands/hostcatalogscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostcatalogscmd
 

--- a/internal/cmd/commands/hostcatalogscmd/plugin_funcs.go
+++ b/internal/cmd/commands/hostcatalogscmd/plugin_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostcatalogscmd
 

--- a/internal/cmd/commands/hostcatalogscmd/static_funcs.go
+++ b/internal/cmd/commands/hostcatalogscmd/static_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostcatalogscmd
 

--- a/internal/cmd/commands/hostscmd/funcs.go
+++ b/internal/cmd/commands/hostscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostscmd
 

--- a/internal/cmd/commands/hostscmd/static_funcs.go
+++ b/internal/cmd/commands/hostscmd/static_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostscmd
 

--- a/internal/cmd/commands/hostsetscmd/funcs.go
+++ b/internal/cmd/commands/hostsetscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostsetscmd
 

--- a/internal/cmd/commands/hostsetscmd/plugin_funcs.go
+++ b/internal/cmd/commands/hostsetscmd/plugin_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostsetscmd
 

--- a/internal/cmd/commands/hostsetscmd/static_funcs.go
+++ b/internal/cmd/commands/hostsetscmd/static_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostsetscmd
 

--- a/internal/cmd/commands/logout/logout.go
+++ b/internal/cmd/commands/logout/logout.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package logout
 

--- a/internal/cmd/commands/managedgroupscmd/funcs.go
+++ b/internal/cmd/commands/managedgroupscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package managedgroupscmd
 

--- a/internal/cmd/commands/managedgroupscmd/ldap_funcs.go
+++ b/internal/cmd/commands/managedgroupscmd/ldap_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package managedgroupscmd
 

--- a/internal/cmd/commands/managedgroupscmd/oidc_funcs.go
+++ b/internal/cmd/commands/managedgroupscmd/oidc_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package managedgroupscmd
 

--- a/internal/cmd/commands/rolescmd/funcs.go
+++ b/internal/cmd/commands/rolescmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package rolescmd
 

--- a/internal/cmd/commands/scopescmd/destroy_key_version.go
+++ b/internal/cmd/commands/scopescmd/destroy_key_version.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scopescmd
 

--- a/internal/cmd/commands/scopescmd/funcs.go
+++ b/internal/cmd/commands/scopescmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scopescmd
 

--- a/internal/cmd/commands/scopescmd/list_key_version_destruction_jobs.go
+++ b/internal/cmd/commands/scopescmd/list_key_version_destruction_jobs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scopescmd
 

--- a/internal/cmd/commands/scopescmd/list_keys.go
+++ b/internal/cmd/commands/scopescmd/list_keys.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scopescmd
 

--- a/internal/cmd/commands/scopescmd/rotate_keys.go
+++ b/internal/cmd/commands/scopescmd/rotate_keys.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scopescmd
 

--- a/internal/cmd/commands/server/controller_db_swap_test.go
+++ b/internal/cmd/commands/server/controller_db_swap_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/cmd/commands/server/listener_reload_test.go
+++ b/internal/cmd/commands/server/listener_reload_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build !hsm
 // +build !hsm

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/cmd/commands/server/server_test.go
+++ b/internal/cmd/commands/server/server_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/cmd/commands/server/worker_initial_upstreams_reload_test.go
+++ b/internal/cmd/commands/server/worker_initial_upstreams_reload_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build !hsm
 

--- a/internal/cmd/commands/server/worker_shutdown_reload_test.go
+++ b/internal/cmd/commands/server/worker_shutdown_reload_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build !hsm
 // +build !hsm

--- a/internal/cmd/commands/server/worker_tags_reload_test.go
+++ b/internal/cmd/commands/server/worker_tags_reload_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build !hsm
 // +build !hsm

--- a/internal/cmd/commands/sessionrecordingscmd/download.go
+++ b/internal/cmd/commands/sessionrecordingscmd/download.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sessionrecordingscmd
 

--- a/internal/cmd/commands/sessionrecordingscmd/funcs.go
+++ b/internal/cmd/commands/sessionrecordingscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sessionrecordingscmd
 

--- a/internal/cmd/commands/sessionscmd/funcs.go
+++ b/internal/cmd/commands/sessionscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sessionscmd
 

--- a/internal/cmd/commands/storagebucketscmd/funcs.go
+++ b/internal/cmd/commands/storagebucketscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package storagebucketscmd
 

--- a/internal/cmd/commands/targetscmd/funcs.go
+++ b/internal/cmd/commands/targetscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package targetscmd
 

--- a/internal/cmd/commands/targetscmd/ssh_funcs.go
+++ b/internal/cmd/commands/targetscmd/ssh_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package targetscmd
 

--- a/internal/cmd/commands/targetscmd/tcp_funcs.go
+++ b/internal/cmd/commands/targetscmd/tcp_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package targetscmd
 

--- a/internal/cmd/commands/userscmd/funcs.go
+++ b/internal/cmd/commands/userscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package userscmd
 

--- a/internal/cmd/commands/version/version.go
+++ b/internal/cmd/commands/version/version.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package version
 

--- a/internal/cmd/commands/workerscmd/certificate-authority.go
+++ b/internal/cmd/commands/workerscmd/certificate-authority.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package workerscmd
 

--- a/internal/cmd/commands/workerscmd/controller-led_funcs.go
+++ b/internal/cmd/commands/workerscmd/controller-led_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package workerscmd
 

--- a/internal/cmd/commands/workerscmd/funcs.go
+++ b/internal/cmd/commands/workerscmd/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package workerscmd
 

--- a/internal/cmd/commands/workerscmd/worker-led_funcs.go
+++ b/internal/cmd/commands/workerscmd/worker-led_funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package workerscmd
 

--- a/internal/cmd/commands_nonwindows.go
+++ b/internal/cmd/commands_nonwindows.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build !windows
 // +build !windows

--- a/internal/cmd/commands_windows.go
+++ b/internal/cmd/commands_windows.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build windows
 // +build windows

--- a/internal/cmd/common/flags.go
+++ b/internal/cmd/common/flags.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/cmd/common/flags_test.go
+++ b/internal/cmd/common/flags_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/cmd/common/help.go
+++ b/internal/cmd/common/help.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/cmd/common/option.go
+++ b/internal/cmd/common/option.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/cmd/common/option_test.go
+++ b/internal/cmd/common/option_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package config
 

--- a/internal/cmd/config/config_load_test.go
+++ b/internal/cmd/config/config_load_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package config_test
 

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package config
 

--- a/internal/cmd/gencli/input.go
+++ b/internal/cmd/gencli/input.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/internal/cmd/gencli/main.go
+++ b/internal/cmd/gencli/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cmd
 

--- a/internal/cmd/ops/server.go
+++ b/internal/cmd/ops/server.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package ops encapsulates the lifecycle of Boundary's ops-purpose listeners
 // and servers: Creating, setting them up, starting and shutdown.

--- a/internal/cmd/ops/server_test.go
+++ b/internal/cmd/ops/server_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package ops
 

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package credential defines interfaces shared by other packages that
 // manage credentials for Boundary sessions.

--- a/internal/credential/options.go
+++ b/internal/credential/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credential
 

--- a/internal/credential/options_test.go
+++ b/internal/credential/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credential
 

--- a/internal/credential/public_ids.go
+++ b/internal/credential/public_ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credential
 

--- a/internal/credential/redact.go
+++ b/internal/credential/redact.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credential
 

--- a/internal/credential/redact_test.go
+++ b/internal/credential/redact_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credential
 

--- a/internal/credential/static/credential_store.go
+++ b/internal/credential/static/credential_store.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/credential_store_test.go
+++ b/internal/credential/static/credential_store_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/doc.go
+++ b/internal/credential/static/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package static implements a credential store for static credentials.
 package static

--- a/internal/credential/static/fields.go
+++ b/internal/credential/static/fields.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/json_credential.go
+++ b/internal/credential/static/json_credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/json_credential_test.go
+++ b/internal/credential/static/json_credential_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/options.go
+++ b/internal/credential/static/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/options_test.go
+++ b/internal/credential/static/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/public_ids.go
+++ b/internal/credential/static/public_ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/query.go
+++ b/internal/credential/static/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/repository.go
+++ b/internal/credential/static/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/repository_credential.go
+++ b/internal/credential/static/repository_credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/repository_credential_store.go
+++ b/internal/credential/static/repository_credential_store.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/repository_credential_store_test.go
+++ b/internal/credential/static/repository_credential_store_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/repository_credential_test.go
+++ b/internal/credential/static/repository_credential_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/repository_credentials.go
+++ b/internal/credential/static/repository_credentials.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/repository_credentials_test.go
+++ b/internal/credential/static/repository_credentials_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/repository_test.go
+++ b/internal/credential/static/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/rewrapping.go
+++ b/internal/credential/static/rewrapping.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/rewrapping_test.go
+++ b/internal/credential/static/rewrapping_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/ssh_private_key_credential.go
+++ b/internal/credential/static/ssh_private_key_credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/ssh_private_key_credential_test.go
+++ b/internal/credential/static/ssh_private_key_credential_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/testing.go
+++ b/internal/credential/static/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/testing_test.go
+++ b/internal/credential/static/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/usernamepassword_credential.go
+++ b/internal/credential/static/usernamepassword_credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/static/usernamepassword_credential_test.go
+++ b/internal/credential/static/usernamepassword_credential_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/credential/vault/client_certificate.go
+++ b/internal/credential/vault/client_certificate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/client_certificate_test.go
+++ b/internal/credential/vault/client_certificate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/credential.go
+++ b/internal/credential/vault/credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/credential_library.go
+++ b/internal/credential/vault/credential_library.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/credential_library_test.go
+++ b/internal/credential/vault/credential_library_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/credential_store.go
+++ b/internal/credential/vault/credential_store.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/credential_store_test.go
+++ b/internal/credential/vault/credential_store_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/credential_test.go
+++ b/internal/credential/vault/credential_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/doc.go
+++ b/internal/credential/vault/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package vault provides access to credentials retrieved from a Vault
 // server.

--- a/internal/credential/vault/docker.go
+++ b/internal/credential/vault/docker.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/fields.go
+++ b/internal/credential/vault/fields.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/internal/sshprivatekey/doc.go
+++ b/internal/credential/vault/internal/sshprivatekey/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package sshprivatekey provides access to the username and ssh private key
 // stored in a Vault secret.

--- a/internal/credential/vault/internal/sshprivatekey/sshprivatekey.go
+++ b/internal/credential/vault/internal/sshprivatekey/sshprivatekey.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sshprivatekey
 

--- a/internal/credential/vault/internal/sshprivatekey/sshprivatekey_test.go
+++ b/internal/credential/vault/internal/sshprivatekey/sshprivatekey_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sshprivatekey
 

--- a/internal/credential/vault/internal/usernamepassword/doc.go
+++ b/internal/credential/vault/internal/usernamepassword/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package usernamepassword provides access to the username and password
 // stored in a Vault secret.

--- a/internal/credential/vault/internal/usernamepassword/usernamepassword.go
+++ b/internal/credential/vault/internal/usernamepassword/usernamepassword.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package usernamepassword
 

--- a/internal/credential/vault/internal/usernamepassword/usernamepassword_test.go
+++ b/internal/credential/vault/internal/usernamepassword/usernamepassword_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package usernamepassword
 

--- a/internal/credential/vault/jobs.go
+++ b/internal/credential/vault/jobs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/jobs_test.go
+++ b/internal/credential/vault/jobs_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/mapping_overriders.go
+++ b/internal/credential/vault/mapping_overriders.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/mapping_overriders_test.go
+++ b/internal/credential/vault/mapping_overriders_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/options.go
+++ b/internal/credential/vault/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/options_test.go
+++ b/internal/credential/vault/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/private_credential.go
+++ b/internal/credential/vault/private_credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/private_library.go
+++ b/internal/credential/vault/private_library.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/private_library_test.go
+++ b/internal/credential/vault/private_library_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/private_store.go
+++ b/internal/credential/vault/private_store.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/private_store_test.go
+++ b/internal/credential/vault/private_store_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/public_ids.go
+++ b/internal/credential/vault/public_ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/query.go
+++ b/internal/credential/vault/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/repository.go
+++ b/internal/credential/vault/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/repository_credential_library.go
+++ b/internal/credential/vault/repository_credential_library.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/repository_credential_library_test.go
+++ b/internal/credential/vault/repository_credential_library_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/repository_credential_store.go
+++ b/internal/credential/vault/repository_credential_store.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/repository_credential_store_test.go
+++ b/internal/credential/vault/repository_credential_store_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/repository_credentials.go
+++ b/internal/credential/vault/repository_credentials.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/repository_credentials_test.go
+++ b/internal/credential/vault/repository_credentials_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault_test
 

--- a/internal/credential/vault/repository_ssh_certificate_credential_library.go
+++ b/internal/credential/vault/repository_ssh_certificate_credential_library.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/repository_ssh_certificate_credential_library_test.go
+++ b/internal/credential/vault/repository_ssh_certificate_credential_library_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/repository_test.go
+++ b/internal/credential/vault/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/rewrapping.go
+++ b/internal/credential/vault/rewrapping.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/rewrapping_test.go
+++ b/internal/credential/vault/rewrapping_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/secret.go
+++ b/internal/credential/vault/secret.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/secret_test.go
+++ b/internal/credential/vault/secret_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/setup_manual_test.go
+++ b/internal/credential/vault/setup_manual_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault_test
 

--- a/internal/credential/vault/ssh_certificate_credential_library.go
+++ b/internal/credential/vault/ssh_certificate_credential_library.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/supported.go
+++ b/internal/credential/vault/supported.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build linux || darwin || windows
 // +build linux darwin windows

--- a/internal/credential/vault/testing.go
+++ b/internal/credential/vault/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/testing_external_test.go
+++ b/internal/credential/vault/testing_external_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault_test
 

--- a/internal/credential/vault/testing_test.go
+++ b/internal/credential/vault/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/vault.go
+++ b/internal/credential/vault/vault.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/vault_capabilities.go
+++ b/internal/credential/vault/vault_capabilities.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/vault_capabilities_test.go
+++ b/internal/credential/vault/vault_capabilities_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/vault_test.go
+++ b/internal/credential/vault/vault_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/vault_token.go
+++ b/internal/credential/vault/vault_token.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/credential/vault/vault_token_test.go
+++ b/internal/credential/vault/vault_token_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/internal/daemon/cluster/connstate.go
+++ b/internal/daemon/cluster/connstate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/daemon/cluster/connstate_test.go
+++ b/internal/daemon/cluster/connstate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/daemon/cluster/downstreammanager.go
+++ b/internal/daemon/cluster/downstreammanager.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/daemon/cluster/downstreammanager_test.go
+++ b/internal/daemon/cluster/downstreammanager_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/daemon/cluster/handlers/multihop_service.go
+++ b/internal/daemon/cluster/handlers/multihop_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/cluster/handlers/options.go
+++ b/internal/daemon/cluster/handlers/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/cluster/handlers/testing.go
+++ b/internal/daemon/cluster/handlers/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/cluster/handlers/upstream_message_service_controller.go
+++ b/internal/daemon/cluster/handlers/upstream_message_service_controller.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/cluster/handlers/upstream_message_service_test.go
+++ b/internal/daemon/cluster/handlers/upstream_message_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/cluster/handlers/upstream_message_service_worker.go
+++ b/internal/daemon/cluster/handlers/upstream_message_service_worker.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/cluster/handlers/worker_service.go
+++ b/internal/daemon/cluster/handlers/worker_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/cluster/handlers/worker_service_status_test.go
+++ b/internal/daemon/cluster/handlers/worker_service_status_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/cluster/handlers/worker_service_test.go
+++ b/internal/daemon/cluster/handlers/worker_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/cluster/tracking_listener.go
+++ b/internal/daemon/cluster/tracking_listener.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/daemon/common/client_ip.go
+++ b/internal/daemon/common/client_ip.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/daemon/common/client_ip_test.go
+++ b/internal/daemon/common/client_ip_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/daemon/common/const.go
+++ b/internal/daemon/common/const.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/daemon/common/handler.go
+++ b/internal/daemon/common/handler.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/daemon/common/handler_test.go
+++ b/internal/daemon/common/handler_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/daemon/common/worker_list.go
+++ b/internal/daemon/common/worker_list.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/daemon/controller/auth/auth.go
+++ b/internal/daemon/controller/auth/auth.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package auth
 

--- a/internal/daemon/controller/auth/auth_test.go
+++ b/internal/daemon/controller/auth/auth_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package auth
 

--- a/internal/daemon/controller/auth/authorized_actions.go
+++ b/internal/daemon/controller/auth/authorized_actions.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package auth
 

--- a/internal/daemon/controller/auth/option.go
+++ b/internal/daemon/controller/auth/option.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package auth
 

--- a/internal/daemon/controller/auth/options_test.go
+++ b/internal/daemon/controller/auth/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package auth
 

--- a/internal/daemon/controller/auth/testing.go
+++ b/internal/daemon/controller/auth/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package auth
 

--- a/internal/daemon/controller/common/common.go
+++ b/internal/daemon/controller/common/common.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/daemon/controller/common/doc.go
+++ b/internal/daemon/controller/common/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package common contains types and helper functions that are used across the different packages under
 // internal/server/controller.

--- a/internal/daemon/controller/common/scopeids/scope_ids.go
+++ b/internal/daemon/controller/common/scopeids/scope_ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scopeids
 

--- a/internal/daemon/controller/common/scopeids/scope_ids_test.go
+++ b/internal/daemon/controller/common/scopeids/scope_ids_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scopeids_test
 

--- a/internal/daemon/controller/config.go
+++ b/internal/daemon/controller/config.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/controller.go
+++ b/internal/daemon/controller/controller.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/controller_test.go
+++ b/internal/daemon/controller/controller_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/cors_test.go
+++ b/internal/daemon/controller/cors_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/gateway.go
+++ b/internal/daemon/controller/gateway.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/gateway_test.go
+++ b/internal/daemon/controller/gateway_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/handler.go
+++ b/internal/daemon/controller/handler.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/handler_noui.go
+++ b/internal/daemon/controller/handler_noui.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/handler_test.go
+++ b/internal/daemon/controller/handler_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/handler_ui.go
+++ b/internal/daemon/controller/handler_ui.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build ui
 

--- a/internal/daemon/controller/handler_ui_test.go
+++ b/internal/daemon/controller/handler_ui_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build ui
 

--- a/internal/daemon/controller/handlers/accounts/account_service.go
+++ b/internal/daemon/controller/handlers/accounts/account_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package accounts
 

--- a/internal/daemon/controller/handlers/accounts/account_service_test.go
+++ b/internal/daemon/controller/handlers/accounts/account_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package accounts_test
 

--- a/internal/daemon/controller/handlers/accounts/validate_test.go
+++ b/internal/daemon/controller/handlers/accounts/validate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package accounts
 

--- a/internal/daemon/controller/handlers/authmethods/authmethod_service.go
+++ b/internal/daemon/controller/handlers/authmethods/authmethod_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods
 

--- a/internal/daemon/controller/handlers/authmethods/authmethod_service_test.go
+++ b/internal/daemon/controller/handlers/authmethods/authmethod_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods_test
 

--- a/internal/daemon/controller/handlers/authmethods/authmethod_test.go
+++ b/internal/daemon/controller/handlers/authmethods/authmethod_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods
 

--- a/internal/daemon/controller/handlers/authmethods/ldap.go
+++ b/internal/daemon/controller/handlers/authmethods/ldap.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods
 

--- a/internal/daemon/controller/handlers/authmethods/ldap_test.go
+++ b/internal/daemon/controller/handlers/authmethods/ldap_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods_test
 

--- a/internal/daemon/controller/handlers/authmethods/oidc.go
+++ b/internal/daemon/controller/handlers/authmethods/oidc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods
 

--- a/internal/daemon/controller/handlers/authmethods/oidc_test.go
+++ b/internal/daemon/controller/handlers/authmethods/oidc_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods_test
 

--- a/internal/daemon/controller/handlers/authmethods/password.go
+++ b/internal/daemon/controller/handlers/authmethods/password.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods
 

--- a/internal/daemon/controller/handlers/authmethods/password_test.go
+++ b/internal/daemon/controller/handlers/authmethods/password_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods_test
 

--- a/internal/daemon/controller/handlers/authtokens/authtoken_service.go
+++ b/internal/daemon/controller/handlers/authtokens/authtoken_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtokens
 

--- a/internal/daemon/controller/handlers/authtokens/authtoken_service_test.go
+++ b/internal/daemon/controller/handlers/authtokens/authtoken_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtokens_test
 

--- a/internal/daemon/controller/handlers/credentiallibraries/credentiallibrary_service.go
+++ b/internal/daemon/controller/handlers/credentiallibraries/credentiallibrary_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentiallibraries
 

--- a/internal/daemon/controller/handlers/credentiallibraries/credentiallibrary_service_test.go
+++ b/internal/daemon/controller/handlers/credentiallibraries/credentiallibrary_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentiallibraries
 

--- a/internal/daemon/controller/handlers/credentials/credential_service.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentials
 

--- a/internal/daemon/controller/handlers/credentials/credential_service_test.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentials
 

--- a/internal/daemon/controller/handlers/credentialstores/credentialstore_service.go
+++ b/internal/daemon/controller/handlers/credentialstores/credentialstore_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialstores
 

--- a/internal/daemon/controller/handlers/credentialstores/credentialstore_service_test.go
+++ b/internal/daemon/controller/handlers/credentialstores/credentialstore_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialstores
 

--- a/internal/daemon/controller/handlers/credentialstores/vault.go
+++ b/internal/daemon/controller/handlers/credentialstores/vault.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialstores
 

--- a/internal/daemon/controller/handlers/credentialstores/vault_test.go
+++ b/internal/daemon/controller/handlers/credentialstores/vault_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialstores
 

--- a/internal/daemon/controller/handlers/errors.go
+++ b/internal/daemon/controller/handlers/errors.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/errors_test.go
+++ b/internal/daemon/controller/handlers/errors_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/filtering.go
+++ b/internal/daemon/controller/handlers/filtering.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/filtering_test.go
+++ b/internal/daemon/controller/handlers/filtering_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/groups/group_service.go
+++ b/internal/daemon/controller/handlers/groups/group_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package groups
 

--- a/internal/daemon/controller/handlers/groups/group_service_test.go
+++ b/internal/daemon/controller/handlers/groups/group_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package groups_test
 

--- a/internal/daemon/controller/handlers/health/health.go
+++ b/internal/daemon/controller/handlers/health/health.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package health
 

--- a/internal/daemon/controller/handlers/health/health_test.go
+++ b/internal/daemon/controller/handlers/health/health_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package health
 

--- a/internal/daemon/controller/handlers/host_catalogs/host_catalog_service.go
+++ b/internal/daemon/controller/handlers/host_catalogs/host_catalog_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host_catalogs
 

--- a/internal/daemon/controller/handlers/host_catalogs/host_catalog_service_test.go
+++ b/internal/daemon/controller/handlers/host_catalogs/host_catalog_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host_catalogs_test
 

--- a/internal/daemon/controller/handlers/host_sets/host_set_service.go
+++ b/internal/daemon/controller/handlers/host_sets/host_set_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host_sets
 

--- a/internal/daemon/controller/handlers/host_sets/host_set_service_test.go
+++ b/internal/daemon/controller/handlers/host_sets/host_set_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host_sets_test
 

--- a/internal/daemon/controller/handlers/hosts/host_service.go
+++ b/internal/daemon/controller/handlers/hosts/host_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hosts
 

--- a/internal/daemon/controller/handlers/hosts/host_service_test.go
+++ b/internal/daemon/controller/handlers/hosts/host_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hosts_test
 

--- a/internal/daemon/controller/handlers/managed_groups/managed_group_service.go
+++ b/internal/daemon/controller/handlers/managed_groups/managed_group_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package managed_groups
 

--- a/internal/daemon/controller/handlers/managed_groups/managed_group_service_test.go
+++ b/internal/daemon/controller/handlers/managed_groups/managed_group_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package managed_groups_test
 

--- a/internal/daemon/controller/handlers/managed_groups/validate_test.go
+++ b/internal/daemon/controller/handlers/managed_groups/validate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package managed_groups
 

--- a/internal/daemon/controller/handlers/marshaler.go
+++ b/internal/daemon/controller/handlers/marshaler.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/mask_manager.go
+++ b/internal/daemon/controller/handlers/mask_manager.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/mask_manager_test.go
+++ b/internal/daemon/controller/handlers/mask_manager_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/option_test.go
+++ b/internal/daemon/controller/handlers/option_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/options.go
+++ b/internal/daemon/controller/handlers/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/outgoing_response_filter.go
+++ b/internal/daemon/controller/handlers/outgoing_response_filter.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/outgoing_response_filter_test.go
+++ b/internal/daemon/controller/handlers/outgoing_response_filter_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/roles/role_service.go
+++ b/internal/daemon/controller/handlers/roles/role_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package roles
 

--- a/internal/daemon/controller/handlers/roles/role_service_test.go
+++ b/internal/daemon/controller/handlers/roles/role_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package roles_test
 

--- a/internal/daemon/controller/handlers/scopes/scope_service.go
+++ b/internal/daemon/controller/handlers/scopes/scope_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scopes
 

--- a/internal/daemon/controller/handlers/scopes/scope_service_test.go
+++ b/internal/daemon/controller/handlers/scopes/scope_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scopes_test
 

--- a/internal/daemon/controller/handlers/session_recordings/session_recording_service.go
+++ b/internal/daemon/controller/handlers/session_recordings/session_recording_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session_recordings
 

--- a/internal/daemon/controller/handlers/sessions/session_list_benchmarks_test.go
+++ b/internal/daemon/controller/handlers/sessions/session_list_benchmarks_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sessions_test
 

--- a/internal/daemon/controller/handlers/sessions/session_service.go
+++ b/internal/daemon/controller/handlers/sessions/session_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sessions
 

--- a/internal/daemon/controller/handlers/sessions/session_service_test.go
+++ b/internal/daemon/controller/handlers/sessions/session_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sessions_test
 

--- a/internal/daemon/controller/handlers/storage_buckets/storage_bucket_service.go
+++ b/internal/daemon/controller/handlers/storage_buckets/storage_bucket_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package storage_buckets
 

--- a/internal/daemon/controller/handlers/storage_buckets/storage_bucket_service_test.go
+++ b/internal/daemon/controller/handlers/storage_buckets/storage_bucket_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package storage_buckets
 

--- a/internal/daemon/controller/handlers/subtypes.go
+++ b/internal/daemon/controller/handlers/subtypes.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/subtypes_test.go
+++ b/internal/daemon/controller/handlers/subtypes_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/targets/credentials.go
+++ b/internal/daemon/controller/handlers/targets/credentials.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package targets
 

--- a/internal/daemon/controller/handlers/targets/registry.go
+++ b/internal/daemon/controller/handlers/targets/registry.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package targets
 

--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package targets
 

--- a/internal/daemon/controller/handlers/targets/target_service_test.go
+++ b/internal/daemon/controller/handlers/targets/target_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package targets
 

--- a/internal/daemon/controller/handlers/targets/tcp/target_service_test.go
+++ b/internal/daemon/controller/handlers/targets/tcp/target_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp_test
 

--- a/internal/daemon/controller/handlers/targets/tcp/tcp.go
+++ b/internal/daemon/controller/handlers/targets/tcp/tcp.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp
 

--- a/internal/daemon/controller/handlers/targets/testing.go
+++ b/internal/daemon/controller/handlers/targets/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package targets
 

--- a/internal/daemon/controller/handlers/users/user_service.go
+++ b/internal/daemon/controller/handlers/users/user_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package users
 

--- a/internal/daemon/controller/handlers/users/user_service_test.go
+++ b/internal/daemon/controller/handlers/users/user_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package users_test
 

--- a/internal/daemon/controller/handlers/verifiers.go
+++ b/internal/daemon/controller/handlers/verifiers.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/verifiers_test.go
+++ b/internal/daemon/controller/handlers/verifiers_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package handlers
 

--- a/internal/daemon/controller/handlers/workers/worker_service.go
+++ b/internal/daemon/controller/handlers/workers/worker_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package workers
 

--- a/internal/daemon/controller/handlers/workers/worker_service_test.go
+++ b/internal/daemon/controller/handlers/workers/worker_service_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package workers
 

--- a/internal/daemon/controller/interceptor.go
+++ b/internal/daemon/controller/interceptor.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/interceptor_test.go
+++ b/internal/daemon/controller/interceptor_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/internal/metric/api.go
+++ b/internal/daemon/controller/internal/metric/api.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package metric provides functions to initialize the controller specific
 // collectors and hooks to measure metrics and update the relevant collectors.

--- a/internal/daemon/controller/internal/metric/api_test.go
+++ b/internal/daemon/controller/internal/metric/api_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package metric
 

--- a/internal/daemon/controller/internal/metric/cluster.go
+++ b/internal/daemon/controller/internal/metric/cluster.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package metric
 

--- a/internal/daemon/controller/kms_conn_router.go
+++ b/internal/daemon/controller/kms_conn_router.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/listeners.go
+++ b/internal/daemon/controller/listeners.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/listeners_test.go
+++ b/internal/daemon/controller/listeners_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/multi_test.go
+++ b/internal/daemon/controller/multi_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller_test
 

--- a/internal/daemon/controller/rewrapping_test.go
+++ b/internal/daemon/controller/rewrapping_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/rpc_registration.go
+++ b/internal/daemon/controller/rpc_registration.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/rpc_registration_test.go
+++ b/internal/daemon/controller/rpc_registration_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller_test
 

--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/testing_test.go
+++ b/internal/daemon/controller/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/tickers.go
+++ b/internal/daemon/controller/tickers.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/controller/worker_tls_config.go
+++ b/internal/daemon/controller/worker_tls_config.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/internal/daemon/metric/initialize_metrics.go
+++ b/internal/daemon/metric/initialize_metrics.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package metric provides functions to initialize the controller specific
 // collectors and hooks to measure metrics and update the relevant collectors.

--- a/internal/daemon/metric/initialize_metrics_test.go
+++ b/internal/daemon/metric/initialize_metrics_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package metric
 

--- a/internal/daemon/metric/instrument_handlers.go
+++ b/internal/daemon/metric/instrument_handlers.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package metric provides functions to initialize the controller specific
 // collectors and hooks to measure metrics and update the relevant collectors.

--- a/internal/daemon/metric/instrument_handlers_test.go
+++ b/internal/daemon/metric/instrument_handlers_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package metric
 

--- a/internal/daemon/metric/testing.go
+++ b/internal/daemon/metric/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package metric
 

--- a/internal/daemon/worker/addressreceiver.go
+++ b/internal/daemon/worker/addressreceiver.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/auth_rotation.go
+++ b/internal/daemon/worker/auth_rotation.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/auth_rotation_test.go
+++ b/internal/daemon/worker/auth_rotation_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker_test
 

--- a/internal/daemon/worker/common/common.go
+++ b/internal/daemon/worker/common/common.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/daemon/worker/common/doc.go
+++ b/internal/daemon/worker/common/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package common contains types and helper functions that are used across the different packages under
 // internal/server/worker.

--- a/internal/daemon/worker/config.go
+++ b/internal/daemon/worker/config.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/controller_connection.go
+++ b/internal/daemon/worker/controller_connection.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/countingconn.go
+++ b/internal/daemon/worker/countingconn.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/countingconn_test.go
+++ b/internal/daemon/worker/countingconn_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/handler.go
+++ b/internal/daemon/worker/handler.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/health.go
+++ b/internal/daemon/worker/health.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/health_test.go
+++ b/internal/daemon/worker/health_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/internal/metric/cluster_client.go
+++ b/internal/daemon/worker/internal/metric/cluster_client.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package metric
 

--- a/internal/daemon/worker/internal/metric/cluster_client_test.go
+++ b/internal/daemon/worker/internal/metric/cluster_client_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package metric
 

--- a/internal/daemon/worker/internal/metric/cluster_server.go
+++ b/internal/daemon/worker/internal/metric/cluster_server.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package metric
 

--- a/internal/daemon/worker/internal/metric/proxy_http.go
+++ b/internal/daemon/worker/internal/metric/proxy_http.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package metric provides functions to initialize the worker specific
 // collectors and hooks to measure metrics and update the relevant collectors.

--- a/internal/daemon/worker/internal/metric/proxy_ws.go
+++ b/internal/daemon/worker/internal/metric/proxy_ws.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package metric
 

--- a/internal/daemon/worker/internal/metric/proxy_ws_test.go
+++ b/internal/daemon/worker/internal/metric/proxy_ws_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package metric
 

--- a/internal/daemon/worker/listeners.go
+++ b/internal/daemon/worker/listeners.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/listeners_test.go
+++ b/internal/daemon/worker/listeners_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/package_registration.go
+++ b/internal/daemon/worker/package_registration.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/proxy/doc.go
+++ b/internal/daemon/worker/proxy/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package proxy contains a collection of proxy handlers for the worker to call once a
 // connection has been authorized. Each proxy handler should mark the connection as

--- a/internal/daemon/worker/proxy/options.go
+++ b/internal/daemon/worker/proxy/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package proxy
 

--- a/internal/daemon/worker/proxy/options_test.go
+++ b/internal/daemon/worker/proxy/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package proxy
 

--- a/internal/daemon/worker/proxy/proxy.go
+++ b/internal/daemon/worker/proxy/proxy.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package proxy
 

--- a/internal/daemon/worker/proxy/proxy_conn_tracker.go
+++ b/internal/daemon/worker/proxy/proxy_conn_tracker.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package proxy
 

--- a/internal/daemon/worker/proxy/proxy_conn_tracker_test.go
+++ b/internal/daemon/worker/proxy/proxy_conn_tracker_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package proxy
 

--- a/internal/daemon/worker/proxy/proxy_test.go
+++ b/internal/daemon/worker/proxy/proxy_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package proxy
 

--- a/internal/daemon/worker/proxy/proxydialer.go
+++ b/internal/daemon/worker/proxy/proxydialer.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package proxy
 

--- a/internal/daemon/worker/proxy/proxydialer_test.go
+++ b/internal/daemon/worker/proxy/proxydialer_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package proxy
 

--- a/internal/daemon/worker/proxy/tcp/tcp.go
+++ b/internal/daemon/worker/proxy/tcp/tcp.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp
 

--- a/internal/daemon/worker/proxy/tcp/tcp_test.go
+++ b/internal/daemon/worker/proxy/tcp/tcp_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp
 

--- a/internal/daemon/worker/proxy/testing.go
+++ b/internal/daemon/worker/proxy/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package proxy
 

--- a/internal/daemon/worker/proxy/testing_test.go
+++ b/internal/daemon/worker/proxy/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package proxy
 

--- a/internal/daemon/worker/proxy/websocket_codes.go
+++ b/internal/daemon/worker/proxy/websocket_codes.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package proxy
 

--- a/internal/daemon/worker/rpc_registration.go
+++ b/internal/daemon/worker/rpc_registration.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/rpc_registration_test.go
+++ b/internal/daemon/worker/rpc_registration_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker_test
 

--- a/internal/daemon/worker/session/manager.go
+++ b/internal/daemon/worker/session/manager.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/daemon/worker/session/manager_test.go
+++ b/internal/daemon/worker/session/manager_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/daemon/worker/session/session.go
+++ b/internal/daemon/worker/session/session.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/daemon/worker/session/session_test.go
+++ b/internal/daemon/worker/session/session_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/daemon/worker/status.go
+++ b/internal/daemon/worker/status.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/status_test.go
+++ b/internal/daemon/worker/status_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/testing.go
+++ b/internal/daemon/worker/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/testing_test.go
+++ b/internal/daemon/worker/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/worker_proxy_service.go
+++ b/internal/daemon/worker/worker_proxy_service.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/worker_test.go
+++ b/internal/daemon/worker/worker_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/daemon/worker/workerdisconnect_test.go
+++ b/internal/daemon/worker/workerdisconnect_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package worker
 

--- a/internal/db/assert/asserts.go
+++ b/internal/db/assert/asserts.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package dbassert
 

--- a/internal/db/assert/asserts_test.go
+++ b/internal/db/assert/asserts_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package dbassert
 

--- a/internal/db/assert/docs.go
+++ b/internal/db/assert/docs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package dbassert provides a set of assertions for testing the boundary database
 // applications.

--- a/internal/db/backoff.go
+++ b/internal/db/backoff.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/changesafe_reader_writer.go
+++ b/internal/db/changesafe_reader_writer.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/clause.go
+++ b/internal/db/clause.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/common/db.go
+++ b/internal/db/common/db.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package common
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/db_test/db.go
+++ b/internal/db/db_test/db.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package db_test provides some helper funcs for testing db integrations
 package db_test

--- a/internal/db/domains_test.go
+++ b/internal/db/domains_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/id.go
+++ b/internal/db/id.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/id_test.go
+++ b/internal/db/id_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/option.go
+++ b/internal/db/option.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/option_test.go
+++ b/internal/db/option_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/package_registration.go
+++ b/internal/db/package_registration.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/read_writer.go
+++ b/internal/db/read_writer.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/read_writer_ext_test.go
+++ b/internal/db/read_writer_ext_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db_test
 

--- a/internal/db/read_writer_oplog.go
+++ b/internal/db/read_writer_oplog.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/read_writer_test.go
+++ b/internal/db/read_writer_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/sanitize/doc.go
+++ b/internal/db/sanitize/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package sanitize contains a set of functions that sanitizes input received from external
 // systems before being persisted in the database.

--- a/internal/db/sanitize/sanitize.go
+++ b/internal/db/sanitize/sanitize.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sanitize
 

--- a/internal/db/sanitize/sanitize_test.go
+++ b/internal/db/sanitize/sanitize_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sanitize
 

--- a/internal/db/schema/doc.go
+++ b/internal/db/schema/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package schema is used to apply sql migrations to modify the state of a
 // database instance.  It also provides functionality to report on the state of

--- a/internal/db/schema/edition.go
+++ b/internal/db/schema/edition.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema
 

--- a/internal/db/schema/edition_test.go
+++ b/internal/db/schema/edition_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema_test
 

--- a/internal/db/schema/errors.go
+++ b/internal/db/schema/errors.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema
 

--- a/internal/db/schema/export_test.go
+++ b/internal/db/schema/export_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema
 

--- a/internal/db/schema/internal/edition/edition.go
+++ b/internal/db/schema/internal/edition/edition.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package edition provides internal structs for the schema package for
 // defining and organizing database migration editions.

--- a/internal/db/schema/internal/edition/edition_test.go
+++ b/internal/db/schema/internal/edition/edition_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package edition_test
 

--- a/internal/db/schema/internal/edition/options.go
+++ b/internal/db/schema/internal/edition/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package edition
 

--- a/internal/db/schema/internal/log/doc.go
+++ b/internal/db/schema/internal/log/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package log provides internal structs and options for the schema package for
 // tracking logs generated when applying migrations.

--- a/internal/db/schema/internal/log/entry.go
+++ b/internal/db/schema/internal/log/entry.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package log
 

--- a/internal/db/schema/internal/log/options.go
+++ b/internal/db/schema/internal/log/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package log
 

--- a/internal/db/schema/internal/postgres/doc.go
+++ b/internal/db/schema/internal/postgres/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package postgres provides an implementation of the schema.driver interface
 // for a PostgreSQL database.

--- a/internal/db/schema/internal/postgres/ensure_version_test.go
+++ b/internal/db/schema/internal/postgres/ensure_version_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package postgres_test
 

--- a/internal/db/schema/internal/postgres/lock_test.go
+++ b/internal/db/schema/internal/postgres/lock_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package postgres_test
 

--- a/internal/db/schema/internal/postgres/migration_log_test.go
+++ b/internal/db/schema/internal/postgres/migration_log_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package postgres_test
 

--- a/internal/db/schema/internal/postgres/postgres_test.go
+++ b/internal/db/schema/internal/postgres/postgres_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package postgres_test
 

--- a/internal/db/schema/internal/postgres/query.go
+++ b/internal/db/schema/internal/postgres/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package postgres
 

--- a/internal/db/schema/internal/postgres/state_test.go
+++ b/internal/db/schema/internal/postgres/state_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package postgres_test
 

--- a/internal/db/schema/internal/postgres/testing_test.go
+++ b/internal/db/schema/internal/postgres/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package postgres_test
 

--- a/internal/db/schema/internal/provider/provider.go
+++ b/internal/db/schema/internal/provider/provider.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package provider provides an iterator for iterating over all of the
 // migration statements that need to be applied. It will provide the statements

--- a/internal/db/schema/internal/provider/provider_test.go
+++ b/internal/db/schema/internal/provider/provider_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package provider_test
 

--- a/internal/db/schema/manager.go
+++ b/internal/db/schema/manager.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema
 

--- a/internal/db/schema/manager_example_test.go
+++ b/internal/db/schema/manager_example_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema_test
 

--- a/internal/db/schema/manager_test.go
+++ b/internal/db/schema/manager_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema_test
 

--- a/internal/db/schema/migration/migration.go
+++ b/internal/db/schema/migration/migration.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package migration
 

--- a/internal/db/schema/migration_log.go
+++ b/internal/db/schema/migration_log.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema
 

--- a/internal/db/schema/migrations/base.go
+++ b/internal/db/schema/migrations/base.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package migrations contains the base sql statements needed to bootstrap the
 // migration process. These statements setup the tables necessary for tracking

--- a/internal/db/schema/migrations/oss/internal/hook46001/hook.go
+++ b/internal/db/schema/migrations/oss/internal/hook46001/hook.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package hook46001 implements the hook CheckFunc & RepairFunc definitions for CVE-2022-36130.
 //

--- a/internal/db/schema/migrations/oss/internal/hook46001/query.go
+++ b/internal/db/schema/migrations/oss/internal/hook46001/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hook46001
 

--- a/internal/db/schema/migrations/oss/oss.go
+++ b/internal/db/schema/migrations/oss/oss.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package oss is used to embed the sql statements for the oss edition and
 // registering the edition for the schema.Manager.

--- a/internal/db/schema/migrations/oss/oss_test.go
+++ b/internal/db/schema/migrations/oss/oss_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres/8/08_connection_test.go
+++ b/internal/db/schema/migrations/oss/postgres/8/08_connection_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package migration
 

--- a/internal/db/schema/migrations/oss/postgres/9/managed_group_test.go
+++ b/internal/db/schema/migrations/oss/postgres/9/managed_group_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package migration
 

--- a/internal/db/schema/migrations/oss/postgres_11_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_11_01_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres_12_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_12_01_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres_20_05_test.go
+++ b/internal/db/schema/migrations/oss/postgres_20_05_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres_26_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_26_01_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres_2_10_test.go
+++ b/internal/db/schema/migrations/oss/postgres_2_10_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres_30_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_30_01_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres_40_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_40_01_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres_46_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_46_01_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres_52_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_52_01_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres_53_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_53_01_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres_56_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_56_01_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/migrations/oss/postgres_57_01_test.go
+++ b/internal/db/schema/migrations/oss/postgres_57_01_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oss_test
 

--- a/internal/db/schema/options.go
+++ b/internal/db/schema/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema
 

--- a/internal/db/schema/options_test.go
+++ b/internal/db/schema/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema
 

--- a/internal/db/schema/repair.go
+++ b/internal/db/schema/repair.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema
 

--- a/internal/db/schema/repair_test.go
+++ b/internal/db/schema/repair_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema_test
 

--- a/internal/db/schema/schema.go
+++ b/internal/db/schema/schema.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema
 

--- a/internal/db/schema/schema_test.go
+++ b/internal/db/schema/schema_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema_test
 

--- a/internal/db/schema/state.go
+++ b/internal/db/schema/state.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema
 

--- a/internal/db/schema/testing.go
+++ b/internal/db/schema/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package schema
 

--- a/internal/db/sentinel/doc.go
+++ b/internal/db/sentinel/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package sentinel allows for the use of Unicode non-characters to distinguish between
 // Boundary defined sentinels and values provided by external systems.

--- a/internal/db/sentinel/sentinel.go
+++ b/internal/db/sentinel/sentinel.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sentinel
 

--- a/internal/db/sentinel/sentinel_test.go
+++ b/internal/db/sentinel/sentinel_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sentinel
 

--- a/internal/db/testing.go
+++ b/internal/db/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/testing_test.go
+++ b/internal/db/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package db
 

--- a/internal/db/timestamp/scanners.go
+++ b/internal/db/timestamp/scanners.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package timestamp
 

--- a/internal/db/timestamp/scanners_test.go
+++ b/internal/db/timestamp/scanners_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package timestamp
 

--- a/internal/db/timestamp/timestamp.go
+++ b/internal/db/timestamp/timestamp.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package timestamp
 

--- a/internal/errors/code.go
+++ b/internal/errors/code.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors
 

--- a/internal/errors/code_test.go
+++ b/internal/errors/code_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors
 

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors
 

--- a/internal/errors/error_test.go
+++ b/internal/errors/error_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors_test
 

--- a/internal/errors/info.go
+++ b/internal/errors/info.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors
 

--- a/internal/errors/is.go
+++ b/internal/errors/is.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors
 

--- a/internal/errors/is_test.go
+++ b/internal/errors/is_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors_test
 

--- a/internal/errors/kind.go
+++ b/internal/errors/kind.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors
 

--- a/internal/errors/kind_test.go
+++ b/internal/errors/kind_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors
 

--- a/internal/errors/match.go
+++ b/internal/errors/match.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors
 

--- a/internal/errors/match_test.go
+++ b/internal/errors/match_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors
 

--- a/internal/errors/option.go
+++ b/internal/errors/option.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors
 

--- a/internal/errors/option_test.go
+++ b/internal/errors/option_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package errors
 

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package filter
 

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package filter
 

--- a/internal/gen/controller/servers/services/testing.go
+++ b/internal/gen/controller/servers/services/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package services
 

--- a/internal/gen/testing/event/taggable.go
+++ b/internal/gen/testing/event/taggable.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package globals
 

--- a/internal/host/endpoint.go
+++ b/internal/host/endpoint.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host
 

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host
 

--- a/internal/host/host_dns_address.go
+++ b/internal/host/host_dns_address.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host
 

--- a/internal/host/host_ip_address.go
+++ b/internal/host/host_ip_address.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host
 

--- a/internal/host/options.go
+++ b/internal/host/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host
 

--- a/internal/host/options_test.go
+++ b/internal/host/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host
 

--- a/internal/host/plugin/host.go
+++ b/internal/host/plugin/host.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/host_address_test.go
+++ b/internal/host/plugin/host_address_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/host_catalog.go
+++ b/internal/host/plugin/host_catalog.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package plugin provides a plugin host catalog, and plugin host set resource
 // which are used to interact with a host plugin as well as a repository to

--- a/internal/host/plugin/host_catalog_secret.go
+++ b/internal/host/plugin/host_catalog_secret.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/host_catalog_secret_test.go
+++ b/internal/host/plugin/host_catalog_secret_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/host_catalog_test.go
+++ b/internal/host/plugin/host_catalog_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/host_set.go
+++ b/internal/host/plugin/host_set.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/host_set_member.go
+++ b/internal/host/plugin/host_set_member.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/host_set_member_test.go
+++ b/internal/host/plugin/host_set_member_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/host_set_test.go
+++ b/internal/host/plugin/host_set_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/host_test.go
+++ b/internal/host/plugin/host_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/ids.go
+++ b/internal/host/plugin/ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/immutable_fields_test.go
+++ b/internal/host/plugin/immutable_fields_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/job_orphaned_host_cleanup.go
+++ b/internal/host/plugin/job_orphaned_host_cleanup.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/job_orphaned_host_cleanup_test.go
+++ b/internal/host/plugin/job_orphaned_host_cleanup_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/job_set_sync.go
+++ b/internal/host/plugin/job_set_sync.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/job_set_sync_test.go
+++ b/internal/host/plugin/job_set_sync_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/jobs.go
+++ b/internal/host/plugin/jobs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/options.go
+++ b/internal/host/plugin/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/options_test.go
+++ b/internal/host/plugin/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/query.go
+++ b/internal/host/plugin/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/repository.go
+++ b/internal/host/plugin/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package plugin provides a plugin host catalog, and plugin host set resource
 // which are used to interact with a host plugin as well as a repository to

--- a/internal/host/plugin/repository_host.go
+++ b/internal/host/plugin/repository_host.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/repository_host_catalog.go
+++ b/internal/host/plugin/repository_host_catalog.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/repository_host_catalog_test.go
+++ b/internal/host/plugin/repository_host_catalog_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/repository_host_set.go
+++ b/internal/host/plugin/repository_host_set.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/repository_host_set_test.go
+++ b/internal/host/plugin/repository_host_set_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/repository_host_test.go
+++ b/internal/host/plugin/repository_host_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/repository_host_util.go
+++ b/internal/host/plugin/repository_host_util.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/repository_host_util_test.go
+++ b/internal/host/plugin/repository_host_util_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/repository_test.go
+++ b/internal/host/plugin/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/rewrapping.go
+++ b/internal/host/plugin/rewrapping.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/rewrapping_test.go
+++ b/internal/host/plugin/rewrapping_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/testing.go
+++ b/internal/host/plugin/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/plugin/testing_test.go
+++ b/internal/host/plugin/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/host/preferred_endpoint.go
+++ b/internal/host/preferred_endpoint.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host
 

--- a/internal/host/preferred_endpoint_test.go
+++ b/internal/host/preferred_endpoint_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package host_test
 

--- a/internal/host/static/doc.go
+++ b/internal/host/static/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package static provides a host, a host catalog, and a host set suitable
 // for hosts with a static address.

--- a/internal/host/static/example_test.go
+++ b/internal/host/static/example_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static_test
 

--- a/internal/host/static/host.go
+++ b/internal/host/static/host.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/host_catalog.go
+++ b/internal/host/static/host_catalog.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/host_catalog_test.go
+++ b/internal/host/static/host_catalog_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/host_set.go
+++ b/internal/host/static/host_set.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/host_set_member.go
+++ b/internal/host/static/host_set_member.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/host_set_member_test.go
+++ b/internal/host/static/host_set_member_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/host_set_test.go
+++ b/internal/host/static/host_set_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/host_test.go
+++ b/internal/host/static/host_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/immutable_fields_test.go
+++ b/internal/host/static/immutable_fields_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/options.go
+++ b/internal/host/static/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/options_test.go
+++ b/internal/host/static/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/public_ids.go
+++ b/internal/host/static/public_ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/query.go
+++ b/internal/host/static/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/repository.go
+++ b/internal/host/static/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/repository_host.go
+++ b/internal/host/static/repository_host.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/repository_host_catalog.go
+++ b/internal/host/static/repository_host_catalog.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/repository_host_catalog_test.go
+++ b/internal/host/static/repository_host_catalog_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/repository_host_set.go
+++ b/internal/host/static/repository_host_set.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/repository_host_set_member.go
+++ b/internal/host/static/repository_host_set_member.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/repository_host_set_member_test.go
+++ b/internal/host/static/repository_host_set_member_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/repository_host_set_test.go
+++ b/internal/host/static/repository_host_set_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/repository_host_test.go
+++ b/internal/host/static/repository_host_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/repository_test.go
+++ b/internal/host/static/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/testing.go
+++ b/internal/host/static/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/host/static/testing_test.go
+++ b/internal/host/static/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package static
 

--- a/internal/iam/account.go
+++ b/internal/iam/account.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/account_test.go
+++ b/internal/iam/account_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/action.go
+++ b/internal/iam/action.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/action_test.go
+++ b/internal/iam/action_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/docs.go
+++ b/internal/iam/docs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // iam package is for identity access management of boundary.  It includes typical
 // iam resources like Orgs, Projects, Users, Groups, etc.

--- a/internal/iam/group.go
+++ b/internal/iam/group.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/group_member.go
+++ b/internal/iam/group_member.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/group_member_test.go
+++ b/internal/iam/group_member_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/group_test.go
+++ b/internal/iam/group_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/ids.go
+++ b/internal/iam/ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/ids_test.go
+++ b/internal/iam/ids_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/immutable_fields_test.go
+++ b/internal/iam/immutable_fields_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/options.go
+++ b/internal/iam/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/options_test.go
+++ b/internal/iam/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/principal_role.go
+++ b/internal/iam/principal_role.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/principal_role_ext_test.go
+++ b/internal/iam/principal_role_ext_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam_test
 

--- a/internal/iam/principal_role_test.go
+++ b/internal/iam/principal_role_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository.go
+++ b/internal/iam/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_group.go
+++ b/internal/iam/repository_group.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_group_test.go
+++ b/internal/iam/repository_group_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_principal_role.go
+++ b/internal/iam/repository_principal_role.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_principal_role_ext_test.go
+++ b/internal/iam/repository_principal_role_ext_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam_test
 

--- a/internal/iam/repository_principal_role_test.go
+++ b/internal/iam/repository_principal_role_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_role.go
+++ b/internal/iam/repository_role.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_role_grant_ext_test.go
+++ b/internal/iam/repository_role_grant_ext_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam_test
 

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_role_test.go
+++ b/internal/iam/repository_role_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_scope.go
+++ b/internal/iam/repository_scope.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_scope_primary_auth_method_id_test.go
+++ b/internal/iam/repository_scope_primary_auth_method_id_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam_test
 

--- a/internal/iam/repository_scope_test.go
+++ b/internal/iam/repository_scope_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_test.go
+++ b/internal/iam/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_user.go
+++ b/internal/iam/repository_user.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_user_iam_pkg_test.go
+++ b/internal/iam/repository_user_iam_pkg_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/repository_user_test.go
+++ b/internal/iam/repository_user_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam_test
 

--- a/internal/iam/resource.go
+++ b/internal/iam/resource.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/resource_test.go
+++ b/internal/iam/resource_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/role.go
+++ b/internal/iam/role.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/role_grant.go
+++ b/internal/iam/role_grant.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/role_grant_test.go
+++ b/internal/iam/role_grant_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/role_test.go
+++ b/internal/iam/role_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/scope.go
+++ b/internal/iam/scope.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/scope_test.go
+++ b/internal/iam/scope_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/testing.go
+++ b/internal/iam/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/testing_test.go
+++ b/internal/iam/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/user.go
+++ b/internal/iam/user.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/iam/user_test.go
+++ b/internal/iam/user_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package iam
 

--- a/internal/kms/const.go
+++ b/internal/kms/const.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/data_key_version_destruction_job.go
+++ b/internal/kms/data_key_version_destruction_job.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/data_key_version_destruction_job_progress.go
+++ b/internal/kms/data_key_version_destruction_job_progress.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/data_key_version_destruction_job_progress_test.go
+++ b/internal/kms/data_key_version_destruction_job_progress_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/data_key_version_destruction_job_run.go
+++ b/internal/kms/data_key_version_destruction_job_run.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/data_key_version_destruction_job_run_allowed_table_name.go
+++ b/internal/kms/data_key_version_destruction_job_run_allowed_table_name.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/data_key_version_destruction_job_run_allowed_table_name_test.go
+++ b/internal/kms/data_key_version_destruction_job_run_allowed_table_name_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/data_key_version_destruction_job_run_test.go
+++ b/internal/kms/data_key_version_destruction_job_run_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/data_key_version_destruction_job_test.go
+++ b/internal/kms/data_key_version_destruction_job_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/external_wrappers.go
+++ b/internal/kms/external_wrappers.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/external_wrappers_test.go
+++ b/internal/kms/external_wrappers_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/job/data_key_version_destruction_monitor_job.go
+++ b/internal/kms/job/data_key_version_destruction_monitor_job.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/kms/job/data_key_version_destruction_monitor_job_test.go
+++ b/internal/kms/job/data_key_version_destruction_monitor_job_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/kms/job/job.go
+++ b/internal/kms/job/job.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/kms/job/job_test.go
+++ b/internal/kms/job/job_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/kms/job/table_rewrapping_job.go
+++ b/internal/kms/job/table_rewrapping_job.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/kms/job/table_rewrapping_job_test.go
+++ b/internal/kms/job/table_rewrapping_job_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/kms_ext_test.go
+++ b/internal/kms/kms_ext_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms_test
 

--- a/internal/kms/kms_test.go
+++ b/internal/kms/kms_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/option_test.go
+++ b/internal/kms/option_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/options.go
+++ b/internal/kms/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/query.go
+++ b/internal/kms/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/rewrapping.go
+++ b/internal/kms/rewrapping.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/kms/testing.go
+++ b/internal/kms/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms
 

--- a/internal/libs/crypto/derived_reader.go
+++ b/internal/libs/crypto/derived_reader.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package crypto
 

--- a/internal/libs/crypto/derived_reader_test.go
+++ b/internal/libs/crypto/derived_reader_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package crypto
 

--- a/internal/libs/crypto/error.go
+++ b/internal/libs/crypto/error.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package crypto
 

--- a/internal/libs/crypto/hmac_sha256.go
+++ b/internal/libs/crypto/hmac_sha256.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package crypto
 

--- a/internal/libs/crypto/hmac_sha256_test.go
+++ b/internal/libs/crypto/hmac_sha256_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package crypto
 

--- a/internal/libs/crypto/options.go
+++ b/internal/libs/crypto/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package crypto
 

--- a/internal/libs/crypto/options_test.go
+++ b/internal/libs/crypto/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package crypto
 

--- a/internal/libs/crypto/testing.go
+++ b/internal/libs/crypto/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package crypto
 

--- a/internal/libs/endpoint/doc.go
+++ b/internal/libs/endpoint/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package endpoint
 

--- a/internal/libs/endpoint/matcher.go
+++ b/internal/libs/endpoint/matcher.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package endpoint
 

--- a/internal/libs/endpoint/matcher_test.go
+++ b/internal/libs/endpoint/matcher_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package endpoint
 

--- a/internal/libs/endpoint/option.go
+++ b/internal/libs/endpoint/option.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package endpoint
 

--- a/internal/libs/endpoint/options_test.go
+++ b/internal/libs/endpoint/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package endpoint
 

--- a/internal/libs/endpoint/preferencer.go
+++ b/internal/libs/endpoint/preferencer.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package endpoint
 

--- a/internal/libs/endpoint/preferencer_test.go
+++ b/internal/libs/endpoint/preferencer_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package endpoint
 

--- a/internal/libs/patchstruct/patchstruct.go
+++ b/internal/libs/patchstruct/patchstruct.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package patchstruct
 

--- a/internal/libs/patchstruct/patchstruct_test.go
+++ b/internal/libs/patchstruct/patchstruct_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package patchstruct
 

--- a/internal/observability/event/audit_config.go
+++ b/internal/observability/event/audit_config.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/audit_config_test.go
+++ b/internal/observability/event/audit_config_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/cloudevents_formatter_node.go
+++ b/internal/observability/event/cloudevents_formatter_node.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/cloudevents_formatter_node_test.go
+++ b/internal/observability/event/cloudevents_formatter_node_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/common_keys_values.go
+++ b/internal/observability/event/common_keys_values.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/context.go
+++ b/internal/observability/event/context.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/context_test.go
+++ b/internal/observability/event/context_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event_test
 

--- a/internal/observability/event/context_unexported_test.go
+++ b/internal/observability/event/context_unexported_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/data_classification.go
+++ b/internal/observability/event/data_classification.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/data_classification_test.go
+++ b/internal/observability/event/data_classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/errors.go
+++ b/internal/observability/event/errors.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event.go
+++ b/internal/observability/event/event.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event_audit.go
+++ b/internal/observability/event/event_audit.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event_audit_test.go
+++ b/internal/observability/event/event_audit_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event_delivery_guarantee.go
+++ b/internal/observability/event/event_delivery_guarantee.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event_delivery_guarantee_test.go
+++ b/internal/observability/event/event_delivery_guarantee_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event_error.go
+++ b/internal/observability/event/event_error.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event_error_test.go
+++ b/internal/observability/event/event_error_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event_observation.go
+++ b/internal/observability/event/event_observation.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event_observation_test.go
+++ b/internal/observability/event/event_observation_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event_sys.go
+++ b/internal/observability/event/event_sys.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event_sys_test.go
+++ b/internal/observability/event/event_sys_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/event_type.go
+++ b/internal/observability/event/event_type.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/eventer.go
+++ b/internal/observability/event/eventer.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/eventer_config.go
+++ b/internal/observability/event/eventer_config.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/eventer_config_test.go
+++ b/internal/observability/event/eventer_config_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/eventer_gate_test.go
+++ b/internal/observability/event/eventer_gate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/eventer_retry.go
+++ b/internal/observability/event/eventer_retry.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/eventer_retry_test.go
+++ b/internal/observability/event/eventer_retry_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/eventer_test.go
+++ b/internal/observability/event/eventer_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/filter_operation.go
+++ b/internal/observability/event/filter_operation.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/filter_operation_test.go
+++ b/internal/observability/event/filter_operation_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/hclog_event_adapter.go
+++ b/internal/observability/event/hclog_event_adapter.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/hclog_event_adapter_test.go
+++ b/internal/observability/event/hclog_event_adapter_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/hclog_formatter_node.go
+++ b/internal/observability/event/hclog_formatter_node.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/hclog_formatter_node_test.go
+++ b/internal/observability/event/hclog_formatter_node_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/id.go
+++ b/internal/observability/event/id.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/id_test.go
+++ b/internal/observability/event/id_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/options.go
+++ b/internal/observability/event/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/options_test.go
+++ b/internal/observability/event/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/serialized_writer.go
+++ b/internal/observability/event/serialized_writer.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/serialized_writer_test.go
+++ b/internal/observability/event/serialized_writer_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/signer.go
+++ b/internal/observability/event/signer.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/sink_config.go
+++ b/internal/observability/event/sink_config.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/sink_config_test.go
+++ b/internal/observability/event/sink_config_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/sink_format.go
+++ b/internal/observability/event/sink_format.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/sink_type.go
+++ b/internal/observability/event/sink_type.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/testing.go
+++ b/internal/observability/event/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event
 

--- a/internal/observability/event/testing_test.go
+++ b/internal/observability/event/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package event_test
 

--- a/internal/oplog/docs.go
+++ b/internal/oplog/docs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package oplog is a package for writing operational log (oplog) entries for
 // the purpose of replication and verification of the data stored in the

--- a/internal/oplog/immutable_fields_test.go
+++ b/internal/oplog/immutable_fields_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/oplog.go
+++ b/internal/oplog/oplog.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/oplog_test.go
+++ b/internal/oplog/oplog_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/oplog_test/db.go
+++ b/internal/oplog/oplog_test/db.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package oplog_test provides some gorm helper funcs for testing oplog database integrations
 package oplog_test

--- a/internal/oplog/options.go
+++ b/internal/oplog/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/options_test.go
+++ b/internal/oplog/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/queue.go
+++ b/internal/oplog/queue.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/queue_test.go
+++ b/internal/oplog/queue_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/replayable.go
+++ b/internal/oplog/replayable.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/store/doc.go
+++ b/internal/oplog/store/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package store provides storage types/behavior for the oplog
 package store

--- a/internal/oplog/store/oplog_entry.go
+++ b/internal/oplog/store/oplog_entry.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package store
 

--- a/internal/oplog/testing.go
+++ b/internal/oplog/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/testing_test.go
+++ b/internal/oplog/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/ticketer.go
+++ b/internal/oplog/ticketer.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/ticketer_test.go
+++ b/internal/oplog/ticketer_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/type_catalog.go
+++ b/internal/oplog/type_catalog.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/type_catalog_test.go
+++ b/internal/oplog/type_catalog_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/writer.go
+++ b/internal/oplog/writer.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/oplog/writer_test.go
+++ b/internal/oplog/writer_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package oplog
 

--- a/internal/perms/acl.go
+++ b/internal/perms/acl.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package perms
 

--- a/internal/perms/acl_test.go
+++ b/internal/perms/acl_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package perms
 

--- a/internal/perms/doc.go
+++ b/internal/perms/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 /*
 Package perms provides the boundary permissions engine using grants which are

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package perms
 

--- a/internal/perms/grants_test.go
+++ b/internal/perms/grants_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package perms
 

--- a/internal/perms/option.go
+++ b/internal/perms/option.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package perms
 

--- a/internal/perms/option_test.go
+++ b/internal/perms/option_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package perms
 

--- a/internal/perms/output_fields.go
+++ b/internal/perms/output_fields.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package perms
 

--- a/internal/perms/output_fields_test.go
+++ b/internal/perms/output_fields_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package perms
 

--- a/internal/plugin/doc.go
+++ b/internal/plugin/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package plugin contains other packages related to the different plugin
 // types and any helpers related to working with non type specific plugins.

--- a/internal/plugin/ids.go
+++ b/internal/plugin/ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/plugin/immutable_fields_test.go
+++ b/internal/plugin/immutable_fields_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/plugin/loopback/client.go
+++ b/internal/plugin/loopback/client.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package loopback
 

--- a/internal/plugin/loopback/host.go
+++ b/internal/plugin/loopback/host.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package loopback
 

--- a/internal/plugin/loopback/host_test.go
+++ b/internal/plugin/loopback/host_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package loopback
 

--- a/internal/plugin/loopback/loopback.go
+++ b/internal/plugin/loopback/loopback.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package loopback
 

--- a/internal/plugin/loopback/options.go
+++ b/internal/plugin/loopback/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package loopback
 

--- a/internal/plugin/loopback/storage.go
+++ b/internal/plugin/loopback/storage.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package loopback
 

--- a/internal/plugin/loopback/storage_test.go
+++ b/internal/plugin/loopback/storage_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package loopback
 

--- a/internal/plugin/loopback/testing_grpc_stream.go
+++ b/internal/plugin/loopback/testing_grpc_stream.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package loopback
 

--- a/internal/plugin/loopback/testing_grpc_stream_test.go
+++ b/internal/plugin/loopback/testing_grpc_stream_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package loopback
 

--- a/internal/plugin/options.go
+++ b/internal/plugin/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/plugin/options_test.go
+++ b/internal/plugin/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/plugin/repository.go
+++ b/internal/plugin/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/plugin/repository_plugin.go
+++ b/internal/plugin/repository_plugin.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/plugin/repository_plugin_test.go
+++ b/internal/plugin/repository_plugin_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/plugin/repository_test.go
+++ b/internal/plugin/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/plugin/testing.go
+++ b/internal/plugin/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/plugin/testing_test.go
+++ b/internal/plugin/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/proto/controller/api/.copywrite.hcl
+++ b/internal/proto/controller/api/.copywrite.hcl
@@ -1,0 +1,8 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2024
+
+  header_ignore = []
+}

--- a/internal/proto/controller/custom_options/.copywrite.hcl
+++ b/internal/proto/controller/custom_options/.copywrite.hcl
@@ -1,0 +1,8 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2024
+
+  header_ignore = []
+}

--- a/internal/proto/plugin/.copywrite.hcl
+++ b/internal/proto/plugin/.copywrite.hcl
@@ -1,0 +1,8 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2024
+
+  header_ignore = []
+}

--- a/internal/requests/options.go
+++ b/internal/requests/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package requests
 

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package requests
 

--- a/internal/requests/requests_test.go
+++ b/internal/requests/requests_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package requests
 

--- a/internal/scheduler/additional_verification_test.go
+++ b/internal/scheduler/additional_verification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scheduler
 

--- a/internal/scheduler/cleaner/cleaner.go
+++ b/internal/scheduler/cleaner/cleaner.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cleaner
 

--- a/internal/scheduler/cleaner/cleaner_job.go
+++ b/internal/scheduler/cleaner/cleaner_job.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cleaner
 

--- a/internal/scheduler/cleaner/cleaner_test.go
+++ b/internal/scheduler/cleaner/cleaner_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cleaner_test
 

--- a/internal/scheduler/doc.go
+++ b/internal/scheduler/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package scheduler allows callers to register recurring jobs on the controller.  The scheduler
 // will periodically query the repository for registered jobs that should be run.

--- a/internal/scheduler/job.go
+++ b/internal/scheduler/job.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scheduler
 

--- a/internal/scheduler/job/additional_verification_test.go
+++ b/internal/scheduler/job/additional_verification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/doc.go
+++ b/internal/scheduler/job/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package job provides a Job and a Run struct suitable for persisting to
 // the repository.

--- a/internal/scheduler/job/immutable_fields_test.go
+++ b/internal/scheduler/job/immutable_fields_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/job.go
+++ b/internal/scheduler/job/job.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/job_test.go
+++ b/internal/scheduler/job/job_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/options.go
+++ b/internal/scheduler/job/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/options_test.go
+++ b/internal/scheduler/job/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/query.go
+++ b/internal/scheduler/job/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/repository.go
+++ b/internal/scheduler/job/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/repository_job.go
+++ b/internal/scheduler/job/repository_job.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/repository_job_test.go
+++ b/internal/scheduler/job/repository_job_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/repository_run.go
+++ b/internal/scheduler/job/repository_run.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/repository_run_test.go
+++ b/internal/scheduler/job/repository_run_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/repository_test.go
+++ b/internal/scheduler/job/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/run.go
+++ b/internal/scheduler/job/run.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/run_test.go
+++ b/internal/scheduler/job/run_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/status.go
+++ b/internal/scheduler/job/status.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/testing.go
+++ b/internal/scheduler/job/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/job/testing_test.go
+++ b/internal/scheduler/job/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package job
 

--- a/internal/scheduler/options.go
+++ b/internal/scheduler/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scheduler
 

--- a/internal/scheduler/options_test.go
+++ b/internal/scheduler/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scheduler
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scheduler
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scheduler
 

--- a/internal/scheduler/testing.go
+++ b/internal/scheduler/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scheduler
 

--- a/internal/server/job/jobs.go
+++ b/internal/server/job/jobs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package servers
 

--- a/internal/server/job/options.go
+++ b/internal/server/job/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package servers
 

--- a/internal/server/job/options_test.go
+++ b/internal/server/job/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package servers
 

--- a/internal/server/job/rotate_roots_job.go
+++ b/internal/server/job/rotate_roots_job.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package servers
 

--- a/internal/server/job/rotate_roots_job_test.go
+++ b/internal/server/job/rotate_roots_job_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package servers
 

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/options_test.go
+++ b/internal/server/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/public_ids.go
+++ b/internal/server/public_ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/query.go
+++ b/internal/server/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/repository.go
+++ b/internal/server/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/repository_controller.go
+++ b/internal/server/repository_controller.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/repository_controller_test.go
+++ b/internal/server/repository_controller_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/repository_nonce.go
+++ b/internal/server/repository_nonce.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/repository_nonce_test.go
+++ b/internal/server/repository_nonce_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server_test
 

--- a/internal/server/repository_worker.go
+++ b/internal/server/repository_worker.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/repository_worker_test.go
+++ b/internal/server/repository_worker_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server_test
 

--- a/internal/server/repository_workerauth.go
+++ b/internal/server/repository_workerauth.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/repository_workerauth_test.go
+++ b/internal/server/repository_workerauth_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/rewrapping.go
+++ b/internal/server/rewrapping.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/rewrapping_test.go
+++ b/internal/server/rewrapping_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/root_certificate.go
+++ b/internal/server/root_certificate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/root_info.go
+++ b/internal/server/root_info.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/service_reinitialize_roots.go
+++ b/internal/server/service_reinitialize_roots.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/service_reinitialize_roots_test.go
+++ b/internal/server/service_reinitialize_roots_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/service_rotate_roots.go
+++ b/internal/server/service_rotate_roots.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/service_rotate_roots_test.go
+++ b/internal/server/service_rotate_roots_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/state.go
+++ b/internal/server/state.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/store/gorm.go
+++ b/internal/server/store/gorm.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package store
 

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/testing_test.go
+++ b/internal/server/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/worker.go
+++ b/internal/server/worker.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/worker_auth.go
+++ b/internal/server/worker_auth.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/worker_auth_server_led_activation_token.go
+++ b/internal/server/worker_auth_server_led_activation_token.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/worker_auth_server_led_activation_token_test.go
+++ b/internal/server/worker_auth_server_led_activation_token_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/worker_tag.go
+++ b/internal/server/worker_tag.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/worker_tags_test.go
+++ b/internal/server/worker_tags_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/worker_test.go
+++ b/internal/server/worker_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/server/workerauth_store_test.go
+++ b/internal/server/workerauth_store_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package server
 

--- a/internal/session/connection.go
+++ b/internal/session/connection.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/connection_closed_reason.go
+++ b/internal/session/connection_closed_reason.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/connection_closed_with.go
+++ b/internal/session/connection_closed_with.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/connection_closed_with_test.go
+++ b/internal/session/connection_closed_with_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/connection_state.go
+++ b/internal/session/connection_state.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/connection_state_test.go
+++ b/internal/session/connection_state_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/connection_test.go
+++ b/internal/session/connection_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/credential.go
+++ b/internal/session/credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/dynamic_credential.go
+++ b/internal/session/dynamic_credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/ids.go
+++ b/internal/session/ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/ids_test.go
+++ b/internal/session/ids_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/immutable_fields_test.go
+++ b/internal/session/immutable_fields_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/job_delete_terminated_sessions.go
+++ b/internal/session/job_delete_terminated_sessions.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/job_delete_terminated_sessions_test.go
+++ b/internal/session/job_delete_terminated_sessions_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/job_session_cleanup.go
+++ b/internal/session/job_session_cleanup.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/job_session_cleanup_test.go
+++ b/internal/session/job_session_cleanup_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/jobs.go
+++ b/internal/session/jobs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/options.go
+++ b/internal/session/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/options_test.go
+++ b/internal/session/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/query.go
+++ b/internal/session/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/repository.go
+++ b/internal/session/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/repository_connection.go
+++ b/internal/session/repository_connection.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/repository_connection_test.go
+++ b/internal/session/repository_connection_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/repository_credential.go
+++ b/internal/session/repository_credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/repository_credential_test.go
+++ b/internal/session/repository_credential_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/repository_session_test.go
+++ b/internal/session/repository_session_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/repository_test.go
+++ b/internal/session/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/rewrapping.go
+++ b/internal/session/rewrapping.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/rewrapping_test.go
+++ b/internal/session/rewrapping_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/service_authorize_connection.go
+++ b/internal/session/service_authorize_connection.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/service_authorize_connection_test.go
+++ b/internal/session/service_authorize_connection_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/service_close_connections.go
+++ b/internal/session/service_close_connections.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/service_close_connections_test.go
+++ b/internal/session/service_close_connections_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/service_worker_status_report.go
+++ b/internal/session/service_worker_status_report.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/service_worker_status_report_test.go
+++ b/internal/session/service_worker_status_report_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session_test
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/session_connect_with.go
+++ b/internal/session/session_connect_with.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/session_connect_with_test.go
+++ b/internal/session/session_connect_with_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/session_host_set_host.go
+++ b/internal/session/session_host_set_host.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/session_target_address.go
+++ b/internal/session/session_target_address.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/session_worker_protocol.go
+++ b/internal/session/session_worker_protocol.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/state.go
+++ b/internal/session/state.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/state_test.go
+++ b/internal/session/state_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/static_credential.go
+++ b/internal/session/static_credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/term_reason.go
+++ b/internal/session/term_reason.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/testing.go
+++ b/internal/session/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/testing_test.go
+++ b/internal/session/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/util.go
+++ b/internal/session/util.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/session/util_test.go
+++ b/internal/session/util_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package session
 

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package snapshot
 

--- a/internal/snapshot/snapshot_job.go
+++ b/internal/snapshot/snapshot_job.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package snapshot
 

--- a/internal/storage/doc.go
+++ b/internal/storage/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package storage can be used for writing and reading files from storage buckets
 // within external object stores.

--- a/internal/storage/options.go
+++ b/internal/storage/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package storage
 

--- a/internal/storage/options_test.go
+++ b/internal/storage/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package storage
 

--- a/internal/storage/plugin/ids.go
+++ b/internal/storage/plugin/ids.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/storage/plugin/options.go
+++ b/internal/storage/plugin/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/storage/plugin/options_test.go
+++ b/internal/storage/plugin/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/storage/plugin/repository.go
+++ b/internal/storage/plugin/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/storage/plugin/repository_test.go
+++ b/internal/storage/plugin/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/storage/plugin/rewrapping.go
+++ b/internal/storage/plugin/rewrapping.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/storage/plugin/rewrapping_test.go
+++ b/internal/storage/plugin/rewrapping_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/storage/plugin/storage_bucket.go
+++ b/internal/storage/plugin/storage_bucket.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package plugin
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package storage
 

--- a/internal/target/address.go
+++ b/internal/target/address.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/address_test.go
+++ b/internal/target/address_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target_test
 

--- a/internal/target/credential.go
+++ b/internal/target/credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/credential_library.go
+++ b/internal/target/credential_library.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/credential_library_test.go
+++ b/internal/target/credential_library_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target_test
 

--- a/internal/target/credential_source.go
+++ b/internal/target/credential_source.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/credential_test.go
+++ b/internal/target/credential_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target_test
 

--- a/internal/target/exports_test.go
+++ b/internal/target/exports_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/host_set.go
+++ b/internal/target/host_set.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/host_source.go
+++ b/internal/target/host_source.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/options.go
+++ b/internal/target/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/options_test.go
+++ b/internal/target/options_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/query.go
+++ b/internal/target/query.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/registry.go
+++ b/internal/target/registry.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/repository.go
+++ b/internal/target/repository.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/repository_address.go
+++ b/internal/target/repository_address.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/repository_credential_source.go
+++ b/internal/target/repository_credential_source.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/repository_credential_source_test.go
+++ b/internal/target/repository_credential_source_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target_test
 

--- a/internal/target/repository_host_source.go
+++ b/internal/target/repository_host_source.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/repository_test.go
+++ b/internal/target/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/target/target_test.go
+++ b/internal/target/target_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target_test
 

--- a/internal/target/targettest/target.go
+++ b/internal/target/targettest/target.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package targettest provides a test target subtype for use by the target
 // package.  Note that it leverages the tcp.Target's database table to avoid

--- a/internal/target/tcp/exports_test.go
+++ b/internal/target/tcp/exports_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp
 

--- a/internal/target/tcp/immutable_fields_test.go
+++ b/internal/target/tcp/immutable_fields_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp_test
 

--- a/internal/target/tcp/register.go
+++ b/internal/target/tcp/register.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp
 

--- a/internal/target/tcp/repository_credential_source_test.go
+++ b/internal/target/tcp/repository_credential_source_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp_test
 

--- a/internal/target/tcp/repository_host_source_test.go
+++ b/internal/target/tcp/repository_host_source_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp_test
 

--- a/internal/target/tcp/repository_tcp_target_test.go
+++ b/internal/target/tcp/repository_tcp_target_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp_test
 

--- a/internal/target/tcp/repository_test.go
+++ b/internal/target/tcp/repository_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp_test
 

--- a/internal/target/tcp/target.go
+++ b/internal/target/tcp/target.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package tcp provides a Target subtype for a TCP Target.
 // Importing this package will register it with the target package and

--- a/internal/target/tcp/target_test.go
+++ b/internal/target/tcp/target_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp_test
 

--- a/internal/target/tcp/testing.go
+++ b/internal/target/tcp/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp
 

--- a/internal/target/tcp/testing_test.go
+++ b/internal/target/tcp/testing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package tcp_test
 

--- a/internal/target/testing.go
+++ b/internal/target/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package target
 

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package test
 

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package test
 

--- a/internal/tests/api/accounts/account_test.go
+++ b/internal/tests/api/accounts/account_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package accounts_test
 

--- a/internal/tests/api/authmethods/authenticate_test.go
+++ b/internal/tests/api/authmethods/authenticate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods_test
 

--- a/internal/tests/api/authmethods/authmethod_test.go
+++ b/internal/tests/api/authmethods/authmethod_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods_test
 

--- a/internal/tests/api/authmethods/classification_test.go
+++ b/internal/tests/api/authmethods/classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods_test
 

--- a/internal/tests/api/authmethods/service_classification_test.go
+++ b/internal/tests/api/authmethods/service_classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authmethods_test
 

--- a/internal/tests/api/authtokens/authtoken_test.go
+++ b/internal/tests/api/authtokens/authtoken_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtokens_test
 

--- a/internal/tests/api/authtokens/classification_test.go
+++ b/internal/tests/api/authtokens/classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package authtokens_test
 

--- a/internal/tests/api/credentiallibraries/credentiallibrary_classification_test.go
+++ b/internal/tests/api/credentiallibraries/credentiallibrary_classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentiallibraries_test
 

--- a/internal/tests/api/credentiallibraries/credentiallibrary_test.go
+++ b/internal/tests/api/credentiallibraries/credentiallibrary_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentiallibraries_test
 

--- a/internal/tests/api/credentials/credentials_classification_test.go
+++ b/internal/tests/api/credentials/credentials_classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentials_test
 

--- a/internal/tests/api/credentials/credentials_test.go
+++ b/internal/tests/api/credentials/credentials_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentials_test
 

--- a/internal/tests/api/credentialstores/credentialstore_test.go
+++ b/internal/tests/api/credentialstores/credentialstore_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialstores_test
 

--- a/internal/tests/api/credentialstores/credentialstores_classification_test.go
+++ b/internal/tests/api/credentialstores/credentialstores_classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package credentialstores_test
 

--- a/internal/tests/api/groups/classification_test.go
+++ b/internal/tests/api/groups/classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package groups_test
 

--- a/internal/tests/api/groups/group_test.go
+++ b/internal/tests/api/groups/group_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package groups_test
 

--- a/internal/tests/api/hostcatalogs/classification_test.go
+++ b/internal/tests/api/hostcatalogs/classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostcatalogs_test
 

--- a/internal/tests/api/hostcatalogs/host_catalog_test.go
+++ b/internal/tests/api/hostcatalogs/host_catalog_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostcatalogs_test
 

--- a/internal/tests/api/hosts/classification_test.go
+++ b/internal/tests/api/hosts/classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hosts_test
 

--- a/internal/tests/api/hosts/host_test.go
+++ b/internal/tests/api/hosts/host_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hosts_test
 

--- a/internal/tests/api/hostsets/classification_test.go
+++ b/internal/tests/api/hostsets/classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostsets_test
 

--- a/internal/tests/api/hostsets/host_set_test.go
+++ b/internal/tests/api/hostsets/host_set_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package hostsets_test
 

--- a/internal/tests/api/managedgroups/classification_test.go
+++ b/internal/tests/api/managedgroups/classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package managedgroups_test
 

--- a/internal/tests/api/managedgroups/managedgroups_test.go
+++ b/internal/tests/api/managedgroups/managedgroups_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package managedgroups_test
 

--- a/internal/tests/api/roles/classification_test.go
+++ b/internal/tests/api/roles/classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package roles_test
 

--- a/internal/tests/api/roles/role_test.go
+++ b/internal/tests/api/roles/role_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package roles_test
 

--- a/internal/tests/api/scopes/scope_test.go
+++ b/internal/tests/api/scopes/scope_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scopes_test
 

--- a/internal/tests/api/sessions/classification_test.go
+++ b/internal/tests/api/sessions/classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package sessions_test
 

--- a/internal/tests/api/targets/classification_test.go
+++ b/internal/tests/api/targets/classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package targets_test
 

--- a/internal/tests/api/targets/target_test.go
+++ b/internal/tests/api/targets/target_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package targets_test
 

--- a/internal/tests/api/testing.go
+++ b/internal/tests/api/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package api
 

--- a/internal/tests/api/users/classification_test.go
+++ b/internal/tests/api/users/classification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package users_test
 

--- a/internal/tests/api/users/user_test.go
+++ b/internal/tests/api/users/user_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package users_test
 

--- a/internal/tests/api/workers/worker_test.go
+++ b/internal/tests/api/workers/worker_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package workers_test
 

--- a/internal/tests/cluster/anon_listing_test.go
+++ b/internal/tests/cluster/anon_listing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/ipv6_listener_test.go
+++ b/internal/tests/cluster/ipv6_listener_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/multi_controller_worker_test.go
+++ b/internal/tests/cluster/multi_controller_worker_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/package_registry_test.go
+++ b/internal/tests/cluster/package_registry_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/recursive_anon_listing_test.go
+++ b/internal/tests/cluster/recursive_anon_listing_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/session_cleanup_test.go
+++ b/internal/tests/cluster/session_cleanup_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/switch_kms_method_test.go
+++ b/internal/tests/cluster/switch_kms_method_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/unix_listener_test.go
+++ b/internal/tests/cluster/unix_listener_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/util.go
+++ b/internal/tests/cluster/util.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/worker_bytesupdown_test.go
+++ b/internal/tests/cluster/worker_bytesupdown_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/worker_proxy_test.go
+++ b/internal/tests/cluster/worker_proxy_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/worker_replay_test.go
+++ b/internal/tests/cluster/worker_replay_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/worker_tagging_test.go
+++ b/internal/tests/cluster/worker_tagging_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/cluster/x509_verification_test.go
+++ b/internal/tests/cluster/x509_verification_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package cluster
 

--- a/internal/tests/helper/testing_helper.go
+++ b/internal/tests/helper/testing_helper.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package helper
 

--- a/internal/types/action/action.go
+++ b/internal/types/action/action.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package action
 

--- a/internal/types/action/action_test.go
+++ b/internal/types/action/action_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package action
 

--- a/internal/types/resource/resource.go
+++ b/internal/types/resource/resource.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package resource
 

--- a/internal/types/resource/resource_test.go
+++ b/internal/types/resource/resource_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package resource
 

--- a/internal/types/scope/scope.go
+++ b/internal/types/scope/scope.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scope
 

--- a/internal/types/scope/scope_test.go
+++ b/internal/types/scope/scope_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package scope
 

--- a/internal/types/subtypes/attribute_transform.go
+++ b/internal/types/subtypes/attribute_transform.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes
 

--- a/internal/types/subtypes/attribute_transform_test.go
+++ b/internal/types/subtypes/attribute_transform_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes
 

--- a/internal/types/subtypes/attributes.go
+++ b/internal/types/subtypes/attributes.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes
 

--- a/internal/types/subtypes/attributes_test.go
+++ b/internal/types/subtypes/attributes_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes
 

--- a/internal/types/subtypes/error.go
+++ b/internal/types/subtypes/error.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes
 

--- a/internal/types/subtypes/interceptor.go
+++ b/internal/types/subtypes/interceptor.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes
 

--- a/internal/types/subtypes/interceptor_ext_test.go
+++ b/internal/types/subtypes/interceptor_ext_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes_test
 

--- a/internal/types/subtypes/interceptor_test.go
+++ b/internal/types/subtypes/interceptor_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes
 

--- a/internal/types/subtypes/registry.go
+++ b/internal/types/subtypes/registry.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package subtypes provides helpers to work with boundary resource subtypes.
 package subtypes

--- a/internal/types/subtypes/registry_global.go
+++ b/internal/types/subtypes/registry_global.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes
 

--- a/internal/types/subtypes/registry_test.go
+++ b/internal/types/subtypes/registry_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes_test
 

--- a/internal/types/subtypes/source_registry.go
+++ b/internal/types/subtypes/source_registry.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes
 

--- a/internal/types/subtypes/transformations.go
+++ b/internal/types/subtypes/transformations.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package subtypes
 

--- a/internal/ui/assets.go
+++ b/internal/ui/assets.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build ui
 // +build ui

--- a/internal/ui/dummy.go
+++ b/internal/ui/dummy.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build !ui
 // +build !ui

--- a/internal/util/is_nil.go
+++ b/internal/util/is_nil.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package util
 

--- a/internal/util/is_nil_test.go
+++ b/internal/util/is_nil_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package util_test
 

--- a/internal/util/pointer.go
+++ b/internal/util/pointer.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package util
 

--- a/internal/util/template/doc.go
+++ b/internal/util/template/doc.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package template
 

--- a/internal/util/template/funcs.go
+++ b/internal/util/template/funcs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package template
 

--- a/internal/util/template/generate.go
+++ b/internal/util/template/generate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package template
 

--- a/internal/util/template/generate_test.go
+++ b/internal/util/template/generate_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package template
 

--- a/internal/util/template/types.go
+++ b/internal/util/template/types.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package template
 

--- a/internal/website/permstable/permstable.go
+++ b/internal/website/permstable/permstable.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/plugins/boundary/assets.go
+++ b/plugins/boundary/assets.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary_plugin_assets
 

--- a/plugins/boundary/const.go
+++ b/plugins/boundary/const.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary_plugin_assets
 

--- a/plugins/boundary/mains/aws/main.go
+++ b/plugins/boundary/mains/aws/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/plugins/boundary/mains/azure/main.go
+++ b/plugins/boundary/mains/azure/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/plugins/kms/assets.go
+++ b/plugins/kms/assets.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms_plugin_assets
 

--- a/plugins/kms/builtin.go
+++ b/plugins/kms/builtin.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms_plugin_assets
 

--- a/plugins/kms/const.go
+++ b/plugins/kms/const.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package kms_plugin_assets
 

--- a/plugins/kms/mains/alicloudkms/main.go
+++ b/plugins/kms/mains/alicloudkms/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/plugins/kms/mains/awskms/main.go
+++ b/plugins/kms/mains/awskms/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/plugins/kms/mains/azurekeyvault/main.go
+++ b/plugins/kms/mains/azurekeyvault/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/plugins/kms/mains/gcpckms/main.go
+++ b/plugins/kms/mains/gcpckms/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/plugins/kms/mains/ocikms/main.go
+++ b/plugins/kms/mains/ocikms/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/plugins/kms/mains/transit/main.go
+++ b/plugins/kms/mains/transit/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/scripts/remove-gotags-comments/main.go
+++ b/scripts/remove-gotags-comments/main.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package main
 

--- a/testing/controller/controller.go
+++ b/testing/controller/controller.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package controller
 

--- a/testing/controller/docs.go
+++ b/testing/controller/docs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package controller is a package meant for internal testing only.  The interfaces may change or be removed at any time without warning.
 package controller

--- a/testing/dbtest/docs.go
+++ b/testing/dbtest/docs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package dbtest provides a way to create a clean database for tests using
 // template databases.  For it to function properly a postgres database server

--- a/testing/dbtest/option.go
+++ b/testing/dbtest/option.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package dbtest
 

--- a/testing/dbtest/session_list_benchmarks_dump_generation_test.go
+++ b/testing/dbtest/session_list_benchmarks_dump_generation_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package dbtest_test
 

--- a/testing/dbtest/template.go
+++ b/testing/dbtest/template.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package dbtest
 

--- a/testing/dbtest/template_test.go
+++ b/testing/dbtest/template_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package dbtest_test
 

--- a/testing/internal/e2e/boundary/account.go
+++ b/testing/internal/e2e/boundary/account.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/authenticate.go
+++ b/testing/internal/e2e/boundary/authenticate.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/authtoken.go
+++ b/testing/internal/e2e/boundary/authtoken.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/boundary.go
+++ b/testing/internal/e2e/boundary/boundary.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package boundary provides methods for commonly used boundary actions that are used in end-to-end tests.
 package boundary

--- a/testing/internal/e2e/boundary/connect.go
+++ b/testing/internal/e2e/boundary/connect.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/credential.go
+++ b/testing/internal/e2e/boundary/credential.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/env.go
+++ b/testing/internal/e2e/boundary/env.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/group.go
+++ b/testing/internal/e2e/boundary/group.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/host.go
+++ b/testing/internal/e2e/boundary/host.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/role.go
+++ b/testing/internal/e2e/boundary/role.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/scope.go
+++ b/testing/internal/e2e/boundary/scope.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/session.go
+++ b/testing/internal/e2e/boundary/session.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/target.go
+++ b/testing/internal/e2e/boundary/target.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/boundary/user.go
+++ b/testing/internal/e2e/boundary/user.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package boundary
 

--- a/testing/internal/e2e/helpers.go
+++ b/testing/internal/e2e/helpers.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package e2e
 

--- a/testing/internal/e2e/infra/docker.go
+++ b/testing/internal/e2e/infra/docker.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package infra
 

--- a/testing/internal/e2e/infra/env.go
+++ b/testing/internal/e2e/infra/env.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package infra
 

--- a/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_empty_test.go
+++ b/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_empty_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package aws_test
 

--- a/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_test.go
+++ b/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package aws_test
 

--- a/testing/internal/e2e/tests/aws/env_test.go
+++ b/testing/internal/e2e/tests/aws/env_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package aws_test
 

--- a/testing/internal/e2e/tests/aws/worker_test.go
+++ b/testing/internal/e2e/tests/aws/worker_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package aws_test
 

--- a/testing/internal/e2e/tests/base/auth_token_delete_test.go
+++ b/testing/internal/e2e/tests/base/auth_token_delete_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/authenticate_primary_test.go
+++ b/testing/internal/e2e/tests/base/authenticate_primary_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/bytes_up_down_empty_test.go
+++ b/testing/internal/e2e/tests/base/bytes_up_down_empty_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/bytes_up_down_test.go
+++ b/testing/internal/e2e/tests/base/bytes_up_down_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/credential_store_test.go
+++ b/testing/internal/e2e/tests/base/credential_store_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/env_test.go
+++ b/testing/internal/e2e/tests/base/env_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/key_destruction_test.go
+++ b/testing/internal/e2e/tests/base/key_destruction_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/session_cancel_admin_test.go
+++ b/testing/internal/e2e/tests/base/session_cancel_admin_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/session_cancel_group_test.go
+++ b/testing/internal/e2e/tests/base/session_cancel_group_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/session_cancel_user_test.go
+++ b/testing/internal/e2e/tests/base/session_cancel_user_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/session_end_delete_host_set_test.go
+++ b/testing/internal/e2e/tests/base/session_end_delete_host_set_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/session_end_delete_host_test.go
+++ b/testing/internal/e2e/tests/base/session_end_delete_host_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/session_end_delete_project_test.go
+++ b/testing/internal/e2e/tests/base/session_end_delete_project_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/session_end_delete_target_test.go
+++ b/testing/internal/e2e/tests/base/session_end_delete_target_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/session_end_delete_user_test.go
+++ b/testing/internal/e2e/tests/base/session_end_delete_user_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/target_tcp_address_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_address_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/target_tcp_connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_authz_token_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/target_tcp_connect_localhost_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_localhost_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/target_tcp_connect_ssh_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_ssh_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/target_tcp_connect_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base/version_test.go
+++ b/testing/internal/e2e/tests/base/version_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_test
 

--- a/testing/internal/e2e/tests/base_with_vault/credential_store_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/credential_store_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_with_vault_test
 

--- a/testing/internal/e2e/tests/base_with_vault/env_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/env_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_with_vault_test
 

--- a/testing/internal/e2e/tests/base_with_vault/target_tcp_connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/target_tcp_connect_authz_token_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_with_vault_test
 

--- a/testing/internal/e2e/tests/base_with_vault/target_tcp_connect_ssh_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/target_tcp_connect_ssh_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_with_vault_test
 

--- a/testing/internal/e2e/tests/base_with_vault/target_tcp_connect_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/target_tcp_connect_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package base_with_vault_test
 

--- a/testing/internal/e2e/tests/database/env_test.go
+++ b/testing/internal/e2e/tests/database/env_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package database_test
 

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package database_test
 

--- a/testing/internal/e2e/vault/env.go
+++ b/testing/internal/e2e/vault/env.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/testing/internal/e2e/vault/vault.go
+++ b/testing/internal/e2e/vault/vault.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package vault provides methods for commonly used vault actions that are used in end-to-end tests.
 package vault

--- a/testing/vault/docs.go
+++ b/testing/vault/docs.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 // Package vault is a package meant for internal testing only.  The interfaces may change or be removed at any time without warning.
 package vault

--- a/testing/vault/vault.go
+++ b/testing/vault/vault.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package vault
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build tools
 // +build tools

--- a/version/cgo.go
+++ b/version/cgo.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 //go:build cgo
 // +build cgo

--- a/version/feature_manager.go
+++ b/version/feature_manager.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package version
 

--- a/version/feature_manager_test.go
+++ b/version/feature_manager_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package version
 

--- a/version/testing.go
+++ b/version/testing.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package version
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package version
 

--- a/version/version_base.go
+++ b/version/version_base.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package version
 

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
+
 
 package version
 


### PR DESCRIPTION

DO NOT MERGE UNTIL EOY 2023

Migrates to BSL, updates headers.

Implements MPL exceptions workaround from https://github.com/hashicorp/boundary/pull/3569

Updates text in license and copywrite bot files for 2024.
