### PR TITLE
chore(e2e): Add session recording resources for UI tests

### DIFF
--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -75,6 +75,10 @@ scenario "e2e_ui_aws" {
     }
   }
 
+  locals {
+    egress_tag = "egress"
+  }
+
   step "create_boundary_cluster" {
     module = module.aws_boundary
     depends_on = [
@@ -98,6 +102,7 @@ scenario "e2e_ui_aws" {
       vpc_tag_module           = step.create_base_infra.vpc_tag_module
       worker_count             = var.worker_count
       worker_instance_type     = var.worker_instance_type
+      worker_type_tags         = [local.egress_tag]
     }
   }
 
@@ -200,6 +205,7 @@ scenario "e2e_ui_aws" {
       aws_secret_access_key     = step.iam_setup.secret_access_key
       aws_host_set_filter       = step.create_tag_inputs.tag_string
       aws_host_set_ips          = step.create_targets_with_tag.target_ips
+      worker_tag_egress         = local.egress_tag
     }
   }
 

--- a/enos/modules/aws_boundary/templates/worker_bsr.hcl
+++ b/enos/modules/aws_boundary/templates/worker_bsr.hcl
@@ -21,6 +21,8 @@ worker {
     type   = ${type}
     region = ["${region}"]
   }
+
+  recording_storage_path = "${recording_storage_path}"
 }
 
 # must be same key as used on controller config

--- a/enos/modules/aws_boundary/variables.tf
+++ b/enos/modules/aws_boundary/variables.tf
@@ -28,6 +28,12 @@ variable "worker_instance_type" {
   default     = "t2.micro"
 }
 
+variable "worker_type_tags" {
+  description = "Tag to set on worker for use in worker filters"
+  type        = list(string)
+  default     = ["collocated", "prod", "webservers"]
+}
+
 variable "worker_ebs_iops" {
   description = "EBS IOPS for the root volume"
   type        = number
@@ -357,4 +363,10 @@ variable "vpc_tag_module" {
   description = "Name of the Module Tag tied to the VPC"
   type        = string
   default     = "aws_vpc"
+}
+
+variable "recording_storage_path" {
+  description = "Path on instance to store recordings"
+  type        = string
+  default     = ""
 }

--- a/enos/modules/test_e2e_ui/main.tf
+++ b/enos/modules/test_e2e_ui/main.tf
@@ -108,6 +108,16 @@ variable "aws_host_set_filter" {
   type        = string
   default     = ""
 }
+variable "aws_region" {
+  description = "AWS region where the resources will be created"
+  type        = string
+  default     = ""
+}
+variable "aws_bucket_name" {
+  description = "AWS S3 bucket name"
+  type        = string
+  default     = ""
+}
 variable "aws_host_set_ips" {
   description = "List of IP addresses in aws_host_set_filter1"
   type        = list(string)
@@ -153,6 +163,11 @@ variable "worker_token" {
   type        = string
   default     = ""
 }
+variable "worker_tag_egress" {
+  description = "Worker tag for the egress worker"
+  type        = string
+  default     = ""
+}
 
 locals {
   aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
@@ -180,6 +195,8 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_AWS_SECRET_ACCESS_KEY     = var.aws_secret_access_key
     E2E_AWS_HOST_SET_FILTER       = var.aws_host_set_filter
     E2E_AWS_HOST_SET_IPS          = local.aws_host_set_ips
+    E2E_AWS_REGION                = var.aws_region
+    E2E_AWS_BUCKET_NAME           = var.aws_bucket_name
     E2E_LDAP_ADDR                 = var.ldap_address
     E2E_LDAP_DOMAIN_DN            = var.ldap_domain_dn
     E2E_LDAP_ADMIN_DN             = var.ldap_admin_dn
@@ -188,6 +205,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_LDAP_USER_PASSWORD        = var.ldap_user_password
     E2E_LDAP_GROUP_NAME           = var.ldap_group_name
     E2E_WORKER_TOKEN              = var.worker_token
+    E2E_WORKER_TAG_EGRESS         = var.worker_tag_egress
   }
 
   inline = var.debug_no_run ? [""] : ["set -o pipefail; PATH=\"${var.local_boundary_dir}:$PATH\" yarn --cwd ${var.local_boundary_ui_src_dir}/ui/admin run e2e 2>&1 | tee ${path.module}/../../test-e2e-ui.log"]


### PR DESCRIPTION
This PR updates some enos modules to add session recording resources support for UI tests. There will be a follow-up PR to add a `UI_AWS_ENT` scenario.