### PR TITLE
docs: Document billing command

### DIFF
--- a/website/content/docs/commands/billing/index.mdx
+++ b/website/content/docs/commands/billing/index.mdx
@@ -20,7 +20,9 @@ Boundary provides auth tokens to users when they authenticate using an auth meth
 The following command queries the number of active users between September 2023 and February 2024:
 
 ```shell-session
-$ boundary billing monthly-active-users -start-time="2023-09" -end-time="2024-02"
+$ boundary billing monthly-active-users /
+     -start-time="2023-09" /
+     -end-time="2024-02"
 ```
 
 ## Usage

--- a/website/content/docs/commands/billing/index.mdx
+++ b/website/content/docs/commands/billing/index.mdx
@@ -17,7 +17,7 @@ Boundary provides auth tokens to users when they authenticate using an auth meth
 
 ## Examples
 
-The following command queries the number of active users between September 2023 and February 2024:
+The following command retrieves the number of monthly active users between September 2023 and February 2024:
 
 ```shell-session
 $ boundary billing monthly-active-users /

--- a/website/content/docs/commands/billing/index.mdx
+++ b/website/content/docs/commands/billing/index.mdx
@@ -2,22 +2,22 @@
 layout: docs
 page_title: billing - Command
 description: |-
-  The "billing" command lets you collect reports about billing for active users.
+  The "billing" command retrieves the number of active users to help you predict user-based pricing.
 ---
 
 # billing
 
 Command: `boundary billing`
 
-The `billing` command lets you retrieve the number of monthly active Boundary users in your organization to predict billing information.
+The `billing` command retrieves the number of active Boundary users in your organization to help you predict billing information.
 
-An active user is defined as any unique Boundary user resource that has performed at least one authenticated action during the relevant billing time.
-Users perform authenticated actions when they call an API endpoint that requires a valid auth token to be included in the request.
-Users get auth tokens when they authenticate to Boundary using an auth method.
+An active user is any unique Boundary user resource that has performed at least one authenticated action during the relevant billing period.
+Users perform authenticated actions when they call API endpoints that require a valid auth token.
+Boundary provides auth tokens to users when they authenticate using an auth method.
 
 ## Examples
 
-The following command queries the number of monthly active users between September 2023 and February 2024:
+The following command queries the number of active users between September 2023 and February 2024:
 
 ```shell-session
 $ boundary billing monthly-active-users -start-time="2023-09" -end-time="2024-02"
@@ -33,7 +33,7 @@ Usage: boundary billing [sub command] [options] [args]
   # ...
 
 Subcommand:
-    monthly-active-users       Displays the number of monthly active users.
+    monthly-active-users       Display the number of monthly active users
 ```
 
 </CodeBlockConfig>

--- a/website/content/docs/commands/billing/index.mdx
+++ b/website/content/docs/commands/billing/index.mdx
@@ -1,0 +1,43 @@
+---
+layout: docs
+page_title: billing - Command
+description: |-
+  The "billing" command lets you collect reports about billing for active users.
+---
+
+# billing
+
+Command: `boundary billing`
+
+The `billing` command lets you retrieve the number of monthly active Boundary users in your organization to predict billing information.
+
+An active user is defined as any unique Boundary user resource that has performed at least one authenticated action during the relevant billing time.
+Users perform authenticated actions when they call an API endpoint that requires a valid auth token to be included in the request.
+Users get auth tokens when they authenticate to Boundary using an auth method.
+
+## Examples
+
+The following command queries the number of monthly active users between September 2023 and February 2024:
+
+```shell-session
+$ boundary billing monthly-active-users -start-time="2023-09" -end-time="2024-02"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary billing [sub command] [options] [args]
+
+  # ...
+
+Subcommand:
+    monthly-active-users       Displays the number of monthly active users.
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage, click on the name of the subcommand in the sidebar or the link below:
+
+- [monthly-active-users](/boundary/docs/commands/billing/monthly-active-users)

--- a/website/content/docs/commands/billing/monthly-active-users.mdx
+++ b/website/content/docs/commands/billing/monthly-active-users.mdx
@@ -1,0 +1,38 @@
+---
+layout: docs
+page_title: billing monthly-active-users - Command
+description: |-
+  The "billing monthly-active-users" command lets you query the number of monthly active users to predict Boundary pricing.
+---
+
+# billing monthly-active-users
+
+Command: `boundary billing monthly-active-users`
+
+The `boundary billing monthly-active-users` command lets you query the number of monthly active users your organization has to predict billing information.
+
+## Example
+
+The following command queries the number of monthly active users between September 2023 and February 2024:
+
+```shell-session
+$ boundary billing monthly-active-users -start-time="2023-09" -end-time="2024-02"
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary billing monthly-active-users [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `end-time=<string>` -  The end date for which you want to view monthly users in YYYY-MM format.
+If you do not include an end time, the query runs from the start time to the current month.
+- `start-time=<string>` -  The start time for which you want to view monthly users in YYYY-MM format.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/billing/monthly-active-users.mdx
+++ b/website/content/docs/commands/billing/monthly-active-users.mdx
@@ -2,18 +2,18 @@
 layout: docs
 page_title: billing monthly-active-users - Command
 description: |-
-  The "billing monthly-active-users" command lets you query the number of monthly active users to predict Boundary pricing.
+  The "billing monthly-active-users" command retrieves the number of monthly active users during a specified time to help you predict user-based pricing.
 ---
 
 # billing monthly-active-users
 
 Command: `boundary billing monthly-active-users`
 
-The `boundary billing monthly-active-users` command lets you query the number of monthly active users your organization has to predict billing information.
+The `billing monthly-active-users` command retrieves the number of monthly active Boundary users in your organization during a specific time to help predict billing information.
 
 ## Example
 
-The following command queries the number of monthly active users between September 2023 and February 2024:
+The following command retrieves the number of monthly active users between September 2023 and February 2024:
 
 ```shell-session
 $ boundary billing monthly-active-users -start-time="2023-09" -end-time="2024-02"
@@ -32,7 +32,7 @@ $ boundary billing monthly-active-users [options] [args]
 ### Command options
 
 - `end-time=<string>` -  The end date for which you want to view monthly users in YYYY-MM format.
-If you do not include an end time, the query runs from the start time to the current month.
-- `start-time=<string>` -  The start time for which you want to view monthly users in YYYY-MM format.
+If you do not include an end time, the command retrieves active users from the start time to the current month.
+- `start-time=<string>` -  The start date for which you want to view monthly users in YYYY-MM format.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/billing/monthly-active-users.mdx
+++ b/website/content/docs/commands/billing/monthly-active-users.mdx
@@ -31,8 +31,14 @@ $ boundary billing monthly-active-users [options] [args]
 
 ### Command options
 
-- `end-time=<string>` -  The end date for which you want to view monthly users in YYYY-MM format.
-If you do not include an end time, the command retrieves active users from the start time to the current month.
-- `start-time=<string>` -  The start date for which you want to view monthly users in YYYY-MM format.
+- `end-time=<string>` -  The end date for which you want to view monthly active users in YYYY-MM format.
+If you do not include an end time, the command retrieves active users from the start time through the current month.
+
+   The end time is exclusive, so the command returns monthly active users up to, but not including, the month you enter.
+   If the end time is **2024-07**, for example, the results include all active users from June (2024-06), but they would not include any users from July (2024-07).
+- `start-time=<string>` -  The start date for which you want to view monthly active users in YYYY-MM format.
+
+   The start time is inclusive, so any active users from the month you enter are included in the results.
+   If the start time is **2024-06**, for example, the command returns all users from June (2024-06) through the specified end time.
 
 @include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/billing/monthly-active-users.mdx
+++ b/website/content/docs/commands/billing/monthly-active-users.mdx
@@ -16,7 +16,9 @@ The `billing monthly-active-users` command retrieves the number of monthly activ
 The following command retrieves the number of monthly active users between September 2023 and February 2024:
 
 ```shell-session
-$ boundary billing monthly-active-users -start-time="2023-09" -end-time="2024-02"
+$ boundary billing monthly-active-users /
+     -start-time="2023-09" /
+     -end-time="2024-02"
 ```
 
 ## Usage

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -820,6 +820,19 @@
         ]
       },
       {
+        "title": "billing",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "commands/billing"
+          },
+          {
+            "title": "monthly-active-users",
+            "path": "commands/billing/monthly-active-users"
+          }
+        ]
+      },
+      {
         "title": "authenticate",
         "routes": [
           {


### PR DESCRIPTION
A new command was added when we released user-based pricing. The command lets users query the system to find out the number of active users in a given time period (by month) to help predict pricing impacts. This PR adds the `billing` command and the `monthly-active-users` subcommand to the CLI docs.

View the update in the preview deployment:

- [billing](https://boundary-iruh6clzw-hashicorp.vercel.app/boundary/docs/commands/billing)
- [billing monthly-active-users](https://boundary-iruh6clzw-hashicorp.vercel.app/boundary/docs/commands/billing/monthly-active-users)