### PR TITLE
Update create-storage-bucket.mdx

### DIFF
--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -58,7 +58,7 @@ and how long a BSR will be retained in the storage bucket.
    You can configure static credentials using an access key and secret key or dynamic credentials using the AWS [`AssumeRole` API](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole).
 - An AWS IAM role policy with the following statement:
    ```json
-    {
+  {
       "Version": "2012-10-17",
       "Statement": [
          {


### PR DESCRIPTION
This single incorrectly spaced opening bracket is causing an error in AWS 'invalid policy syntax'.