### PR TITLE
Disable postgres JIT for boudary dev

### DIFF
--- a/testing/dbtest/docker/Dockerfile.14-alpine
+++ b/testing/dbtest/docker/Dockerfile.14-alpine
@@ -1,0 +1,7 @@
+FROM postgres:14-alpine
+
+ADD init-db.sh /docker-entrypoint-initdb.d/00-init-db.sh
+ADD restore-benchmark-dumps.sh /docker-entrypoint-initdb.d/01-restore-benchmark-dumps.sh
+ADD postgresql.conf /etc/postgresql/postgresql.conf
+
+CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]

--- a/testing/dbtest/docker/Dockerfile.15-alpine
+++ b/testing/dbtest/docker/Dockerfile.15-alpine
@@ -1,0 +1,7 @@
+FROM postgres:15-alpine
+
+ADD init-db.sh /docker-entrypoint-initdb.d/00-init-db.sh
+ADD restore-benchmark-dumps.sh /docker-entrypoint-initdb.d/01-restore-benchmark-dumps.sh
+ADD postgresql.conf /etc/postgresql/postgresql.conf
+
+CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]

--- a/testing/dbtest/docker/Dockerfile.16-alpine
+++ b/testing/dbtest/docker/Dockerfile.16-alpine
@@ -1,0 +1,7 @@
+FROM postgres:16-alpine
+
+ADD init-db.sh /docker-entrypoint-initdb.d/00-init-db.sh
+ADD restore-benchmark-dumps.sh /docker-entrypoint-initdb.d/01-restore-benchmark-dumps.sh
+ADD postgresql.conf /etc/postgresql/postgresql.conf
+
+CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]

--- a/testing/dbtest/docker/postgresql.conf
+++ b/testing/dbtest/docker/postgresql.conf
@@ -34,3 +34,4 @@ lc_monetary                = 'en_US.utf8'
 lc_numeric                 = 'en_US.utf8'
 lc_time                    = 'en_US.utf8'
 default_text_search_config = 'pg_catalog.english'
+jit                        = off     # Disable JIT since it seems to just cause overhead and no gain


### PR DESCRIPTION
After updating `boundary dev` to use postgres:12 by default, it was noticed
that the responsiveness of boundary was noticeably slower. This is due to
the introduction of JIT being enabled by default in postgres:12. JIT seems
to incur noticeable overhead without providing benefits, at least for the
instance used for `boundary dev`.

It is also worth noting that for postgres:14 and newer, JIT does not get
triggered for the same queries since they seem to result in a cheaper query
plan that does not exceed the default threshold for JIT.

This also updates the docker image used by tests to also disable JIT,
and adds additional docker images for tests for other postgres versions.