### PR TITLE
docs: Backport redirects to 0.14.x branch

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -143,4 +143,12 @@ module.exports = [
     destination: '/boundary/docs/concepts/connection-workflows/workflow-ssh-proxycommand',
     permanent: true,
   },
+  {
+    source: '/boundary/docs/api-clients/cli',
+    destination: '/boundary/docs/commands/',
+  },
+  {
+    source: '/boundary/docs/concepts/service-discovery',
+    destination: '/boundary/docs/concepts/host-discovery',
+  }
 ]


### PR DESCRIPTION
This PR backports the update from #4280 to the release 0.14.x branch.