### PR TITLE
fix(bsr): resolve race condition errors in signature file

### DIFF
--- a/internal/bsr/internal/sign/sign.go
+++ b/internal/bsr/internal/sign/sign.go
@@ -31,6 +31,8 @@ type Writer struct {
 	w   io.Writer
 	tee io.Writer
 
+	// This lock protects the buf and w variables defined in this Writer struct as a
+	// consequence of these variables both being written to at the same time using tee
 	l sync.Mutex
 }
 


### PR DESCRIPTION
# Summary

This PR fixes the following race condition errors:
```
Write at 0x00c005a89e50 by goroutine 4628:
  bytes.(*Buffer).Write()
      /opt/homebrew/Cellar/go/1.21.7/libexec/src/bytes/buffer.go:176 +0x38
  io.(*multiWriter).Write()
      /opt/homebrew/Cellar/go/1.21.7/libexec/src/io/multi.go:85 +0xb0
  github.com/hashicorp/boundary/internal/bsr/internal/sign.(*Writer).Write()
      /Users/ddebko/github/boundary-enterprise/internal/bsr/internal/sign/sign.go:60 +0x80
  github.com/hashicorp/boundary/internal/bsr/internal/sign.(*File).Write()
      <autogenerated>:1 +0x20
  github.com/hashicorp/boundary/internal/bsr/internal/checksum.(*File).WriteAndClose()
      /Users/ddebko/github/boundary-enterprise/internal/bsr/internal/checksum/checksum.go:148 +0x6d4
  github.com/hashicorp/boundary/internal/bsr.ChunkEncoder.Encode()
      /Users/ddebko/github/boundary-enterprise/internal/bsr/encode.go:133 +0x7b8
....

Previous write at 0x00c005a89e50 by goroutine 4629:
  bytes.(*Buffer).Write()
      /opt/homebrew/Cellar/go/1.21.7/libexec/src/bytes/buffer.go:176 +0x38
  io.(*multiWriter).Write()
      /opt/homebrew/Cellar/go/1.21.7/libexec/src/io/multi.go:85 +0xb0
  github.com/hashicorp/boundary/internal/bsr/internal/sign.(*Writer).Write()
      /Users/ddebko/github/boundary-enterprise/internal/bsr/internal/sign/sign.go:60 +0x80
  github.com/hashicorp/boundary/internal/bsr/internal/sign.(*File).Write()
      <autogenerated>:1 +0x20
  github.com/hashicorp/boundary/internal/bsr/internal/checksum.(*File).WriteAndClose()
      /Users/ddebko/github/boundary-enterprise/internal/bsr/internal/checksum/checksum.go:148 +0x6d4
  github.com/hashicorp/boundary/internal/bsr.ChunkEncoder.Encode()
      /Users/ddebko/github/boundary-enterprise/internal/bsr/encode.go:133 +0x7b8
...
```
