### PR TITLE
docs: Backport #4192 to stable website

### DIFF
--- a/website/content/docs/release-notes/v0_13_0.mdx
+++ b/website/content/docs/release-notes/v0_13_0.mdx
@@ -35,6 +35,17 @@ Boundary Enterprise has the same feature set as HCP Boundary and seamless migrat
 
 For more information, refer to [Boundary Enterprise](/boundary/docs/enterprise).
 
+<Note>
+
+The version of Go that was used in Boundary Enterprise release 0.13.0 contained CVE-2023-39326.
+Refer to the [advisory](https://github.com/advisories/GHSA-9f76-wg39-x86h) for more information.
+The issue was fixed in Go versions 1.21.5. Boundary was updated to use the new Go versions in Boundary Enterprise release 0.13.5.
+You should [upgrade Boundary](/boundary/tutorials/self-managed-deployment/upgrade-version) to version 0.13.5 or later.
+
+Community users should upgrade to version 0.14.3 or later.
+
+</Note>
+
 **SSH session recording <sup>HCP/ENT</sup>**: A fundamental challenge of securing access to sensitive computing resources is creating a system of record around users' access and actions over remote sessions.
 This release introduces session recording to help you address your compliance and threat management needs.
 

--- a/website/content/docs/release-notes/v0_14_0.mdx
+++ b/website/content/docs/release-notes/v0_14_0.mdx
@@ -187,13 +187,40 @@ description: |-
     (Fixed in 0.14.1)
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Go CVE-2023-39325
+    Go CVE-2023-39325 and Go CVE-2023-39326
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    The version of Go that was used in Boundary release 0.14.0 contained a CVE. The issue was fixed in Go versions 1.21.3 and 1.20. Boundary was updated to use the new Go versions in release 0.14.1, and the issue is resolved.
+    The version of Go that was used in Boundary release 0.14.0 contained security vulnerabilities. The vulnerabilities were fixed in Go version 1.21.3. Boundary was updated to use the new Go version in release 0.14.1, and the issue is resolved.
     <br /><br />
     Learn more:&nbsp;
-    <a href="https://github.com/advisories/GHSA-4374-p667-p6c8">HTTP/2 rapid reset can cause excessive work in net/http</a>
+    <br /><br />
+    Go CVE-2023-39325: <a href="https://github.com/advisories/GHSA-4374-p667-p6c8">HTTP/2 rapid reset can cause excessive work in net/http</a>
+    <br /><br />
+    Go CVE-2023-39326: <a href="https://github.com/advisories/GHSA-9f76-wg39-x86h">A malicious HTTP sender can use chunk extensions</a>
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.14.0
+    <br /><br />
+    (Fixed in 0.14.3 and 0.13.5 <sup>HCP/ENT</sup>)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Go CVE-2023-39322 and Go CVE-2022-45285
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    The version of Go that was used in Boundary release 0.14.0 contained security vulnerabilities. The vulnerabilities were fixed in Go version 1.21.5. Boundary was updated to use the new Go version in release 0.14.3, and the issue is resolved.
+    <br /><br />
+    Note that version 0.13.5 of HCP Boundary and Boundary Enterprise was also updated to use the new Go version.
+    <br /><br />
+    Learn more:&nbsp;
+    <br /><br />
+    Go CVE-2023-39322: <a href="https://github.com/advisories/GHSA-892h-r6cr-53g4">QUIC connections do not set an upper bound on the amount of data buffered</a>
+    <br /><br />
+    Go CVE-2022-45285: <a href="https://github.com/advisories/GHSA-5f94-vhjq-rpg8">Using go get to fetch a module with the ".git" suffix may unexpectedly fallback to insecure protocol</a>
     <br /><br />
     <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
     </td>


### PR DESCRIPTION
This pull request backports the updates from #4192 to the `stable-website` branch:

* docs: Update release notes with fixes

* docs: Add note re fix in HCP/ENT

* docs: Update version numbers

* Update website/content/docs/release-notes/v0_14_0.mdx

Co-authored-by: Robin Beck <stellarsquall@users.noreply.github.com>

---------

Co-authored-by: Robin Beck <stellarsquall@users.noreply.github.com>