### PR TITLE
fix: boundary authenticate returns an API error code when auth fails

### DIFF
--- a/internal/cmd/commands/authenticate/authenticate.go
+++ b/internal/cmd/commands/authenticate/authenticate.go
@@ -101,26 +101,27 @@ func (c *Command) Run(args []string) int {
 
 	c.FlagAuthMethodId = pri
 
+	var result int
 	switch {
 	case strings.HasPrefix(c.FlagAuthMethodId, globals.PasswordAuthMethodPrefix):
 		cmd := PasswordCommand{Command: c.Command}
 		cmd.Opts = append(c.Opts, base.WithSkipScopeIdFlag(true))
-		cmd.Run([]string{})
+		result = cmd.Run([]string{})
 
 	case strings.HasPrefix(c.FlagAuthMethodId, globals.OidcAuthMethodPrefix):
 		cmd := OidcCommand{Command: c.Command}
 		cmd.Opts = append(c.Opts, base.WithSkipScopeIdFlag(true))
-		cmd.Run([]string{})
+		result = cmd.Run([]string{})
 
 	case strings.HasPrefix(c.FlagAuthMethodId, globals.LdapAuthMethodPrefix):
 		cmd := LdapCommand{Command: c.Command}
 		cmd.Opts = append(c.Opts, base.WithSkipScopeIdFlag(true))
-		cmd.Run([]string{})
+		result = cmd.Run([]string{})
 
 	default:
 		c.PrintCliError(fmt.Errorf("The primary auth method was of an unsupported type. The given ID was %s; only 'ampw' (password), 'amoidc' (OIDC) and 'amldap' (LDAP) auth method prefixes are supported.", c.FlagAuthMethodId))
 		return cli.RunResultHelp
 	}
 
-	return 0
+	return result
 }


### PR DESCRIPTION
Despite the behavior of always returning 0 has been there for a while, I decided to direct this to release/0.15.x branch because of how it interacts with the client cache.  It hangs and attempts to add an auth token to the cache.