### PR TITLE
docs: Updating redirects for old pages

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -143,4 +143,12 @@ module.exports = [
     destination: '/boundary/docs/concepts/connection-workflows/workflow-ssh-proxycommand',
     permanent: true,
   },
+  {
+    source: '/boundary/docs/api-clients/cli',
+    destination: '/boundary/docs/commands/',
+  },
+  {
+    source: '/boundary/docs/concepts/service-discovery',
+    destination: '/boundary/docs/concepts/host-discovery',
+  }
 ]


### PR DESCRIPTION
In testing links for the new release, we realized some old pages that were moved never got added as redirects. This PR adds them.

These links should redirect:

(Old) https://boundary-38zwua70r-hashicorp.vercel.app//boundary/docs/api-clients/cli > (New) https://boundary-38zwua70r-hashicorp.vercel.app/boundary/docs/commands

(Old) https://boundary-38zwua70r-hashicorp.vercel.app//boundary/docs/concepts/service-discovery > (New) https://boundary-38zwua70r-hashicorp.vercel.app/boundary/docs/concepts/host-discovery