### PR TITLE
Update worker-tags.mdx to remove Enterprise tag on Vault worker filter

### DIFF
--- a/website/content/docs/concepts/filtering/worker-tags.mdx
+++ b/website/content/docs/concepts/filtering/worker-tags.mdx
@@ -190,7 +190,7 @@ resource "boundary_target" "aws-webservers-prod" {
 
 ### Example worker filter for Vault credential store
 
-<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
 
 Tags are used to control which [workers] can manage Vault requests by specifying
 a `worker_filter`attribute when configuring [credential stores].


### PR DESCRIPTION
Vault worker filters are not an Enterprise feature, so we're removing it.