### PR TITLE
internal/db: use more efficient index for host listing

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/81/09_host_table_updates.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/81/09_host_table_updates.up.sql
@@ -4,18 +4,18 @@
 begin;
 
   -- Add new indexes for the create time and update time queries.
-  create index host_plugin_host_create_time_public_id_idx
-      on host_plugin_host (create_time desc, public_id desc);
-  create index host_plugin_host_update_time_public_id_idx
-      on host_plugin_host (update_time desc, public_id desc);
+  create index host_plugin_host_catalog_id_create_time_public_id_idx
+      on host_plugin_host (catalog_id, create_time desc, public_id desc);
+  create index host_plugin_host_catalog_id_update_time_public_id_idx
+      on host_plugin_host (catalog_id, update_time desc, public_id desc);
 
   analyze host_plugin_host;
 
   -- Add new indexes for the create time and update time queries.
-  create index static_host_create_time_public_id_idx
-      on static_host (create_time desc, public_id desc);
-  create index static_host_update_time_public_id_idx
-      on static_host (update_time desc, public_id desc);
+  create index static_host_catalog_id_create_time_public_id_idx
+      on static_host (catalog_id, create_time desc, public_id desc);
+  create index static_host_catalog_id_update_time_public_id_idx
+      on static_host (catalog_id, update_time desc, public_id desc);
 
   analyze static_host;
 

--- a/internal/db/sqltest/tests/pagination/host.sql
+++ b/internal/db/sqltest/tests/pagination/host.sql
@@ -4,11 +4,11 @@
 begin;
   select plan(4);
 
-  select has_index('host_plugin_host', 'host_plugin_host_create_time_public_id_idx', array['create_time', 'public_id']);
-  select has_index('host_plugin_host', 'host_plugin_host_update_time_public_id_idx', array['update_time', 'public_id']);
+  select has_index('host_plugin_host', 'host_plugin_host_catalog_id_create_time_public_id_idx', array['catalog_id', 'create_time', 'public_id']);
+  select has_index('host_plugin_host', 'host_plugin_host_catalog_id_update_time_public_id_idx', array['catalog_id', 'update_time', 'public_id']);
 
-  select has_index('static_host', 'static_host_create_time_public_id_idx', array['create_time', 'public_id']);
-  select has_index('static_host', 'static_host_update_time_public_id_idx', array['update_time', 'public_id']);
+  select has_index('static_host', 'static_host_catalog_id_create_time_public_id_idx', array['catalog_id', 'create_time', 'public_id']);
+  select has_index('static_host', 'static_host_catalog_id_update_time_public_id_idx', array['catalog_id', 'update_time', 'public_id']);
 
   select * from finish();
 


### PR DESCRIPTION
In tests, the index including the `catalog_id` performs significantly better.

I'm adding this to the host_plugin_host table too without actually having tested it (I will test it next), because it also looks up by catalog_id so it seems a reasonable starting point.