### PR TITLE
Use correct argument name in log line

### DIFF
--- a/internal/session/repository_connection.go
+++ b/internal/session/repository_connection.go
@@ -391,7 +391,7 @@ func (r *ConnectionRepository) DeleteConnection(ctx context.Context, publicId st
 	return rowsDeleted, nil
 }
 
-// closeOrphanedConnections looks for connections that are still active, but where not reported by the worker.
+// closeOrphanedConnections looks for connections that are still active, but were not reported by the worker.
 func (r *ConnectionRepository) closeOrphanedConnections(ctx context.Context, workerId string, reportedConnections []string) ([]string, error) {
 	const op = "session.(ConnectionRepository).closeOrphanedConnections"
 

--- a/internal/session/service_worker_status_report.go
+++ b/internal/session/service_worker_status_report.go
@@ -60,7 +60,7 @@ func WorkerStatusReport(ctx context.Context, repo *Repository, connRepo *Connect
 		merr = stderrors.Join(merr, errors.New(ctx, errors.Internal, op, fmt.Sprintf("Error closing orphaned connections for worker %s: %v", workerId, err)))
 	}
 	if len(closed) > 0 {
-		event.WriteSysEvent(ctx, op, "marked unclaimed connections as closed", "controller_id", workerId, "count", len(closed))
+		event.WriteSysEvent(ctx, op, "marked unclaimed connections as closed", "worker_id", workerId, "count", len(closed))
 	}
 
 	if merr != nil {


### PR DESCRIPTION
This commit modifies a log line produced in the WorkerStatusReport function when closing orphaned connections that appears to incorrectly label a worker identifier as a controller identifier.