### PR TITLE
chore(e2e): Name output based on scenario

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -261,10 +261,15 @@ jobs:
             for f in *.log; do mv --  "$f" "${f%.log}_${scenario%% *}.log"; done
           fi
           popd
+      - name: Split matrix filter name
+        id: split
+        run: |
+          SCENARIO=$(echo "${{ matrix.filter }}" | cut -d' ' -f1)
+          echo fragment="${SCENARIO}" >> "$GITHUB_OUTPUT"
       - name: Upload e2e tests output
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
-          name: test-e2e-output
+          name: test-${{ steps.split.outputs.fragment }}
           path: enos/*.log
           retention-days: 5
       - name: Get logs from postgres container


### PR DESCRIPTION
In GitHub Action `upload-artifact v4.0`, there was a breaking change for uploading multiple files to the same name (https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes). Previously, when you did that, it was bundled into a single zip file. Now, that is no longer allowed and files now need to have unique artifact names.

We will need this change when the action is updated to the new version.

Before:
![Screenshot 2024-01-30 at 3 57 47 PM](https://github.com/hashicorp/boundary/assets/2474253/ca032804-29d8-406e-a752-fb2c041806f5)

After:
![Screenshot 2024-01-30 at 3 29 16 PM](https://github.com/hashicorp/boundary/assets/2474253/84070ce1-4d90-43ab-aa2b-4bac6c898977)
