### PR TITLE
docs: Update session-recordings CLI doc

### DIFF
--- a/website/content/docs/commands/session-recordings/delete.mdx
+++ b/website/content/docs/commands/session-recordings/delete.mdx
@@ -1,0 +1,38 @@
+---
+layout: docs
+page_title: session-recordings delete - Command
+description: |-
+  The "session-recordings delete" command lets you delete a session recording.
+---
+
+# session-recordings delete
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+Command: `session-recordings delete`
+
+The `session-recordings delete` command lets you delete a session recording.
+
+## Example
+
+This example deletes a session recording with the ID `sr_1234567890`:
+
+```shell-session
+$ boundary session-recordings delete -id sr_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary session-recordings delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - The ID of the session recording you want to delete.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/session-recordings/index.mdx
+++ b/website/content/docs/commands/session-recordings/index.mdx
@@ -29,9 +29,11 @@ $ boundary session-recordings download -id chr_1234567890
 Usage: boundary session-recordings <subcommand> [options] [args]
   # ...
 Subcommands:
-    download    Download a session recording
-    list        List a session recording
-    read        Read a session recording
+    delete                    Delete a session recording
+    download                  Download a session recording
+    list                      List a session recording
+    read                      Read a session recording
+    reapply-storage-policy    Reapply storage policy to a session recording
 ```
 
 </CodeBlockConfig>
@@ -39,6 +41,8 @@ Subcommands:
 For more information, examples, and usage, click on the name
 of the subcommand in the sidebar or one of the links below:
 
+- [delete](/boundary/docs/commands/session-recordings/delete)
 - [download](/boundary/docs/commands/session-recordings/download)
 - [list](/boundary/docs/commands/session-recordings/list)
 - [read](/boundary/docs/commands/session-recordings/read)
+- [reapply-storage-policy](/boundary/docs/commands/session-recordings/reapply-storage-policy)

--- a/website/content/docs/commands/session-recordings/read.mdx
+++ b/website/content/docs/commands/session-recordings/read.mdx
@@ -15,10 +15,10 @@ The `boundary session-recordings read` command lets you read information about a
 
 ## Example
 
-This example reads the details of a session recording with the ID `s_1234567890`:
+This example reads the details of a session recording with the ID `sr_1234567890`:
 
 ```shell-session
-$ boundary session-recordings read -id s_1234567890
+$ boundary session-recordings read -id sr_1234567890
 ```
 
 ## Usage

--- a/website/content/docs/commands/session-recordings/reapply-storage-policy.mdx
+++ b/website/content/docs/commands/session-recordings/reapply-storage-policy.mdx
@@ -1,0 +1,38 @@
+---
+layout: docs
+page_title: session-recordings reapply-storage-policy - Command
+description: |-
+  The "session-recordings reapply-storage-policy" command lets you reapply a storage policy to a session recording.
+---
+
+# session-recordings reapply-storage-policy
+
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+
+Command: `session-recordings reapplly-storage-policy`
+
+The `session-recordings reapply-storage-policy` command lets you reapply a storage policy to a session recording.
+
+## Example
+
+This example reapplies a storage policy to a session recording with the ID `sr_1234567890`:
+
+```shell-session
+$ boundary session-recordings reapply-storage-policy -id sr_1234567890
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary session-recordings delete [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `-id=<string>` - The ID of the session recording you want to reapply the storage policy to.
+
+@include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1373,6 +1373,10 @@
             "path": "commands/session-recordings"
           },
           {
+            "title": "delete",
+            "path": "commands/session-recordings/delete"
+          },
+          {
             "title": "download",
             "path": "commands/session-recordings/download"
           },
@@ -1383,6 +1387,10 @@
           {
             "title": "read",
             "path": "commands/session-recordings/read"
+          },
+          {
+            "title": "reapply-storage-policy",
+            "path": "commands/session-recordings/reapply-storage-policy"
           }
         ]
       },


### PR DESCRIPTION
This PR adds the sub-commands `delete` and `reapply-storage-policy` to the `session-recordings` CLI documentation, and fixes the id in the read command.

View the update in the preview deployment:

- [`delete`](https://boundary-eyr0mu7wp-hashicorp.vercel.app/boundary/docs/commands/session-recordings/delete)
- [`reapply-storage-policy`](https://boundary-eyr0mu7wp-hashicorp.vercel.app/boundary/docs/commands/session-recordings/reapply-storage-policy)
- [`read`](https://boundary-eyr0mu7wp-hashicorp.vercel.app/boundary/docs/commands/session-recordings/read)