### PR TITLE
docs: Update `id` field for grants

### DIFF
--- a/website/content/docs/commands/roles/add-grants.mdx
+++ b/website/content/docs/commands/roles/add-grants.mdx
@@ -36,7 +36,10 @@ $ boundary roles add-grants [options] [args]
 You can specify grants in compact string format or JSON.
 If you use JSON, be sure to escape it properly.
 You can optionally specify multiple grants.
-- `-id=<string>` - The ID of the role you want to add grants to.
+- `-ids=<string>` - The IDs of the roles you want to add grants to.
+You can specify one or more IDs.
+If you specify multiple IDs using text, use commas to separate the IDs.
+If you specify multiple IDs using JSON, use an array.
 - `-version=<int>` The version of the role to add grants to.
 If you do not specify a version, the command performs a check-and-set automatically.
 

--- a/website/content/docs/commands/roles/remove-grants.mdx
+++ b/website/content/docs/commands/roles/remove-grants.mdx
@@ -36,7 +36,7 @@ $ boundary roles remove-grants [options] [args]
 You can specify grants in compact string format or JSON.
 If you use JSON, be sure to escape it properly.
 You can optionally specify multiple grants.
-- `-ids=<string>` - The IDs of the role you want to remove grants from.
+- `-ids=<string>` - The IDs of the roles you want to remove grants from.
 You can specify one or more IDs.
 If you specify multiple IDs using text, use commas to separate the IDs.
 If you specify multiple IDs using JSON, use an array.

--- a/website/content/docs/commands/roles/remove-grants.mdx
+++ b/website/content/docs/commands/roles/remove-grants.mdx
@@ -36,7 +36,10 @@ $ boundary roles remove-grants [options] [args]
 You can specify grants in compact string format or JSON.
 If you use JSON, be sure to escape it properly.
 You can optionally specify multiple grants.
-- `-id=<string>` - The ID of the role you want to remove grants from.
+- `-ids=<string>` - The IDs of the role you want to remove grants from.
+You can specify one or more IDs.
+If you specify multiple IDs using text, use commas to separate the IDs.
+If you specify multiple IDs using JSON, use an array.
 - `-version=<int>` - The version of the role you want to remove grants from.
 If you do not specify a version, the command performs a check-and-set automatically.
 

--- a/website/content/docs/commands/roles/set-grants.mdx
+++ b/website/content/docs/commands/roles/set-grants.mdx
@@ -37,7 +37,10 @@ $ boundary roles set-grants [options] [args]
 You can specify grants in compact string format or JSON.
 If you use JSON, be sure to escape it properly.
 You can optionally specify multiple grants.
-- `-id=<string>` - The ID of the role you want to set grants on.
+- `-ids=<string>` - The IDs of the role you want to set grants on.
+You can specify one or more IDs.
+If you specify multiple IDs using text, use commas to separate the IDs.
+If you specify multiple IDs using JSON, use an array.
 - `-version=<int>` The version of the role to set grants on.
 If you do not specify a version, the command performs a check-and-set automatically.
 

--- a/website/content/docs/commands/roles/set-grants.mdx
+++ b/website/content/docs/commands/roles/set-grants.mdx
@@ -37,7 +37,7 @@ $ boundary roles set-grants [options] [args]
 You can specify grants in compact string format or JSON.
 If you use JSON, be sure to escape it properly.
 You can optionally specify multiple grants.
-- `-ids=<string>` - The IDs of the role you want to set grants on.
+- `-ids=<string>` - The IDs of the roles you want to set grants on.
 You can specify one or more IDs.
 If you specify multiple IDs using text, use commas to separate the IDs.
 If you specify multiple IDs using JSON, use an array.


### PR DESCRIPTION
The `id` field was deprecated for grants in 0.13.1 in favor of an `ids` field. This PR updates the following command docs:

- [add-grants](https://boundary-oyrmli4jn-hashicorp.vercel.app/boundary/docs/commands/roles/add-grants)
- [remove-grants](https://boundary-oyrmli4jn-hashicorp.vercel.app/boundary/docs/commands/roles/remove-grants)
- [set-grants](https://boundary-oyrmli4jn-hashicorp.vercel.app/boundary/docs/commands/roles/set-grants)

Additional docs updates were made in #4274 and are already merged to `main`.