### PR TITLE
clientagentcmd: use "localhost" to call client agent

### DIFF
--- a/internal/cmd/commands/clientagentcmd/clientagentcmd.go
+++ b/internal/cmd/commands/clientagentcmd/clientagentcmd.go
@@ -68,5 +68,5 @@ func (c *ClientAgentCommand) Run(args []string) int {
 
 // clientAgentUrl constructs the full URL for a client agent request given a port and path.
 func clientAgentUrl(port uint, path string) string {
-	return fmt.Sprintf("http://127.0.0.1:%d/%s", port, path)
+	return fmt.Sprintf("http://localhost:%d/%s", port, path)
 }


### PR DESCRIPTION
The client agent serves on `localhost:9300` by default. It appears on some systems this resolves to `::1:9300` and on some systems `127.0.0.1:9300`. We should use the same address on the client as the server to avoid any incompatibilities between systems.