### PR TITLE
test(e2e): Provide public ca key to UI tests

### DIFF
--- a/enos/enos-scenario-e2e-ui-docker.hcl
+++ b/enos/enos-scenario-e2e-ui-docker.hcl
@@ -100,7 +100,7 @@ scenario "e2e_ui_docker" {
   }
 
   step "create_host" {
-    module = module.docker_openssh_server
+    module = module.docker_openssh_server_ca_key
     depends_on = [
       step.create_docker_network
     ]
@@ -166,6 +166,8 @@ scenario "e2e_ui_docker" {
       target_address            = step.create_host.address
       target_port               = step.create_host.port
       target_user               = "ubuntu"
+      target_ca_key             = step.create_host.ca_key
+      target_ca_key_public      = step.create_host.ca_key_public
       vault_addr                = step.create_vault.address
       vault_addr_internal       = step.create_vault.address_internal
       vault_root_token          = step.create_vault.token

--- a/enos/enos-scenario-e2e-ui-docker.hcl
+++ b/enos/enos-scenario-e2e-ui-docker.hcl
@@ -166,7 +166,7 @@ scenario "e2e_ui_docker" {
       target_address            = step.create_host.address
       target_port               = step.create_host.port
       target_user               = "ubuntu"
-      target_ca_key             = step.create_host.ca_key
+      target_ca_key             = step.create_host.ca_key_private
       target_ca_key_public      = step.create_host.ca_key_public
       vault_addr                = step.create_vault.address
       vault_addr_internal       = step.create_vault.address_internal

--- a/enos/modules/docker_openssh_server_ca_key/main.tf
+++ b/enos/modules/docker_openssh_server_ca_key/main.tf
@@ -123,3 +123,7 @@ output "port" {
 output "ca_key" {
   value = base64encode(tls_private_key.ca_key.private_key_openssh)
 }
+
+output "ca_key_public" {
+  value = base64encode(local.ca_public_key)
+}

--- a/enos/modules/docker_openssh_server_ca_key/main.tf
+++ b/enos/modules/docker_openssh_server_ca_key/main.tf
@@ -120,7 +120,7 @@ output "port" {
   value = "2222"
 }
 
-output "ca_key" {
+output "ca_key_private" {
   value = base64encode(tls_private_key.ca_key.private_key_openssh)
 }
 

--- a/enos/modules/test_e2e_ui/main.tf
+++ b/enos/modules/test_e2e_ui/main.tf
@@ -63,6 +63,16 @@ variable "target_port" {
   type        = string
   default     = ""
 }
+variable "target_ca_key" {
+  description = "CA Private Key (base64 encoded)"
+  type        = string
+  default     = ""
+}
+variable "target_ca_key_public" {
+  description = "CA Public Key (base64 encoded)"
+  type        = string
+  default     = ""
+}
 variable "vault_addr" {
   description = "External network address of Vault. Will be converted to a URL below"
   type        = string
@@ -161,6 +171,8 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_TARGET_PORT               = var.target_port
     E2E_SSH_USER                  = var.target_user
     E2E_SSH_KEY_PATH              = local.aws_ssh_private_key_path
+    E2E_SSH_CA_KEY                = var.target_ca_key
+    E2E_SSH_CA_KEY_PUBLIC         = var.target_ca_key_public
     VAULT_ADDR                    = local.vault_addr
     VAULT_TOKEN                   = var.vault_root_token
     E2E_VAULT_ADDR                = local.vault_addr_internal


### PR DESCRIPTION
This PR updates the `docker_openssh_server_ca_key` module to return the public CA key so that it can be passed to the UI tests. This is to support the an Admin UI SSH certificate injection test.

I was trying to figure out how to generate the public key from the private key within the Admin UI test itself (using `node.js`), but I wasn't able to find a solution that worked for all keys without adding additional dependencies in the UI project. Also, the built-in `crypto` node module didn't supported OpenSSH keys. 