### PR TITLE
test(bats): Update aliases bats tests

### DIFF
--- a/internal/tests/cli/boundary/_aliases.bash
+++ b/internal/tests/cli/boundary/_aliases.bash
@@ -12,6 +12,17 @@ function create_target_alias() {
     -format json
 }
 
+function create_target_alias_with_host_id() {
+  local value=$1
+  local destid=$2
+  local hostid=$3
+  boundary aliases create target \
+    -value $value \
+    -destination-id $destid \
+    -authorize-session-host-id $hostid \
+    -format json
+}
+
 function read_alias(){
   boundary aliases read -id $1 -format json
 }

--- a/internal/tests/cli/boundary/alias.bats
+++ b/internal/tests/cli/boundary/alias.bats
@@ -17,6 +17,16 @@ export NEW_HOST="host_for_alias_test"
   [ "$status" -eq 0 ]
 }
 
+@test "boundary/alias: admin user cannot create alias with incorrectly formatted destination id" {
+  run create_target_alias $ALIAS_VALUE incorrectly-formatted-destination-id
+  [ "$status" -eq 1 ]
+}
+
+@test "boundary/alias: admin user cannot create alias with incorrectly formatted host id" {
+  run create_target_alias_with_host_id $ALIAS_VALUE $DEFAULT_TARGET incorrectly-formatted-host-id
+  [ "$status" -eq 1 ]
+}
+
 @test "boundary/alias: admin user can create alias" {
   run create_target_alias $ALIAS_VALUE $DEFAULT_TARGET
   echo $output
@@ -58,6 +68,18 @@ export NEW_HOST="host_for_alias_test"
   local id=$(alias_id_from_target_alias $ALIAS_VALUE)
   run update_target_alias_host_id $id $DEFAULT_HOST
   [ "$status" -eq 0 ]
+}
+
+@test "boundary/alias: admin user cannot update alias with incorrectly formatted host id" {
+  local id=$(alias_id_from_target_alias $ALIAS_VALUE)
+  run update_target_alias_host_id $id incorrectly-formatted-host-id
+  [ "$status" -eq 1 ]
+}
+
+@test "boundary/alias: admin user cannot update alias with incorrectly formatted destination id" {
+  local id=$(alias_id_from_target_alias $ALIAS_VALUE)
+  run update_target_alias_destination_id $id incorrectly-formatted-destination-id
+  [ "$status" -eq 1 ]
 }
 
 @test "boundary/alias: admin user can connect using an alias configured with host id" {

--- a/internal/tests/cli/boundary/alias.bats
+++ b/internal/tests/cli/boundary/alias.bats
@@ -27,6 +27,17 @@ export NEW_HOST="host_for_alias_test"
   [ "$status" -eq 1 ]
 }
 
+@test "boundary/alias: admin user can create alias with host id" {
+  run create_target_alias_with_host_id $ALIAS_VALUE $DEFAULT_TARGET $DEFAULT_HOST
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/alias: delete alias with host id" {
+  local id=$(alias_id_from_target_alias $ALIAS_VALUE)
+  run delete_alias $id
+  [ "$status" -eq 0 ]
+}
+
 @test "boundary/alias: admin user can create alias" {
   run create_target_alias $ALIAS_VALUE $DEFAULT_TARGET
   echo $output


### PR DESCRIPTION
This PR moves verifications previously added to [the aliases e2e-test](https://github.com/hashicorp/boundary/pull/4691) to the bats test suite