### PR TITLE
Order public_id descending

### DIFF
--- a/internal/authtoken/query.go
+++ b/internal/authtoken/query.go
@@ -17,7 +17,7 @@ with auth_tokens as (
             expiration_time,
             status
        from auth_token
-   order by create_time desc, public_id asc
+   order by create_time desc, public_id desc
       limit %d
 ),
 auth_accounts as (
@@ -47,7 +47,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 	listAuthTokensPageTemplate = `
 with auth_tokens as (
@@ -60,7 +60,7 @@ with auth_tokens as (
             status
        from auth_token
       where (create_time, public_id) < (@last_item_create_time, @last_item_id)
-   order by create_time desc, public_id asc
+   order by create_time desc, public_id desc
       limit %d
 ),
 auth_accounts as (
@@ -90,7 +90,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 	refreshAuthTokensTemplate = `
 with auth_tokens as (
@@ -103,7 +103,7 @@ with auth_tokens as (
             status
        from auth_token
       where update_time > @updated_after_time
-   order by update_time desc, public_id asc
+   order by update_time desc, public_id desc
       limit %d
 ),
 auth_accounts as (
@@ -133,7 +133,7 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 	refreshAuthTokensPageTemplate = `
 with auth_tokens as (
@@ -147,7 +147,7 @@ with auth_tokens as (
        from auth_token
       where update_time > @updated_after_time
         and (update_time, public_id) < (@last_item_update_time, @last_item_id)
-   order by update_time desc, public_id asc
+   order by update_time desc, public_id desc
       limit %d
 ),
 auth_accounts as (
@@ -177,6 +177,6 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 )

--- a/internal/credential/query.go
+++ b/internal/credential/query.go
@@ -26,7 +26,7 @@ with stores as (
     select public_id
       from credential_store
      where %s -- search condition for project IDs is constructed
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 vault_stores as (
@@ -102,7 +102,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	listStoresPageTemplate = `
@@ -111,7 +111,7 @@ with stores as (
       from credential_store
      where (create_time, public_id) < (@last_item_create_time, @last_item_id) and
            %s -- search condition for project IDs is constructed
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 vault_stores as (
@@ -187,7 +187,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	listStoresRefreshTemplate = `
@@ -196,7 +196,7 @@ with stores as (
       from credential_store
      where update_time > @updated_after_time and
            %s -- search condition for project IDs is constructed
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 vault_stores as (
@@ -272,7 +272,7 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 
 	listStoresRefreshPageTemplate = `
@@ -282,7 +282,7 @@ with stores as (
      where update_time > @updated_after_time and
            (update_time, public_id) < (@last_item_update_time, @last_item_id) and
            %s -- search condition for project IDs is constructed
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 vault_stores as (
@@ -358,6 +358,6 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 )

--- a/internal/credential/static/query.go
+++ b/internal/credential/static/query.go
@@ -56,7 +56,7 @@ with credentials as (
     select public_id
       from credential_static
      where store_id = @store_id
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 json_creds as (
@@ -122,7 +122,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	listCredentialsPageTemplate = `
@@ -131,7 +131,7 @@ with credentials as (
       from credential_static
      where store_id = @store_id
        and (create_time, public_id) < (@last_item_create_time, @last_item_id)
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 json_creds as (
@@ -197,7 +197,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	listCredentialsRefreshTemplate = `
@@ -206,7 +206,7 @@ with credentials as (
       from credential_static
      where store_id = @store_id
        and update_time > @updated_after_time
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 json_creds as (
@@ -272,7 +272,7 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 
 	listCredentialsRefreshPageTemplate = `
@@ -282,7 +282,7 @@ with credentials as (
      where store_id = @store_id
        and update_time > @updated_after_time
        and (update_time, public_id) < (@last_item_update_time, @last_item_id)
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 json_creds as (
@@ -348,6 +348,6 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 )

--- a/internal/credential/vault/query.go
+++ b/internal/credential/vault/query.go
@@ -204,7 +204,7 @@ with libraries as (
     select public_id
       from credential_library
      where store_id = @store_id
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 generic_libs as (
@@ -266,7 +266,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	listLibrariesPageTemplate = `
@@ -275,7 +275,7 @@ with libraries as (
       from credential_library
      where store_id = @store_id
        and (create_time, public_id) < (@last_item_create_time, @last_item_id)
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 generic_libs as (
@@ -337,7 +337,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	listLibrariesRefreshTemplate = `
@@ -346,7 +346,7 @@ with libraries as (
       from credential_library
      where store_id = @store_id
        and update_time > @updated_after_time
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 generic_libs as (
@@ -408,7 +408,7 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 
 	listLibrariesRefreshPageTemplate = `
@@ -418,7 +418,7 @@ with libraries as (
      where store_id = @store_id
        and update_time > @updated_after_time
        and (update_time, public_id) < (@last_item_update_time, @last_item_id)
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 generic_libs as (
@@ -480,6 +480,6 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 )

--- a/internal/db/schema/migrations/oss/postgres/80/02_target_base_table_updates.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/80/02_target_base_table_updates.up.sql
@@ -36,9 +36,9 @@ begin;
 
   -- Add new indexes for the update time queries.
   create index target_create_time_public_id_idx
-      on target (create_time desc, public_id asc);
+      on target (create_time desc, public_id desc);
   create index target_update_time_public_id_idx
-      on target (update_time desc, public_id asc);
+      on target (update_time desc, public_id desc);
 
   analyze target;
 

--- a/internal/db/schema/migrations/oss/postgres/80/03_credential_static_base_table_updates.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/80/03_credential_static_base_table_updates.up.sql
@@ -60,9 +60,9 @@ begin;
 
   -- Add new indexes for the create and update time queries.
   create index credential_static_create_time_public_id_idx
-      on credential_static (create_time desc, public_id asc);
+      on credential_static (create_time desc, public_id desc);
   create index credential_static_update_time_public_id_idx
-      on credential_static (update_time desc, public_id asc);
+      on credential_static (update_time desc, public_id desc);
 
   analyze credential_static;
 

--- a/internal/db/schema/migrations/oss/postgres/80/04_credential_library_base_table_updates.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/80/04_credential_library_base_table_updates.up.sql
@@ -54,9 +54,9 @@ begin;
 
   -- Add new indexes for the create and update time queries.
   create index credential_library_create_time_public_id_idx
-      on credential_library (create_time desc, public_id asc);
+      on credential_library (create_time desc, public_id desc);
   create index credential_library_update_time_public_id_idx
-      on credential_library (update_time desc, public_id asc);
+      on credential_library (update_time desc, public_id desc);
 
   analyze credential_library;
 

--- a/internal/db/schema/migrations/oss/postgres/80/05_session_base_table_updates.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/80/05_session_base_table_updates.up.sql
@@ -5,9 +5,9 @@ begin;
 
   -- Add new indexes for the create time and update time queries.
   create index session_create_time_public_id_idx
-      on session (create_time desc, public_id asc);
+      on session (create_time desc, public_id desc);
   create index session_update_time_public_id_idx
-      on session (update_time desc, public_id asc);
+      on session (update_time desc, public_id desc);
 
   analyze session;
 

--- a/internal/db/schema/migrations/oss/postgres/80/06_auth_token_base_table_updates.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/80/06_auth_token_base_table_updates.up.sql
@@ -5,9 +5,9 @@ begin;
 
   -- Add new indexes for the create time and update time queries.
   create index auth_token_create_time_public_id_idx
-      on auth_token (create_time desc, public_id asc);
+      on auth_token (create_time desc, public_id desc);
   create index auth_token_update_time_public_id_idx
-      on auth_token (update_time desc, public_id asc);
+      on auth_token (update_time desc, public_id desc);
 
   analyze auth_token;
 

--- a/internal/db/schema/migrations/oss/postgres/80/07_credential_store_base_table_updates.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/80/07_credential_store_base_table_updates.up.sql
@@ -50,9 +50,9 @@ begin;
 
   -- Add new indexes for the create and update time queries.
   create index credential_store_create_time_public_id_idx
-      on credential_store (create_time desc, public_id asc);
+      on credential_store (create_time desc, public_id desc);
   create index credential_store_update_time_public_id_idx
-      on credential_store (update_time desc, public_id asc);
+      on credential_store (update_time desc, public_id desc);
 
   analyze credential_store;
 

--- a/internal/db/schema/migrations/oss/postgres/80/08_iam_updates.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/80/08_iam_updates.up.sql
@@ -5,9 +5,9 @@ begin;
 
   -- Add new indexes for the create time and update time queries.
   create index iam_role_create_time_public_id_idx
-      on iam_role (create_time desc, public_id asc);
+      on iam_role (create_time desc, public_id desc);
   create index iam_role_update_time_public_id_idx
-      on iam_role (update_time desc, public_id asc);
+      on iam_role (update_time desc, public_id desc);
 
   analyze iam_role;
 

--- a/internal/db/schema/migrations/oss/postgres/80/09_host_table_updates.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/80/09_host_table_updates.up.sql
@@ -5,17 +5,17 @@ begin;
 
   -- Add new indexes for the create time and update time queries.
   create index host_plugin_host_create_time_public_id_idx
-      on host_plugin_host (create_time desc, public_id asc);
+      on host_plugin_host (create_time desc, public_id desc);
   create index host_plugin_host_update_time_public_id_idx
-      on host_plugin_host (update_time desc, public_id asc);
+      on host_plugin_host (update_time desc, public_id desc);
 
   analyze host_plugin_host;
 
   -- Add new indexes for the create time and update time queries.
   create index static_host_create_time_public_id_idx
-      on static_host (create_time desc, public_id asc);
+      on static_host (create_time desc, public_id desc);
   create index static_host_update_time_public_id_idx
-      on static_host (update_time desc, public_id asc);
+      on static_host (update_time desc, public_id desc);
 
   analyze static_host;
 

--- a/internal/host/plugin/query.go
+++ b/internal/host/plugin/query.go
@@ -72,7 +72,7 @@ with hosts as (
            version
       from host_plugin_host
      where catalog_id = @catalog_id
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 host_catalog as (
@@ -126,7 +126,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	listHostsPageTemplate = `
@@ -143,7 +143,7 @@ with hosts as (
       from host_plugin_host
      where catalog_id = @catalog_id
        and (create_time, public_id) < (@last_item_create_time, @last_item_id)
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 host_catalog as (
@@ -197,7 +197,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	listHostsRefreshTemplate = `
@@ -214,7 +214,7 @@ with hosts as (
       from host_plugin_host
      where catalog_id = @catalog_id
        and update_time > @updated_after_time
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 host_catalog as (
@@ -268,7 +268,7 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 
 	listHostsRefreshPageTemplate = `
@@ -286,7 +286,7 @@ with hosts as (
      where catalog_id = @catalog_id
        and update_time > @updated_after_time
        and (update_time, public_id) < (@last_item_update_time, @last_item_id)
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 host_catalog as (
@@ -340,6 +340,6 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 )

--- a/internal/host/static/query.go
+++ b/internal/host/static/query.go
@@ -63,7 +63,7 @@ with hosts as (
            version
       from static_host
      where catalog_id = @catalog_id
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 host_set_ids as (
@@ -88,7 +88,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	listHostsPageTemplate = `
@@ -104,7 +104,7 @@ with hosts as (
       from static_host
      where catalog_id = @catalog_id
        and (create_time, public_id) < (@last_item_create_time, @last_item_id)
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 host_set_ids as (
@@ -129,7 +129,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	listHostsRefreshTemplate = `
@@ -145,7 +145,7 @@ with hosts as (
       from static_host
      where catalog_id = @catalog_id
        and update_time > @updated_after_time
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 host_set_ids as (
@@ -170,7 +170,7 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 	listHostsRefreshPageTemplate = `
 with hosts as (
@@ -186,7 +186,7 @@ with hosts as (
      where catalog_id = @catalog_id
        and update_time > @updated_after_time
        and (update_time, public_id) < (@last_item_update_time, @last_item_id)
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 host_set_ids as (
@@ -211,6 +211,6 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 )

--- a/internal/iam/repository_role.go
+++ b/internal/iam/repository_role.go
@@ -215,7 +215,7 @@ func (r *Repository) listRoles(ctx context.Context, withScopeIds []string, opt .
 			sql.Named("last_item_id", opts.withStartPageAfterItem.GetPublicId()),
 		)
 	}
-	dbOpts := []db.Option{db.WithLimit(limit), db.WithOrder("create_time desc, public_id asc")}
+	dbOpts := []db.Option{db.WithLimit(limit), db.WithOrder("create_time desc, public_id desc")}
 	return r.queryRoles(ctx, whereClause, args, dbOpts...)
 }
 
@@ -257,7 +257,7 @@ func (r *Repository) listRolesRefresh(ctx context.Context, updatedAfter time.Tim
 		)
 	}
 
-	dbOpts := []db.Option{db.WithLimit(limit), db.WithOrder("update_time desc, public_id asc")}
+	dbOpts := []db.Option{db.WithLimit(limit), db.WithOrder("update_time desc, public_id desc")}
 	return r.queryRoles(ctx, whereClause, args, dbOpts...)
 }
 

--- a/internal/session/query.go
+++ b/internal/session/query.go
@@ -429,13 +429,13 @@ with session_ids as (
       from session
            -- search condition for applying permissions is constructed
      where %s
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 )
    select *
      from session_list
     where session_list.public_id in (select * from session_ids)
- order by create_time desc, public_id asc;
+ order by create_time desc, public_id desc;
 `
 	listSessionsPageTemplate = `
 with session_ids as (
@@ -444,13 +444,13 @@ with session_ids as (
      where (create_time, public_id) < (@last_item_create_time, @last_item_id)
            -- search condition for applying permissions is constructed
        and %s
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 )
    select *
      from session_list
     where session_list.public_id in (select * from session_ids)
- order by create_time desc, public_id asc;
+ order by create_time desc, public_id desc;
 `
 	refreshSessionsTemplate = `
 with session_ids as (
@@ -459,13 +459,13 @@ with session_ids as (
      where update_time > @updated_after_time
            -- search condition for applying permissions is constructed
        and %s
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 )
   select *
     from session_list
    where session_list.public_id in (select * from session_ids)
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 	refreshSessionsPageTemplate = `
 with session_ids as (
@@ -475,13 +475,13 @@ with session_ids as (
        and (update_time, public_id) < (@last_item_update_time, @last_item_id)
            -- search condition for applying permissions is constructed
        and %s
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 )
   select *
     from session_list
    where session_list.public_id in (select * from session_ids)
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 	estimateCountSessions = `
     select reltuples::bigint as estimate from pg_class where oid in ('session'::regclass)

--- a/internal/target/query.go
+++ b/internal/target/query.go
@@ -68,7 +68,7 @@ with targets as (
     select public_id
       from target
      where %s -- search condition for applying permissions is constructed
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 tcp_targets as (
@@ -122,7 +122,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	listTargetsPageTemplate = `
@@ -131,7 +131,7 @@ with targets as (
       from target
      where (create_time, public_id) < (@last_item_create_time, @last_item_id)
        and %s -- search condition for applying permissions is constructed
-  order by create_time desc, public_id asc
+  order by create_time desc, public_id desc
      limit %d
 ),
 tcp_targets as (
@@ -185,7 +185,7 @@ final as (
 )
   select *
     from final
-order by create_time desc, public_id asc;
+order by create_time desc, public_id desc;
 `
 
 	refreshTargetsTemplate = `
@@ -194,7 +194,7 @@ with targets as (
       from target
      where update_time > @updated_after_time
        and %s -- search condition for applying permissions is constructed
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 tcp_targets as (
@@ -248,7 +248,7 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 
 	refreshTargetsPageTemplate = `
@@ -258,7 +258,7 @@ with targets as (
      where update_time > @updated_after_time
        and (update_time, public_id) < (@last_item_update_time, @last_item_id)
        and %s -- search condition for applying permissions is constructed
-  order by update_time desc, public_id asc
+  order by update_time desc, public_id desc
      limit %d
 ),
 tcp_targets as (
@@ -312,6 +312,6 @@ final as (
 )
   select *
     from final
-order by update_time desc, public_id asc;
+order by update_time desc, public_id desc;
 `
 )


### PR DESCRIPTION
As @talanknight found, ordering the public_id by ascending while using the compound `(create_time, public_id) <` comparison risks missing items with identical update or create times. Order public_id by descending to keep ordering consistent.