### PR TITLE
Remove announced deprecated code allowing ports in target addrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   removed. Since 0.13.0, unless the `use_deprecated_kms_auth_method` value was
   set on the worker config, the new `kms` mechanism was already being used; this
   is simply no longer an available option.
+* Per the notes in Boundary 0.12.0 and 0.14.0, it is now an error if an address
+  on a host or target contains a port. As of this release, this restriction also
+  affects existing addresses (not just creation/updating via the API) so any
+  existing addresses containing a port will not be able to be used as part of a
+  target's session authorization call.
 
 ### New and Improved
 

--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -935,22 +935,16 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 	}
 
 	// Ensure we don't have a port from the address, which would be unexpected
-	// FIXME: We've decided to hold off on making this an error until 0.14. In
-	// the meantime, ignore any port coming from the host address.
-	hostWithoutPort, _, err := net.SplitHostPort(h)
+	_, _, err = net.SplitHostPort(h)
 	switch {
 	case err != nil && strings.Contains(err.Error(), globals.MissingPortErrStr):
 		// This is what we expect
 	case err != nil:
 		return nil, errors.Wrap(ctx, err, op, errors.WithMsg("error when parsing the chosen endpoint host address"))
 	case err == nil:
-		h = hostWithoutPort
-		// Use below logic for 0.14:
-		/*
-			return nil, handlers.ApiErrorWithCodeAndMessage(
-				codes.FailedPrecondition,
-				"Address specified for use unexpectedly contains a port.")
-		*/
+		return nil, handlers.ApiErrorWithCodeAndMessage(
+			codes.FailedPrecondition,
+			"Address specified for use unexpectedly contains a port.")
 	}
 
 	// Generate the endpoint URL

--- a/internal/daemon/controller/handlers/targets/tcp/target_service_test.go
+++ b/internal/daemon/controller/handlers/targets/tcp/target_service_test.go
@@ -2916,7 +2916,6 @@ func TestAuthorizeSession(t *testing.T) {
 	shsWithPort := static.TestSets(t, conn, hcWithPort.GetPublicId(), 1)[0]
 	_ = static.TestSetMembers(t, conn, shsWithPort.GetPublicId(), []*static.Host{hWithPort})
 	hWithPortBareAddress := hWithPort.GetAddress()
-	hWithPort.Address = fmt.Sprintf("%s:54321", hWithPort.GetAddress())
 	hWithPort, _, err = staticRepo.UpdateHost(ctx, hcWithPort.GetProjectId(), hWithPort, hWithPort.GetVersion(), []string{"address"})
 	require.NoError(t, err)
 
@@ -3822,7 +3821,6 @@ func TestAuthorizeSession_Errors(t *testing.T) {
 			HostSourceIds: []string{hs.GetPublicId()},
 		})
 		require.NoError(t, err)
-		h.Address = fmt.Sprintf("%s:54321", h.GetAddress())
 		repo, err := staticHostRepoFn()
 		require.NoError(t, err)
 		_, _, err = repo.UpdateHost(ctx, hc.GetProjectId(), h, h.GetVersion(), []string{"address"})


### PR DESCRIPTION
We made it an error in the API to do this a while back; this cleans up the logic to disallow it for existing targets too.