### PR TITLE
feat: Add support for correlationId

### DIFF
--- a/globals/globals.go
+++ b/globals/globals.go
@@ -18,6 +18,11 @@ const (
 	GrantScopeThis        = "this"
 	GrantScopeChildren    = "children"
 	GrantScopeDescendants = "descendants"
+
+	// CorrelationIdKey defines the http header and grpc metadata key used for specifying a
+	// correlation id. When getting the correlationId (from the http header or grpc metadata)
+	// ensure the comparison is case-insensitive.
+	CorrelationIdKey = "x-correlation-id"
 )
 
 type (

--- a/internal/credential/vault/private_credential.go
+++ b/internal/credential/vault/private_credential.go
@@ -48,6 +48,7 @@ type privateCredential struct {
 	CtClientKey          []byte
 	ClientKeyHmac        []byte
 	ClientKeyId          string
+	SessionCorrelationId string
 }
 
 func (pc *privateCredential) decrypt(ctx context.Context, cipher wrapping.Wrapper) error {

--- a/internal/credential/vault/vault.go
+++ b/internal/credential/vault/vault.go
@@ -30,6 +30,7 @@ type vaultClient interface {
 	get(context.Context, string) (*vault.Secret, error)
 	post(context.Context, string, []byte) (*vault.Secret, error)
 	capabilities(context.Context, []string) (pathCapabilities, error)
+	headers(ctx context.Context) (http.Header, error)
 }
 
 var vaultClientFactoryFn = vaultClientFactory
@@ -269,4 +270,9 @@ func (c *client) capabilities(ctx context.Context, paths []string) (pathCapabili
 	}
 
 	return newPathCapabilities(res), nil
+}
+
+// headers returns the underlying Vault Client http headers
+func (c *client) headers(_ context.Context) (http.Header, error) {
+	return c.cl.Headers(), nil
 }

--- a/internal/credential/vault/vault.go
+++ b/internal/credential/vault/vault.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/event"
 	"github.com/hashicorp/go-rootcerts"
 	vault "github.com/hashicorp/vault/api"
 	"github.com/mitchellh/mapstructure"
@@ -114,6 +116,10 @@ func newClient(ctx context.Context, c *clientConfig) (*client, error) {
 
 	if c.Namespace != "" {
 		vClient.SetNamespace(c.Namespace)
+	}
+
+	if correlationId, ok := event.CorrelationIdFromContext(ctx); ok {
+		vClient.AddHeader(globals.CorrelationIdKey, correlationId)
 	}
 
 	return &client{

--- a/internal/credential/vault/vault_test.go
+++ b/internal/credential/vault/vault_test.go
@@ -11,7 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/event"
+	"github.com/hashicorp/go-uuid"
 	vault "github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,19 +23,27 @@ import (
 func Test_newClient(t *testing.T) {
 	t.Parallel()
 	v := NewTestVaultServer(t)
-	ctx := context.Background()
+
+	corId, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	corCtx, err := event.NewCorrelationIdContext(context.Background(), corId)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name         string
+		ctx          context.Context
 		wantErr      bool
+		wantCorId    string
 		clientConfig *clientConfig
 	}{
 		{
 			name:    "nil-config",
+			ctx:     context.Background(),
 			wantErr: true,
 		},
 		{
 			name: "empty-addr",
+			ctx:  context.Background(),
 			clientConfig: &clientConfig{
 				Token: TokenSecret(v.RootToken),
 			},
@@ -40,6 +51,7 @@ func Test_newClient(t *testing.T) {
 		},
 		{
 			name: "empty-token",
+			ctx:  context.Background(),
 			clientConfig: &clientConfig{
 				Addr: v.Addr,
 			},
@@ -47,17 +59,28 @@ func Test_newClient(t *testing.T) {
 		},
 		{
 			name: "valid-config",
+			ctx:  context.Background(),
 			clientConfig: &clientConfig{
 				Addr:  v.Addr,
 				Token: TokenSecret(v.RootToken),
 			},
+			wantCorId: "",
+		},
+		{
+			name: "valid-config-with-correlation-id",
+			ctx:  corCtx,
+			clientConfig: &clientConfig{
+				Addr:  v.Addr,
+				Token: TokenSecret(v.RootToken),
+			},
+			wantCorId: corId,
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
-			client, err := newClient(ctx, tt.clientConfig)
+			client, err := newClient(tt.ctx, tt.clientConfig)
 			if tt.wantErr {
 				require.Error(err)
 				assert.Nil(client)
@@ -65,6 +88,9 @@ func Test_newClient(t *testing.T) {
 			}
 			require.NoError(err)
 			assert.NotNil(client)
+
+			corIdHeader := client.cl.Headers().Get(globals.CorrelationIdKey)
+			assert.Equal(tt.wantCorId, corIdHeader)
 		})
 	}
 }

--- a/internal/daemon/controller/interceptor_test.go
+++ b/internal/daemon/controller/interceptor_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/alias"
 	talias "github.com/hashicorp/boundary/internal/alias/target"
 	"github.com/hashicorp/boundary/internal/authtoken"
@@ -32,6 +33,7 @@ import (
 	"github.com/hashicorp/boundary/internal/server"
 	"github.com/hashicorp/boundary/internal/target/tcp"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
 	"github.com/mr-tron/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -986,5 +988,81 @@ func (g *testGreeter) SayHello(ctx context.Context, req *interceptor.SayHelloReq
 		return nil, errors.New(ctx, errors.Internal, op, "nil response error msg")
 	default:
 		return &interceptor.SayHelloResponse{Message: "hello"}, nil
+	}
+}
+
+func Test_correlationIdInterceptor(t *testing.T) {
+	interceptor := correlationIdInterceptor(context.Background())
+	require.NotNil(t, interceptor)
+
+	corId, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+
+	returnCtxHandler := func(ctx context.Context, req any) (any, error) {
+		return ctx, nil
+	}
+
+	cases := []struct {
+		name       string
+		ctx        context.Context
+		wantCorId  string
+		wantErr    bool
+		wantErrStr string
+	}{
+		{
+			name:       "no metadata",
+			ctx:        context.Background(),
+			wantErr:    true,
+			wantErrStr: "controller.correlationIdInterceptor: no metadata",
+		},
+		{
+			name: "no correlation id",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				"not-correlation-id": "this is not a correlation id",
+			})),
+			wantErr:    true,
+			wantErrStr: "controller.correlationIdInterceptor: missing correlation id metadata",
+		},
+		{
+			name: "too many correlation ids",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				globals.CorrelationIdKey: corId,
+				"x-Correlation-id":       corId, // metadata.New does a toLower so this is an easy way to add multiple of same key
+			})),
+			wantErr:    true,
+			wantErrStr: "controller.correlationIdInterceptor: expected 1 value for x-correlation-id metadata and got 2",
+		},
+		{
+			name: "invalid correlation id",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				globals.CorrelationIdKey: "this is wrong",
+			})),
+			wantErr:    true,
+			wantErrStr: "controller.correlationIdInterceptor: failed to validated correlation id",
+		},
+		{
+			name: "valid correlation id",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				globals.CorrelationIdKey: corId,
+			})),
+			wantCorId: corId,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &pbs.GetAccountRequest{Id: "test"}
+
+			retCtx, err := interceptor(tc.ctx, req, nil, returnCtxHandler)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErrStr)
+				return
+			}
+			assert.NoError(t, err)
+
+			corId, ok := event.CorrelationIdFromContext(retCtx.(context.Context))
+			require.True(t, ok)
+			assert.Equal(t, tc.wantCorId, corId)
+		})
 	}
 }

--- a/internal/db/schema/migrations/oss/postgres/56/02_add_data_key_foreign_key_references.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/56/02_add_data_key_foreign_key_references.up.sql
@@ -290,7 +290,8 @@ begin;
     'credential_vault_token_renewal_revocation is a view where each row contains a credential store and the credential store''s data needed to connect to Vault. '
     'The view returns a separate row for each active token in Vault (current, maintaining and revoke tokens); this view should only be used for token renewal and revocation. '
     'Each row may contain encrypted data. This view should not be used to retrieve data which will be returned external to boundary.';
-    
+
+  -- Replaced in 87/01_session.up.sql
   create view credential_vault_credential_private as
      select credential.public_id         as public_id,
             credential.library_id        as library_id,

--- a/internal/db/schema/migrations/oss/postgres/59/01_target_ingress_egress_worker_filters.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/59/01_target_ingress_egress_worker_filters.up.sql
@@ -264,7 +264,7 @@ where scd.library_id = cl.public_id
   and o.public_id = p.parent_id
   and o.type = 'org';
 
--- Update session immutable columns
+-- Replaced in 87/01_session.up.sql
 drop trigger immutable_columns on session;
 create trigger immutable_columns before update on session
   for each row execute procedure immutable_columns('public_id', 'certificate', 'expiration_time', 'connection_limit',

--- a/internal/db/schema/migrations/oss/postgres/87/01_session.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/87/01_session.up.sql
@@ -41,6 +41,7 @@ begin;
          store.ca_cert                as ca_cert,
          store.tls_server_name        as tls_server_name,
          store.tls_skip_verify        as tls_skip_verify,
+         store.worker_filter          as worker_filter,
          cert.certificate             as client_cert,
          cert.certificate_key         as ct_client_key, -- encrypted
          cert.certificate_key_hmac    as client_cert_key_hmac,

--- a/internal/db/schema/migrations/oss/postgres/87/01_session.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/87/01_session.up.sql
@@ -1,0 +1,64 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+
+  alter table session
+    add column correlation_id uuid;
+
+  -- Replaces trigger from 59/01_target_ingress_egress_worker_filters.up.sql
+  drop trigger immutable_columns on session;
+  create trigger immutable_columns before update on session
+    for each row execute procedure immutable_columns('public_id', 'certificate', 'expiration_time', 'connection_limit',
+    'create_time', 'endpoint', 'worker_filter', 'egress_worker_filter', 'ingress_worker_filter', 'correlation_id');
+
+  -- Replaces view from 56/02_add_data_key_foreign_key_references.up.sql
+  drop view credential_vault_credential_private;
+  create view credential_vault_credential_private as
+  select credential.public_id         as public_id,
+         credential.library_id        as library_id,
+         credential.session_id        as session_id,
+         credential.create_time       as create_time,
+         credential.update_time       as update_time,
+         credential.version           as version,
+         credential.external_id       as external_id,
+         credential.last_renewal_time as last_renewal_time,
+         credential.expiration_time   as expiration_time,
+         credential.is_renewable      as is_renewable,
+         credential.status            as status,
+         credential.last_renewal_time + (credential.expiration_time - credential.last_renewal_time) / 2 as renewal_time,
+         token.token_hmac             as token_hmac,
+         token.token                  as ct_token, -- encrypted
+         token.create_time            as token_create_time,
+         token.update_time            as token_update_time,
+         token.last_renewal_time      as token_last_renewal_time,
+         token.expiration_time        as token_expiration_time,
+         token.key_id                 as token_key_id,
+         token.status                 as token_status,
+         store.project_id             as project_id,
+         store.vault_address          as vault_address,
+         store.namespace              as namespace,
+         store.ca_cert                as ca_cert,
+         store.tls_server_name        as tls_server_name,
+         store.tls_skip_verify        as tls_skip_verify,
+         cert.certificate             as client_cert,
+         cert.certificate_key         as ct_client_key, -- encrypted
+         cert.certificate_key_hmac    as client_cert_key_hmac,
+         cert.key_id                  as client_key_id,
+         sess.correlation_id          as session_correlation_id
+    from credential_vault_credential credential
+    join credential_vault_token token
+      on credential.token_hmac = token.token_hmac
+    join credential_vault_store store
+      on token.store_id = store.public_id
+    left join session sess
+      on credential.session_id = sess.public_id
+    left join credential_vault_client_certificate cert
+      on store.public_id = cert.store_id
+   where credential.expiration_time != 'infinity'::date;
+  comment on view credential_vault_credential_private is
+    'credential_vault_credential_private is a view where each row contains a credential, '
+    'the vault token used to issue the credential, and the credential store data needed to connect to Vault. '
+    'Each row may contain encrypted data. This view should not be used to retrieve data which will be returned external to boundary.';
+
+commit;

--- a/internal/errors/code.go
+++ b/internal/errors/code.go
@@ -128,6 +128,8 @@ const (
 	UnexpectedRowsAffected Code = 1107
 	// ImmutableColumn is used when an operation attempted to mutate an immutable column.
 	ImmutableColumn Code = 1108
+	// InvalidTextRepresentation represents a value does not have the correct text representation.
+	InvalidTextRepresentation Code = 1109
 
 	// Migration setup errors are codes 2000-2999
 	MigrationIntegrity Code = 2000 // MigrationIntegrity represents an error with the generated migration related code

--- a/internal/errors/code_test.go
+++ b/internal/errors/code_test.go
@@ -420,6 +420,11 @@ func TestCode_Both_String_Info(t *testing.T) {
 			c:    InvalidListToken,
 			want: InvalidListToken,
 		},
+		{
+			name: "InvalidTextRepresentation",
+			c:    InvalidTextRepresentation,
+			want: InvalidTextRepresentation,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -198,6 +198,9 @@ func Convert(e error) *Err {
 			return E(ctx, WithoutEvent(), WithCode(ColumnNotFound), WithMsg(pgxError.Message)).(*Err)
 		case "P0001":
 			return E(ctx, WithoutEvent(), WithCode(Exception), WithMsg(pgxError.Message)).(*Err)
+		case "22P02":
+			return E(ctx, WithoutEvent(), WithCode(InvalidTextRepresentation), WithMsg(pgxError.Message)).(*Err)
+
 		}
 	}
 	// unfortunately, we can't help.

--- a/internal/errors/info.go
+++ b/internal/errors/info.go
@@ -43,6 +43,10 @@ var errorCodeInfo = map[Code]Info{
 		Message: "key/version not found",
 		Kind:    Integrity,
 	},
+	InvalidTextRepresentation: {
+		Message: "invalid text representation",
+		Kind:    Integrity,
+	},
 	TicketAlreadyRedeemed: {
 		Message: "ticket already redeemed",
 		Kind:    Integrity,

--- a/internal/event/event_audit.go
+++ b/internal/event/event_audit.go
@@ -22,15 +22,16 @@ const (
 
 // audit defines the data of audit events
 type audit struct {
-	Id          string       `json:"id"`                     // std audit/boundary field
-	Version     string       `json:"version"`                // std audit/boundary field
-	Type        string       `json:"type"`                   // std audit field
-	Timestamp   time.Time    `json:"timestamp"`              // std audit field
-	RequestInfo *RequestInfo `json:"request_info,omitempty"` // boundary field
-	Auth        *Auth        `json:"auth,omitempty"`         // std audit field
-	Request     *Request     `json:"request,omitempty"`      // std audit field
-	Response    *Response    `json:"response,omitempty"`     // std audit field
-	Flush       bool         `json:"-"`
+	Id            string       `json:"id"`                     // std audit/boundary field
+	Version       string       `json:"version"`                // std audit/boundary field
+	Type          string       `json:"type"`                   // std audit field
+	Timestamp     time.Time    `json:"timestamp"`              // std audit field
+	RequestInfo   *RequestInfo `json:"request_info,omitempty"` // boundary field
+	Auth          *Auth        `json:"auth,omitempty"`         // std audit field
+	Request       *Request     `json:"request,omitempty"`      // std audit field
+	Response      *Response    `json:"response,omitempty"`     // std audit field
+	Flush         bool         `json:"-"`
+	CorrelationId string       `json:"correlation_id,omitempty"`
 }
 
 func newAudit(fromOperation Op, opt ...Option) (*audit, error) {
@@ -55,15 +56,16 @@ func newAudit(fromOperation Op, opt ...Option) (*audit, error) {
 	}
 
 	a := &audit{
-		Id:          opts.withId,
-		Version:     auditVersion,
-		Type:        string(ApiRequest),
-		Timestamp:   dtm,
-		RequestInfo: opts.withRequestInfo,
-		Auth:        opts.withAuth,
-		Request:     opts.withRequest,
-		Response:    opts.withResponse,
-		Flush:       opts.withFlush,
+		Id:            opts.withId,
+		Version:       auditVersion,
+		Type:          string(ApiRequest),
+		Timestamp:     dtm,
+		RequestInfo:   opts.withRequestInfo,
+		Auth:          opts.withAuth,
+		Request:       opts.withRequest,
+		Response:      opts.withResponse,
+		Flush:         opts.withFlush,
+		CorrelationId: opts.withCorrelationId,
 	}
 	if err := a.validate(); err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
@@ -164,6 +166,9 @@ func (a *audit) ComposeFrom(events []*eventlogger.Event) (eventlogger.EventType,
 		}
 		if !gated.Timestamp.IsZero() {
 			payload.Timestamp = gated.Timestamp
+		}
+		if gated.CorrelationId != "" {
+			payload.CorrelationId = gated.CorrelationId
 		}
 	}
 	payload.Id = validId

--- a/internal/event/options.go
+++ b/internal/event/options.go
@@ -49,6 +49,7 @@ type options struct {
 	withGating           bool
 	withNoGateLocking    bool
 	withTelemetry        bool
+	withCorrelationId    string
 
 	// These options are related to the hclog adapter
 	withHclogLevel hclog.Level
@@ -129,6 +130,13 @@ func WithInfoMsg(msg string, args ...any) Option {
 func WithRequestInfo(i *RequestInfo) Option {
 	return func(o *options) {
 		o.withRequestInfo = i
+	}
+}
+
+// withCorrelationId allows an optional CorrelationId
+func withCorrelationId(id string) Option {
+	return func(o *options) {
+		o.withCorrelationId = id
 	}
 }
 

--- a/internal/event/options_test.go
+++ b/internal/event/options_test.go
@@ -203,6 +203,13 @@ func Test_GetOpts(t *testing.T) {
 		testOpts.withTelemetry = true
 		assert.Equal(opts, testOpts)
 	})
+	t.Run("withCorrelationId", func(t *testing.T) {
+		assert := assert.New(t)
+		testOpts := getDefaultOptions()
+		assert.Empty(testOpts.withCorrelationId)
+		opts := getOpts(withCorrelationId("12345"))
+		assert.Equal("12345", opts.withCorrelationId)
+	})
 }
 
 // testWrapper initializes an AEAD wrapping.Wrapper for testing.  Note: this

--- a/internal/session/repository_test.go
+++ b/internal/session/repository_test.go
@@ -158,5 +158,7 @@ func TestRepository_convertToSessions(t *testing.T) {
 	sess.CtTofuToken = nil
 	sess.TofuToken = nil
 	sess.KeyId = ""
+	// CorrelationId is an internal attribute and not returned
+	sess.CorrelationId = ""
 	assert.Equal(t, sessions[0], sess)
 }

--- a/internal/session/service_list_ext_test.go
+++ b/internal/session/service_list_ext_test.go
@@ -69,7 +69,7 @@ func TestService_List(t *testing.T) {
 	require.NoError(t, err)
 
 	cmpIgnoreUnexportedOpts := cmpopts.IgnoreUnexported(session.Session{}, session.State{}, timestamp.Timestamp{}, timestamppb.Timestamp{})
-	cmpIgnoreFieldsOpts := cmpopts.IgnoreFields(session.Session{}, "CtCertificatePrivateKey", "CertificatePrivateKey", "KeyId")
+	cmpIgnoreFieldsOpts := cmpopts.IgnoreFields(session.Session{}, "CtCertificatePrivateKey", "CertificatePrivateKey", "KeyId", "CorrelationId")
 
 	t.Run("List validation", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
While doing manual testing I found that the renewal jobs where not being forwarded to Vault via the worker, since I was already modifying the view to include the `CorrelationId` I decided to fix the Vault `worker_filter` bug in this PR in it's own commit since it touches the same view. I also add a test to make sure we get the `worker_filter` if one is included in the Credential Store. 

I will have a follow up PR that adds support for `CorrelationId` over multihop workers.

I have validated the `CorrelationId` being sent to Vault via log lines in my local instance and in audit events in HCPb / HVD.

From Vault:
```
"headers": {
  "x-correlation-id": [
    "e1bece17-241f-7afe-4cfb-46442e02ce18"
  ]
}
```

From Boundary:
```
 "correlation_id": "e1bece17-241f-7afe-4cfb-46442e02ce18",
```
    