### PR TITLE
chore: add storage policy documentation

### DIFF
--- a/website/content/docs/commands/policies/create.mdx
+++ b/website/content/docs/commands/policies/create.mdx
@@ -44,6 +44,7 @@ $ boundary policies create storage [options] [args]
 - `-description=<string>` - The description to set for the policy.
 - `-name=<string>` -The name to set on the policy.
 The name is optional, but if you set it, it must be unique within the scope ID.
+If you do not provide a name, Boundary uses the storage policy ID as the default name.
 - `-scope-id=<string>` - Scope in which to create the policy.
 The default scope is global.
 You can also specify a scope using the **BOUNDARY_SCOPE_ID** environment variable.

--- a/website/content/docs/commands/policies/create.mdx
+++ b/website/content/docs/commands/policies/create.mdx
@@ -1,0 +1,60 @@
+---
+layout: docs
+page_title: policies create - Command
+description: |-
+  The "policies create" command lets you create Boundary policies.
+---
+
+# policies create
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+Command: `boundary policies create`
+
+The `boundary policies create` command lets you create Boundary policies.
+
+Storage policies codify how long session recordings must be kept and when they should be deleted.
+For more information, refer to the [storage policies](/boundary/docs/concepts/domain-model/storage-policy) documentation.
+
+## Example
+
+This example creates a storage policy with the name `prod` and the description `Prod Storage Policy`.
+The policy has a retention period of 10 days, and it will be deleted after 20 days:
+
+```shell-session
+$ boundary policies create storage -name prod -description "Prod Storage Policy" -retain-for-days 10 -delete-after-days 20
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary policies create storage [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Subcommands
+
+- `storage` - Creates a storage type policy.
+
+### Command options
+
+- `-description=<string>` - The description to set for the policy.
+- `-name=<string>` -The name to set on the policy.
+The name is optional, but if you set it, it must be unique within the scope ID.
+- `-scope-id=<string>` - Scope in which to create the policy.
+The default scope is global.
+You can also specify a scope using the **BOUNDARY_SCOPE_ID** environment variable.
+
+### Storage policy options
+
+- `-delete-after-days=<string>` - The number of days after which Boundary will delete a session recording.
+- `-delete-after-overridable=<string>` - Whether the policy's deletion period can be overridden by downstream policies.
+The value can be `true` or `false`.
+- `-retain-for-days=<string>` - The number of days a session recording should be retained for.
+- `-retain-for-overridable=<string>` - Whether the policy's retention period can be overriden by downstream storage policies.
+The value can be `true` or `false`.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/policies/delete.mdx
+++ b/website/content/docs/commands/policies/delete.mdx
@@ -1,0 +1,38 @@
+---
+layout: docs
+page_title: policies delete - Command
+description: |-
+  The "policies delete" command lets you delete Boundary policies.
+---
+
+# policies delete
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+Command: `boundary policies delete`
+
+The `boundary policies delete` command lets you delete Boundary policies.
+
+## Example
+
+This example deletes a policy with the ID `p_1234567890`:
+
+```shell-session
+$ boundary policies delete -id p_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary policies delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - The ID of the policy you want to delete.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/policies/index.mdx
+++ b/website/content/docs/commands/policies/index.mdx
@@ -1,0 +1,51 @@
+---
+layout: docs
+page_title: policies - Command
+description: |-
+  The "policies" command lets you perform operations on Boundary policy resources.
+---
+
+# policies
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+Command: `boundary policies`
+
+The `policies` command lets you perform operations on Boundary policies.
+
+Storage policies codify how long session recordings must be kept and when they should be deleted.
+For more information, refer to the [storage policies](/boundary/docs/concepts/domain-model/storage-policy) documentation.
+
+## Example
+
+The following command reads a policy with the id `pst_1234567890`:
+
+```shell-session
+$ boundary policies read -id chr_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary policies <subcommand> [options] [args]
+  # ...
+Subcommands:
+    create      Create a policy
+    delete      Delete a policy
+    list        List a policy
+    read        Read a policy
+    update      Update a policy
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [create](/boundary/docs/commands/policies/create)
+- [delete](/boundary/docs/commands/policies/delete)
+- [list](/boundary/docs/commands/policies/list)
+- [read](/boundary/docs/commands/policies/read)
+- [update](/boundary/docs/commands/policies/update)

--- a/website/content/docs/commands/policies/list.mdx
+++ b/website/content/docs/commands/policies/list.mdx
@@ -1,0 +1,47 @@
+---
+layout: docs
+page_title: policies list - Command
+description: |-
+  The "policies list" command lists the policies within a given scope or resource.
+---
+
+# policies list
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+Command: `policies list`
+
+The `policies list` command lets you list the policies within a given scope or resource.
+
+## Example
+
+This example lists all policies within the scope `s_1234567890`.
+The `recursive` option means Boundary runs the operation recursively on any child scopes, if applicable:
+
+```shell-session
+$ boundary policies list -scope-id s_1234567890 -recursive
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary policies list [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-filter=<string>` - If set, Boundary filters the list operation before the results are returned.
+The filter operates against each item in the list.
+We recommend that you use single quotes, because the filters contain double quotes.
+Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
+- `recursive` - If set, runs the list operation recursively on any child scopes, if the type supports it.
+The default value is `false`.
+- `scope-id=<string>` - The scope from which to list policies.
+The default value is `global`.
+You can also specify this value using the **BOUNDARY_SCOPE_ID** environment variable.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/policies/read.mdx
+++ b/website/content/docs/commands/policies/read.mdx
@@ -1,0 +1,38 @@
+---
+layout: docs
+page_title: policies read - Command
+description: |-
+  The "policies read" command lets you read information about Boundary policies.
+---
+
+# policies read
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+Command: `boundary policies read`
+
+The `boundary policies read` command lets you read information about Boundary policies.
+
+## Example
+
+This example reads the details of a policy with the ID `p_1234567890`:
+
+```shell-session
+$ boundary policies read -id p_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary policies read [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - The ID of the policy you want to read.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/policies/update.mdx
+++ b/website/content/docs/commands/policies/update.mdx
@@ -1,0 +1,60 @@
+---
+layout: docs
+page_title: policies update - Command
+description: |-
+  The "policies update" command lets you update Boundary policies.
+---
+
+# policies update
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+Command: `boundary policies update`
+
+The `boundary policies update` command lets you update Boundary policies.
+
+Storage policies codify how long session recordings must be kept and when they should be deleted.
+For more information, refer to the [storage policies](/boundary/docs/concepts/domain-model/storage-policy) documentation.
+
+## Example
+
+This example updates a storage policy with the ID `pst_1234567890` to add the name `dev` and the description `Dev Storage Policy`.
+The policy has a retention period of 1 day, and it will be deleted after 2 days:
+
+```shell-session
+$ boundary policies update storage -id pst_1234567890 -name dev -description "Dev Storage Policy" -retain-for-days 1 -delete-after-days 2
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary policies update storage [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Subcommands
+
+- `storage` - Updates a storage type policy.
+
+### Command options
+
+- `-description=<string>` - The description to set for the policy.
+- `-id=<string>` - The ID of the policy you want to update.
+- `-name=<string>` -The name to set on the policy.
+The name is optional, but if you set it, it must be unique within the scope ID.
+- `-version=<int>` - The version of the policy to update.
+If you do not specify a version, the command performs a check-and-set automatically.
+
+### Storage policy options
+
+- `-delete-after-days=<string>` - The number of days after which Boundary will delete a session recording.
+- `-delete-after-overridable=<string>` - Whether the policy's deletion period can be overridden by downstream policies.
+The value can be `true` or `false`.
+- `-retain-for-days=<string>` - The number of days a session recording should be retained for.
+- `-retain-for-overridable=<string>` - Whether the policy's retention period can be overriden by downstream storage policies.
+The value can be `true` or `false`.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/policies/update.mdx
+++ b/website/content/docs/commands/policies/update.mdx
@@ -45,6 +45,7 @@ $ boundary policies update storage [options] [args]
 - `-id=<string>` - The ID of the policy you want to update.
 - `-name=<string>` -The name to set on the policy.
 The name is optional, but if you set it, it must be unique within the scope ID.
+If you do not provide a name, Boundary uses the storage policy ID as the default name.
 - `-version=<int>` - The version of the policy to update.
 If you do not specify a version, the command performs a check-and-set automatically.
 

--- a/website/content/docs/concepts/domain-model/scopes.mdx
+++ b/website/content/docs/concepts/domain-model/scopes.mdx
@@ -67,21 +67,22 @@ A scope has the following configurable attributes:
 
 - `description` - (optional)
 
-### Storage policy association
+## Storage policy association
 
 <EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
-A storage policy that is created with the Global scope can be associated to any org scope.
-However, a storage policy created with an Org scope can only be associated with the same Org scope.
-Changing the assigned Storage Policy of a scope can impact the resultant set of policy, such a change will only affect future recordings created within that scope or with that Storage Policy.
+[Storage policies][] that are created in the global scope can be associated with any org scope.
+However, a storage policy created in an org scope can only be associated with that org scope.
+Changing the storage policy assigned to a scope can impact the resultant set of policy, but such a change only affects future recordings that you create within that scope or using that storage policy.
 
 ## Referenced by
 
-- [Auth Method][]
-- [Credential Store][]
+- [Auth method][]
+- [Credential store][]
 - [Group][]
-- [Host Catalog][]
+- [Host catalog][]
 - [Role][]
+- [Storage policies][]
 - [Target][]
 - [User][]
 
@@ -102,6 +103,7 @@ Changing the assigned Storage Policy of a scope can impact the resultant set of 
 [projects]: /boundary/docs/concepts/domain-model/scopes#projects
 [role]: /boundary/docs/concepts/domain-model/roles
 [roles]: /boundary/docs/concepts/domain-model/roles
+[storage policies]: /boundary/docs/concepts/domain-model/storage-policy
 [target]: /boundary/docs/concepts/domain-model/targets
 [targets]: /boundary/docs/concepts/domain-model/targets
 [user]: /boundary/docs/concepts/domain-model/users

--- a/website/content/docs/concepts/domain-model/scopes.mdx
+++ b/website/content/docs/concepts/domain-model/scopes.mdx
@@ -67,6 +67,14 @@ A scope has the following configurable attributes:
 
 - `description` - (optional)
 
+### Storage policy association
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+A storage policy that is created with the Global scope can be associated to any org scope.
+However, a storage policy created with an Org scope can only be associated with the same Org scope.
+Changing the assigned Storage Policy of a scope can impact the resultant set of policy, such a change will only affect future recordings created within that scope or with that Storage Policy.
+
 ## Referenced by
 
 - [Auth Method][]

--- a/website/content/docs/concepts/domain-model/session-recordings.mdx
+++ b/website/content/docs/concepts/domain-model/session-recordings.mdx
@@ -45,9 +45,24 @@ A session recording belongs to the scope of the [storage bucket][]
 it is stored in. The scope can be either the global scope or an [organization][]
 scope.
 
-## Referenced by
+## Resultant Set Of Policy Calculation
 
-- [Storage Bucket][]
+A storage policy codifies how long a session recording must be kept and when they should be deleted.
+The Resultant Set of Policy (RSoP) refers to the set of policy attributes that will be used on a resource.
+When policies are applied on multiple levels the results can conflict, for storage [olicies when evaluating the RSoP the system will evaluate each policy attribute individually starting at the global scope and moving down.
+This means that evaluating the storage policy assigned to the global scope then evaluating the storage policy assigned to the org scope.
+When evaluating the RSoP, the system will make use of the following principles, in order:
+
+1. Retention wins over deletion. The retention duration parameter guarantees that a session recording will be retained for at least that duration. Before the retention duration has transpired manual deletes will fail and Boundary will not attempt to automatically delete any session recordings.
+2. Longest retention wins. When evaluating multiple storage policies the longer retention duration parameter will apply to the session recording.
+3. The shortest deletion wins. When evaluating multiple storage policies the shorter delete after duration parameter will apply to the session recording.
+
+Each attribute of a storage policy also indicates whether the attribute can be overridden or not.
+If the attribute cannot be overridden Boundary will stop evaluating the RSoP for that attribute at lower scopes.
+
+Changing the assigned policy of a scope or changing an attribute of a storage policy can impact the RSoP.
+Such a change will only affect future session recordings created within that scope or with that storage policy.
+When a session recording is not in compliance with the current RSoP the session recording API will indicate that it is out of compliance with the current policy.
 
 ## Service API docs
 

--- a/website/content/docs/concepts/domain-model/session-recordings.mdx
+++ b/website/content/docs/concepts/domain-model/session-recordings.mdx
@@ -65,6 +65,34 @@ Changing the policy assigned to a scope or changing an attribute of a storage po
 Such a change only affects future session recordings created in that scope or using that storage policy.
 If a session recording is not in compliance with the current RSoP, the session recording API indicates that it is out of compliance with the current policy.
 
+### Examples
+
+Case 1: 
+In this case, the retention value is derived from the org policy and the deletion value is derived from the global policy.
+
+|               | Global Policy | Org Policy    | Result Policy |
+| ------------------------------ | ------------- | ---------- | ------------- |
+| Retain For Days(Overridable)                                 | 10(True)                   | 20(True)             | 20                         |
+| Delete After Days(Overridable)                               | 30(True)                   | 40(True)             | 30                         |
+
+Case 2:
+In this case, the org policy values are ignored because the global policy values are not overridable.
+
+|               | Global Policy | Org Policy    | Result Policy |
+| ------------------------------ | ------------- | ---------- | ------------- |
+| Retain For Days(Overridable)                                 | 10(False)                  | 20(True)             | 10                         |
+| Delete After Days(Overridable)                               | 30(False)                  | 40(True)             | 30                         |
+
+Case 3:
+In this case, the longest retention value is 30 and the shortest deletion value is 20, howerever delete_after_days cannot be less than retain_for_days.
+Therefore, the deletion value is set to the retention value.
+
+|               | Global Policy | Org Policy    | Result Policy |
+| ------------------------------ | ------------- | ---------- | ------------- |
+| Retain For Days(Overridable)                                 | 30(True)                   | 20(True)             | 30                         |
+| Delete After Days(Overridable)                               | 50(True)                   | 20(True)             | 30                         |
+
+
 ## Service API docs
 
 The following services are relevant to this resource:

--- a/website/content/docs/concepts/domain-model/session-recordings.mdx
+++ b/website/content/docs/concepts/domain-model/session-recordings.mdx
@@ -55,8 +55,8 @@ Boundary evaluates each storage policy attribute individually, starting at the g
 In accordance with the RSoP, Boundary considers the following principles in order:
 
 1. Retention wins over deletion. The retention duration parameter guarantees that a session recording is retained for at least that duration. Before the retention duration has transpired, manual deletes will fail and Boundary will not attempt to automatically delete any session recordings.
-2. Longest retention wins. When evaluating multiple storage policies, the longer retention duration parameter applies to the session recording.
-3. The shortest deletion wins. When evaluating multiple storage policies, the shorter delete after duration parameter applies to the session recording.
+2. Longest retention wins. When Boundary evaluates multiple storage policies, the longer retention duration parameter applies to the session recording.
+3. The shortest deletion wins. When Boundary evaluates multiple storage policies, the shorter delete after duration parameter applies to the session recording.
 
 Each storage policy attribute also indicates whether the attribute can be overridden or not.
 If the attribute cannot be overridden, Boundary stops evaluating the RSoP for that attribute at lower scopes.
@@ -67,31 +67,36 @@ If a session recording is not in compliance with the current RSoP, the session r
 
 ### Examples
 
-Case 1: 
+In the following examples, Boundary determines the resultant set of policies using the `retain_for_days_overridable` and `delete_after_days_overridable` attributes.
+A value of `true` indicates the number of days can be overridden, while a value of `false` indicates that it cannot be overridden.
+
+#### Example 1
 In this case, the retention value is derived from the org policy and the deletion value is derived from the global policy.
 
-|               | Global Policy | Org Policy    | Result Policy |
+|               | Global policy | Org policy    | Result policy |
 | ------------------------------ | ------------- | ---------- | ------------- |
-| Retain For Days(Overridable)                                 | 10(True)                   | 20(True)             | 20                         |
-| Delete After Days(Overridable)                               | 30(True)                   | 40(True)             | 30                         |
+| Retain for days (Overridable)                                 | 10 (True)                   | 20 (True)             | 20                         |
+| Delete after days (Overridable)                               | 30 (True)                   | 40 (True)             | 30                         |
 
-Case 2:
-In this case, the org policy values are ignored because the global policy values are not overridable.
+#### Example 2
+In this case, Boundary ignores the org policy values because the global policy values are not overridable.
 
-|               | Global Policy | Org Policy    | Result Policy |
+|               | Global policy | Org policy    | Result policy |
 | ------------------------------ | ------------- | ---------- | ------------- |
-| Retain For Days(Overridable)                                 | 10(False)                  | 20(True)             | 10                         |
-| Delete After Days(Overridable)                               | 30(False)                  | 40(True)             | 30                         |
+| Retain for days (Overridable)                                 | 10 (False)                  | 20 (True)             | 10                         |
+| Delete after days (Overridable)                               | 30 (False)                  | 40 (True)             | 30                         |
 
-Case 3:
-In this case, the longest retention value is 30 and the shortest deletion value is 20, howerever delete_after_days cannot be less than retain_for_days.
-Therefore, the deletion value is set to the retention value.
+#### Example 3
+In this case, the longest retention value is 30, and the shortest deletion value is 20.
+However, the `delete_after_days` value cannot be less than the `retain_for_days` value.
+Therefore, Boundary sets the deletion value to the retention value.
 
-|               | Global Policy | Org Policy    | Result Policy |
+|               | Global policy | Org policy    | Result policy |
 | ------------------------------ | ------------- | ---------- | ------------- |
-| Retain For Days(Overridable)                                 | 30(True)                   | 20(True)             | 30                         |
-| Delete After Days(Overridable)                               | 50(True)                   | 20(True)             | 30                         |
+| Retain for days (Overridable)                                 | 30 (True)                   | 20 (True)             | 30                         |
+| Delete after days (Overridable)                               | 50 (True)                   | 20 (True)             | 30                         |
 
+For more information, refer to the [storage policy attributes](/boundary/docs/concepts/domain-model/storage-policy#attributes) documentation.
 
 ## Service API docs
 

--- a/website/content/docs/concepts/domain-model/session-recordings.mdx
+++ b/website/content/docs/concepts/domain-model/session-recordings.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Domain model - session recordings
 description: |-
-  The anatomy of a Boundary session recording
+  Use session recordings to audit user sessions in Boundary. Learn how to configure session recordings to monitor usage.
 ---
 
 # Session recordings
@@ -45,24 +45,25 @@ A session recording belongs to the scope of the [storage bucket][]
 it is stored in. The scope can be either the global scope or an [organization][]
 scope.
 
-## Resultant Set Of Policy Calculation
+## Resultant set of policy calculation
 
-A storage policy codifies how long a session recording must be kept and when they should be deleted.
-The Resultant Set of Policy (RSoP) refers to the set of policy attributes that will be used on a resource.
-When policies are applied on multiple levels the results can conflict, for storage [olicies when evaluating the RSoP the system will evaluate each policy attribute individually starting at the global scope and moving down.
-This means that evaluating the storage policy assigned to the global scope then evaluating the storage policy assigned to the org scope.
-When evaluating the RSoP, the system will make use of the following principles, in order:
+[Storage policies][] codify how long session recordings must be kept and when they should be deleted.
+The resultant set of policy (RSoP) refers to the set of policy attributes that apply to a resource.
+When you apply policies on multiple levels, the results can conflict.
+Boundary evaluates each storage policy attribute individually, starting at the global scope and then evaluating any storage policies assigned to org scopes.
 
-1. Retention wins over deletion. The retention duration parameter guarantees that a session recording will be retained for at least that duration. Before the retention duration has transpired manual deletes will fail and Boundary will not attempt to automatically delete any session recordings.
-2. Longest retention wins. When evaluating multiple storage policies the longer retention duration parameter will apply to the session recording.
-3. The shortest deletion wins. When evaluating multiple storage policies the shorter delete after duration parameter will apply to the session recording.
+In accordance with the RSoP, Boundary considers the following principles in order:
 
-Each attribute of a storage policy also indicates whether the attribute can be overridden or not.
-If the attribute cannot be overridden Boundary will stop evaluating the RSoP for that attribute at lower scopes.
+1. Retention wins over deletion. The retention duration parameter guarantees that a session recording is retained for at least that duration. Before the retention duration has transpired, manual deletes will fail and Boundary will not attempt to automatically delete any session recordings.
+2. Longest retention wins. When evaluating multiple storage policies, the longer retention duration parameter applies to the session recording.
+3. The shortest deletion wins. When evaluating multiple storage policies, the shorter delete after duration parameter applies to the session recording.
 
-Changing the assigned policy of a scope or changing an attribute of a storage policy can impact the RSoP.
-Such a change will only affect future session recordings created within that scope or with that storage policy.
-When a session recording is not in compliance with the current RSoP the session recording API will indicate that it is out of compliance with the current policy.
+Each storage policy attribute also indicates whether the attribute can be overridden or not.
+If the attribute cannot be overridden, Boundary stops evaluating the RSoP for that attribute at lower scopes.
+
+Changing the policy assigned to a scope or changing an attribute of a storage policy can impact the RSoP.
+Such a change only affects future session recordings created in that scope or using that storage policy.
+If a session recording is not in compliance with the current RSoP, the session recording API indicates that it is out of compliance with the current policy.
 
 ## Service API docs
 
@@ -80,3 +81,4 @@ The following services are relevant to this resource:
 [organization]: /boundary/docs/concepts/domain-model/scopes#organizations
 [session]: /boundary/docs/concepts/domain-model/sessions
 [storage bucket]: /boundary/docs/concepts/domain-model/storage-buckets
+[storage policies]: /boundary/docs/concepts/domain-model/storage-policy

--- a/website/content/docs/concepts/domain-model/storage-policy.mdx
+++ b/website/content/docs/concepts/domain-model/storage-policy.mdx
@@ -1,8 +1,8 @@
 ---
 layout: docs
-page_title: Domain model - storage policy
+page_title: Domain model - storage policies
 description: |-
-  The anatomy of a Boundary storage policy
+    Use storage policies to manage session recording retention in Boundary. Learn how to configure policies for global and org scopes, and specify retention periods.
 ---
 
 # Storage policies
@@ -13,10 +13,10 @@ A resource known as a storage policy is used to codify how long [session recordi
 A storage policy's name is optional, but it must be unique if you define one.
 Storage policies can only be assigned to the global [scope][] or an org scope.
 
-A storage policy exists in either the Global scope or an Org scope.
-A storage policy that is created with the Global scope can be associated to any org scope.
-However, a storage policy created with an Org scope can only be associated with the same Org scope.
-Any storage policy associated with an Org scope are deleted when the Org itself is deleted.
+A storage policy exists in either the global scope or an org scope.
+Storage policies that are created in the global scope can be associated with any org scope.
+However, a storage policy created in an org scope can only be associated with that org scope.
+Any storage policies associated with an org scope are deleted when you delete the org itself.
 
 ## Attributes
 
@@ -26,20 +26,21 @@ A storage policy has the following configurable attributes:
 The name is optional, but if you set it, it must be unique within the scope ID.
 - `description` - (Optional) A description of the resource.
 - `retain_for_days` - (Optional) The number of days a session recording must be kept.
-Negative one indicates an infinite retention.
-- `retain_for_days_overridable` - (Optional) Indicates that a lower scope can override the retain for days attribute value.
-Defaults to true.
-- `delete_after_days` - (Optional) The number of days a session recording should be deleted.
-- `delete_after_days_overridable` - (Optional) Indicates that a lower scope can override the delete after days attribute value.
-Defaults to true.
+A value of `-1` indicates an infinite retention.
+- `retain_for_days_overridable` - (Optional) Indicates that a lower scope can override the `retain_for_days` attribute value.
+The default value is `true`.
+- `delete_after_days` - (Optional) The number of days after which a session recording should be deleted.
+- `delete_after_days_overridable` - (Optional) Indicates that a lower scope can override the  `delete_after_days` attribute value.
+The default value is `true`.
 
-## Retention and Deletion Guidelines
+## Retention and deletion guidelines
 
-- Setting the retain_for_days value to -1 (infinity) requires the delete_after_days value to be set to zero.
-- If delete_after_days is set, the value must be greater than or equal to zero.
-- The delete_after_days value must be greater than or equal to retain_for_days, unless delete_after_days is set to zero.
-- Both retain_for_days and delete_after_days cannot be set to zero.
-- Changing an attribute of a Storage Policy that is assigned to a scope can impact the resultant set of policy, such a change will only affect future recordings created within that scope or with that Storage Policy.
+- Setting the `retain_for_days` value to `-1` (infinity) requires the `delete_after_days` value to be set to `0`.
+- If you set the `delete_after_days` value, it must be greater than or equal to 0.
+- The `delete_after_days` value must be greater than or equal to the `retain_for_days` value, unless you set `delete_after_days` to `0`.
+- You cannot set the `retain_for_days` and `delete_after_days` values to 0.
+- Changing an attribute of a storage policy that is assigned to a scope can impact the resultant set of policy.
+However, such a change only affects future recordings created within that scope or using that storage policy.
 
 ## Referenced by
 

--- a/website/content/docs/concepts/domain-model/storage-policy.mdx
+++ b/website/content/docs/concepts/domain-model/storage-policy.mdx
@@ -1,0 +1,57 @@
+---
+layout: docs
+page_title: Domain model - storage policy
+description: |-
+  The anatomy of a Boundary storage policy
+---
+
+# Storage policies
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+A resource known as a storage policy is used to codify how long [session recordings][] must be kept and when they should be deleted.
+A storage policy's name is optional, but it must be unique if you define one.
+Storage policies can only be assigned to the global [scope][] or an org scope.
+
+A storage policy exists in either the Global scope or an Org scope.
+A storage policy that is created with the Global scope can be associated to any org scope.
+However, a storage policy created with an Org scope can only be associated with the same Org scope.
+Any storage policy associated with an Org scope are deleted when the Org itself is deleted.
+
+## Attributes
+
+A storage policy has the following configurable attributes:
+
+- `name` - (Optional) The name of the resource in Boundary.
+The name is optional, but if you set it, it must be unique within the scope ID.
+- `description` - (Optional) A description of the resource.
+- `retain_for_days` - (Optional) The number of days a session recording must be kept.
+Negative one indicates an infinite retention.
+- `retain_for_days_overridable` - (Optional) Indicates that a lower scope can override the retain for days attribute value.
+Defaults to true.
+- `delete_after_days` - (Optional) The number of days a session recording should be deleted.
+- `delete_after_days_overridable` - (Optional) Indicates that a lower scope can override the delete after days attribute value.
+Defaults to true.
+
+## Retention and Deletion Guidelines
+
+- Setting the retain_for_days value to -1 (infinity) requires the delete_after_days value to be set to zero.
+- If delete_after_days is set, the value must be greater than or equal to zero.
+- The delete_after_days value must be greater than or equal to retain_for_days, unless delete_after_days is set to zero.
+- Both retain_for_days and delete_after_days cannot be set to zero.
+- Changing an attribute of a Storage Policy that is assigned to a scope can impact the resultant set of policy, such a change will only affect future recordings created within that scope or with that Storage Policy.
+
+## Referenced by
+
+- [scopes](/boundary/docs/concepts/domain-model/scopes)
+- [session recordings](/boundary/docs/concepts/domain-model/session-recordings)
+
+## Service API docs
+
+The following services are relevant to this resource:
+
+- [Scope Service](/boundary/api-docs/scope-service)
+- [Policy Service](/boundary/api-docs/policy-service)
+
+[session recordings]: /boundary/docs/concepts/domain-model/session-recordings
+[scope]: /boundary/docs/concepts/domain-model/scopes

--- a/website/content/docs/concepts/domain-model/storage-policy.mdx
+++ b/website/content/docs/concepts/domain-model/storage-policy.mdx
@@ -24,6 +24,7 @@ A storage policy has the following configurable attributes:
 
 - `name` - (Optional) The name of the resource in Boundary.
 The name is optional, but if you set it, it must be unique within the scope ID.
+If you do not provide a name, Boundary uses the storage policy ID as the default name.
 - `description` - (Optional) A description of the resource.
 - `retain_for_days` - (Optional) The number of days a session recording must be kept.
 A value of `-1` indicates an infinite retention.

--- a/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
+++ b/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
@@ -62,7 +62,7 @@ Complete the following steps to create a storage policy in Boundary for session 
    - **Deletion Policy**: (Required) Specifies when to delete a recording, in days.
    Policy values include:
    - `Do not delete`: Do not delete recordings, even after the retention policy is met.
-   - `Custom`: Specify the number of days after the retention policy before recordings are deleted.
+   - `Custom`: Specifies the number of days after creation when a session recording should be deleted.
 
    As an example, the following settings would create a SOC 2 compliant policy:
 
@@ -99,7 +99,7 @@ Complete the following steps to create a storage policy in Boundary for session 
    - `scope-id`: (Optional) The ID of the scope (global or an org) that owns the policy. Defaults to `global`.
    - `retain-for-days`: (Optional) The number of days a session recording must be kept. A value of `-1` indicates an infinite retention.
    - `retain-for-overridable`: (Optional) Indicates that a lower scope can override the `retain_for_days` attribute value. Defaults to `true`.
-   - `delete-after-days`: (Optional) The number of days after which a session recording should be deleted.
+   - `delete-after-days`: (Optional) The number of days after creation when a session recording should be deleted.
    - `delete-after-overridable`: (Optional) Indicates that a lower scope can override the  `delete_after_days` attribute value. Defaults to `true`.
 
 </Tab>
@@ -195,6 +195,8 @@ The following example applies the policy created above to an org named `prod-dat
 1. Log in to Boundary.
 1. Obtain the storage policy ID:
 
+   <CodeBlockConfig highlight="1,3">
+
    ```shell-session
    $ boundary policies list
    Policy information: 
@@ -210,11 +212,13 @@ The following example applies the policy created above to an org named `prod-dat
          no-op
    ```
 
+   </CodeBlockConfig>
+
 1. Use the following command to apply the storage policy to the `prod-databases` org:
 
    ```shell-session
    $ boundary scopes attach-storage-policy \
-       -id <ORG_ID> \
+       -id o_aDkVBCDTvY \
        -storage-policy-id pst_WZ3SQSSYJY
    ```
 
@@ -241,7 +245,7 @@ $ curl --header "Content-Type: application/json" \
     --header "Authorization: Bearer $(boundary config get-token)" \
     --request POST \
     --data '{"storage_policy_id":"pst_WZ3SQSSYJY","version":2}'' \
-    $BOUNDARY_ADDR/v1/scopes/<ORG_ID>:attach-storage-policy' | jq
+    $BOUNDARY_ADDR/v1/scopes/o_aDkVBCDTvY:attach-storage-policy' | jq
 ```
 
 **Example output:**
@@ -338,10 +342,10 @@ Check that the storage policy was successfully attached to the `prod-databases` 
 1. Log in to Boundary.
 1. Read the details of the `prod-databases` org:
 
-   <CodeBlockConfig highlight="1-6">
+   <CodeBlockConfig highlight="1,5-6">
 
    ```shell-session
-   $ boundary scopes read -id <ORG_ID>
+   $ boundary scopes read -id o_aDkVBCDTvY
    Scope information:
      Created Time:        Thu, 25 Jan 2024 21:22:45 MST
      ID:                  o_aDkVBCDTvY
@@ -376,8 +380,6 @@ Check that the storage policy was successfully attached to the `prod-databases` 
 
 The following API call is an example of reading the details of the `prod-databases` scope by ID (`o_aDkVBCDTvY` in this example).
 
-First, obtain the storage policy ID.
-
 ```shell-session
 $ curl --header "Content-Type: application/json" \
     --header "Authorization: Bearer $(boundary config get-token)" \
@@ -387,7 +389,7 @@ $ curl --header "Content-Type: application/json" \
 
 **Example output:**
 
-<CodeBlockConfig hideClipboard highlight="1-9,61">
+<CodeBlockConfig hideClipboard highlight="2-3,63">
 
 ```plaintext
 {
@@ -479,10 +481,11 @@ New session recordings under the `prod-databases` scope should now show a `retai
 </Tab>
 <Tab heading="CLI" group="cli">
 
+1. Create a new session recording on a target within the `prod-databases` org.
 1. Log in to Boundary.
 1. List the available session recordings:
 
-   <CodeBlockConfig>
+   <CodeBlockConfig highlight="1,4">
 
    ```shell-session
    $ boundary session-recordings list
@@ -508,11 +511,11 @@ New session recordings under the `prod-databases` scope should now show a `retai
 
    </CodeBlockConfig>
 
-   Copy the recording **ID**.
+   Copy the recording **ID** (such as `sr_nt5dFeBYdh`).
 
 1. Read the recording details by ID.
 
-   <CodeBlockConfig highlight="1-3,6-7,11">
+   <CodeBlockConfig highlight="1,3,6-7,11">
 
    ```shell-session
    $ boundary session-recordings read -id sr_nt5dFeBYdh
@@ -545,93 +548,94 @@ New session recordings under the `prod-databases` scope should now show a `retai
 </Tab>
 <Tab heading="API call using cURL" group="api">
 
-The following API call is an example of reading the details of a session recording with the `soc2-policy` storage policy applied to the `prod-databases` scope.
+1. Create a new session recording on a target within the `prod-databases` org.
+1. The following API call is an example of reading the details of a session recording with the `soc2-policy` storage policy applied to the `prod-databases` scope.
 
-List the available session recordings. This example recursively lists all recordings within the global scope.
+   List the available session recordings. This example recursively lists all recordings    within the global scope.
+   
+   ```shell-session
+   $ curl --header "Content-Type: application/json" \
+       --header "Authorization: Bearer $(boundary config get-token)" \
+       --request GET \
+       $BOUNDARY_ADDR/v1/session-recordings?recursive=true&scope_id=global | jq
+   ```
+   
+   **Example output:**
+   
+   <CodeBlockConfig hideClipboard highlight="4,57-58">
+   
+   ```plaintext
+   {
+     "items": [
+       {
+         "id": "sr_nt5dFeBYdh",
+         "scope": {
+           "id": "global",
+           "type": "global",
+           "name": "global",
+           "description": "Global Scope"
+         },
+         "storage_bucket_id": "sb_DC8SPb9uc2",
+         "created_time": "2024-01-30T06:25:31.873628Z",
+         "updated_time": "2024-01-30T07:26:01.182513Z",
+         "start_time": "2024-01-30T06:25:32.412373Z",
+         "end_time": "2024-01-30T06:25:53.431183Z",
+         "duration": "21.018810s",
+         "type": "ssh",
+         "state": "available",
+         "endpoint": "ssh://xx.xxx.xxx.xxx:22",
+         "create_time_values": {
+           "user": {
+             "id": "u_lLWuYy70Wo",
+             "name": "admin_user",
+             "description": "Global admin user",
+             "scope": {
+               "id": "global",
+               "type": "global",
+               "name": "global",
+               "description": "Global Scope"
+             }
+           },
+           "target": {
+             "id": "tssh_cjTsFSU10p",
+             "name": "recording-target",
+             "scope": {
+               "id": "p_ocJPxzrz2p",
+               "type": "project",
+               "name": "recording-project",
+               "parent_scope_id": "o_aDkVBCDTvY"
+             },
+             "session_max_seconds": 28800,
+             "session_connection_limit": -1,
+             "egress_worker_filter": "\"recording-worker\" in \"/tags/type\"",
+             "type": "ssh",
+             "attributes": {
+               "default_port": 22
+             }
+           }
+         },
+         "authorized_actions": [
+           "reapply-storage-policy",
+           "no-op",
+           "read",
+           "download",
+           "delete"
+         ],
+         "retain_until": "2031-01-30T06:25:53.431183Z",
+         "delete_after": "2031-05-10T06:25:53.431183Z"
+       }
+     ],
+     "response_type": "complete",
+     "list_token":    "GnJNt3mPNy6Cp62MUBCnZPdrQF7cvh4udEoW4CjL5k2ufvesMfKAheSJyNHmKf3zwL5aVKHT4P6q",
+     "sort_by": "created_time",
+     "sort_dir": "desc",
+     "est_item_count": 1
+   }
+   ```
 
-```shell-session
-$ curl --header "Content-Type: application/json" \
-    --header "Authorization: Bearer $(boundary config get-token)" \
-    --request GET \
-    $BOUNDARY_ADDR/v1/session-recordings?recursive=true&scope_id=global | jq
-```
+   </CodeBlockConfig>
 
-**Example output:**
-
-<CodeBlockConfig hideClipboard highlight="1-4,47-48">
-
-```plaintext
-{
-  "items": [
-    {
-      "id": "sr_nt5dFeBYdh",
-      "scope": {
-        "id": "global",
-        "type": "global",
-        "name": "global",
-        "description": "Global Scope"
-      },
-      "storage_bucket_id": "sb_DC8SPb9uc2",
-      "created_time": "2024-01-30T06:25:31.873628Z",
-      "updated_time": "2024-01-30T07:26:01.182513Z",
-      "start_time": "2024-01-30T06:25:32.412373Z",
-      "end_time": "2024-01-30T06:25:53.431183Z",
-      "duration": "21.018810s",
-      "type": "ssh",
-      "state": "available",
-      "endpoint": "ssh://xx.xxx.xxx.xxx:22",
-      "create_time_values": {
-        "user": {
-          "id": "u_lLWuYy70Wo",
-          "name": "admin_user",
-          "description": "Global admin user",
-          "scope": {
-            "id": "global",
-            "type": "global",
-            "name": "global",
-            "description": "Global Scope"
-          }
-        },
-        "target": {
-          "id": "tssh_cjTsFSU10p",
-          "name": "recording-target",
-          "scope": {
-            "id": "p_ocJPxzrz2p",
-            "type": "project",
-            "name": "recording-project",
-            "parent_scope_id": "o_aDkVBCDTvY"
-          },
-          "session_max_seconds": 28800,
-          "session_connection_limit": -1,
-          "egress_worker_filter": "\"recording-worker\" in \"/tags/type\"",
-          "type": "ssh",
-          "attributes": {
-            "default_port": 22
-          }
-        }
-      },
-      "authorized_actions": [
-        "reapply-storage-policy",
-        "no-op",
-        "read",
-        "download",
-        "delete"
-      ],
-      "retain_until": "2031-01-30T06:25:53.431183Z",
-      "delete_after": "2031-05-10T06:25:53.431183Z"
-    }
-  ],
-  "response_type": "complete",
-  "list_token": "GnJNt3mPNy6Cp62MUBCnZPdrQF7cvh4udEoW4CjL5k2ufvesMfKAheSJyNHmKf3zwL5aVKHT4P6q",
-  "sort_by": "created_time",
-  "sort_dir": "desc",
-  "est_item_count": 1
-}
-```
-
-</CodeBlockConfig>
-
-Verify that the `retain_until` and `delete_after` dates match the durations defined in the `soc2-policy`.
+1. Verify that the `retain_until` and `delete_after` dates match the durations defined in the `soc2-policy`.
 
 Alternatively, the recording details can also be queried directly by ID:
 

--- a/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
+++ b/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
@@ -54,7 +54,7 @@ Complete the following steps to create a storage policy in Boundary for session 
    - **Description**: (Optional) An optional description of the Boundary storage policy for identification purposes.
    - **Retention Policy**: (Required) Specifies how long a recording must be stored, in days. 
    Policy values include:
-     - `Forever`: if enabled, Deletion Policy is disabled.
+     - `Forever`: If enabled, the **Deletion Policy** field is disabled.
      - `Custom`: Specify a custom retention policy in days.
      - `Do not protect, allow deletion at any time`
      - `SOC 2 (7 years)`
@@ -64,7 +64,7 @@ Complete the following steps to create a storage policy in Boundary for session 
    - `Do not delete`: Do not delete recordings, even after the retention policy is met.
    - `Custom`: Specify the number of days after the retention policy before recordings are deleted.
 
-   As an example, the following would create a SOC 2 compliant policy:
+   As an example, the following settings would create a SOC 2 compliant policy:
 
    - **Name**: `soc2-policy`
    - **Description**: `SOC 2 compliant storage policy for session recordings`
@@ -96,7 +96,7 @@ Complete the following steps to create a storage policy in Boundary for session 
 
    - `name`: (Optional) An optional human readable name.
    - `description`: (Optional) An optional human readable description.
-   - `scope-id`: (Optional) The ID of the scope (Global or an Org) that will own the policy. Defaults to `global`.
+   - `scope-id`: (Optional) The ID of the scope (global or an org) that owns the policy. Defaults to `global`.
    - `retain-for-days`: (Optional) The number of days a session recording must be kept. A value of `-1` indicates an infinite retention.
    - `retain-for-overridable`: (Optional) Indicates that a lower scope can override the `retain_for_days` attribute value. Defaults to `true`.
    - `delete-after-days`: (Optional) The number of days after which a session recording should be deleted.
@@ -169,13 +169,13 @@ In this example, recordings stored within the global scope must be retained for 
 
 <Warning>
 
-  Boundary does not support an undo action. Storage policies are meant to enforce compliance to a specific law or regulation. Updating the Storage policy of a session recording can have immediate and possibly unexpected results such as the immediate deletion of session recordings. 
+  Boundary does not support an undo action. Storage policies are meant to enforce compliance to a specific law or regulation. Updating the storage policy of a session recording can have immediate and possibly unexpected results such as the immediate deletion of session recordings. 
 
 </Warning>
 
 ## Attach storage policies to a scope
 
-Storage policies must be applied to a scope (`global` or a specific org) to take effect. Once attached, all recordings within the child scopes inherit the storage policy, unless overridden by a policy applied to the child scope.
+You must apply storage policies to a scope (`global` or a specific org) to take effect. Once attached, all recordings within the child scopes inherit the storage policy, unless overridden by a policy applied to the child scope.
 
 The following example applies the policy created above to an org named `prod-databases` with the org ID `o_aDkVBCDTvY`.
 
@@ -330,7 +330,7 @@ Check that the storage policy was successfully attached to the `prod-databases` 
 1. Log in to Boundary.
 1. Select **Orgs** in the navigation panel and select the `prod-databases` org.
 1. Select **Org Settings** in the navigation panel for the `prod-databases` org.
-1. Verify that the 'soc2-policy' is listed under **Storage Policy**.
+1. Verify that the `soc2-policy` is listed under **Storage Policy**.
 
 </Tab>
 <Tab heading="CLI" group="cli">
@@ -474,7 +474,7 @@ New session recordings under the `prod-databases` scope should now show a `retai
 1. Log in to Boundary.
 1. Select **Session Recordings** in the navigation panel. 
 1. Select **View** for a new recording that was made after the storage policy was attached to the `prod-databases` scope.
-1. Under **Session details**, verify that the *Retain until* and *Delete after* dates match the durations defined in the 'soc2-policy'.
+1. Under **Session details**, verify that the *Retain until* and *Delete after* dates match the durations defined in the `soc2-policy`.
 
 </Tab>
 <Tab heading="CLI" group="cli">
@@ -631,7 +631,7 @@ $ curl --header "Content-Type: application/json" \
 
 </CodeBlockConfig>
 
-Verify that the `retain_until` and `delete_after` dates match the durations defined in the 'soc2-policy'.
+Verify that the `retain_until` and `delete_after` dates match the durations defined in the `soc2-policy`.
 
 Alternatively, the recording details can also be queried directly by ID:
 

--- a/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
+++ b/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
@@ -47,7 +47,7 @@ Complete the following steps to create a storage policy in Boundary for session 
 <Tab heading="UI" group="ui">
 
 1. Log in to Boundary.
-1. Select **Storage Policies** in the navigation panel.
+1. Select **Storage Policies** in the navigation panel in the `global` scope.
 1. Click **Create a new storage policy**.
 1. Complete the following fields to create the Boundary storage policy:
    - **Name**: (Optional) The name field is optional, but if you enter a name it must be unique.

--- a/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
+++ b/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
@@ -1,0 +1,660 @@
+---
+layout: docs
+page_title: Configure storage bucket policies
+description: |-
+  How to configure storage bucket lifecycle policies for session recording in Boundary
+---
+
+# Configure storage bucket policies
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+As of Boundary 0.15.0, retention policies can codify storage bucket lifecycle management for [session recordings][].
+A Boundary resource known as a [storage bucket][] is used to store recorded sessions.
+A resource known as a [storage policy][] is used to codify how long session recordings must be kept and when they should be deleted.
+
+A storage policy exists in either the global scope or an org scope.
+Storage policies that are created in the global scope can be associated with any org scope.
+However, a storage policy created in an org scope can only be associated with that org scope.
+Any storage policies associated with an org scope are deleted when you delete the org itself.
+
+For more information about using session recording to audit user sessions, refer to [Auditing](/boundary/docs/concepts/auditing).
+
+## Requirements
+
+Before you can create a storage bucket in Boundary, you must ensure that your environment meets certain requirements.
+Session recording requires specific configuration for both the external store and the Boundary worker.
+At this time, the only supported storage is AWS S3.
+
+A Boundary worker configured for local storage is also required to set up session recording and configure recording bucket policies.
+
+Refer to [Create a storage bucket](/boundary/docs/configuration/session-recording/create-storage-bucket) to learn more about setting up storage for session recordings.
+
+## Example storage policies
+
+A storage policy defines how long the recording within a scope should retain its session recordings. Storage policy examples include:
+
+- Keep forever
+- Do not delete
+- Do not retain
+- Custom retention period
+
+## Create a storage policy
+
+Complete the following steps to create a storage policy in Boundary for session recording:
+
+<Tabs>
+<Tab heading="UI" group="ui">
+
+1. Log in to Boundary.
+1. Select **Storage Policies** in the navigation panel.
+1. Click **Create a new storage policy**.
+1. Complete the following fields to create the Boundary storage policy:
+   - **Name**: (Optional) The name field is optional, but if you enter a name it must be unique.
+   - **Description**: (Optional) An optional description of the Boundary storage policy for identification purposes.
+   - **Retention Policy**: (Required) Specifies how long a recording must be stored, in days. 
+   Policy values include:
+     - `Forever`: if enabled, Deletion Policy is disabled.
+     - `Custom`: Specify a custom retention policy in days.
+     - `Do not protect, allow deletion at any time`
+     - `SOC 2 (7 years)`
+     - `HIPPA (6 years)`
+   - **Deletion Policy**: (Required) Specifies when to delete a recording, in days.
+   Policy values include:
+   - `Do not delete`: Do not delete recordings, even after the retention policy is met.
+   - `Custom`: Specify the number of days after the retention policy before recordings are deleted.
+
+   As an example, the following would create a SOC 2 compliant policy:
+
+   - **Name**: `soc2-policy`
+   - **Description**: `SOC 2 compliant storage policy for session recordings`
+   - **Retention Policy**: `SOC 2 (7 years)`
+   - **Deletion Policy**: `Custom`
+   Delete after: `2657` days
+   Toggle the switch beside **Allow orgs to override**.
+
+1. Click **Save**.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+1. Log in to Boundary.
+1. Use the following command to create a storage policy in Boundary:
+
+   ```shell-session
+   $ boundary policies create storage \
+       -name soc2-policy \
+       -description 'SOC 2 compliant storage policy for session recordings' \
+       -scope-id global \
+       -retain-for-days 2557 \
+       -retain-for-overridable false \
+       -delete-after-days 2657 \
+       -delete-after-overridable true
+   ```
+
+   The following [attributes](/boundary/docs/concepts/domain-model/storage-policies) can be used when defining a storage policy:
+
+   - `name`: (Optional) An optional human readable name.
+   - `description`: (Optional) An optional human readable description.
+   - `scope-id`: (Optional) The ID of the scope (Global or an Org) that will own the policy. Defaults to `global`.
+   - `retain-for-days`: (Optional) The number of days a session recording must be kept. A value of `-1` indicates an infinite retention.
+   - `retain-for-overridable`: (Optional) Indicates that a lower scope can override the `retain_for_days` attribute value. Defaults to `true`.
+   - `delete-after-days`: (Optional) The number of days after which a session recording should be deleted.
+   - `delete-after-overridable`: (Optional) Indicates that a lower scope can override the  `delete_after_days` attribute value. Defaults to `true`.
+
+</Tab>
+<Tab heading="API call using cURL" group="api">
+
+The following API call is an example of creating a storage policy in Boundary:
+
+```shell-session
+$ curl --header "Content-Type: application/json" \
+    --header "Authorization: Bearer $(boundary config get-token)" \
+    --request POST \
+    --data '{"attributes":{"retain_for":{"days":2557,"overridable":false},"delete_after":{"days":2657,"overridable":true}},"scope_id":"global","description":"SOC 2 compliant storage policy for session recordings","name":"soc2-policy","type":"storage"}' \
+    $BOUNDARY_ADDR/v1/policies | jq
+```
+
+<Note>
+
+  This example uses [jq](https://stedolan.github.io/jq/download/) to process the JSON output for readability.
+
+</Note>
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+{
+  "id": "pst_wV4bWSYYwL",
+  "scope_id": "global",
+  "scope": {
+    "id": "global",
+    "type": "global",
+    "name": "global",
+    "description": "Global Scope"
+  },
+  "name": "soc2-api-test",
+  "description": "SOC 2 compliant storage policy for session recordings",
+  "created_time": "2024-01-26T03:44:58.119640Z",
+  "updated_time": "2024-01-26T03:44:58.119640Z",
+  "type": "storage",
+  "version": 1,
+  "attributes": {
+    "delete_after": {
+      "days": 2657,
+      "overridable": true
+    },
+    "retain_for": {
+      "days": 2557,
+      "overridable": false
+    }
+  },
+  "authorized_actions": [
+    "no-op",
+    "read",
+    "update",
+    "delete"
+  ]
+}
+```
+
+</CodeBlockConfig>
+
+</Tab>
+</Tabs>
+
+In this example, recordings stored within the global scope must be retained for 7 years (2557 days), and will be automatically deleted 100 days later (at 2657 days). Scopes beneath `global` will not be able to override this retention policy, but are able to override the deletion policy.
+
+<Warning>
+
+  Boundary does not support an undo action. Storage policies are meant to enforce compliance to a specific law or regulation. Updating the Storage policy of a session recording can have immediate and possibly unexpected results such as the immediate deletion of session recordings. 
+
+</Warning>
+
+## Attach storage policies to a scope
+
+Storage policies must be applied to a scope (`global` or a specific org) to take effect. Once attached, all recordings within the child scopes inherit the storage policy, unless overridden by a policy applied to the child scope.
+
+The following example applies the policy created above to an org named `prod-databases` with the org ID `o_aDkVBCDTvY`.
+
+<Tabs>
+<Tab heading="UI" group="ui">
+
+1. Log in to Boundary.
+1. Select **Orgs** in the navigation panel and select the `prod-databases` org.
+1. Select **Org Settings** in the navigation panel for the `prod-databases` org.
+1. Under **Storage Policy**, click **Add Storage Policy**.
+1. Select the `soc2-policy`.
+1. Click **Save**. This applies the policy to this scope and its children.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+1. Log in to Boundary.
+1. Obtain the storage policy ID:
+
+   ```shell-session
+   $ boundary policies list
+   Policy information: 
+     ID:                    pst_WZ3SQSSYJY
+       Version:             1
+       Type:                storage
+       Name:                soc2-policy
+       Description:         SOC 2 compliant storage policy for session recordings
+       Authorized Actions:
+         read
+         update
+         delete
+         no-op
+   ```
+
+1. Use the following command to apply the storage policy to the `prod-databases` org:
+
+   ```shell-session
+   $ boundary scopes attach-storage-policy \
+       -id <ORG_ID> \
+       -storage-policy-id pst_WZ3SQSSYJY
+   ```
+
+</Tab>
+<Tab heading="API call using cURL" group="api">
+
+The following API call is an example of attaching a storage policy to a scope.
+
+First, obtain the storage policy ID.
+
+```shell-session
+$ curl --header "Content-Type: application/json" \
+    --header "Authorization: Bearer $(boundary config get-token)" \
+    --request POST \
+    $BOUNDARY_ADDR/v1/policies?scope_id=global' | jq
+```
+
+In this example, the storage policy ID is `pst_WZ3SQSSYJY`.
+
+Now attach the policy to the org.
+
+```shell-session
+$ curl --header "Content-Type: application/json" \
+    --header "Authorization: Bearer $(boundary config get-token)" \
+    --request POST \
+    --data '{"storage_policy_id":"pst_WZ3SQSSYJY","version":2}'' \
+    $BOUNDARY_ADDR/v1/scopes/<ORG_ID>:attach-storage-policy' | jq
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+{
+  "id": "o_aDkVBCDTvY",
+  "scope_id": "global",
+  "scope": {
+    "id": "global",
+    "type": "global",
+    "name": "global",
+    "description": "Global Scope"
+  },
+  "name": "prod-databases",
+  "created_time": "2024-01-26T04:22:45.891800Z",
+  "updated_time": "2024-01-26T05:00:27.333892Z",
+  "version": 3,
+  "type": "org",
+  "authorized_actions": [
+    "delete",
+    "attach-storage-policy",
+    "detach-storage-policy",
+    "no-op",
+    "read",
+    "update"
+  ],
+  "authorized_collection_actions": {
+    "auth-methods": [
+      "create",
+      "list"
+    ],
+    "auth-tokens": [
+      "list"
+    ],
+    "groups": [
+      "create",
+      "list"
+    ],
+    "policies": [
+      "list",
+      "create"
+    ],
+    "roles": [
+      "list",
+      "create"
+    ],
+    "scopes": [
+      "list",
+      "list-keys",
+      "rotate-keys",
+      "list-key-version-destruction-jobs",
+      "destroy-key-version",
+      "create"
+    ],
+    "session-recordings": [
+      "list"
+    ],
+    "storage-buckets": [
+      "list",
+      "create"
+    ],
+    "users": [
+      "create",
+      "list"
+    ]
+  },
+  "storage_policy_id": "pst_WZ3SQSSYJY"
+}
+```
+
+</CodeBlockConfig>
+
+</Tab>
+</Tabs>
+
+### Verify attached policies
+
+Check that the storage policy was successfully attached to the `prod-databases` scope.
+
+<Tabs>
+<Tab heading="UI">
+
+1. Log in to Boundary.
+1. Select **Orgs** in the navigation panel and select the `prod-databases` org.
+1. Select **Org Settings** in the navigation panel for the `prod-databases` org.
+1. Verify that the 'soc2-policy' is listed under **Storage Policy**.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+1. Log in to Boundary.
+1. Read the details of the `prod-databases` org:
+
+   <CodeBlockConfig highlight="1-6">
+
+   ```shell-session
+   $ boundary scopes read -id <ORG_ID>
+   Scope information:
+     Created Time:        Thu, 25 Jan 2024 21:22:45 MST
+     ID:                  o_aDkVBCDTvY
+     Name:                prod-databases
+     Storage Policy ID:   pst_WZ3SQSSYJY
+     Updated Time:        Thu, 25 Jan 2024 22:00:27 MST
+     Version:             7
+   
+     Scope (parent):
+       ID:                global
+       Name:              global
+       Type:              global
+   
+     Authorized Actions:
+       detach-storage-policy
+       no-op
+       read
+       update
+       delete
+       attach-storage-policy
+    ...
+    ... More Output ...
+    ...
+   ```
+
+   </CodeBlockConfig>
+
+   Verify that the `soc2-policy` ID (`pst_WZ3SQSSYJY` in this example) is listed under **Storage Policy ID**.
+
+</Tab>
+<Tab heading="API call using cURL" group="api">
+
+The following API call is an example of reading the details of the `prod-databases` scope by ID (`o_aDkVBCDTvY` in this example).
+
+First, obtain the storage policy ID.
+
+```shell-session
+$ curl --header "Content-Type: application/json" \
+    --header "Authorization: Bearer $(boundary config get-token)" \
+    --request GET \
+    $BOUNDARY_ADDR/v1/scopes/o_aDkVBCDTvY | jq
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard highlight="1-9,61">
+
+```plaintext
+{
+  "id": "o_aDkVBCDTvY",
+  "scope_id": "global",
+  "scope": {
+    "id": "global",
+    "type": "global",
+    "name": "global",
+    "description": "Global Scope"
+  },
+  "name": "prod-databases",
+  "created_time": "2024-01-26T04:22:45.891800Z",
+  "updated_time": "2024-01-26T05:00:27.333892Z",
+  "version": 7,
+  "type": "org",
+  "authorized_actions": [
+    "update",
+    "delete",
+    "attach-storage-policy",
+    "detach-storage-policy",
+    "no-op",
+    "read"
+  ],
+  "authorized_collection_actions": {
+    "auth-methods": [
+      "create",
+      "list"
+    ],
+    "auth-tokens": [
+      "list"
+    ],
+    "groups": [
+      "create",
+      "list"
+    ],
+    "policies": [
+      "list",
+      "create"
+    ],
+    "roles": [
+      "list",
+      "create"
+    ],
+    "scopes": [
+      "list",
+      "list-keys",
+      "rotate-keys",
+      "list-key-version-destruction-jobs",
+      "destroy-key-version",
+      "create"
+    ],
+    "session-recordings": [
+      "list"
+    ],
+    "storage-buckets": [
+      "create",
+      "list"
+    ],
+    "users": [
+      "create",
+      "list"
+    ]
+  },
+  "storage_policy_id": "pst_WZ3SQSSYJY"
+}
+```
+
+</CodeBlockConfig>
+
+Verify that the `soc2-policy` ID (`pst_WZ3SQSSYJY` in this example) is listed under `storage_policy_id`.
+
+</Tab>
+</Tabs>
+
+### Read and list session recordings
+
+New session recordings under the `prod-databases` scope should now show a `retain_until` and `delete_after` date corresponding to the `soc2-policy` storage policy.
+
+<Tabs>
+<Tab heading="UI" group="ui">
+
+1. Create a new session recording on a target within the `prod-databases` org.
+1. Log in to Boundary.
+1. Select **Session Recordings** in the navigation panel. 
+1. Select **View** for a new recording that was made after the storage policy was attached to the `prod-databases` scope.
+1. Under **Session details**, verify that the *Retain until* and *Delete after* dates match the durations defined in the 'soc2-policy'.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+1. Log in to Boundary.
+1. List the available session recordings:
+
+   <CodeBlockConfig>
+
+   ```shell-session
+   $ boundary session-recordings list
+
+   Session Recording information:
+     ID:                    sr_nt5dFeBYdh
+       Storage Bucket ID:   sb_DC8SPb9uc2
+       Created Time:        Mon, 29 Jan 2024 23:25:31 MST
+       Updated Time:        Tue, 30 Jan 2024 00:26:01 MST
+       Start Time:          Mon, 29 Jan 2024 23:25:32 MST
+       End Time:            Mon, 29 Jan 2024 23:25:53 MST
+       Type:                ssh
+       State:               available
+       Retain Until:        Wed, 29 Jan 2031 23:25:53 MST
+       Delete After:        Sat, 10 May 2031 00:25:53 MDT
+       Authorized Actions:
+         reapply-storage-policy
+         no-op
+         read
+         download
+         delete
+   ```
+
+   </CodeBlockConfig>
+
+   Copy the recording **ID**.
+
+1. Read the recording details by ID.
+
+   <CodeBlockConfig highlight="1-3,6-7,11">
+
+   ```shell-session
+   $ boundary session-recordings read -id sr_nt5dFeBYdh
+
+   Session Recording information:
+     Bytes Down:           710
+     Bytes Up:             36
+     Created Time:         Mon, 29 Jan 2024 23:25:31 MST
+     Delete After:         Sat, 10 May 2031 00:25:53 MDT
+     Duration (Seconds):   21.01881
+     Endpoint:             ssh://xx.xxx.xxx.xxx:22
+     ID:                   sr_nt5dFeBYdh
+     Retain Until:         Wed, 29 Jan 2031 23:25:53 MST
+     Scope ID:             global
+     Start Time:           Mon, 29 Jan 2024 23:25:32 MST
+     State:                available
+     Storage Bucket ID:    sb_DC8SPb9uc2
+     Type:                 ssh
+     Updated Time:         Mon, 29 Jan 2024 23:25:53 MST
+   
+     ...
+     ... More Output ...
+     ...
+   ```
+
+   </CodeBlockConfig>
+
+   Verify that the `Retain Until` and `Delete After` dates match the durations defined in the 'soc2-policy'.
+
+</Tab>
+<Tab heading="API call using cURL" group="api">
+
+The following API call is an example of reading the details of a session recording with the `soc2-policy` storage policy applied to the `prod-databases` scope.
+
+List the available session recordings. This example recursively lists all recordings within the global scope.
+
+```shell-session
+$ curl --header "Content-Type: application/json" \
+    --header "Authorization: Bearer $(boundary config get-token)" \
+    --request GET \
+    $BOUNDARY_ADDR/v1/session-recordings?recursive=true&scope_id=global | jq
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard highlight="1-4,47-48">
+
+```plaintext
+{
+  "items": [
+    {
+      "id": "sr_nt5dFeBYdh",
+      "scope": {
+        "id": "global",
+        "type": "global",
+        "name": "global",
+        "description": "Global Scope"
+      },
+      "storage_bucket_id": "sb_DC8SPb9uc2",
+      "created_time": "2024-01-30T06:25:31.873628Z",
+      "updated_time": "2024-01-30T07:26:01.182513Z",
+      "start_time": "2024-01-30T06:25:32.412373Z",
+      "end_time": "2024-01-30T06:25:53.431183Z",
+      "duration": "21.018810s",
+      "type": "ssh",
+      "state": "available",
+      "endpoint": "ssh://xx.xxx.xxx.xxx:22",
+      "create_time_values": {
+        "user": {
+          "id": "u_lLWuYy70Wo",
+          "name": "admin_user",
+          "description": "Global admin user",
+          "scope": {
+            "id": "global",
+            "type": "global",
+            "name": "global",
+            "description": "Global Scope"
+          }
+        },
+        "target": {
+          "id": "tssh_cjTsFSU10p",
+          "name": "recording-target",
+          "scope": {
+            "id": "p_ocJPxzrz2p",
+            "type": "project",
+            "name": "recording-project",
+            "parent_scope_id": "o_aDkVBCDTvY"
+          },
+          "session_max_seconds": 28800,
+          "session_connection_limit": -1,
+          "egress_worker_filter": "\"recording-worker\" in \"/tags/type\"",
+          "type": "ssh",
+          "attributes": {
+            "default_port": 22
+          }
+        }
+      },
+      "authorized_actions": [
+        "reapply-storage-policy",
+        "no-op",
+        "read",
+        "download",
+        "delete"
+      ],
+      "retain_until": "2031-01-30T06:25:53.431183Z",
+      "delete_after": "2031-05-10T06:25:53.431183Z"
+    }
+  ],
+  "response_type": "complete",
+  "list_token": "GnJNt3mPNy6Cp62MUBCnZPdrQF7cvh4udEoW4CjL5k2ufvesMfKAheSJyNHmKf3zwL5aVKHT4P6q",
+  "sort_by": "created_time",
+  "sort_dir": "desc",
+  "est_item_count": 1
+}
+```
+
+</CodeBlockConfig>
+
+Verify that the `retain_until` and `delete_after` dates match the durations defined in the 'soc2-policy'.
+
+Alternatively, the recording details can also be queried directly by ID:
+
+```shell-session
+$ curl --header "Content-Type: application/json" \
+    --header "Authorization: Bearer $(boundary config get-token)" \
+    --request GET \
+    $BOUNDARY_ADDR/v1/session-recordings/sr_nt5dFeBYdh | jq
+```
+
+</Tab>
+</Tabs>
+
+<Note>
+
+  Existing recordings within a scope or its children do not automatically have new or updated polices applied to them. Policies must be re-applied to existing recordings to take effect. Refer to the [Update storage bucket policies](/boundary/docs/configuration/session-recording/update-storage-policy) page for more details.
+
+</Note>
+
+## Next steps
+
+After the storage policy is configured in Boundary, new recordings within the applied scope adhere to the defined policy. To retroactively apply the configured policy to existing recordings, refer to [update storage bucket policies](/boundary/docs/configuration/session-recording/update-storage-policy).
+
+[storage bucket]: /boundary/docs/concepts/domain-model/storage-buckets
+[storage policy]: /boundary/docs/concepts/domain-model/storage-policy
+[session recordings]: /boundary/docs/concepts/domain-model/session-recordings

--- a/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
+++ b/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
@@ -651,6 +651,12 @@ $ curl --header "Content-Type: application/json" \
 
 </Note>
 
+### Manual deletion
+
+Deleting a session recording will set the `delete_after` field of a session recording to the current database time. Deleting a session recording will fail if the retention duration has not been met.
+
+If `delete_after` or `delete_time` is after the current time, the session recording will no longer be included in list responses; it also cannot be read, downloaded or played back.
+
 ## Next steps
 
 After the storage policy is configured in Boundary, new recordings within the applied scope adhere to the defined policy. To retroactively apply the configured policy to existing recordings, refer to [update storage bucket policies](/boundary/docs/configuration/session-recording/update-storage-policy).

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -50,6 +50,7 @@ At this time, the only supported storage is AWS S3.
                "s3:ListBucket"
             ],
             "Effect": "Allow",
+            "Resource": "arn:aws:s3:::session_recording_storage*",
             "Resource": "arn:aws:s3:::session_recording_storage/foo/bar/zoo/*"
          },
          {

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -14,10 +14,10 @@ A Boundary resource known as a [storage bucket](/boundary/docs/concepts/domain-m
 The storage bucket represents a bucket in an external store.
 Before you can enable session recording, you must create one or more storage buckets in Boundary and associate them with the external store.
 
-A storage bucket can only belong to the Global scope or an Org scope.
-A storage bucket that is associated with the Global scope can be associated with any target.
-However, a storage bucket in an Org scope can only be associated with targets in a project from the same Org scope.
-Any storage buckets associated with an Org scope are deleted when the Org itself is deleted.
+A storage bucket can only belong to the global scope or an org scope.
+A storage bucket that is associated with the global scope can be associated with any target.
+However, a storage bucket in an Org scope can only be associated with targets in a project from the same org scope.
+Any storage buckets associated with an Org scope are deleted when the org itself is deleted.
 
 For more information about using session recording to audit user sessions, refer to [Auditing](/boundary/docs/concepts/auditing).
 

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -45,7 +45,9 @@ At this time, the only supported storage is AWS S3.
             "Action": [
                "s3:PutObject",
                "s3:GetObject",
-               "s3:GetObjectAttributes"
+               "s3:GetObjectAttributes",
+               "s3:DeleteObject",
+               "s3:ListBucket"
             ],
             "Effect": "Allow",
             "Resource": "arn:aws:s3:::session_recording_storage/foo/bar/zoo/*"
@@ -86,7 +88,9 @@ At this time, the only supported storage is AWS S3.
             "Action": [
                "s3:PutObject",
                "s3:GetObject",
-               "s3:GetObjectAttributes"
+               "s3:GetObjectAttributes",
+               "s3:DeleteObject",
+               "s3:ListBucket"
             ],
             "Resource": [
                "arn:aws:s3:::test-session-recording-bucket/*"

--- a/website/content/docs/configuration/session-recording/update-storage-policy.mdx
+++ b/website/content/docs/configuration/session-recording/update-storage-policy.mdx
@@ -80,6 +80,8 @@ The following is an example of updating the `soc2-policy` policy.
 1. Log in to Boundary.
 1. List the available storage policies and copy the `soc2-policy` ID.
 
+   <CodeBlockConfig highlight="1,3">
+
    ```shell-session
    $ boundary policies list
    Policy information:
@@ -94,6 +96,8 @@ The following is an example of updating the `soc2-policy` policy.
          delete
          no-op
    ```
+
+   </CodeBlockConfig>
 
 1. Use the following command to update the `soc2-policy` storage policy to reflect the new deletion requirements:
 
@@ -229,7 +233,7 @@ In the event that an updated policy should be retroactively applied to existing 
 
 1. Re-apply the storage policy to the session recording by providing its ID:
 
-   <CodeBlockConfig highlight="1-2,6">
+   <CodeBlockConfig highlight="1,6">
 
    ```shell-session
    $ boundary session-recordings reapply-storage-policy -id sr_nt5dFeBYdh

--- a/website/content/docs/configuration/session-recording/update-storage-policy.mdx
+++ b/website/content/docs/configuration/session-recording/update-storage-policy.mdx
@@ -1,0 +1,322 @@
+---
+layout: docs
+page_title: Update storage bucket policies
+description: |-
+  How to update a storage bucket policy for session recordings in Boundary
+---
+
+# Update storage bucket policies
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+A [storage policy][] codifies [storage bucket][] lifecycle management for [session recordings][].
+
+A storage policy exists in either the global scope or an org scope. Storage policies that are created in the global scope can be associated with any org scope.
+
+When a storage policy is updated, new session recordings within a scope where the policy is applied will conform to the updated policy. Existing recordings will maintain the previous policy unless the new policy is retroactively applied.
+
+This page describes the process for applying updated storage policies to existing recordings within a scope.
+
+For more information about setting up storage bucket policies, refer to the [configure storage bucket policies](/boundary/docs/configuration/session-recording/configure-storage-policy) page.
+
+## Requirements
+
+This page continues the workflows outlined in the [configure storage bucket policies](/boundary/docs/configuration/session-recording/configure-storage-policy) page. The requirements outlined in that page are prerequisites for the workflow defined below.
+
+To apply an updated storage policy to existing session recordings, you first need:
+
+1. An external storage provider configured to store session recordings.
+1. A Boundary worker configured for local storage.
+1. A Boundary storage bucket with a defined retention and/or deletion policy.
+1. A scope with the storage policy attached.
+1. A set of session recordings made when the storage policy was attached.
+
+The policies mentioned here demonstrate how to apply an updated storage policy to an existing set of [session recordings][].
+
+## Storage policy changes
+
+A storage policy defines how long the recording within a scope should retain its session recordings. 
+
+Over time, storage policies may be updated to reflect new organizational requirements, compliance changes, or cost management strategies. While updated policies automatically apply to new session recordings within the scopes associated with that policy, existing recordings maintain the previous policies unless the new policy is directly applied to those recordings.
+
+In the [configure storage bucket policies](/boundary/docs/configuration/session-recording/configure-storage-policy) page, the following policy was created to implement compliance with SOC-2 retention requirement of 7 years:
+
+- Name: `soc2-policy`
+- Description: `SOC 2 compliant storage policy for session recordings`
+- Retention policy: `2557` days, Overridable: `false`
+- Deletion policy: `2657` days, Overridable: `true`
+
+## Update a storage policy
+
+In the following example, the `soc2-policy` should be updated to the following:
+
+- Name: `soc2-policy`
+- Description: `SOC 2 compliant storage policy for session recordings, V2`
+- Retention policy: `2557` days, Overridable: `false`
+- Deletion policy: `2757` days, Overridable: `false`
+
+The updated policy requires the deletion of recordings after `2757` days, 200 days after the standard SOC 2 retention requirements. It also changes Overridable to `false`, preventing lower scopes from overwriting the Deletion policy.
+
+The following is an example of updating the `soc2-policy` policy.
+
+<Tabs>
+<Tab heading="UI" group="ui">
+
+1. Log in to Boundary.
+1. Select **Storage Policies** in the navigation panel and select the `global` scope.
+1. Click on **`soc2-policy`**.
+1. Click the **Edit Form** button and update the following fields:
+   - **Description**: `SOC 2 compliant storage policy for session recordings, V2`
+   - **Retention Policy**: `SOC 2 (7 years)`
+   - **Deletion Policy**: `Custom`
+   **Delete after**: `2757` days
+   Toggle the switch beside **Allow orgs to override** to the off position.
+
+1. Click **Save**.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+1. Log in to Boundary.
+1. List the available storage policies and copy the `soc2-policy` ID.
+
+   ```shell-session
+   $ boundary policies list
+   Policy information:
+     ID:                    pst_WZ3SQSSYJY
+       Version:             1
+       Type:                storage
+       Name:                soc2-policy
+       Description:         SOC 2 compliant storage policy for session recordings
+       Authorized Actions:
+         read
+         update
+         delete
+         no-op
+   ```
+
+1. Use the following command to update the `soc2-policy` storage policy to reflect the new deletion requirements:
+
+   ```shell-session
+   $ boundary policies update storage \
+       -id pst_WZ3SQSSYJY \
+       -description 'SOC 2 compliant storage policy for session recordings, V2' \
+       -scope-id global \
+       -retain-for-days 2557 \
+       -retain-for-overridable false \
+       -delete-after-days 2757 \
+       -delete-after-overridable false
+   ```
+
+</Tab>
+<Tab heading="API call using cURL" group="api">
+
+The following API call is an example of updating a storage policy in Boundary:
+
+```shell-session
+$ curl --header "Content-Type: application/json" \
+    --header "Authorization: Bearer $(boundary config get-token)" \
+    --request PATCH \
+    --data '{"attributes":{"retain_for":{"days":2557,"overridable":false},"delete_after":{"days":2757,"overridable":false}},"scope_id":"global","description":"SOC 2 compliant storage policy for session recordings, V2","type":"storage","version":"2"}' \
+    $BOUNDARY_ADDR/v1/policies/pst_WZ3SQSSYJY | jq
+```
+
+<Note>
+
+  This example uses [jq](https://stedolan.github.io/jq/download/) to process the JSON output for readability.
+
+</Note>
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+{
+  "id": "pst_WZ3SQSSYJY",
+  "scope_id": "global",
+  "scope": {
+    "id": "global",
+    "type": "global",
+    "name": "global",
+    "description": "Global Scope"
+  },
+  "name": "soc2-policy",
+  "description": "SOC 2 compliant storage policy for session recordings, V2",
+  "created_time": "2024-01-25T22:05:52.112677Z",
+  "updated_time": "2024-01-30T22:44:08.890715Z",
+  "type": "storage",
+  "version": 2,
+  "attributes": {
+    "delete_after": {
+      "days": 2757,
+      "overridable": false
+    },
+    "retain_for": {
+      "days": 2557,
+      "overridable": false
+    }
+  },
+  "authorized_actions": [
+    "no-op",
+    "read",
+    "update",
+    "delete"
+  ]
+}
+```
+
+</CodeBlockConfig>
+
+</Tab>
+</Tabs>
+
+This policy was applied to the `prod-databases` org in the [configure storage bucket policies](/boundary/docs/configuration/session-recording/configure-storage-policy) page.
+
+New recordings within the `prod-databases` org will automatically have the updated version of the `soc2-policy` applied.
+
+### Reapply a storage policy
+
+Many organizations compliance standards will require that previous versions of storage policies remain applied to existing recordings.
+
+<Note>
+
+  During the initial migration to a Boundary version that includes storage policies, all existing session recordings will have a `retain_for` attribute of `-1`, which retains the recording forever.
+
+</Note>
+
+In the event that an updated policy should be retroactively applied to existing session recordings, a storage policy should be reapplied.
+
+<Tabs>
+<Tab heading="UI" group="ui">
+
+1. Log in to Boundary.
+1. Select **Session Recordings** in the navigation panel in the `global` scope.
+1. Click on **View** for a session recording that should have the storage policy re-applied.
+1. Click the **Manage** dropdown and select **Re-apply storage policy**.
+1. Verify the *Delete after* field has been updated under the recording's **Session details**.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+1. Log in to Boundary.
+1. Find the ID of the session recording that should have the storage policy re-applied.
+
+   <CodeBlockConfig highlight="1,3">
+
+   ```shell-session
+   $ boundary session-recordings list
+   Session Recording information:
+     ID:                    sr_nt5dFeBYdh
+       Storage Bucket ID:   sb_DC8SPb9uc2
+       Created Time:        Mon, 29 Jan 2024 23:25:31 MST
+       Updated Time:        Tue, 30 Jan 2024 16:14:13 MST
+       Start Time:          Mon, 29 Jan 2024 23:25:32 MST
+       End Time:            Mon, 29 Jan 2024 23:25:53 MST
+       Type:                ssh
+       State:               available
+       Retain Until:        Wed, 29 Jan 2031 23:25:53 MST
+       Delete After:        Mon, 18 Aug 2031 00:25:53 MDT
+       Authorized Actions:
+         no-op
+         read
+         download
+         delete
+         reapply-storage-policy
+   ```
+
+   </CodeBlockConfig>
+
+1. Re-apply the storage policy to the session recording by providing its ID:
+
+   <CodeBlockConfig highlight="1-2,6">
+
+   ```shell-session
+   $ boundary session-recordings reapply-storage-policy -id sr_nt5dFeBYdh
+   Session Recording information:
+     Bytes Down:           710
+     Bytes Up:             36
+     Created Time:         Mon, 29 Jan 2024 23:25:31 MST
+     Delete After:         Mon, 18 Aug 2031 00:25:53 MDT
+     Duration (Seconds):   21.01881
+     Endpoint:             ssh://54.159.144.135:22
+     ID:                   sr_nt5dFeBYdh
+     Retain Until:         Wed, 29 Jan 2031 23:25:53 MST
+     Scope ID:             global
+     Start Time:           Mon, 29 Jan 2024 23:25:32 MST
+     State:                available
+     Storage Bucket ID:    sb_DC8SPb9uc2
+     Type:                 ssh
+     Updated Time:         Mon, 29 Jan 2024 23:25:53 MST
+
+   ...
+   ... More Output ...
+   ...
+   ```
+
+   </CodeBlockConfig>
+
+   Verify that the `Delete After` attribute reflects the updated storage policy.
+
+</Tab>
+<Tab heading="API call using cURL" group="api">
+
+The following API call is an example of re-applying a storage policy to a session recording by providing the recording's ID:
+
+```shell-session
+$ curl --header "Content-Type: application/json" \
+    --header "Authorization: Bearer $(boundary config get-token)" \
+    --request POST \
+    $BOUNDARY_ADDR/v1/session-recordings/sr_nt5dFeBYdh:reapply-storage-policy | jq
+```
+
+**Example output:**
+
+<CodeBlockConfig hideClipboard highlight="2,25-26">
+
+```plaintext
+{
+  "id": "sr_nt5dFeBYdh",
+  "scope": {
+    "id": "global",
+    "type": "global",
+    "name": "global",
+    "description": "Global Scope"
+  },
+  "storage_bucket_id": "sb_DC8SPb9uc2",
+  "bytes_up": "36",
+  "bytes_down": "710",
+  "created_time": "2024-01-30T06:25:31.873628Z",
+  "updated_time": "2024-01-30T23:14:13.881110Z",
+  "start_time": "2024-01-30T06:25:32.412373Z",
+  "end_time": "2024-01-30T06:25:53.431183Z",
+  "duration": "21.018810s",
+  "type": "ssh",
+  "state": "available",
+  "endpoint": "ssh://xx.xxx.xxx.xxx:22",
+
+...
+... More Output ...
+...
+
+  "retain_until": "2031-01-30T06:25:53.431183Z",
+  "delete_after": "2031-08-18T06:25:53.431183Z"
+}
+```
+
+</CodeBlockConfig>
+
+Verify that the `delete_after` attribute reflects the updated storage policy.
+
+</Tab>
+</Tabs>
+
+### Detached or deleted storage policies
+
+If a scope's storage policy is detached or deleted, new session recordings within that scope will automatically be retained forever, unless there is an overriding policy.
+
+Existing session recordings will maintain their existing storage policy attributes until a new policy is re-applied, including any overriding policy from another scope.
+
+[storage bucket]: /boundary/docs/concepts/domain-model/storage-buckets
+[storage policy]: /boundary/docs/concepts/domain-model/storage-policy
+[session recordings]: /boundary/docs/concepts/domain-model/session-recordings

--- a/website/content/docs/configuration/session-recording/update-storage-policy.mdx
+++ b/website/content/docs/configuration/session-recording/update-storage-policy.mdx
@@ -13,7 +13,7 @@ A [storage policy][] codifies [storage bucket][] lifecycle management for [sessi
 
 A storage policy exists in either the global scope or an org scope. Storage policies that are created in the global scope can be associated with any org scope.
 
-When a storage policy is updated, new session recordings within a scope where the policy is applied will conform to the updated policy. Existing recordings will maintain the previous policy unless the new policy is retroactively applied.
+When you update a storage policy, new session recordings within a scope where the policy is applied will conform to the updated policy. Existing recordings will maintain the previous policy unless the new policy is retroactively applied.
 
 This page describes the process for applying updated storage policies to existing recordings within a scope.
 
@@ -37,7 +37,7 @@ The policies mentioned here demonstrate how to apply an updated storage policy t
 
 A storage policy defines how long the recording within a scope should retain its session recordings. 
 
-Over time, storage policies may be updated to reflect new organizational requirements, compliance changes, or cost management strategies. While updated policies automatically apply to new session recordings within the scopes associated with that policy, existing recordings maintain the previous policies unless the new policy is directly applied to those recordings.
+Over time, you may update storage policies to reflect new organizational requirements, compliance changes, or cost management strategies. While updated policies automatically apply to new session recordings within the scopes associated with that policy, existing recordings maintain the previous policies unless you apply the new policy directly to those recordings.
 
 In the [configure storage bucket policies](/boundary/docs/configuration/session-recording/configure-storage-policy) page, the following policy was created to implement compliance with SOC-2 retention requirement of 7 years:
 
@@ -189,7 +189,7 @@ Many organizations compliance standards will require that previous versions of s
 
 </Note>
 
-In the event that an updated policy should be retroactively applied to existing session recordings, a storage policy should be reapplied.
+In the event that an updated policy should be retroactively applied to existing session recordings, you must reapply the storage policy.
 
 <Tabs>
 <Tab heading="UI" group="ui">

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -311,6 +311,15 @@
             "path": "concepts/domain-model/storage-buckets"
           },
           {
+            "title": "Storage policies",
+            "badge": {
+              "text": "HCP/ENT",
+              "type": "outlined",
+              "color": "neutral"
+            },
+            "path": "concepts/domain-model/storage-policies"
+          },
+          {
             "title": "Targets",
             "path": "concepts/domain-model/targets"
           },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -461,6 +461,10 @@
           {
             "title": "Configure storage policies",
             "path": "configuration/session-recording/configure-storage-policy"
+          },
+          {
+            "title": "Update storage policies",
+            "path": "configuration/session-recording/update-storage-policy"
           }
         ]
       },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -317,7 +317,7 @@
               "type": "outlined",
               "color": "neutral"
             },
-            "path": "concepts/domain-model/storage-policies"
+            "path": "concepts/domain-model/storage-policy"
           },
           {
             "title": "Targets",

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1045,6 +1045,40 @@
         ]
       },
       {
+        "title": "policies",
+        "badge": {
+          "text": "HCP/ENT",
+          "type": "outlined",
+          "color": "neutral"
+        },
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "commands/policies"
+          },
+          {
+            "title": "create",
+            "path": "commands/policies/create"
+          },
+          {
+            "title": "delete",
+            "path": "commands/policies/delete"
+          },
+          {
+            "title": "list",
+            "path": "commands/policies/list"
+          },
+          {
+            "title": "read",
+            "path": "commands/policies/read"
+          },
+          {
+            "title": "update",
+            "path": "commands/policies/update"
+          }
+        ]
+      },
+      {
         "title": "roles",
         "routes": [
           {

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1041,6 +1041,40 @@
         ]
       },
       {
+        "title": "policies",
+        "badge": {
+          "text": "HCP/ENT",
+          "type": "outlined",
+          "color": "neutral"
+        },
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "commands/policies"
+          },
+          {
+            "title": "create",
+            "path": "commands/policies/create"
+          },
+          {
+            "title": "delete",
+            "path": "commands/policies/delete"
+          },
+          {
+            "title": "list",
+            "path": "commands/policies/list"
+          },
+          {
+            "title": "read",
+            "path": "commands/policies/read"
+          },
+          {
+            "title": "update",
+            "path": "commands/policies/update"
+          }
+        ]
+      },
+      {
         "title": "roles",
         "routes": [
           {

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -457,6 +457,10 @@
           {
             "title": "Enable session recording",
             "path": "configuration/session-recording/enable-session-recording"
+          },
+          {
+            "title": "Configure storage policies",
+            "path": "configuration/session-recording/configure-storage-policy"
           }
         ]
       },
@@ -1037,40 +1041,6 @@
           {
             "title": "update",
             "path": "commands/managed-groups/update"
-          }
-        ]
-      },
-      {
-        "title": "policies",
-        "badge": {
-          "text": "HCP/ENT",
-          "type": "outlined",
-          "color": "neutral"
-        },
-        "routes": [
-          {
-            "title": "Overview",
-            "path": "commands/policies"
-          },
-          {
-            "title": "create",
-            "path": "commands/policies/create"
-          },
-          {
-            "title": "delete",
-            "path": "commands/policies/delete"
-          },
-          {
-            "title": "list",
-            "path": "commands/policies/list"
-          },
-          {
-            "title": "read",
-            "path": "commands/policies/read"
-          },
-          {
-            "title": "update",
-            "path": "commands/policies/update"
           }
         ]
       },


### PR DESCRIPTION
# Summary

This PR updates the create storage bucket documentation to include new aws s3 actions that are required permissions for the recent changes in the aws storage plugin. The following new permissions are required: `DeleteObjects` `ListBucket`