### PR TITLE
test(db): Fix skip command

### DIFF
--- a/internal/db/sqltest/tests/hcp/billing/monthly_active_users_all_timezone.sql
+++ b/internal/db/sqltest/tests/hcp/billing/monthly_active_users_all_timezone.sql
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
 begin;
-  select plan(27);
+  select plan(11);
 
   create function test_is_not_same_month(start_time timestamptz, end_time timestamptz) returns boolean
   as $$
@@ -94,7 +94,7 @@ begin;
 
   -- calling the view directly yields results at NZ month boundaries.
   select case when test_is_not_same_month('yesterday'::timestamptz, now())
-         then skip('certain tests don''t work on the first day of the month', 3)
+         then skip('certain tests don''t work on the first day of the month', 1)
          else results_eq(
            'select * from hcp_billing_monthly_active_users_all',
            $$
@@ -117,7 +117,7 @@ begin;
 
   -- calling the function yields results at UTC month boundaries.
   select case when test_is_not_same_month('yesterday'::timestamptz, now())
-         then skip('certain tests don''t work on the first day of the month', 3)
+         then skip('certain tests don''t work on the first day of the month', 1)
          else results_eq(
            'select count(*) from hcp_billing_monthly_active_users_all()',
            $$
@@ -125,7 +125,7 @@ begin;
            $$)
          end;
   select case when test_is_not_same_month('yesterday'::timestamptz, now())
-         then skip('certain tests don''t work on the first day of the month', 3)
+         then skip('certain tests don''t work on the first day of the month', 1)
          else results_eq(
            'select * from hcp_billing_monthly_active_users_all()',
            $$
@@ -146,14 +146,14 @@ begin;
            $$)
          end;
   select case when test_is_not_same_month('yesterday'::timestamptz, now())
-         then skip('certain tests don''t work on the first day of the month', 3)
+         then skip('certain tests don''t work on the first day of the month', 1)
          else results_ne(
             'select * from hcp_billing_monthly_active_users_all()',
             'select * from hcp_billing_monthly_active_users_all')
          end;
   -- can provide a start time (inclusive) to limit the results.
   select case when test_is_not_same_month('yesterday'::timestamptz, now())
-         then skip('certain tests don''t work on the first day of the month', 3)
+         then skip('certain tests don''t work on the first day of the month', 1)
          else results_eq(
            $$
            select * from hcp_billing_monthly_active_users_all(date_trunc('month', now() - interval '5 month', 'utc'));
@@ -169,7 +169,7 @@ begin;
          end;
   -- can provide a start time (inclusive) and end time (exclusive) to limit results.
   select case when test_is_not_same_month('yesterday'::timestamptz, now())
-         then skip('certain tests don''t work on the first day of the month', 3)
+         then skip('certain tests don''t work on the first day of the month', 1)
          else results_eq(
            $$
            select * from hcp_billing_monthly_active_users_all(date_trunc('month', now() - interval '5 month', 'utc'),
@@ -182,7 +182,7 @@ begin;
          end;
   -- can provide an end time (exclusive) to limit results.
   select case when test_is_not_same_month('yesterday'::timestamptz, now())
-         then skip('certain tests don''t work on the first day of the month', 3)
+         then skip('certain tests don''t work on the first day of the month', 1)
          else results_eq(
            $$
            select * from hcp_billing_monthly_active_users_all(null,
@@ -203,7 +203,7 @@ begin;
          end;
   -- an end time that is before the start time will yield no results.
   select case when test_is_not_same_month('yesterday'::timestamptz, now())
-         then skip('certain tests don''t work on the first day of the month', 3)
+         then skip('certain tests don''t work on the first day of the month', 1)
          else is_empty(
            $$
            select * from hcp_billing_monthly_active_users_all(date_trunc('month', now() - interval '2 month', 'utc'),


### PR DESCRIPTION
This PR is a follow-up to https://github.com/hashicorp/boundary/pull/4855

I observed today that the sql tests are failing for the following reason
```
Test Summary Report
-------------------
/test/hcp/billing/monthly_active_users_all_timezone.sql                               (Wstat: 0 Tests: 11 Failed: 0)
  Parse errors: Bad plan.  You planned 27 tests but ran 11.
Files=147, Tests=2175, 21 wallclock secs ( 0.38 usr  0.18 sys +  0.41 cusr  0.56 csys =  1.53 CPU)
```
https://github.com/hashicorp/boundary/actions/runs/9349282645/job/25730230873?pr=4858

Looking back at the PR, I think I had an error using the `skip` command and that it should be set to `skip('', 1)`. I think this makes sense -- by setting it to `skip('', 3`) in 8 tests, that would have increased the number by 16 (i.e. 8 * 2), changing the original plan from `11` to `27`. 