### PR TITLE
chore(e2e): Fix iam user creation

### DIFF
--- a/enos/modules/aws_iam_setup/main.tf
+++ b/enos/modules/aws_iam_setup/main.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 resource "aws_iam_user" "boundary" {
-  name                 = "demo-boundary-e2e-${var.test_id}"
+  name                 = "demo-${local.user_email}-${var.test_id}"
   tags                 = { boundary-demo = local.user_email }
   permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser"
 }


### PR DESCRIPTION
This PR addresses an issue in the e2e test suite after switching to use the [DemoUser](https://github.com/hashicorp/boundary/pull/4255) permissions boundary. I was getting the following error when running locally
```
Error: creating IAM User (demo-boundary-e2e-DXqX0): AccessDenied: User: arn:aws:sts::807078899029:assumed-role/boundary_team_acctest_dev-developer/michael.li@hashicorp.com is not authorized to perform: iam:CreateUser on resource: arn:aws:iam::807078899029:user/demo-boundary-e2e-DXqX0 because no identity-based policy allows the iam:CreateUser action
        status code: 403, request id: 6c553fb1-a23e-45e9-86ad-e7d4db55188d

  with module.iam_setup.aws_iam_user.boundary,
  on ../../modules/aws_iam_setup/main.tf line 14, in resource "aws_iam_user" "boundary":
  14: resource "aws_iam_user" "boundary" {
```

When using `DemoUser`, the name of the user must follow a specific format
```
demo-{user_email}*
```

Reference: https://hashicorp.slack.com/archives/C01CZDLRW8H/p1696362325372389?thread_ts=1696355368.495479&cid=C01CZDLRW8H