### PR TITLE
fix(bsr): acquire mutex lock on all methods of Sha256SumWriter

### DIFF
--- a/internal/bsr/internal/checksum/sha256sums.go
+++ b/internal/bsr/internal/checksum/sha256sums.go
@@ -131,6 +131,8 @@ func (w *Sha256SumWriter) Write(b []byte) (int, error) {
 // WriteString will write the string to hash.
 func (w *Sha256SumWriter) WriteString(s string) (int, error) {
 	const op = "checksum.(Sha256SumWriter).WriteString"
+	w.l.Lock()
+	defer w.l.Unlock()
 	n, err := w.hash.Write([]byte(s))
 	if err != nil {
 		return n, fmt.Errorf("%s: %w", op, err)
@@ -168,6 +170,8 @@ func (w *Sha256SumWriter) WriteAndClose(b []byte) (int, error) {
 // and if so, then Close() is called; otherwise this is a noop
 func (w *Sha256SumWriter) Close() error {
 	const op = "checksum.(Sha256SumWriter).Close"
+	w.l.Lock()
+	defer w.l.Unlock()
 	var i interface{} = w.underlying
 	if v, ok := i.(io.Closer); ok {
 		if err := v.Close(); err != nil {


### PR DESCRIPTION
# Summary

This PR fixes a mistake of not acquiring the mutex lock for the `Close()` & `WriteString()` methods of the Sha256SumWriter object. This fix also prevents the panic we were seeing in a flaky test.