### PR TITLE
test(e2e): Add module for iam user with credential rotation support

### DIFF
--- a/enos/modules/aws_iam_setup/main.tf
+++ b/enos/modules/aws_iam_setup/main.tf
@@ -5,6 +5,12 @@ data "aws_caller_identity" "current" {}
 
 variable "test_id" {}
 variable "test_email" {}
+variable "enable_credential_rotation" {
+  description = "Sets up the IAM user to support the use of credential rotation in Boundary"
+  type        = bool
+  default     = false
+}
+
 
 locals {
   # Use the AWS provided email if users are running this, override with variable for CI
@@ -15,6 +21,9 @@ resource "aws_iam_user" "boundary" {
   name                 = "demo-${local.user_email}-${var.test_id}"
   tags                 = { boundary-demo = local.user_email }
   permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser"
+  # If credential rotation is used, this is necessary to delete the user since a new access
+  # key will be generated.
+  force_destroy = var.enable_credential_rotation ? true : false
 }
 
 resource "aws_iam_user_policy" "boundary" {
@@ -33,6 +42,27 @@ resource "aws_iam_user_policy" "boundary" {
     ]
   })
 }
+
+resource "aws_iam_user_policy" "rotate_keys" {
+  count = var.enable_credential_rotation ? 1 : 0
+  name  = "boundary_e2e_${var.test_id}_rotate_keys"
+  user  = aws_iam_user.boundary.name
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : [
+          "iam:DeleteAccessKey",
+          "iam:GetUser",
+          "iam:CreateAccessKey"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "${aws_iam_user.boundary.arn}",
+      }
+    ]
+  })
+}
+
 
 resource "aws_iam_access_key" "boundary" {
   user = aws_iam_user.boundary.name


### PR DESCRIPTION
This PR updates an enos module that creates an IAM user to add support for credential rotation. The module was updated with the following
- a new variable to the module to decide whether or not credential rotation support is needed (default: `false`)
- if credential rotation support is enabled, the IAM user needs the `force_destroy` option set to true in order for terraform to successfully clean up afterwards (otherwise you'll get an error like `Cannot delete entity, must delete access keys first.` since new access keys were created)
- if credential rotation is enabled, another policy is added to the user that allows the user to rotate its access keys

There will be a follow-up PR in `boundary-enterprise` to add the associated tests.
There will also be follow-up work to add similar tests using MinIO