### PR TITLE
docs: Clarify credentials and SSH targets

### DIFF
--- a/website/content/docs/concepts/domain-model/targets.mdx
+++ b/website/content/docs/concepts/domain-model/targets.mdx
@@ -88,13 +88,16 @@ A target has the following configurable attributes:
 ## Target types
 
 Boundary supports TCP and SSH target types.
-An SSH target **must** have at least one injected application credential.
+An SSH target **must** have at least one injected application credential to establish the SSH connection.
 A TCP target **cannot** have any injected application credentials.
+
 Note the following target type requirements:
 
 - **To use brokered credentials to connect to a target that runs SSH**: you must use a `tcp` target type.
 - **To use injected application credentials to connect to a target that runs SSH**: you must use an `ssh` target type.
 - **To enable session recording for a target that runs SSH**: you must use injected application credentials and an `ssh` target type.
+
+You can configure brokered credentials for use with SSH targets for purposes other than establishing the initial SSH connection.
 
 ### TCP target attributes
 
@@ -110,6 +113,10 @@ TCP targets have the following additional attribute:
 SSH targets use injected application credentials to authenticate an SSH session between the client and end host.
 Injected credentials allow users to securely connect to remost hosts using SSH, while never being in the possession of a valid credential for that target host.
 The injected credentials can be a username/password or username/private key credential from Vault [credential libraries][] or they can be static [credentials][] or an SSH certificate from Vault SSH credential libraries.
+
+You cannot establish an SSH connection to a target using brokered credentials.
+If you do not configure injected credentials to make the SSH connection, any attempts to connect to the SSH target result in an error.
+However, you can use brokered credentials with SSH targets for purposes other than establishing the initial SSH connection.
 
 SSH targets have the following additional attributes:
 


### PR DESCRIPTION
This PR attempts to clarify some confusion about the credentials required to connect to SSH targets. We should note that while injected credentials are required to establish an SSH connection, SSH targets do support brokered credentials for other purposes.

From a Slack conversation:

https://hashicorp.slack.com/archives/CP48EV08Z/p1717371877997419

View the update in the preview deployment:

https://boundary-r6prcoxo9-hashicorp.vercel.app/boundary/docs/concepts/domain-model/targets