### PR TITLE
[Manual] Backport of Add observation tags for Session Recording Service into release/0.16.x

### DIFF
--- a/internal/gen/controller.swagger.json
+++ b/internal/gen/controller.swagger.json
@@ -7373,7 +7373,6 @@
         },
         "host_catalog": {
           "$ref": "#/definitions/controller.api.resources.sessionrecordings.v1.HostCatalog",
-          "description": "",
           "title": "The Host Catalog this Host is in"
         },
         "name": {
@@ -7414,7 +7413,6 @@
         },
         "scope": {
           "$ref": "#/definitions/controller.api.resources.scopes.v1.ScopeInfo",
-          "description": "",
           "title": "The scope that the Host Catalog is in"
         },
         "plugin_id": {

--- a/internal/gen/controller/api/services/session_recording_service.pb.go
+++ b/internal/gen/controller/api/services/session_recording_service.pb.go
@@ -33,7 +33,7 @@ type GetSessionRecordingRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the Session recording, or the ID of the Session that was recorded.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 }
 
 func (x *GetSessionRecordingRequest) Reset() {
@@ -130,11 +130,11 @@ type ListSessionRecordingsRequest struct {
 
 	// The scope in which to list session recordings.
 	// Must be set unless recursive is set.
-	ScopeId string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: class:"public"
+	ScopeId string `protobuf:"bytes,1,opt,name=scope_id,json=scopeId,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// Whether to recurse into child scopes when listing.
 	// If set and scope_id is empty, shows session recordings in
 	// all scopes the caller has access to.
-	Recursive bool `protobuf:"varint,2,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public"` // @gotags: class:"public"
+	Recursive bool `protobuf:"varint,2,opt,name=recursive,proto3" json:"recursive,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// An opaque token that Boundary uses to continue an existing iteration or
 	// request updated items. If you do not specify a token, pagination
 	// starts from the beginning. To learn more about list pagination
@@ -144,7 +144,7 @@ type ListSessionRecordingsRequest struct {
 	// If you do not set a page size, Boundary uses the configured default page size.
 	// If the page_size is greater than the default page size configured,
 	// Boundary truncates the page size to this number.
-	PageSize uint32 `protobuf:"varint,4,opt,name=page_size,proto3" json:"page_size,omitempty" class:"public"` // @gotags: `class:"public"`
+	PageSize uint32 `protobuf:"varint,4,opt,name=page_size,proto3" json:"page_size,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 }
 
 func (x *ListSessionRecordingsRequest) Reset() {
@@ -218,22 +218,22 @@ type ListSessionRecordingsResponse struct {
 	// Delta signifies that this is part of a paginated result
 	// or an update to a previously completed pagination.
 	// Complete signifies that it is the last page.
-	ResponseType string `protobuf:"bytes,2,opt,name=response_type,proto3" json:"response_type,omitempty" class:"public"` // @gotags: `class:"public"`
+	ResponseType string `protobuf:"bytes,2,opt,name=response_type,proto3" json:"response_type,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// An opaque token used to continue an existing pagination or
 	// request updated items. Use this token in the next list request
 	// to request the next page.
 	ListToken string `protobuf:"bytes,3,opt,name=list_token,proto3" json:"list_token,omitempty" class:"public"` // @gotags: `class:"public"`
 	// The name of the field which the items are sorted by.
-	SortBy string `protobuf:"bytes,4,opt,name=sort_by,proto3" json:"sort_by,omitempty" class:"public"` // @gotags: `class:"public"`
+	SortBy string `protobuf:"bytes,4,opt,name=sort_by,proto3" json:"sort_by,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The direction of the sort, either "asc" or "desc".
-	SortDir string `protobuf:"bytes,5,opt,name=sort_dir,proto3" json:"sort_dir,omitempty" class:"public"` // @gotags: `class:"public"`
+	SortDir string `protobuf:"bytes,5,opt,name=sort_dir,proto3" json:"sort_dir,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// A list of item IDs that have been removed since they were returned
 	// as part of a pagination. They should be dropped from any client cache.
 	// This may contain items that are not known to the cache, if they were
 	// created and deleted between listings.
-	RemovedIds []string `protobuf:"bytes,6,rep,name=removed_ids,proto3" json:"removed_ids,omitempty" class:"public"` // @gotags: `class:"public"`
+	RemovedIds []string `protobuf:"bytes,6,rep,name=removed_ids,proto3" json:"removed_ids,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// An estimate at the total items available. This may change during pagination.
-	EstItemCount uint32 `protobuf:"varint,7,opt,name=est_item_count,proto3" json:"est_item_count,omitempty" class:"public"` // @gotags: `class:"public"`
+	EstItemCount uint32 `protobuf:"varint,7,opt,name=est_item_count,proto3" json:"est_item_count,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 }
 
 func (x *ListSessionRecordingsResponse) Reset() {
@@ -326,10 +326,10 @@ type DownloadRequest struct {
 	//   - Session ID and Session recording ID for Session recordings
 	//   - Connection ID and Connection recording ID for Connection recordings
 	//   - Channel recording ID for Channel recordings
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The format of the response. The only supported mime type is "application/x-asciicast".
 	// Defaults to "application/x-asciicast" if not set.
-	MimeType string `protobuf:"bytes,2,opt,name=mime_type,proto3" json:"mime_type,omitempty" class:"public"` // @gotags: class:"public"
+	MimeType string `protobuf:"bytes,2,opt,name=mime_type,proto3" json:"mime_type,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 }
 
 func (x *DownloadRequest) Reset() {
@@ -384,7 +384,7 @@ type ReApplyStoragePolicyRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The Session Recording ID
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 }
 
 func (x *ReApplyStoragePolicyRequest) Reset() {
@@ -479,7 +479,7 @@ type DeleteSessionRecordingRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: `class:"public"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 }
 
 func (x *DeleteSessionRecordingRequest) Reset() {

--- a/internal/proto/controller/api/resources/sessionrecordings/v1/session_recording.proto
+++ b/internal/proto/controller/api/resources/sessionrecordings/v1/session_recording.proto
@@ -18,62 +18,62 @@ option go_package = "github.com/hashicorp/boundary/sdk/pbs/controller/api/resour
 // Channels are only present in multiplexed protocols, such as SSH.
 message ChannelRecording {
   // The ID of the Channel recording.
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 
   // The total number of bytes uploaded from the client in the Channel.
-  uint64 bytes_up = 2 [json_name = "bytes_up"]; // @gotags: class:"public"
+  uint64 bytes_up = 2 [json_name = "bytes_up"]; // @gotags: class:"public" eventstream:"observation"
 
   // The total number of bytes downloaded to the client in the Channel.
-  uint64 bytes_down = 3 [json_name = "bytes_down"]; // @gotags: class:"public"
+  uint64 bytes_down = 3 [json_name = "bytes_down"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time the Channel was created in the controller.
-  google.protobuf.Timestamp created_time = 4 [json_name = "created_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp created_time = 4 [json_name = "created_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time of the most recent update to the Channel.
-  google.protobuf.Timestamp updated_time = 5 [json_name = "updated_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp updated_time = 5 [json_name = "updated_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time the Channel started.
-  google.protobuf.Timestamp start_time = 6 [json_name = "start_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp start_time = 6 [json_name = "start_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time the Channel ended.
-  google.protobuf.Timestamp end_time = 7 [json_name = "end_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp end_time = 7 [json_name = "end_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The total duration of the Channel.
-  google.protobuf.Duration duration = 8; // @gotags: class:"public"
+  google.protobuf.Duration duration = 8; // @gotags: class:"public" eventstream:"observation"
 
   // MimeTypes define the mime types that can
   // be used to consume the recording of this Channel.
   // The only supported mime type is "application/x-asciicast".
-  repeated string mime_types = 9 [json_name = "mime_types"]; // @gotags: class:"public"
+  repeated string mime_types = 9 [json_name = "mime_types"]; // @gotags: class:"public" eventstream:"observation"
 }
 
 // ConnectionRecording contains the recording of a single Connection within a Session.
 message ConnectionRecording {
   // The ID of the Connection recording.
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 
   // The total number of bytes uploaded from the client in the Connection.
   // This includes any protocol overhead.
-  uint64 bytes_up = 2 [json_name = "bytes_up"]; // @gotags: class:"public"
+  uint64 bytes_up = 2 [json_name = "bytes_up"]; // @gotags: class:"public" eventstream:"observation"
 
   // The total number of bytes downloaded to the client in the Connection.
   // This includes any protocol overhead.
-  uint64 bytes_down = 3 [json_name = "bytes_down"]; // @gotags: class:"public"
+  uint64 bytes_down = 3 [json_name = "bytes_down"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time the Connection was created in the controller.
-  google.protobuf.Timestamp created_time = 4 [json_name = "created_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp created_time = 4 [json_name = "created_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time of the most recent update to the Connection.
-  google.protobuf.Timestamp updated_time = 5 [json_name = "updated_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp updated_time = 5 [json_name = "updated_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time the Connection started.
-  google.protobuf.Timestamp start_time = 6 [json_name = "start_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp start_time = 6 [json_name = "start_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time the Connection ended.
-  google.protobuf.Timestamp end_time = 7 [json_name = "end_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp end_time = 7 [json_name = "end_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The total duration of the Connection.
-  google.protobuf.Duration duration = 8; // @gotags: class:"public"
+  google.protobuf.Duration duration = 8; // @gotags: class:"public" eventstream:"observation"
 
   // MimeTypes define the mime types that can
   // be used to consume the recording of this Connection.
@@ -88,7 +88,7 @@ message ConnectionRecording {
 // User describes an authenticated user in Boundary.
 message User {
   // The ID of the User.
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 
   // The name of the User that created the Session.
   string name = 2; // @gotags: class:"sensitive"
@@ -104,13 +104,13 @@ message User {
 // recorded session.
 message HostCatalog {
   // The ID of the Host Catalog
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 
   // The scope that the Host Catalog is in
-  resources.scopes.v1.ScopeInfo scope = 2; // @gotags: class:"public"
+  resources.scopes.v1.ScopeInfo scope = 2;
 
   // The plugin id used by this Host Catalog, if any.
-  string plugin_id = 3 [json_name = "plugin_id"]; // @gotags: class:"public"
+  string plugin_id = 3 [json_name = "plugin_id"]; // @gotags: class:"public" eventstream:"observation"
 
   // The name of the Host Catalog, if set
   string name = 4; // @gotags: class:"public"
@@ -119,7 +119,7 @@ message HostCatalog {
   string description = 5; // @gotags: class:"public"
 
   // The type of the Host Catalog.  This will be either "static" or "plugin"
-  string type = 6; // @gotags: class:"public"
+  string type = 6; // @gotags: class:"public" eventstream:"observation"
 
   oneof attrs {
     // The attributes of the Host Catalog.
@@ -130,10 +130,10 @@ message HostCatalog {
 // Host describes the Host that was chosen for the recorded session.
 message Host {
   // The ID of the Host
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 
   // The Host Catalog this Host is in
-  HostCatalog host_catalog = 2 [json_name = "host_catalog"]; // @gotags: class:"public"
+  HostCatalog host_catalog = 2 [json_name = "host_catalog"];
 
   // The name of the Host, if set.
   string name = 3; // @gotags: class:"public"
@@ -142,7 +142,7 @@ message Host {
   string description = 4; // @gotags: class:"public"
 
   // The type of the host. This will be either "static" or "plugin"
-  string type = 5; // @gotags: class:"public"
+  string type = 5; // @gotags: class:"public" eventstream:"observation"
 
   oneof attrs {
     // Here we use the google.protobuf.Struct so the generated structs in
@@ -174,7 +174,7 @@ message StaticHostAttributes {
 // Target describes a target in Boundary.
 message Target {
   // The ID of the Target.
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 
   // The name of the Target, if set.
   string name = 2; // @gotags: class:"public"
@@ -186,10 +186,10 @@ message Target {
   resources.scopes.v1.ScopeInfo scope = 4;
 
   // Maximum total lifetime of a created Session, in seconds.
-  uint32 session_max_seconds = 5 [json_name = "session_max_seconds"]; // @gotags: class:"public"
+  uint32 session_max_seconds = 5 [json_name = "session_max_seconds"]; // @gotags: class:"public" eventstream:"observation"
 
   // Maximum number of connections allowed in a Session.  Unlimited is indicated by the value -1.
-  int32 session_connection_limit = 6 [json_name = "session_connection_limit"]; // @gotags: class:"public"
+  int32 session_connection_limit = 6 [json_name = "session_connection_limit"]; // @gotags: class:"public" eventstream:"observation"
 
   // Optional boolean expression to filter the workers that are allowed to satisfy this request.
   string worker_filter = 7 [json_name = "worker_filter"]; // @gotags: class:"public"
@@ -201,7 +201,7 @@ message Target {
   string ingress_worker_filter = 9 [json_name = "ingress_worker_filter"]; // @gotags: class:"public"
 
   // The type of the Target.
-  string type = 10; // @gotags: `class:"public"`
+  string type = 10; // @gotags: class:"public" eventstream:"observation"
 
   oneof attrs {
     // Here we use the google.protobuf.Struct so the generated structs in
@@ -231,10 +231,10 @@ message SshTargetAttributes {
 // CredentialStore contains all fields related to a Credential Store resource
 message CredentialStore {
   // The ID of the Credential Store.
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 
   // The ID of the Scope of which this Credential Store is a part.
-  string scope_id = 2 [json_name = "scope_id"]; // @gotags: class:"public"
+  string scope_id = 2 [json_name = "scope_id"]; // @gotags: class:"public" eventstream:"observation"
 
   // The name for identification purposes if set.
   string name = 3; // @gotags: class:"public"
@@ -243,7 +243,7 @@ message CredentialStore {
   string description = 4; // @gotags: class:"public"
 
   // The Credential Store type.
-  string type = 5; // @gotags: class:"public"
+  string type = 5; // @gotags: class:"public" eventstream:"observation"
 
   oneof attrs {
     // The attributes that are applicable for the specific Credential Store type.
@@ -276,10 +276,10 @@ message VaultCredentialStoreAttributes {
 // Credential contains fields related to an Credential resource
 message Credential {
   // The ID of the Credential.
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 
   // The Credential Store of which this Credential is a part.
-  CredentialStore credential_store = 2 [json_name = "credential_store"]; // @gotags: class:"public"
+  CredentialStore credential_store = 2 [json_name = "credential_store"];
 
   // The name of the credential.
   string name = 3; // @gotags: class:"public"
@@ -291,7 +291,7 @@ message Credential {
   repeated string purposes = 5; // @gotags: class:"public"
 
   // The Credential type.
-  string type = 6; // @gotags: class:"public"
+  string type = 6; // @gotags: class:"public" eventstream:"observation"
 
   oneof attrs {
     // The attributes that are applicable for the specific Credential type.
@@ -341,10 +341,10 @@ message JsonCredentialAttributes {
 // CredentialLibrary contains all fields related to an Credential Library resource
 message CredentialLibrary {
   // The ID of the Credential Library.
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 
   // The credential store of which this library is a part.
-  CredentialStore credential_store = 2 [json_name = "credential_store"]; // @gotags: class:"public"
+  CredentialStore credential_store = 2 [json_name = "credential_store"];
 
   //  Optional name of this Credential Library.
   string name = 3; // @gotags: class:"public"
@@ -356,7 +356,7 @@ message CredentialLibrary {
   repeated string purposes = 5; // @gotags: class:"public"
 
   // The Credential Library type.
-  string type = 6; // @gotags: class:"public"
+  string type = 6; // @gotags: class:"public" eventstream:"observation"
 
   oneof attrs {
     // The attributes that are applicable for the specific Credential Library type.
@@ -445,42 +445,42 @@ message SessionRecording {
   resources.scopes.v1.ScopeInfo scope = 2; // @gotags: class:"public"
 
   // The ID of the Session which this Session Recording recorded.
-  string session_id = 3 [json_name = "session_id"]; // @gotags: class:"public"
+  string session_id = 3 [json_name = "session_id"]; // @gotags: class:"public" eventstream:"observation"
 
   // The ID of the Storage Bucket for the Target of this Session Recording.
-  string storage_bucket_id = 4 [json_name = "storage_bucket_id"]; // @gotags: class:"public"
+  string storage_bucket_id = 4 [json_name = "storage_bucket_id"]; // @gotags: class:"public" eventstream:"observation"
 
   // The total number of bytes uploaded from the client in the Session.
   // This includes all bytes uploaded over all Connections, including
   // any protocol overhead.
-  uint64 bytes_up = 5 [json_name = "bytes_up"]; // @gotags: class:"public"
+  uint64 bytes_up = 5 [json_name = "bytes_up"]; // @gotags: class:"public" eventstream:"observation"
 
   // The total number of bytes downloaded to the client in the Session.
   // This includes all bytes downloaded over all Connections, including
   // any protocol overhead.
-  uint64 bytes_down = 6 [json_name = "bytes_down"]; // @gotags: class:"public"
+  uint64 bytes_down = 6 [json_name = "bytes_down"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time the Session Recording was created in the controller.
-  google.protobuf.Timestamp created_time = 7 [json_name = "created_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp created_time = 7 [json_name = "created_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time of the most recent update to the Session Recording.
-  google.protobuf.Timestamp updated_time = 8 [json_name = "updated_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp updated_time = 8 [json_name = "updated_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time the Session started.
-  google.protobuf.Timestamp start_time = 9 [json_name = "start_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp start_time = 9 [json_name = "start_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time the Session ended.
-  google.protobuf.Timestamp end_time = 10 [json_name = "end_time"]; // @gotags: class:"public"
+  google.protobuf.Timestamp end_time = 10 [json_name = "end_time"]; // @gotags: class:"public" eventstream:"observation"
 
   // The total duration of the Session.
-  google.protobuf.Duration duration = 11; // @gotags: class:"public"
+  google.protobuf.Duration duration = 11; // @gotags: class:"public" eventstream:"observation"
 
   // Type of the Session that was recorded (e.g. ssh).
-  string type = 12; // @gotags: class:"public"
+  string type = 12; // @gotags: class:"public" eventstream:"observation"
 
   // The current state of the session recording. One of
   // "started", "available" and "unknown".
-  string state = 13; // @gotags: class:"public"
+  string state = 13; // @gotags: class:"public" eventstream:"observation"
 
   // Any error seen during the closing of the session recording.
   // Currently only set if state is "unknown".
@@ -489,7 +489,7 @@ message SessionRecording {
   // MimeTypes define the mime types that can
   // be used to consume the recording of this Session.
   // No mime types are currently supported.
-  repeated string mime_types = 15 [json_name = "mime_types"]; // @gotags: class:"public"
+  repeated string mime_types = 15 [json_name = "mime_types"]; // @gotags: class:"public" eventstream:"observation"
 
   // The endpoint of the Session; that is, the address to which the egress worker connected.
   string endpoint = 16; // @gotags: class:"public"
@@ -506,8 +506,8 @@ message SessionRecording {
   repeated string authorized_actions = 19 [json_name = "authorized_actions"]; // @gotags: class:"public"
 
   // The time until a session recording is required to be stored.
-  google.protobuf.Timestamp retain_until = 20 [json_name = "retain_until"]; // @gotags: class:"public"
+  google.protobuf.Timestamp retain_until = 20 [json_name = "retain_until"]; // @gotags: class:"public" eventstream:"observation"
 
   // The time a session recording is scheduled to be automatically deleted.
-  google.protobuf.Timestamp delete_after = 21 [json_name = "delete_after"]; // @gotags: class:"public"
+  google.protobuf.Timestamp delete_after = 21 [json_name = "delete_after"]; // @gotags: class:"public" eventstream:"observation"
 }

--- a/internal/proto/controller/api/services/v1/session_recording_service.proto
+++ b/internal/proto/controller/api/services/v1/session_recording_service.proto
@@ -76,7 +76,7 @@ service SessionRecordingService {
 
 message GetSessionRecordingRequest {
   // The ID of the Session recording, or the ID of the Session that was recorded.
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 }
 
 message GetSessionRecordingResponse {
@@ -87,11 +87,11 @@ message GetSessionRecordingResponse {
 message ListSessionRecordingsRequest {
   // The scope in which to list session recordings.
   // Must be set unless recursive is set.
-  string scope_id = 1; // @gotags: class:"public"
+  string scope_id = 1; // @gotags: class:"public" eventstream:"observation"
   // Whether to recurse into child scopes when listing.
   // If set and scope_id is empty, shows session recordings in
   // all scopes the caller has access to.
-  bool recursive = 2; // @gotags: class:"public"
+  bool recursive = 2; // @gotags: class:"public" eventstream:"observation"
   // An opaque token that Boundary uses to continue an existing iteration or
   // request updated items. If you do not specify a token, pagination
   // starts from the beginning. To learn more about list pagination
@@ -101,7 +101,7 @@ message ListSessionRecordingsRequest {
   // If you do not set a page size, Boundary uses the configured default page size.
   // If the page_size is greater than the default page size configured,
   // Boundary truncates the page size to this number.
-  uint32 page_size = 4 [json_name = "page_size"]; // @gotags: `class:"public"`
+  uint32 page_size = 4 [json_name = "page_size"]; // @gotags: class:"public" eventstream:"observation"
 }
 
 message ListSessionRecordingsResponse {
@@ -111,22 +111,22 @@ message ListSessionRecordingsResponse {
   // Delta signifies that this is part of a paginated result
   // or an update to a previously completed pagination.
   // Complete signifies that it is the last page.
-  string response_type = 2 [json_name = "response_type"]; // @gotags: `class:"public"`
+  string response_type = 2 [json_name = "response_type"]; // @gotags: class:"public" eventstream:"observation"
   // An opaque token used to continue an existing pagination or
   // request updated items. Use this token in the next list request
   // to request the next page.
   string list_token = 3 [json_name = "list_token"]; // @gotags: `class:"public"`
   // The name of the field which the items are sorted by.
-  string sort_by = 4 [json_name = "sort_by"]; // @gotags: `class:"public"`
+  string sort_by = 4 [json_name = "sort_by"]; // @gotags: class:"public" eventstream:"observation"
   // The direction of the sort, either "asc" or "desc".
-  string sort_dir = 5 [json_name = "sort_dir"]; // @gotags: `class:"public"`
+  string sort_dir = 5 [json_name = "sort_dir"]; // @gotags: class:"public" eventstream:"observation"
   // A list of item IDs that have been removed since they were returned
   // as part of a pagination. They should be dropped from any client cache.
   // This may contain items that are not known to the cache, if they were
   // created and deleted between listings.
-  repeated string removed_ids = 6 [json_name = "removed_ids"]; // @gotags: `class:"public"`
+  repeated string removed_ids = 6 [json_name = "removed_ids"]; // @gotags: class:"public" eventstream:"observation"
   // An estimate at the total items available. This may change during pagination.
-  uint32 est_item_count = 7 [json_name = "est_item_count"]; // @gotags: `class:"public"`
+  uint32 est_item_count = 7 [json_name = "est_item_count"]; // @gotags: class:"public" eventstream:"observation"
 }
 
 message DownloadRequest {
@@ -134,15 +134,15 @@ message DownloadRequest {
   //   - Session ID and Session recording ID for Session recordings
   //   - Connection ID and Connection recording ID for Connection recordings
   //   - Channel recording ID for Channel recordings
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
   // The format of the response. The only supported mime type is "application/x-asciicast".
   // Defaults to "application/x-asciicast" if not set.
-  string mime_type = 2 [json_name = "mime_type"]; // @gotags: class:"public"
+  string mime_type = 2 [json_name = "mime_type"]; // @gotags: class:"public" eventstream:"observation"
 }
 
 message ReApplyStoragePolicyRequest {
   // The Session Recording ID
-  string id = 1; // @gotags: class:"public"
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 }
 
 message ReApplyStoragePolicyResponse {
@@ -151,7 +151,7 @@ message ReApplyStoragePolicyResponse {
 }
 
 message DeleteSessionRecordingRequest {
-  string id = 1; // @gotags: `class:"public"`
+  string id = 1; // @gotags: class:"public" eventstream:"observation"
 }
 
 message DeleteSessionRecordingResponse {}

--- a/sdk/pbs/controller/api/resources/session_recordings/session_recording.pb.go
+++ b/sdk/pbs/controller/api/resources/session_recordings/session_recording.pb.go
@@ -37,25 +37,25 @@ type ChannelRecording struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the Channel recording.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The total number of bytes uploaded from the client in the Channel.
-	BytesUp uint64 `protobuf:"varint,2,opt,name=bytes_up,proto3" json:"bytes_up,omitempty" class:"public"` // @gotags: class:"public"
+	BytesUp uint64 `protobuf:"varint,2,opt,name=bytes_up,proto3" json:"bytes_up,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The total number of bytes downloaded to the client in the Channel.
-	BytesDown uint64 `protobuf:"varint,3,opt,name=bytes_down,proto3" json:"bytes_down,omitempty" class:"public"` // @gotags: class:"public"
+	BytesDown uint64 `protobuf:"varint,3,opt,name=bytes_down,proto3" json:"bytes_down,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time the Channel was created in the controller.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: class:"public"
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time of the most recent update to the Channel.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: class:"public"
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time the Channel started.
-	StartTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=start_time,proto3" json:"start_time,omitempty" class:"public"` // @gotags: class:"public"
+	StartTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=start_time,proto3" json:"start_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time the Channel ended.
-	EndTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=end_time,proto3" json:"end_time,omitempty" class:"public"` // @gotags: class:"public"
+	EndTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=end_time,proto3" json:"end_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The total duration of the Channel.
-	Duration *durationpb.Duration `protobuf:"bytes,8,opt,name=duration,proto3" json:"duration,omitempty" class:"public"` // @gotags: class:"public"
+	Duration *durationpb.Duration `protobuf:"bytes,8,opt,name=duration,proto3" json:"duration,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// MimeTypes define the mime types that can
 	// be used to consume the recording of this Channel.
 	// The only supported mime type is "application/x-asciicast".
-	MimeTypes []string `protobuf:"bytes,9,rep,name=mime_types,proto3" json:"mime_types,omitempty" class:"public"` // @gotags: class:"public"
+	MimeTypes []string `protobuf:"bytes,9,rep,name=mime_types,proto3" json:"mime_types,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 }
 
 func (x *ChannelRecording) Reset() {
@@ -160,23 +160,23 @@ type ConnectionRecording struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the Connection recording.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The total number of bytes uploaded from the client in the Connection.
 	// This includes any protocol overhead.
-	BytesUp uint64 `protobuf:"varint,2,opt,name=bytes_up,proto3" json:"bytes_up,omitempty" class:"public"` // @gotags: class:"public"
+	BytesUp uint64 `protobuf:"varint,2,opt,name=bytes_up,proto3" json:"bytes_up,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The total number of bytes downloaded to the client in the Connection.
 	// This includes any protocol overhead.
-	BytesDown uint64 `protobuf:"varint,3,opt,name=bytes_down,proto3" json:"bytes_down,omitempty" class:"public"` // @gotags: class:"public"
+	BytesDown uint64 `protobuf:"varint,3,opt,name=bytes_down,proto3" json:"bytes_down,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time the Connection was created in the controller.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: class:"public"
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time of the most recent update to the Connection.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: class:"public"
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time the Connection started.
-	StartTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=start_time,proto3" json:"start_time,omitempty" class:"public"` // @gotags: class:"public"
+	StartTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=start_time,proto3" json:"start_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time the Connection ended.
-	EndTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=end_time,proto3" json:"end_time,omitempty" class:"public"` // @gotags: class:"public"
+	EndTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=end_time,proto3" json:"end_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The total duration of the Connection.
-	Duration *durationpb.Duration `protobuf:"bytes,8,opt,name=duration,proto3" json:"duration,omitempty" class:"public"` // @gotags: class:"public"
+	Duration *durationpb.Duration `protobuf:"bytes,8,opt,name=duration,proto3" json:"duration,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// MimeTypes define the mime types that can
 	// be used to consume the recording of this Connection.
 	// No mime types are currently supported.
@@ -295,7 +295,7 @@ type User struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the User.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The name of the User that created the Session.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" class:"sensitive"` // @gotags: class:"sensitive"
 	// The description of the User that created the Session.
@@ -372,17 +372,17 @@ type HostCatalog struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the Host Catalog
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The scope that the Host Catalog is in
-	Scope *scopes.ScopeInfo `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty" class:"public"` // @gotags: class:"public"
+	Scope *scopes.ScopeInfo `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
 	// The plugin id used by this Host Catalog, if any.
-	PluginId string `protobuf:"bytes,3,opt,name=plugin_id,proto3" json:"plugin_id,omitempty" class:"public"` // @gotags: class:"public"
+	PluginId string `protobuf:"bytes,3,opt,name=plugin_id,proto3" json:"plugin_id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The name of the Host Catalog, if set
 	Name string `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty" class:"public"` // @gotags: class:"public"
 	// The description of the Host Catalog.
 	Description string `protobuf:"bytes,5,opt,name=description,proto3" json:"description,omitempty" class:"public"` // @gotags: class:"public"
 	// The type of the Host Catalog.  This will be either "static" or "plugin"
-	Type string `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: class:"public"
+	Type string `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// Types that are assignable to Attrs:
 	//
 	//	*HostCatalog_Attributes
@@ -495,15 +495,15 @@ type Host struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the Host
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The Host Catalog this Host is in
-	HostCatalog *HostCatalog `protobuf:"bytes,2,opt,name=host_catalog,proto3" json:"host_catalog,omitempty" class:"public"` // @gotags: class:"public"
+	HostCatalog *HostCatalog `protobuf:"bytes,2,opt,name=host_catalog,proto3" json:"host_catalog,omitempty"`
 	// The name of the Host, if set.
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty" class:"public"` // @gotags: class:"public"
 	// The description of the Host, if set.
 	Description string `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty" class:"public"` // @gotags: class:"public"
 	// The type of the host. This will be either "static" or "plugin"
-	Type string `protobuf:"bytes,5,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: class:"public"
+	Type string `protobuf:"bytes,5,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// Types that are assignable to Attrs:
 	//
 	//	*Host_Attributes
@@ -689,7 +689,7 @@ type Target struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the Target.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The name of the Target, if set.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" class:"public"` // @gotags: class:"public"
 	// The description of the Target, if set.
@@ -697,9 +697,9 @@ type Target struct {
 	// The scope that the Target is in.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Maximum total lifetime of a created Session, in seconds.
-	SessionMaxSeconds uint32 `protobuf:"varint,5,opt,name=session_max_seconds,proto3" json:"session_max_seconds,omitempty" class:"public"` // @gotags: class:"public"
+	SessionMaxSeconds uint32 `protobuf:"varint,5,opt,name=session_max_seconds,proto3" json:"session_max_seconds,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// Maximum number of connections allowed in a Session.  Unlimited is indicated by the value -1.
-	SessionConnectionLimit int32 `protobuf:"varint,6,opt,name=session_connection_limit,proto3" json:"session_connection_limit,omitempty" class:"public"` // @gotags: class:"public"
+	SessionConnectionLimit int32 `protobuf:"varint,6,opt,name=session_connection_limit,proto3" json:"session_connection_limit,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// Optional boolean expression to filter the workers that are allowed to satisfy this request.
 	WorkerFilter string `protobuf:"bytes,7,opt,name=worker_filter,proto3" json:"worker_filter,omitempty" class:"public"` // @gotags: class:"public"
 	// Optional boolean expressions to filter the egress workers that are allowed to satisfy this request.
@@ -707,7 +707,7 @@ type Target struct {
 	// Optional boolean expressions to filter the ingress workers that are allowed to satisfy this request.
 	IngressWorkerFilter string `protobuf:"bytes,9,opt,name=ingress_worker_filter,proto3" json:"ingress_worker_filter,omitempty" class:"public"` // @gotags: class:"public"
 	// The type of the Target.
-	Type string `protobuf:"bytes,10,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
+	Type string `protobuf:"bytes,10,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// Types that are assignable to Attrs:
 	//
 	//	*Target_Attributes
@@ -920,15 +920,15 @@ type CredentialStore struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the Credential Store.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The ID of the Scope of which this Credential Store is a part.
-	ScopeId string `protobuf:"bytes,2,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public"` // @gotags: class:"public"
+	ScopeId string `protobuf:"bytes,2,opt,name=scope_id,proto3" json:"scope_id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The name for identification purposes if set.
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty" class:"public"` // @gotags: class:"public"
 	// The description for identification purposes if set.
 	Description string `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty" class:"public"` // @gotags: class:"public"
 	// The Credential Store type.
-	Type string `protobuf:"bytes,5,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: class:"public"
+	Type string `protobuf:"bytes,5,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// Types that are assignable to Attrs:
 	//
 	//	*CredentialStore_Attributes
@@ -1133,9 +1133,9 @@ type Credential struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the Credential.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The Credential Store of which this Credential is a part.
-	CredentialStore *CredentialStore `protobuf:"bytes,2,opt,name=credential_store,proto3" json:"credential_store,omitempty" class:"public"` // @gotags: class:"public"
+	CredentialStore *CredentialStore `protobuf:"bytes,2,opt,name=credential_store,proto3" json:"credential_store,omitempty"`
 	// The name of the credential.
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty" class:"public"` // @gotags: class:"public"
 	// Optional user-set description.
@@ -1143,7 +1143,7 @@ type Credential struct {
 	// The purposes for which this Credential was attached to the sesssion.
 	Purposes []string `protobuf:"bytes,5,rep,name=purposes,proto3" json:"purposes,omitempty" class:"public"` // @gotags: class:"public"
 	// The Credential type.
-	Type string `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: class:"public"
+	Type string `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// Types that are assignable to Attrs:
 	//
 	//	*Credential_Attributes
@@ -1472,9 +1472,9 @@ type CredentialLibrary struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The ID of the Credential Library.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public"` // @gotags: class:"public"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The credential store of which this library is a part.
-	CredentialStore *CredentialStore `protobuf:"bytes,2,opt,name=credential_store,proto3" json:"credential_store,omitempty" class:"public"` // @gotags: class:"public"
+	CredentialStore *CredentialStore `protobuf:"bytes,2,opt,name=credential_store,proto3" json:"credential_store,omitempty"`
 	// Optional name of this Credential Library.
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty" class:"public"` // @gotags: class:"public"
 	// Optional user-set description of this Credential Library.
@@ -1482,7 +1482,7 @@ type CredentialLibrary struct {
 	// The purposes for which this CredentialLibrary was attached to the sesssion.
 	Purposes []string `protobuf:"bytes,5,rep,name=purposes,proto3" json:"purposes,omitempty" class:"public"` // @gotags: class:"public"
 	// The Credential Library type.
-	Type string `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: class:"public"
+	Type string `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// Types that are assignable to Attrs:
 	//
 	//	*CredentialLibrary_Attributes
@@ -1909,39 +1909,39 @@ type SessionRecording struct {
 	// with the target.
 	Scope *scopes.ScopeInfo `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty" class:"public"` // @gotags: class:"public"
 	// The ID of the Session which this Session Recording recorded.
-	SessionId string `protobuf:"bytes,3,opt,name=session_id,proto3" json:"session_id,omitempty" class:"public"` // @gotags: class:"public"
+	SessionId string `protobuf:"bytes,3,opt,name=session_id,proto3" json:"session_id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The ID of the Storage Bucket for the Target of this Session Recording.
-	StorageBucketId string `protobuf:"bytes,4,opt,name=storage_bucket_id,proto3" json:"storage_bucket_id,omitempty" class:"public"` // @gotags: class:"public"
+	StorageBucketId string `protobuf:"bytes,4,opt,name=storage_bucket_id,proto3" json:"storage_bucket_id,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The total number of bytes uploaded from the client in the Session.
 	// This includes all bytes uploaded over all Connections, including
 	// any protocol overhead.
-	BytesUp uint64 `protobuf:"varint,5,opt,name=bytes_up,proto3" json:"bytes_up,omitempty" class:"public"` // @gotags: class:"public"
+	BytesUp uint64 `protobuf:"varint,5,opt,name=bytes_up,proto3" json:"bytes_up,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The total number of bytes downloaded to the client in the Session.
 	// This includes all bytes downloaded over all Connections, including
 	// any protocol overhead.
-	BytesDown uint64 `protobuf:"varint,6,opt,name=bytes_down,proto3" json:"bytes_down,omitempty" class:"public"` // @gotags: class:"public"
+	BytesDown uint64 `protobuf:"varint,6,opt,name=bytes_down,proto3" json:"bytes_down,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time the Session Recording was created in the controller.
-	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public"` // @gotags: class:"public"
+	CreatedTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=created_time,proto3" json:"created_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time of the most recent update to the Session Recording.
-	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public"` // @gotags: class:"public"
+	UpdatedTime *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=updated_time,proto3" json:"updated_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time the Session started.
-	StartTime *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=start_time,proto3" json:"start_time,omitempty" class:"public"` // @gotags: class:"public"
+	StartTime *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=start_time,proto3" json:"start_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time the Session ended.
-	EndTime *timestamppb.Timestamp `protobuf:"bytes,10,opt,name=end_time,proto3" json:"end_time,omitempty" class:"public"` // @gotags: class:"public"
+	EndTime *timestamppb.Timestamp `protobuf:"bytes,10,opt,name=end_time,proto3" json:"end_time,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The total duration of the Session.
-	Duration *durationpb.Duration `protobuf:"bytes,11,opt,name=duration,proto3" json:"duration,omitempty" class:"public"` // @gotags: class:"public"
+	Duration *durationpb.Duration `protobuf:"bytes,11,opt,name=duration,proto3" json:"duration,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// Type of the Session that was recorded (e.g. ssh).
-	Type string `protobuf:"bytes,12,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: class:"public"
+	Type string `protobuf:"bytes,12,opt,name=type,proto3" json:"type,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The current state of the session recording. One of
 	// "started", "available" and "unknown".
-	State string `protobuf:"bytes,13,opt,name=state,proto3" json:"state,omitempty" class:"public"` // @gotags: class:"public"
+	State string `protobuf:"bytes,13,opt,name=state,proto3" json:"state,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// Any error seen during the closing of the session recording.
 	// Currently only set if state is "unknown".
 	ErrorDetails string `protobuf:"bytes,14,opt,name=error_details,json=errorDetails,proto3" json:"error_details,omitempty" class:"public"` // @gotags: class:"public"
 	// MimeTypes define the mime types that can
 	// be used to consume the recording of this Session.
 	// No mime types are currently supported.
-	MimeTypes []string `protobuf:"bytes,15,rep,name=mime_types,proto3" json:"mime_types,omitempty" class:"public"` // @gotags: class:"public"
+	MimeTypes []string `protobuf:"bytes,15,rep,name=mime_types,proto3" json:"mime_types,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The endpoint of the Session; that is, the address to which the egress worker connected.
 	Endpoint string `protobuf:"bytes,16,opt,name=endpoint,proto3" json:"endpoint,omitempty" class:"public"` // @gotags: class:"public"
 	// The recordings of the connections that were created in the Session.
@@ -1953,9 +1953,9 @@ type SessionRecording struct {
 	// The available actions on this resource for this user.
 	AuthorizedActions []string `protobuf:"bytes,19,rep,name=authorized_actions,proto3" json:"authorized_actions,omitempty" class:"public"` // @gotags: class:"public"
 	// The time until a session recording is required to be stored.
-	RetainUntil *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=retain_until,proto3" json:"retain_until,omitempty" class:"public"` // @gotags: class:"public"
+	RetainUntil *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=retain_until,proto3" json:"retain_until,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 	// The time a session recording is scheduled to be automatically deleted.
-	DeleteAfter *timestamppb.Timestamp `protobuf:"bytes,21,opt,name=delete_after,proto3" json:"delete_after,omitempty" class:"public"` // @gotags: class:"public"
+	DeleteAfter *timestamppb.Timestamp `protobuf:"bytes,21,opt,name=delete_after,proto3" json:"delete_after,omitempty" class:"public" eventstream:"observation"` // @gotags: class:"public" eventstream:"observation"
 }
 
 func (x *SessionRecording) Reset() {


### PR DESCRIPTION
Recreates auto-generated https://github.com/hashicorp/boundary/pull/4826.

Adds observation tags to fields Session Recording Service messages.