### PR TITLE
test(e2e): Add test to check target's `-session-max-seconds`

### DIFF
--- a/testing/internal/e2e/boundary/target.go
+++ b/testing/internal/e2e/boundary/target.go
@@ -90,6 +90,9 @@ func CreateNewTargetCli(t testing.TB, ctx context.Context, projectId string, def
 	if opts.WithSessionConnectionLimit != 0 {
 		args = append(args, "-session-connection-limit", fmt.Sprintf("%d", opts.WithSessionConnectionLimit))
 	}
+	if opts.WithSessionMaxSeconds != 0 {
+		args = append(args, "-session-max-seconds", fmt.Sprintf("%d", opts.WithSessionMaxSeconds))
+	}
 
 	output := e2e.RunCommand(ctx, "boundary",
 		e2e.WithArgs("targets", "create"),

--- a/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package base_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/internal/session"
+	"github.com/hashicorp/boundary/internal/target"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCliTcpTargetConnectTargetWithSessionMaxSeconds connects to a target that
+// has session max seconds defined. An error should return when trying to
+// connect to the target after the time limit has been reached.
+func TestCliTcpTargetConnectTargetWithSessionMaxSeconds(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+	c, err := loadTestConfig()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	boundary.AuthenticateAdminCli(t, ctx)
+	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
+	sessionMaxSeconds := 7
+	newTargetId := boundary.CreateNewTargetCli(
+		t,
+		ctx,
+		newProjectId,
+		c.TargetPort,
+		target.WithAddress(c.TargetAddress),
+		target.WithSessionMaxSeconds(uint32(sessionMaxSeconds)),
+	)
+
+	// Start a long-running session
+	var start time.Time
+	ctxCancel, cancel := context.WithCancel(context.Background())
+	sessionChannel := make(chan *e2e.CommandResult)
+	go func() {
+		start = time.Now()
+		sessionChannel <- e2e.RunCommand(ctxCancel, "boundary",
+			e2e.WithArgs(
+				"connect",
+				"-target-id", newTargetId,
+				"-exec", "/usr/bin/ssh", "--",
+				"-l", c.TargetSshUser,
+				"-i", c.TargetSshKeyPath,
+				"-o", "UserKnownHostsFile=/dev/null",
+				"-o", "StrictHostKeyChecking=no",
+				"-o", "IdentitiesOnly=yes", // forces the use of the provided key
+				"-p", "{{boundary.port}}", // this is provided by boundary
+				"{{boundary.ip}}",
+				"hostname -i; sleep 60",
+			),
+		)
+	}()
+	t.Cleanup(cancel)
+	s := boundary.WaitForSessionCli(t, ctx, newProjectId)
+	boundary.WaitForSessionStatusCli(t, ctx, s.Id, session.StatusActive.String())
+
+	// Check that session was closed once time limit is reached
+	select {
+	case output := <-sessionChannel:
+		require.Equal(t, 255, output.ExitCode, string(output.Stdout), string(output.Stderr))
+
+		// Ensure that the session did not run for longer than the time limit
+		// (plus a small buffer)
+		require.Less(t, time.Since(start).Seconds(), float64(sessionMaxSeconds+1))
+	case <-time.After(time.Second * time.Duration(sessionMaxSeconds+5)):
+		t.Fatal("Timed out waiting for session command to exit")
+	}
+}

--- a/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCliTcpTargetConnectTargetWithSessionMaxSeconds connects to a target that
-// has session max seconds defined. An error should return when trying to
-// connect to the target after the time limit has been reached.
-func TestCliTcpTargetConnectTargetWithSessionMaxSeconds(t *testing.T) {
+// TestCliTcpTargetConnectTargetWithSessionMaxSecondsTearDown connects to a
+// target that has session max seconds defined and executes a long-running
+// script. The session should end once the time limit has reached.
+func TestCliTcpTargetConnectTargetWithSessionMaxSecondsTearDown(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
@@ -79,5 +79,81 @@ func TestCliTcpTargetConnectTargetWithSessionMaxSeconds(t *testing.T) {
 		require.Less(t, time.Since(start).Seconds(), float64(sessionMaxSeconds+1))
 	case <-time.After(time.Second * time.Duration(sessionMaxSeconds+5)):
 		t.Fatal("Timed out waiting for session command to exit")
+	}
+}
+
+// TestCliTcpTargetConnectTargetWithSessionMaxSecondsRejectNew connects to a
+// target that has session max seconds defined. An error should return when
+// trying to connect to the target after the time limit has been reached.
+func TestCliTcpTargetConnectTargetWithSessionMaxSecondsRejectNew(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+	c, err := loadTestConfig()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	boundary.AuthenticateAdminCli(t, ctx)
+	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
+	sessionMaxSeconds := 7
+	newTargetId := boundary.CreateNewTargetCli(
+		t,
+		ctx,
+		newProjectId,
+		c.TargetPort,
+		target.WithAddress(c.TargetAddress),
+		target.WithSessionMaxSeconds(uint32(sessionMaxSeconds)),
+	)
+
+	// Start a session
+	var start time.Time
+	ctxCancel, cancel := context.WithCancel(context.Background())
+	port := "12345"
+	sessionChannel := make(chan *e2e.CommandResult)
+	go func() {
+		start = time.Now()
+		t.Logf("Starting session... %s", start)
+		sessionChannel <- e2e.RunCommand(ctxCancel, "boundary",
+			e2e.WithArgs(
+				"connect",
+				"-target-id", newTargetId,
+				"-listen-port", port,
+				"-format", "json",
+			),
+		)
+	}()
+	t.Cleanup(cancel)
+	boundary.WaitForSessionCli(t, ctx, newProjectId)
+
+	// Start connections. Expect an error once the time limit is reached
+	t.Log("Creating connections...")
+	for {
+		t.Log(time.Now())
+		output := e2e.RunCommand(ctx, "ssh",
+			e2e.WithArgs(
+				"localhost",
+				"-p", port,
+				"-l", c.TargetSshUser,
+				"-i", c.TargetSshKeyPath,
+				"-o", "UserKnownHostsFile=/dev/null",
+				"-o", "StrictHostKeyChecking=no",
+				"-o", "IdentitiesOnly=yes", // forces the use of the provided key
+				"hostname -i;",
+			),
+		)
+
+		if output.Err != nil {
+			break
+		}
+
+		// Ensure that time limit has not been reached yet
+		// (plus a small buffer)
+		require.Less(t, time.Since(start).Seconds(), float64(sessionMaxSeconds+1))
+		time.Sleep(time.Second)
 	}
 }


### PR DESCRIPTION
This PR adds an e2e test to validate the `-session-max-seconds` option on a target.

The test does the following
- creates a target with `-session-max-seconds` set to 7
- starts a session on a target
- confirms that connections created within the time limit are successful
- confirms that a connection created after the time limit will be refused