### PR TITLE
all: fix test failures after rebase

### DIFF
--- a/internal/clientcache/internal/cache/repository_targets_test.go
+++ b/internal/clientcache/internal/cache/repository_targets_test.go
@@ -463,8 +463,18 @@ func TestDefaultTargetRetrievalFunc(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, refTok)
 	assert.Empty(t, removed)
-	assert.Contains(t, got, tar1.Item)
-	assert.Contains(t, got, tar2.Item)
+	found1 := false
+	found2 := false
+	for _, t := range got {
+		if t.Id == tar1.Item.Id {
+			found1 = true
+		}
+		if t.Id == tar2.Item.Id {
+			found2 = true
+		}
+	}
+	assert.True(t, found1, "expected to find target %s in list", tar1.Item.Id)
+	assert.True(t, found2, "expected to find target %s in list", tar2.Item.Id)
 
 	got2, removed2, refTok2, err := defaultTargetFunc(tc.Context(), tc.ApiAddrs()[0], tc.Token().Token, refTok)
 	assert.NoError(t, err)

--- a/internal/daemon/controller/handlers/authtokens/authtoken_service_test.go
+++ b/internal/daemon/controller/handlers/authtokens/authtoken_service_test.go
@@ -608,6 +608,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListAuthTokensResponse{}, "list_token"),
 		),
@@ -630,6 +633,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListAuthTokensResponse{}, "list_token"),
 		),
@@ -653,6 +659,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListAuthTokensResponse{}, "list_token"),
 		),
@@ -698,6 +707,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   []string{deletedAuthToken.Id},
 				EstItemCount: 11,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListAuthTokensResponse{}, "list_token"),
 		),
@@ -720,6 +732,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 11,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListAuthTokensResponse{}, "list_token"),
 		),
@@ -745,6 +760,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 11,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListAuthTokensResponse{}, "list_token"),
 		),
@@ -765,6 +783,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 11,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListAuthTokensResponse{}, "list_token"),
 		),

--- a/internal/daemon/controller/handlers/credentiallibraries/credentiallibrary_service_test.go
+++ b/internal/daemon/controller/handlers/credentiallibraries/credentiallibrary_service_test.go
@@ -2814,6 +2814,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialLibrariesResponse{}, "list_token"),
 		),
@@ -2836,6 +2839,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialLibrariesResponse{}, "list_token"),
 		),
@@ -2859,6 +2865,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialLibrariesResponse{}, "list_token"),
 		),
@@ -2922,6 +2931,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   []string{deletedCredLib.Id},
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialLibrariesResponse{}, "list_token"),
 		),
@@ -2944,6 +2956,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialLibrariesResponse{}, "list_token"),
 		),
@@ -2969,6 +2984,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialLibrariesResponse{}, "list_token"),
 		),
@@ -2989,6 +3007,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialLibrariesResponse{}, "list_token"),
 		),
@@ -3014,6 +3035,9 @@ func TestListPagination(t *testing.T) {
 				SortBy:       "created_time",
 				SortDir:      "desc",
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 		),
 	)

--- a/internal/daemon/controller/handlers/credentials/credential_service_test.go
+++ b/internal/daemon/controller/handlers/credentials/credential_service_test.go
@@ -1594,6 +1594,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 15,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialsResponse{}, "list_token"),
 		),
@@ -1617,6 +1620,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 15,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialsResponse{}, "list_token"),
 		),
@@ -1641,6 +1647,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 15,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialsResponse{}, "list_token"),
 		),
@@ -1707,6 +1716,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   []string{deletedCred.Id},
 				EstItemCount: 15,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialsResponse{}, "list_token"),
 		),
@@ -1728,6 +1740,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 15,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialsResponse{}, "list_token"),
 		),
@@ -1754,6 +1769,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 15,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialsResponse{}, "list_token"),
 		),
@@ -1775,6 +1793,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 15,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialsResponse{}, "list_token"),
 		),
@@ -1802,6 +1823,9 @@ func TestListPagination(t *testing.T) {
 				SortDir:      "desc",
 				RemovedIds:   nil,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialsResponse{}, "list_token"),
 		),

--- a/internal/daemon/controller/handlers/credentialstores/credentialstore_service_test.go
+++ b/internal/daemon/controller/handlers/credentialstores/credentialstore_service_test.go
@@ -1752,6 +1752,12 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
+			cmpopts.SortSlices(func(a, b protocmp.Message) bool {
+				return a.String() < b.String()
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialStoresResponse{}, "list_token"),
 		),
@@ -1775,6 +1781,12 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
+			cmpopts.SortSlices(func(a, b protocmp.Message) bool {
+				return a.String() < b.String()
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialStoresResponse{}, "list_token"),
 		),
@@ -1799,6 +1811,12 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
+			cmpopts.SortSlices(func(a, b protocmp.Message) bool {
+				return a.String() < b.String()
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialStoresResponse{}, "list_token"),
 		),
@@ -1860,6 +1878,12 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   []string{deletedCredStore.Id},
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
+			cmpopts.SortSlices(func(a, b protocmp.Message) bool {
+				return a.String() < b.String()
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialStoresResponse{}, "list_token"),
 		),
@@ -1881,6 +1905,12 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
+			cmpopts.SortSlices(func(a, b protocmp.Message) bool {
+				return a.String() < b.String()
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialStoresResponse{}, "list_token"),
 		),
@@ -1907,6 +1937,12 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
+			cmpopts.SortSlices(func(a, b protocmp.Message) bool {
+				return a.String() < b.String()
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialStoresResponse{}, "list_token"),
 		),
@@ -1928,6 +1964,12 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
+			cmpopts.SortSlices(func(a, b protocmp.Message) bool {
+				return a.String() < b.String()
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialStoresResponse{}, "list_token"),
 		),
@@ -1956,6 +1998,12 @@ func TestListPagination(t *testing.T) {
 				SortDir:      "desc",
 				RemovedIds:   nil,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
+			cmpopts.SortSlices(func(a, b protocmp.Message) bool {
+				return a.String() < b.String()
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListCredentialStoresResponse{}, "list_token"),
 		),

--- a/internal/daemon/controller/handlers/sessions/session_service_test.go
+++ b/internal/daemon/controller/handlers/sessions/session_service_test.go
@@ -665,7 +665,8 @@ func TestList(t *testing.T) {
 				cmpopts.SortSlices(func(a, b string) bool {
 					return a < b
 				}),
-			), "ListSessions(%q) got response %q, wanted %q", tc.req, got, tc.res)
+				protocmp.IgnoreFields(&pbs.ListSessionsResponse{}, "list_token"),
+			))
 
 			// Test with other user
 			otherRequestInfo := authpb.RequestInfo{
@@ -836,6 +837,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListSessionsResponse{}, "list_token"),
 		),
@@ -858,6 +862,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListSessionsResponse{}, "list_token"),
 		),
@@ -881,6 +888,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListSessionsResponse{}, "list_token"),
 		),
@@ -970,6 +980,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   []string{deletedSession.Id},
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListSessionsResponse{}, "list_token"),
 		),
@@ -992,6 +1005,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListSessionsResponse{}, "list_token"),
 		),
@@ -1017,6 +1033,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListSessionsResponse{}, "list_token"),
 		),
@@ -1037,6 +1056,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListSessionsResponse{}, "list_token"),
 		),

--- a/internal/daemon/controller/handlers/targets/tcp/target_service_test.go
+++ b/internal/daemon/controller/handlers/targets/tcp/target_service_test.go
@@ -569,6 +569,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListTargetsResponse{}, "list_token"),
 		),
@@ -591,6 +594,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListTargetsResponse{}, "list_token"),
 		),
@@ -614,6 +620,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListTargetsResponse{}, "list_token"),
 		),
@@ -691,6 +700,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   []string{deletedTarget.Id},
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListTargetsResponse{}, "list_token"),
 		),
@@ -713,6 +725,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListTargetsResponse{}, "list_token"),
 		),
@@ -738,6 +753,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListTargetsResponse{}, "list_token"),
 		),
@@ -758,6 +776,9 @@ func TestListPagination(t *testing.T) {
 				RemovedIds:   nil,
 				EstItemCount: 10,
 			},
+			cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}),
 			protocmp.Transform(),
 			protocmp.IgnoreFields(&pbs.ListTargetsResponse{}, "list_token"),
 		),


### PR DESCRIPTION
The stability of the authorized_actions have been removed in main, so we need to add these sorts to all our new tests.