### PR TITLE
test(e2e): Decrease rate limit in boundary config to resolve failures

### DIFF
--- a/enos/modules/docker_boundary/boundary-config-rate-limit.hcl
+++ b/enos/modules/docker_boundary/boundary-config-rate-limit.hcl
@@ -35,8 +35,8 @@ controller {
     resources = ["host"]
     actions = ["read"]
     per = "auth-token"
-    limit = 5
-    period = "5s"
+    limit = 3
+    period = "10s"
   }
 
   api_rate_limit_max_quotas = 1

--- a/testing/internal/e2e/tests/base_plus/rate_limit_test.go
+++ b/testing/internal/e2e/tests/base_plus/rate_limit_test.go
@@ -359,7 +359,7 @@ func TestCliRateLimit(t *testing.T) {
 	// Log in as a second user and confirm you get a HTTP 503 response
 	t.Log("Logging in as another user...")
 	boundary.AuthenticateCli(t, ctx, bc.AuthMethodId, acctName, acctPassword)
-	for i := 0; i < policyLimit; i++ {
+	for i := 0; i <= policyLimit; i++ {
 		output = e2e.RunCommand(ctx, "boundary", e2e.WithArgs("hosts", "read", "-id", newHostId))
 		t.Log(output.Duration)
 		if output.Err != nil {


### PR DESCRIPTION
In `llb-list-pagination2`, TestCliRateLimit was failing for the following reason
```
    rate_limit_test.go:326: Getting rate limit info...
    rate_limit_test.go:343: Sending multiple CLI requests to hit rate limit...
    rate_limit_test.go:347: 1.356015783s
    rate_limit_test.go:347: 1.354126404s
    rate_limit_test.go:347: 1.355090349s
    rate_limit_test.go:347: 1.352092617s
    rate_limit_test.go:347: 1.352088211s
    rate_limit_test.go:347: 1.353169131s
    rate_limit_test.go:354: 
        	Error Trace:	/src/boundary/testing/internal/e2e/tests/base_plus/rate_limit_test.go:354
        	Error:      	An error is expected but got nil.
        	Test:       	TestCliRateLimit
```

`llb-list-pagination` increased CLI request times, which caused `TestCliRateLimit` to send commands after the first quota expires, preventing the test from being rate-limited. The increased CLI request times is due to the client daemon doing an auth token lookup in the keyring. 

This PR updates the controller config used in the test to reduce the limit so that the test will be able to hit the limit still.