### PR TITLE
docs: Update deprecated install command

### DIFF
--- a/website/content/docs/install-boundary/install.mdx
+++ b/website/content/docs/install-boundary/install.mdx
@@ -46,12 +46,12 @@ binary:
    package-signing key:
 
     ```shell-session
-    $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+    $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
     ```
 1. Add the official HashiCorp Linux repository:
 
     ```shell-session
-    $ sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+    $ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
     ```
 
 1. Update the package index:
@@ -121,7 +121,7 @@ binary:
    package-signing key:
 
     ```shell-session
-    $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+    $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
     ```
 1. Add the official HashiCorp Linux repository:
 

--- a/website/content/docs/install-boundary/install.mdx
+++ b/website/content/docs/install-boundary/install.mdx
@@ -126,7 +126,7 @@ binary:
 1. Add the official HashiCorp Linux repository:
 
     ```shell-session
-    $ sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+    $ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
     ```
 
 1. Update the package index:


### PR DESCRIPTION
This PR updates the instructions for installing Boundary on Ubuntu per [SPE-726](https://hashicorp.atlassian.net/browse/SPE-726).

[View the update in the preview deployment](https://boundary-8i2epkgly-hashicorp.vercel.app/boundary/docs/install-boundary/install).

[SPE-726]: https://hashicorp.atlassian.net/browse/SPE-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ