### PR TITLE
build: include LICENSE.txt in all artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,6 +261,11 @@ jobs:
         with:
           name: ${{ env.PKG_NAME }}_${{ needs.set-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           path: out/${{ env.PKG_NAME }}_${{ needs.set-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+      - name: Copy license file to config_dir
+        env:
+          LICENSE_DIR: ".release/linux/package/usr/share/doc/${{ env.PKG_NAME }}"
+        run: |
+          mkdir -p "$LICENSE_DIR" && cp LICENSE "$LICENSE_DIR/LICENSE.txt"
       - name: Package
         uses: hashicorp/actions-packaging-linux@v1  # TSCCR: loading action configs: failed to query HEAD reference: failed to get advertised references: authorization failed
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,11 @@ RUN chmod -R 640 /boundary/*
 EXPOSE 9200 9201 9202
 VOLUME /boundary/
 
+LABEL org.opencontainers.image.licenses="BUSL-1.1"
+
 COPY .release/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY bin/LICENSE.txt /usr/share/doc/boundary/LICENSE.txt
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["server", "-config", "/boundary/config.hcl"]
 
@@ -47,7 +51,8 @@ LABEL name="Boundary" \
       version=$PRODUCT_VERSION \
       release=$PRODUCT_VERSION \
       summary="Boundary provides simple and secure access to hosts and services" \
-      description="The Boundary Docker image is designed to enable practitioners to run Boundary in server mode on a container scheduler"
+      description="The Boundary Docker image is designed to enable practitioners to run Boundary in server mode on a container scheduler" \
+      org.opencontainers.image.licenses="BUSL-1.1"
 
 RUN set -eux && \
     addgroup boundary && \
@@ -70,6 +75,7 @@ RUN set -eux && \
     grep boundary_${PRODUCT_VERSION}_linux_${boundaryArch}.zip boundary_${PRODUCT_VERSION}_SHA256SUMS | sha256sum -c && \
     unzip -d /bin boundary_${PRODUCT_VERSION}_linux_${boundaryArch}.zip && \
     rm boundary_${PRODUCT_VERSION}_linux_${boundaryArch}.zip boundary_${PRODUCT_VERSION}_SHA256SUMS boundary_${PRODUCT_VERSION}_SHA256SUMS.sig && \
+    cp /bin/LICENSE.txt /usr/share/doc/boundary/LICENSE.txt && \
     mkdir /boundary
 
 COPY .release/docker/config.hcl /boundary/config.hcl
@@ -81,6 +87,7 @@ EXPOSE 9200 9201 9202
 VOLUME /boundary/
 
 COPY .release/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["server", "-config", "/boundary/config.hcl"]
 
@@ -103,7 +110,8 @@ LABEL name="Boundary" \
       version=$PRODUCT_VERSION \
       release=$PRODUCT_VERSION \
       summary="Boundary provides simple and secure access to hosts and services" \
-      description="The Boundary Docker image is designed to enable practitioners to run Boundary in server mode on a container scheduler"
+      description="The Boundary Docker image is designed to enable practitioners to run Boundary in server mode on a container scheduler" \
+      org.opencontainers.image.licenses="BUSL-1.1"
 
 # Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
 ENV NAME=$NAME
@@ -117,6 +125,7 @@ RUN apk add --no-cache wget ca-certificates dumb-init gnupg libcap openssl su-ex
 COPY .release/docker/config.hcl /boundary/config.hcl
 
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+COPY dist/$TARGETOS/$TARGETARCH/LICENSE.txt /usr/share/doc/boundary/LICENSE.txt
 
 RUN chown -R ${NAME}:${NAME} /boundary
 RUN chmod -R 640 /boundary/*

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,6 +93,8 @@ if [ "${BOUNDARY_INSTALL_BINARY}x" != "x" ]; then
     mv -f "${BIN_PATH}" "${GOPATH}/bin/"
 fi
 
+cp LICENSE "${BIN_PARENT_DIR}/LICENSE.txt"
+
 # Done!
 echo "==> Results:"
 ls -hl ${BIN_PARENT_DIR}


### PR DESCRIPTION
Adds our LICENSE file as LICENSE.txt to our binary .zip files, Docker containers, and RPM files.

I've downloaded the .zip, .rpm, and .deb files and docker tarballs produced and confirmed they contain the LICENSE.txt as expected.