### PR TITLE
update script to not print null values

### DIFF
--- a/enos/scripts/test_e2e_env.sh
+++ b/enos/scripts/test_e2e_env.sh
@@ -8,6 +8,6 @@ SCRIPTS_DIR=$( cd -- "$( dirname -- "$0" )" &> /dev/null && pwd )
 STATEDIR=$(ls -td $SCRIPTS_DIR/../.enos/*/ | head -1) # get latest directory
 
 cd $STATEDIR
-terraform show -json terraform.tfstate | jq -r '.values.root_module.child_modules[].resources[] | select(.address=="module.run_e2e_test.enos_local_exec.run_e2e_test") | .values.environment | to_entries[] | "export \(.key)=\(.value|@sh)"'
+terraform show -json terraform.tfstate | jq -r '.values.root_module.child_modules[].resources[] | select(.address=="module.run_e2e_test.enos_local_exec.run_e2e_test") | .values.environment | to_entries[] | select(.value != "") | "export \(.key)=\(.value|@sh)"'
 
 cd $DIR


### PR DESCRIPTION
Added a `select(.value != "")` entry to the jq statement to avoid it printing null values. This is to make life easier when copy/pasting the output from the script.

This solves the problem of people overwriting existing values they already may have set and do not want overwritten, namely `VAULT_ADDR` and `VAULT_TOKEN`.

before:

```
➜  enos git:(main) ✗ bash scripts/test_e2e_env.sh               
export BOUNDARY_ADDR='http://some-address:9200'
export BOUNDARY_LICENSE=''
export E2E_AWS_ACCESS_KEY_ID=''
export E2E_AWS_BUCKET_NAME=''
export E2E_AWS_HOST_SET_FILTER=''
export E2E_AWS_HOST_SET_FILTER2=''
export E2E_AWS_HOST_SET_IPS='[""]'
export E2E_AWS_HOST_SET_IPS2='[""]'
export E2E_AWS_REGION=''
export E2E_AWS_SECRET_ACCESS_KEY=''
export E2E_MAX_PAGE_SIZE='10'
export E2E_PASSWORD_ADMIN_LOGIN_NAME='admin'
export E2E_PASSWORD_ADMIN_PASSWORD='xdBht'
export E2E_PASSWORD_AUTH_METHOD_ID='ampw_UI0wkZdCfJ'
export E2E_SSH_CA_KEY=''
export E2E_SSH_KEY_PATH='/Users/something.pem'
export E2E_SSH_USER='ubuntu'
export E2E_TARGET_ADDRESS='10.13.1.254'
export E2E_TARGET_PORT='22'
export E2E_TESTS='true'
export E2E_VAULT_ADDR=''
export E2E_WORKER_ADDRESS=''
export E2E_WORKER_TAG_EGRESS=''
export E2E_WORKER_TAG_INGRESS=''
export VAULT_ADDR=''
export VAULT_TOKEN=''
```

after:

```
➜  enos git:(main) ✗ bash scripts/test_e2e_env.sh               
export BOUNDARY_ADDR='http://some-address:9200'
export E2E_AWS_HOST_SET_IPS='[""]'
export E2E_AWS_HOST_SET_IPS2='[""]'
export E2E_MAX_PAGE_SIZE='10'
export E2E_PASSWORD_ADMIN_LOGIN_NAME='admin'
export E2E_PASSWORD_ADMIN_PASSWORD='xdBht'
export E2E_PASSWORD_AUTH_METHOD_ID='ampw_UI0wkZdCfJ'
export E2E_SSH_CA_KEY=''
export E2E_SSH_KEY_PATH='/Users/something.pem'
export E2E_SSH_USER='ubuntu'
export E2E_TARGET_ADDRESS='10.13.1.254'
export E2E_TARGET_PORT='22'
export E2E_TESTS='true'
```