### PR TITLE
docs: Backport #4505 to release 0.15.x

### DIFF
--- a/website/content/docs/release-notes/v0_14_0.mdx
+++ b/website/content/docs/release-notes/v0_14_0.mdx
@@ -253,6 +253,36 @@ description: |-
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.14.0
+    <br /><br />
+    (Fixed in 0.14.5)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Go CVE-2024-24783, Go CVE-2024-24784, Go CVE-2024-24785, Go CVE-2024-24786, Go CVE-2023-45289, Go CVE-2023-45290
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    The version of Go that was used in Boundary release 0.14.0 contained security vulnerabilities. The vulnerabilities were fixed in Go version 1.21.8. Boundary was updated to use the new Go version in release 0.14.5, and the issue is resolved.
+    <br /><br />
+    Learn more:&nbsp;
+    <br /><br />
+    CVE-2024-24783: <a href="https://www.cve.org/CVERecord?id=CVE-2024-24783">Verify panics on certificates with an unknown public key algorithm in crypto/x509</a>
+    <br /><br />
+    CVE-2024-24784: <a href="https://www.cve.org/CVERecord?id=CVE-2024-24784">Comments in display names are incorrectly handled in net/mail</a>
+    <br /><br />
+    CVE-2024-24785: <a href="https://www.cve.org/CVERecord?id=CVE-2024-24785">Errors returned from JSON marshaling may break template escaping in html/template</a>
+    <br /><br />
+    CVE-2024-24786: <a href="https://www.cve.org/CVERecord?id=CVE-2024-24786">Infinite loop in JSON unmarshaling in google.golang.org/protobuf</a>
+    <br /><br />
+    CVE-2023-45289: <a href="https://www.cve.org/CVERecord?id=CVE-2023-45289">Incorrect forwarding of sensitive headers and cookies on HTTP redirect in net/http</a>
+    <br /><br />
+    CVE-2023-45290: <a href="https://www.cve.org/CVERecord?id=CVE-2023-45290">Memory exhaustion in multipart form parsing in net/textproto and net/http</a>
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
   </tbody>
 </table>
 

--- a/website/content/docs/release-notes/v0_15_0.mdx
+++ b/website/content/docs/release-notes/v0_15_0.mdx
@@ -201,6 +201,36 @@ description: |-
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.15.0
+    <br /><br />
+    (Fixed in 0.15.2)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Go CVE-2024-24783, Go CVE-2024-24784, Go CVE-2024-24785, Go CVE-2024-24786, Go CVE-2023-45289, Go CVE-2023-45290
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    The version of Go that was used in Boundary release 0.15.0 contained security vulnerabilities. The vulnerabilities were fixed in Go version 1.21.8. Boundary was updated to use the new Go version in release 0.15.2, and the issue is resolved.
+    <br /><br />
+    Learn more:&nbsp;
+    <br /><br />
+    CVE-2024-24783: <a href="https://www.cve.org/CVERecord?id=CVE-2024-24783">Verify panics on certificates with an unknown public key algorithm in crypto/x509</a>
+    <br /><br />
+    CVE-2024-24784: <a href="https://www.cve.org/CVERecord?id=CVE-2024-24784">Comments in display names are incorrectly handled in net/mail</a>
+    <br /><br />
+    CVE-2024-24785: <a href="https://www.cve.org/CVERecord?id=CVE-2024-24785">Errors returned from JSON marshaling may break template escaping in html/template</a>
+    <br /><br />
+    CVE-2024-24786: <a href="https://www.cve.org/CVERecord?id=CVE-2024-24786">Infinite loop in JSON unmarshaling in google.golang.org/protobuf</a>
+    <br /><br />
+    CVE-2023-45289: <a href="https://www.cve.org/CVERecord?id=CVE-2023-45289">Incorrect forwarding of sensitive headers and cookies on HTTP redirect in net/http</a>
+    <br /><br />
+    CVE-2023-45290: <a href="https://www.cve.org/CVERecord?id=CVE-2023-45290">Memory exhaustion in multipart form parsing in net/textproto and net/http</a>
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
 
   </tbody>
 </table>


### PR DESCRIPTION
This PR backports #4505 to release/0.15.x.