### PR TITLE
docs: Backport redirects fix to release 0.14.x

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -140,15 +140,18 @@ module.exports = [
   },
   {
     source: '/boundary/docs/common-workflows/workflow-ssh-proxycommand',
-    destination: '/boundary/docs/concepts/connection-workflows/workflow-ssh-proxycommand',
+    destination:
+      '/boundary/docs/concepts/connection-workflows/workflow-ssh-proxycommand',
     permanent: true,
   },
   {
     source: '/boundary/docs/api-clients/cli',
     destination: '/boundary/docs/commands/',
+    permanent: true,
   },
   {
     source: '/boundary/docs/concepts/service-discovery',
     destination: '/boundary/docs/concepts/host-discovery',
-  }
+    permanent: true,
+  },
 ]


### PR DESCRIPTION
Heat fixed an error with our redirects in #4301. This PR backports the fix to release 0.14.x.