### PR TITLE
docs: Backport #4561 to release 0.15.x

### DIFF
--- a/website/content/docs/install-boundary/terraform-patterns/index.mdx
+++ b/website/content/docs/install-boundary/terraform-patterns/index.mdx
@@ -1,0 +1,64 @@
+---
+layout: docs
+page_title: Terraform patterns for Boundary
+description: |-
+  Learn how to configure the Terraform Boundary provider so that you can use Terraform patterns to install and manage Boundary.
+---
+
+# Terraform patterns for Boundary
+
+HashiCorp recommends using Terraform to deploy and maintain your Boundary environment.
+
+This following topics outline MVP (Minimum Viable Product) patterns to deploy and maintain Boundary using Terraform.
+
+## Requirements
+
+This document assumes the reader has:
+
+- An understanding of [Terraform](/terraform/docs) fundamentals
+- An existing Boundary installation. Refer to [Initialize Boundary](/boundary/docs/install-boundary/initialize) to learn about deploying Boundary.
+
+## Terraform provider configuration
+
+To use Terraform to manage your Boundary environment, you must first configure the Terraform Boundary provider.
+
+The following code block provides an example of provider configuration using the userpass authentication method.
+You can use any of the available Boundary authentication methods by specifying the appropriate `auth_method_id`.
+
+```hcl
+terraform {
+  required_providers {
+    # Declare the provider
+    boundary = {
+      source  = "hashicorp/boundary"
+    }
+  }
+}
+
+# Configure the provider
+# This example assumes that you have stored your Boundary cluster address and credentials in Terraform variables
+
+provider "boundary" {
+  addr                   = var.boundary_addr
+  auth_method_login_name = var.boundary_login_name
+  auth_method_password   = var.boundary_password
+}
+```
+## More information
+
+Refer to the [Boundary provider documentation](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/) for more information on the available authentication methods.
+
+## Next steps
+
+The following pages provide examples and patterns for configuring Boundary resources with Terraform.
+
+If you are configuring Boundary resources for the first time, you may want to start by creating a scope.
+You create scopes to partition resources and then assign ownership of those resources to users and groups.
+
+- [Scopes](/boundary/docs/install-boundary/terraform-patterns/terraform-scopes)
+- [Users and auth methods](/boundary/docs/install-boundary/terraform-patterns/terraform-users-and-auth-methods)
+- [Groups and role-based-access-control (RBAC)](/boundary/docs/install-boundary/terraform-patterns/terraform-groups-and-rbac)
+- [Hosts and host management](/boundary/docs/install-boundary/terraform-patterns/terraform-hosts-and-host-management)
+- [Credentials and credential stores](/boundary/docs/install-boundary/terraform-patterns/terraform-credentials-and-credential-stores)
+- [Session recording](/boundary/docs/install-boundary/terraform-patterns/terraform-session-recording)
+- [Targets](/boundary/docs/install-boundary/terraform-patterns/terraform-targets)

--- a/website/content/docs/install-boundary/terraform-patterns/terraform-credentials-and-credential-stores.mdx
+++ b/website/content/docs/install-boundary/terraform-patterns/terraform-credentials-and-credential-stores.mdx
@@ -1,0 +1,199 @@
+---
+layout: docs
+page_title: Terraform patterns for Boundary credentials and credential stores
+description: |-
+   Use Terraform patterns to create and manage Boundary credentials and credential stores. Learn how to create static or Vault credential stores, add credentials.
+---
+
+# Terraform patterns for Boundary credentials and credential stores
+
+Boundary supports multiple types of static credentials and Vault dynamic credentials. A credential store stores credentials for hosts. Static credential stores can hold username/passwords, JSON tokens, SSH key pairs, and SSH certificates.
+
+## Requirements
+
+This document assumes the reader has:
+
+- An understanding of [Terraform](/terraform/docs) fundamentals
+- An existing Boundary installation. Refer to [Initialize Boundary](/boundary/docs/install-boundary/initialize) to learn about deploying Boundary.
+- Configured the [Terraform Boundary provider](/boundary/docs/install-boundary/terraform-patterns/#terraform-provider-configuration).
+- Configured [hosts](/boundary/docs/install-boundary/terraform-patterns/terraform-hosts-and-host-management) for any credential store you plan to create.
+
+## Static credential store configuration
+
+This example creates both a static credential store and a Vault credential store.
+
+```hcl
+# Create a static credential store
+resource "boundary_credential_store_static" "example" {
+  name        = "example_static_credential_store"
+  description = "My first static credential store"
+  scope_id    = boundary_scope.project.id
+}
+
+# Create a Vault credential store
+resource "boundary_credential_store_vault" "example" {
+  name        = "vault_store"
+  description = "My first Vault credential store"
+
+  # change to your Vault address
+  address     = "http://127.0.0.1:8200"
+
+  # Use a token that has rights to access the secrets in Vault that
+  # Boundary should use
+  token       = var.vault_token
+  scope_id    = boundary_scope.project.id
+}
+```
+
+After you create a credential store, you can create one or more credentials in that store.
+
+### Add static credentials configuration
+
+This example creates static credentials that Boundary manages. The credentials are for a user named Carlos.
+
+```hcl
+# Create a username/password combination
+resource "boundary_credential_username_password" "carlos" {
+  name                = "example_username_password"
+  description         = "My first username password credential"
+  credential_store_id = boundary_credential_store_static.example.id
+  username            = "Carlos"
+  password            = "Carlos-password"
+}
+
+# Create an ssh private key
+resource "boundary_credential_ssh_private_key" "carlos_ssh" {
+  name                   = "example_ssh_private_key"
+  description            = "My first ssh private key credential"
+  credential_store_id    = boundary_credential_store_static.example.id
+  username               = "carlos"
+
+  # You can also load the private_key from a file using the Terraform file() function.
+  private_key            = var.carlos_ssh_key
+
+  # change to the passphrase of the private key, if required
+  private_key_passphrase = "optional-passphrase"
+}
+
+# Create a JSON credential
+resource "boundary_credential_json" "example" {
+  name                = "example_json"
+  description         = "My first json credential"
+  credential_store_id = boundary_credential_store_static.example.id
+
+  # This points to the actual json file.  You can also load this from a variable.
+  object              = file("~/object.json")
+}
+```
+
+## Vault credential store configuration
+
+For Vault credential stores, you can then create a credential library which distributes credentials of a specific access level from a Vault path.
+
+This example creates a credential library that reads secrets from a Vault path called `my/secret/foo`.
+
+```hcl
+
+resource "boundary_credential_library_vault" "foo" {
+  name                = "foo"
+  description         = "My first Vault credential library"
+  credential_store_id = boundary_credential_store_vault.example.id
+
+  # Defines a valid Vault secret path
+  path                = "my/secret/foo"
+  http_method         = "GET"
+}
+```
+
+### Translate key names from Vault configuration
+
+If you need to translate the key names from Vault into values expected by
+Boundary, use this pattern.
+
+```hcl
+resource "boundary_credential_library_vault" "baz" {
+  name                = "baz"
+  description         = "vault username password credential with mapping overrides"
+  credential_store_id = boundary_credential_store_vault.example.id
+
+  # Defines the vault path that contains the secret you need
+  path                = "my/secret/baz"
+  http_method         = "GET"
+  credential_type     = "username_password"
+
+  # This maps the username and password field names in Vault to their names in Boundary
+  credential_mapping_overrides = {
+    password_attribute = "alternative_password_label"
+    username_attribute = "alternative_username_label"
+  }
+}
+```
+
+### Use SSH certificates as credentials configuration
+
+To use SSH certificates as credentials, you use the `boundary_credential_vault_ssh_certificate` resource as shown in this example.
+
+```hcl
+resource "boundary_credential_library_vault_ssh_certificate" "example" {
+  name                = "foo"
+  description         = "My first Vault SSH certificate credential library"
+  credential_store_id = boundary_credential_store_vault.foo.id
+
+  # Declares the vault path that generates certificates
+  path                = "ssh/sign/foo"
+
+  # Defines the username
+  username            = "foo"
+}
+```
+### Declare additional certificate attributes and extensions configuration
+
+This example declares additional certificate attributes and extensions. Note that you can enable extensions by declaring their names and setting their values to empty strings.
+
+```hcl
+resource "boundary_credential_library_vault_ssh_certificate" "example" {
+  name                = "baz"
+  description         = "vault "
+  credential_store_id = boundary_credential_store_vault.foo.id
+  path                = "ssh/issue/foo" # change to the Vault endpoint and role
+  username            = "foo"
+
+  # Defines additional optional certificate attributes
+  key_type            = "rsa"
+  key_bits            = 4096
+
+  extensions = {
+    permit-pty            = ""
+    permit-X11-forwarding = ""
+  }
+
+  critical_options = {
+    force-command = "/bin/some_script"
+  }
+}
+```
+
+## More information
+
+For more information about the Boundary resources mentioned in this topic, refer to the domain model documentation:
+
+- [Credential stores](/boundary/docs/concepts/domain-model/credential-stores)
+- [Credentials](/boundary/docs/concepts/domain-model/credentials)
+- [Credential libraries](/boundary/docs/concepts/domain-model/credential-libraries)
+
+For more information about managing the following resources using Terraform, refer to the Boundary provider documentation:
+
+- Credentials
+    - [JSON](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/credential_json/)
+    - [SSH private keys](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/credential_ssh_private_key/)
+    - [Username/passwords](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/credential_username_password/)
+- Credential libraries
+    - [Vault](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/credential_library_vault/)
+    - [Vault SSH certificates](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/credential_library_vault_ssh_certificate/)
+- Credential stores
+    - [Static](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/credential_store_static/)
+    - [Vault](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/credential_store_vault/)
+
+## Next steps
+
+Once you have configured credentials and credential stores, you may want to enable [session recording](/boundary/docs/install-boundary/terraform-patterns/terraform-session-recording) for auditing purposes or configure [targets](/boundary/docs/install-boundary/terraform-patterns/terraform-targets) for your users to connect to.

--- a/website/content/docs/install-boundary/terraform-patterns/terraform-groups-and-rbac.mdx
+++ b/website/content/docs/install-boundary/terraform-patterns/terraform-groups-and-rbac.mdx
@@ -1,0 +1,100 @@
+---
+layout: docs
+page_title: Terraform patterns for Boundary groups and RBAC
+description: |-
+  Use Terraform patterns to create and manage Boundary groups and role-based access control (RBAC). Learn how to add users to managed groups and assign roles.
+---
+
+# Terraform patterns for Boundary groups and RBAC
+
+The following pattern demonstrates how to aggregate users into groups.
+
+Security best-practices recommend that you use Role-Based Access Control (RBAC) when you make authorization decisions. RBAC is a methodology in which you create a role that defines the actions that a user is allowed to take, and then assign one or more users to that role.
+
+In Boundary, you can assign users directly to a role, but a better pattern is to put users with equivalent access into groups. You can then assign groups to roles that grant least-privileges to your Boundary environment.
+
+## Requirements
+
+This document assumes the reader has:
+
+- An understanding of [Terraform](/terraform/docs) fundamentals
+- An existing Boundary installation. Refer to [Initialize Boundary](/boundary/docs/install-boundary/initialize) to learn about deploying Boundary.
+- Configured the [Terraform Boundary provider](/boundary/docs/install-boundary/terraform-patterns/#terraform-provider-configuration).
+- Created Boundary [users and auth methods](/boundary/docs/install-boundary/terraform-patterns/terraform-users-and-auth-methods) to assign to the group you plan to create.
+
+## Group configuration
+
+This example adds users to the `Accounting` group.
+
+```hcl
+# Add Jeff and Susmitha to the Accounting group
+resource "boundary_group" "Accounting" {
+  name        = "Accounting"
+  description = "The Accounting Department"
+  member_ids  = [boundary_user.susmitha,id, boundary_user.jeff.id]
+  scope_id    = boundary_scope.project.id
+}
+```
+
+You are not required to populate groups manually, and can instead take advantage of the pre-existing groups provided by an identity provider.
+
+## Managed group configuration
+
+This example creates a managed group that is automatically populated based on an LDAP group called `Engineering`.
+
+```hcl
+resource "boundary_managed_group_ldap" "Engineering" {
+  name           = "Engineering"
+  description    = "Engineering Managed LDAP Group"
+  auth_method_id = boundary_auth_method_ldap.forumsys_ldap.id
+  group_names    = ["Engineering"]
+}
+```
+
+HashiCorp recommends using managed groups whenever possible because it abstracts the management of group membership and simplifies Boundary administration.
+
+## Role configuration
+
+After you have created a group, you must assign one or more roles to that group to enable the group members to do useful work in Boundary.
+
+This pattern creates a role called `readonly` that include a grant
+that allows the user read-only access to all Boundary resources. This example also associates the `Accounting` static group and the `Engineering` managed group with that role.
+
+```hcp
+resource "boundary_role" "readonly" {
+  name          = "readonly"
+  description   = "A readonly role"
+
+  # Assign Accounting and Engineering to this role
+  principal_ids = [boundary_group.accounting.id, boundary_managed_group_ldap.Engineering.id]
+
+  # This is the grant string provides read-only access to all objects in the current scope.
+  grant_strings = ["ids=*;type=*;actions=read"]
+  scope_id      = boundary_scope.project.id
+}
+```
+
+## More information
+
+For more information about the Boundary resources mentioned in this topic, refer to the domain model documentation:
+
+- [Roles](/boundary/docs/concepts/domain-model/roles)
+- [Groups](/boundary/docs/concepts/domain-model/groups)
+- [Managed groups](/boundary/docs/concepts/domain-model/managed-groups)
+- [Grants](/boundary/docs/concepts/security/permissions#grant-strings)
+
+For more information about managing the following resources using Terraform, refer to the Boundary provider documentation:
+
+- Accounts
+    - [Password accounts](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/account_password/)
+    - [LDAP accounts](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/account_ldap/)
+    - [OIDC accounts](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/account_oidc/)
+- [Users](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/user/)
+- [Groups](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/group/)
+- [LDAP managed groups](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/managed_group_ldap/)
+- [Roles](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/role/)
+
+## Next steps
+
+You may want to create [hosts and host sets](/boundary/docs/install-boundary/terraform-patterns/terraform-hosts-and-host-management) so that you can configure targets for your users to connect to.
+Targets require an address or host, and credentials to connect to that host.

--- a/website/content/docs/install-boundary/terraform-patterns/terraform-hosts-and-host-management.mdx
+++ b/website/content/docs/install-boundary/terraform-patterns/terraform-hosts-and-host-management.mdx
@@ -1,0 +1,152 @@
+---
+layout: docs
+page_title: Terraform patterns for Boundary hosts and host management
+description: |-
+   Use Terraform patterns to create and manage Boundary hosts and host catalogs. Learn how to add static or plugin-based hosts to static or dynamic host catalogs.
+---
+
+# Terraform patterns for Boundary hosts and host management
+
+Before you can access a system, you must create a target. Targets require an address or host, and credentials to connect to that host.
+
+You can define target addresses directly to simplify access, but HashiCorp does not recommend that pattern at scale.
+Instead, HashiCorp recommends adding hosts to a host set, and then attaching the host set to a target.
+
+## Requirements
+
+This document assumes the reader has:
+
+- An understanding of [Terraform](/terraform/docs) fundamentals
+- An existing Boundary installation. Refer to [Initialize Boundary](/boundary/docs/install-boundary/initialize) to learn about deploying Boundary.
+- Configured the [Terraform Boundary provider](/boundary/docs/install-boundary/terraform-patterns/#terraform-provider-configuration).
+
+## Static host catalog configuration
+
+The following example shows how to create a Boundary static host catalog and add a known host to that catalog.
+
+```hcl
+# Create the host catalog
+resource "boundary_host_catalog_static" "example" {
+  name        = "My static catalog"
+  description = "My static host catalog"
+  scope_id    = boundary_scope.project.id
+}
+
+# Create the static host
+resource "boundary_host" "example" {
+  type            = "static"
+  name            = "example_host"
+  description     = "My first host"
+  address         = "10.0.0.1"
+
+  # Associate the host with the static host catalog
+  host_catalog_id = boundary_host_catalog.static.id
+}
+```
+
+Static host catalogs increase your administrative burden and should only be used when necessary.
+
+## Dynamic host catalog configuration
+
+When you use cloud providers like Amazon Web Services (AWS) and Microsoft Azure, a better pattern is to use a plugin-based host catalog that automatically discovers hosts based on the filtering criteria for a given cloud.
+
+This example creates a dynamic host catalog that auto-discovers AWS hosts in `us-east-1`.
+
+```hcl
+resource "boundary_host_catalog_plugin" "aws_example" {
+  name            = "My AWS catalog"
+  description     = "My AWS dynamic host catalog"
+  scope_id        = boundary_scope.project.id
+
+  # Delare the cloud plugin to use and the region to search for hosts
+  plugin_name     = "aws"
+  attributes_json = jsonencode({ "region" = "us-east-1" })
+
+  # Define the cloud credentials to use for searching
+  secrets_json = jsonencode({
+    "access_key_id"     = "aws_access_key_id_value",
+    "secret_access_key" = "aws_secret_access_key_value"
+  })
+}
+```
+
+## Azure host catalog configuration
+
+This host catalog example discovers hosts in Azure. Notice that it is very similar to the AWS example.
+
+```hcl
+resource "boundary_host_catalog_plugin" "azure_example" {
+  name        = "My Azure catalog"
+  description = "My Azure dynamic host catalog"
+  scope_id    = boundary_scope.project.id
+  plugin_name = "azure"
+
+  # HashiCorp recommends providing Azure secrets using a file() or environment variables
+
+  # The attributes below must be generated in Azure by creating an Entra ID application
+  attributes_json = jsonencode({
+    "disable_credential_rotation" = "true",
+    "tenant_id"                   = "ARM_TENANT_ID",
+    "subscription_id"             = "ARM_SUBSCRIPTION_ID",
+    "client_id"                   = "ARM_CLIENT_ID"
+  })
+
+  # The secrets below must be generated in Azure by creating an Entra ID application
+  secrets_json = jsonencode({
+    "secret_value" = "ARM_CLIENT_SECRET"
+  })
+}
+```
+
+## Add static hosts to hosts sets configuration
+
+This example adds static hosts to static host sets.
+
+```hcl
+resource "boundary_host_set_static" "web" {
+  host_catalog_id = boundary_host_catalog_static.example.id
+  host_ids = [
+    # This is the static Boundary host created in the example above.
+    boundary_host_static.example.id
+  ]
+}
+```
+
+## Add plugin-based hosts to host sets configuration
+
+Hosts discovered using a plugin-based host catalog should be added to a `boundary_host_set_plugin` host set.
+
+This example demonstrates how to add hosts from the AWS host catalog to a host set using tags as a filtering criteria. In this example, the filter looks for tags named `service-type` that have a value of `web`.
+
+```hcl
+resource "boundary_host_set_plugin" "web" {
+  name            = "My web host set plugin"
+
+  # This is the AWS host catalog that was created above
+  host_catalog_id = boundary_host_catalog_plugin.aws_example.id
+
+  # This is the filter that looks for specific tags using AWS filtering syntax
+  attributes_json = jsonencode({ "filters" = ["tag:service-type=web"] })
+}
+```
+
+## More information
+
+For more information about the Boundary resources mentioned in this topic, refer to the domain model documentation:
+
+- [Targets](/boundary/docs/concepts/domain-model/targets)
+- [Hosts](/boundary/docs/concepts/domain-model/hosts)
+- [Host sets](/boundary/docs/concepts/domain-model/host-sets)
+- [Host catalogs](/boundary/docs/concepts/domain-model/host-catalogs)
+
+For more information about managing the following resources using Terraform, refer to the Boundary provider documentation:
+
+- [Static hosts](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/host_static/)
+- [Static host catalogs](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/host_catalog_static/)
+- [Static host sets](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/host_set_static/)
+- [Plugin-based host catalogs](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/host_catalog_plugin/)
+- [Plugin-based host sets](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/host_set_plugin/)
+
+## Next steps
+
+Once you have configured hosts, you may want to configure [credentials and credential stores](/boundary/docs/install-boundary/terraform-patterns/terraform-credentials-and-credential-stores) for your hosts and users.

--- a/website/content/docs/install-boundary/terraform-patterns/terraform-scopes.mdx
+++ b/website/content/docs/install-boundary/terraform-patterns/terraform-scopes.mdx
@@ -1,0 +1,59 @@
+---
+layout: docs
+page_title: Terraform patterns for Boundary scopes
+description: |-
+  Use Terraform patterns to create and manage Boundary scopes. Learn how to configure global, org-level, and project-level scopes using the Boundary provider.
+---
+
+# Terraform patterns for Boundary scopes
+
+You can use the following patterns to create org-level and project-level scopes.
+
+## Requirements
+
+This document assumes the reader has:
+
+- An understanding of [Terraform](/terraform/docs) fundamentals
+- An existing Boundary installation. Refer to [Initialize Boundary](/boundary/docs/install-boundary/initialize) to learn about deploying Boundary.
+- Configured the [Terraform Boundary provider](/boundary/docs/install-boundary/terraform-patterns/#terraform-provider-configuration).
+
+## Scopes configuration
+
+The `scope_id` parameter determines what kind of scope to create according to these rules:
+
+- If `scope_id` is the global scope, an org-level scope is created.
+- If `scope_id` is an org-level scope, a project-level scope is created.
+- If `scope_id` is a project-level scope, a nested project-level scope is created.
+
+```hcl
+resource "boundary_scope" "project" {
+  name                     = "Basic Boundary Demo"
+  description              = "First Ever Boundary Demo"
+
+  # This parameter is the parent scope.  It can be either the global scope, an
+  # org-level scope, or a project-level scope.
+  scope_id                 = var.se_org_scope
+
+  # Using the auto_create_x_role flags can help you get set up faster
+  # becasue you won't have to explicitly define these roles.
+  auto_create_admin_role   = true
+  auto_create_default_role = true
+}
+```
+
+## More information
+
+For more information about the Boundary resources mentioned in this topic, refer to the domain model documentation:
+
+- [Scopes](/boundary/docs/concepts/domain-model/scopes)
+- [Org-level scopes](/boundary/docs/concepts/domain-model/scopes#organizations)
+- [Project-level scopes](/boundary/docs/concepts/domain-model/scopes#projects)
+
+For more information about managing the following resources using Terraform, refer to the Boundary provider documentation:
+
+- [Scopes](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/scope/)
+
+## Next steps
+
+You use scopes to partition resources and assign them to users.
+Once you have created scopes, you may want to create [users and auth methods](/boundary/docs/install-boundary/terraform-patterns/terraform-users-and-auth-methods).

--- a/website/content/docs/install-boundary/terraform-patterns/terraform-session-recording.mdx
+++ b/website/content/docs/install-boundary/terraform-patterns/terraform-session-recording.mdx
@@ -1,0 +1,88 @@
+---
+layout: docs
+page_title: Terraform patterns for Boundary session recording
+description: |-
+   Use Terraform patterns to enable session recording for auditing user sessions in Boundary. Learn how to configure prerequisite storage policies and buckets.
+---
+
+# Terraform patterns for Boundary session recording
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+Session recording requires that you create a storage policy for your current scope and then allocate an AWS S3 bucket to store the recordings. This example does not demonstrate creating the S3 bucket or the associated IAM policies. Refer to the [create storage buckets](/boundary/docs/configuration/session-recording/create-storage-bucket) documentation to learn how to configure AWS.
+
+## Requirements
+
+This document assumes the reader has:
+
+- An understanding of [Terraform](/terraform/docs) fundamentals
+- An existing Boundary installation. Refer to [Initialize Boundary](/boundary/docs/install-boundary/initialize) to learn about deploying Boundary.
+- Configured the [Terraform Boundary provider](/boundary/docs/install-boundary/terraform-patterns/#terraform-provider-configuration).
+- Created a [scope](/boundary/docs/install-boundary/terraform-patterns/terraform-scopes) for any storage policy you plan to create.
+- A licensed version of HCP Boundary or Boundary Enterprise.
+
+## Storage policy configuration
+
+This example creates a Boundary storage policy for a project scope.
+
+```hcl
+# Create the storage policy. This policy is effective for the attached scope
+resource "boundary_policy_storage" "example" {
+
+  # The policy applies to all recordings in this scope
+  scope_id = boundary_scope.project.id
+
+  name = "soc2-policy"
+  description = "SOC 2 compliant storage policy for session recordings"
+
+  # These define your retention parameters
+  retain_for_days = 2557
+  retain_for_overridable = false
+
+  delete_after_days = 2657
+  delete_after_overridable = true
+}
+```
+
+## Storage bucket configuration
+
+This example creates the Boundary storage bucket and attaches it to the S3 bucket.
+
+```hcl
+resource "boundary_storage_bucket" "aws_bucket" {
+  name        = "My aws storage bucket with dynamic credentials"
+  description = "My first storage bucket"
+  scope_id    = boundary_scop.project.id
+  plugin_name = "aws"
+
+  # This must match the name of the AWS S3 bucket that stores the recordings
+  bucket_name = "mybucket1"
+
+  # The role_arn value must be the same arn used as the instance profile
+  # attached to your Boundary Worker ec2 instance
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
+  attributes_json = jsonencode({
+    "region"                      = "us-east-1"
+    "role_arn"                    = "arn:aws:iam::123456789012:role/S3Access"
+    "disable_credential_rotation" = true
+  })
+}
+```
+
+You have configured the prerequisites for session recording. The last task is to enable recording on a Boundary target.
+
+## More information
+
+For more information about the Boundary resources mentioned in this topic, refer to the domain model documentation:
+
+- [Session recordings](/boundary/docs/concepts/domain-model/session-recordings)
+- [Storage buckets](/boundary/docs/concepts/domain-model/storage-buckets)
+
+For more information about managing the following resources using Terraform, refer to the Boundary provider documentation:
+
+- [Storage buckets](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/storage_bucket/)
+- [Storage policies](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/policy_storage/)
+
+## Next steps
+
+Once you have configured the prerequisites for session recording, you can enable recording on a Boundary [target](/boundary/docs/install-boundary/terraform-patterns/terraform-targets).

--- a/website/content/docs/install-boundary/terraform-patterns/terraform-targets.mdx
+++ b/website/content/docs/install-boundary/terraform-patterns/terraform-targets.mdx
@@ -1,0 +1,125 @@
+---
+layout: docs
+page_title: Terraform patterns for Boundary targets
+description: |-
+   Use Terraform patterns to create and manage Boundary targets. Learn how to configure SSH and TCP targets, inject passwords, and enable session recording.
+---
+
+# Terraform patterns for Boundary targets
+
+Once you have defined a host, a host catalog, and a credential store, you
+can create [targets](/boundary/docs/concepts/domain-model/targets).
+
+## Requirements
+
+This document assumes the reader has:
+
+- An understanding of [Terraform](/terraform/docs) fundamentals
+- An existing Boundary installation. Refer to [Initialize Boundary](/boundary/docs/install-boundary/initialize) to learn about deploying Boundary.
+- Configured the [Terraform Boundary provider](/boundary/docs/install-boundary/terraform-patterns/#terraform-provider-configuration).
+- Defined a host, [host catalog](/boundary/docs/install-boundary/terraform-patterns/terraform-hosts-and-host-management), and [credential store](/boundary/docs/install-boundary/terraform-patterns/terraform-credentials-and-credential-stores).
+- (Optional) Configured a storage policy and storage bucket for any targets you want to enable for [session recording](/boundary/docs/install-boundary/terraform-patterns/terraform-session-recording).
+
+## Target configuration
+
+This example creates a target with an injected username and password.
+
+<Note>
+
+  [Credential injection](/boundary/docs/concepts/credential-management#credential-injection) and SSH target types are only supported for HCP Boundary and Boundary Enterprise. You can configure [credential brokering](/boundary/docs/concepts/credential-management#credential-brokering) instead using `brokered_credential_source_ids`.
+
+</Note>
+
+```hcl
+resource "boundary_target" "ssh_foo" {
+  name         = "ssh_foo"
+  description  = "SSH target"
+  scope_id     = boundary_scope.project.id
+
+  # Declare the target type and connection port
+  type         = "ssh"
+  default_port = "22"
+
+  # Declare the host set
+  host_source_ids = [
+    boundary_host_set.foo.id
+  ]
+
+  # Declare the injected credentials
+  injected_application_credential_source_ids = [
+    boundary_credential_library_vault.example.id
+  ]
+
+  # Enable session recording
+  enable_session_recording = true
+  storage_bucket_id        = boundary_storage_bucket.aws_bucket.id
+}
+
+```
+## Session recording configuration
+
+This example enables session recording, but uses brokered credentials instead.
+
+```hcl
+resource "boundary_target" "ssh_foo" {
+  name         = "ssh_foo"
+  description  = "SSH target"
+  scope_id     = boundary_scope.project.id
+
+  # Declare the target type and connection port
+  type         = "ssh"
+  default_port = "22"
+
+  # Declare the host set
+  host_source_ids = [
+    boundary_host_set.foo.id
+  ]
+
+  # Declare the brokered credentials
+  # This uses a static credential library created earlier
+  brokered_application_credential_source_ids = [
+    boundary_credential_library.example.id
+  ]
+
+   # Enable session recording.
+  enable_session_recording = true
+  storage_bucket_id        = boundary_storage_bucket.aws_bucket.id
+}
+```
+
+## TCP target configuration
+
+This example creates a `tcp` target that connects to Windows servers using RDP.
+
+```hcl
+resource "boundary_target" "rdp_foo" {
+  name         = "rdp_foo"
+  description  = "RDP target"
+  scope_id     = boundary_scope.project.id
+
+  # Declare the target type and connection port
+  type         = "tcp"
+  default_port = "3389"
+
+  # Declare the host set. This assumes that this host set contains Windows hosts
+  host_source_ids = [
+    boundary_host_set.foo.id
+  ]
+
+  # The credentials we will use to connect. RDP requires the use of brokered credentials
+  # This uses a static credential library created earlier
+  brokered_application_credential_source_ids = [
+    boundary_credential_library.example.id
+  ]
+}
+```
+
+## More information
+
+For more information about the Boundary resources mentioned in this topic, refer to the domain model documentation:
+
+- [Targets](/boundary/docs/concepts/domain-model/targets)
+
+For more information about managing the following resources using Terraform, refer to the Boundary provider documentation:
+
+- [Targets](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/target/)

--- a/website/content/docs/install-boundary/terraform-patterns/terraform-users-and-auth-methods.mdx
+++ b/website/content/docs/install-boundary/terraform-patterns/terraform-users-and-auth-methods.mdx
@@ -1,0 +1,106 @@
+---
+layout: docs
+page_title: Terraform patterns for Boundary users and auth methods
+description: |-
+  Use Terraform patterns to create and manage Boundary users and auth methods. Learn how to configure password and LDAP auth methods, add accounts, create users.
+---
+
+# Terraform patterns for Boundary users and auth methods
+
+Boundary supports password, OIDC, and LDAP auth methods.
+
+## Requirements
+
+This document assumes the reader has:
+
+- An understanding of [Terraform](/terraform/docs) fundamentals
+- An existing Boundary installation. Refer to [Initialize Boundary](/boundary/docs/install-boundary/initialize) to learn about deploying Boundary.
+- Configured the [Terraform Boundary provider](/boundary/docs/install-boundary/terraform-patterns/#terraform-provider-configuration).
+- Created a [scope](/boundary/docs/install-boundary/terraform-patterns/terraform-scopes) to add the users and auth methods to.
+
+## Auth method configuration
+
+Below is an example of creating a password auth method.  Terraform creates the auth method in the scope that is specified by the `scope_id` option.
+
+```hcl
+resource "boundary_auth_method" "password" {
+  scope_id = boundary_scope.org.id
+  type     = "password"
+}
+```
+
+### LDAP auth method configuration
+
+The next example demonstrates how to create an LDAP auth method.
+
+```hcl
+resource "boundary_auth_method_ldap" "forumsys_ldap" {
+  name          = "forumsys public LDAP"
+  scope_id      = "global"                               # add the new auth method to the global scope
+  urls          = ["ldap://ldap.forumsys.com"]           # the addr of the LDAP server
+  user_dn       = "dc=example,dc=com"                    # the basedn for users
+  user_attr     = "uid"                                  # the user attribute
+  group_dn      = "dc=example,dc=com"                    # the basedn for groups
+  bind_dn       = "cn=read-only-admin,dc=example,dc=com" # the dn to use when binding
+  bind_password = "password"                             # passwd to use when binding
+  state         = "active-public"                        # make sure the new auth-method is available to everyone
+  enable_groups = true                                   # this turns-on the discovery of a user's groups
+  discover_dn   = true                                   # this turns-on the discovery of an authenticating user's dn
+}
+```
+
+## Account and user configuration
+
+After you create an auth method, you need to add accounts to it and create users to represent the accounts. Users and accounts are different constructs. A user is a "parent" object associated to one or more accounts created using a supported auth method.
+
+This example creates 2 accounts using the password auth method and associated users.
+
+```hcl
+# Create a user named "Jeff"
+resource "boundary_account_password" "jeff" {
+  auth_method_id = boundary_auth_method.password.id
+  type           = "password"
+  login_name     = "jeff"
+  password       = "$uper$ecure"
+}
+
+# Associate the Jeff account with a user alias
+resource "boundary_user" "jeff" {
+  name        = "jeff"
+  description = "Jeff's user resource"
+  account_ids = [boundary_account_password.jeff.id]
+  scope_id    = boundary_scope.org.id
+}
+
+#Create a user named Susmitha
+resource "boundary_account_password" "susmitha" {
+  auth_method_id = boundary_auth_method.password.id
+  type           = "password"
+  login_name     = "susmitha"
+  password       = "more$super$ecure"
+}
+
+# And this associates the account with a user alias
+resource "boundary_user" "susmitha" {
+  name        = "susmitha"
+  description = "Susmitha's user resource"
+  account_ids = [boundary_account_password.susmitha.id]
+  scope_id    = boundary_scope.org.id
+}
+```
+
+## More information
+
+For more information about the Boundary resources mentioned in this topic, refer to the domain model documentation:
+- [Auth methods](/boundary/docs/concepts/domain-model/auth-methods)
+- [Users](/boundary/docs/concepts/domain-model/users)
+- [Accounts](/boundary/docs/concepts/domain-model/accounts)
+
+For more information about managing the following resources using Terraform, refer to the Boundary provider documentation:
+- [LDAP accounts](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/account_ldap/)
+- [OIDC accounts](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/account_oidc/)
+- [Password accounts](https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/account_password/)
+
+## Next steps
+
+Once you have created users and auth methods, you may want to create [groups for your users or configure RBAC](/boundary/docs/install-boundary/terraform-patterns/terraform-groups-and-rbac) to define the actions a user is allowed to take.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -127,6 +127,48 @@
         "title": "Systemd install",
         "hidden": true,
         "path": "install-boundary/systemd"
+      },
+      {
+        "title": "Terraform patterns",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "install-boundary/terraform-patterns"
+          },
+          {
+            "title": "Scopes",
+            "path": "install-boundary/terraform-patterns/terraform-scopes"
+          },
+          {
+            "title": "Users and auth methods",
+            "path": "install-boundary/terraform-patterns/terraform-users-and-auth-methods"
+          },
+          {
+            "title": "Groups and RBAC",
+            "path": "install-boundary/terraform-patterns/terraform-groups-and-rbac"
+          },
+          {
+            "title": "Hosts and host management",
+            "path": "install-boundary/terraform-patterns/terraform-hosts-and-host-management"
+          },
+          {
+            "title": "Credentials and credential stores",
+            "path": "install-boundary/terraform-patterns/terraform-credentials-and-credential-stores"
+          },
+          {
+            "title": "Session recording",
+            "badge": {
+              "text": "HCP/ENT",
+              "type": "outlined",
+              "color": "neutral"
+            },
+            "path": "install-boundary/terraform-patterns/terraform-session-recording"
+          },
+          {
+            "title": "Targets",
+            "path": "install-boundary/terraform-patterns/terraform-targets"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
The automatic backport of #4561 failed. This PR manually recreates it.

* Added using-terraform.mdx to the Install Boundary section

* Initial revision

* formatting on the list and adding in some links to the provider

* Renamed file

* Added assumptions.

* Updated index.

* Fixed some typos

* Folded in Carlos's session recording code

* small changes

* fixes headers

* fixes internal developer links

* style guide and formatting enhancements

* updates Initialize Boundary link

* docs: Updates for style/standards

* docs: Break topic into smaller pieces

* docs: Clean up commented text, rename index file

* docs: Trigger a new Vercel build

---------

Co-authored-by: Daniel Greeninger <daniel.greeninger@hashicorp.com>
Co-authored-by: Adam Bouhmad <adbouhmad@gmail.com>
Co-authored-by: Robin Beck <stellarsquall@protonmail.ch>
Co-authored-by: Dan Heath <76443935+Dan-Heath@users.noreply.github.com>