### PR TITLE
chore: Bump UI commit

### DIFF
--- a/internal/ui/VERSION
+++ b/internal/ui/VERSION
@@ -1,4 +1,4 @@
-f366f0a8585e42cacc3c8474bbacd463c7e2d79e
+5c6c9bb69f7cd3190c292fd8bde29ea23e27da51
 # This file determines the version of the UI to embed in the boundary binary.
 # Update this file by running 'make update-ui-version' from the root of this repo.
 # Set UI_COMMITISH when running the above target to update to a specific version.


### PR DESCRIPTION
This PR bumps the UI version in `main` to the commit used in `0.15.1`.