### PR TITLE
docs: Add bsr purpose key examples

### DIFF
--- a/website/content/docs/configuration/controller.mdx
+++ b/website/content/docs/configuration/controller.mdx
@@ -193,9 +193,23 @@ And optionally, a KMS stanza for configuration encryption purpose:
 # Configuration encryption block: decrypts sensitive values in the
 # configuration file. See `boundary config [encrypt|decrypt] -h`.
 kms "aead" {
-  purpose   = "config"`
+  purpose = "config"`
   aead_type = "aes-gcm"
-  key       = "7xtkEoS5EXPbgynwd+dDLHopaCqK8cq0Rpep4eooaTs="
+  key = "7xtkEoS5EXPbgynwd+dDLHopaCqK8cq0Rpep4eooaTs="
+}
+```
+
+And optionally, a KMS stanza to enable the session recording feature:
+
+```hcl
+# BSR encryption block: encrypts data and checks the integrity
+# of session recordings. If you do not add a BSR key to your
+# controller configuration, you cannot enable session recording.
+kms "aead" {
+  purpose = "bsr"`
+  aead_type = "aes-gcm"
+  key = "8Vg!XCbS.fzNKB@Uu.ccB588H#4iyHAd:TpgjuwC/;J;"
+  key_id = "session_recording"
 }
 ```
 
@@ -314,5 +328,15 @@ kms "aead" {
   aead_type = "aes-gcm"
   key = "8fZBjCUfN0TzjEGLQldGY4+iE9AkOvCfjh7+p0GtRBQ="
   key_id = "global_recovery"
+}
+
+# BSR encryption block: encrypts data and checks the integrity
+# of session recordings. If you do not add a BSR key to your
+# controller configuration, you cannot enable session recording.
+kms "aead" {
+  purpose = "bsr"`
+  aead_type = "aes-gcm"
+  key = "8Vg!XCbS.fzNKB@Uu.ccB588H#4iyHAd:TpgjuwC/;J;"
+  key_id = "session_recording"
 }
 ```

--- a/website/content/docs/configuration/controller.mdx
+++ b/website/content/docs/configuration/controller.mdx
@@ -193,7 +193,7 @@ And optionally, a KMS stanza for configuration encryption purpose:
 # Configuration encryption block: decrypts sensitive values in the
 # configuration file. See `boundary config [encrypt|decrypt] -h`.
 kms "aead" {
-  purpose = "config"`
+  purpose = "config"
   aead_type = "aes-gcm"
   key = "7xtkEoS5EXPbgynwd+dDLHopaCqK8cq0Rpep4eooaTs="
 }
@@ -206,7 +206,7 @@ And optionally, a KMS stanza to enable the session recording feature:
 # of session recordings. If you do not add a BSR key to your
 # controller configuration, you cannot enable session recording.
 kms "aead" {
-  purpose = "bsr"`
+  purpose = "bsr"
   aead_type = "aes-gcm"
   key = "8Vg!XCbS.fzNKB@Uu.ccB588H#4iyHAd:TpgjuwC/;J;"
   key_id = "session_recording"
@@ -334,7 +334,7 @@ kms "aead" {
 # of session recordings. If you do not add a BSR key to your
 # controller configuration, you cannot enable session recording.
 kms "aead" {
-  purpose = "bsr"`
+  purpose = "bsr"
   aead_type = "aes-gcm"
   key = "8Vg!XCbS.fzNKB@Uu.ccB588H#4iyHAd:TpgjuwC/;J;"
   key_id = "session_recording"

--- a/website/content/docs/install-boundary/configure-controllers.mdx
+++ b/website/content/docs/install-boundary/configure-controllers.mdx
@@ -38,10 +38,13 @@ The DEKs are encrypted with the scope's root KEK, and this is in turn encrypted 
 A nonce and creation time are included as an encrypted payload, formatted as a token, and sent to the controller.
 The time and nonce are used to ensure that a value cannot be replayed by an adversary, and also to ensure that each operation must be individually authenticated by a client, so that revoking access to the KMS has an immediate result.
 
-The following key is optional:
+The following keys are optional:
 
 - **Worker-auth key (Optional)**: The worker-auth KMS key is shared by the controller and worker to authenticate a worker to the controller.
 If a worker is used with PKI authentication, this is unnecessary.
+- **BSR key (Optional)**: The BSR KMS key is required for session recording.
+Boundary uses the BSR key for encrypting data and checking the integrity of recordings.
+If you do not add a BSR key to your controller configuration, you receive an error when you attempt to enable session recording.
 
 There are other optional KMS keys that you can configure for different encryption scenarios.
 These scenarios include Boundary worker PKI auth encryption and Boundary worker or controller configuration encryption.
@@ -237,12 +240,21 @@ kms "awskms" {
   endpoint   = "https://vpce-0e1bb1852241f8cc6-pzi0do8n.kms.us-east-1.vpce.amazonaws.com"
 }
 
-# Worker-Auth KMS Key (optional, only needed if using
+# Worker-Auth KMS Key (optional, only needed if you use
 # KMS authenticated workers)
 kms "awskms" {
   purpose    = "worker-auth"
   region     = "us-east-1"
   kms_key_id = "19ec80b0-dfdd-4d97-8164-c6examplekey3"
+  endpoint   = "https://vpce-0e1bb1852241f8cc6-pzi0do8n.kms.us-east-1.vpce.amazonaws.com"
+}
+
+# BSR KMS Key (optional, only needed if you use the
+# session recording feature)
+kms "awskms" {
+  purpose    = "bsr"
+  region     = "us-east-1"
+  kms_key_id = "19ec80b0-dfdd-4d97-8164-c6examplekey4"
   endpoint   = "https://vpce-0e1bb1852241f8cc6-pzi0do8n.kms.us-east-1.vpce.amazonaws.com"
 }
 ```


### PR DESCRIPTION
This PR attempts to alleviate some confusion about the need for a bsr purpose key to enable session recording. It adds bsr KMS stanzas to the controller configuration examples in the Install guide and the Controller concept topic.

Inspired by Slack conversations [here](https://hashicorp.slack.com/archives/C016ZKNM05T/p1715003124734679) and [here](https://hashicorp.slack.com/archives/C01AQDJF3SA/p1712948354314109?thread_ts=1712947090.165509&cid=C01AQDJF3SA).

View the update in the preview deployment:

Install Boundary > Configure controllers:

- [Prepare KMS keys](https://boundary-p3awwe2kz-hashicorp.vercel.app/boundary/docs/install-boundary/configure-controllers#prepare-kms-keys)
- [Create the controller configuration](https://boundary-p3awwe2kz-hashicorp.vercel.app/boundary/docs/install-boundary/configure-controllers#create-the-controller-configuration)


Configuration > Controller:

- [KMS configuration](https://boundary-p3awwe2kz-hashicorp.vercel.app/boundary/docs/configuration/controller#kms-configuration)
- [Complete configuration example](https://boundary-p3awwe2kz-hashicorp.vercel.app/boundary/docs/configuration/controller#complete-configuration-example)