### PR TITLE
docs: Add links for multi grant scopes

### DIFF
--- a/website/content/docs/commands/roles/create.mdx
+++ b/website/content/docs/commands/roles/create.mdx
@@ -33,7 +33,7 @@ $ boundary roles create [options] [args]
 
 - `-description=<string>` - The description to assign to the role.
 - `-grant-scope-id=<string>` - The scope ID for any grants set on the role.
-The `grant-scope-id` field is now deprecated in favor of multiple grant scope support.
+The `grant-scope-id` field is now deprecated in favor of multiple grant scope support using [add-grant-scopes](/boundary/docs/commands/roles/add-grant-scopes).
 For more information, refer to [Version 0.15.0 feature deprecations and EOL](/boundary/docs/release-notes/v0_15_0#feature-deprecations-and-eol).
 - `-name=<string>` - The name to assign to the role.
 - `-scope-id=<string>` - The scope in which you want to create the role.

--- a/website/content/docs/commands/roles/create.mdx
+++ b/website/content/docs/commands/roles/create.mdx
@@ -33,6 +33,8 @@ $ boundary roles create [options] [args]
 
 - `-description=<string>` - The description to assign to the role.
 - `-grant-scope-id=<string>` - The scope ID for any grants set on the role.
+The `grant-scope-id` field is now deprecated in favor of multiple grant scope support.
+For more information, refer to [Version 0.15.0 feature deprecations and EOL](/boundary/docs/release-notes/v0_15_0#feature-deprecations-and-eol).
 - `-name=<string>` - The name to assign to the role.
 - `-scope-id=<string>` - The scope in which you want to create the role.
 The default is `global`.

--- a/website/content/docs/commands/roles/update.mdx
+++ b/website/content/docs/commands/roles/update.mdx
@@ -33,7 +33,7 @@ $ boundary roles update [options] [args]
 
 - `-description=<string>` - The description to set on the role.
 - `-grant-scope-id=<string>` - The scope ID for any grants set on the role.
-The `grant-scope-id` field is now deprecated in favor of multiple grant scope support.
+The `grant-scope-id` field is now deprecated in favor of multiple grant scope support using [add-grant-scopes](/boundary/docs/commands/roles/add-grant-scopes).
 For more information, refer to [Version 0.15.0 feature deprecations and EOL](/boundary/docs/release-notes/v0_15_0#feature-deprecations-and-eol).
 - `-id=<string>` - The ID of the role you want to update.
 - `-name=<string>` - The name to set on the role.

--- a/website/content/docs/commands/roles/update.mdx
+++ b/website/content/docs/commands/roles/update.mdx
@@ -33,6 +33,8 @@ $ boundary roles update [options] [args]
 
 - `-description=<string>` - The description to set on the role.
 - `-grant-scope-id=<string>` - The scope ID for any grants set on the role.
+The `grant-scope-id` field is now deprecated in favor of multiple grant scope support.
+For more information, refer to [Version 0.15.0 feature deprecations and EOL](/boundary/docs/release-notes/v0_15_0#feature-deprecations-and-eol).
 - `-id=<string>` - The ID of the role you want to update.
 - `-name=<string>` - The name to set on the role.
 - `-version=<int>` - The version of the role you want to update.

--- a/website/content/docs/release-notes/v0_15_0.mdx
+++ b/website/content/docs/release-notes/v0_15_0.mdx
@@ -83,6 +83,8 @@ description: |-
     </td>
     <td style={{verticalAlign: 'middle'}}>
       Roles now support multiple grant scopes, along with the special values <code>this</code>, <code>children</code> (global/org scopes only) to apply to all direct children of a scope, and <code>descendants</code> (global only) to apply to all descendants of a scope. You can apply the new values by using the commands <code>add-grant-scopes</code>, <code>set-grant-scopes</code>, and <code>remove-grant-scopes</code> on roles. You can continue to use the existing <code>grant_scope_id</code> field for now, but it has been deprecated.
+      <br /><br />
+      Learn more:&nbsp;<a href="/boundary/docs/commands/roles/add-grant-scopes"><code>add-grant-scopes</code></a>, <a href="/boundary/docs/commands/roles/remove-grant-scopes"><code>remove-grant-scopes</code></a>, and <a href="/boundary/docs/commands/roles/set-grant-scopes"><code>set-grant-scopes</code></a>
     </td>
   </tr>
 
@@ -229,10 +231,12 @@ description: |-
 
   <tr>
     <td style={{verticalAlign: 'middle'}}>
-      <code>grant_scope_id</code> field for roles
+      <code>grant-scope-id</code> field for roles
     </td>
     <td style={{verticalAlign: 'middle'}}>
-     The <code>grant_scope_id</code> field is now deprecated in favor of multiple grant scope support.
+     The <code>grant-scope-id</code> field is now deprecated in favor of multiple grant scope support.
+      <br /><br />
+      Learn more:&nbsp;<a href="/boundary/docs/commands/roles/add-grant-scopes"><code>add-grant-scopes</code></a>, <a href="/boundary/docs/commands/roles/remove-grant-scopes"><code>remove-grant-scopes</code></a>, and <a href="/boundary/docs/commands/roles/set-grant-scopes"><code>set-grant-scopes</code></a>
     </td>
   </tr>
 


### PR DESCRIPTION
This PR creates links from the 0.15.0 release notes to the command documentation for multi-grant scope support. It also adds a deprecation notice for the `grant-scope-id` field in the relevant command docs.

View the updates in the preview deployment:

- [Version 0.15.0 release notes](https://boundary-qwetn9q2a-hashicorp.vercel.app/boundary/docs/release-notes/v0_15_0)
- [`roles create`](https://boundary-qwetn9q2a-hashicorp.vercel.app/boundary/docs/commands/roles/create)
- [`roles update`](https://boundary-qwetn9q2a-hashicorp.vercel.app/boundary/docs/commands/roles/update)