### PR TITLE
docs: Backport fix for redirects to 0.15.x branch

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -157,9 +157,11 @@ module.exports = [
   {
     source: '/boundary/docs/configuration/worker/kms-worker',
     destination: '/boundary/docs/configuration/worker/worker-configuration',
+    permanent: true,
   },
   {
     source: '/boundary/docs/configuration/worker/pki-worker',
-    destination: '/boundary/docs/configuration/worker/worker-configuration'
+    destination: '/boundary/docs/configuration/worker/worker-configuration',
+    permanent: true,
   },
 ]


### PR DESCRIPTION
In PR #4338, Heat fixed a syntax error with Boundary redirects that were causing build errors. The fix was merged to `main` and `stable-website`, but it should also be backported to the `release/0.15.x` branch. This PR is that backport.