### PR TITLE
test(e2e): Add worker ip to aws tests

### DIFF
--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -135,6 +135,10 @@ variable "worker_tag_egress" {
   type    = string
   default = ""
 }
+variable "worker_address" {
+  type    = string
+  default = ""
+}
 variable "test_timeout" {
   type    = string
   default = "15m"
@@ -179,6 +183,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_AWS_BUCKET_NAME           = var.aws_bucket_name
     E2E_WORKER_TAG_INGRESS        = var.worker_tag_ingress
     E2E_WORKER_TAG_EGRESS         = var.worker_tag_egress
+    E2E_WORKER_ADDRESS            = var.worker_address
   }
 
   inline = var.debug_no_run ? [""] : [

--- a/testing/internal/e2e/tests/aws/env_test.go
+++ b/testing/internal/e2e/tests/aws/env_test.go
@@ -19,6 +19,7 @@ type config struct {
 	TargetPort         string `envconfig:"E2E_TARGET_PORT" required:"true"`          // e.g. "22"
 	TargetAddress      string `envconfig:"E2E_TARGET_ADDRESS" required:"true"`       // e.g. "192.168.0.1"
 	WorkerTagEgress    string `envconfig:"E2E_WORKER_TAG_EGRESS" required:"true"`    // e.g. "egress"
+	WorkerAddress      string `envconfig:"E2E_WORKER_ADDRESS" required:"true"`       // e.g. ""192.168.0.2"
 }
 
 func loadTestConfig() (*config, error) {


### PR DESCRIPTION
[ICU-11880](https://hashicorp.atlassian.net/browse/ICU-11880)

This PR updates the e2e test suite to pass in the IP address of a worker to the aws test package. This allows for a test to execute a system command on the worker instance. The desired use case here is to test a scenario where we temporarily fill up the disk space on a worker during session recording.

We will need to update boundary-enterprise's `enos-scenario-e2e-aws_ent` to pass in the worker address to the test.
```
worker_address                = step.create_isolated_worker.worker_address
```

I tested this with the following test...
```
func TestFalloc(t *testing.T) {
	e2e.MaybeSkipTest(t)
	c, err := loadTestConfig()
	require.NoError(t, err)

	ctx := context.Background()
	boundary.AuthenticateAdminCli(t, ctx)

	output := e2e.RunCommand(ctx, "ssh",
		e2e.WithArgs(
			"-i", c.TargetSshKeyPath,
			"-l", c.TargetSshUser,
			"-o", "UserKnownHostsFile=/dev/null",
			"-o", "StrictHostKeyChecking=no",
			"-o", "IdentitiesOnly=yes", // forces the use of the provided key
			c.WorkerAddress,
			"--",
			"df", "-kh",
		),
	)
	require.NoError(t, output.Err, string(output.Stderr))
	t.Log(string(output.Stdout))

	output = e2e.RunCommand(ctx, "ssh",
		e2e.WithArgs(
			"-i", c.TargetSshKeyPath,
			"-l", c.TargetSshUser,
			"-o", "UserKnownHostsFile=/dev/null",
			"-o", "StrictHostKeyChecking=no",
			"-o", "IdentitiesOnly=yes", // forces the use of the provided key
			c.WorkerAddress,
			"--",
			"fallocate", "-l", "1G", "test.txt",
		),
	)
	require.NoError(t, output.Err, string(output.Stderr))
	t.Cleanup(func() {
		output := e2e.RunCommand(ctx, "ssh",
			e2e.WithArgs(
				"-i", c.TargetSshKeyPath,
				"-l", c.TargetSshUser,
				"-o", "UserKnownHostsFile=/dev/null",
				"-o", "StrictHostKeyChecking=no",
				"-o", "IdentitiesOnly=yes", // forces the use of the provided key
				c.WorkerAddress,
				"--",
				"rm", "test.txt",
			),
		)
		require.NoError(t, output.Err, string(output.Stderr))
	})

	output = e2e.RunCommand(ctx, "ssh",
		e2e.WithArgs(
			"-i", c.TargetSshKeyPath,
			"-l", c.TargetSshUser,
			"-o", "UserKnownHostsFile=/dev/null",
			"-o", "StrictHostKeyChecking=no",
			"-o", "IdentitiesOnly=yes", // forces the use of the provided key
			c.WorkerAddress,
			"--",
			"df", "-kh",
		),
	)
	require.NoError(t, output.Err, string(output.Stderr))
	t.Log(string(output.Stdout))
}
```
```
❯ go test -v -count=1  github.com/hashicorp/boundary/testing/internal/e2e/tests/aws -run TestFalloc
=== RUN   TestFalloc
    falloc_test.go:36: Filesystem      Size  Used Avail Use% Mounted on
        /dev/root       7.6G  1.9G  5.8G  25% /
        devtmpfs        470M     0  470M   0% /dev
        tmpfs           478M     0  478M   0% /dev/shm
        tmpfs            96M  864K   95M   1% /run
        tmpfs           5.0M     0  5.0M   0% /run/lock
        tmpfs           478M     0  478M   0% /sys/fs/cgroup
        /dev/loop0       25M   25M     0 100% /snap/amazon-ssm-agent/7628
        /dev/loop1       56M   56M     0 100% /snap/core18/2812
        /dev/loop3       92M   92M     0 100% /snap/lxd/24061
        /dev/loop2       64M   64M     0 100% /snap/core20/2015
        /dev/loop4       41M   41M     0 100% /snap/snapd/20290
        /dev/xvda15     105M  6.1M   99M   6% /boot/efi
        tmpfs            96M     0   96M   0% /run/user/1000
        
    falloc_test.go:80: Filesystem      Size  Used Avail Use% Mounted on
        /dev/root       7.6G  2.9G  4.8G  38% /
        devtmpfs        470M     0  470M   0% /dev
        tmpfs           478M     0  478M   0% /dev/shm
        tmpfs            96M  864K   95M   1% /run
        tmpfs           5.0M     0  5.0M   0% /run/lock
        tmpfs           478M     0  478M   0% /sys/fs/cgroup
        /dev/loop0       25M   25M     0 100% /snap/amazon-ssm-agent/7628
        /dev/loop1       56M   56M     0 100% /snap/core18/2812
        /dev/loop3       92M   92M     0 100% /snap/lxd/24061
        /dev/loop2       64M   64M     0 100% /snap/core20/2015
        /dev/loop4       41M   41M     0 100% /snap/snapd/20290
        /dev/xvda15     105M  6.1M   99M   6% /boot/efi
        tmpfs            96M     0   96M   0% /run/user/1000
        
--- PASS: TestFalloc (4.02s)
PASS
ok      github.com/hashicorp/boundary/testing/internal/e2e/tests/aws    4.411s
```


[ICU-11880]: https://hashicorp.atlassian.net/browse/ICU-11880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ