### PR TITLE
test(e2e): Verify host id and invalid input for aliases

### DIFF
--- a/testing/internal/e2e/tests/base/alias_test.go
+++ b/testing/internal/e2e/tests/base/alias_test.go
@@ -165,7 +165,13 @@ func TestCliAlias(t *testing.T) {
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
 
-	// Update the alias to include a host id
+	// Create invalid host and add it to the host set
+	invalidHostId, err := boundary.CreateHostCli(t, ctx, hostCatalogId, "invalid-address")
+	require.NoError(t, err)
+	err = boundary.AddHostToHostSetCli(t, ctx, hostSetId, invalidHostId)
+	require.NoError(t, err)
+
+	// Update the alias to include the valid host id
 	output = e2e.RunCommand(ctx, "boundary",
 		e2e.WithArgs(
 			"aliases", "update", "target",


### PR DESCRIPTION
This PR updates the e2e-test for aliases. It adds the following verifications:
- When there is multiple hosts are added to the host set used for the target, an alias with a host id points to the specified one