### PR TITLE
Manually build the socket url

### DIFF
--- a/internal/clientcache/cmd/daemon/addtoken.go
+++ b/internal/clientcache/cmd/daemon/addtoken.go
@@ -138,11 +138,8 @@ func (c *AddTokenCommand) Add(ctx context.Context, apiClient *api.Client, keyrin
 }
 
 func addToken(ctx context.Context, daemonPath string, p *daemon.UpsertTokenRequest, opt ...client.Option) (*api.Response, *api.Error, error) {
-	addr, err := daemon.SocketAddress(daemonPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Error when retrieving the socket address: %w", err)
-	}
-	_, err = os.Stat(addr.Path)
+	addr := daemon.SocketAddress(daemonPath)
+	_, err := os.Stat(addr.Path)
 	if addr.Scheme == "unix" && err != nil {
 		return nil, nil, fmt.Errorf("Error when detecting if the domain socket is present: %w.", err)
 	}

--- a/internal/clientcache/cmd/daemon/command_wrapper.go
+++ b/internal/clientcache/cmd/daemon/command_wrapper.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hashicorp/boundary/internal/clientcache/internal/daemon"
 	"github.com/hashicorp/boundary/internal/cmd/base"
-	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/mitchellh/cli"
 )
 
@@ -134,10 +133,7 @@ func waitForDaemon(ctx context.Context) error {
 	}
 	timer := time.NewTimer(0)
 
-	addr, err := daemon.SocketAddress(dotPath)
-	if err != nil {
-		return errors.Wrap(ctx, err, op)
-	}
+	addr := daemon.SocketAddress(dotPath)
 	_, err = os.Stat(addr.Path)
 	for os.IsNotExist(err) {
 		select {

--- a/internal/clientcache/cmd/daemon/status.go
+++ b/internal/clientcache/cmd/daemon/status.go
@@ -106,11 +106,8 @@ func (c *StatusCommand) Status(ctx context.Context) (*api.Response, *daemon.Stat
 
 func status(ctx context.Context, daemonPath string, opt ...client.Option) (*api.Response, *daemon.StatusResult, *api.Error, error) {
 	const op = "daemon.status"
-	addr, err := daemon.SocketAddress(daemonPath)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Error getting socket address: %w", err)
-	}
-	_, err = os.Stat(addr.Path)
+	addr := daemon.SocketAddress(daemonPath)
+	_, err := os.Stat(addr.Path)
 	if addr.Scheme == "unix" && err != nil {
 		return nil, nil, nil, errDaemonNotRunning
 	}

--- a/internal/clientcache/cmd/daemon/stop_windows.go
+++ b/internal/clientcache/cmd/daemon/stop_windows.go
@@ -66,11 +66,7 @@ func (s *StopCommand) stop(ctx context.Context) error {
 }
 
 func stopThroughHandler(ctx context.Context, dotPath string) (*api.Error, error) {
-	addr, err := daemon.SocketAddress(dotPath)
-	if err != nil {
-		return nil, fmt.Errorf("Error when retrieving the socket address: %w", err)
-	}
-
+	addr := daemon.SocketAddress(dotPath)
 	c, err := client.New(ctx, addr)
 	if err != nil {
 		return nil, err

--- a/internal/clientcache/cmd/search/search.go
+++ b/internal/clientcache/cmd/search/search.go
@@ -173,11 +173,8 @@ func (c *SearchCommand) Search(ctx context.Context) (*api.Response, *daemon.Sear
 }
 
 func search(ctx context.Context, daemonPath string, fb filterBy, opt ...client.Option) (*api.Response, *daemon.SearchResult, *api.Error, error) {
-	addr, err := daemon.SocketAddress(daemonPath)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Error getting socket address: %w", err)
-	}
-	_, err = os.Stat(addr.Path)
+	addr := daemon.SocketAddress(daemonPath)
+	_, err := os.Stat(addr.Path)
 	if addr.Scheme == "unix" && err != nil {
 		return nil, nil, nil, errDaemonNotRunning
 	}

--- a/internal/clientcache/internal/daemon/listener.go
+++ b/internal/clientcache/internal/daemon/listener.go
@@ -5,7 +5,6 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/url"
 	"os"
@@ -53,7 +52,12 @@ func listener(ctx context.Context, path string) (net.Listener, error) {
 	return l, nil
 }
 
-// SocketAddress returns the unix socket *url.URL with the scheme set to 'unix'.
-func SocketAddress(path string) (*url.URL, error) {
-	return url.Parse(fmt.Sprintf("unix://%s", filepath.Join(path, sockAddr)))
+// SocketAddress returns the unix socket *url.URL with the scheme set to 'unix'
+// and the path set to the provided path. Verifying the path is valid is the
+// responsibility of the caller.
+func SocketAddress(path string) *url.URL {
+	return &url.URL{
+		Scheme: "unix",
+		Path:   filepath.Join(path, sockAddr),
+	}
 }

--- a/internal/clientcache/internal/daemon/listener_test.go
+++ b/internal/clientcache/internal/daemon/listener_test.go
@@ -45,7 +45,7 @@ func TestListenComms(t *testing.T) {
 
 	client, err := api.NewClient(nil)
 	require.NoError(t, err)
-	u, err := SocketAddress(path)
+	u := SocketAddress(path)
 	require.NoError(t, err)
 	require.NoError(t, client.SetAddr(u.String()))
 	client.SetToken("")


### PR DESCRIPTION
Url parsing breaks when trying to build a unix socket for windows.  Since we expect unix:// scheme urls to always have the path be an absolute path to the unix socket file, we'll just build the url ourselves always and leave it up to the caller to validate the path is valid.