### PR TITLE
docs: Update release notes for April 9 release

### DIFF
--- a/website/content/docs/release-notes/v0_14_0.mdx
+++ b/website/content/docs/release-notes/v0_14_0.mdx
@@ -304,6 +304,26 @@ description: |-
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.14.0
+    <br /><br />
+    (Fixed in 0.14.6)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Go CVE-2023-45288
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    The version of Go that was used in Boundary release 0.14.0 contained security vulnerabilities. The vulnerabilities were fixed in Go version 1.21.9. Boundary was updated to use the new Go version in release 0.14.6, and the issue is resolved.
+    <br /><br />
+    Learn more:&nbsp;
+    <br /><br />
+    CVE-2023-45288: <a href="https://www.cve.org/CVERecord?id=CVE-2023-45288">HTTP/2 CONTINUATION flood in net/http</a>
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
 
   </tbody>
 </table>

--- a/website/content/docs/release-notes/v0_15_0.mdx
+++ b/website/content/docs/release-notes/v0_15_0.mdx
@@ -270,6 +270,27 @@ description: |-
     </td>
   </tr>
 
+   <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.15.0
+    <br /><br />
+    (Fixed in 0.15.4)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Go CVE-2023-45288
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    The version of Go that was used in Boundary release 0.15.0 contained security vulnerabilities. The vulnerabilities were fixed in Go version 1.21.9. Boundary was updated to use the new Go version in release 0.15.4, and the issue is resolved.
+    <br /><br />
+    Learn more:&nbsp;
+    <br /><br />
+    CVE-2023-45288: <a href="https://www.cve.org/CVERecord?id=CVE-2023-45288">HTTP/2 CONTINUATION flood in net/http</a>
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+
 
   </tbody>
 </table>

--- a/website/content/docs/release-notes/v0_15_0.mdx
+++ b/website/content/docs/release-notes/v0_15_0.mdx
@@ -270,7 +270,7 @@ description: |-
     </td>
   </tr>
 
-   <tr>
+  <tr>
     <td style={{verticalAlign: 'middle'}}>
     0.15.0
     <br /><br />


### PR DESCRIPTION
This PR updates the 0.14.x and 0.15.x known issues with information about the 0.14.6 and 0.15.4 releases.

View the updates in the preview deployment:

- [Version 0.14.x known issues](https://boundary-rllxarhs2-hashicorp.vercel.app/boundary/docs/release-notes/v0_14_0#known-issues-and-breaking-changes)
- [Version 0.15.x known issues](https://boundary-rllxarhs2-hashicorp.vercel.app/boundary/docs/release-notes/v0_15_0#known-issues-and-breaking-changes)