### PR TITLE
enos: support max_page_size in AWS scenarios

### DIFF
--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -134,6 +134,7 @@ scenario "e2e_aws_base" {
       target_address           = step.create_target.target_ips[0]
       target_user              = "ubuntu"
       target_port              = "22"
+      max_page_size            = step.create_boundary_cluster.max_page_size
     }
   }
 

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -254,6 +254,7 @@ scenario "e2e_aws" {
       aws_host_set_ips2        = step.create_targets_with_tag2.target_ips
       target_address           = step.create_isolated_target.target_ips[0]
       worker_tag_egress        = local.egress_tag
+      max_page_size            = step.create_boundary_cluster.max_page_size
     }
   }
 

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -127,6 +127,7 @@ scenario "e2e_database" {
       aws_access_key_id        = step.iam_setup.access_key_id
       aws_secret_access_key    = step.iam_setup.secret_access_key
       aws_host_set_filter1     = step.create_tag_inputs.tag_string
+      max_page_size            = 10
     }
   }
 

--- a/enos/modules/aws_boundary/boundary-instances.tf
+++ b/enos/modules/aws_boundary/boundary-instances.tf
@@ -89,6 +89,7 @@ resource "enos_file" "controller_config" {
     ops_port                = var.listener_ops_port
     cluster_port            = var.listener_cluster_port
     region                  = var.aws_region
+    max_page_size           = var.max_page_size
   })
   for_each = toset([for idx in range(var.controller_count) : tostring(idx)])
 

--- a/enos/modules/aws_boundary/outputs.tf
+++ b/enos/modules/aws_boundary/outputs.tf
@@ -152,6 +152,10 @@ output "project_scope_name" {
   value       = try(enos_boundary_init.controller[0].project_scope_name, null)
 }
 
+output "max_page_size" {
+  value = var.max_page_size
+}
+
 output "target_id" {
   description = "Generated target id from boundary init"
   value       = try(enos_boundary_init.controller[0].target_id, null)

--- a/enos/modules/aws_boundary/templates/controller.hcl
+++ b/enos/modules/aws_boundary/templates/controller.hcl
@@ -20,6 +20,8 @@ listener "tcp" {
   purpose = "api"
   tls_disable = true
 
+  max_page_size = ${max_page_size}
+
   # Uncomment to enable CORS for the Admin UI. Be sure to set the allowed origin(s)
   # to appropriate values.
   #cors_enabled = true

--- a/enos/modules/aws_boundary/templates/controller_bsr.hcl
+++ b/enos/modules/aws_boundary/templates/controller_bsr.hcl
@@ -20,6 +20,8 @@ listener "tcp" {
   purpose = "api"
   tls_disable = true
 
+  max_page_size = ${max_page_size}
+
   # Uncomment to enable CORS for the Admin UI. Be sure to set the allowed origin(s)
   # to appropriate values.
   #cors_enabled = true

--- a/enos/modules/aws_boundary/variables.tf
+++ b/enos/modules/aws_boundary/variables.tf
@@ -316,6 +316,12 @@ variable "healthcheck_path" {
   default     = "/health"
 }
 
+variable "max_page_size" {
+  description = "Max allowed page size for pagination requests"
+  type        = number
+  default     = 10
+}
+
 variable "alb_sg_additional_ips" {
   description = "Additional IPs to be allowed (ingress) on an ALB Security Group"
   type        = list(string)

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -38,6 +38,10 @@ variable "auth_password" {
   type        = string
   default     = ""
 }
+variable "max_page_size" {
+  description = "Max allowed page size for pagination requests"
+  type        = number
+}
 variable "local_boundary_dir" {
   description = "Local Path to boundary executable"
   type        = string
@@ -184,6 +188,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_WORKER_TAG_INGRESS        = var.worker_tag_ingress
     E2E_WORKER_TAG_EGRESS         = var.worker_tag_egress
     E2E_WORKER_ADDRESS            = var.worker_address
+    E2E_MAX_PAGE_SIZE             = var.max_page_size
   }
 
   inline = var.debug_no_run ? [""] : [

--- a/testing/internal/e2e/tests/aws/env_test.go
+++ b/testing/internal/e2e/tests/aws/env_test.go
@@ -20,6 +20,7 @@ type config struct {
 	TargetAddress      string `envconfig:"E2E_TARGET_ADDRESS" required:"true"`       // e.g. "192.168.0.1"
 	WorkerTagEgress    string `envconfig:"E2E_WORKER_TAG_EGRESS" required:"true"`    // e.g. "egress"
 	WorkerAddress      string `envconfig:"E2E_WORKER_ADDRESS" required:"true"`       // e.g. ""192.168.0.2"
+	MaxPageSize        int    `envconfig:"E2E_MAX_PAGE_SIZE" default:"1000"`
 }
 
 func loadTestConfig() (*config, error) {


### PR DESCRIPTION
This is needed to add e2e tests for paginating storage buckets and session recordings.