### PR TITLE
test: Fix tests due to time

### DIFF
--- a/internal/billing/repository_test.go
+++ b/internal/billing/repository_test.go
@@ -74,8 +74,16 @@ func TestRepository_MonthlyActiveUsers(t *testing.T) {
 	TestGenerateActiveUsers(t, conn)
 
 	today := time.Now().UTC()
-	threeMonthsAgo := time.Date(today.AddDate(0, -3, 0).Year(), today.AddDate(0, -3, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
-	oneMonthAgo := time.Date(today.AddDate(0, -1, 0).Year(), today.AddDate(0, -1, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
+	// Some time calculations are impacted when using the current day vs. the
+	// start of the month. For example, if...
+	// today -> May 30th
+	// today.AddDate(0, -3, 0).Month() -> March
+	// February was expcted here, but we get March. This seems to be a
+	// rounding thing since February 30th is not a valid date. Instead, the
+	// start of the month is used to ensure the correct months are calculated.
+	monthStart := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, time.UTC)
+	threeMonthsAgo := time.Date(monthStart.AddDate(0, -3, 0).Year(), monthStart.AddDate(0, -3, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
+	oneMonthAgo := time.Date(monthStart.AddDate(0, -1, 0).Year(), monthStart.AddDate(0, -1, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
 	midMonth := time.Date(today.Year(), today.Month(), 15, 0, 0, 0, 0, time.UTC)
 
 	t.Run("valid-no-options", func(t *testing.T) {
@@ -125,14 +133,14 @@ func TestRepository_MonthlyActiveUsers(t *testing.T) {
 		activeUsers, err := repo.MonthlyActiveUsers(ctx, WithStartTime(&threeMonthsAgo), WithEndTime(&oneMonthAgo))
 		assert.NoError(t, err)
 		require.Len(t, activeUsers, 2)
-		expectedStartTime := time.Date(today.AddDate(0, -2, 0).Year(), today.AddDate(0, -2, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
-		expectedEndTime := time.Date(today.AddDate(0, -1, 0).Year(), today.AddDate(0, -1, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
+		expectedStartTime := time.Date(monthStart.AddDate(0, -2, 0).Year(), monthStart.AddDate(0, -2, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
+		expectedEndTime := time.Date(monthStart.AddDate(0, -1, 0).Year(), monthStart.AddDate(0, -1, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
 		require.Equal(t, uint32(6), activeUsers[0].ActiveUsersCount)
 		assert.Equal(t, expectedStartTime, activeUsers[0].StartTime)
 		assert.Equal(t, expectedEndTime, activeUsers[0].EndTime)
 
-		expectedStartTime = time.Date(today.AddDate(0, -3, 0).Year(), today.AddDate(0, -3, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
-		expectedEndTime = time.Date(today.AddDate(0, -2, 0).Year(), today.AddDate(0, -2, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
+		expectedStartTime = time.Date(monthStart.AddDate(0, -3, 0).Year(), monthStart.AddDate(0, -3, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
+		expectedEndTime = time.Date(monthStart.AddDate(0, -2, 0).Year(), monthStart.AddDate(0, -2, 0).Month(), 1, 0, 0, 0, 0, time.UTC)
 		require.Equal(t, uint32(6), activeUsers[1].ActiveUsersCount)
 		assert.Equal(t, expectedStartTime, activeUsers[1].StartTime)
 		assert.Equal(t, expectedEndTime, activeUsers[1].EndTime)

--- a/internal/billing/repository_test.go
+++ b/internal/billing/repository_test.go
@@ -78,7 +78,7 @@ func TestRepository_MonthlyActiveUsers(t *testing.T) {
 	// start of the month. For example, if...
 	// today -> May 30th
 	// today.AddDate(0, -3, 0).Month() -> March
-	// February was expcted here, but we get March. This seems to be a
+	// February was expected here, but we get March. This seems to be a
 	// rounding thing since February 30th is not a valid date. Instead, the
 	// start of the month is used to ensure the correct months are calculated.
 	monthStart := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, time.UTC)

--- a/internal/daemon/controller/handlers/billing/billing_service_test.go
+++ b/internal/daemon/controller/handlers/billing/billing_service_test.go
@@ -45,7 +45,7 @@ func Test_MonthlyActiveUsers(t *testing.T) {
 	// start of the month. For example, if...
 	// today -> May 30th
 	// today.AddDate(0, -3, 0).Month() -> March
-	// February was expcted here, but we get March. This seems to be a
+	// February was expected here, but we get March. This seems to be a
 	// rounding thing since February 30th is not a valid date. Instead, the
 	// start of the month is used to ensure the correct months are calculated.
 	monthStart := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, time.UTC)

--- a/internal/daemon/controller/handlers/billing/billing_service_test.go
+++ b/internal/daemon/controller/handlers/billing/billing_service_test.go
@@ -41,8 +41,16 @@ func Test_MonthlyActiveUsers(t *testing.T) {
 	}
 
 	today := time.Now().UTC()
-	threeMonthsAgo := time.Date(today.AddDate(0, -3, 0).Year(), today.AddDate(0, -3, 0).Month(), 1, 0, 0, 0, 0, time.UTC).Format("2006-01")
-	oneMonthAgo := time.Date(today.AddDate(0, -1, 0).Year(), today.AddDate(0, -1, 0).Month(), 1, 0, 0, 0, 0, time.UTC).Format("2006-01")
+	// Some time calculations are impacted when using the current day vs. the
+	// start of the month. For example, if...
+	// today -> May 30th
+	// today.AddDate(0, -3, 0).Month() -> March
+	// February was expcted here, but we get March. This seems to be a
+	// rounding thing since February 30th is not a valid date. Instead, the
+	// start of the month is used to ensure the correct months are calculated.
+	monthStart := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, time.UTC)
+	threeMonthsAgo := time.Date(monthStart.AddDate(0, -3, 0).Year(), monthStart.AddDate(0, -3, 0).Month(), 1, 0, 0, 0, 0, time.UTC).Format("2006-01")
+	oneMonthAgo := time.Date(monthStart.AddDate(0, -1, 0).Year(), monthStart.AddDate(0, -1, 0).Month(), 1, 0, 0, 0, 0, time.UTC).Format("2006-01")
 	badFormat := time.Date(today.Year(), today.Month(), 15, 0, 0, 0, 0, time.UTC).String()
 
 	cases := []struct {


### PR DESCRIPTION
This PR addresses two failing tests.

### Test 1
`TestRepository_MonthlyActiveUsers` was failing for the following reason
```
=== RUN   TestRepository_MonthlyActiveUsers/valid-with-start-time
    repository_test.go:102: 
                Error Trace:    /Users/mycow/Developer/boundary/internal/billing/repository_test.go:102
                Error:          "[{2024-05-01 00:00:00 +0000 UTC 2024-05-31 14:00:00 +0000 UTC 0} {2024-04-01 00:00:00 +0000 UTC 2024-05-01 00:00:00 +0000 UTC 6} {2024-03-01 00:00:00 +0000 UTC 2024-04-01 00:00:00 +0000 UTC 6}]" should have 4 item(s), but has 3
                Test:           TestRepository_MonthlyActiveUsers/valid-with-start-time
=== RUN   TestRepository_MonthlyActiveUsers/valid-with-start-and-end-time
    repository_test.go:131: 
                Error Trace:    /Users/mycow/Developer/boundary/internal/billing/repository_test.go:131
                Error:          Not equal: 
                                expected: time.Date(2024, time.March, 1, 0, 0, 0, 0, time.UTC)
                                actual  : time.Date(2024, time.April, 1, 0, 0, 0, 0, time.UTC)
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,2 +1,2 @@
                                -(time.Time) 2024-03-01 00:00:00 +0000 UTC
                                +(time.Time) 2024-04-01 00:00:00 +0000 UTC
                                 
                Test:           TestRepository_MonthlyActiveUsers/valid-with-start-and-end-time
    repository_test.go:138: 
                Error Trace:    /Users/mycow/Developer/boundary/internal/billing/repository_test.go:138
                Error:          Not equal: 
                                expected: time.Date(2024, time.March, 1, 0, 0, 0, 0, time.UTC)
                                actual  : time.Date(2024, time.April, 1, 0, 0, 0, 0, time.UTC)
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,2 +1,2 @@
                                -(time.Time) 2024-03-01 00:00:00 +0000 UTC
                                +(time.Time) 2024-04-01 00:00:00 +0000 UTC
                                 
                Test:           TestRepository_MonthlyActiveUsers/valid-with-start-and-end-time
```
This was due to an issue with calculating times relative to the current date. In this case, with today being May 31, `threeMonthsAgo` would return `March` instead of the expected `February`. This PR forces those calculations to use the start of the month to avoid differences in month duration.

### Test 2
`monthly_active_users_all_timezone.sql` was failing for the following reason
```
# Failed test 5
#     Results differ beginning at row 1:
#         have: (13)
#         want: (14)
# Failed test 6
#     Results differ beginning at row 2:
#         have: ("2024-04-01 13:00:00+13","2024-05-01 12:00:00+12",6)
#         want: ("2024-04-01 13:00:00+13","2024-05-01 12:00:00+12",0)
# Failed test 8
#     Results differ beginning at row 2:
#         have: ("2024-04-01 13:00:00+13","2024-05-01 12:00:00+12",6)
#         want: ("2024-04-01 13:00:00+13","2024-05-01 12:00:00+12",0)
# Failed test 10
#     Results differ beginning at row 10:
#         have: NULL
#         want: ("2023-04-01 13:00:00+13","2023-05-01 12:00:00+12",6)
```
This was due to an issue with timezones. The test sets up data in New Zealand time (e.g. June 1), but it's still May 31 in UTC time, resulting in some conflicts when querying for expected data. The fix follows a similar implementation as https://github.com/hashicorp/boundary/pull/3273/files to skip this test from running when it meets this condition. 