### PR TITLE
Remove worker type from CLI output

### DIFF
--- a/internal/cmd/commands/workerscmd/funcs.go
+++ b/internal/cmd/commands/workerscmd/funcs.go
@@ -193,11 +193,6 @@ func (c *Command) printListTable(items []*workers.Worker) string {
 				fmt.Sprintf("    Scope ID:                %s", item.ScopeId),
 			)
 		}
-		if item.Type != "" {
-			output = append(output,
-				fmt.Sprintf("    Type:                    %s", item.Type),
-			)
-		}
 		if item.Version > 0 {
 			output = append(output,
 				fmt.Sprintf("    Version:                 %d", item.Version),


### PR DESCRIPTION
This does not currently remove the field from the message on the API but since it will now always show `pki` it's meaningless and causing confusion for some users.