### PR TITLE
chore(e2e): Bump e2e test timeout

### DIFF
--- a/enos/modules/test_e2e_docker/main.tf
+++ b/enos/modules/test_e2e_docker/main.tf
@@ -230,7 +230,7 @@ variable "ldap_group_name" {
 }
 variable "test_timeout" {
   type    = string
-  default = "20m"
+  default = "25m"
 }
 
 resource "enos_local_exec" "get_go_version" {


### PR DESCRIPTION
This PR bumps the e2e test suite timeout to `25m`. 

There have been a few instances where the e2e tests runtime hit this limit. For now, we will update the timeout to make things pass more regularly. There will also be some additional activity to reorganize the e2e tests as runtime has become too long.