### PR TITLE
Cherry Pick: Add Error logging and hclog.Logger debug logging throughout the daemon (#4384)

### DIFF
--- a/internal/clientcache/internal/cache/refresh_test.go
+++ b/internal/clientcache/internal/cache/refresh_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/boundary/api/sessions"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/internal/clientcache/internal/db"
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
@@ -139,7 +140,7 @@ func TestCleanAndPickTokens(t *testing.T) {
 		mapBasedAuthTokenKeyringLookup(atMap),
 		fakeBoundaryLookupFn)
 	require.NoError(t, err)
-	rs, err := NewRefreshService(ctx, r, 0, 0)
+	rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 	require.NoError(t, err)
 
 	t.Run("unknown user", func(t *testing.T) {
@@ -355,7 +356,7 @@ func TestRefreshForSearch(t *testing.T) {
 		require.NoError(t, err)
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
-		rs, err := NewRefreshService(ctx, r, time.Millisecond, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), time.Millisecond, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -406,7 +407,7 @@ func TestRefreshForSearch(t *testing.T) {
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
 		// Everything can stay stale for an hour
-		rs, err := NewRefreshService(ctx, r, time.Hour, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), time.Hour, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -460,7 +461,7 @@ func TestRefreshForSearch(t *testing.T) {
 		require.NoError(t, err)
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
-		rs, err := NewRefreshService(ctx, r, 0, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -513,7 +514,7 @@ func TestRefreshForSearch(t *testing.T) {
 		require.NoError(t, err)
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
-		rs, err := NewRefreshService(ctx, r, 0, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -561,7 +562,7 @@ func TestRefreshForSearch(t *testing.T) {
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
 		// Everything stays fresh for 1 hour
-		rs, err := NewRefreshService(ctx, r, time.Hour, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), time.Hour, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -632,7 +633,7 @@ func TestRefresh(t *testing.T) {
 		require.NoError(t, err)
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
-		rs, err := NewRefreshService(ctx, r, 0, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -673,7 +674,7 @@ func TestRefresh(t *testing.T) {
 		require.NoError(t, err)
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
-		rs, err := NewRefreshService(ctx, r, 0, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -713,7 +714,7 @@ func TestRefresh(t *testing.T) {
 		require.NoError(t, err)
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
-		rs, err := NewRefreshService(ctx, r, 0, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -741,7 +742,7 @@ func TestRefresh(t *testing.T) {
 		require.NoError(t, err)
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
-		rs, err := NewRefreshService(ctx, r, 0, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -795,7 +796,7 @@ func TestRecheckCachingSupport(t *testing.T) {
 		require.NoError(t, err)
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
-		rs, err := NewRefreshService(ctx, r, 0, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -829,7 +830,7 @@ func TestRecheckCachingSupport(t *testing.T) {
 		require.NoError(t, err)
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
-		rs, err := NewRefreshService(ctx, r, 0, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -863,7 +864,7 @@ func TestRecheckCachingSupport(t *testing.T) {
 		require.NoError(t, err)
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
-		rs, err := NewRefreshService(ctx, r, 0, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 
@@ -897,7 +898,7 @@ func TestRecheckCachingSupport(t *testing.T) {
 		require.NoError(t, err)
 		r, err := NewRepository(ctx, s, &sync.Map{}, mapBasedAuthTokenKeyringLookup(atMap), sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
 		require.NoError(t, err)
-		rs, err := NewRefreshService(ctx, r, 0, 0)
+		rs, err := NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 		require.NoError(t, err)
 		require.NoError(t, r.AddKeyringToken(ctx, boundaryAddr, KeyringToken{KeyringType: "k", TokenName: "t", AuthTokenId: at.Id}))
 

--- a/internal/clientcache/internal/cache/search.go
+++ b/internal/clientcache/internal/cache/search.go
@@ -99,20 +99,20 @@ func (s *SearchService) Supported(ctx context.Context, t *AuthToken) (bool, erro
 	const op = "cache.(SearchService).Supported"
 	switch {
 	case util.IsNil(t):
-		return false, errors.New(ctx, errors.InvalidParameter, op, "auth token is nil")
+		return false, errors.New(ctx, errors.InvalidParameter, op, "auth token is nil", errors.WithoutEvent())
 	case t.UserId == "":
-		return false, errors.New(ctx, errors.InvalidParameter, op, "auth token's user id is empty")
+		return false, errors.New(ctx, errors.InvalidParameter, op, "auth token's user id is empty", errors.WithoutEvent())
 	}
 	u, err := s.repo.lookupUser(ctx, t.UserId)
 	if err != nil {
-		return false, errors.Wrap(ctx, err, op)
+		return false, errors.Wrap(ctx, err, op, errors.WithoutEvent())
 	}
 	if u == nil {
-		return false, errors.New(ctx, errors.NotFound, op, "user not found for auth token")
+		return false, errors.New(ctx, errors.NotFound, op, "user not found for auth token", errors.WithoutEvent())
 	}
 	cs, err := s.repo.cacheSupportState(ctx, u)
 	if err != nil {
-		return false, errors.Wrap(ctx, err, op)
+		return false, errors.Wrap(ctx, err, op, errors.WithoutEvent())
 	}
 	return cs.supported != NotSupportedCacheSupport, nil
 }

--- a/internal/clientcache/internal/daemon/options.go
+++ b/internal/clientcache/internal/daemon/options.go
@@ -9,15 +9,18 @@ import (
 	"time"
 
 	"github.com/hashicorp/boundary/internal/clientcache/internal/cache"
+	"github.com/hashicorp/go-hclog"
 )
 
 type options struct {
-	withDebug                              bool
 	withRefreshInterval                    time.Duration
 	withRecheckSupportInterval             time.Duration
 	testWithIntervalRandomizationFactor    float64
 	testWithIntervalRandomizationFactorSet bool
 	withBoundaryTokenReaderFunc            cache.BoundaryTokenReaderFn
+
+	withUrl    string
+	withLogger hclog.Logger
 }
 
 // Option - how options are passed as args
@@ -36,14 +39,6 @@ func getOpts(opt ...Option) (options, error) {
 		}
 	}
 	return opts, nil
-}
-
-// WithDebug provides an optional debug flag.
-func WithDebug(_ context.Context, debug bool) Option {
-	return func(o *options) error {
-		o.withDebug = debug
-		return nil
-	}
 }
 
 // withRefreshInterval provides an optional refresh interval.
@@ -77,6 +72,22 @@ func testWithIntervalRandomizationFactor(_ context.Context, f float64) Option {
 		}
 		o.testWithIntervalRandomizationFactor = f
 		o.testWithIntervalRandomizationFactorSet = true
+		return nil
+	}
+}
+
+// WithUrl provides optional url
+func WithUrl(_ context.Context, url string) Option {
+	return func(o *options) error {
+		o.withUrl = url
+		return nil
+	}
+}
+
+// WithLogger provides an optional logger.
+func WithLogger(_ context.Context, logger hclog.Logger) Option {
+	return func(o *options) error {
+		o.withLogger = logger
 		return nil
 	}
 }

--- a/internal/clientcache/internal/daemon/options_test.go
+++ b/internal/clientcache/internal/daemon/options_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/boundary/api/authtokens"
 	"github.com/hashicorp/boundary/internal/clientcache/internal/cache"
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,11 +25,19 @@ func Test_GetOpts(t *testing.T) {
 		testOpts := options{}
 		assert.Equal(t, opts, testOpts)
 	})
-	t.Run("WithDebug", func(t *testing.T) {
-		opts, err := getOpts(WithDebug(ctx, true))
+	t.Run("WithUrl", func(t *testing.T) {
+		opts, err := getOpts(WithUrl(ctx, "http://localhost:9200"))
 		require.NoError(t, err)
 		testOpts := getDefaultOptions()
-		testOpts.withDebug = true
+		testOpts.withUrl = "http://localhost:9200"
+		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("WithLogger", func(t *testing.T) {
+		testLogger := hclog.NewNullLogger()
+		opts, err := getOpts(WithLogger(ctx, testLogger))
+		require.NoError(t, err)
+		testOpts := getDefaultOptions()
+		testOpts.withLogger = testLogger
 		assert.Equal(t, opts, testOpts)
 	})
 	t.Run("withRefreshInterval", func(t *testing.T) {

--- a/internal/clientcache/internal/daemon/server.go
+++ b/internal/clientcache/internal/daemon/server.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -59,6 +58,8 @@ type ClientProvider interface {
 type CacheServer struct {
 	conf *Config
 
+	logger hclog.Logger
+
 	infoKeys []string
 	info     map[string]string
 
@@ -76,7 +77,6 @@ type Config struct {
 	RefreshInterval        time.Duration
 	RecheckSupportInterval time.Duration
 	DatabaseUrl            string
-	StoreDebug             bool
 	LogLevel               string
 	LogFormat              string
 	LogWriter              io.Writer
@@ -123,9 +123,11 @@ func New(ctx context.Context, conf *Config) (*CacheServer, error) {
 		tickerWg:     new(sync.WaitGroup),
 		shutdownOnce: new(sync.Once),
 	}
-	if err := s.setupLogging(ctx, conf.LogWriter); err != nil {
+	logger, err := s.setupLogging(ctx, conf.LogWriter)
+	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
+	s.logger = logger
 	return s, nil
 }
 
@@ -222,18 +224,17 @@ func (s *CacheServer) Serve(ctx context.Context, cmd Commander, opt ...Option) e
 
 	s.info["Listening address"] = l.Addr().String()
 	s.infoKeys = append(s.infoKeys, "Listening address")
-	s.info["Store debug"] = strconv.FormatBool(s.conf.StoreDebug)
-	s.infoKeys = append(s.infoKeys, "Store debug")
 
 	var store *db.DB
-	store, s.storeUrl, err = openStore(ctx, s.conf.DatabaseUrl, s.conf.StoreDebug)
+	store, err = openStore(ctx,
+		WithUrl(ctx, s.conf.DatabaseUrl),
+		WithLogger(ctx, s.logger))
 	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
 	s.store.Store(store)
-
-	if s.storeUrl != "" {
-		s.info["Database URL"] = s.storeUrl
+	if s.conf.DatabaseUrl != "" {
+		s.info["Database URL"] = s.conf.DatabaseUrl
 		s.infoKeys = append(s.infoKeys, "Database URL")
 	}
 	maxSearchRefreshTimeout := DefaultSearchRefreshTimeout
@@ -270,7 +271,7 @@ func (s *CacheServer) Serve(ctx context.Context, cmd Commander, opt ...Option) e
 		return errors.Wrap(ctx, err, op)
 	}
 
-	refreshService, err := cache.NewRefreshService(ctx, repo, maxSearchStaleness, maxSearchRefreshTimeout)
+	refreshService, err := cache.NewRefreshService(ctx, repo, s.logger, maxSearchStaleness, maxSearchRefreshTimeout)
 	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
@@ -293,7 +294,7 @@ func (s *CacheServer) Serve(ctx context.Context, cmd Commander, opt ...Option) e
 	}()
 
 	mux := http.NewServeMux()
-	searchFn, err := newSearchHandlerFunc(ctx, repo, refreshService)
+	searchFn, err := newSearchHandlerFunc(ctx, repo, refreshService, s.logger)
 	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
@@ -311,7 +312,7 @@ func (s *CacheServer) Serve(ctx context.Context, cmd Commander, opt ...Option) e
 	}
 	mux.Handle("/v1/log", serverMetadataInterceptor(logHandlerFn, s.conf.RunningInBackground))
 
-	tokenFn, err := newTokenHandlerFunc(ctx, repo, tic)
+	tokenFn, err := newTokenHandlerFunc(ctx, repo, tic, s.logger)
 	if err != nil {
 		return errors.Wrap(ctx, err, op)
 	}
@@ -389,11 +390,11 @@ func (s *CacheServer) printInfo(ctx context.Context) {
 	event.WriteSysEvent(ctx, op, strings.Join(output, "\n"))
 }
 
-func (s *CacheServer) setupLogging(ctx context.Context, w io.Writer) error {
+func (s *CacheServer) setupLogging(ctx context.Context, w io.Writer) (hclog.Logger, error) {
 	const op = "daemon.(Command).setupLogging"
 	switch {
 	case util.IsNil(w):
-		return errors.New(ctx, errors.InvalidParameter, op, "log writer is nil")
+		return nil, errors.New(ctx, errors.InvalidParameter, op, "log writer is nil")
 	}
 
 	logFormat := logging.StandardFormat
@@ -401,7 +402,7 @@ func (s *CacheServer) setupLogging(ctx context.Context, w io.Writer) error {
 		var err error
 		logFormat, err = logging.ParseLogFormat(s.conf.LogFormat)
 		if err != nil {
-			return fmt.Errorf("%s: %w", op, err)
+			return nil, fmt.Errorf("%s: %w", op, err)
 		}
 	}
 
@@ -425,7 +426,7 @@ func (s *CacheServer) setupLogging(ctx context.Context, w io.Writer) error {
 	case "err", "error":
 		level = hclog.Error
 	default:
-		return fmt.Errorf("%s: unknown log level: %s", op, logLevel)
+		return nil, fmt.Errorf("%s: unknown log level: %s", op, logLevel)
 	}
 	var logLock sync.Mutex
 	logger := hclog.New(&hclog.LoggerOptions{
@@ -435,7 +436,7 @@ func (s *CacheServer) setupLogging(ctx context.Context, w io.Writer) error {
 		Mutex:      &logLock,
 	})
 	if err := event.InitFallbackLogger(logger); err != nil {
-		return fmt.Errorf("%s: %w", op, err)
+		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
 	s.info["log level"] = level.String()
@@ -445,10 +446,10 @@ func (s *CacheServer) setupLogging(ctx context.Context, w io.Writer) error {
 
 	var err error
 	if err = setupEventing(ctx, logger, &logLock, logFormat, w); err != nil {
-		return errors.Wrap(ctx, err, op)
+		return nil, errors.Wrap(ctx, err, op)
 	}
 
-	return nil
+	return logger, nil
 }
 
 func setupEventing(ctx context.Context, logger hclog.Logger, serializationLock *sync.Mutex, logFormat logging.LogFormat, w io.Writer) error {
@@ -495,21 +496,28 @@ func setupEventing(ctx context.Context, logger hclog.Logger, serializationLock *
 	return nil
 }
 
-func openStore(ctx context.Context, url string, flagDebugStore bool) (*db.DB, string, error) {
+func openStore(ctx context.Context, opt ...Option) (*db.DB, error) {
 	const op = "daemon.openStore"
-	var err error
-	opts := []cachedb.Option{cachedb.WithDebug(flagDebugStore)}
-	switch {
-	case url != "":
-		url, err = parseutil.ParsePath(url)
-		if err != nil && !errors.Is(err, parseutil.ErrNotAUrl) {
-			return nil, "", errors.Wrap(ctx, err, op)
-		}
-		opts = append(opts, cachedb.WithUrl(url))
-	}
-	store, err := cachedb.Open(ctx, opts...)
+	opts, err := getOpts(opt...)
 	if err != nil {
-		return nil, "", errors.Wrap(ctx, err, op)
+		return nil, errors.Wrap(ctx, err, op)
 	}
-	return store, url, nil
+
+	var dbOpts []cachedb.Option
+	switch {
+	case opts.withUrl != "":
+		url, err := parseutil.ParsePath(opts.withUrl)
+		if err != nil && !errors.Is(err, parseutil.ErrNotAUrl) {
+			return nil, errors.Wrap(ctx, err, op)
+		}
+		dbOpts = append(dbOpts, cachedb.WithUrl(url))
+	}
+	if !util.IsNil(opts.withLogger) {
+		dbOpts = append(dbOpts, cachedb.WithGormFormatter(opts.withLogger))
+	}
+	store, err := cachedb.Open(ctx, dbOpts...)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
+	return store, nil
 }

--- a/internal/clientcache/internal/daemon/testing.go
+++ b/internal/clientcache/internal/daemon/testing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/boundary/api/sessions"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/internal/clientcache/internal/cache"
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,16 +28,12 @@ type TestServer struct {
 func NewTestServer(t *testing.T, cmd Commander, opt ...Option) *TestServer {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
-
-	opts, err := getOpts(opt...)
-	require.NoError(t, err)
 	dotDir := t.TempDir()
 
 	cfg := &Config{
 		ContextCancel:          cancel,
 		RefreshInterval:        DefaultRefreshInterval,
 		RecheckSupportInterval: DefaultRecheckSupportInterval,
-		StoreDebug:             opts.withDebug,
 		LogWriter:              io.Discard,
 		DotDirectory:           dotDir,
 	}
@@ -101,7 +98,7 @@ func (s *TestServer) AddResources(t *testing.T, p *authtokens.AuthToken, tars []
 		}
 		return sess, nil, "addedsessions", nil
 	}
-	rs, err := cache.NewRefreshService(ctx, r, 0, 0)
+	rs, err := cache.NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 	require.NoError(t, err)
 	require.NoError(t, rs.Refresh(ctx, cache.WithTargetRetrievalFunc(tarFn), cache.WithSessionRetrievalFunc(sessFn)))
 }
@@ -130,7 +127,7 @@ func (s *TestServer) AddUnsupportedCachingData(t *testing.T, p *authtokens.AuthT
 		}
 		return []*sessions.Session{}, nil, "", cache.ErrRefreshNotSupported
 	}
-	rs, err := cache.NewRefreshService(ctx, r, 0, 0)
+	rs, err := cache.NewRefreshService(ctx, r, hclog.NewNullLogger(), 0, 0)
 	require.NoError(t, err)
 	err = rs.Refresh(ctx, cache.WithTargetRetrievalFunc(tarFn), cache.WithSessionRetrievalFunc(sessFn))
 	require.ErrorContains(t, err, "not supported for this controller")

--- a/internal/clientcache/internal/db/options.go
+++ b/internal/clientcache/internal/db/options.go
@@ -5,12 +5,14 @@ package db
 
 import (
 	"github.com/hashicorp/go-dbw"
+	"github.com/hashicorp/go-hclog"
 )
 
 type options struct {
-	withDebug  bool
-	withUrl    string
-	withDbType dbw.DbType
+	withDebug         bool
+	withUrl           string
+	withDbType        dbw.DbType
+	withGormFormatter hclog.Logger
 }
 
 // Option - how options are passed as args
@@ -31,6 +33,13 @@ func getOpts(opt ...Option) (options, error) {
 		}
 	}
 	return opts, nil
+}
+
+func WithGormFormatter(logger hclog.Logger) Option {
+	return func(o *options) error {
+		o.withGormFormatter = logger
+		return nil
+	}
 }
 
 // WithUrls provides optional url


### PR DESCRIPTION

* Save and assign hclogger throughout the client cache daemon

* Don't event for errors happening outside of the handlers or tickers.

* Hide and ignore -store-debug and expose the -log-level flag