### PR TITLE
Release Notes: adds note about future auto-role creation deprecation

### DIFF
--- a/website/content/docs/release-notes/v0_16_0.mdx
+++ b/website/content/docs/release-notes/v0_16_0.mdx
@@ -11,6 +11,12 @@ description: |-
 
 @include 'release-notes/intro.mdx'
 
+<Note>
+
+  In a future version Boundary will no longer automatically create roles when new scopes are created. This was implemented prior to multi-scope grants to ensure administrators and users had default permissions in new scopes. Since Boundary 0.15, initial roles created for new clusters provide these permissions by default to all scopes using multi-scope grants.
+
+</Note>
+
 ## New features
 
 <table>


### PR DESCRIPTION
This PR adds a note to the 0.16 release notes regarding the deprecation of auto-role creation when new scopes are created in light of multi-scope grants.