### PR TITLE
boundary daemon add-token to return returns 403 Forbidden when Boundary returns the same

### DIFF
--- a/internal/clientcache/internal/daemon/server.go
+++ b/internal/clientcache/internal/daemon/server.go
@@ -182,7 +182,10 @@ func defaultBoundaryTokenReader(ctx context.Context, cp ClientProvider) (cache.B
 
 		at, err := atClient.Read(ctx, atId)
 		if err != nil {
-			return nil, errors.Wrap(ctx, err, op)
+			if api.ErrPermissionDenied.Is(err) {
+				return nil, errors.Wrap(ctx, err, op, errors.WithMsg("Failed to get auth token from Boundary"), errors.WithCode(errors.Forbidden), errors.WithoutEvent())
+			}
+			return nil, errors.Wrap(ctx, err, op, errors.WithoutEvent())
 		}
 		return at.GetItem(), nil
 	}, nil

--- a/internal/clientcache/internal/daemon/token_handler.go
+++ b/internal/clientcache/internal/daemon/token_handler.go
@@ -115,16 +115,26 @@ func newTokenHandlerFunc(ctx context.Context, repo *cache.Repository, refresher 
 				AuthTokenId: perReq.AuthTokenId,
 			}
 			if err = repo.AddKeyringToken(ctx, perReq.BoundaryAddr, kt); err != nil {
+				errCode := http.StatusInternalServerError
+				if errors.Match(errors.T(errors.Forbidden), err) {
+					errCode = http.StatusForbidden
+				}
+
 				err := fmt.Errorf("Failed to add a keyring stored token with id %q: %w", perReq.AuthTokenId, err)
 				event.WriteError(ctx, op, err)
-				writeError(w, err.Error(), http.StatusInternalServerError)
+				writeError(w, err.Error(), errCode)
 				return
 			}
 		case perReq.AuthToken != "":
 			if err = repo.AddRawToken(ctx, perReq.BoundaryAddr, perReq.AuthToken); err != nil {
+				errCode := http.StatusInternalServerError
+				if errors.Match(errors.T(errors.Forbidden), err) {
+					errCode = http.StatusForbidden
+				}
+
 				err := fmt.Errorf("Failed to add a raw token with id %q: %w", perReq.AuthTokenId, err)
 				event.WriteError(ctx, op, err)
-				writeError(w, fmt.Sprintf("Failed to add a raw token: %v", err), http.StatusInternalServerError)
+				writeError(w, err.Error(), errCode)
 				return
 			}
 		}


### PR DESCRIPTION
Previously the response from the client cache daemon was set as an internal error. Now it returns a 403 with a snippet that says "Failed to get auth token from Boundary".

This will only happen when the user has had their read:self grants removed for auth tokens.