### PR TITLE
test(e2e): Temporarily turn off cache daemon in CLI Rate Limit test

### DIFF
--- a/testing/internal/e2e/tests/base_plus/rate_limit_test.go
+++ b/testing/internal/e2e/tests/base_plus/rate_limit_test.go
@@ -275,6 +275,14 @@ func TestCliRateLimit(t *testing.T) {
 
 	ctx := context.Background()
 
+	// TODO: Remove this whem CLI request time is improved (when cache daemon is enabled)
+	cmd := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("daemon", "stop"))
+	require.NoError(t, cmd.Err, string(cmd.Stderr))
+	os.Setenv("BOUNDARY_SKIP_CACHE_DAEMON", "true")
+	t.Cleanup(func() {
+		os.Unsetenv("BOUNDARY_SKIP_CACHE_DAEMON")
+	})
+
 	boundary.AuthenticateAdminCli(t, ctx)
 	newOrgId := boundary.CreateNewOrgCli(t, ctx)
 	t.Cleanup(func() {


### PR DESCRIPTION
This PR turns off the client cache daemon during the CLI rate limit e2e test in order to make it pass for now. We will need to remove this once we improve CLI request times when the client cache daemon is enabled.