### PR TITLE
docs: Backport scope ID fix to website

### DIFF
--- a/internal/cmd/commands/rolescmd/funcs.go
+++ b/internal/cmd/commands/rolescmd/funcs.go
@@ -147,7 +147,7 @@ func (c *Command) extraHelpFunc(helpMap map[string]func() string) string {
 			"",
 			`  Adds grant scopes to a role given its ID. The "grant-scope-id" flag can be specified multiple times. Example:`,
 			"",
-			`    $ boundary roles add-grant-scopes -id o_1234567890 -grant-scope-id "this" -grant-scope-id "children"`,
+			`    $ boundary roles add-grant-scopes -id r_1234567890 -grant-scope-id "this" -grant-scope-id "children"`,
 			"",
 			"",
 		})
@@ -158,7 +158,7 @@ func (c *Command) extraHelpFunc(helpMap map[string]func() string) string {
 			"",
 			`  Sets the complete set of grant scopes on a role given its ID. The "grant-scope-id" flag can be specified multiple times. Example:`,
 			"",
-			`    $ boundary roles set-grant-scopes -id o_1234567890 -grant-scope-id "this" -grant-scope-id "children"`,
+			`    $ boundary roles set-grant-scopes -id r_1234567890 -grant-scope-id "this" -grant-scope-id "children"`,
 			"",
 			"",
 		})
@@ -169,7 +169,7 @@ func (c *Command) extraHelpFunc(helpMap map[string]func() string) string {
 			"",
 			`  Removes grant scopes from a role given its ID. The "grant-scope-id" flags can be specified multiple times. Example:`,
 			"",
-			`    $ boundary roles remove-grant-scopes -id o_1234567890 -grant-scope-id "this" -grant-scope-id "children"`,
+			`    $ boundary roles remove-grant-scopes -id r_1234567890 -grant-scope-id "this" -grant-scope-id "children"`,
 			"",
 			"",
 		})

--- a/website/content/docs/commands/roles/add-grant-scopes.mdx
+++ b/website/content/docs/commands/roles/add-grant-scopes.mdx
@@ -14,7 +14,7 @@ You can specify multiple grant scopes per role.
 
 ## Example
 
-This example adds a grant to a role with the ID `o_1234567890` in the current scope and any children scopes:
+This example adds a grant to a role with the ID `r_1234567890` in the current scope and any children scopes:
 
 ```shell-session
 $ boundary roles add-grant-scopes -id r_1234567890 -grant-scope-id "this" -grant-scope-id "children"


### PR DESCRIPTION
PR #4348 fixed an example in the CLI help and docs. It was merged to `main`, but must be merged to the stable website branch to make the change appear in the Boundary docs. This PR backports the change.