### PR TITLE
handlers: always return pagination parameters in list

### DIFF
--- a/internal/daemon/controller/handlers/accounts/account_service_test.go
+++ b/internal/daemon/controller/handlers/accounts/account_service_test.go
@@ -1238,6 +1238,27 @@ func TestListPagination(t *testing.T) {
 				protocmp.IgnoreFields(&pbs.ListAccountsResponse{}, "list_token"),
 			),
 		)
+
+		// Create unauthenticated user
+		unauthAt := authtoken.TestAuthToken(t, conn, kmsCache, o.GetPublicId())
+		unauthR := iam.TestRole(t, conn, pwt.GetPublicId())
+		_ = iam.TestUserRole(t, conn, unauthR.GetPublicId(), unauthAt.GetIamUserId())
+
+		// Make a request with the unauthenticated user,
+		// ensure the response is 403 forbidden.
+		requestInfo = authpb.RequestInfo{
+			TokenFormat: uint32(requestauth.AuthTokenTypeBearer),
+			PublicId:    unauthAt.GetPublicId(),
+			Token:       unauthAt.GetToken(),
+		}
+		requestContext = context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+		ctx = requestauth.NewVerifierContext(requestContext, iamRepoFn, tokenRepoFn, serversRepoFn, kmsCache, &requestInfo)
+
+		_, err = s.ListAccounts(ctx, &pbs.ListAccountsRequest{
+			AuthMethodId: authMethod.GetPublicId(),
+		})
+		require.Error(t, err)
+		assert.Equal(t, handlers.ForbiddenError(), err)
 	})
 
 	t.Run("oidc", func(t *testing.T) {
@@ -1555,6 +1576,27 @@ func TestListPagination(t *testing.T) {
 				protocmp.IgnoreFields(&pbs.ListAccountsResponse{}, "list_token"),
 			),
 		)
+
+		// Create unauthenticated user
+		unauthAt := authtoken.TestAuthToken(t, conn, kmsCache, o.GetPublicId())
+		unauthR := iam.TestRole(t, conn, pwt.GetPublicId())
+		_ = iam.TestUserRole(t, conn, unauthR.GetPublicId(), unauthAt.GetIamUserId())
+
+		// Make a request with the unauthenticated user,
+		// ensure the response is 403 forbidden.
+		requestInfo = authpb.RequestInfo{
+			TokenFormat: uint32(requestauth.AuthTokenTypeBearer),
+			PublicId:    unauthAt.GetPublicId(),
+			Token:       unauthAt.GetToken(),
+		}
+		requestContext = context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+		ctx = requestauth.NewVerifierContext(requestContext, iamRepoFn, tokenRepoFn, serversRepoFn, kmsCache, &requestInfo)
+
+		_, err = s.ListAccounts(ctx, &pbs.ListAccountsRequest{
+			AuthMethodId: authMethod.GetPublicId(),
+		})
+		require.Error(t, err)
+		assert.Equal(t, handlers.ForbiddenError(), err)
 	})
 
 	t.Run("ldap", func(t *testing.T) {
@@ -1869,6 +1911,27 @@ func TestListPagination(t *testing.T) {
 				protocmp.IgnoreFields(&pbs.ListAccountsResponse{}, "list_token"),
 			),
 		)
+
+		// Create unauthenticated user
+		unauthAt := authtoken.TestAuthToken(t, conn, kmsCache, o.GetPublicId())
+		unauthR := iam.TestRole(t, conn, pwt.GetPublicId())
+		_ = iam.TestUserRole(t, conn, unauthR.GetPublicId(), unauthAt.GetIamUserId())
+
+		// Make a request with the unauthenticated user,
+		// ensure the response is 403 forbidden.
+		requestInfo = authpb.RequestInfo{
+			TokenFormat: uint32(requestauth.AuthTokenTypeBearer),
+			PublicId:    unauthAt.GetPublicId(),
+			Token:       unauthAt.GetToken(),
+		}
+		requestContext = context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+		ctx = requestauth.NewVerifierContext(requestContext, iamRepoFn, tokenRepoFn, serversRepoFn, kmsCache, &requestInfo)
+
+		_, err = s.ListAccounts(ctx, &pbs.ListAccountsRequest{
+			AuthMethodId: authMethod.GetPublicId(),
+		})
+		require.Error(t, err)
+		assert.Equal(t, handlers.ForbiddenError(), err)
 	})
 }
 

--- a/internal/daemon/controller/handlers/authmethods/authmethod_service.go
+++ b/internal/daemon/controller/handlers/authmethods/authmethod_service.go
@@ -189,10 +189,6 @@ func (s Service) ListAuthMethods(ctx context.Context, req *pbs.ListAuthMethodsRe
 	if err != nil {
 		return nil, err
 	}
-	// If no scopes match, return an empty response
-	if len(scopeIds) == 0 {
-		return &pbs.ListAuthMethodsResponse{}, nil
-	}
 
 	var filterItemFn func(ctx context.Context, item auth.AuthMethod) (bool, error)
 	switch {

--- a/internal/daemon/controller/handlers/authtokens/authtoken_service.go
+++ b/internal/daemon/controller/handlers/authtokens/authtoken_service.go
@@ -103,10 +103,6 @@ func (s Service) ListAuthTokens(ctx context.Context, req *pbs.ListAuthTokensRequ
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
-	// If no scopes match, return an empty response
-	if len(scopeIds) == 0 {
-		return &pbs.ListAuthTokensResponse{}, nil
-	}
 
 	pageSize := int(s.maxPageSize)
 	// Use the requested page size only if it is smaller than

--- a/internal/daemon/controller/handlers/groups/group_service.go
+++ b/internal/daemon/controller/handlers/groups/group_service.go
@@ -114,10 +114,6 @@ func (s Service) ListGroups(ctx context.Context, req *pbs.ListGroupsRequest) (*p
 	if err != nil {
 		return nil, err
 	}
-	// If no scopes match, return an empty response
-	if len(scopeIds) == 0 {
-		return &pbs.ListGroupsResponse{}, nil
-	}
 
 	pageSize := int(s.maxPageSize)
 	// Use the requested page size only if it is smaller than

--- a/internal/daemon/controller/handlers/host_catalogs/host_catalog_service.go
+++ b/internal/daemon/controller/handlers/host_catalogs/host_catalog_service.go
@@ -174,10 +174,6 @@ func (s Service) ListHostCatalogs(ctx context.Context, req *pbs.ListHostCatalogs
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
-	// If no scopes match, return an empty response
-	if len(scopeIds) == 0 {
-		return &pbs.ListHostCatalogsResponse{}, nil
-	}
 	pageSize := int(s.maxPageSize)
 	// Use the requested page size only if it is smaller than
 	// the configured max.

--- a/internal/daemon/controller/handlers/host_sets/host_set_service_test.go
+++ b/internal/daemon/controller/handlers/host_sets/host_set_service_test.go
@@ -856,6 +856,27 @@ func TestListPagination(t *testing.T) {
 				protocmp.IgnoreFields(&pbs.ListHostSetsResponse{}, "list_token"),
 			),
 		)
+
+		// Create unauthenticated user
+		unauthAt := authtoken.TestAuthToken(t, conn, kms, org.GetPublicId())
+		unauthR := iam.TestRole(t, conn, proj.GetPublicId())
+		_ = iam.TestUserRole(t, conn, unauthR.GetPublicId(), unauthAt.GetIamUserId())
+
+		// Make a request with the unauthenticated user,
+		// ensure the response contains the pagination parameters.
+		requestInfo := authpb.RequestInfo{
+			TokenFormat: uint32(auth.AuthTokenTypeBearer),
+			PublicId:    unauthAt.GetPublicId(),
+			Token:       unauthAt.GetToken(),
+		}
+		requestContext := context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+		ctx := auth.NewVerifierContext(requestContext, iamRepoFn, tokenRepoFn, serversRepoFn, kms, &requestInfo)
+
+		_, err = s.ListHostSets(ctx, &pbs.ListHostSetsRequest{
+			HostCatalogId: shc.GetPublicId(),
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, handlers.ForbiddenError(), err)
 	})
 
 	t.Run("plugin-host-sets", func(t *testing.T) {
@@ -1086,6 +1107,27 @@ func TestListPagination(t *testing.T) {
 				protocmp.IgnoreFields(&pbs.ListHostSetsResponse{}, "list_token"),
 			),
 		)
+
+		// Create unauthenticated user
+		unauthAt := authtoken.TestAuthToken(t, conn, kms, org.GetPublicId())
+		unauthR := iam.TestRole(t, conn, proj.GetPublicId())
+		_ = iam.TestUserRole(t, conn, unauthR.GetPublicId(), unauthAt.GetIamUserId())
+
+		// Make a request with the unauthenticated user,
+		// ensure the response contains the pagination parameters.
+		requestInfo := authpb.RequestInfo{
+			TokenFormat: uint32(auth.AuthTokenTypeBearer),
+			PublicId:    unauthAt.GetPublicId(),
+			Token:       unauthAt.GetToken(),
+		}
+		requestContext := context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+		ctx := auth.NewVerifierContext(requestContext, iamRepoFn, tokenRepoFn, serversRepoFn, kms, &requestInfo)
+
+		_, err = s.ListHostSets(ctx, &pbs.ListHostSetsRequest{
+			HostCatalogId: phc.GetPublicId(),
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, handlers.ForbiddenError(), err)
 	})
 }
 

--- a/internal/daemon/controller/handlers/hosts/host_service_test.go
+++ b/internal/daemon/controller/handlers/hosts/host_service_test.go
@@ -867,6 +867,27 @@ func TestListPagination(t *testing.T) {
 				protocmp.IgnoreFields(&pbs.ListHostsResponse{}, "list_token"),
 			),
 		)
+
+		// Create unauthenticated user
+		unauthAt := authtoken.TestAuthToken(t, conn, kms, org.GetPublicId())
+		unauthR := iam.TestRole(t, conn, proj.GetPublicId())
+		_ = iam.TestUserRole(t, conn, unauthR.GetPublicId(), unauthAt.GetIamUserId())
+
+		// Make a request with the unauthenticated user,
+		// ensure the response contains the pagination parameters.
+		requestInfo := authpb.RequestInfo{
+			TokenFormat: uint32(auth.AuthTokenTypeBearer),
+			PublicId:    unauthAt.GetPublicId(),
+			Token:       unauthAt.GetToken(),
+		}
+		requestContext := context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+		ctx := auth.NewVerifierContext(requestContext, iamRepoFn, tokenRepoFn, serversRepoFn, kms, &requestInfo)
+
+		_, err = s.ListHosts(ctx, &pbs.ListHostsRequest{
+			HostCatalogId: shc.GetPublicId(),
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, handlers.ForbiddenError(), err)
 	})
 
 	t.Run("plugin-hosts", func(t *testing.T) {
@@ -1044,6 +1065,26 @@ func TestListPagination(t *testing.T) {
 				protocmp.IgnoreFields(&pbs.ListHostsResponse{}, "list_token"),
 			),
 		)
+		// Create unauthenticated user
+		unauthAt := authtoken.TestAuthToken(t, conn, kms, org.GetPublicId())
+		unauthR := iam.TestRole(t, conn, proj.GetPublicId())
+		_ = iam.TestUserRole(t, conn, unauthR.GetPublicId(), unauthAt.GetIamUserId())
+
+		// Make a request with the unauthenticated user,
+		// ensure the response contains the pagination parameters.
+		requestInfo := authpb.RequestInfo{
+			TokenFormat: uint32(auth.AuthTokenTypeBearer),
+			PublicId:    unauthAt.GetPublicId(),
+			Token:       unauthAt.GetToken(),
+		}
+		requestContext := context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+		ctx := auth.NewVerifierContext(requestContext, iamRepoFn, tokenRepoFn, serversRepoFn, kms, &requestInfo)
+
+		_, err = s.ListHosts(ctx, &pbs.ListHostsRequest{
+			HostCatalogId: phc.GetPublicId(),
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, handlers.ForbiddenError(), err)
 	})
 }
 

--- a/internal/daemon/controller/handlers/managed_groups/managed_group_service_test.go
+++ b/internal/daemon/controller/handlers/managed_groups/managed_group_service_test.go
@@ -997,6 +997,27 @@ func TestListPagination(t *testing.T) {
 				protocmp.IgnoreFields(&pbs.ListManagedGroupsResponse{}, "list_token"),
 			),
 		)
+
+		// Create unauthenticated user
+		unauthAt := authtoken.TestAuthToken(t, conn, kmsCache, o.GetPublicId())
+		unauthR := iam.TestRole(t, conn, pwt.GetPublicId())
+		_ = iam.TestUserRole(t, conn, unauthR.GetPublicId(), unauthAt.GetIamUserId())
+
+		// Make a request with the unauthenticated user,
+		// ensure the response contains the pagination parameters.
+		requestInfo = authpb.RequestInfo{
+			TokenFormat: uint32(auth.AuthTokenTypeBearer),
+			PublicId:    unauthAt.GetPublicId(),
+			Token:       unauthAt.GetToken(),
+		}
+		requestContext = context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+		ctx = auth.NewVerifierContext(requestContext, iamRepoFn, tokenRepoFn, serversRepoFn, kmsCache, &requestInfo)
+
+		_, err = s.ListManagedGroups(ctx, &pbs.ListManagedGroupsRequest{
+			AuthMethodId: authMethod.GetPublicId(),
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, handlers.ForbiddenError(), err)
 	})
 
 	t.Run("ldap", func(t *testing.T) {
@@ -1296,6 +1317,27 @@ func TestListPagination(t *testing.T) {
 				protocmp.IgnoreFields(&pbs.ListManagedGroupsResponse{}, "list_token"),
 			),
 		)
+
+		// Create unauthenticated user
+		unauthAt := authtoken.TestAuthToken(t, conn, kmsCache, o.GetPublicId())
+		unauthR := iam.TestRole(t, conn, pwt.GetPublicId())
+		_ = iam.TestUserRole(t, conn, unauthR.GetPublicId(), unauthAt.GetIamUserId())
+
+		// Make a request with the unauthenticated user,
+		// ensure the response contains the pagination parameters.
+		requestInfo = authpb.RequestInfo{
+			TokenFormat: uint32(auth.AuthTokenTypeBearer),
+			PublicId:    unauthAt.GetPublicId(),
+			Token:       unauthAt.GetToken(),
+		}
+		requestContext = context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+		ctx = auth.NewVerifierContext(requestContext, iamRepoFn, tokenRepoFn, serversRepoFn, kmsCache, &requestInfo)
+
+		_, err = s.ListManagedGroups(ctx, &pbs.ListManagedGroupsRequest{
+			AuthMethodId: authMethod.GetPublicId(),
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, handlers.ForbiddenError(), err)
 	})
 }
 

--- a/internal/daemon/controller/handlers/roles/role_service.go
+++ b/internal/daemon/controller/handlers/roles/role_service.go
@@ -123,10 +123,6 @@ func (s Service) ListRoles(ctx context.Context, req *pbs.ListRolesRequest) (*pbs
 	if err != nil {
 		return nil, err
 	}
-	// If no scopes match, return an empty response
-	if len(scopeIds) == 0 {
-		return &pbs.ListRolesResponse{}, nil
-	}
 
 	pageSize := int(s.maxPageSize)
 	// Use the requested page size only if it is smaller than

--- a/internal/daemon/controller/handlers/roles/role_service_test.go
+++ b/internal/daemon/controller/handlers/roles/role_service_test.go
@@ -760,6 +760,28 @@ func TestListPagination(t *testing.T) {
 			protocmp.IgnoreFields(&pbs.ListRolesResponse{}, "list_token"),
 		),
 	)
+
+	// Create unauthenticated user
+	unauthAt := authtoken.TestAuthToken(t, conn, kms, oWithRoles.GetPublicId())
+	unauthR := iam.TestRole(t, conn, pWithRoles.GetPublicId())
+	_ = iam.TestUserRole(t, conn, unauthR.GetPublicId(), unauthAt.GetIamUserId())
+
+	// Make a request with the unauthenticated user,
+	// ensure the response contains the pagination parameters.
+	requestInfo = authpb.RequestInfo{
+		TokenFormat: uint32(auth.AuthTokenTypeBearer),
+		PublicId:    unauthAt.GetPublicId(),
+		Token:       unauthAt.GetToken(),
+	}
+	requestContext = context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
+	ctx = auth.NewVerifierContext(requestContext, iamRepoFn, tokenRepoFn, serversRepoFn, kms, &requestInfo)
+
+	_, err = a.ListRoles(ctx, &pbs.ListRolesRequest{
+		ScopeId:   "global",
+		Recursive: true,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, handlers.ForbiddenError(), err)
 }
 
 func TestDelete(t *testing.T) {

--- a/internal/daemon/controller/handlers/scopes/scope_service.go
+++ b/internal/daemon/controller/handlers/scopes/scope_service.go
@@ -185,10 +185,6 @@ func (s *Service) ListScopes(ctx context.Context, req *pbs.ListScopesRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	// If no scopes match, return an empty response
-	if len(scopeIds) == 0 {
-		return &pbs.ListScopesResponse{}, nil
-	}
 
 	pageSize := int(s.maxPageSize)
 	// Use the requested page size only if it is smaller than

--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -234,7 +234,11 @@ func (s Service) ListTargets(ctx context.Context, req *pbs.ListTargetsRequest) (
 	// Get all user permissions for the requested scope(s).
 	userPerms := authResults.ACL().ListPermissions(authzScopes, resource.Target, IdActions, authResults.UserId)
 	if len(userPerms) == 0 {
-		return &pbs.ListTargetsResponse{}, nil
+		return &pbs.ListTargetsResponse{
+			ResponseType: "complete",
+			SortBy:       "created_time",
+			SortDir:      "desc",
+		}, nil
 	}
 
 	pageSize := int(s.maxPageSize)

--- a/internal/daemon/controller/handlers/users/user_service.go
+++ b/internal/daemon/controller/handlers/users/user_service.go
@@ -113,10 +113,6 @@ func (s Service) ListUsers(ctx context.Context, req *pbs.ListUsersRequest) (*pbs
 	if err != nil {
 		return nil, err
 	}
-	// If no scopes match, return an empty response
-	if len(scopeIds) == 0 {
-		return &pbs.ListUsersResponse{}, nil
-	}
 
 	pageSize := int(s.maxPageSize)
 	// Use the requested page size only if it is smaller than


### PR DESCRIPTION
Ensure that pagination parameters are always returned from successful list calls. Turns out the only affected list endpoint was targets (🙄 of course), but I've also added tests to all the other endpoints. The removed lines are never hit as an error is returned from the called function if there are no scopes available.