### PR TITLE
cmd: default dev postgres version to 16

### DIFF
--- a/internal/cmd/base/option.go
+++ b/internal/cmd/base/option.go
@@ -51,7 +51,7 @@ type Options struct {
 
 func getDefaultOptions() Options {
 	return Options{
-		withContainerImage: "postgres",
+		withContainerImage: "postgres:16",
 		withDialect:        "postgres",
 	}
 }


### PR DESCRIPTION
This changes the default boundary dev postgres version from 12 to 16 due to observed responsiveness differences between 11 (the old default) and 12.