### PR TITLE
test(e2e): Add resource IPs to output

### DIFF
--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -133,7 +133,7 @@ scenario "e2e_aws_base_with_vault" {
       enos_user            = var.enos_user
       instance_type        = var.target_instance_type
       vpc_id               = step.create_base_infra.vpc_id
-      target_count         = 1
+      target_count         = var.target_count
       subnet_ids           = step.create_boundary_cluster.subnet_ids
     }
   }
@@ -155,7 +155,7 @@ scenario "e2e_aws_base_with_vault" {
       auth_password            = step.create_boundary_cluster.auth_password
       local_boundary_dir       = local.local_boundary_dir
       aws_ssh_private_key_path = local.aws_ssh_private_key_path
-      target_address           = step.create_target.target_ips[0]
+      target_address           = step.create_target.target_private_ips[0]
       target_user              = "ubuntu"
       target_port              = "22"
       vault_addr               = step.create_vault_cluster.instance_public_ips[0]
@@ -167,5 +167,21 @@ scenario "e2e_aws_base_with_vault" {
 
   output "test_results" {
     value = step.run_e2e_test.test_results
+  }
+
+  output "controller_ips" {
+    value = step.create_boundary_cluster.controller_ips
+  }
+
+  output "worker_ips" {
+    value = step.create_boundary_cluster.worker_ips
+  }
+
+  output "target_ips" {
+    value = step.create_target.target_public_ips
+  }
+
+  output "vault_ips" {
+    value = step.create_vault_cluster.instance_public_ips
   }
 }

--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -111,7 +111,7 @@ scenario "e2e_aws_base" {
       enos_user            = var.enos_user
       instance_type        = var.target_instance_type
       vpc_id               = step.create_base_infra.vpc_id
-      target_count         = 1
+      target_count         = var.target_count
       subnet_ids           = step.create_boundary_cluster.subnet_ids
     }
   }
@@ -132,7 +132,7 @@ scenario "e2e_aws_base" {
       auth_password            = step.create_boundary_cluster.auth_password
       local_boundary_dir       = local.local_boundary_dir
       aws_ssh_private_key_path = local.aws_ssh_private_key_path
-      target_address           = step.create_target.target_ips[0]
+      target_address           = step.create_target.target_private_ips[0]
       target_user              = "ubuntu"
       target_port              = "22"
       max_page_size            = step.create_boundary_cluster.max_page_size
@@ -142,5 +142,17 @@ scenario "e2e_aws_base" {
 
   output "test_results" {
     value = step.run_e2e_test.test_results
+  }
+
+  output "controller_ips" {
+    value = step.create_boundary_cluster.controller_ips
+  }
+
+  output "worker_ips" {
+    value = step.create_boundary_cluster.worker_ips
+  }
+
+  output "target_ips" {
+    value = step.create_target.target_public_ips
   }
 }

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -126,7 +126,7 @@ scenario "e2e_aws" {
       enos_user            = var.enos_user
       instance_type        = var.target_instance_type
       vpc_id               = step.create_base_infra.vpc_id
-      target_count         = 2
+      target_count         = var.target_count <= 1 ? 2 : var.target_count
       additional_tags      = step.create_tag1_inputs.tag_map
       subnet_ids           = step.create_boundary_cluster.subnet_ids
     }
@@ -233,10 +233,10 @@ scenario "e2e_aws" {
       aws_access_key_id        = step.iam_setup.access_key_id
       aws_secret_access_key    = step.iam_setup.secret_access_key
       aws_host_set_filter1     = step.create_tag1_inputs.tag_string
-      aws_host_set_ips1        = step.create_targets_with_tag1.target_ips
+      aws_host_set_ips1        = step.create_targets_with_tag1.target_private_ips
       aws_host_set_filter2     = step.create_tag2_inputs.tag_string
-      aws_host_set_ips2        = step.create_isolated_target.target_ips
-      target_address           = step.create_isolated_target.target_ips[0]
+      aws_host_set_ips2        = step.create_isolated_target.target_private_ips
+      target_address           = step.create_isolated_target.target_private_ips[0]
       worker_tag_egress        = local.egress_tag
       max_page_size            = step.create_boundary_cluster.max_page_size
       aws_region               = var.aws_region
@@ -245,5 +245,17 @@ scenario "e2e_aws" {
 
   output "test_results" {
     value = step.run_e2e_test.test_results
+  }
+
+  output "controller_ips" {
+    value = step.create_boundary_cluster.controller_ips
+  }
+
+  output "worker_ips" {
+    value = step.create_boundary_cluster.worker_ips
+  }
+
+  output "target_ips" {
+    value = step.create_targets_with_tag1.target_public_ips
   }
 }

--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -153,7 +153,7 @@ scenario "e2e_ui_aws" {
       enos_user            = var.enos_user
       instance_type        = var.target_instance_type
       vpc_id               = step.create_base_infra.vpc_id
-      target_count         = 2
+      target_count         = var.target_count <= 1 ? 2 : var.target_count
       additional_tags      = step.create_tag_inputs.tag_map
       subnet_ids           = step.create_boundary_cluster.subnet_ids
     }
@@ -197,7 +197,7 @@ scenario "e2e_ui_aws" {
       local_boundary_dir        = local.local_boundary_dir
       local_boundary_ui_src_dir = local.local_boundary_ui_src_dir
       aws_ssh_private_key_path  = local.aws_ssh_private_key_path
-      target_address            = step.create_targets_with_tag.target_ips[0]
+      target_address            = step.create_targets_with_tag.target_private_ips[0]
       target_user               = "ubuntu"
       target_port               = "22"
       vault_addr                = step.create_vault_cluster.instance_public_ips[0]
@@ -205,7 +205,7 @@ scenario "e2e_ui_aws" {
       aws_access_key_id         = step.iam_setup.access_key_id
       aws_secret_access_key     = step.iam_setup.secret_access_key
       aws_host_set_filter       = step.create_tag_inputs.tag_string
-      aws_host_set_ips          = step.create_targets_with_tag.target_ips
+      aws_host_set_ips          = step.create_targets_with_tag.target_private_ips
       worker_tag_egress         = local.egress_tag
       aws_region                = var.aws_region
     }

--- a/enos/modules/aws_boundary/boundary-instances.tf
+++ b/enos/modules/aws_boundary/boundary-instances.tf
@@ -196,7 +196,7 @@ resource "enos_file" "worker_config" {
     id                     = each.value
     kms_key_id             = data.aws_kms_key.kms_key.id,
     controller_ips         = jsonencode(aws_instance.controller.*.private_ip),
-    public_addr            = aws_instance.worker.0.public_ip
+    public_addr            = aws_instance.worker[tonumber(each.value)].public_ip
     region                 = var.aws_region
     type                   = jsonencode(var.worker_type_tags)
     recording_storage_path = var.recording_storage_path

--- a/enos/modules/aws_target/main.tf
+++ b/enos/modules/aws_target/main.tf
@@ -93,6 +93,10 @@ resource "enos_remote_exec" "wait" {
   }
 }
 
-output "target_ips" {
+output "target_private_ips" {
   value = aws_instance.target.*.private_ip
+}
+
+output "target_public_ips" {
+  value = aws_instance.target.*.public_ip
 }


### PR DESCRIPTION
This PR updates enos scenarios to output IP addresses for the resources it creates. This only applies to AWS-based scenarios.

This PR also addresses a few issues related to multi-worker and multi-target configurations
- Addresses an issue with multi-worker registration. Took a fix from here: https://github.com/hashicorp/terraform-enos-aws-boundary/pull/42
- Modifies some scenarios to respect the `target_count` variable

Example:
```
❯ enos scenario output e2e_aws builder:local
Scenario: e2e_aws [builder:local] ✅
  target_ips = [
    "3.238.63.109",
    "3.80.33.188",
  ]
  test_results = ""
  worker_ips = [
    "3.231.55.31",
    "54.90.134.206",
  ]
  controller_ips = [
    "34.201.25.85",
    "3.88.140.74",
  ]

❯ ssh -i <key> ubuntu@34.201.25.85
```

https://hashicorp.atlassian.net/browse/ICU-14021
https://hashicorp.atlassian.net/browse/ICU-14022
