### PR TITLE
fix(e2e): Add extra buffer in -session-max-seconds test again

### DIFF
--- a/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_session_max_seconds_test.go
@@ -77,7 +77,7 @@ func TestCliTcpTargetConnectTargetWithSessionMaxSecondsTearDown(t *testing.T) {
 		// Ensure that the session did not run for longer than the time limit
 		// (plus a small buffer)
 		end := time.Since(start).Seconds()
-		require.Less(t, end, float64(sessionMaxSeconds+1))
+		require.Less(t, end, float64(sessionMaxSeconds+2))
 		require.Greater(t, end, float64(sessionMaxSeconds-1))
 	case <-time.After(time.Second * time.Duration(sessionMaxSeconds+5)):
 		t.Fatal("Timed out waiting for session command to exit")


### PR DESCRIPTION
Similar to https://github.com/hashicorp/boundary/pull/4428, this PR adjusts a different `-session-max-seconds` tests to increase the buffer to allow for another second in duration.