### PR TITLE
chore(e2e): Remove tparse

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -27,11 +27,6 @@ env:
 
 jobs:
   setup:
-    outputs:
-      cache-go-build: ${{ steps.go-cache-paths.outputs.go-build }}
-      cache-go-mod: ${{ steps.go-cache-paths.outputs.go-mod }}
-      cache-go-bin: ${{ steps.go-cache-paths.outputs.go-bin }}
-      go-cache-key: ${{ steps.go-cache-key.outputs.key }}
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -42,30 +37,6 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
           cache: false
-      - name: Determine go cache key
-        id: go-cache-key
-        run: |
-          echo "key=${{ runner.os }}-go-${{ hashFiles('**/go.sum', './Makefile', './tools/tools.go') }}" >> "$GITHUB_OUTPUT"
-      - name: Determine Go cache paths
-        id: go-cache-paths
-        run: |
-          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
-          echo "go-bin=$(go env GOPATH)/bin" >> "$GITHUB_OUTPUT"
-      - name: Set up Go modules cache
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
-        with:
-          path: |
-            ${{ steps.go-cache-paths.outputs.go-build }}
-            ${{ steps.go-cache-paths.outputs.go-mod }}
-            ${{ steps.go-cache-paths.outputs.go-bin }}
-          key: ${{ steps.go-cache-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-go
-      - name: Install Tools
-        run: |
-          go mod download
-          make tools
   enos:
     name: Integration
     needs:
@@ -110,17 +81,6 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
           cache: false
-      - name: Set up Go modules cache
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
-        with:
-          path: |
-            ${{ needs.setup.outputs.cache-go-build }}
-            ${{ needs.setup.outputs.cache-go-mod }}
-            ${{ needs.setup.outputs.cache-go-bin }}
-          key: ${{ needs.setup.outputs.go-cache-key }}
-          restore-keys: |
-            ${{ runner.os }}-go
-          fail-on-cache-miss: true
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36    # TSCCR: loading action configs: failed to query HEAD reference: failed to get advertised references: authorization failed
         with:

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -192,7 +192,7 @@ resource "enos_local_exec" "run_e2e_test" {
   }
 
   inline = var.debug_no_run ? [""] : [
-    "set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json -timeout ${var.test_timeout}| tparse -follow -format plain 2>&1 | tee ${path.module}/../../test-e2e-${local.package_name}.log"
+    "set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" go test -v ${var.test_package} -count=1 -json -timeout ${var.test_timeout} | tee ${path.module}/../../test-e2e-${local.package_name}.log"
   ]
 }
 

--- a/enos/modules/test_e2e_docker/test_runner.sh
+++ b/enos/modules/test_e2e_docker/test_runner.sh
@@ -49,8 +49,6 @@ docker run \
     -e "E2E_MAX_PAGE_SIZE=$E2E_MAX_PAGE_SIZE" \
     --mount type=bind,src=$BOUNDARY_DIR,dst=/src/boundary/ \
     --mount type=bind,src=$MODULE_DIR/../..,dst=/testlogs \
-    --mount type=bind,src=$(go env GOCACHE),dst=/root/.cache/go-build \
-    --mount type=bind,src=$(go env GOMODCACHE),dst=/go/pkg/mod \
     -v "$MODULE_DIR/test.sh:/scripts/test.sh" \
     -v "$E2E_SSH_KEY_PATH:/keys/target.pem" \
     -v "$BOUNDARY_CLI_DIR:/boundary.zip" \


### PR DESCRIPTION
This PR removes the use of `tparse` in the e2e test suite (it was only being used in AWS-based enos scenarios). Doing so also removes the need to use the go cache, saving some time in CI (~20 seconds)

Note on the below times:
- `setup` has the most time-savings
- There's some time variability in the scenarios, but it saves ~10 seconds now that it does not have to restore the go cache.

Before:
https://github.com/hashicorp/boundary/actions/runs/7786366940/job/21231734235
<img width="604" alt="Screenshot 2024-02-05 at 11 21 43 AM" src="https://github.com/hashicorp/boundary/assets/2474253/eec7f093-93f9-4e99-94e4-c907ad851773">

After:
https://github.com/hashicorp/boundary/actions/runs/7763621684/job/21176203742
<img width="593" alt="Screenshot 2024-02-05 at 11 21 37 AM" src="https://github.com/hashicorp/boundary/assets/2474253/523c8f20-76b9-403b-9d68-8ed054f66400">
