### PR TITLE
chore(e2e): Avoid error in action if no log files are found

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -255,7 +255,11 @@ jobs:
         run: |
           pushd enos
           scenario="${{ matrix.filter }}"
-          for f in *.log; do mv --  "$f" "${f%.log}_${scenario%% *}.log"; done
+          count=$(find ./*.log 2>/dev/null | wc -l | xargs)
+          if [ "$count" != 0 ]
+          then
+            for f in *.log; do mv --  "$f" "${f%.log}_${scenario%% *}.log"; done
+          fi
           popd
       - name: Upload e2e tests output
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3


### PR DESCRIPTION
This PR makes a small update to the e2e test GitHub Actions workflow. This updates avoids an error showing up in the action summary if no log files were found (i.e. the test failed on the first run). 