### PR TITLE
internal/db: db migrations for session recordings

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/80/12_recording_session_updates.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/80/12_recording_session_updates.up.sql
@@ -1,0 +1,14 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+
+  -- Add new indexes for the create time and update time queries.
+  create index recording_session_create_time_public_id_idx
+      on recording_session (create_time desc, public_id desc);
+  create index recording_session_update_time_public_id_idx
+      on recording_session (update_time desc, public_id desc);
+
+  analyze recording_session;
+
+commit;

--- a/internal/db/sqltest/tests/pagination/session_recording.sql
+++ b/internal/db/sqltest/tests/pagination/session_recording.sql
@@ -1,0 +1,12 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+  select plan(2);
+
+  select has_index('recording_session', 'recording_session_create_time_public_id_idx', array['create_time', 'public_id']);
+  select has_index('recording_session', 'recording_session_update_time_public_id_idx', array['update_time', 'public_id']);
+
+  select * from finish();
+
+rollback;


### PR DESCRIPTION
Session recordings will not require any new columns but will join storage buckets in the query to access the scope id.