### PR TITLE
docs: Add client cache documentation

### DIFF
--- a/website/content/docs/api-clients/client-cache.mdx
+++ b/website/content/docs/api-clients/client-cache.mdx
@@ -62,7 +62,7 @@ For more information, refer to the [`daemon status`](/boundary/docs/commands/dae
 ### Auth tokens
 
 By default, the Boundary CLI uses the platform's default keyring and token name to store and receive auth tokens.
-Whenever you use an auth token to interact with Boundary, the auth token is stored and the client cache syncs data to it.
+Whenever you use an auth token to interact with Boundary, the client cache stores the auth token retrieves its data.
 If you authenticate to multiple Boundary instances, the client cache stores multiple auth tokens and syncs data from each instance to the corresponding token.
 
 To view the client cache for a specific Boundary instance, you can specify the appropriate auth token using the `boundary daemon add-token` command.

--- a/website/content/docs/api-clients/client-cache.mdx
+++ b/website/content/docs/api-clients/client-cache.mdx
@@ -2,12 +2,12 @@
 layout: docs
 page_title: Client cache
 description: |-
-  Learn how the client cache enables Boundary to quickly retrieve local information about sessions and resources.
+  Learn how the client cache enables Boundary to quickly retrieve local information about session and target resources.
 ---
 
 # Client cache
 
-The Boundary client daemon runs on end users' computers and locally caches session and resource information from Boundary instances.
+The Boundary client daemon runs on end users' computers and locally caches session and target resource information from Boundary instances.
 The cache helps expedite searches.
 
 ## Boundary `list` vs. `search`
@@ -26,7 +26,7 @@ For more information, refer to the [`search`](/boundary/docs/commands/search) co
 ## Client cache management
 
 The Boundary client daemon starts automatically in the background when a user runs a CLI command that interacts with a Boundary instance.
-If you do not want the daemon to automatically start, you can include the `-skip-cache` flag or set the **BOUNDARY_SKIP_CACHE_DAEMON** environment variable when you run the `boundary search` command.
+If you do not want the daemon to automatically start, you can include the `-skip-cache` flag or set the **BOUNDARY_SKIP_CACHE_DAEMON** environment variable when using the boundary cli to interact with a boundary instance.
 
 ### Startup and customization
 
@@ -37,10 +37,8 @@ You can start it in the background by adding the `-background` flag.
 If you start the daemon manually, you can customize the caching behavior.
 Include any of the following options to customize the behavior:
 
-- `max-search-staleness` - The amount of time that can pass since the last refresh before the client cache causes a blocking refresh.
-The blocking refresh occurs when you perform the `boundary search` command.
-It requires Boundary to refresh the local cache using the control plane.
-- `max-search-refresh-timeout` - The amount of time the `boundary search` blocking refresh can take before it times out.
+- `max-search-staleness` - The amount of time that can pass since the last refresh before calling `boundary search` results in a blocking refresh from the Boundary instance of the resources being searched.
+- `max-search-refresh-timeout` - The amount of time the `boundary search` blocking refresh can take before it times out. In the event of a timeout the stale data currently in the cache is used.
 - `refresh-interval` - A duration that specifies how frequently the client cache should query Boundary for changes to sessions and targets.
 Note that Boundary only searches sessions and targets that the user who ran the command has access to.
 

--- a/website/content/docs/api-clients/client-cache.mdx
+++ b/website/content/docs/api-clients/client-cache.mdx
@@ -26,7 +26,7 @@ For more information, refer to the [`search`](/boundary/docs/commands/search) co
 ## Client cache management
 
 The Boundary client daemon starts automatically in the background when a user runs a CLI command that interacts with a Boundary instance.
-If you do not want the daemon to automatically start, you can include the `-skip-cache` flag or set the **BOUNDARY_SKIP_CACHE_DAEMON** environment variable when using the boundary cli to interact with a boundary instance.
+If you do not want the daemon to automatically start, you can include the `-skip-cache` flag or set the **BOUNDARY_SKIP_CACHE_DAEMON** environment variable when you use the Boundary CLI to interact with a Boundary instance.
 
 ### Startup and customization
 
@@ -38,7 +38,8 @@ If you start the daemon manually, you can customize the caching behavior.
 Include any of the following options to customize the behavior:
 
 - `max-search-staleness` - The amount of time that can pass since the last refresh before calling `boundary search` results in a blocking refresh from the Boundary instance of the resources being searched.
-- `max-search-refresh-timeout` - The amount of time the `boundary search` blocking refresh can take before it times out. In the event of a timeout the stale data currently in the cache is used.
+- `max-search-refresh-timeout` - The amount of time the `boundary search` blocking refresh can take before it times out.
+In the event of a timeout, Boundary uses the stale data that is currently in the cache.
 - `refresh-interval` - A duration that specifies how frequently the client cache should query Boundary for changes to sessions and targets.
 Note that Boundary only searches sessions and targets that the user who ran the command has access to.
 
@@ -50,10 +51,6 @@ The client cache stores a log file in the **~/.boundary** directory.
 Boundary automatically rotates the log once it reaches 5 MB.
 It compresses and keeps the last 3 rotated logs before deleting a log.
 
-To log the specific searches that were performed against the cache, include the `-store-debug` flag when you manually start the client cache.
-
-For more information, refer to the [`daemon start`](/boundary/docs/commands/daemon/start) command documentation.
-
 ### Status
 
 You can check the status of the cache using the `boundary daemon status` command.
@@ -64,9 +61,10 @@ For more information, refer to the [`daemon status`](/boundary/docs/commands/dae
 
 ### Auth tokens
 
-If you want to view another user's client cache, you can use that user's auth token.
+By default, the Boundary CLI uses the platform's default keyring and token name to store and receive auth tokens.
+Whenever you use an auth token to interact with Boundary, the auth token is stored and the client cache syncs data to it.
+If you authenticate to multiple Boundary instances, the client cache stores multiple auth tokens and syncs data from each instance to the corresponding token.
 
-To select a specific auth token with which to view the client cache, specify the auth token using the `boundary daemon add-token` command.
-You can only view the resources that are available to that user, when you are logged in using an auth token.
+To view the client cache for a specific Boundary instance, you can specify the appropriate auth token using the `boundary daemon add-token` command.
 
 For more information, refer to the [`daemon add-token`](/boundary/docs/commands/daemon/add-token) command documentation.

--- a/website/content/docs/api-clients/client-cache.mdx
+++ b/website/content/docs/api-clients/client-cache.mdx
@@ -1,0 +1,27 @@
+---
+layout: docs
+page_title: Client cache
+description: |-
+  Learn how the client cache enables Boundary to quickly retrieve local information about sessions and resources.
+---
+
+# Client cache
+
+The Boundary client daemon runs on end users' computers and locally caches session and resource information from Boundary instances.
+The cache helps expedite searches.
+
+## Boundary `list` vs. `search`
+
+You can use the Boundary API or CLI to `list` resources like targets, sessions, hosts, and users.
+When you use the `list` command, Boundary searches the control plane to provide a current total of resources when it produces the list of results.
+Some Boundary resources can provide a signficant number of items in the response.
+
+Because large lists of results may overwhelm your system resources, the client daemon caches the results of the `list` operation.
+You can search the local cache instead of the control plane to help protect your system resources.
+The Boundary `search` command also produces a list of Boundary resources.
+When you use the `search` command, however, Boundary searches the local cache to create the list.
+
+## Start the client cache
+
+The Boundary client daemon starts automatically in the background when a user runs a CLI command that interacts with a Boundary instance.
+If you do not want the daemon to automatically start, you can include the `-skip-cache` flag or set the **BOUNDARY_SKIP_CACHE_DAEMON** environment variable when you run the `boundary search` command.

--- a/website/content/docs/api-clients/client-cache.mdx
+++ b/website/content/docs/api-clients/client-cache.mdx
@@ -61,10 +61,10 @@ For more information, refer to the [`daemon status`](/boundary/docs/commands/dae
 
 ### Auth tokens
 
-By default, the Boundary CLI uses the platform's default keyring and token name to store and receive auth tokens.
-Whenever you use an auth token to interact with Boundary, the client cache stores the auth token retrieves its data.
-If you authenticate to multiple Boundary instances, the client cache stores multiple auth tokens and syncs data from each instance to the corresponding token.
+By default, the Boundary CLI tries to use a keyring to store and receive auth tokens.
+Whenever you use an auth token to interact with Boundary, the client cache stores the auth token and syncs the data associated with it.
+If you authenticate to multiple Boundary instances, the client cache stores multiple auth tokens and syncs the data associated with each token.
 
-To view the client cache for a specific Boundary instance, you can specify the appropriate auth token using the `boundary daemon add-token` command.
+To search the client cache for a specific Boundary instance, you can specify the appropriate auth token using the `boundary daemon add-token` command.
 
 For more information, refer to the [`daemon add-token`](/boundary/docs/commands/daemon/add-token) command documentation.

--- a/website/content/docs/api-clients/client-cache.mdx
+++ b/website/content/docs/api-clients/client-cache.mdx
@@ -26,7 +26,7 @@ For more information, refer to the [`search`](/boundary/docs/commands/search) co
 ## Client cache management
 
 The Boundary client daemon starts automatically in the background when a user runs a CLI command that interacts with a Boundary instance.
-If you do not want the daemon to automatically start, you can include the `-skip-cache` flag or set the **BOUNDARY_SKIP_CACHE_DAEMON** environment variable when you use the Boundary CLI to interact with a Boundary instance.
+If you do not want the daemon to automatically start, you can include the `-skip-cache-daemon` flag or set the **BOUNDARY_SKIP_CACHE_DAEMON** environment variable when you use the Boundary CLI to interact with a Boundary instance.
 
 ### Startup and customization
 

--- a/website/content/docs/api-clients/client-cache.mdx
+++ b/website/content/docs/api-clients/client-cache.mdx
@@ -44,7 +44,7 @@ It requires Boundary to refresh the local cache using the control plane.
 - `refresh-interval` - A duration that specifies how frequently the client cache should query Boundary for changes to sessions and targets.
 Note that Boundary only searches sessions and targets that the user who ran the command has access to.
 
-For more information, refer to the [`daemon tart`](/boundary/docs/commands/daemon/start) command documentation.
+For more information, refer to the [`daemon start`](/boundary/docs/commands/daemon/start) command documentation.
 
 ### Logging
 

--- a/website/content/docs/api-clients/client-cache.mdx
+++ b/website/content/docs/api-clients/client-cache.mdx
@@ -14,14 +14,50 @@ The cache helps expedite searches.
 
 You can use the Boundary API or CLI to `list` resources like targets, sessions, hosts, and users.
 When you use the `list` command, Boundary searches the control plane to provide a current total of resources when it produces the list of results.
-Some Boundary resources can provide a signficant number of items in the response.
+Some Boundary resources can provide a significant number of items in the response.
 
 Because large lists of results may overwhelm your system resources, the client daemon caches the results of the `list` operation.
 You can search the local cache instead of the control plane to help protect your system resources.
 The Boundary `search` command also produces a list of Boundary resources.
 When you use the `search` command, however, Boundary searches the local cache to create the list.
 
-## Start the client cache
+## Client cache management
 
 The Boundary client daemon starts automatically in the background when a user runs a CLI command that interacts with a Boundary instance.
 If you do not want the daemon to automatically start, you can include the `-skip-cache` flag or set the **BOUNDARY_SKIP_CACHE_DAEMON** environment variable when you run the `boundary search` command.
+
+### Startup and customization
+
+You can start the daemon manually using the `boundary daemon start` command.
+By default, the daemon starts in the foreground.
+You can start it in the background by including the `-background` flag.
+
+If you start the daemon manually, you can customize the caching behavior.
+Include any of the following options to customize the behavior:
+
+- `max-search-staleness` - The amount of time that can pass since the last refresh before the client cache causes a blocking refresh.
+The blocking refresh occurs when you perform the `boundary search` command.
+It requires Boundary to refresh the local cache using the control plane.
+- `max-search-refresh-timeout` - The amount of time the `boundary search` blocking refresh can take before it times out.
+- `refresh-interval` - A duration that specifies how frequently the client cache should query Boundary for changes to sessions and targets.
+Note that Boundary only searches sessions and targets that the user who ran the command has access to.
+
+For more information, refer to the [start](/boundary/docs/commands/daemon/start) command documentation.
+
+### Logging
+
+The client cache stores a log file in the **~/.boundary** directory.
+Boundary automatically rotates the log once it reaches 5 MB.
+It compresses and keeps the last 3 rotated logs before deleting a log.
+
+To log the specific searches that were performed against the cache, include the `-store-debug` flag when you manually start the client cache.
+
+For more information, refer to the [start](/boundary/docs/commands/daemon/start) command documentation.
+
+### Auth tokens
+
+If you want to view another user's client cache, you can use that user's auth token.
+
+To select a specific auth token with which to view the client cache, specify the auth token using the `boundary daemon add-token` command.
+
+For more information, refer to the [add-token](/boundary/docs/commands/daemon/add-token) command documentation.

--- a/website/content/docs/api-clients/client-cache.mdx
+++ b/website/content/docs/api-clients/client-cache.mdx
@@ -44,7 +44,7 @@ It requires Boundary to refresh the local cache using the control plane.
 - `refresh-interval` - A duration that specifies how frequently the client cache should query Boundary for changes to sessions and targets.
 Note that Boundary only searches sessions and targets that the user who ran the command has access to.
 
-For more information, refer to the [`start`](/boundary/docs/commands/daemon/start) command documentation.
+For more information, refer to the [`daemon tart`](/boundary/docs/commands/daemon/start) command documentation.
 
 ### Logging
 
@@ -54,14 +54,14 @@ It compresses and keeps the last 3 rotated logs before deleting a log.
 
 To log the specific searches that were performed against the cache, include the `-store-debug` flag when you manually start the client cache.
 
-For more information, refer to the [`start`](/boundary/docs/commands/daemon/start) command documentation.
+For more information, refer to the [`daemon start`](/boundary/docs/commands/daemon/start) command documentation.
 
 ### Status
 
 You can check the status of the cache using the `boundary daemon status` command.
 The command returns information about the cache including the uptime, user count, user information, and which Boundary resources the cache is tracking.
 
-For more information, refer to the [`status`](/boundary/docs/commands/daemon/status) command documentation.
+For more information, refer to the [`daemon status`](/boundary/docs/commands/daemon/status) command documentation.
 
 
 ### Auth tokens
@@ -71,4 +71,4 @@ If you want to view another user's client cache, you can use that user's auth to
 To select a specific auth token with which to view the client cache, specify the auth token using the `boundary daemon add-token` command.
 You can only view the resources that are available to that user, when you are logged in using an auth token.
 
-For more information, refer to the [`add-token`](/boundary/docs/commands/daemon/add-token) command documentation.
+For more information, refer to the [`daemon add-token`](/boundary/docs/commands/daemon/add-token) command documentation.

--- a/website/content/docs/api-clients/client-cache.mdx
+++ b/website/content/docs/api-clients/client-cache.mdx
@@ -21,6 +21,8 @@ You can search the local cache instead of the control plane to help protect your
 The Boundary `search` command also produces a list of Boundary resources.
 When you use the `search` command, however, Boundary searches the local cache to create the list.
 
+For more information, refer to the [`search`](/boundary/docs/commands/search) command documentation.
+
 ## Client cache management
 
 The Boundary client daemon starts automatically in the background when a user runs a CLI command that interacts with a Boundary instance.
@@ -30,7 +32,7 @@ If you do not want the daemon to automatically start, you can include the `-skip
 
 You can start the daemon manually using the `boundary daemon start` command.
 By default, the daemon starts in the foreground.
-You can start it in the background by including the `-background` flag.
+You can start it in the background by adding the `-background` flag.
 
 If you start the daemon manually, you can customize the caching behavior.
 Include any of the following options to customize the behavior:
@@ -42,7 +44,7 @@ It requires Boundary to refresh the local cache using the control plane.
 - `refresh-interval` - A duration that specifies how frequently the client cache should query Boundary for changes to sessions and targets.
 Note that Boundary only searches sessions and targets that the user who ran the command has access to.
 
-For more information, refer to the [start](/boundary/docs/commands/daemon/start) command documentation.
+For more information, refer to the [`start`](/boundary/docs/commands/daemon/start) command documentation.
 
 ### Logging
 
@@ -52,12 +54,21 @@ It compresses and keeps the last 3 rotated logs before deleting a log.
 
 To log the specific searches that were performed against the cache, include the `-store-debug` flag when you manually start the client cache.
 
-For more information, refer to the [start](/boundary/docs/commands/daemon/start) command documentation.
+For more information, refer to the [`start`](/boundary/docs/commands/daemon/start) command documentation.
+
+### Status
+
+You can check the status of the cache using the `boundary daemon status` command.
+The command returns information about the cache including the uptime, user count, user information, and which Boundary resources the cache is tracking.
+
+For more information, refer to the [`status`](/boundary/docs/commands/daemon/status) command documentation.
+
 
 ### Auth tokens
 
 If you want to view another user's client cache, you can use that user's auth token.
 
 To select a specific auth token with which to view the client cache, specify the auth token using the `boundary daemon add-token` command.
+You can only view the resources that are available to that user, when you are logged in using an auth token.
 
-For more information, refer to the [add-token](/boundary/docs/commands/daemon/add-token) command documentation.
+For more information, refer to the [`add-token`](/boundary/docs/commands/daemon/add-token) command documentation.

--- a/website/content/docs/commands/daemon/add-token.mdx
+++ b/website/content/docs/commands/daemon/add-token.mdx
@@ -11,7 +11,7 @@ Command: `boundary daemon add-token`
 
 The `boundary daemon add-token` command lets you add an auth token from your keyring to a Boundary daemon that is running.
 
-By default, the Boundary CLI uses the platform's default keyring and token name to store and receive auth tokens.
+By default, the Boundary CLI tries to use a keyring to store and receive auth tokens.
 Whenever you use an auth token to interact with Boundary, the auth token is stored and the client cache syncs data to it.
 If you authenticate to multiple Boundary instances, the client cache stores multiple auth tokens and syncs data from each instance to the corresponding token.
 
@@ -22,7 +22,7 @@ By adding auth tokens to your client cache, you can select which specific Bounda
 The following command adds the auth token `at_LvUqeYz80B` to the client cache from your keyring:
 
 ```shell-session
-$ boundary daemon add-token at_LvUqeYz80B
+$ boundary daemon add-token
 ```
 
 The following command specifies that you only want to search the Boundary instance associated with the auth token `at_LvUqeYz80B`:
@@ -36,13 +36,13 @@ $ boundary daemon add-token -token-name at_LvUqeYz80B
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary daemon add-token [options] [args]
+$ boundary daemon add-token [options]
 ```
 
 </CodeBlockConfig>
 
 ### Command options
 
-- `token-name` - Specifies the name of the token you want to use for search.
+- `token-name` - Specifies the name of the token you want to sync data for.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/daemon/add-token.mdx
+++ b/website/content/docs/commands/daemon/add-token.mdx
@@ -55,8 +55,6 @@ Depending on your platform, available values include:
   You can also specify the keyring type using the **BOUNDARY_KEYRING_TYPE** environment variable.
 - `output-curl-string` - Specifies that Boundary should print an equivalent cURL command string and exit, instead of executing the request.
 The default value is `false`.
-- `recovery-config=<string>` - If specified, Boundary parses the given config file for a "kms" block with the purpose "recovery" and uses the recovery mechanism to authorize the call.
-You can also specify a recovery config value using the **BOUNDARY_RECOVERY_CONFIG** environment variable.
 - `token` = A URL that points to a file on disk (file://) from which Boundary reads a token or an environment variable (env://) from which the token will be read.
 If you set this parameter, it overrides the `token-name` parameter.
 - `token-name` - If specified, Boundary uses the value in this parameter as the name when it stores the token in the system credential store.

--- a/website/content/docs/commands/daemon/add-token.mdx
+++ b/website/content/docs/commands/daemon/add-token.mdx
@@ -25,10 +25,10 @@ The following command adds an auth token to the client cache from your keyring:
 $ boundary daemon add-token
 ```
 
-The following command specifies the name of the keyring `at_LvUqeYz80B` from which you want to add the token:
+The following command specifies the name of the keyring `development` from which you want to add the token:
 
 ```shell-session
-$ boundary daemon add-token -token-name at_LvUqeYz80B
+$ boundary daemon add-token -token-name development
 ```
 
 ## Usage

--- a/website/content/docs/commands/daemon/add-token.mdx
+++ b/website/content/docs/commands/daemon/add-token.mdx
@@ -9,15 +9,26 @@ description: |-
 
 Command: `boundary daemon add-token`
 
-The `boundary daemon add-token` command lets you add an auth token to a Boundary daemon that is running.
-You can only view the resources that are available to that user, when you are logged in using an auth token.
+The `boundary daemon add-token` command lets you add an auth token from your keyring to a Boundary daemon that is running.
 
-## Example
+By default, the Boundary CLI uses the platform's default keyring and token name to store and receive auth tokens.
+Whenever you use an auth token to interact with Boundary, the auth token is stored and the client cache syncs data to it.
+If you authenticate to multiple Boundary instances, the client cache stores multiple auth tokens and syncs data from each instance to the corresponding token.
 
-The following command adds the auth token `at_LvUqeYz80B`:
+By adding auth tokens to your client cache, you can select which specific Boundary instance you want to search.
+
+## Examples
+
+The following command adds the auth token `at_LvUqeYz80B` to the client cache from your keyring:
 
 ```shell-session
-$ boundary daemon add-token -id at_LvUqeYz80B
+$ boundary daemon add-token at_LvUqeYz80B
+```
+
+The following command specifies that you only want to search the Boundary instance associated with the auth token `at_LvUqeYz80B`:
+
+```shell-session
+$ boundary daemon add-token -token-name at_LvUqeYz80B
 ```
 
 ## Usage
@@ -29,5 +40,9 @@ $ boundary daemon add-token [options] [args]
 ```
 
 </CodeBlockConfig>
+
+### Command options
+
+- `token-name` - Specifies the name of the token you want to use for search.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/daemon/add-token.mdx
+++ b/website/content/docs/commands/daemon/add-token.mdx
@@ -10,7 +10,6 @@ description: |-
 Command: `boundary daemon add-token`
 
 The `boundary daemon add-token` command lets you add an auth token to a Boundary daemon that is running.
-You can use the auth token to view another user's client cache.
 You can only view the resources that are available to that user, when you are logged in using an auth token.
 
 ## Example

--- a/website/content/docs/commands/daemon/add-token.mdx
+++ b/website/content/docs/commands/daemon/add-token.mdx
@@ -12,20 +12,20 @@ Command: `boundary daemon add-token`
 The `boundary daemon add-token` command lets you add an auth token from your keyring to a Boundary daemon that is running.
 
 By default, the Boundary CLI tries to use a keyring to store and receive auth tokens.
-Whenever you use an auth token to interact with Boundary, the auth token is stored and the client cache syncs data to it.
-If you authenticate to multiple Boundary instances, the client cache stores multiple auth tokens and syncs data from each instance to the corresponding token.
+Whenever you use an auth token to interact with Boundary, the client cache stores the auth token and syncs the data associated with it.
+If you authenticate to multiple Boundary instances, the client cache stores multiple auth tokens and syncs the data associated with each token.
 
 By adding auth tokens to your client cache, you can select which specific Boundary instance you want to search.
 
 ## Examples
 
-The following command adds the auth token `at_LvUqeYz80B` to the client cache from your keyring:
+The following command adds an auth token to the client cache from your keyring:
 
 ```shell-session
 $ boundary daemon add-token
 ```
 
-The following command specifies that you only want to search the Boundary instance associated with the auth token `at_LvUqeYz80B`:
+The following command specifies the name of the keyring `at_LvUqeYz80B` from which you want to add the token:
 
 ```shell-session
 $ boundary daemon add-token -token-name at_LvUqeYz80B
@@ -43,6 +43,24 @@ $ boundary daemon add-token [options]
 
 ### Command options
 
-- `token-name` - Specifies the name of the token you want to sync data for.
+- `keyring-type=<string>` - Specifies the type of keyring to use.
+The default value is `auto` which uses the Windows credential manager, OS X keychain, or cross-platform password store, depending on your platform.
+Use the value `none` to disable keyring functionality.
+Depending on your platform, available values include:
+   - `wincred`
+   - `keychain`
+   - `pass`
+   - `secret-service`
+
+  You can also specify the keyring type using the **BOUNDARY_KEYRING_TYPE** environment variable.
+- `output-curl-string` - Specifies that Boundary should print an equivalent cURL command string and exit, instead of executing the request.
+The default value is `false`.
+- `recovery-config=<string>` - If specified, Boundary parses the given config file for a "kms" block with the purpose "recovery" and uses the recovery mechanism to authorize the call.
+You can also specify a recovery config value using the **BOUNDARY_RECOVERY_CONFIG** environment variable.
+- `token` = A URL that points to a file on disk (file://) from which Boundary reads a token or an environment variable (env://) from which the token will be read.
+If you set this parameter, it overrides the `token-name` parameter.
+- `token-name` - If specified, Boundary uses the value in this parameter as the name when it stores the token in the system credential store.
+You can use this value to switch user identities for different commands.
+You can also specify a token name using the **BOUNDARY_TOKEN_NAME** environment variable.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/daemon/add-token.mdx
+++ b/website/content/docs/commands/daemon/add-token.mdx
@@ -10,6 +10,8 @@ description: |-
 Command: `boundary daemon add-token`
 
 The `boundary daemon add-token` command lets you add an auth token to a Boundary daemon that is running.
+You can use the auth token to view another user's client cache.
+You can only view the resources that are available to that user, when you are logged in using an auth token.
 
 ## Example
 

--- a/website/content/docs/commands/daemon/add-token.mdx
+++ b/website/content/docs/commands/daemon/add-token.mdx
@@ -1,0 +1,32 @@
+---
+layout: docs
+page_title: daemon add-token - Command
+description: |-
+  The "daemon add-token" command lets you add an auth token to a Boundary daemon that is running.
+---
+
+# daemon add-token
+
+Command: `boundary daemon add-token`
+
+The `boundary daemon add-token` command lets you add an auth token to a Boundary daemon that is running.
+
+## Example
+
+The following command adds the auth token `at_LvUqeYz80B`:
+
+```shell-session
+$ boundary daemon add-token -id at_LvUqeYz80B
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary daemon add-token [options] [args]
+```
+
+</CodeBlockConfig>
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/daemon/index.mdx
+++ b/website/content/docs/commands/daemon/index.mdx
@@ -1,0 +1,41 @@
+---
+layout: docs
+page_title: daemon - Command
+description: |-
+  Boundary's "daemon" command lets you manage a local cache of information to facilitate searches and protect your system resources from being overwhelmed.
+---
+
+# daemon
+
+Command: `boundary daemon`
+
+The `daemon` command lets you manage the Boundary daemon and perform operations on the local cache of information.
+
+## Example
+
+The following command starts the Boundary daemon in the background:
+
+```shell-session
+$ boundary daemon start -background
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary daemon <subcommand> [options] [args]
+  # ...
+Subcommands:
+    start    Starts the Boundary daemon.
+    stop     Stops the Boundary daemon.
+    status   Prints out a status report of the daemon.
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage, click on the name of the subcommand in the sidebar or one of the links below:
+
+- [start](/boundary/docs/commands/daemon/start)
+- [status](/boundary/docs/commands/daemon/status)
+- [stop](/boundary/docs/commands/daemon/stop)

--- a/website/content/docs/commands/daemon/index.mdx
+++ b/website/content/docs/commands/daemon/index.mdx
@@ -27,15 +27,17 @@ $ boundary daemon start -background
 Usage: boundary daemon <subcommand> [options] [args]
   # ...
 Subcommands:
-    start    Starts the Boundary daemon.
-    stop     Stops the Boundary daemon.
-    status   Prints out a status report of the daemon.
+    add-token   Add an auth token to a Boundary daemon that is currently running.
+    start       Starts the Boundary daemon.
+    status      Gets the status information of a Boundary daemon that is currently running.
+    stop        Stops the Boundary daemon.
 ```
 
 </CodeBlockConfig>
 
 For more information, examples, and usage, click on the name of the subcommand in the sidebar or one of the links below:
 
+- [add-token](/boundary/docs/commands/daemon/add-token)
 - [start](/boundary/docs/commands/daemon/start)
 - [status](/boundary/docs/commands/daemon/status)
 - [stop](/boundary/docs/commands/daemon/stop)

--- a/website/content/docs/commands/daemon/start.mdx
+++ b/website/content/docs/commands/daemon/start.mdx
@@ -32,12 +32,17 @@ $ boundary daemon start [options] [args]
 ### Command options
 
 - `background` - Starts the Boundary daemon in the background.
+The default value is `false`.
 By default, the daemon starts in the foreground.
-- `max-search-staleness` - The amount of time that can pass since the last refresh before the client cache causes a blocking refresh.
+- `log-format=<string>` - Specifies the log format, mostly as a fallback for events.
+Supported values are `standard` and `json`.
+- `max-search-refresh-timeout=<duration>` - If a search request triggers a best effort refresh, this value specifies how long the refresh should run before time out.
+In the event of a timeout, Boundary uses the stale data that is currently in the cache.
+The default value is 7 seconds.
+- `max-search-staleness=<duration>` - The amount of time that can pass since the last refresh before the client cache causes a blocking refresh.
 The blocking refresh occurs when you perform the `boundary search` command.
 It requires Boundary to refresh the local cache using the control plane.
-- `max-search-refresh-timeout` - The amount of time the `boundary search` blocking refresh can take before it times out.
-In the event of a timeout, Boundary uses the stale data that is currently in the cache.
+The default value is 30 seconds.
 - `refresh-interval` - A duration that specifies how frequently the client cache should query Boundary for changes to sessions and targets.
 Note that Boundary only searches sessions and targets that the user who ran the command has access to.
 

--- a/website/content/docs/commands/daemon/start.mdx
+++ b/website/content/docs/commands/daemon/start.mdx
@@ -16,7 +16,7 @@ The `boundary daemon start` command lets you manually start the Boundary daemon 
 The following command starts the Boundary daemon in the background:
 
 ```shell-session
-$ boundary daemon start background
+$ boundary daemon start -background
 ```
 
 ## Usage

--- a/website/content/docs/commands/daemon/start.mdx
+++ b/website/content/docs/commands/daemon/start.mdx
@@ -1,0 +1,46 @@
+---
+layout: docs
+page_title: daemon start - Command
+description: |-
+  The "daemon start" command lets you manually start the Boundary daemon and customize the behavior of the local cache.
+---
+
+# daemon start
+
+Command: `boundary daemon start`
+
+The `boundary daemon start` command lets you manually start the Boundary daemon and customize the behavior of the local cache.
+
+## Example
+
+The following command starts the Boundary daemon in the background:
+
+```shell-session
+$ boundary daemon start background
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary daemon start [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `background` - Starts the Boundary daemon in the background.
+By default, the daemon starts in the foreground.
+- `max-search-staleness` - The amount of time that can pass since the last refresh before the client cache causes a blocking refresh.
+The blocking refresh occurs when you perform the `boundary search` command.
+It requires Boundary to refresh the local cache using the control plane.
+- `max-search-refresh-timeout` - The amount of time the `boundary search` blocking refresh can take before it times out.
+- `refresh-interval` - A duration that specifies how frequently the client cache should query Boundary for changes to sessions and targets.
+Note that Boundary only searches sessions and targets that the user who ran the command has access to.
+- `store-debug` - Indicates that you want to output the specific queries performed to a log file.
+By default, the log file is stored in the **~/.boundary** directory.
+Boundary automatically rotates the log once it reaches 5 MB and keeps the last three rotated logs.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/daemon/start.mdx
+++ b/website/content/docs/commands/daemon/start.mdx
@@ -37,10 +37,8 @@ By default, the daemon starts in the foreground.
 The blocking refresh occurs when you perform the `boundary search` command.
 It requires Boundary to refresh the local cache using the control plane.
 - `max-search-refresh-timeout` - The amount of time the `boundary search` blocking refresh can take before it times out.
+In the event of a timeout, Boundary uses the stale data that is currently in the cache.
 - `refresh-interval` - A duration that specifies how frequently the client cache should query Boundary for changes to sessions and targets.
 Note that Boundary only searches sessions and targets that the user who ran the command has access to.
-- `store-debug` - Indicates that you want to output the specific queries performed to a log file.
-By default, the log file is stored in the **~/.boundary** directory.
-Boundary automatically rotates the log once it reaches 5 MB and keeps the last three rotated logs.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/daemon/status.mdx
+++ b/website/content/docs/commands/daemon/status.mdx
@@ -20,6 +20,19 @@ The following command checks the status of the Boundary daemon:
 $ boundary daemon status
 ```
 
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Status:
+  Domain Socket:       /Users/dhh/.boundary/socket/daemon.sock
+  Uptime:              22s
+  User Count:          8
+```
+
+</CodeBlockConfig>
+
 ## Usage
 
 <CodeBlockConfig hideClipboard>

--- a/website/content/docs/commands/daemon/status.mdx
+++ b/website/content/docs/commands/daemon/status.mdx
@@ -44,4 +44,9 @@ $ boundary daemon status [options] [args]
 
 </CodeBlockConfig>
 
+### Command options
+
+- `output-curl-string` - Specifies that Boundary should print an equivalent cURL command string and exit, instead of executing the request.
+The default value is `false`.
+
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/daemon/status.mdx
+++ b/website/content/docs/commands/daemon/status.mdx
@@ -26,9 +26,10 @@ $ boundary daemon status
 
 ```plaintext
 Status:
-  Domain Socket:       /Users/dhh/.boundary/socket/daemon.sock
-  Uptime:              22s
-  User Count:          8
+  Domain Socket:       /home/my_user/.boundary/socket/daemon.sock
+  Log Location:        /home/my_user/.boundary/cache.log
+  Uptime:              15m22s
+  User Count:          1
 ```
 
 </CodeBlockConfig>

--- a/website/content/docs/commands/daemon/status.mdx
+++ b/website/content/docs/commands/daemon/status.mdx
@@ -10,7 +10,7 @@ description: |-
 Command: `boundary daemon status`
 
 The `boundary daemon status` command lets you manually check the status of the Boundary daemon.
-Boundary prints out a status report that includes configuration information, the start time, resource update times, persona and resource counts, and any recent errors.
+Boundary prints out a status report that includes configuration, user, and resource information.
 
 ## Example
 

--- a/website/content/docs/commands/daemon/status.mdx
+++ b/website/content/docs/commands/daemon/status.mdx
@@ -1,0 +1,33 @@
+---
+layout: docs
+page_title: daemon status - Command
+description: |-
+  The "daemon status" command lets you manually check the status of the Boundary daemon.
+---
+
+# daemon status
+
+Command: `boundary daemon status`
+
+The `boundary daemon status` command lets you manually check the status of the Boundary daemon.
+Boundary prints out a status report that includes configuration information, the start time, resource update times, persona and resource counts, and any recent errors.
+
+## Example
+
+The following command checks the status of the Boundary daemon:
+
+```shell-session
+$ boundary daemon status
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary daemon status [options] [args]
+```
+
+</CodeBlockConfig>
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/daemon/stop.mdx
+++ b/website/content/docs/commands/daemon/stop.mdx
@@ -1,0 +1,32 @@
+---
+layout: docs
+page_title: daemon stop - Command
+description: |-
+  The "daemon stop" command lets you manually stop the Boundary daemon.
+---
+
+# daemon stop
+
+Command: `boundary daemon stop`
+
+The `boundary daemon stop` command lets you manually stop the Boundary daemon.
+
+## Example
+
+The following command stops the Boundary daemon:
+
+```shell-session
+$ boundary daemon stop
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary daemon stop [options] [args]
+```
+
+</CodeBlockConfig>
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/search/index.mdx
+++ b/website/content/docs/commands/search/index.mdx
@@ -18,7 +18,7 @@ For more information, refer to [Boundary `list` vs `search`](/boundary/docs/api-
 The following example searches for all targets that are available in the local cache for the user.
 
 ```shell-session
-$ boundary search -resource targets
+$ boundary search -resource targets -query 'type="tcp" and name%"Generated"'
 ```
 
 **Example output:**
@@ -86,14 +86,14 @@ $ boundary search [options]
 - `-resource` `(string: "")` - The type of resource you want to search the cache for.
 This is a required field.
 You can search for the following:
-   - `-sessions` - Searches for any sessions associated with the user.
-   - `-targets` - Searches for any targets associated with the user.
+   - `sessions` - Searches for any sessions associated with the user.
+   - `targets` - Searches for any targets associated with the user.
 
 - `-query` `(optional)` - If set, specifies the [MQL](https://github.com/hashicorp/mql/blob/main/GRAMMAR.md) query you want to use to search for the indexed fields on the resource you specified.
 If you do not provide a `-query` value, the search lists all resources of the specified type that have been cached.
-The available fields for each resource include:
+The available fields that can be used in the search query for each resource include:
 
-   - targets: ID, name, description, type, address, scope_id
-   - sessions: ID, type, endpoint, status, scope_id, target_id, user_id
+   - targets: id, name, description, type, address, scope_id
+   - sessions: id, type, endpoint, status, scope_id, target_id, user_id
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/search/index.mdx
+++ b/website/content/docs/commands/search/index.mdx
@@ -1,0 +1,43 @@
+---
+layout: docs
+page_title: search - Command
+description: |-
+  The "search" command let's you search the Boundary local cache for information about sessions and targets.
+---
+
+# search
+
+Command: `boundary search`
+
+The `search` command lets you search Boundary's local cache for information about sessions and targets.
+
+For more information, refer to [Boundary `list` vs `search`](/boundary/docs/api-clients/client-cache/#boundary-list-vs-search).
+
+## Examples
+
+The following example
+
+```shell-session
+$ boundary search
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary search [sub command] [options] [args]
+
+  # ...
+
+Subcommands:
+    resource   The resource you want to search for
+    query       The mql query used for searching on any of the indexed fields for the specific resource
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage, click on the name of the subcommand in the sidebar or one of the links below:
+
+- [resource]
+- [query]

--- a/website/content/docs/commands/search/index.mdx
+++ b/website/content/docs/commands/search/index.mdx
@@ -15,29 +15,85 @@ For more information, refer to [Boundary `list` vs `search`](/boundary/docs/api-
 
 ## Examples
 
-The following example
+The following example searches for all targets that are available in the local cache for the user.
 
 ```shell-session
-$ boundary search
+$ boundary search -resource targets
 ```
+
+Example output:
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Target information:
+  ID:                  ttcp_0987654321
+    Scope ID:          p_1234567890
+    Version:           2
+    Type:              tcp
+    Name:              Generated target using host sources
+    Description:       Provides a target using host sources in Boundary
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+      add-host-sources
+      set-host-sources
+      remove-host-sources
+      add-credential-sources
+      set-credential-sources
+      remove-credential-sources
+      authorize-session
+
+  ID:                  ttcp_1234567890
+    Scope ID:          p_1234567890
+    Version:           1
+    Type:              tcp
+    Name:              Generated target with a direct address
+    Description:       Provides an initial target using an address in Boundary
+    Address:           127.8.0.1
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+      add-host-sources
+      set-host-sources
+      remove-host-sources
+      add-credential-sources
+      set-credential-sources
+      remove-credential-sources
+      authorize-session
+```
+
+</CodeBlockConfig>
+
+
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-Usage: boundary search [sub command] [options] [args]
-
-  # ...
-
-Subcommands:
-    resource   The resource you want to search for
-    query       The mql query used for searching on any of the indexed fields for the specific resource
+$ boundary search [options]
 ```
 
 </CodeBlockConfig>
 
-For more information, examples, and usage, click on the name of the subcommand in the sidebar or one of the links below:
+### Command options
 
-- [resource]
-- [query]
+- `-resource` `(string: "")` - The type of resource you want to search the cache for.
+This is a required field.
+You can search for the following:
+   - `-sessions` - Searches for any sessions associated with the user.
+   - `-targets` - Searches for any targets associated with the user.
+
+- `-query` `(optional)` - If set, specifies the [MQL](https://github.com/hashicorp/mql/blob/main/GRAMMAR.md) query you want to use to search for the indexed fields on the resource you specified.
+If you do not provide a `-query` value, the search lists all resources of the specified type that have been cached.
+The available fields for each resource include:
+
+   - targets: ID, name, description, type, address, scope_id
+   - sessions: ID, type, endpoint, status, scope_id, target_id, user_id
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/search/index.mdx
+++ b/website/content/docs/commands/search/index.mdx
@@ -15,7 +15,7 @@ For more information, refer to [Boundary `list` vs `search`](/boundary/docs/api-
 
 ## Examples
 
-The following example searches for all targets that are available in the local cache for the user.
+The following example searches the local cache for all TCP targets that have the word "Generated" in the name.
 
 ```shell-session
 $ boundary search -resource targets -query 'type="tcp" and name%"Generated"'

--- a/website/content/docs/commands/search/index.mdx
+++ b/website/content/docs/commands/search/index.mdx
@@ -96,4 +96,11 @@ The available fields that can be used in the search query for each resource incl
    - targets: id, name, description, type, address, scope_id
    - sessions: id, type, endpoint, status, scope_id, target_id, user_id
 
+- `token` = A URL that points to a file on disk (file://) from which Boundary reads a token or an environment variable (env://) from which the token will be read.
+If you set this parameter, it overrides the `token-name` parameter.
+- `token-name` - If specified, Boundary uses the value in this parameter as the name when it stores the token in the system credential store.
+You can use this value to switch user identities for different commands.
+You can also specify a token name using the **BOUNDARY_TOKEN_NAME** environment variable.
+
+
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/search/index.mdx
+++ b/website/content/docs/commands/search/index.mdx
@@ -21,7 +21,7 @@ The following example searches for all targets that are available in the local c
 $ boundary search -resource targets
 ```
 
-Example output:
+**Example output:**
 
 <CodeBlockConfig hideClipboard>
 

--- a/website/content/docs/commands/search/index.mdx
+++ b/website/content/docs/commands/search/index.mdx
@@ -96,7 +96,7 @@ The available fields that can be used in the search query for each resource incl
    - targets: id, name, description, type, address, scope_id
    - sessions: id, type, endpoint, status, scope_id, target_id, user_id
 
-- `token` = A URL that points to a file on disk (file://) from which Boundary reads a token or an environment variable (env://) from which the token will be read.
+- `token` - A URL that points to a file on disk (file://) from which Boundary reads a token or an environment variable (env://) from which the token will be read.
 If you set this parameter, it overrides the `token-name` parameter.
 - `token-name` - If specified, Boundary uses the value in this parameter as the name when it stores the token in the system credential store.
 You can use this value to switch user identities for different commands.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -845,6 +845,10 @@
             "path": "commands/daemon"
           },
           {
+            "title": "add-token",
+            "path": "commands/daemon/add-token"
+          },
+          {
             "title": "start",
             "path": "commands/daemon/start"
           },
@@ -1149,6 +1153,10 @@
             "path": "commands/scopes/update"
           }
         ]
+      },
+      {
+        "title": "search",
+        "path": "commands/search"
       },
       {
         "title": "server",

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -838,6 +838,27 @@
         ]
       },
       {
+        "title": "daemon",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "commands/daemon"
+          },
+          {
+            "title": "start",
+            "path": "commands/daemon/start"
+          },
+          {
+            "title": "status",
+            "path": "commands/daemon/status"
+          },
+          {
+            "title": "stop",
+            "path": "commands/daemon/stop"
+          }
+        ]
+      },
+      {
         "title": "database",
         "routes": [
           {
@@ -1382,6 +1403,10 @@
       {
         "title": "Desktop",
         "href": "https://learn.hashicorp.com/tutorials/boundary/hcp-getting-started-desktop-app"
+      },
+      {
+        "title": "Client cache",
+        "path": "api-clients/client-cache"
       }
     ]
   },


### PR DESCRIPTION
This PR adds information about the new `boundary search` command and the client cache. The following topics were added or updated:

- [Client cache](https://boundary-gzhgt8rgo-hashicorp.vercel.app/boundary/docs/api-clients/client-cache) - new overview topic about how the local cache works with `search`
- New command documentation:
    - [`search`](https://boundary-gzhgt8rgo-hashicorp.vercel.app/boundary/docs/commands/search)
    - `daemon`:
       - [Overview](https://boundary-gzhgt8rgo-hashicorp.vercel.app/boundary/docs/commands/daemon)
       - [`add-token`](https://boundary-gzhgt8rgo-hashicorp.vercel.app/boundary/docs/commands/daemon/add-token)
       - [`start`](https://boundary-gzhgt8rgo-hashicorp.vercel.app/boundary/docs/commands/daemon/start)
       - [`status`](https://boundary-gzhgt8rgo-hashicorp.vercel.app/boundary/docs/commands/daemon/status)
       - [`stop`](https://boundary-gzhgt8rgo-hashicorp.vercel.app/boundary/docs/commands/daemon/stop)