### PR TITLE
chore(e2e): Clean up UI docker scenario

### DIFF
--- a/enos/enos-scenario-e2e-ui-docker.hcl
+++ b/enos/enos-scenario-e2e-ui-docker.hcl
@@ -134,26 +134,6 @@ scenario "e2e_ui_docker" {
     }
   }
 
-  step "create_worker_token" {
-    module = module.docker_worker
-    depends_on = [
-      step.create_docker_network,
-      step.build_boundary_docker_image,
-      step.create_boundary
-    ]
-    variables {
-      image_name              = matrix.builder == "crt" ? var.boundary_docker_image_name : step.build_boundary_docker_image.image_name
-      boundary_license        = var.boundary_edition != "oss" ? step.read_license.license : ""
-      config_file             = "worker-config-worker-led.hcl"
-      container_name          = "worker_token"
-      initial_upstream        = step.create_boundary.upstream_address
-      network_name            = [local.network_cluster]
-      tags                    = ["token"]
-      port                    = "9502"
-      worker_led_registration = true
-    }
-  }
-
   step "create_ldap_server" {
     module = module.docker_ldap
     depends_on = [
@@ -171,6 +151,7 @@ scenario "e2e_ui_docker" {
       step.create_boundary,
       step.create_vault,
       step.create_host,
+      step.create_worker,
       step.create_ldap_server,
     ]
     variables {
@@ -198,7 +179,6 @@ scenario "e2e_ui_docker" {
       ldap_user_name            = step.create_ldap_server.user_name
       ldap_user_password        = step.create_ldap_server.user_password
       ldap_group_name           = step.create_ldap_server.group_name
-      worker_token              = step.create_worker_token.worker_led_token
       worker_tag_egress         = local.egress_tag
     }
   }

--- a/enos/modules/test_e2e_ui/main.tf
+++ b/enos/modules/test_e2e_ui/main.tf
@@ -143,11 +143,6 @@ variable "bucket_name" {
   type        = string
   default     = ""
 }
-variable "bucket_user_id" {
-  description = "User ID created in bucket"
-  type        = string
-  default     = ""
-}
 variable "bucket_endpoint_url" {
   description = "Endpoint URL for the storage bucket"
   type        = string
@@ -229,7 +224,6 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_AWS_BUCKET_NAME           = var.aws_bucket_name
     E2E_BUCKET_NAME               = var.bucket_name
     E2E_BUCKET_ENDPOINT_URL       = var.bucket_endpoint_url
-    E2E_BUCKET_USER_ID            = var.bucket_user_id
     E2E_BUCKET_ACCESS_KEY_ID      = var.access_key_id
     E2E_BUCKET_SECRET_ACCESS_KEY  = var.secret_access_key
     E2E_REGION                    = var.region


### PR DESCRIPTION
This PR is both a clean up of the UI docker e2e test scenario as well as a follow-up to https://github.com/hashicorp/boundary/pull/4840.
- This scenario previously set up an extra docker container for a worker in order to generate a worker token. However, I think we need to rethink that approach as a worker token is a one-time use token and we want to run tests on each browser type
- In the above PR, we added some variables to support an Admin UI MinIO test. One of the variables added was not necessary.