### PR TITLE
chore(e2e): Increase timeout when setting up openssh container

### DIFF
--- a/enos/modules/docker_openssh_server_ca_key/main.tf
+++ b/enos/modules/docker_openssh_server_ca_key/main.tf
@@ -105,7 +105,7 @@ resource "enos_local_exec" "wait" {
     docker_container.openssh_server
   ]
 
-  inline = ["timeout 20s bash -c 'until ssh -t -t -i ${var.private_key_file_path} -p 2222 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes ${var.target_user}@localhost hostname; do sleep 2; done'"]
+  inline = ["timeout 30s bash -c 'until ssh -t -t -i ${var.private_key_file_path} -p 2222 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes ${var.target_user}@localhost hostname; do sleep 2; done'"]
 }
 
 output "user" {


### PR DESCRIPTION
When setting up the docker container in the `docker_openssh_ca_key` module, there's a an additional script that runs (`00-trust-user-ca`) that takes some time to execute. This can occasionally take longer than the current 20s timeout, resulting in an error when starting a scenario using this module. If you launch the scenario again afterwards, it succeeds. Here is an example error:
```
Error: Execution Error

  with module.create_host.enos_local_exec.wait,
  on ../../modules/docker_openssh_server_ca_key/main.tf line 103, in resource "enos_local_exec" "wait":
 103: resource "enos_local_exec" "wait" {

failed to execute commands due to: running inline command failed, due to:
failed to execute command due to: exit status 124

output:
kex_exchange_identification: Connection closed by remote host
Connection closed by ::1 port 2222
kex_exchange_identification: Connection closed by remote host
Connection closed by ::1 port 2222
kex_exchange_identification: read: Connection reset by peer
Connection reset by ::1 port 2222
kex_exchange_identification: Connection closed by remote host
Connection closed by ::1 port 2222
```

This PR increases the timeout when setting up this module.