### PR TITLE
refact(e2e): Create vault-generic credential library helper method

### DIFF
--- a/testing/internal/e2e/boundary/credential.go
+++ b/testing/internal/e2e/boundary/credential.go
@@ -6,12 +6,15 @@ package boundary
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/boundary/api"
+	"github.com/hashicorp/boundary/api/credentiallibraries"
 	"github.com/hashicorp/boundary/api/credentials"
 	"github.com/hashicorp/boundary/api/credentialstores"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/go-secure-stdlib/base62"
 	"github.com/stretchr/testify/require"
 )
 
@@ -86,6 +89,36 @@ func CreateNewCredentialStoreStaticCli(t testing.TB, ctx context.Context, projec
 	t.Logf("Created Credential Store: %s", newCredentialStoreId)
 
 	return newCredentialStoreId
+}
+
+// CreateVaultGenericCredentialLibraryCli creates a vault-generic credential library using the cli
+func CreateVaultGenericCredentialLibraryCli(t testing.TB, ctx context.Context, credentialStoreId string, vaultPath string, credentialType string) (string, error) {
+	name, err := base62.Random(16)
+	require.NoError(t, err)
+
+	output := e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"credential-libraries", "create", "vault-generic",
+			"-credential-store-id", credentialStoreId,
+			"-vault-path", vaultPath,
+			"-credential-type", credentialType,
+			"-name", fmt.Sprintf("e2e Credential Library %s", name),
+			"-description", "e2e",
+			"-format", "json",
+		),
+	)
+	if output.Err != nil {
+		return "", fmt.Errorf("%s", output.Stderr)
+	}
+
+	var newCredentialLibraryResult credentiallibraries.CredentialLibraryCreateResult
+	err = json.Unmarshal(output.Stdout, &newCredentialLibraryResult)
+	if err != nil {
+		return "", err
+	}
+	credentialLibraryId := newCredentialLibraryResult.Item.Id
+	t.Logf("Created Credential Library: %s", credentialLibraryId)
+	return credentialLibraryId, nil
 }
 
 // CreateNewStaticCredentialPrivateKeyCli uses the cli to create a new private key credential in the

--- a/testing/internal/e2e/boundary/credential.go
+++ b/testing/internal/e2e/boundary/credential.go
@@ -91,10 +91,14 @@ func CreateNewCredentialStoreStaticCli(t testing.TB, ctx context.Context, projec
 	return newCredentialStoreId
 }
 
-// CreateVaultGenericCredentialLibraryCli creates a vault-generic credential library using the cli
+// CreateVaultGenericCredentialLibraryCli creates a vault-generic credential
+// library using the cli
+// Returns the id of the credential library or an error
 func CreateVaultGenericCredentialLibraryCli(t testing.TB, ctx context.Context, credentialStoreId string, vaultPath string, credentialType string) (string, error) {
 	name, err := base62.Random(16)
-	require.NoError(t, err)
+	if err != nil {
+		return "", err
+	}
 
 	output := e2e.RunCommand(ctx, "boundary",
 		e2e.WithArgs(

--- a/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_connect_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_connect_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/boundary/api/credentiallibraries"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
@@ -101,22 +100,14 @@ func TestCliTcpTargetVaultConnectTarget(t *testing.T) {
 	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, c.VaultAddr, credStoreToken)
 
 	// Create a credential library
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"credential-libraries", "create", "vault-generic",
-			"-credential-store-id", newCredentialStoreId,
-			"-vault-path", fmt.Sprintf("%s/data/%s", c.VaultSecretPath, privateKeySecretName),
-			"-name", "e2e Automated Test Vault Credential Library",
-			"-credential-type", "ssh_private_key",
-			"-format", "json",
-		),
+	newCredentialLibraryId, err := boundary.CreateVaultGenericCredentialLibraryCli(
+		t,
+		ctx,
+		newCredentialStoreId,
+		fmt.Sprintf("%s/data/%s", c.VaultSecretPath, privateKeySecretName),
+		"ssh_private_key",
 	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	var newCredentialLibraryResult credentiallibraries.CredentialLibraryCreateResult
-	err = json.Unmarshal(output.Stdout, &newCredentialLibraryResult)
 	require.NoError(t, err)
-	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
-	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
 
 	// Add brokered credentials to target
 	boundary.AddBrokeredCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialLibraryId)

--- a/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_authz_token_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/boundary/api/credentiallibraries"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
@@ -100,22 +99,14 @@ func TestCliTcpTargetVaultGenericConnectTargetWithAuthzToken(t *testing.T) {
 	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, c.VaultAddr, credStoreToken)
 
 	// Create a credential library
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"credential-libraries", "create", "vault-generic",
-			"-credential-store-id", newCredentialStoreId,
-			"-vault-path", fmt.Sprintf("%s/data/%s", c.VaultSecretPath, privateKeySecretName),
-			"-name", "e2e Automated Test Vault Credential Library",
-			"-credential-type", "ssh_private_key",
-			"-format", "json",
-		),
+	newCredentialLibraryId, err := boundary.CreateVaultGenericCredentialLibraryCli(
+		t,
+		ctx,
+		newCredentialStoreId,
+		fmt.Sprintf("%s/data/%s", c.VaultSecretPath, privateKeySecretName),
+		"ssh_private_key",
 	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	var newCredentialLibraryResult credentiallibraries.CredentialLibraryCreateResult
-	err = json.Unmarshal(output.Stdout, &newCredentialLibraryResult)
 	require.NoError(t, err)
-	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
-	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
 
 	boundary.AddBrokeredCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialLibraryId)
 

--- a/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_ssh_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_ssh_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/boundary/api/credentiallibraries"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
@@ -100,22 +99,14 @@ func TestCliTcpTargetVaultGenericConnectTargetWithSsh(t *testing.T) {
 	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, c.VaultAddr, credStoreToken)
 
 	// Create a credential library
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"credential-libraries", "create", "vault-generic",
-			"-credential-store-id", newCredentialStoreId,
-			"-vault-path", fmt.Sprintf("%s/data/%s", c.VaultSecretPath, privateKeySecretName),
-			"-name", "e2e Automated Test Vault Credential Library",
-			"-credential-type", "ssh_private_key",
-			"-format", "json",
-		),
+	newCredentialLibraryId, err := boundary.CreateVaultGenericCredentialLibraryCli(
+		t,
+		ctx,
+		newCredentialStoreId,
+		fmt.Sprintf("%s/data/%s", c.VaultSecretPath, privateKeySecretName),
+		"ssh_private_key",
 	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	var newCredentialLibraryResult credentiallibraries.CredentialLibraryCreateResult
-	err = json.Unmarshal(output.Stdout, &newCredentialLibraryResult)
 	require.NoError(t, err)
-	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
-	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
 
 	// Add brokered credentials to target
 	boundary.AddBrokeredCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialLibraryId)

--- a/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/target_tcp_vault_generic_connect_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/boundary/api/credentiallibraries"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
@@ -101,22 +100,14 @@ func TestCliTcpTargetVaultGenericConnectTarget(t *testing.T) {
 	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, c.VaultAddr, credStoreToken)
 
 	// Create a credential library
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"credential-libraries", "create", "vault-generic",
-			"-credential-store-id", newCredentialStoreId,
-			"-vault-path", fmt.Sprintf("%s/data/%s", c.VaultSecretPath, privateKeySecretName),
-			"-name", "e2e Automated Test Vault Credential Library",
-			"-credential-type", "ssh_private_key",
-			"-format", "json",
-		),
+	newCredentialLibraryId, err := boundary.CreateVaultGenericCredentialLibraryCli(
+		t,
+		ctx,
+		newCredentialStoreId,
+		fmt.Sprintf("%s/data/%s", c.VaultSecretPath, privateKeySecretName),
+		"ssh_private_key",
 	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	var newCredentialLibraryResult credentiallibraries.CredentialLibraryCreateResult
-	err = json.Unmarshal(output.Stdout, &newCredentialLibraryResult)
 	require.NoError(t, err)
-	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
-	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
 
 	// Add brokered credentials to target
 	boundary.AddBrokeredCredentialSourceToTargetCli(t, ctx, newTargetId, newCredentialLibraryId)

--- a/testing/internal/e2e/tests/base_with_worker/target_tcp_worker_connect_ssh_test.go
+++ b/testing/internal/e2e/tests/base_with_worker/target_tcp_worker_connect_ssh_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/boundary/api/credentiallibraries"
 	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
@@ -98,22 +97,14 @@ func TestCliTcpTargetWorkerConnectTarget(t *testing.T) {
 	newCredentialStoreId := boundary.CreateNewCredentialStoreVaultCli(t, ctx, newProjectId, c.VaultAddr, credStoreToken)
 
 	// Create a credential library
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"credential-libraries", "create", "vault-generic",
-			"-credential-store-id", newCredentialStoreId,
-			"-vault-path", fmt.Sprintf("%s/data/%s", c.VaultSecretPath, privateKeySecretName),
-			"-name", "e2e Automated Test Vault Credential Library",
-			"-credential-type", "ssh_private_key",
-			"-format", "json",
-		),
+	newCredentialLibraryId, err := boundary.CreateVaultGenericCredentialLibraryCli(
+		t,
+		ctx,
+		newCredentialStoreId,
+		fmt.Sprintf("%s/data/%s", c.VaultSecretPath, privateKeySecretName),
+		"ssh_private_key",
 	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	var newCredentialLibraryResult credentiallibraries.CredentialLibraryCreateResult
-	err = json.Unmarshal(output.Stdout, &newCredentialLibraryResult)
 	require.NoError(t, err)
-	newCredentialLibraryId := newCredentialLibraryResult.Item.Id
-	t.Logf("Created Credential Library: %s", newCredentialLibraryId)
 
 	// Try to set a worker filter on a vault credential-store
 	output = e2e.RunCommand(ctx, "boundary",


### PR DESCRIPTION
This PR does a refactor in the e2e test suite to create a helper method for creating vault-generic credential libraries. It also continues the new pattern of returning `err`  and giving the entity a random name.