### PR TITLE
Some pagination test fixes

### DIFF
--- a/internal/credential/service_list_credentials_ext_test.go
+++ b/internal/credential/service_list_credentials_ext_test.go
@@ -453,7 +453,7 @@ func TestService_List(t *testing.T) {
 		require.Empty(t, cmp.Diff(resp7.Items[0], newCred3, cmpOpts...))
 
 		// Refresh again, should get newCred2
-		resp8, err := credential.ListRefreshPage(ctx, []byte("some hash"), 1, filterFunc, resp6.ListToken, repo, credStore.GetPublicId())
+		resp8, err := credential.ListRefreshPage(ctx, []byte("some hash"), 1, filterFunc, resp7.ListToken, repo, credStore.GetPublicId())
 		require.NoError(t, err)
 		require.Equal(t, resp8.ListToken.GrantsHash, []byte("some hash"))
 		require.False(t, resp8.CompleteListing)
@@ -463,7 +463,7 @@ func TestService_List(t *testing.T) {
 		require.Empty(t, cmp.Diff(resp8.Items[0], newCred2, cmpOpts...))
 
 		// Refresh again, should get newCred1
-		resp9, err := credential.ListRefreshPage(ctx, []byte("some hash"), 1, filterFunc, resp6.ListToken, repo, credStore.GetPublicId())
+		resp9, err := credential.ListRefreshPage(ctx, []byte("some hash"), 1, filterFunc, resp8.ListToken, repo, credStore.GetPublicId())
 		require.NoError(t, err)
 		require.Equal(t, resp9.ListToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp9.CompleteListing)
@@ -473,7 +473,7 @@ func TestService_List(t *testing.T) {
 		require.Empty(t, cmp.Diff(resp9.Items[0], newCred1, cmpOpts...))
 
 		// Refresh again, should get no results
-		resp10, err := credential.ListRefresh(ctx, []byte("some hash"), 1, filterFunc, resp6.ListToken, repo, credStore.GetPublicId())
+		resp10, err := credential.ListRefresh(ctx, []byte("some hash"), 1, filterFunc, resp9.ListToken, repo, credStore.GetPublicId())
 		require.NoError(t, err)
 		require.Equal(t, resp10.ListToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp10.CompleteListing)

--- a/internal/credential/service_list_libraries_ext_test.go
+++ b/internal/credential/service_list_libraries_ext_test.go
@@ -423,7 +423,7 @@ func TestLibraryService_List(t *testing.T) {
 		require.Empty(t, cmp.Diff(resp7.Items[0], newLib2, cmpOpts...))
 
 		// Refresh again, should get newLib1
-		resp8, err := credential.ListLibrariesRefreshPage(ctx, []byte("some hash"), 1, filterFunc, resp6.ListToken, repo, credStore.GetPublicId())
+		resp8, err := credential.ListLibrariesRefreshPage(ctx, []byte("some hash"), 1, filterFunc, resp7.ListToken, repo, credStore.GetPublicId())
 		require.NoError(t, err)
 		require.Equal(t, resp8.ListToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp8.CompleteListing)
@@ -433,7 +433,7 @@ func TestLibraryService_List(t *testing.T) {
 		require.Empty(t, cmp.Diff(resp8.Items[0], newLib1, cmpOpts...))
 
 		// Refresh again, should get no results
-		resp9, err := credential.ListLibrariesRefresh(ctx, []byte("some hash"), 1, filterFunc, resp6.ListToken, repo, credStore.GetPublicId())
+		resp9, err := credential.ListLibrariesRefresh(ctx, []byte("some hash"), 1, filterFunc, resp8.ListToken, repo, credStore.GetPublicId())
 		require.NoError(t, err)
 		require.Equal(t, resp9.ListToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp9.CompleteListing)

--- a/internal/session/service_list_ext_test.go
+++ b/internal/session/service_list_ext_test.go
@@ -539,7 +539,7 @@ func TestService_List(t *testing.T) {
 		require.Empty(t, cmp.Diff(resp7.Items[0], newS2, cmpIgnoreUnexportedOpts, cmpIgnoreFieldsOpts))
 
 		// Refresh again, should get newS1
-		resp8, err := session.ListRefreshPage(ctx, []byte("some hash"), 1, filterFunc, resp6.ListToken, repo, true)
+		resp8, err := session.ListRefreshPage(ctx, []byte("some hash"), 1, filterFunc, resp7.ListToken, repo, true)
 		require.NoError(t, err)
 		require.Equal(t, resp8.ListToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp8.CompleteListing)
@@ -549,7 +549,7 @@ func TestService_List(t *testing.T) {
 		require.Empty(t, cmp.Diff(resp8.Items[0], newS1, cmpIgnoreUnexportedOpts, cmpIgnoreFieldsOpts))
 
 		// Refresh again, should get no results
-		resp9, err := session.ListRefresh(ctx, []byte("some hash"), 1, filterFunc, resp6.ListToken, repo, true)
+		resp9, err := session.ListRefresh(ctx, []byte("some hash"), 1, filterFunc, resp8.ListToken, repo, true)
 		require.NoError(t, err)
 		require.Equal(t, resp9.ListToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp9.CompleteListing)

--- a/internal/target/service_list_ext_test.go
+++ b/internal/target/service_list_ext_test.go
@@ -408,7 +408,7 @@ func TestService_List(t *testing.T) {
 		require.Empty(t, cmp.Diff(resp7.Items[0], newT2, cmpOpts))
 
 		// Refresh again, should get newT1
-		resp8, err := target.ListRefreshPage(ctx, []byte("some hash"), 1, filterFunc, resp6.ListToken, repo)
+		resp8, err := target.ListRefreshPage(ctx, []byte("some hash"), 1, filterFunc, resp7.ListToken, repo)
 		require.NoError(t, err)
 		require.Equal(t, resp8.ListToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp8.CompleteListing)
@@ -418,7 +418,7 @@ func TestService_List(t *testing.T) {
 		require.Empty(t, cmp.Diff(resp8.Items[0], newT1, cmpOpts))
 
 		// Refresh again, should get no results
-		resp9, err := target.ListRefresh(ctx, []byte("some hash"), 1, filterFunc, resp6.ListToken, repo)
+		resp9, err := target.ListRefresh(ctx, []byte("some hash"), 1, filterFunc, resp8.ListToken, repo)
 		require.NoError(t, err)
 		require.Equal(t, resp9.ListToken.GrantsHash, []byte("some hash"))
 		require.True(t, resp9.CompleteListing)


### PR DESCRIPTION
It might be surprising that these were passing, but I think functionally this doesn't change anything since our pagination logic actually mutates the incoming list token directly. Better still to have this look correct to avoid confusion.