### PR TITLE
changes sync_interval_seconds default to 600

### DIFF
--- a/website/content/docs/concepts/domain-model/host-sets.mdx
+++ b/website/content/docs/concepts/domain-model/host-sets.mdx
@@ -39,8 +39,7 @@ A host set has the following configurable attributes:
 
 - `sync_interval_seconds` - (optional)
   The number of seconds between the time boundary syncs the [hosts][] in this
-  set using this host set's plugin. If not provided a system determined default
-  is used.
+  set using this host set's plugin. Defaults to `600` seconds, or 10 minutes.
 
 ## Referenced by
 


### PR DESCRIPTION
This PR updates the host-set domain model docs `sync_interval_seconds` attribute default to 600 seconds.