### PR TITLE
doc: Fix typo in api template

### DIFF
--- a/api/accounts/option.gen.go
+++ b/api/accounts/option.gen.go
@@ -14,7 +14,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/authmethods/option.gen.go
+++ b/api/authmethods/option.gen.go
@@ -15,7 +15,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/authtokens/option.gen.go
+++ b/api/authtokens/option.gen.go
@@ -15,7 +15,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/credentiallibraries/option.gen.go
+++ b/api/credentiallibraries/option.gen.go
@@ -14,7 +14,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/credentials/option.gen.go
+++ b/api/credentials/option.gen.go
@@ -14,7 +14,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/credentialstores/option.gen.go
+++ b/api/credentialstores/option.gen.go
@@ -15,7 +15,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/groups/option.gen.go
+++ b/api/groups/option.gen.go
@@ -15,7 +15,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/hostcatalogs/option.gen.go
+++ b/api/hostcatalogs/option.gen.go
@@ -16,7 +16,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/hosts/option.gen.go
+++ b/api/hosts/option.gen.go
@@ -14,7 +14,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/hostsets/option.gen.go
+++ b/api/hostsets/option.gen.go
@@ -14,7 +14,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/managedgroups/option.gen.go
+++ b/api/managedgroups/option.gen.go
@@ -14,7 +14,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/policies/option.gen.go
+++ b/api/policies/option.gen.go
@@ -15,7 +15,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/roles/option.gen.go
+++ b/api/roles/option.gen.go
@@ -15,7 +15,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/scopes/option.gen.go
+++ b/api/scopes/option.gen.go
@@ -16,7 +16,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/sessionrecordings/option.gen.go
+++ b/api/sessionrecordings/option.gen.go
@@ -14,7 +14,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/sessions/option.gen.go
+++ b/api/sessions/option.gen.go
@@ -16,7 +16,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/storagebuckets/option.gen.go
+++ b/api/storagebuckets/option.gen.go
@@ -16,7 +16,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/targets/option.gen.go
+++ b/api/targets/option.gen.go
@@ -15,7 +15,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/users/option.gen.go
+++ b/api/users/option.gen.go
@@ -15,7 +15,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/api/workers/option.gen.go
+++ b/api/workers/option.gen.go
@@ -15,7 +15,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -834,7 +834,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in ther order they
+// default. When an API call is made options are processed in the order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)


### PR DESCRIPTION
This PR addresses the following `make-gen-delta` CI error on `release/0.15.x`
```
diff --git a/api/billing/option.gen.go b/api/billing/option.gen.go
index 932777f7f..c3ebdbb28 100644
--- a/api/billing/option.gen.go
+++ b/api/billing/option.gen.go
@@ -15,7 +15,7 @@ import (
 // to be used directly, but instead option arguments are built from the
 // functions in this package. WithX options set a value to that given in the
 // argument; DefaultX options indicate that the value should be set to its
-// default. When an API call is made options are processed in the order they
+// default. When an API call is made options are processed in ther order they
 // appear in the function call, so for a given argument X, a succession of WithX
 // or DefaultX calls will result in the last call taking effect.
 type Option func(*options)
```

This PR applies the typo fix to the template and regenerates the api files using `make api`.