### PR TITLE
test(e2e): Verify long scripts complete successfully on tcp targets

### DIFF
--- a/testing/internal/e2e/tests/base/target_tcp_connect_exec_long_lasting_script_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_exec_long_lasting_script_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package base_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/target"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestCliTcpTargetConnectExecLongLastingScript verifies that SSH requests sent to target
+// can execute long-lasting scripts successfully.
+// It sends two SSH requests:
+// - to execute the script saved on the target
+// - to execute the script sent with the SSH request
+func TestCliTcpTargetConnectExecLongLastingScript(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+	c, err := loadTestConfig()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	boundary.AuthenticateAdminCli(t, ctx)
+
+	// Create test organization
+	newOrgId := boundary.CreateNewOrgCli(t, ctx)
+
+	// Delete organization after the test is completed
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", newOrgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+	// Create test project
+	newProjectId := boundary.CreateNewProjectCli(t, ctx, newOrgId)
+
+	// Create static credentials
+	newCredentialStoreId := boundary.CreateNewCredentialStoreStaticCli(t, ctx, newProjectId)
+	newCredentialsId := boundary.CreateNewStaticCredentialPrivateKeyCli(t, ctx, newCredentialStoreId, c.TargetSshUser, c.TargetSshKeyPath)
+
+	// Create TCP target
+	newTargetId := boundary.CreateNewTargetCli(t, ctx, newProjectId, c.TargetPort,
+		target.WithType("tcp"),
+		target.WithAddress(c.TargetAddress),
+	)
+	boundary.AddBrokeredCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialsId)
+
+	// Start a session
+	ctxCancel, cancel := context.WithCancel(context.Background())
+	proxyPort := "12345"
+	cmdChan := make(chan *e2e.CommandResult)
+	go func() {
+		t.Log("Starting session...")
+		cmdChan <- e2e.RunCommand(ctxCancel, "boundary",
+			e2e.WithArgs(
+				"connect",
+				"-target-id", newTargetId,
+				"-listen-port", proxyPort,
+				"-format", "json",
+			),
+		)
+	}()
+	t.Cleanup(cancel)
+	boundary.WaitForSessionCli(t, ctx, newProjectId)
+
+	t.Log("Copying script to host...")
+	output := e2e.RunCommand(ctx, "scp",
+		e2e.WithArgs(
+			"-i", c.TargetSshKeyPath,
+			"-P", proxyPort,
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "IdentitiesOnly=yes", // forces the use of the provided key
+			"testdata/long_lasting_test_script.sh",
+			fmt.Sprintf("%s@localhost:%s", c.TargetSshUser, "long_lasting_test_script.sh"),
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+
+	// Send SSH requests to the target to execute long-lasting scripts
+	var eg errgroup.Group
+	eg.Go(func() error {
+		t.Log("Executing the long-lasting script saved on the target...")
+		cmd := exec.CommandContext(ctx, "/usr/bin/ssh",
+			"-v",
+			"-l", c.TargetSshUser,
+			"-i", c.TargetSshKeyPath,
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "StrictHostKeyChecking=no",
+			"-p", proxyPort,
+			"localhost",
+			"./long_lasting_test_script.sh")
+		return cmd.Run()
+	})
+
+	eg.Go(func() error {
+		t.Log("Executing a long-lasting script sent with the ssh request...")
+		cmd := exec.CommandContext(ctx, "/usr/bin/ssh",
+			"-v",
+			"-l", c.TargetSshUser,
+			"-i", c.TargetSshKeyPath,
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "StrictHostKeyChecking=no",
+			"-p", proxyPort,
+			"localhost",
+			"sleep 10")
+		return cmd.Run()
+	})
+
+	require.NoError(t, eg.Wait())
+}

--- a/testing/internal/e2e/tests/base/testdata/long_lasting_test_script.sh
+++ b/testing/internal/e2e/tests/base/testdata/long_lasting_test_script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+for i in {1..10}
+do
+  echo iteration $i
+  sleep 1;
+done
+exit 0;


### PR DESCRIPTION
This PR adds an e2e-test to verify that SSH requests sent to target can execute long-lasting scripts successfully.

The test saves a ~10s-long script on the target and sends two SSH requests:
- to execute the script saved on the target
- to execute a script sent with the SSH request

This PR relates to this [bug fix](https://github.com/hashicorp/boundary-enterprise/pull/926). The test for ssh-targets will be added to boundary-enterprise in a separate PR.