### PR TITLE
test(e2e): Fix error in migration test

### DIFF
--- a/testing/internal/e2e/infra/docker.go
+++ b/testing/internal/e2e/infra/docker.go
@@ -245,6 +245,7 @@ func ConnectToTarget(t testing.TB, pool *dockertest.Pool, network *dockertest.Ne
 			"boundary", "connect",
 			"-token", "env://E2E_AUTH_TOKEN",
 			"-target-id", targetId,
+			"-keyring-type", "none",
 			"-exec", "ls", // Execute something so that the command exits
 			// Note: Would have used `connect ssh` here, but ssh does not exist in the image. Also,
 			// this method only cares about creating a session entry in the database, so the ssh is unnecessary

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -343,6 +343,7 @@ func populateBoundaryDatabase(t testing.TB, ctx context.Context, c *config, te T
 			"-auth-method-id", te.DbInitInfo.AuthMethod.AuthMethodId,
 			"-login-name", te.DbInitInfo.AuthMethod.LoginName,
 			"-password", "env://E2E_TEST_BOUNDARY_PASSWORD",
+			"-keyring-type", "none",
 			"-format", "json",
 		},
 		dockertest.ExecOptions{


### PR DESCRIPTION
This is a fix to get the migration test passing due to changes in boundary (specifically the client cache daemon). This PR is an extension of this closed PR: https://github.com/hashicorp/boundary/pull/4344

If I understand the issue correctly...
The test is currently failing for the following reason
```
migration_test.go:389: 
│         	Error Trace:	/home/runner/work/boundary/boundary/testing/internal/e2e/tests/database/migration_test.go:389
│         	            				/home/runner/work/boundary/boundary/testing/internal/e2e/tests/database/migration_test.go:54
│         	Error:      	Should be empty, but was Error opening keyring: Specified keyring backend not available
│         	            	Token must be provided via BOUNDARY_TOKEN env var or -token flag. Reading the token can also be disabled via -keyring-type=none.
```
With the newly introduced client cache daemon, it needs the auth token when a user logs in so it can use that to refresh its contents. If a user uses `-format json` in the `authenticate` command, it currently is unable to intercept the auth token (`-format json` only returns the auth token in the JSON blob; it doesn't store it anywhere else). As a result, the command spits out a error, which is caught by 
```
require.Empty(t, ebuf)
```

This PR updates the migration test to supply the `-keyring-type none` option to avoid this error.

We'll want to cherry-pick this to the `0.15.x` release branch.