### PR TITLE
Use appropriate gRPC error codes for OIDC

### DIFF
--- a/internal/daemon/controller/handlers/authmethods/authmethod_service.go
+++ b/internal/daemon/controller/handlers/authmethods/authmethod_service.go
@@ -1423,19 +1423,19 @@ func (s Service) ConvertInternalAuthTokenToApiAuthToken(ctx context.Context, tok
 func (s Service) convertToAuthenticateResponse(ctx context.Context, req *pbs.AuthenticateRequest, authResults *requestauth.VerifyResults, tok *pba.AuthToken) (*pbs.AuthenticateResponse, error) {
 	const op = "authmethod.convertToAuthenticateResponse"
 	if req == nil {
-		return nil, errors.New(ctx, errors.InvalidParameter, op, "Missing request.")
+		return nil, handlers.InvalidArgumentErrorf("Nil request.", nil)
 	}
 	if authResults == nil {
-		return nil, errors.New(ctx, errors.InvalidParameter, op, "Missing auth results.")
+		return nil, handlers.InvalidArgumentErrorf("Nil auth results.", nil)
 	}
 	if authResults.Scope == nil {
-		return nil, errors.New(ctx, errors.InvalidParameter, op, "Missing auth results scope.")
+		return nil, handlers.InvalidArgumentErrorf("Missing auth results scope.", nil)
 	}
 	if authResults.Scope.Id == "" {
-		return nil, errors.New(ctx, errors.InvalidParameter, op, "Missing auth results scope ID.")
+		return nil, handlers.InvalidArgumentErrorf("Missing auth results scope ID.", nil)
 	}
 	if tok == nil {
-		return nil, errors.New(ctx, errors.InvalidParameter, op, "Missing auth token.")
+		return nil, handlers.InvalidArgumentErrorf("Missing auth token", nil)
 	}
 	res := &perms.Resource{
 		ScopeId: authResults.Scope.Id,

--- a/internal/daemon/controller/handlers/authmethods/oidc_test.go
+++ b/internal/daemon/controller/handlers/authmethods/oidc_test.go
@@ -1761,7 +1761,7 @@ func TestAuthenticate_OIDC_Token(t *testing.T) {
 				Command:      "token",
 				AuthMethodId: s.authMethod.GetPublicId(),
 			},
-			wantErrMatch: errors.T(errors.InvalidParameter),
+			wantErr: handlers.ApiErrorWithCode(codes.InvalidArgument),
 		},
 		{
 			name: "success",
@@ -1796,7 +1796,7 @@ func TestAuthenticate_OIDC_Token(t *testing.T) {
 					},
 				},
 			},
-			wantErrMatch: errors.T(errors.AuthAttemptExpired),
+			wantErr: handlers.ApiErrorWithCode(codes.PermissionDenied),
 		},
 		{
 			name: "invalid-token-id-not-encoded-encrypted-proto",
@@ -1809,7 +1809,7 @@ func TestAuthenticate_OIDC_Token(t *testing.T) {
 					},
 				},
 			},
-			wantErrMatch: errors.T(errors.Unknown),
+			wantErr: handlers.ApiErrorWithCode(codes.Internal),
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
This commit makes modifications to the OIDC request handlers to return appropriate gRPC status codes on errors. Before this change, boundary presents the internal error codes to clients. This causes problems for reverse proxies, as these status codes are mapped to non-standard HTTP response codes which are ultimately all turned into 500 responses when 4xx status codes are more appropriate and descriptive of the error returned.

Some modifications in this commit include calls to `event.WriteError` so that the internal error is written to the controller log for visibility. Comments about potential duplicate logs are now removed as `event.WriteError` is not called when using functions from the `handlers` package.