### PR TITLE
docs: Clarify need for permissions to search

### DIFF
--- a/website/content/docs/api-clients/client-cache.mdx
+++ b/website/content/docs/api-clients/client-cache.mdx
@@ -23,6 +23,15 @@ When you use the `search` command, however, Boundary searches the local cache to
 
 For more information, refer to the [`search`](/boundary/docs/commands/search) command documentation.
 
+<Note>
+
+The `search` operation only displays the resources that you have read permissions to view.
+If you are logged in as a user who does not have the permissions to view a resource, it does not display in the list of results.
+
+For more information, refer to [Identity and access management (IAM)](/boundary/docs/concepts/iam).
+
+</Note>
+
 ## Client cache management
 
 The Boundary client daemon starts automatically in the background when a user runs a CLI command that interacts with a Boundary instance.

--- a/website/content/docs/commands/daemon/add-token.mdx
+++ b/website/content/docs/commands/daemon/add-token.mdx
@@ -17,6 +17,15 @@ If you authenticate to multiple Boundary instances, the client cache stores mult
 
 By adding auth tokens to your client cache, you can select which specific Boundary instance you want to search.
 
+<Note>
+
+The `search` operation only displays the resources that you have read permissions to view.
+If you are logged in as a user who does not have the permissions to view a resource, it does not display in the list of results.
+
+For more information, refer to [Identity and access management (IAM)](/boundary/docs/concepts/iam).
+
+</Note>
+
 ## Examples
 
 The following command adds an auth token to the client cache from your keyring:

--- a/website/content/docs/commands/daemon/add-token.mdx
+++ b/website/content/docs/commands/daemon/add-token.mdx
@@ -19,7 +19,8 @@ By adding auth tokens to your client cache, you can select which specific Bounda
 
 <Note>
 
-The `search` operation only displays the resources that you have read permissions to view.
+The `search` operation only displays the resources that you have permissions to view.
+You must have the `read` or `read:self` grant on the auth token to successfully add it.
 If you are logged in as a user who does not have the permissions to view a resource, it does not display in the list of results.
 
 For more information, refer to [Identity and access management (IAM)](/boundary/docs/concepts/iam).


### PR DESCRIPTION
This PR attempts to address some confusion around why search results are not displaying in scenarios where a user does not have permission to view them.

View the updates in the preview deployment:

[Client cache](https://boundary-bg4tn2t78-hashicorp.vercel.app/boundary/docs/api-clients/client-cache)
[`daemon add-token`](https://boundary-bg4tn2t78-hashicorp.vercel.app/boundary/docs/commands/daemon/add-token)