### PR TITLE
test(e2e): Update postgres version

### DIFF
--- a/enos/modules/aws_boundary/variables.tf
+++ b/enos/modules/aws_boundary/variables.tf
@@ -139,7 +139,7 @@ variable "db_class" {
 variable "db_version" {
   description = "AWS RDS DBS engine version (for postgres/mysql)"
   type        = string
-  default     = "15.3"
+  default     = "15.6"
 }
 
 variable "db_engine" {


### PR DESCRIPTION
Some e2e tests were failing for the following reason
```
Error: creating RDS DB Instance (boundary-db-djcdlozc): InvalidParameterCombination: Cannot find version 15.3 for postgres
	status code: 400, request id: 97d6281e-b440-4885-b6fe-12a03827a6dc

  with module.create_boundary_cluster.aws_db_instance.boundary[0],
  on ../../modules/aws_boundary/rds.tf line 9, in resource "aws_db_instance" "boundary":
   9: resource "aws_db_instance" "boundary" {
  Validate: success!
  Plan: success!
```

This PR bumps the postgres version.