### PR TITLE
make newSendCtx also handle context.DeadlineExceeded

### DIFF
--- a/internal/event/context.go
+++ b/internal/event/context.go
@@ -341,7 +341,7 @@ func newSendCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	switch {
 	case ctx == nil:
 		return context.Background(), nil
-	case ctx.Err() == context.Canceled:
+	case ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded:
 		sendCtx, sendCancel = context.WithTimeout(context.Background(), cancelledSendTimeout)
 		info, ok := RequestInfoFromContext(ctx)
 		if ok {

--- a/internal/event/context_unexported_test.go
+++ b/internal/event/context_unexported_test.go
@@ -6,6 +6,7 @@ package event
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,6 +40,28 @@ func Test_newSendCtx(t *testing.T) {
 			name: "cancelled-no-info",
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				return ctx
+			}(),
+			wantCancel: true,
+		},
+		{
+			name: "deadline-exceeded-with-info",
+			ctx: func() context.Context {
+				var err error
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Millisecond))
+				defer cancel()
+				ctx, err = NewRequestInfoContext(ctx, testInfo)
+				require.NoError(t, err)
+				return ctx
+			}(),
+			wantCancel: true,
+			wantInfo:   true,
+		},
+		{
+			name: "deadline-exceeded-no-info",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Millisecond))
 				defer cancel()
 				return ctx
 			}(),

--- a/internal/event/context_unexported_test.go
+++ b/internal/event/context_unexported_test.go
@@ -88,6 +88,7 @@ func Test_newSendCtx(t *testing.T) {
 			ctx, cancel := newSendCtx(tt.ctx)
 			require.NotNil(ctx)
 			assert.True(ctx.Err() != context.Canceled)
+			assert.True(ctx.Err() != context.DeadlineExceeded)
 			if tt.wantCancel {
 				require.NotNil(cancel)
 			} else {


### PR DESCRIPTION
When running into `context deadline exceeded`, Boundary attempts to use the same context to publish events which may lead to further failure. Adding a check to also create a new `context` when `ctx.Err() == context.DeadlineExceeded`