### PR TITLE
test(worker): Address flake in TestMonitorUpstreamConnectionState

### DIFF
--- a/internal/daemon/worker/controller_connection_test.go
+++ b/internal/daemon/worker/controller_connection_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/nettest"
 	"google.golang.org/grpc"
@@ -92,7 +91,6 @@ func TestMonitorUpstreamConnectionState(t *testing.T) {
 
 			require.NoError(t, cc.Close())
 			cancelStateCtx()
-			assert.Equal(t, connectivity.Shutdown, cc.GetState())
 		})
 	}
 }

--- a/internal/daemon/worker/controller_connection_test.go
+++ b/internal/daemon/worker/controller_connection_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	opsservices "github.com/hashicorp/boundary/internal/gen/ops/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/nettest"
@@ -60,10 +59,9 @@ func TestMonitorUpstreamConnectionState(t *testing.T) {
 	})
 
 	tests := []struct {
-		name             string
-		expectedResponse *opsservices.GetHealthResponse
-		addresses        []string
-		expectedState    connectivity.State
+		name          string
+		addresses     []string
+		expectedState connectivity.State
 	}{
 		{
 			name:          "connection with 1 good address",
@@ -100,9 +98,6 @@ func TestMonitorUpstreamConnectionState(t *testing.T) {
 			case <-time.After(2 * time.Second):
 				t.Error("Time out waiting for condition")
 			}
-
-			got := upstreamConnectionState.Load()
-			assert.Equal(t, tt.expectedState, got)
 		})
 	}
 }


### PR DESCRIPTION
We have observed `TestMonitorUpstreamConnectionState` failing due to the following
```
--- FAIL: TestMonitorUpstreamConnectionState (0.02s)
  --- FAIL: TestMonitorUpstreamConnectionState/connection_with_multiple_good_addresses (0.00s)

    controller_connection_test.go:105: 
        	Error Trace:	/home/runner/work/boundary/boundary/internal/daemon/worker/controller_connection_test.go:105
        	Error:      	Not equal: 
        	            	expected: 2
        	            	actual  : 1
        	Test:       	TestMonitorUpstreamConnectionState/connection_with_multiple_good_addresses
```
where...
`1` = Connecting
`2` = Ready

This PR modifies the test to remove the extra check at the end of the test. `waitForConnectionStateCondition` will already have observed the expected state.

https://hashicorp.atlassian.net/browse/ICU-13235