### PR TITLE
chore: Fix typos

### DIFF
--- a/internal/cmd/commands/policiescmd/funcs.go
+++ b/internal/cmd/commands/policiescmd/funcs.go
@@ -19,7 +19,7 @@ var keySubstMap = map[string]string{
 	"overridable":  "Overridable",
 }
 
-func (c *Command) extraHelpFunc(helpMap map[string]func() string) string {
+func (c *Command) extraHelpFunc(_ map[string]func() string) string {
 	var helpStr string
 	switch c.Func {
 	case "":
@@ -121,7 +121,7 @@ func (c *Command) printListTable(items []*policies.Policy) string {
 	return base.WrapForHelpText(output)
 }
 
-func printItemTable(item *policies.Policy, resp *api.Response) string {
+func printItemTable(item *policies.Policy, _ *api.Response) string {
 	nonAttributeMap := map[string]any{}
 	if item.Id != "" {
 		nonAttributeMap["ID"] = item.Id

--- a/internal/cmd/commands/policiescmd/storage_funcs.go
+++ b/internal/cmd/commands/policiescmd/storage_funcs.go
@@ -27,7 +27,7 @@ type extraStorageCmdVars struct {
 	flagDeleteAfter map[string]string
 }
 
-func (c *StorageCommand) extraStorageHelpFunc(helpMap map[string]func() string) string {
+func (c *StorageCommand) extraStorageHelpFunc(_ map[string]func() string) string {
 	var helpStr string
 	switch c.Func {
 	case "create":
@@ -61,7 +61,7 @@ func extraStorageActionsFlagsMapFuncImpl() map[string][]string {
 	}
 }
 
-func extraStorageFlagsFuncImpl(c *StorageCommand, set *base.FlagSets, f *base.FlagSet) {
+func extraStorageFlagsFuncImpl(c *StorageCommand, set *base.FlagSets, _ *base.FlagSet) {
 	fs := set.NewFlagSet("Storage Policy Options")
 
 	for _, name := range flagsStorageMap[c.Func] {

--- a/internal/cmd/commands/sessionrecordingscmd/funcs.go
+++ b/internal/cmd/commands/sessionrecordingscmd/funcs.go
@@ -120,7 +120,7 @@ func (c *Command) printListTable(items []*sessionrecordings.SessionRecording) st
 			var retention string
 			switch item.RetainUntil {
 			case recording.InfinityTS:
-				retention = "Keep Forever"
+				retention = "Forever"
 			default:
 				retention = item.RetainUntil.Local().Format(time.RFC1123)
 			}
@@ -186,7 +186,7 @@ func printItemTable(item *sessionrecordings.SessionRecording, resp *api.Response
 		var retention string
 		switch item.RetainUntil {
 		case recording.InfinityTS:
-			retention = "Keep Forever"
+			retention = "Forever"
 		default:
 			retention = item.RetainUntil.Local().Format(time.RFC1123)
 		}

--- a/internal/cmd/commands/sessionrecordingscmd/reapply_storage_policy.go
+++ b/internal/cmd/commands/sessionrecordingscmd/reapply_storage_policy.go
@@ -90,7 +90,7 @@ func (c *ReApplyStoragePolicyCommand) Run(args []string) int {
 	result, err := sClient.ReApplyStoragePolicy(c.Context, c.FlagId)
 	if err != nil {
 		if apiErr := api.AsServerError(err); apiErr != nil {
-			c.PrintApiError(apiErr, "Error from controller when reapplying strorage policy to session recording")
+			c.PrintApiError(apiErr, "Error from controller when reapplying storage policy to session recording")
 			return base.CommandApiError
 		}
 		c.PrintCliError(fmt.Errorf("Reappling storage policy error: %w", err))

--- a/internal/recording/time.go
+++ b/internal/recording/time.go
@@ -6,5 +6,5 @@ package recording
 import "time"
 
 // InfinityTS is the max protobuf timestamp value of 9999-12-31T23:59:59.999999999Z. It is
-// used to represent a infinite retention value in session recording.
+// used to represent an infinite retention value in session recording.
 var InfinityTS = time.Date(9999, time.December, 31, 23, 23, 23, 1e9-1, time.UTC)


### PR DESCRIPTION
This mainly fixes a typo in the reapply error string and changes `Retain Until: Keep Forever` to `Retain Until: Forever` to align the text with what the UI will display. Plus a couple of minor things my IDE was complaining about