### PR TITLE
docs: Revise HTTP header documentation

### DIFF
--- a/website/content/docs/api-clients/api/index.mdx
+++ b/website/content/docs/api-clients/api/index.mdx
@@ -89,7 +89,10 @@ Responses may contain the following headers:
 
 - `RateLimit` - Provides the current limit, number of remaining requests, and the time at which the quota will reset for the limit that is closest to being exhausted for the requested resource and action.
 - `RateLimit-Policy` - Describes the limits for the requested resource and action.
-- `x-correlation-id` - Indicates that an API request that came in to Boundary is also related to an audit event in Vault.
+- `X-Correlation-ID` - Identifies a transaction over a series of requests and responses.
+The `X-Correlation-ID` header is a universally unique identifier (UUIDv4).
+If you provide an `X-Correlation-ID` header in an HTTP request, Boundary logs that value for all audit events related to the request.
+It uses that value as the header when it makes related requests to an external system, such as Vault, so that you can correlate the event between the product logs.
 
 ## Manage system resources
 

--- a/website/content/docs/api-clients/api/index.mdx
+++ b/website/content/docs/api-clients/api/index.mdx
@@ -89,6 +89,7 @@ Responses may contain the following headers:
 
 - `RateLimit` - Provides the current limit, number of remaining requests, and the time at which the quota will reset for the limit that is closest to being exhausted for the requested resource and action.
 - `RateLimit-Policy` - Describes the limits for the requested resource and action.
+- `x-correlation-id` - Indicates that an API request that came in to Boundary is also related to an audit event in Vault.
 
 ## Manage system resources
 

--- a/website/content/docs/api-clients/api/index.mdx
+++ b/website/content/docs/api-clients/api/index.mdx
@@ -82,6 +82,14 @@ The following method conventions are used within Boundary's API:
 
 `DELETE` is used for deleting a specific resource, and is only used against a particular resource path.
 
+## HTTP headers
+
+Clients that make requests to the controller API can inspect HTTP response headers to understand the configured limits and current usage.
+Responses may contain the following headers:
+
+- `RateLimit` - Provides the current limit, number of remaining requests, and the time at which the quota will reset for the limit that is closest to being exhausted for the requested resource and action.
+- `RateLimit-Policy` - Describes the limits for the requested resource and action.
+
 ## Manage system resources
 
 If your controllers try to process every API request, they may either run out of resources or overwhelm the database server.

--- a/website/content/docs/api-clients/api/index.mdx
+++ b/website/content/docs/api-clients/api/index.mdx
@@ -92,7 +92,8 @@ Responses may contain the following headers:
 - `X-Correlation-ID` - Identifies a transaction over a series of requests and responses.
 The `X-Correlation-ID` header is a universally unique identifier (UUIDv4).
 If you provide an `X-Correlation-ID` header in an HTTP request, Boundary logs that value for all audit events related to the request.
-It uses that value as the header when it makes related requests to an external system, such as Vault, so that you can correlate the event between the product logs.
+It then uses that value as the header when it makes related requests to an external system, such as Vault, so that you can correlate the event between the product logs.
+If you do not provide an `X-Correlation-ID` header, Boundary generates a unique value for each incoming request.
 
 ## Manage system resources
 

--- a/website/content/docs/api-clients/api/rate-limiting.mdx
+++ b/website/content/docs/api-clients/api/rate-limiting.mdx
@@ -41,16 +41,15 @@ The default limits for all other actions are:
 
 You can override the default settings and configure other specific limitations using the `api_rate_limit` stanza in the controller configuration.
 
-## HTTP headers
+## Rate limiting HTTP headers
 
 Clients that make requests to the controller API can inspect HTTP response headers to understand the configured limits and current usage.
-Each response contains the following headers:
+Each response contains the `RateLimit` and `RateLimit-Policy` headers.
 
-- `RateLimit` - Provides the current limit, number of remaining requests, and the time at which the quota will reset for the limit that is closest to being exhausted for the requested resource and action.
-- `RateLimit-Policy` - Describes the limits for the requested resource and action.
-
-If the request is limited, Boundary sends the client a 429 HTTP status code with a `Retry-After` header.
+If the request is rate limited, Boundary sends the client a 429 HTTP status code with a `Retry-After` header.
 The `Retry-After` header contains the number of seconds the client should wait before it sends the request again.
+
+For more information, refer to [HTTP headers](/boundary/docs/api-clients/api#http-headers).
 
 ## More information
 


### PR DESCRIPTION
This PR adds the `x-correlation-id` HTTP header to the API Overview docs.

View the update in the preview deployment:

https://boundary-gwxwnbon6-hashicorp.vercel.app/boundary/docs/api-clients/api#http-headers