### PR TITLE
chore(e2e): Clean up comments in enos.vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ tmp-errors-Test*
 /enos/terraform-plugin-cache
 /enos/*.zip
 /enos/support
+enos/enos-local.vars.hcl
 # Enos local Terraform files
 enos/.terraform/*
 enos/.terraform.lock.hcl

--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -17,7 +17,7 @@ scenario "e2e_aws_base_with_vault" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    local_boundary_dir       = abspath(var.local_boundary_dir)
+    local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     build_path = {
       "local" = "/tmp",
       "crt"   = var.crt_bundle_path == null ? null : abspath(var.crt_bundle_path)

--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -17,7 +17,7 @@ scenario "e2e_aws_base" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    local_boundary_dir       = abspath(var.local_boundary_dir)
+    local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     build_path = {
       "local" = "/tmp",
       "crt"   = var.crt_bundle_path == null ? null : abspath(var.crt_bundle_path)

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -17,7 +17,7 @@ scenario "e2e_aws" {
   locals {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
-    local_boundary_dir       = abspath(var.local_boundary_dir)
+    local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
     build_path = {
       "local" = "/tmp",

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -11,7 +11,7 @@ scenario "e2e_database" {
 
   locals {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
-    local_boundary_dir       = abspath(var.local_boundary_dir)
+    local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
 
     tags = merge({

--- a/enos/enos-scenario-e2e-docker-base-plus.hcl
+++ b/enos/enos-scenario-e2e-docker-base-plus.hcl
@@ -17,8 +17,8 @@ scenario "e2e_docker_base_plus" {
 
   locals {
     aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
-    local_boundary_dir         = abspath(var.local_boundary_dir)
-    local_boundary_src_dir     = abspath(var.local_boundary_src_dir)
+    local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
+    local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
 

--- a/enos/enos-scenario-e2e-docker-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-vault.hcl
@@ -17,8 +17,8 @@ scenario "e2e_docker_base_with_vault" {
 
   locals {
     aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
-    local_boundary_dir         = abspath(var.local_boundary_dir)
-    local_boundary_src_dir     = abspath(var.local_boundary_src_dir)
+    local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
+    local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
 

--- a/enos/enos-scenario-e2e-docker-base-with-worker.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-worker.hcl
@@ -18,8 +18,8 @@ scenario "e2e_docker_base_with_worker" {
 
   locals {
     aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
-    local_boundary_dir         = abspath(var.local_boundary_dir)
-    local_boundary_src_dir     = abspath(var.local_boundary_src_dir)
+    local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
+    local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
 

--- a/enos/enos-scenario-e2e-docker-base.hcl
+++ b/enos/enos-scenario-e2e-docker-base.hcl
@@ -17,8 +17,8 @@ scenario "e2e_docker_base" {
 
   locals {
     aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
-    local_boundary_dir         = abspath(var.local_boundary_dir)
-    local_boundary_src_dir     = abspath(var.local_boundary_src_dir)
+    local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
+    local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
 

--- a/enos/enos-scenario-e2e-docker-worker-registration-controller-led.hcl
+++ b/enos/enos-scenario-e2e-docker-worker-registration-controller-led.hcl
@@ -18,8 +18,8 @@ scenario "e2e_docker_worker_registration_controller_led" {
 
   locals {
     aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
-    local_boundary_dir         = abspath(var.local_boundary_dir)
-    local_boundary_src_dir     = abspath(var.local_boundary_src_dir)
+    local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
+    local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
 

--- a/enos/enos-scenario-e2e-docker-worker-registration-worker-led.hcl
+++ b/enos/enos-scenario-e2e-docker-worker-registration-worker-led.hcl
@@ -18,8 +18,8 @@ scenario "e2e_docker_worker_registration_worker_led" {
 
   locals {
     aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
-    local_boundary_dir         = abspath(var.local_boundary_dir)
-    local_boundary_src_dir     = abspath(var.local_boundary_src_dir)
+    local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
+    local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
 

--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -17,8 +17,8 @@ scenario "e2e_ui_aws" {
     aws_ssh_private_key_path  = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir      = abspath(var.boundary_install_dir)
     license_path              = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    local_boundary_dir        = abspath(var.local_boundary_dir)
-    local_boundary_ui_src_dir = abspath(var.local_boundary_ui_src_dir)
+    local_boundary_dir        = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
+    local_boundary_ui_src_dir = var.local_boundary_ui_src_dir != null ? abspath(var.local_boundary_ui_src_dir) : null
     build_path = {
       "local" = "/tmp",
       "crt"   = var.crt_bundle_path == null ? null : abspath(var.crt_bundle_path)

--- a/enos/enos-scenario-e2e-ui-docker.hcl
+++ b/enos/enos-scenario-e2e-ui-docker.hcl
@@ -17,8 +17,8 @@ scenario "e2e_ui_docker" {
 
   locals {
     aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
-    local_boundary_dir         = abspath(var.local_boundary_dir)
-    local_boundary_ui_src_dir  = abspath(var.local_boundary_ui_src_dir)
+    local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
+    local_boundary_ui_src_dir  = var.local_boundary_ui_src_dir != null ? abspath(var.local_boundary_ui_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
 

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -94,11 +94,13 @@ variable "target_count" {
 variable "local_boundary_dir" {
   description = "Path to local boundary executable"
   type        = string
+  default     = null
 }
 
 variable "local_boundary_src_dir" {
   description = "Path to local boundary source code directory"
   type        = string
+  default     = null
 }
 
 variable "local_boundary_ui_src_dir" {

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -4,41 +4,45 @@
 // Example variable inputs. Set these to valid values and uncomment them before
 // running scenarios.
 
-// The AWS region you want to create the resources in. Make sure you choose a
-// region where you've got an AWS keypair.
-// aws_region = "us-east-1"
+// Recommended to copy this file to enos-local.vars.hcl and modify the values
+// there to avoid accidentally committing sensitive information.
 
-// The name of the AWS keypair. You can look them up in the AWS console on a per-
-// region basis. E.g. https://us-east-1.console.aws.amazon.com/ec2/v2/home?region=us-east-1#KeyPairs:
-// aws_ssh_keypair_name = "mykeypair"
-
-// The path to the private key associated with your keypair.
-// aws_ssh_private_key_path = "/Users/<user>/.ssh/mykeypair.pem
-
-// The username to use for boundary. The github username of the user who trigger
-// the workflow will be used automatically in the CI.
-// enos_user = "enos"
-
-// The directory that contains the copy of boundary you want to local execution
-// from. `make install` should install it into the $GOBIN, which is usually
-// similar to what is listed below.
-// local_boundary_dir = "/Users/<user>/.go/bin"
-
-// The directory that contains the copy of boundary you want to use for e2e tests
-// local_boundary_src_dir = "/Users/<user>/Developer/boundary"
-
-// The directory that contains the copy of boundary-ui you want to use for UI tests
-// local_boundary_ui_src_dir = "/Users/<user>/Developer/boundary-ui"
-
-// Path to a license file if required
-// boundary_license_path = "./support/boundary.hclic"
-
-// Built binary custom name, if not "boundary"
-// boundary_binary_name = "boundary"
-
-// Build edition from CRT
+// ==============================================================================
+// REQUIRED VARIABLES
+// ==============================================================================
+// Build edition
+// If using community edition, set to "oss"
+// If using enterprise edition, set to "enterprise"
 // boundary_edition = "oss"
 
+// Prevents the end-to-end test suites from running when starting scenarios.
+// Recommend setting this to true unless running in CI.
+// e2e_debug_no_run = true
+
+// The AWS region you want to create the resources in. Make sure you choose a
+// region where you've got an AWS keypair. Applies to AWS scenarios only.
+// aws_region = "us-east-1"
+
+// The name of the AWS keypair in EC2 -> Key Pairs. Ensure this key pair is
+// available in the selected region. Applies to AWS scenarios only.
+// aws_ssh_keypair_name = "mykeypair"
+
+// The path to the local copy of the private key associated with your keypair.
+// Applies to AWS scenarios only.
+// aws_ssh_private_key_path = "/Users/<user>/.ssh/mykeypair.pem
+
+// Name of user. This is used to tag resources in AWS to more easily identify
+// your resources. Can be set to any string.
+/// Applies to AWS scenarios only.
+// enos_user = "enos"
+
+// ENTERPRISE ONLY
+// Path to a license file
+// boundary_license_path = "./support/boundary.hclic"
+
+// ==============================================================================
+// OPTIONAL VARIABLES
+// ==============================================================================
 // The path to the installation bundle for the target machines. The existing
 // scenarios all use linux/amd64 architecture so bundle ought to match that
 // architecture. This is only used for variants which use the `crt` builder
@@ -47,14 +51,24 @@
 // of the build workflow.
 // crt_bundle_path = "./boundary_linux_amd64.zip"
 
-// The port the ALB will listen on to proxy controller API requests. This defaults
-// to 9200
-// alb_listener_api_port = 9200
+// Number of controller instances to create. Applies to AWS scenarios only.
+// controller_count = 1
 
-// Generally, if there's failure in the test suite for any reason, enos/terraform will throw an error and you
-// would not be able to access the environment variables needed to test locally. Enabling this
-// will ensure that the enos scenario passes.
-// e2e_debug_no_run = true
+// Number of worker instances to create. Applies to AWS scenarios only.
+// worker_count = 1
 
-// Timeout for `go test` execution in the e2e tests, 10m default
-// go_test_timeout = "10m"
+// Number of target instances to create. Applies to AWS scenarios only.
+// target_count = 1
+
+// The directory that contains the copy of the boundary cli that the e2e tests
+// will use in CI. Only needed if e2e_debug_no_run = false.
+// local_boundary_dir = "/Users/<user>/.go/bin"
+
+// The directory that contains the source code of boundary/boundary-enterprise.
+// This is used in docker scenarios in CI in order to mount the source code into
+// the container. Only needed if e2e_debug_no_run = false.
+// local_boundary_src_dir = "/Users/<user>/Developer/boundary"
+
+// The directory that contains the source code of boundary-ui. This is used for
+// front-end e2e testing (UI scenarios) in CI. Only needed if e2e_debug_no_run = false.
+// local_boundary_ui_src_dir = "/Users/<user>/Developer/boundary-ui"


### PR DESCRIPTION
This PR makes some updates to `enos.vars.hcl` to clarify comments and make it easier to onboard.

Some additional changes were included to accommodate these changes
- `enos-local.vars.hcl` was added to `.gitignore` to allow a local copy of variables without potentially committing them
- Some variables were made optional so that users who don't need to run e2e tests can ignore them.

https://hashicorp.atlassian.net/browse/ICU-14090