### PR TITLE
test(e2e): Add extra buffer in -session-max-seconds test

### DIFF
--- a/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go
@@ -162,6 +162,6 @@ func TestCliTcpTargetConnectTargetWithSessionMaxSecondsRejectNew(t *testing.T) {
 
 	// Ensure that the session did not run for longer than the time limit
 	diff := end.Sub(start).Seconds()
-	require.Less(t, diff, float64(sessionMaxSeconds+1))
+	require.Less(t, diff, float64(sessionMaxSeconds+2))
 	require.Greater(t, diff, float64(sessionMaxSeconds-1))
 }


### PR DESCRIPTION
This PR fixes an e2e test introduced in https://github.com/hashicorp/boundary/pull/4411.

After merging, it was observed that the test would sometimes fail due to the following
```
target_tcp_connect_session_max_seconds_test.go:165: 
Error Trace:	/src/boundary/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go:165
Error:      	"8.637663214" is not less than "8"
Test:       	TestCliTcpTargetConnectTargetWithSessionMaxSecondsRejectNew

target_tcp_connect_session_max_seconds_test.go:165: 
Error Trace:	/src/boundary/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go:165
Error:      	"8.774918861" is not less than "8"
Test:       	TestCliTcpTargetConnectTargetWithSessionMaxSecondsRejectNew

target_tcp_connect_session_max_seconds_test.go:165: 
Error Trace:	/src/boundary/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go:165
Error:      	"8.411845332" is not less than "8"
Test:       	TestCliTcpTargetConnectTargetWithSessionMaxSecondsRejectNew

target_tcp_connect_session_max_seconds_test.go:165: 
Error Trace:	/src/boundary/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go:165
Error:      	"8.412026688" is not less than "8"
Test:       	TestCliTcpTargetConnectTargetWithSessionMaxSecondsRejectNew
````

This PR slightly increases the buffer in this check to allow for another second in duration. 