### PR TITLE
remove macos runners for darwin builds in favor of linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,7 @@ jobs:
     needs:
       - product-metadata
       - set-product-version
-    runs-on: ${{ fromJSON(vars.BUILDER_MACOS) }}
+    runs-on: ${{ fromJSON(vars.BUILDER_LINUX) }}
     strategy:
       matrix:
         goos: [ darwin ]


### PR DESCRIPTION
migrates the darwin builder from macos runners to linux due to how much the macos runners cost - https://hashicorp.atlassian.net/browse/ICU-13634

tested by using the built darwin arm64 binary to run `boundary dev` and add a tcp target and connect to it via `boundary connect` and `ssh`
darwin arm64 action: https://github.com/hashicorp/boundary/actions/runs/9083820967/job/24963374657?pr=4798
![image](https://github.com/hashicorp/boundary/assets/29378233/d6ff9c27-a043-461f-9086-e8aab58ebb89)
built binary available here: https://github.com/hashicorp/boundary/actions/runs/9083820967/artifacts/1502180173