### PR TITLE
internal/db/schema: update recording indexes

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/82/02_recording_session.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/82/02_recording_session.up.sql
@@ -182,4 +182,16 @@ begin;
   comment on view session_recording_aggregate is
     'session_recording_aggregate contains the session recording resource with its storage bucket scope info and historical user info.';
 
+  -- Update the indexes used for listing recordings to include the delete time and delete after,
+  -- since they're now used in the query.
+  drop index recording_session_create_time_public_id_idx;
+  drop index recording_session_update_time_public_id_idx;
+
+  create index recording_session_create_time_public_id_delete_time_delete_idx
+      on recording_session (create_time desc, public_id desc, delete_time, delete_after);
+  create index recording_session_update_time_public_id_delete_time_delete_idx
+      on recording_session (update_time desc, public_id desc, delete_time, delete_after);
+
+  analyze recording_session;
+
 commit;

--- a/internal/db/sqltest/tests/pagination/session_recording.sql
+++ b/internal/db/sqltest/tests/pagination/session_recording.sql
@@ -4,8 +4,16 @@
 begin;
   select plan(2);
 
-  select has_index('recording_session', 'recording_session_create_time_public_id_idx', array['create_time', 'public_id']);
-  select has_index('recording_session', 'recording_session_update_time_public_id_idx', array['update_time', 'public_id']);
+  select has_index(
+    'recording_session',
+    'recording_session_create_time_public_id_delete_time_delete_idx',
+    array['create_time', 'public_id', 'delete_time', 'delete_after']
+  );
+  select has_index(
+    'recording_session',
+    'recording_session_update_time_public_id_delete_time_delete_idx',
+    array['update_time', 'public_id', 'delete_time', 'delete_after']
+  );
 
   select * from finish();
 


### PR DESCRIPTION
The new index includes the new delete_time and delete_after columns, which are used in the list query.