### PR TITLE
chore(e2e): Use AWS region specified in variable

### DIFF
--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -97,6 +97,7 @@ scenario "e2e_aws_base_with_vault" {
       vpc_tag_module           = step.create_base_infra.vpc_tag_module
       worker_count             = var.worker_count
       worker_instance_type     = var.worker_instance_type
+      aws_region               = var.aws_region
     }
   }
 
@@ -159,6 +160,7 @@ scenario "e2e_aws_base_with_vault" {
       target_port              = "22"
       vault_addr               = step.create_vault_cluster.instance_public_ips[0]
       vault_root_token         = step.create_vault_cluster.vault_root_token
+      aws_region               = var.aws_region
     }
   }
 

--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -97,6 +97,7 @@ scenario "e2e_aws_base" {
       vpc_tag_module           = step.create_base_infra.vpc_tag_module
       worker_count             = var.worker_count
       worker_instance_type     = var.worker_instance_type
+      aws_region               = var.aws_region
     }
   }
 
@@ -135,6 +136,7 @@ scenario "e2e_aws_base" {
       target_user              = "ubuntu"
       target_port              = "22"
       max_page_size            = step.create_boundary_cluster.max_page_size
+      aws_region               = var.aws_region
     }
   }
 

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -98,6 +98,7 @@ scenario "e2e_aws" {
       vpc_tag_module           = step.create_base_infra.vpc_tag_module
       worker_count             = var.worker_count
       worker_instance_type     = var.worker_instance_type
+      aws_region               = var.aws_region
     }
   }
 
@@ -239,6 +240,7 @@ scenario "e2e_aws" {
       target_address           = step.create_isolated_target.target_ips[0]
       worker_tag_egress        = local.egress_tag
       max_page_size            = step.create_boundary_cluster.max_page_size
+      aws_region               = var.aws_region
     }
   }
 

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -128,6 +128,7 @@ scenario "e2e_database" {
       aws_secret_access_key    = step.iam_setup.secret_access_key
       aws_host_set_filter1     = step.create_tag_inputs.tag_string
       max_page_size            = 10
+      aws_region               = var.aws_region
     }
   }
 

--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -103,6 +103,7 @@ scenario "e2e_ui_aws" {
       worker_count             = var.worker_count
       worker_instance_type     = var.worker_instance_type
       worker_type_tags         = [local.egress_tag]
+      aws_region               = var.aws_region
     }
   }
 

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -187,6 +187,7 @@ variable "go_test_timeout" {
 variable "aws_region" {
   description = "AWS region where the resources will be created"
   type        = string
+  default     = "us-east-1"
 }
 
 variable "go_version" {

--- a/enos/enos.hcl
+++ b/enos/enos.hcl
@@ -24,7 +24,7 @@ terraform "default" {
 }
 
 provider "aws" "default" {
-  region = "us-east-1"
+  region = var.aws_region
 }
 
 provider "enos" "default" {

--- a/testing/internal/e2e/boundary/host.go
+++ b/testing/internal/e2e/boundary/host.go
@@ -203,7 +203,7 @@ func AddHostToHostSetCli(t testing.TB, ctx context.Context, hostSetId string, ho
 
 // CreateAwsHostCatalogCli uses the cli to create a new AWS dynamic host catalog.
 // Returns the id of the new host catalog.
-func CreateAwsHostCatalogCli(t testing.TB, ctx context.Context, projectId string, accessKeyId string, secretAccessKey string) (string, error) {
+func CreateAwsHostCatalogCli(t testing.TB, ctx context.Context, projectId, accessKeyId, secretAccessKey, region string) (string, error) {
 	name, err := base62.Random(16)
 	if err != nil {
 		return "", err
@@ -215,7 +215,7 @@ func CreateAwsHostCatalogCli(t testing.TB, ctx context.Context, projectId string
 			"-scope-id", projectId,
 			"-plugin-name", "aws",
 			"-attr", "disable_credential_rotation=true",
-			"-attr", "region=us-east-1",
+			"-attr", fmt.Sprintf("region=%s", region),
 			"-secret", "access_key_id=env://E2E_AWS_ACCESS_KEY_ID",
 			"-secret", "secret_access_key=env://E2E_AWS_SECRET_ACCESS_KEY",
 			"-name", fmt.Sprintf("e2e Host Catalog %s", name),

--- a/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_empty_test.go
+++ b/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_empty_test.go
@@ -38,7 +38,7 @@ func TestCliCreateAwsDynamicHostCatalogWithEmptyHostSet(t *testing.T) {
 	})
 	projectId, err := boundary.CreateProjectCli(t, ctx, orgId)
 	require.NoError(t, err)
-	hostCatalogId, err := boundary.CreateAwsHostCatalogCli(t, ctx, projectId, c.AwsAccessKeyId, c.AwsSecretAccessKey)
+	hostCatalogId, err := boundary.CreateAwsHostCatalogCli(t, ctx, projectId, c.AwsAccessKeyId, c.AwsSecretAccessKey, c.AwsRegion)
 	require.NoError(t, err)
 
 	// Set up a host set

--- a/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_test.go
+++ b/testing/internal/e2e/tests/aws/dynamichostcatalog_host_set_test.go
@@ -43,7 +43,7 @@ func TestCliCreateAwsDynamicHostCatalogWithHostSet(t *testing.T) {
 	})
 	projectId, err := boundary.CreateProjectCli(t, ctx, orgId)
 	require.NoError(t, err)
-	hostCatalogId, err := boundary.CreateAwsHostCatalogCli(t, ctx, projectId, c.AwsAccessKeyId, c.AwsSecretAccessKey)
+	hostCatalogId, err := boundary.CreateAwsHostCatalogCli(t, ctx, projectId, c.AwsAccessKeyId, c.AwsSecretAccessKey, c.AwsRegion)
 	require.NoError(t, err)
 
 	// Set up a host set
@@ -178,7 +178,7 @@ func TestApiCreateAwsDynamicHostCatalog(t *testing.T) {
 		hostcatalogs.WithPluginName("aws"),
 		hostcatalogs.WithAttributes(map[string]any{
 			"disable_credential_rotation": true,
-			"region":                      "us-east-1",
+			"region":                      c.AwsRegion,
 		}),
 		hostcatalogs.WithSecrets(map[string]any{
 			"access_key_id":     c.AwsAccessKeyId,

--- a/testing/internal/e2e/tests/database/env_test.go
+++ b/testing/internal/e2e/tests/database/env_test.go
@@ -13,6 +13,7 @@ type config struct {
 	AwsAccessKeyId     string `envconfig:"E2E_AWS_ACCESS_KEY_ID" required:"true"`
 	AwsSecretAccessKey string `envconfig:"E2E_AWS_SECRET_ACCESS_KEY" required:"true"`
 	AwsHostSetFilter   string `envconfig:"E2E_AWS_HOST_SET_FILTER" required:"true"` // e.g. "tag:testtag=true"
+	AwsRegion          string `envconfig:"E2E_AWS_REGION" required:"true"`          // e.g. "us-east-1"
 }
 
 func loadTestConfig() (*config, error) {

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -240,7 +240,7 @@ func populateBoundaryDatabase(t testing.TB, ctx context.Context, c *config, te T
 	require.NoError(t, err)
 
 	// Create AWS dynamic host catalog
-	awsHostCatalogId, err := boundary.CreateAwsHostCatalogCli(t, ctx, projectId, c.AwsAccessKeyId, c.AwsSecretAccessKey)
+	awsHostCatalogId, err := boundary.CreateAwsHostCatalogCli(t, ctx, projectId, c.AwsAccessKeyId, c.AwsSecretAccessKey, c.AwsRegion)
 	require.NoError(t, err)
 	awsHostSetId, err := boundary.CreateAwsHostSetCli(t, ctx, awsHostCatalogId, c.AwsHostSetFilter)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR modifies the e2e test suite to utilize the AWS region specified by the user from their enos variables (as opposed to hard-coding it to `us-east-1`)