### PR TITLE
Feature: Output the Dynamically Allocated Port for Kubernetes Targets Connection

### DIFF
--- a/internal/cmd/commands/connect/kube.go
+++ b/internal/cmd/commands/connect/kube.go
@@ -69,7 +69,7 @@ func (f *kubeFlags) buildArgs(c *Command, port, ip, addr string) ([]string, erro
 	}
 	// Dynamically extract the port
 	extractedPort := extractPort(addr)
-	fmt.Printf("Dynamically allocated port: %s\n", extractedPort)
+	fmt.Printf("Dynamically Allocated Port: %s\n", extractedPort)
 
 	switch f.flagKubeStyle {
 	case "kubectl":

--- a/internal/cmd/commands/connect/kube.go
+++ b/internal/cmd/commands/connect/kube.go
@@ -67,6 +67,10 @@ func (f *kubeFlags) buildArgs(c *Command, port, ip, addr string) ([]string, erro
 		}
 		host = u.Hostname()
 	}
+	// Dynamically extract the port
+	extractedPort := extractPort(addr)
+	fmt.Printf("Dynamically allocated port: %s\n", extractedPort)
+
 	switch f.flagKubeStyle {
 	case "kubectl":
 		if host != "" && f.flagKubeScheme == "https" {
@@ -76,4 +80,13 @@ func (f *kubeFlags) buildArgs(c *Command, port, ip, addr string) ([]string, erro
 		args = append(args, "--server", fmt.Sprintf("%s://%s", f.flagKubeScheme, addr))
 	}
 	return args, nil
+}
+
+// extractPort is a Helper function to extract port from kube addr
+func extractPort(addr string) string {
+	parts := strings.Split(addr, ":")
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
 }


### PR DESCRIPTION
## Description

This PR introduces a new feature to the `boundary connect kube` command, enabling it to output the dynamically allocated port number for Kubernetes targets. This enhancement addresses the need for users to know the exact local port bound by the Boundary CLI, facilitating a smoother integration with other tools and scripts that require this information.

## Background

Previously, when executing `boundary connect kube` to establish a session with a Kubernetes target, the CLI did not provide feedback on the local port used for the proxy connection. This omission required users to manually discover the port, complicating workflows that depend on programmatically accessing the port number when needed by another CLI to be developed on top of `boundary connect kube`

## Changes Introduced
- Modified the connect command to capture and output the local port number upon successful connection establishment.
- Ensured the output format is user-friendly and consistent with Boundary's CLI output standards.

## How to Test
- Build the Boundary CLI with these changes.
- Execute `boundary connect kube -target-id <target_id>` with a valid Kubernetes target ID.
- Observe the output, which should now include the dynamically allocated local port number.

## Why This Is Beneficial
This feature enhances the usability of Boundary for Kubernetes users, streamlining their workflows by providing essential information directly through the CLI. It opens up new possibilities for automation and integration with other development and operations tools