### PR TITLE
test(e2e): Address flake in rate limit test

### DIFF
--- a/testing/internal/e2e/tests/base_plus/rate_limit_test.go
+++ b/testing/internal/e2e/tests/base_plus/rate_limit_test.go
@@ -204,19 +204,26 @@ func TestHttpRateLimit(t *testing.T) {
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tokenAdmin))
 	res, err = http.DefaultClient.Do(req)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		res.Body.Close()
+	})
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	rateLimitHeader = res.Header.Get("Ratelimit")
 	require.NotEmpty(t, rateLimitHeader)
 	t.Log(rateLimitHeader)
 	quota, err = getRateLimitStat(rateLimitHeader, "remaining")
 	require.NoError(t, err)
+
 	for quota > 0 {
 		requestURL = fmt.Sprintf("%s/v1/hosts/%s", bc.Address, hostId)
-		req, err = http.NewRequest(http.MethodGet, requestURL, nil)
+		req, err := http.NewRequest(http.MethodGet, requestURL, nil)
 		require.NoError(t, err)
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tokenAdmin))
-		res, err = http.DefaultClient.Do(req)
+		res, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			res.Body.Close()
+		})
 		require.Equal(t, http.StatusOK, res.StatusCode)
 
 		rateLimitHeader := res.Header.Get("Ratelimit")

--- a/testing/internal/e2e/tests/base_plus/rate_limit_test.go
+++ b/testing/internal/e2e/tests/base_plus/rate_limit_test.go
@@ -259,8 +259,8 @@ func TestHttpRateLimit(t *testing.T) {
 	// require.NotEmpty(t, retryAfterHeader)
 	// retryAfter, err = strconv.Atoi(retryAfterHeader)
 	// require.NoError(t, err)
-	t.Logf("Waiting for %d seconds to retry API request...", policyPeriod)
-	time.Sleep(time.Duration(policyPeriod) * time.Second)
+	t.Logf("Waiting for %d seconds to retry API request...", policyPeriod+1)
+	time.Sleep(time.Duration(policyPeriod+1) * time.Second)
 
 	// Do another request. Verify that request is successful
 	t.Log("Retrying...")


### PR DESCRIPTION
Observed a failure in an e2e test for the following reason
```
 === RUN   TestHttpRateLimit
│     scope.go:85: Created Org Id: o_bIvTZldr5D
│     scope.go:127: Created Project Id: p_PrxnqspsjA
│     host.go:123: Created Host Catalog: hcst_4hOAYpqAeR
│     host.go:188: Created Host: hst_Ee61h11NCX
│     rate_limit_test.go:65: Sending API requests until quota is hit...
│     rate_limit_test.go:85: 3;w=10;comment="auth-token"
│     rate_limit_test.go:89: limit=3, remaining=2, reset=10
│     rate_limit_test.go:109: limit=3, remaining=1, reset=10
│     rate_limit_test.go:109: limit=3, remaining=0, reset=10
│     rate_limit_test.go:119: Checking that next API request is rate limited...
│     rate_limit_test.go:138: Waiting for 10 seconds to retry API request...
│     rate_limit_test.go:142: Retrying...
│     rate_limit_test.go:157: Successfully sent request after waiting
│     account.go:79: Created Account: acctpw_H8XvGJQSPT
│     user.go:65: Created User: u_MZ93hjxYm8
│     role.go:64: Created Role: r_dFjUcem5dc in scope p_PrxnqspsjA
│     role.go:120: Principal u_MZ93hjxYm8 added to role: r_dFjUcem5dc
│     rate_limit_test.go:200: Sending API requests until quota is hit...
│     rate_limit_test.go:210: limit=3, remaining=2, reset=10
│     rate_limit_test.go:224: limit=3, remaining=1, reset=10
│     rate_limit_test.go:224: limit=3, remaining=0, reset=10
│     rate_limit_test.go:234: Checking that next API request is rejected...
│     rate_limit_test.go:255: Waiting for 10 seconds to retry API request...
│     rate_limit_test.go:259: Retrying...
│     rate_limit_test.go:266: 
│           Error Trace:    /src/boundary/testing/internal/e2e/tests/base_plus/rate_limit_test.go:266
│           Error:          Not equal: 
│                           expected: 200
│                           actual  : 503
│           Test:           TestHttpRateLimit
│ --- FAIL: TestHttpRateLimit (48.97s)
```

This part of the test waits for the rate limit to reset after one user exhausts the quota. The second user will attempt to send a request while the quota is exhausted (getting a 503). and then try again after the reset period (which should result in a 200). I'd like to try adding a second to this wait time to see if this resolves the flake. 