### PR TITLE
fixes broken tutorial link

### DIFF
--- a/website/content/docs/concepts/domain-model/credential-libraries.mdx
+++ b/website/content/docs/concepts/domain-model/credential-libraries.mdx
@@ -122,7 +122,7 @@ is useful when using account names/login names since only one may be populated:
 
 ## Tutorial
 
-Refer to the [SSH certificate injection with HCP Boundary](/boundary/tutorials/access-management/hcp-certificate-injection) tutorial to learn how to configure credential injection with SSH certificates using Vault.
+Refer to the [SSH certificate injection with HCP Boundary](/boundary/tutorials/credential-management/hcp-certificate-injection) tutorial to learn how to configure credential injection with SSH certificates using Vault.
 
 ## Referenced by
 


### PR DESCRIPTION
Fixes broken ssh certificates tutorial link on credential libraries page.