### PR TITLE
doc(kms): Fix typo

### DIFF
--- a/website/content/docs/configuration/kms/azurekeyvault.mdx
+++ b/website/content/docs/configuration/kms/azurekeyvault.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # `azurekeyvault` KMS
 
-The Azure Key Vault KMS configures Vault to use Azure Key Vault for key management.
+The Azure Key Vault KMS configures Boundary to use Azure Key Vault for key management.
 The Azure Key Vault KMS is activated by one of the following:
 
 - The presence of a `seal "azurekeyvault"` block in Boundary's configuration file.


### PR DESCRIPTION
This PR fixes a typo from this documentation: https://developer.hashicorp.com/boundary/docs/configuration/kms/azurekeyvault