### PR TITLE
Fix Unix listener causing 500s on Mac

### DIFF
--- a/internal/daemon/common/client_ip.go
+++ b/internal/daemon/common/client_ip.go
@@ -34,7 +34,7 @@ func ClientIpFromRequest(ctx context.Context, listenerCfg *listenerutil.Listener
 		if err != nil {
 			return "", errors.Wrap(ctx, err, op)
 		}
-		if listenerCfg.Type == "unix" {
+		if listenerCfg.Type == "unix" && ip == "" {
 			// Some platforms (Linux) use "@" in this case but some like Mac
 			// leave it empty which causes issues with the rate limiting logic,
 			// so standardize on "@" in this case.

--- a/internal/daemon/common/client_ip.go
+++ b/internal/daemon/common/client_ip.go
@@ -34,6 +34,12 @@ func ClientIpFromRequest(ctx context.Context, listenerCfg *listenerutil.Listener
 		if err != nil {
 			return "", errors.Wrap(ctx, err, op)
 		}
+		if listenerCfg.Type == "unix" {
+			// Some platforms (Linux) use "@" in this case but some like Mac
+			// leave it empty which causes issues with the rate limiting logic,
+			// so standardize on "@" in this case.
+			return "@", nil
+		}
 		return ip, nil
 	case trustedForwardedFor == nil && remoteAddr != nil:
 		// not reachable given listenerutil.TrustedFromXForwardedFor


### PR DESCRIPTION
Some platforms use `@` for a Unix socket address, and some leave it empty. In the empty case this causes the rate limiting code to throw a 500 error. This commit standardizes on using `@` for incoming connections over a Unix socket.