### PR TITLE
chore(e2e): Add boundary to path

### DIFF
--- a/enos/modules/aws_boundary/scripts/set-up-login-shell-profile.sh
+++ b/enos/modules/aws_boundary/scripts/set-up-login-shell-profile.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$BOUNDARY_INSTALL_DIR" ]] && fail "BOUNDARY_INSTALL_DIR env variable has not been set"
+
+# Determine the profile file we should write to. We only want to affect login shells and bash will
+# only read one of these in ordered of precendence.
+determineProfileFile() {
+  if [ -f "$HOME/.bash_profile" ]; then
+    printf "%s/.bash_profile\n" "$HOME"
+    return 0
+  fi
+
+  if [ -f "$HOME/.bash_login" ]; then
+    printf "%s/.bash_login\n" "$HOME"
+    return 0
+  fi
+
+  printf "%s/.profile\n" "$HOME"
+}
+
+appendVaultProfileInformation() {
+  tee -a "$1" <<< "export PATH=$PATH:$BOUNDARY_INSTALL_DIR"
+}
+
+main() {
+  local profile_file
+  if ! profile_file=$(determineProfileFile); then
+    fail "failed to determine login shell profile file location"
+  fi
+
+  # If vault_cluster is used more than once, eg: autopilot or replication, this module can
+  # be called more than once. Short ciruit here if our profile is already set up.
+  if grep VAULT_ADDR < "$profile_file"; then
+    exit 0
+  fi
+
+  if ! appendVaultProfileInformation "$profile_file"; then
+    fail "failed to write vault configuration to login shell profile"
+  fi
+
+  exit 0
+}
+
+main

--- a/enos/modules/aws_worker/main.tf
+++ b/enos/modules/aws_worker/main.tf
@@ -164,6 +164,22 @@ resource "enos_bundle_install" "worker" {
   }
 }
 
+resource "enos_remote_exec" "update_path_worker" {
+  depends_on = [enos_bundle_install.worker]
+
+  environment = {
+    BOUNDARY_INSTALL_DIR = var.boundary_install_dir
+  }
+
+  scripts = [abspath("${path.module}/scripts/set-up-login-shell-profile.sh")]
+
+  transport = {
+    ssh = {
+      host = aws_instance.worker.public_ip
+    }
+  }
+}
+
 resource "enos_file" "worker_config" {
   depends_on = [enos_bundle_install.worker]
 

--- a/enos/modules/aws_worker/scripts/set-up-login-shell-profile.sh
+++ b/enos/modules/aws_worker/scripts/set-up-login-shell-profile.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$BOUNDARY_INSTALL_DIR" ]] && fail "BOUNDARY_INSTALL_DIR env variable has not been set"
+
+# Determine the profile file we should write to. We only want to affect login shells and bash will
+# only read one of these in ordered of precendence.
+determineProfileFile() {
+  if [ -f "$HOME/.bash_profile" ]; then
+    printf "%s/.bash_profile\n" "$HOME"
+    return 0
+  fi
+
+  if [ -f "$HOME/.bash_login" ]; then
+    printf "%s/.bash_login\n" "$HOME"
+    return 0
+  fi
+
+  printf "%s/.profile\n" "$HOME"
+}
+
+appendVaultProfileInformation() {
+  tee -a "$1" <<< "export PATH=$PATH:$BOUNDARY_INSTALL_DIR"
+}
+
+main() {
+  local profile_file
+  if ! profile_file=$(determineProfileFile); then
+    fail "failed to determine login shell profile file location"
+  fi
+
+  # If vault_cluster is used more than once, eg: autopilot or replication, this module can
+  # be called more than once. Short ciruit here if our profile is already set up.
+  if grep VAULT_ADDR < "$profile_file"; then
+    exit 0
+  fi
+
+  if ! appendVaultProfileInformation "$profile_file"; then
+    fail "failed to write vault configuration to login shell profile"
+  fi
+
+  exit 0
+}
+
+main


### PR DESCRIPTION
One request from the Support team was to add `boundary` to the PATH on ec2 instances created by enos. This PR borrows the implementation from [vault](https://github.com/hashicorp/vault/blob/main/enos/modules/vault_cluster/main.tf#L268-L321). 

## Testing
```
> enos scenario launch e2e_aws builder:local
> ssh -i <key> ubuntu@<ec2 instance ip>
> which boundary
/opt/boundary/bin/boundary
```
I checked against the controller/worker created by `aws_boundary` and the "isolated" worker created by `aws_worker`.

https://hashicorp.atlassian.net/browse/ICU-14020