### PR TITLE
test(e2e): Add support for dynamic credentials

### DIFF
--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -160,19 +160,18 @@ scenario "e2e_aws" {
     module     = module.aws_worker
     depends_on = [step.create_boundary_cluster]
     variables {
-      vpc_id                    = step.create_base_infra.vpc_id
-      availability_zones        = step.create_base_infra.availability_zone_names
-      kms_key_arn               = step.create_base_infra.kms_key_arn
-      ubuntu_ami_id             = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      local_artifact_path       = step.build_boundary.artifact_path
-      boundary_install_dir      = local.boundary_install_dir
-      iam_instance_profile_name = step.create_boundary_cluster.iam_instance_profile_name
-      name_prefix               = step.create_boundary_cluster.name_prefix
-      cluster_tag               = step.create_boundary_cluster.cluster_tag
-      controller_addresses      = step.create_boundary_cluster.public_controller_addresses
-      controller_sg_id          = step.create_boundary_cluster.controller_aux_sg_id
-      worker_type_tags          = [local.egress_tag]
-      config_file_path          = "templates/worker.hcl"
+      vpc_id               = step.create_base_infra.vpc_id
+      availability_zones   = step.create_base_infra.availability_zone_names
+      kms_key_arn          = step.create_base_infra.kms_key_arn
+      ubuntu_ami_id        = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      local_artifact_path  = step.build_boundary.artifact_path
+      boundary_install_dir = local.boundary_install_dir
+      name_prefix          = step.create_boundary_cluster.name_prefix
+      cluster_tag          = step.create_boundary_cluster.cluster_tag
+      controller_addresses = step.create_boundary_cluster.public_controller_addresses
+      controller_sg_id     = step.create_boundary_cluster.controller_aux_sg_id
+      worker_type_tags     = [local.egress_tag]
+      config_file_path     = "templates/worker.hcl"
     }
   }
 

--- a/enos/modules/aws_bucket/main.tf
+++ b/enos/modules/aws_bucket/main.tf
@@ -29,6 +29,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 resource "aws_iam_user_policy" "default" {
+  count  = var.is_user ? 1 : 0
   name   = "${aws_s3_bucket.default.id}_${var.user}_access"
   user   = var.user
   policy = data.aws_iam_policy_document.default.json

--- a/enos/modules/aws_bucket/outputs.tf
+++ b/enos/modules/aws_bucket/outputs.tf
@@ -5,3 +5,8 @@ output "bucket_name" {
   value       = aws_s3_bucket.default.id
   description = "The name of the S3 bucket created by this module."
 }
+
+output "bucket_arn" {
+  value       = aws_s3_bucket.default.arn
+  description = "The ARN of the S3 bucket created by this module."
+}

--- a/enos/modules/aws_bucket/variables.tf
+++ b/enos/modules/aws_bucket/variables.tf
@@ -12,7 +12,14 @@ variable "cluster_tag" {
   type        = string
 }
 
+variable "is_user" {
+  description = "Boolean to specify if a user was provided to this module."
+  type        = bool
+  default     = false
+}
+
 variable "user" {
   description = "A username that will be allowed access to this module's bucket."
   type        = string
+  default     = ""
 }

--- a/enos/modules/aws_worker/iam.tf
+++ b/enos/modules/aws_worker/iam.tf
@@ -1,0 +1,74 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+data "aws_iam_policy_document" "boundary_instance_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "boundary_profile" {
+  statement {
+    resources = ["*"]
+
+    actions = ["ec2:DescribeInstances"]
+  }
+
+  statement {
+    resources = [var.kms_key_arn]
+
+    actions = [
+      "kms:DescribeKey",
+      "kms:ListKeys",
+      "kms:Encrypt",
+      "kms:Decrypt",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "bucket_policy_document" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:GetObjectAttributes",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "${var.bucket_arn}/*",
+      "${var.bucket_arn}",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "combined_policy_document" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.boundary_profile.json,
+    data.aws_iam_policy_document.bucket_policy_document.json,
+  ]
+}
+
+resource "aws_iam_role" "boundary_instance_role" {
+  name               = "boundary_instance_role-${random_string.cluster_id.result}"
+  assume_role_policy = data.aws_iam_policy_document.boundary_instance_role.json
+}
+
+resource "aws_iam_instance_profile" "boundary_profile" {
+  name = "boundary_instance_profile-${random_string.cluster_id.result}"
+  role = aws_iam_role.boundary_instance_role.name
+}
+
+resource "aws_iam_role_policy" "boundary_policy" {
+  name   = "boundary_policy-${random_string.cluster_id.result}"
+  role   = aws_iam_role.boundary_instance_role.id
+  policy = var.bucket_arn != "" ? data.aws_iam_policy_document.combined_policy_document.json : data.aws_iam_policy_document.boundary_profile.json
+}

--- a/enos/modules/aws_worker/main.tf
+++ b/enos/modules/aws_worker/main.tf
@@ -130,7 +130,7 @@ resource "aws_instance" "worker" {
   vpc_security_group_ids = [aws_security_group.default.id]
   subnet_id              = aws_subnet.default.id
   key_name               = var.ssh_aws_keypair
-  iam_instance_profile   = var.iam_instance_profile_name
+  iam_instance_profile   = aws_iam_instance_profile.boundary_profile.name
   monitoring             = var.worker_monitoring
 
   root_block_device {
@@ -199,4 +199,12 @@ resource "enos_boundary_start" "worker_start" {
       host = aws_instance.worker.public_ip
     }
   }
+}
+
+resource "random_string" "cluster_id" {
+  length  = 8
+  lower   = true
+  upper   = false
+  numeric = false
+  special = false
 }

--- a/enos/modules/aws_worker/outputs.tf
+++ b/enos/modules/aws_worker/outputs.tf
@@ -20,3 +20,8 @@ output "pet_id" {
   description = "The ID of the random_pet used in this module"
   value       = random_pet.worker.id
 }
+
+output "role_arn" {
+  description = "The ARN of the IAM role used in this module"
+  value       = aws_iam_role.boundary_instance_role.arn
+}

--- a/enos/modules/aws_worker/variables.tf
+++ b/enos/modules/aws_worker/variables.tf
@@ -99,11 +99,6 @@ variable "boundary_install_dir" {
   default     = "/opt/boundary/bin"
 }
 
-variable "iam_instance_profile_name" {
-  description = "The name of the AWS IAM instance profile from the Boundary cluster module"
-  type        = string
-}
-
 variable "name_prefix" {
   description = "The name_prefix from the Boundary cluster module"
   type        = string
@@ -138,6 +133,12 @@ variable "config_file_path" {
 
 variable "recording_storage_path" {
   description = "Path on instance to store recordings"
+  type        = string
+  default     = ""
+}
+
+variable "bucket_arn" {
+  description = "ARN of the S3 bucket to store recordings"
   type        = string
   default     = ""
 }

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -131,6 +131,11 @@ variable "aws_bucket_name" {
   type        = string
   default     = ""
 }
+variable "aws_role_arn" {
+  description = "AWS Role ARN that has access to bucket"
+  type        = string
+  default     = ""
+}
 variable "worker_tag_ingress" {
   type    = string
   default = ""
@@ -185,6 +190,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_AWS_HOST_SET_IPS2         = local.aws_host_set_ips2
     E2E_AWS_REGION                = var.aws_region
     E2E_AWS_BUCKET_NAME           = var.aws_bucket_name
+    E2E_AWS_ROLE_ARN              = var.aws_role_arn
     E2E_WORKER_TAG_INGRESS        = var.worker_tag_ingress
     E2E_WORKER_TAG_EGRESS         = var.worker_tag_egress
     E2E_WORKER_ADDRESS            = var.worker_address


### PR DESCRIPTION
This PR adds support for testing dynamic credentials when creating storage buckets.

Summary of changes
- The bucket module now takes a username as an optional argument. If a user is provided, it will set up the user policy to have access to the bucket. This is needed when testing static credentials
- The worker module now takes a bucket arn as an optional argument. If a bucket arn is provided, it will set up a role to gain access to that bucket, create an instance profile for that role, and attach it to the worker. This is needed when testing dynamic credentials]

There will be a follow-up PR to add a test in `boundary-enterprise`

https://hashicorp.atlassian.net/browse/ICU-13420