### PR TITLE
docs: Update release notes for 0.16.1

### DIFF
--- a/website/content/docs/release-notes/v0_16_0.mdx
+++ b/website/content/docs/release-notes/v0_16_0.mdx
@@ -147,6 +147,8 @@ description: |-
   <tr>
     <td style={{verticalAlign: 'middle'}}>
     0.16.0
+    <br /><br />
+    (Fixed in 0.16.1 for Community and Enterprise editions)
     </td>
     <td style={{verticalAlign: 'middle'}}>
     Controller dead lock with database connections stuck in <code>idle in transaction</code> state
@@ -156,7 +158,7 @@ description: |-
     <br /><br />
     The cause of this problem was due to a combination of issues including the lack of a request timeout for worker-to-controller GRPC requests, and the session repository attempting to use a separate database connection to retrieve a KMS wrapper, after already starting a database transaction.
     <br /><br />
-    This issue is fixed in release 0.16.1. KMS operations now occur outside of the transaction, and a max request duration for GRPC requests is now set based on the cluster's listener configuration.
+    This issue is fixed in release 0.16.1 for Community and Enterprise editions. KMS operations now occur outside of the transaction, and a max request duration for GRPC requests is now set based on the cluster's listener configuration.
     <br /><br />
     <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
     </td>

--- a/website/content/docs/release-notes/v0_16_0.mdx
+++ b/website/content/docs/release-notes/v0_16_0.mdx
@@ -156,9 +156,9 @@ description: |-
     <td style={{verticalAlign: 'middle'}}>
     If you configured a controller to have the maximum number of open connections and it was under enough load from worker requests, the controller could get stuck. Once the controller consumed all the database connections, it would leave them in an <code>idle in transaction</code> state. In extreme cases, this could cause Boundary clusters to become unresponsive.
     <br /><br />
-    The cause of this problem was due to a combination of issues. It included the lack of a request timeout for worker-to-controller GRPC requests. The session repository also attempted to use a separate database connection to retrieve a KMS wrapper after already starting a database transaction.
+    The cause of this problem was due to a combination of issues. There was no request timeout for worker-to-controller GRPC requests. Also, the session repository attempted to use a separate database connection to retrieve a KMS wrapper after already starting a database transaction.
     <br /><br />
-    This issue is fixed in release 0.16.1 for the Community and Enterprise editions. KMS operations now occur outside of the transaction. Boundary also now sets a max request duration for GRPC requests based on the cluster's listener configuration.
+    This issue is fixed in release 0.16.1 for the Community and Enterprise editions. Boundary now sets a max request duration for GRPC requests based on the cluster's listener configuration. KMS operations now occur outside of the transaction.
     <br /><br />
     <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
     </td>

--- a/website/content/docs/release-notes/v0_16_0.mdx
+++ b/website/content/docs/release-notes/v0_16_0.mdx
@@ -144,5 +144,22 @@ description: |-
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.16.0
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Controller dead lock with database connections stuck in <code>idle in transaction</code> state
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    If you configured a controller to have the maximum number of open connections and it was under enough load from worker requests, the controller can get stuck. Once the controller consumed all of the database connections, it would leave them in an <code>idle in transaction</code> state. In extreme cases, this can cause Boundary clusters to become unresponsive.
+    <br /><br />
+    The cause of this problem was due to a combination of issues including the lack of a request timeout for worker-to-controller GRPC requests, and the session repository attempting to use a separate database connection to retrieve a KMS wrapper, after already starting a database transaction.
+    <br /><br />
+    This issue is fixed in release 0.16.1. KMS operations now occur outside of the transaction, and a max request duration for GRPC requests is now set based on the cluster's listener configuration.
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
   </tbody>
 </table>

--- a/website/content/docs/release-notes/v0_16_0.mdx
+++ b/website/content/docs/release-notes/v0_16_0.mdx
@@ -154,11 +154,11 @@ description: |-
     Controller dead lock with database connections stuck in <code>idle in transaction</code> state
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    If you configured a controller to have the maximum number of open connections and it was under enough load from worker requests, the controller can get stuck. Once the controller consumed all of the database connections, it would leave them in an <code>idle in transaction</code> state. In extreme cases, this can cause Boundary clusters to become unresponsive.
+    If you configured a controller to have the maximum number of open connections and it was under enough load from worker requests, the controller could get stuck. Once the controller consumed all the database connections, it would leave them in an <code>idle in transaction</code> state. In extreme cases, this could cause Boundary clusters to become unresponsive.
     <br /><br />
-    The cause of this problem was due to a combination of issues including the lack of a request timeout for worker-to-controller GRPC requests, and the session repository attempting to use a separate database connection to retrieve a KMS wrapper, after already starting a database transaction.
+    The cause of this problem was due to a combination of issues. It included the lack of a request timeout for worker-to-controller GRPC requests. The session repository also attempted to use a separate database connection to retrieve a KMS wrapper after already starting a database transaction.
     <br /><br />
-    This issue is fixed in release 0.16.1 for Community and Enterprise editions. KMS operations now occur outside of the transaction, and a max request duration for GRPC requests is now set based on the cluster's listener configuration.
+    This issue is fixed in release 0.16.1 for the Community and Enterprise editions. KMS operations now occur outside of the transaction. Boundary also now sets a max request duration for GRPC requests based on the cluster's listener configuration.
     <br /><br />
     <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
     </td>


### PR DESCRIPTION
This PR updates the 0.16.0 release notes with a known/resolved issue for release 0.16.1. The issue caused controllers to get stuck when they were under sufficient load from worker requests. This issue is fixed in Community and Enterprise in release 0.16.1. HCP Boundary will be fixed in a subsequent release.

View the update in the preview deployment:

https://boundary-i5g1z0nmi-hashicorp.vercel.app/boundary/docs/release-notes/v0_16_0#known-issues-and-breaking-changes