### PR TITLE
update enos permissions to include s3:ListBucket

### DIFF
--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -224,7 +224,8 @@ data "aws_iam_policy_document" "enos_policy_document" {
       "s3:DeleteBucket*",
       "s3:GetBucket*",
       "s3:HeadBucket",
-      "s3:PutBucket*"
+      "s3:PutBucket*",
+      "s3:ListBucket",
     ]
 
     resources = ["*"]
@@ -265,7 +266,7 @@ data "aws_iam_policy_document" "aws_nuke_policy_document" {
 }
 
 resource "aws_iam_policy" "demo_user" {
-  name        = "BoundaryDemoPermissionsBoundary"
+  name        = "DemoUser"
   path        = "/"
   description = "Used to allow temporary IAM user creation for end-to-end tests"
   policy      = data.aws_iam_policy_document.demo_user_policy_document.json
@@ -289,6 +290,7 @@ data "aws_iam_policy_document" "demo_user_policy_document" {
       "s3:GetObject",
       "s3:GetObjectAttributes",
       "s3:PutObject",
+      "s3:ListBucket",
     ]
 
     condition {
@@ -326,6 +328,7 @@ data "aws_iam_policy_document" "demo_user_policy_document" {
       "s3:GetObject",
       "s3:GetObjectAttributes",
       "s3:PutObject",
+      "s3:ListBucket",
     ]
   }
 }

--- a/enos/modules/aws_bucket/main.tf
+++ b/enos/modules/aws_bucket/main.tf
@@ -18,10 +18,12 @@ data "aws_iam_policy_document" "default" {
       "s3:GetObject",
       "s3:DeleteObject",
       "s3:GetObjectAttributes",
+      "s3:ListBucket",
     ]
 
     resources = [
       "${aws_s3_bucket.default.arn}/*",
+      "${aws_s3_bucket.default.arn}",
     ]
   }
 }

--- a/enos/modules/aws_iam_setup/main.tf
+++ b/enos/modules/aws_iam_setup/main.tf
@@ -12,9 +12,9 @@ locals {
 }
 
 resource "aws_iam_user" "boundary" {
-  name                 = "boundary-e2e-${var.test_id}"
+  name                 = "demo-boundary-e2e-${var.test_id}"
   tags                 = { boundary-demo = local.user_email }
-  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryDemoPermissionsBoundary"
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser"
 }
 
 resource "aws_iam_user_policy" "boundary" {


### PR DESCRIPTION
migrates from deprecated aws permission boundary user `BoundaryDemoPermissionsBoundary` to `DemoUser` and adds `s3:ListBucket` permissions where necessary