### PR TITLE
test(e2e): Add check for ldap account attribute mapping

### DIFF
--- a/enos/modules/docker_ldap/entries/user.ldif
+++ b/enos/modules/docker_ldap/entries/user.ldif
@@ -3,4 +3,5 @@ objectClass: inetOrgPerson
 cn: ${user_name}
 sn: ${user_name}
 uid: ${user_name}
+mail: ${user_name}@mail.com
 userPassword: ${user_password}


### PR DESCRIPTION
This PR adds a check to an e2e test for LDAP account attribute mapping implemented here: https://github.com/hashicorp/boundary/pull/4788.

https://hashicorp.atlassian.net/browse/ICU-13979
