### PR TITLE
fix(cli): StoragePolicyId indent on list scopes

### DIFF
--- a/internal/cmd/commands/scopescmd/funcs.go
+++ b/internal/cmd/commands/scopescmd/funcs.go
@@ -160,7 +160,7 @@ func (c *Command) printListTable(items []*scopes.Scope) string {
 		}
 		if item.StoragePolicyId != "" {
 			output = append(output,
-				fmt.Sprintf("    StoragePolicyId:      %s", item.StoragePolicyId),
+				fmt.Sprintf("    StoragePolicyId:     %s", item.StoragePolicyId),
 			)
 		}
 		if len(item.AuthorizedActions) > 0 {


### PR DESCRIPTION
fixes indentation of `StoragePolicyId` during `boundary scopes list`
before:
```
% boundary scopes list

Scope information:
  ID:                    o_64nJo0tYB1
    Version:             2
    Name:                session-recording-org
    StoragePolicyId:      pst_MurBL06C6I
    Authorized Actions:
      read
      update
      delete
      attach-storage-policy
      detach-storage-policy
      no-op

  ID:                    o_v46NxFsOQz
    Version:             1
    Name:                Generated org scope
    Description:         Provides an initial org scope in Boundary
    Authorized Actions:
      no-op
      read
      update
      delete
      attach-storage-policy
      detach-storage-policy
```

after:
```
% boundary scopes list

Scope information:
  ID:                    o_64nJo0tYB1
    Version:             2
    Name:                session-recording-org
    StoragePolicyId:     pst_MurBL06C6I
    Authorized Actions:
      no-op
      read
      update
      delete
      attach-storage-policy
      detach-storage-policy

  ID:                    o_v46NxFsOQz
    Version:             1
    Name:                Generated org scope
    Description:         Provides an initial org scope in Boundary
    Authorized Actions:
      update
      delete
      attach-storage-policy
      detach-storage-policy
      no-op
      read
```