### PR TITLE
test(e2e): Use vault server instead of vault dev

### DIFF
--- a/enos/modules/docker_vault/config/config.json
+++ b/enos/modules/docker_vault/config/config.json
@@ -1,0 +1,18 @@
+{
+  "storage": {
+    "file": {
+      "path": "/vault/file"
+    }
+  },
+  "listener": [
+    {
+      "tcp": {
+        "address": "0.0.0.0:8200",
+        "tls_disable": true
+      }
+    }
+  ],
+  "default_lease_ttl": "168h",
+  "max_lease_ttl": "720h",
+  "ui": true
+}


### PR DESCRIPTION
This PR updates the e2e test suite to use `vault server` instead of `vault dev` to more closely emulate a production environment. To do so, this PR does the following...
- sets a command to the docker instance to run `vault server`
- after starting the docker image, run `vault operator init`. Extract the data from that output.
- run `vault operator unseal KEY` x3 to unseal vault