### PR TITLE
test: Randomize docker network name

### DIFF
--- a/internal/credential/vault/supported.go
+++ b/internal/credential/vault/supported.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/db/common"
 	"github.com/hashicorp/go-rootcerts"
+	"github.com/hashicorp/go-secure-stdlib/base62"
 	vault "github.com/hashicorp/vault/api"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/ory/dockertest/v3"
@@ -169,7 +170,9 @@ func gotNewServer(t testing.TB, opt ...TestOption) *TestVaultServer {
 	// Engine: 20.10.6
 
 	if opts.dockerNetwork {
-		network, err := pool.CreateNetwork(t.Name())
+		id, err := base62.Random(4)
+		require.NoError(err)
+		network, err := pool.CreateNetwork(fmt.Sprintf("%s-%s", t.Name(), id))
 		require.NoError(err)
 		server.network = network
 		dockerOptions.Networks = []*dockertest.Network{network}


### PR DESCRIPTION
In `boundary-enterprise`, we were seeing the following test failure in CI
```
--- FAIL: TestAuthorizeSession_Errors (0.38s)

{"@level":"error","@message":"event.WriteError: no eventer available to write error: kms.(Kms).GetWrapper: unable to get wrapper: unknown: error #0: kms.(Kms).GetWrapper: error loading root key for scope \"global\": kms.(Kms).loadRoot: missing root key for scope \"global\": key not found","@timestamp":"2024-01-25T22:01:47.165680Z"}
    supported.go:173: 
            Error Trace:    /home/runner/actions-runner/_work/boundary-enterprise/boundary-enterprise/internal/credential/vault/supported.go:173
                                        /home/runner/actions-runner/_work/boundary-enterprise/boundary-enterprise/internal/credential/vault/testing.go:1052
                                        /home/runner/actions-runner/_work/boundary-enterprise/boundary-enterprise/internal/daemon/controller/handlers/targets/ssh/target_service_ent_test.go:3944
            Error:          Received unexpected error:
                            API error (409): network with name TestAuthorizeSession_Errors already exists
            Test:           TestAuthorizeSession_Errors
```

Looking deeper, it turns out that `internal/daemon/controller/handlers/targets/tcp` and `internal/daemon/controller/handlers/targets/ssh` both have a test with the name `TestAuthorizeSession_Errors`, and for some reason, they run on top of each other, causing one of the tests to fail to create a docker network (the code currently creates a network with the test name).

To prevent any conflicts with tests that have the same name, this commit randomizes the network name that is created.

Note: There is a follow-up PR in boundary-enterprise to fix some additional tests that are failing due to a similar error https://github.com/hashicorp/boundary-enterprise/pull/900