### PR TITLE
chore(bats): Fix unzip error

### DIFF
--- a/.github/workflows/test-cli-ui_oss.yml
+++ b/.github/workflows/test-cli-ui_oss.yml
@@ -79,7 +79,7 @@ jobs:
           path: /tmp
       - name: Unpack boundary bundle
         run: |
-          unzip /tmp/${{ inputs.artifact-name }} -d /usr/local/bin
+          unzip -o /tmp/${{ inputs.artifact-name }} -d /usr/local/bin
           rm /tmp/${{ inputs.artifact-name }}
       - name: Versions
         run: |


### PR DESCRIPTION
We observed the bats tests started failing for the following reason
```
Run unzip /tmp/boundary_0.16.0_linux_amd64.zip -d /usr/local/bin
  unzip /tmp/boundary_0.16.0_linux_amd64.zip -d /usr/local/bin
  rm /tmp/boundary_0.16.0_linux_amd64.zip
  shell: /usr/bin/bash -e {0}
replace /usr/local/bin/LICENSE.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
(EOF or read error, treating as "[N]one" ...)
Archive:  /tmp/boundary_0.16.0_linux_amd64.zip
  inflating: /usr/local/bin/boundary  
Error: Process completed with exit code 1.
```

Looking at the log, it points to an issue with a competing file in `/usr/local/bin/LICENSE.txt`. Doing a check [here](https://github.com/hashicorp/boundary/actions/runs/9120111874/job/25077032869), it seems to indicate that the `LICENSE.txt` file is coming from a Packer install
```
Run cat /usr/local/bin/LICENSE.txt
License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
"Business Source License" is a trademark of MariaDB Corporation Ab.

Parameters

Licensor:             HashiCorp, Inc.
Licensed Work:        Packer Version 1.10.0 or later. The Licensed Work is (c) 2024
                      HashiCorp, Inc.
Additional Use Grant: You may make production use of the Licensed Work, provided
                      Your use does not include offering the Licensed Work to third...
```

This PR adds an additional flag to force unzip to overwrite any files that it might run into.