### PR TITLE
docs: Backport #4409 to website

### DIFF
--- a/website/content/docs/install-boundary/install.mdx
+++ b/website/content/docs/install-boundary/install.mdx
@@ -46,12 +46,12 @@ binary:
    package-signing key:
 
     ```shell-session
-    $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+    $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
     ```
 1. Add the official HashiCorp Linux repository:
 
     ```shell-session
-    $ sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+    $ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
     ```
 
 1. Update the package index:
@@ -121,12 +121,12 @@ binary:
    package-signing key:
 
     ```shell-session
-    $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+    $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
     ```
 1. Add the official HashiCorp Linux repository:
 
     ```shell-session
-    $ sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+    $ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
     ```
 
 1. Update the package index:


### PR DESCRIPTION
This PR backports #4409 to the stable-website branch.

* docs: Update deprecated install command

* docs: Update command to add repo