### PR TITLE
fix(session): Use active transaction

### DIFF
--- a/internal/session/repository_connection.go
+++ b/internal/session/repository_connection.go
@@ -416,8 +416,8 @@ func (r *ConnectionRepository) closeOrphanedConnections(ctx context.Context, wor
 		ctx,
 		db.StdRetryCnt,
 		db.ExpBackoff{},
-		func(reader db.Reader, w db.Writer) error {
-			rows, err := r.reader.Query(ctx, fmt.Sprintf(orphanedConnectionsCte, notInClause), args)
+		func(_ db.Reader, w db.Writer) error {
+			rows, err := w.Query(ctx, fmt.Sprintf(orphanedConnectionsCte, notInClause), args)
 			if err != nil {
 				return errors.Wrap(ctx, err, op)
 			}

--- a/internal/session/repository_session.go
+++ b/internal/session/repository_session.go
@@ -830,9 +830,9 @@ func (r *Repository) CheckIfNotActive(ctx context.Context, reportedSessions []st
 		ctx,
 		db.StdRetryCnt,
 		db.ExpBackoff{},
-		func(reader db.Reader, w db.Writer) error {
+		func(reader db.Reader, _ db.Writer) error {
 			var states []*State
-			err := r.reader.SearchWhere(ctx, &states, "end_time is null and session_id in (?)", []any{reportedSessions})
+			err := reader.SearchWhere(ctx, &states, "end_time is null and session_id in (?)", []any{reportedSessions})
 			if err != nil {
 				return errors.Wrap(ctx, err, op)
 			}


### PR DESCRIPTION
When closing orphaned connections and checking if a session is not
active, the repository was opening a transaction, but then calling the
original reader instead of using the reader/writer from the transaction.
This would result in a transaction being opend, then a separate
transaction being used to run the query, and finally the original
transaction would commit without any statements being executed.

Co-authored-by: Sorawis Nilparuk (Bo) <sorawis.nilparuk@hashicorp.com>