### PR TITLE
fix(session): Move encryption/decryption out of database transactions

### DIFF
--- a/internal/session/repository_session_test.go
+++ b/internal/session/repository_session_test.go
@@ -1919,9 +1919,8 @@ func TestRepository_deleteTerminated(t *testing.T) {
 	}
 }
 
-func Test_decryptAndMaybeUpdateSession(t *testing.T) {
+func Test_decrypt(t *testing.T) {
 	conn, _ := db.TestSetup(t, "postgres")
-	rw := db.New(conn)
 	wrapper := db.TestWrapper(t)
 	kmsRepo := kms.TestKms(t, conn, wrapper)
 	iamRepo := iam.TestRepo(t, conn, wrapper)
@@ -1929,89 +1928,41 @@ func Test_decryptAndMaybeUpdateSession(t *testing.T) {
 
 	t.Run("errors-with-invalid-kms", func(t *testing.T) {
 		s := TestDefaultSession(t, conn, wrapper, iamRepo)
-		err := decryptAndMaybeUpdateSession(ctx, nil, s, rw)
+		err := decrypt(ctx, nil, s)
 		require.Error(t, err)
 	})
 	t.Run("errors-with-invalid-session", func(t *testing.T) {
-		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, nil, rw)
-		require.Error(t, err)
-	})
-	t.Run("errors-with-invalid-writer", func(t *testing.T) {
-		s := TestDefaultSession(t, conn, wrapper, iamRepo)
-		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, nil)
+		err := decrypt(ctx, kmsRepo, nil)
 		require.Error(t, err)
 	})
 	t.Run("errors-with-invalid-session-project-id", func(t *testing.T) {
 		s := TestDefaultSession(t, conn, wrapper, iamRepo)
 		s.ProjectId = ""
-		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		err := decrypt(ctx, kmsRepo, s)
 		require.Error(t, err)
 	})
 	t.Run("errors-with-invalid-session-key-id", func(t *testing.T) {
 		s := TestDefaultSession(t, conn, wrapper, iamRepo)
 		s.KeyId = ""
-		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		err := decrypt(ctx, kmsRepo, s)
 		require.Error(t, err)
 	})
 	t.Run("errors-with-invalid-session-user-id", func(t *testing.T) {
 		s := TestDefaultSession(t, conn, wrapper, iamRepo)
 		s.UserId = ""
-		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		err := decrypt(ctx, kmsRepo, s)
 		require.Error(t, err)
 	})
 	t.Run("errors-with-invalid-session-public-id", func(t *testing.T) {
 		s := TestDefaultSession(t, conn, wrapper, iamRepo)
 		s.PublicId = ""
-		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		err := decrypt(ctx, kmsRepo, s)
 		require.Error(t, err)
 	})
 	t.Run("session-with-local-session-key-succeeds", func(t *testing.T) {
 		s := TestDefaultSession(t, conn, wrapper, iamRepo)
-		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
+		err := decrypt(ctx, kmsRepo, s)
 		require.NoError(t, err)
-	})
-	t.Run("session-with-derived-session-key-succeeds", func(t *testing.T) {
-		s := TestDefaultSession(t, conn, wrapper, iamRepo)
-		s.CtCertificatePrivateKey = nil
-		s.CertificatePrivateKey = nil
-		s.TofuToken = nil
-		s.CtTofuToken = nil
-		err := decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
-		require.NoError(t, err)
-	})
-	t.Run("session-with-derived-session-key-and-tofu-token-succeeds", func(t *testing.T) {
-		s := TestDefaultSession(t, conn, wrapper, iamRepo)
-		s.CtCertificatePrivateKey = nil
-		s.CertificatePrivateKey = nil
-		s.TofuToken = []byte("A token")
-		actualKeyId := s.KeyId
-		databaseWrapper, err := kmsRepo.GetWrapper(ctx, s.ProjectId, kms.KeyPurposeDatabase)
-		require.NoError(t, err)
-		err = s.encrypt(ctx, databaseWrapper)
-		require.NoError(t, err)
-		s.KeyId = actualKeyId // Restore this as the encrypt call above will overwrite it.
-		err = decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
-		require.NoError(t, err)
-	})
-	t.Run("session-with-derived-session-key-and-tofu-token-cannot-be-decrypted", func(t *testing.T) {
-		s := TestDefaultSession(t, conn, wrapper, iamRepo)
-		s.CtCertificatePrivateKey = nil
-		s.CertificatePrivateKey = nil
-		s.TofuToken = []byte("A token")
-		actualKeyId := s.KeyId
-		databaseWrapper, err := kmsRepo.GetWrapper(ctx, s.ProjectId, kms.KeyPurposeDatabase)
-		require.NoError(t, err)
-		err = s.encrypt(ctx, databaseWrapper)
-		require.NoError(t, err)
-		databaseKeyId := s.KeyId
-		err = kmsRepo.RotateKeys(ctx, s.ProjectId)
-		require.NoError(t, err)
-		ok, err := kmsRepo.DestroyKeyVersion(ctx, s.ProjectId, databaseKeyId)
-		require.NoError(t, err)
-		assert.True(t, ok)
-		s.KeyId = actualKeyId // Restore this as the encrypt call above will overwrite it.
-		err = decryptAndMaybeUpdateSession(ctx, kmsRepo, s, rw)
-		require.ErrorContains(t, err, "You may need to recreate your session")
 	})
 }
 

--- a/internal/session/rewrapping.go
+++ b/internal/session/rewrapping.go
@@ -109,7 +109,7 @@ func sessionRewrapFn(ctx context.Context, dataKeyVersionId string, scopeId strin
 			}
 			continue
 		}
-		if err := decryptAndMaybeUpdateSession(ctx, kmsRepo, session, writer); err != nil {
+		if err := decrypt(ctx, kmsRepo, session); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to decrypt session"))
 		}
 		wrapper, err := kmsRepo.GetWrapper(ctx, session.GetProjectId(), kms.KeyPurposeSessions)


### PR DESCRIPTION
Several session.Repository methods need to encrypt or decrypt fields
when persisting or retrieving a Session. These encrypt/decrypt
operations where being performed while within a database transaction.

The first step in the encrypt/decrypt operation is to retrieve the
kms.Wrapper. While the wrappers get cached in memory, the retrieval
still results in a database query to check that the kms collection
version has not changed. This query happens with a separate db.Reader,
and therefore uses a separate database connection from the transaction
being used by the session.Repository.

If the controllers are configured with a relatively low
`max_open_connections`, and be under sufficient load interactive with
sessions, the controller can consume all of the available database
connections, and get stuck with open transactions while waiting for a
database connection to execute the kms related queries. This can be see
by checking pg_stat_activity and seeing transactions stuck in `idle in
transaction` with a wait_event of ClientRead.

This commit changes all of the Repository methods the perform any
encryption or decryption operations, including the retrieval of the
kms.Wrapper, outside of a database transaction. An alternative approach
would be to unsure that the kms.Wrapper retrieval happens within the
same database transaction. However, it seems preferable to avoid doing
these relatively expensive operations within a transaction when it is
not necessary.

As part of this fix, it also eliminates some logic that is no longer
needed. During previous would with KMS wrapping, the method of how
sessions were encrypted was changed, and some logic to lazily re-encrypt
sessions was introduced. However, given that terminated sessions are
deleted, and the KMS changes was introduced several versions ago
(0.13.0), this lazy re-encrypt logic should no longer be necessary.

Refs: edd323b73a36a61f37f349e214d4d84515e44ac2
See:
    https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-PG-STAT-ACTIVITY-VIEW
    https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT
    https://developer.hashicorp.com/boundary/docs/configuration/controller#max_open_connections