### PR TITLE
docs: Revise requirements for SSH targets

### DIFF
--- a/website/content/docs/concepts/domain-model/targets.mdx
+++ b/website/content/docs/concepts/domain-model/targets.mdx
@@ -114,7 +114,7 @@ SSH targets use injected application credentials to authenticate an SSH session 
 Injected credentials allow users to securely connect to remost hosts using SSH, while never being in the possession of a valid credential for that target host.
 The injected credentials can be a username/password or username/private key credential from Vault [credential libraries][] or they can be static [credentials][] or an SSH certificate from Vault SSH credential libraries.
 
-SSH targets require you to configure injected credentials in order to create a session.
+SSH targets require you to configure injected credentials to create a session.
 If you attempt to create a session against an SSH target without configuring injected credentials, it results in an error.
 However, you can use brokered credentials with SSH targets for purposes other than establishing the initial SSH connection.
 

--- a/website/content/docs/concepts/domain-model/targets.mdx
+++ b/website/content/docs/concepts/domain-model/targets.mdx
@@ -114,8 +114,8 @@ SSH targets use injected application credentials to authenticate an SSH session 
 Injected credentials allow users to securely connect to remost hosts using SSH, while never being in the possession of a valid credential for that target host.
 The injected credentials can be a username/password or username/private key credential from Vault [credential libraries][] or they can be static [credentials][] or an SSH certificate from Vault SSH credential libraries.
 
-You cannot establish an SSH connection to a target using brokered credentials.
-If you do not configure injected credentials to make the SSH connection, any attempts to connect to the SSH target result in an error.
+SSH targets require you to configure injected credentials in order to create a session.
+If you attempt to create a session against an SSH target without configuring injected credentials, it results in an error.
 However, you can use brokered credentials with SSH targets for purposes other than establishing the initial SSH connection.
 
 SSH targets have the following additional attributes:


### PR DESCRIPTION
Revise wording of recent SSH target update to focus on what is required, rather than what is forbidden. I received some feedback after I merged #4863 that we could be more clear, and I agree. This version is more direct and should be easier for users to understand.

View the update in the preview deployment:

https://boundary-fxbp7ekgg-hashicorp.vercel.app/boundary/docs/concepts/domain-model/targets#ssh-target-attributes