### PR TITLE
docs: Update KMS `purpose` field for BSR

### DIFF
--- a/website/content/docs/configuration/kms/aead.mdx
+++ b/website/content/docs/configuration/kms/aead.mdx
@@ -22,7 +22,7 @@ kms "aead" {
 ```
 
 - `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
-   `root`, `previous-root`, `recovery`, or `config`.
+   `root`, `previous-root`, `recovery`, `bsr`, or `config`.
 
 - `aead_type` - The type of encryption this KMS uses. Currently only `aes-gcm` is implemented.
 

--- a/website/content/docs/configuration/kms/alicloudkms.mdx
+++ b/website/content/docs/configuration/kms/alicloudkms.mdx
@@ -32,7 +32,7 @@ kms "alicloudkms" {
 These parameters apply to the `kms` stanza in the Boundary configuration file:
 
 - `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
-   `root`, `previous-root`, `recovery`, or `config`.
+   `root`, `previous-root`, `recovery`, `bsr`, or `config`.
 
 - `region` `(string: <required> "us-east-1")`: The AliCloud region where the encryption key
   lives. May also be specified by the `ALICLOUD_REGION`

--- a/website/content/docs/configuration/kms/azurekeyvault.mdx
+++ b/website/content/docs/configuration/kms/azurekeyvault.mdx
@@ -33,7 +33,7 @@ kms "azurekeyvault" {
 These parameters apply to the `kms` stanza in the Vault configuration file:
 
 - `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
-   `root`, `previous-root`, `recovery`, or `config`.
+   `root`, `previous-root`, `recovery`, `bsr`, or `config`.
 
 - `tenant_id` `(string: <required>)`: The tenant id for the Azure Active Directory organization. May
   also be specified by the `AZURE_TENANT_ID` environment variable.

--- a/website/content/docs/configuration/kms/gcpckms.mdx
+++ b/website/content/docs/configuration/kms/gcpckms.mdx
@@ -32,7 +32,7 @@ kms "gcpckms" {
 These parameters apply to the `kms` stanza in the Boundary configuration file:
 
 - `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
-   `root`, `previous-root`, `recovery`, or `config`.
+   `root`, `previous-root`, `recovery`, `bsr`, or `config`.
 
 - `credentials` `(string: <required>)`: The path to the credentials JSON file
   to use. May be also specified by the `GOOGLE_CREDENTIALS` or

--- a/website/content/docs/configuration/kms/ocikms.mdx
+++ b/website/content/docs/configuration/kms/ocikms.mdx
@@ -31,7 +31,7 @@ kms "ocikms" {
 These parameters apply to the `kms` stanza in the Boundary configuration file:
 
 - `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
-   `root`, `previous-root`, `recovery`, or `config`.
+   `root`, `previous-root`, `recovery`, `bsr`, or `config`.
 - `key_id` `(string: <required>)`: The OCI KMS key ID to use.
 - `crypto_endpoint` `(string: <required>)`: The OCI KMS cryptographic endpoint (or data plane endpoint)
   to be used to make OCI KMS encryption/decryption requests.

--- a/website/content/docs/configuration/kms/transit.mdx
+++ b/website/content/docs/configuration/kms/transit.mdx
@@ -42,7 +42,7 @@ kms "transit" {
 These parameters apply to the `kms` stanza in the Vault configuration file:
 
 - `purpose` - Purpose of this KMS, acceptable values are: `worker-auth`, `worker-auth-storage`,
-   `root`, `previous-root`, `recovery`, or `config`.
+   `root`, `previous-root`, `recovery`, `bsr`, or `config`.
 
 - `address` `(string: <required>)`: The full address to the Vault cluster.
   This may also be specified by the `VAULT_ADDR` environment variable.


### PR DESCRIPTION
Any of the KMS key types can be used as `bsr` recovery keys, however it is only documented for AWS KMS.