### PR TITLE
internal/authtoken: join to auth_account to filter

### DIFF
--- a/internal/authtoken/query.go
+++ b/internal/authtoken/query.go
@@ -8,175 +8,79 @@ const (
 select reltuples::bigint as estimate from pg_class where oid in ('auth_token'::regclass)
 `
 	listAuthTokensTemplate = `
-with auth_tokens as (
-     select public_id,
-            auth_account_id,
-            create_time,
-            update_time,
-            approximate_last_access_time,
-            expiration_time,
-            status
-       from auth_token
-   order by create_time desc, public_id desc
-      limit %d
-),
-auth_accounts as (
-    select public_id,
-           auth_method_id,
-           scope_id,
-           iam_user_id,
-           iam_user_scope_id
-      from auth_account
-     where %s
-       and public_id in (select auth_account_id from auth_tokens)
-),
-final as (
-    select at.public_id,
-           at.auth_account_id,
-           aa.auth_method_id,
-           aa.scope_id,
-           aa.iam_user_id,
-           aa.iam_user_scope_id,
-           at.create_time,
-           at.update_time,
-           at.approximate_last_access_time,
-           at.expiration_time,
-           at.status
-      from auth_tokens at
-      join auth_accounts aa on aa.public_id = at.auth_account_id
-)
-  select *
-    from final
-order by create_time desc, public_id desc;
+  select at.public_id,
+         at.auth_account_id,
+         aa.scope_id,
+         aa.auth_method_id,
+         aa.iam_user_id,
+         aa.iam_user_scope_id,
+         at.create_time,
+         at.update_time,
+         at.approximate_last_access_time,
+         at.expiration_time,
+         at.status
+    from auth_token at
+    join auth_account aa on aa.public_id = at.auth_account_id
+   where aa.scope_id in @scope_ids
+order by at.create_time desc, at.public_id desc
+   limit %d;
 `
 	listAuthTokensPageTemplate = `
-with auth_tokens as (
-     select public_id,
-            auth_account_id,
-            create_time,
-            update_time,
-            approximate_last_access_time,
-            expiration_time,
-            status
-       from auth_token
-      where (create_time, public_id) < (@last_item_create_time, @last_item_id)
-   order by create_time desc, public_id desc
-      limit %d
-),
-auth_accounts as (
-    select public_id,
-           auth_method_id,
-           scope_id,
-           iam_user_id,
-           iam_user_scope_id
-      from auth_account
-     where %s
-       and public_id in (select auth_account_id from auth_tokens)
-),
-final as (
-    select at.public_id,
-           at.auth_account_id,
-           aa.auth_method_id,
-           aa.scope_id,
-           aa.iam_user_id,
-           aa.iam_user_scope_id,
-           at.create_time,
-           at.update_time,
-           at.approximate_last_access_time,
-           at.expiration_time,
-           at.status
-      from auth_tokens at
-      join auth_accounts aa on aa.public_id = at.auth_account_id
-)
-  select *
-    from final
-order by create_time desc, public_id desc;
+  select at.public_id,
+         at.auth_account_id,
+         aa.scope_id,
+         aa.auth_method_id,
+         aa.iam_user_id,
+         aa.iam_user_scope_id,
+         at.create_time,
+         at.update_time,
+         at.approximate_last_access_time,
+         at.expiration_time,
+         at.status
+    from auth_token at
+    join auth_account aa on aa.public_id = at.auth_account_id
+   where aa.scope_id in @scope_ids
+     and (at.create_time, at.public_id) < (@last_item_create_time, @last_item_id)
+order by at.create_time desc, at.public_id desc
+   limit %d;
 `
 	refreshAuthTokensTemplate = `
-with auth_tokens as (
-     select public_id,
-            auth_account_id,
-            create_time,
-            update_time,
-            approximate_last_access_time,
-            expiration_time,
-            status
-       from auth_token
-      where update_time > @updated_after_time
-   order by update_time desc, public_id desc
-      limit %d
-),
-auth_accounts as (
-    select public_id,
-           auth_method_id,
-           scope_id,
-           iam_user_id,
-           iam_user_scope_id
-      from auth_account
-     where %s
-       and public_id in (select auth_account_id from auth_tokens)
-),
-final as (
-    select at.public_id,
-           at.auth_account_id,
-           aa.auth_method_id,
-           aa.scope_id,
-           aa.iam_user_id,
-           aa.iam_user_scope_id,
-           at.create_time,
-           at.update_time,
-           at.approximate_last_access_time,
-           at.expiration_time,
-           at.status
-      from auth_tokens at
-      join auth_accounts aa on aa.public_id = at.auth_account_id
-)
-  select *
-    from final
-order by update_time desc, public_id desc;
+  select at.public_id,
+         at.auth_account_id,
+         aa.scope_id,
+         aa.auth_method_id,
+         aa.iam_user_id,
+         aa.iam_user_scope_id,
+         at.create_time,
+         at.update_time,
+         at.approximate_last_access_time,
+         at.expiration_time,
+         at.status
+    from auth_token at
+    join auth_account aa on aa.public_id = at.auth_account_id
+   where aa.scope_id in @scope_ids
+     and at.update_time > @updated_after_time
+order by at.update_time desc, at.public_id desc
+   limit %d;
 `
 	refreshAuthTokensPageTemplate = `
-with auth_tokens as (
-     select public_id,
-            auth_account_id,
-            create_time,
-            update_time,
-            approximate_last_access_time,
-            expiration_time,
-            status
-       from auth_token
-      where update_time > @updated_after_time
-        and (update_time, public_id) < (@last_item_update_time, @last_item_id)
-   order by update_time desc, public_id desc
-      limit %d
-),
-auth_accounts as (
-    select public_id,
-           auth_method_id,
-           scope_id,
-           iam_user_id,
-           iam_user_scope_id
-      from auth_account
-     where %s
-       and public_id in (select auth_account_id from auth_tokens)
-),
-final as (
-    select at.public_id,
-           at.auth_account_id,
-           aa.auth_method_id,
-           aa.scope_id,
-           aa.iam_user_id,
-           aa.iam_user_scope_id,
-           at.create_time,
-           at.update_time,
-           at.approximate_last_access_time,
-           at.expiration_time,
-           at.status
-      from auth_tokens at
-      join auth_accounts aa on aa.public_id = at.auth_account_id
-)
-  select *
-    from final
-order by update_time desc, public_id desc;
+  select at.public_id,
+         at.auth_account_id,
+         aa.scope_id,
+         aa.auth_method_id,
+         aa.iam_user_id,
+         aa.iam_user_scope_id,
+         at.create_time,
+         at.update_time,
+         at.approximate_last_access_time,
+         at.expiration_time,
+         at.status
+    from auth_token at
+    join auth_account aa on aa.public_id = at.auth_account_id
+   where aa.scope_id in @scope_ids
+     and at.update_time > @updated_after_time
+     and (at.update_time, at.public_id) < (@last_item_update_time, @last_item_id)
+order by at.update_time desc, at.public_id desc
+   limit %d;
 `
 )

--- a/internal/authtoken/repository.go
+++ b/internal/authtoken/repository.go
@@ -307,11 +307,9 @@ func (r *Repository) listAuthTokens(ctx context.Context, withScopeIds []string, 
 	}
 
 	args := []any{sql.Named("scope_ids", withScopeIds)}
-	whereClause := "scope_id in @scope_ids"
-
-	query := fmt.Sprintf(listAuthTokensTemplate, limit, whereClause)
+	query := fmt.Sprintf(listAuthTokensTemplate, limit)
 	if opts.withStartPageAfterItem != nil {
-		query = fmt.Sprintf(listAuthTokensPageTemplate, limit, whereClause)
+		query = fmt.Sprintf(listAuthTokensPageTemplate, limit)
 		args = append(args,
 			sql.Named("last_item_create_time", opts.withStartPageAfterItem.GetCreateTime()),
 			sql.Named("last_item_id", opts.withStartPageAfterItem.GetPublicId()),
@@ -342,15 +340,13 @@ func (r *Repository) listAuthTokensRefresh(ctx context.Context, updatedAfter tim
 		limit = opts.withLimit
 	}
 
-	args := []any{sql.Named("scope_ids", withScopeIds)}
-	whereClause := "scope_id in @scope_ids"
-
-	query := fmt.Sprintf(refreshAuthTokensTemplate, limit, whereClause)
-	args = append(args,
+	args := []any{
+		sql.Named("scope_ids", withScopeIds),
 		sql.Named("updated_after_time", timestamp.New(updatedAfter)),
-	)
+	}
+	query := fmt.Sprintf(refreshAuthTokensTemplate, limit)
 	if opts.withStartPageAfterItem != nil {
-		query = fmt.Sprintf(refreshAuthTokensPageTemplate, limit, whereClause)
+		query = fmt.Sprintf(refreshAuthTokensPageTemplate, limit)
 		args = append(args,
 			sql.Named("last_item_update_time", opts.withStartPageAfterItem.GetUpdateTime()),
 			sql.Named("last_item_id", opts.withStartPageAfterItem.GetPublicId()),


### PR DESCRIPTION
Instead of doing the scope_id filtering in the second CTE, join the auth_account table to the auth_token table in the query directly.