### PR TITLE
Fix daemon synopsis and command grouping

### DIFF
--- a/internal/clientcache/cmd/daemon/daemon.go
+++ b/internal/clientcache/cmd/daemon/daemon.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package daemon
+
+import (
+	"strings"
+
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*StartCommand)(nil)
+	_ cli.CommandAutocomplete = (*StartCommand)(nil)
+)
+
+type DaemonCommand struct {
+	*base.Command
+}
+
+func (c *DaemonCommand) Synopsis() string {
+	return "Manages the client side Boundary cache daemon"
+}
+
+func (c *DaemonCommand) Help() string {
+	helpText := `
+Usage: boundary daemon [sub command] [options]
+
+  This command allows interacting with the Boundary daemon.
+
+  Start a daemon:
+
+      $ boundary daemon start
+
+  For a full list of examples, please see the documentation.
+
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *DaemonCommand) Flags() *base.FlagSets {
+	return c.FlagSet(base.FlagSetNone)
+}
+
+func (c *DaemonCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *DaemonCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *DaemonCommand) Run(args []string) int {
+	return cli.RunResultHelp
+}

--- a/internal/clientcache/cmd/search/search.go
+++ b/internal/clientcache/cmd/search/search.go
@@ -44,7 +44,7 @@ type SearchCommand struct {
 }
 
 func (c *SearchCommand) Synopsis() string {
-	return "Search resources in boundary"
+	return "Search Boundary resources using client side cache"
 }
 
 func (c *SearchCommand) Help() string {

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -298,7 +298,7 @@ func groupedHelpFunc(f cli.HelpFunc) cli.HelpFunc {
 		typeSpecificCommands := make([]string, 0, len(commands)-cap(genericCommands)-cap(clientCommands))
 		for k := range commands {
 			switch k {
-			case "authenticate", "config", "connect", "dev", "logout", "server":
+			case "authenticate", "config", "connect", "daemon", "dev", "logout", "search", "server":
 				clientCommands = append(clientCommands, k)
 			case "read", "update", "delete":
 				genericCommands = append(genericCommands, k)

--- a/internal/cmd/search_cmd_darwin.go
+++ b/internal/cmd/search_cmd_darwin.go
@@ -14,7 +14,11 @@ func init() {
 	clientCacheWrapper = daemonWrap
 
 	extraCommandsFuncs = append(extraCommandsFuncs, func(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
-		delete(Commands, "daemon")
+		Commands["daemon"] = func() (cli.Command, error) {
+			return &daemon.DaemonCommand{
+				Command: base.NewCommand(ui),
+			}, nil
+		}
 		Commands["daemon start"] = func() (cli.Command, error) {
 			return &daemon.StartCommand{
 				Command: base.NewCommand(ui),

--- a/internal/cmd/search_cmd_freebsd.go
+++ b/internal/cmd/search_cmd_freebsd.go
@@ -16,7 +16,11 @@ func init() {
 	clientCacheWrapper = daemonWrap
 
 	extraCommandsFuncs = append(extraCommandsFuncs, func(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
-		delete(Commands, "daemon")
+		Commands["daemon"] = func() (cli.Command, error) {
+			return &daemon.DaemonCommand{
+				Command: base.NewCommand(ui),
+			}, nil
+		}
 		Commands["daemon start"] = func() (cli.Command, error) {
 			return &daemon.StartCommand{
 				Command: base.NewCommand(ui),

--- a/internal/cmd/search_cmd_linux.go
+++ b/internal/cmd/search_cmd_linux.go
@@ -14,7 +14,11 @@ func init() {
 	clientCacheWrapper = daemonWrap
 
 	extraCommandsFuncs = append(extraCommandsFuncs, func(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
-		delete(Commands, "daemon")
+		Commands["daemon"] = func() (cli.Command, error) {
+			return &daemon.DaemonCommand{
+				Command: base.NewCommand(ui),
+			}, nil
+		}
 		Commands["daemon start"] = func() (cli.Command, error) {
 			return &daemon.StartCommand{
 				Command: base.NewCommand(ui),

--- a/internal/cmd/search_cmd_windows.go
+++ b/internal/cmd/search_cmd_windows.go
@@ -16,7 +16,11 @@ func init() {
 	clientCacheWrapper = daemonWrap
 
 	extraCommandsFuncs = append(extraCommandsFuncs, func(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
-		delete(Commands, "daemon")
+		Commands["daemon"] = func() (cli.Command, error) {
+			return &daemon.DaemonCommand{
+				Command: base.NewCommand(ui),
+			}, nil
+		}
 		Commands["daemon start"] = func() (cli.Command, error) {
 			return &daemon.StartCommand{
 				Command: base.NewCommand(ui),


### PR DESCRIPTION
```
> boundary
Usage: boundary <command> [args]

Local/Client Commands:
    authenticate      Authenticate the local client
    config            Manage the local client's configuration
    connect           Connect to a target through a Boundary worker
    daemon            Manages the client side Boundary cache daemon
    dev               Start a Boundary dev environment
    logout            Delete the current token within Boundary and forget it locally
    search            Search Boundary resources using client side cache
    server            Start a Boundary server

Generic Commands:
    delete      Run a generic delete command against a resource
    read        Run a generic read command against a resource
<snip>
```

and 
```
> boundary daemon
Usage: boundary daemon [sub command] [options]

  This command allows interacting with the Boundary daemon.

  Start a daemon:

      $ boundary daemon start

  For a full list of examples, please see the documentation.

Subcommands:
    add-token    Add an auth token to a running boundary daemon
    start        Start a Boundary daemon
    status       Get the status information of the running boundary daemon
    stop         Stop a Boundary daemon
```