### PR TITLE
[website] Added permanent: true to redirects to fix dev portal build error 

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -157,9 +157,11 @@ module.exports = [
   {
     source: '/boundary/docs/configuration/worker/kms-worker',
     destination: '/boundary/docs/configuration/worker/worker-configuration',
+    permanent: true,
   },
   {
     source: '/boundary/docs/configuration/worker/pki-worker',
-    destination: '/boundary/docs/configuration/worker/worker-configuration'
+    destination: '/boundary/docs/configuration/worker/worker-configuration',
+    permanent: true,
   },
 ]


### PR DESCRIPTION
Added `permanent: true` to the [recently added](https://github.com/hashicorp/boundary/pull/4325) redirects as this is causing a build error in Dev Portal.

Error message:
```
`permanent` is not set to `true` or `false` for route {"source":"/boundary/docs/configuration/worker/kms-worker","destination":"/boundary/docs/configuration/worker/worker-configuration","has":[{"type":"host","value":"developer.hashicorp.com"}]}
`permanent` is not set to `true` or `false` for route {"source":"/boundary/docs/configuration/worker/pki-worker","destination":"/boundary/docs/configuration/worker/worker-configuration","has":[{"type":"host","value":"developer.hashicorp.com"}]}
Error: Invalid redirects found
Error: Command "npm run build" exited with 1
```

- [Asana task](https://app.asana.com/0/1206176289707208/1206490176997280/f)