### PR TITLE
docs: Fix broken link in `Worker configuration` page

### DIFF
--- a/website/content/docs/configuration/worker/worker-configuration.mdx
+++ b/website/content/docs/configuration/worker/worker-configuration.mdx
@@ -168,7 +168,7 @@ kms "aead" {
 }
 ```
 
-[`initial_upstreams`](/boundary/docs/configuration/worker/overview#initial_upstreams)
+[`initial_upstreams`](/boundary/docs/configuration/worker#initial_upstreams)
 are used to connect to upstream Boundary clusters.
 
 ## Resources


### PR DESCRIPTION
This PR fixes a broken link in the `Worker configuration` page. Addresses a fix reported here: https://github.com/hashicorp/boundary/pull/2550

Preview: https://boundary-7npmbsk73-hashicorp.vercel.app/boundary/docs/configuration/worker/worker-configuration
- Click on the link to `initial_upstreams`