### PR TITLE
chore(e2e): Add aws region to UI tests

### DIFF
--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -207,6 +207,7 @@ scenario "e2e_ui_aws" {
       aws_host_set_filter       = step.create_tag_inputs.tag_string
       aws_host_set_ips          = step.create_targets_with_tag.target_ips
       worker_tag_egress         = local.egress_tag
+      aws_region                = var.aws_region
     }
   }
 


### PR DESCRIPTION
This PR adds something that was missing from https://github.com/hashicorp/boundary/pull/4814.

One e2e scenario (the AWS scenario for Admin UI tests) should also use the AWS region specified.