### PR TITLE
chore: Add edu team as codeowners for website

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,7 @@
 
 /.release/                               @hashicorp/github-secure-boundary
 /.github/workflows/build.yml             @hashicorp/github-secure-boundary
+
+# education
+
+/website/content/                        @hashicorp/boundary-education-approvers


### PR DESCRIPTION
This PR adds the docs team as codeowners for any changes in the `website/content` directory