### PR TITLE
[website] Added permanent: true to redirects to fix build error

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -140,15 +140,18 @@ module.exports = [
   },
   {
     source: '/boundary/docs/common-workflows/workflow-ssh-proxycommand',
-    destination: '/boundary/docs/concepts/connection-workflows/workflow-ssh-proxycommand',
+    destination:
+      '/boundary/docs/concepts/connection-workflows/workflow-ssh-proxycommand',
     permanent: true,
   },
   {
     source: '/boundary/docs/api-clients/cli',
     destination: '/boundary/docs/commands/',
+    permanent: true,
   },
   {
     source: '/boundary/docs/concepts/service-discovery',
     destination: '/boundary/docs/concepts/host-discovery',
-  }
+    permanent: true,
+  },
 ]


### PR DESCRIPTION
Added `permanent: true` to the recently added redirects as this is causing a build error in Dev Portal.

Error message:
```
`permanent` is not set to `true` or `false` for route {"source":"/boundary/docs/api-clients/cli","destination":"/boundary/docs/commands/","has":[{"type":"host","value":"developer.hashicorp.com"}]}
`permanent` is not set to `true` or `false` for route {"source":"/boundary/docs/concepts/service-discovery","destination":"/boundary/docs/concepts/host-discovery","has":[{"type":"host","value":"developer.hashicorp.com"}]}
Error: Invalid redirects found
Error: Command "npm run build" exited with 1
```