### PR TITLE
commands: fix plurals

### DIFF
--- a/internal/cmd/commands/authmethodscmd/authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/authmethods.gen.go
@@ -55,7 +55,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "auth method"
+	synopsisStr := "auth-method"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/commands/authmethodscmd/ldap_authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/ldap_authmethods.gen.go
@@ -56,7 +56,7 @@ func (c *LdapCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "auth method"
+	synopsisStr := "auth-method"
 
 	synopsisStr = fmt.Sprintf("%s %s", "ldap-type", synopsisStr)
 

--- a/internal/cmd/commands/authmethodscmd/oidc_authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/oidc_authmethods.gen.go
@@ -56,7 +56,7 @@ func (c *OidcCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "auth method"
+	synopsisStr := "auth-method"
 
 	synopsisStr = fmt.Sprintf("%s %s", "oidc-type", synopsisStr)
 

--- a/internal/cmd/commands/authmethodscmd/password_authmethods.gen.go
+++ b/internal/cmd/commands/authmethodscmd/password_authmethods.gen.go
@@ -56,7 +56,7 @@ func (c *PasswordCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "auth method"
+	synopsisStr := "auth-method"
 
 	synopsisStr = fmt.Sprintf("%s %s", "password-type", synopsisStr)
 

--- a/internal/cmd/commands/authtokenscmd/authtokens.gen.go
+++ b/internal/cmd/commands/authtokenscmd/authtokens.gen.go
@@ -55,7 +55,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "auth token"
+	synopsisStr := "auth-token"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/commands/credentiallibrariescmd/credentiallibraries.gen.go
+++ b/internal/cmd/commands/credentiallibrariescmd/credentiallibraries.gen.go
@@ -55,7 +55,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "credential library"
+	synopsisStr := "credential libraries"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/commands/credentiallibrariescmd/credentiallibraries.gen.go
+++ b/internal/cmd/commands/credentiallibrariescmd/credentiallibraries.gen.go
@@ -55,7 +55,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "credential libraries"
+	synopsisStr := "credential-library"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/commands/credentiallibrariescmd/vault-generic_credentiallibraries.gen.go
+++ b/internal/cmd/commands/credentiallibrariescmd/vault-generic_credentiallibraries.gen.go
@@ -56,7 +56,7 @@ func (c *VaultGenericCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "credential library"
+	synopsisStr := "credential-library"
 
 	synopsisStr = fmt.Sprintf("%s %s", "vault-generic-type", synopsisStr)
 

--- a/internal/cmd/commands/credentiallibrariescmd/vault-ssh-certificate_credentiallibraries.gen.go
+++ b/internal/cmd/commands/credentiallibrariescmd/vault-ssh-certificate_credentiallibraries.gen.go
@@ -56,7 +56,7 @@ func (c *VaultSshCertificateCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "credential library"
+	synopsisStr := "credential-library"
 
 	synopsisStr = fmt.Sprintf("%s %s", "vault-ssh-certificate-type", synopsisStr)
 

--- a/internal/cmd/commands/credentiallibrariescmd/vault_credentiallibraries.gen.go
+++ b/internal/cmd/commands/credentiallibrariescmd/vault_credentiallibraries.gen.go
@@ -56,7 +56,7 @@ func (c *VaultCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "credential library"
+	synopsisStr := "credential-library"
 
 	synopsisStr = fmt.Sprintf("%s %s", "vault-type", synopsisStr)
 

--- a/internal/cmd/commands/credentialstorescmd/credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/credentialstores.gen.go
@@ -55,7 +55,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "credential store"
+	synopsisStr := "credential-store"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/commands/credentialstorescmd/static_credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/static_credentialstores.gen.go
@@ -54,7 +54,7 @@ func (c *StaticCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "credential store"
+	synopsisStr := "credential-store"
 
 	synopsisStr = fmt.Sprintf("%s %s", "static-type", synopsisStr)
 

--- a/internal/cmd/commands/credentialstorescmd/vault_credentialstores.gen.go
+++ b/internal/cmd/commands/credentialstorescmd/vault_credentialstores.gen.go
@@ -56,7 +56,7 @@ func (c *VaultCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "credential store"
+	synopsisStr := "credential-store"
 
 	synopsisStr = fmt.Sprintf("%s %s", "vault-type", synopsisStr)
 

--- a/internal/cmd/commands/hostcatalogscmd/hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/hostcatalogs.gen.go
@@ -55,7 +55,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "host catalog"
+	synopsisStr := "host-catalog"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/commands/hostcatalogscmd/plugin_hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/plugin_hostcatalogs.gen.go
@@ -54,7 +54,7 @@ func (c *PluginCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "host catalog"
+	synopsisStr := "host-catalog"
 
 	synopsisStr = fmt.Sprintf("%s %s", "plugin-type", synopsisStr)
 

--- a/internal/cmd/commands/hostcatalogscmd/static_hostcatalogs.gen.go
+++ b/internal/cmd/commands/hostcatalogscmd/static_hostcatalogs.gen.go
@@ -54,7 +54,7 @@ func (c *StaticCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "host catalog"
+	synopsisStr := "host-catalog"
 
 	synopsisStr = fmt.Sprintf("%s %s", "static-type", synopsisStr)
 

--- a/internal/cmd/commands/hostsetscmd/hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/hostsets.gen.go
@@ -57,7 +57,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "host set"
+	synopsisStr := "host-set"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/commands/hostsetscmd/plugin_hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/plugin_hostsets.gen.go
@@ -56,7 +56,7 @@ func (c *PluginCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "host set"
+	synopsisStr := "host-set"
 
 	synopsisStr = fmt.Sprintf("%s %s", "plugin-type", synopsisStr)
 

--- a/internal/cmd/commands/hostsetscmd/static_hostsets.gen.go
+++ b/internal/cmd/commands/hostsetscmd/static_hostsets.gen.go
@@ -54,7 +54,7 @@ func (c *StaticCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "host set"
+	synopsisStr := "host-set"
 
 	synopsisStr = fmt.Sprintf("%s %s", "static-type", synopsisStr)
 

--- a/internal/cmd/commands/managedgroupscmd/ldap_managedgroups.gen.go
+++ b/internal/cmd/commands/managedgroupscmd/ldap_managedgroups.gen.go
@@ -56,7 +56,7 @@ func (c *LdapCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "managed group"
+	synopsisStr := "managed-group"
 
 	synopsisStr = fmt.Sprintf("%s %s", "ldap-type", synopsisStr)
 

--- a/internal/cmd/commands/managedgroupscmd/managedgroups.gen.go
+++ b/internal/cmd/commands/managedgroupscmd/managedgroups.gen.go
@@ -55,7 +55,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "managed group"
+	synopsisStr := "managed-group"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/commands/managedgroupscmd/oidc_managedgroups.gen.go
+++ b/internal/cmd/commands/managedgroupscmd/oidc_managedgroups.gen.go
@@ -56,7 +56,7 @@ func (c *OidcCommand) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "managed group"
+	synopsisStr := "managed-group"
 
 	synopsisStr = fmt.Sprintf("%s %s", "oidc-type", synopsisStr)
 

--- a/internal/cmd/commands/policiescmd/policies.gen.go
+++ b/internal/cmd/commands/policiescmd/policies.gen.go
@@ -55,7 +55,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "policy"
+	synopsisStr := "policies"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/commands/policiescmd/policies.gen.go
+++ b/internal/cmd/commands/policiescmd/policies.gen.go
@@ -55,7 +55,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "policies"
+	synopsisStr := "policy"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/commands/sessionrecordingscmd/sessionrecordings.gen.go
+++ b/internal/cmd/commands/sessionrecordingscmd/sessionrecordings.gen.go
@@ -57,7 +57,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "session recording"
+	synopsisStr := "session-recording"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/commands/storagebucketscmd/storagebuckets.gen.go
+++ b/internal/cmd/commands/storagebucketscmd/storagebuckets.gen.go
@@ -57,7 +57,7 @@ func (c *Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "storage bucket"
+	synopsisStr := "storage-bucket"
 
 	return common.SynopsisFunc(c.Func, synopsisStr)
 }

--- a/internal/cmd/common/help.go
+++ b/internal/cmd/common/help.go
@@ -15,9 +15,10 @@ import (
 
 func SynopsisFunc(inFunc, resType string) string {
 	if inFunc == "" {
-		return wordwrap.WrapString(fmt.Sprintf("Manage Boundary %ss", resType), base.TermWidth)
+		pluralType := strings.ReplaceAll(resource.Map[resType].PluralString(), "-", " ")
+		return wordwrap.WrapString(fmt.Sprintf("Manage Boundary %s", pluralType), base.TermWidth)
 	}
-	articleType := resType
+	articleType := strings.ReplaceAll(resType, "-", " ")
 	switch resType[0] {
 	case 'a', 'e', 'i', 'o':
 		articleType = fmt.Sprintf("an %s", articleType)

--- a/internal/cmd/gencli/input.go
+++ b/internal/cmd/gencli/input.go
@@ -88,6 +88,9 @@ type cmdInfo struct {
 	SkipClientCallActions []string
 
 	SkipFiltering bool
+
+	// Plural resource value. Default is the resource name with an s at the end
+	PluralResourceString string
 }
 
 var inputStructs = map[string][]*cmdInfo{
@@ -254,12 +257,13 @@ var inputStructs = map[string][]*cmdInfo{
 	},
 	"credentiallibraries": {
 		{
-			ResourceType:     resource.CredentialLibrary.String(),
-			Pkg:              "credentiallibraries",
-			StdActions:       []string{"read", "delete", "list"},
-			HasExtraHelpFunc: true,
-			Container:        "CredentialStore",
-			HasId:            true,
+			ResourceType:         resource.CredentialLibrary.String(),
+			Pkg:                  "credentiallibraries",
+			StdActions:           []string{"read", "delete", "list"},
+			HasExtraHelpFunc:     true,
+			Container:            "CredentialStore",
+			HasId:                true,
+			PluralResourceString: "credential libraries",
 		},
 		{
 			ResourceType:         resource.CredentialLibrary.String(),
@@ -532,13 +536,14 @@ var inputStructs = map[string][]*cmdInfo{
 	},
 	"policies": {
 		{
-			ResourceType:     resource.Policy.String(),
-			Pkg:              "policies",
-			StdActions:       []string{"read", "delete", "list"},
-			HasExtraHelpFunc: true,
-			HasName:          true,
-			HasDescription:   true,
-			Container:        "Scope",
+			ResourceType:         resource.Policy.String(),
+			Pkg:                  "policies",
+			StdActions:           []string{"read", "delete", "list"},
+			HasExtraHelpFunc:     true,
+			HasName:              true,
+			HasDescription:       true,
+			Container:            "Scope",
+			PluralResourceString: "policies",
 		},
 		{
 			ResourceType:         resource.Policy.String(),

--- a/internal/cmd/gencli/input.go
+++ b/internal/cmd/gencli/input.go
@@ -88,9 +88,6 @@ type cmdInfo struct {
 	SkipClientCallActions []string
 
 	SkipFiltering bool
-
-	// Plural resource value. Default is the resource name with an s at the end
-	PluralResourceString string
 }
 
 var inputStructs = map[string][]*cmdInfo{
@@ -257,13 +254,12 @@ var inputStructs = map[string][]*cmdInfo{
 	},
 	"credentiallibraries": {
 		{
-			ResourceType:         resource.CredentialLibrary.String(),
-			Pkg:                  "credentiallibraries",
-			StdActions:           []string{"read", "delete", "list"},
-			HasExtraHelpFunc:     true,
-			Container:            "CredentialStore",
-			HasId:                true,
-			PluralResourceString: "credential libraries",
+			ResourceType:     resource.CredentialLibrary.String(),
+			Pkg:              "credentiallibraries",
+			StdActions:       []string{"read", "delete", "list"},
+			HasExtraHelpFunc: true,
+			Container:        "CredentialStore",
+			HasId:            true,
 		},
 		{
 			ResourceType:         resource.CredentialLibrary.String(),
@@ -536,14 +532,13 @@ var inputStructs = map[string][]*cmdInfo{
 	},
 	"policies": {
 		{
-			ResourceType:         resource.Policy.String(),
-			Pkg:                  "policies",
-			StdActions:           []string{"read", "delete", "list"},
-			HasExtraHelpFunc:     true,
-			HasName:              true,
-			HasDescription:       true,
-			Container:            "Scope",
-			PluralResourceString: "policies",
+			ResourceType:     resource.Policy.String(),
+			Pkg:              "policies",
+			StdActions:       []string{"read", "delete", "list"},
+			HasExtraHelpFunc: true,
+			HasName:          true,
+			HasDescription:   true,
+			Container:        "Scope",
 		},
 		{
 			ResourceType:         resource.Policy.String(),

--- a/internal/cmd/gencli/templates.go
+++ b/internal/cmd/gencli/templates.go
@@ -143,11 +143,7 @@ func (c *{{ camelCase .SubActionPrefix }}Command) Synopsis() string {
 		return extra
 	}
 
-    {{ if .PluralResourceString }}
-		synopsisStr := "{{ .PluralResourceString }}"
-	{{ else }}
-		synopsisStr := "{{ lowerSpaceCase .ResourceType }}"
-	{{ end }}
+	synopsisStr := "{{ .ResourceType }}"
 	
 	{{ if .SubActionPrefix }}
 	synopsisStr = fmt.Sprintf("%s %s", "{{ kebabCase .SubActionPrefix }}-type", synopsisStr)

--- a/internal/cmd/gencli/templates.go
+++ b/internal/cmd/gencli/templates.go
@@ -143,7 +143,12 @@ func (c *{{ camelCase .SubActionPrefix }}Command) Synopsis() string {
 		return extra
 	}
 
-	synopsisStr := "{{ lowerSpaceCase .ResourceType }}"
+    {{ if .PluralResourceString }}
+		synopsisStr := "{{ .PluralResourceString }}"
+	{{ else }}
+		synopsisStr := "{{ lowerSpaceCase .ResourceType }}"
+	{{ end }}
+	
 	{{ if .SubActionPrefix }}
 	synopsisStr = fmt.Sprintf("%s %s", "{{ kebabCase .SubActionPrefix }}-type", synopsisStr)
 	{{ end }}


### PR DESCRIPTION
Fixes plural resource help displayed when using `boundary -h`

```
credential-libraries      Manage Boundary credential librarys
...
policies                  Manage Boundary policys
```
is now
```
credential-libraries      Manage Boundary credential libraries
...
policies                  Manage Boundary policies
```

This will also come in handy for aliases (right now, they would be displayed as `Manage Boundary aliass`)