### PR TITLE
test(e2e): Fix where max_page_size is defined

### DIFF
--- a/enos/modules/aws_boundary/templates/controller.hcl
+++ b/enos/modules/aws_boundary/templates/controller.hcl
@@ -6,6 +6,9 @@ disable_mlock = true
 controller {
   name = "boundary-controller-${id}"
   description = "Enos Boundary controller ${id}"
+
+  max_page_size = ${max_page_size}
+
   database {
     url = "postgresql://${dbuser}:${dbpass}@${dbhost}:${dbport}/${dbname}"
     max_open_connections = ${db_max_open_connections}
@@ -19,8 +22,6 @@ listener "tcp" {
   # The purpose of this listener block
   purpose = "api"
   tls_disable = true
-
-  max_page_size = ${max_page_size}
 
   # Uncomment to enable CORS for the Admin UI. Be sure to set the allowed origin(s)
   # to appropriate values.

--- a/enos/modules/aws_boundary/templates/controller_bsr.hcl
+++ b/enos/modules/aws_boundary/templates/controller_bsr.hcl
@@ -6,6 +6,9 @@ disable_mlock = true
 controller {
   name = "boundary-controller-${id}"
   description = "Enos Boundary controller ${id}"
+
+  max_page_size = ${max_page_size}
+
   database {
     url = "postgresql://${dbuser}:${dbpass}@${dbhost}:${dbport}/${dbname}"
     max_open_connections = ${db_max_open_connections}
@@ -19,8 +22,6 @@ listener "tcp" {
   # The purpose of this listener block
   purpose = "api"
   tls_disable = true
-
-  max_page_size = ${max_page_size}
 
   # Uncomment to enable CORS for the Admin UI. Be sure to set the allowed origin(s)
   # to appropriate values.


### PR DESCRIPTION
This PR applies a fix to https://github.com/hashicorp/boundary/pull/4352/files by moving the `max_page_size` property from the `listener` stanza to the `controller` stanza. 

Reference: https://developer.hashicorp.com/boundary/docs/configuration/controller