### PR TITLE
docs: Backport #4556 to stable-website

### DIFF
--- a/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
+++ b/website/content/docs/configuration/session-recording/configure-storage-policy.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # Configure storage bucket policies
 
-<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary Plus or Boundary Enterprise</a></EnterpriseAlert>
 
 As of Boundary 0.15.0, retention policies can codify storage bucket lifecycle management for [session recordings][].
 A Boundary resource known as a [storage bucket][] is used to store recorded sessions.
@@ -99,6 +99,25 @@ Complete the following steps to create a storage policy in Boundary for session 
    - `retain-for-overridable`: (Optional) Indicates that a lower scope can override the `retain_for_days` attribute value. Defaults to `true`.
    - `delete-after-days`: (Optional) The number of days after creation when a session recording should be deleted.
    - `delete-after-overridable`: (Optional) Indicates that a lower scope can override the  `delete_after_days` attribute value. Defaults to `true`.
+
+</Tab>
+<Tab heading="Terraform" group="terraform">
+
+Apply the following Terraform policy:
+
+```hcl
+resource "boundary_policy_storage" "example" {
+  name = "soc2-policy"
+  description = "SOC 2 compliant storage policy for session recordings"
+  scope_id = data.boundary_scope.org.id
+
+  retain_for_days = 2557
+  retain_for_overridable = false
+
+  delete_after_days = 2657
+  delete_after_overridable = true
+}
+```
 
 </Tab>
 <Tab heading="API call using cURL" group="api">
@@ -219,6 +238,18 @@ The following example applies the policy created above to an org named `prod-dat
        -id o_aDkVBCDTvY \
        -storage-policy-id pst_WZ3SQSSYJY
    ```
+
+</Tab>
+<Tab heading="Terraform" group="terraform">
+
+Apply the following Terraform policy:
+
+```hcl
+resource "boundary_scope_policy_attachment" "example" {
+  policy_id = boundary_policy_storage.example.id
+  scope_id = data.boundary_scope.org.id
+}
+```
 
 </Tab>
 <Tab heading="API call using cURL" group="api">

--- a/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
+++ b/website/content/docs/configuration/session-recording/create-storage-bucket.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # Create a storage bucket
 
-<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary Plus or Boundary Enterprise</a></EnterpriseAlert>
 
 User sessions can be recorded and audited using Boundary 0.13 or greater. A Boundary resource known as a [storage bucket](/boundary/docs/concepts/domain-model/storage-buckets) is used to store the recorded sessions.
 The storage bucket represents a bucket in an external storage provider.
@@ -67,7 +67,6 @@ Complete the following steps to create a storage bucket in Boundary.
       After rotation, only Boundary knows the client secret the plugin uses.
 
    </Tab>
-
    <Tab heading="Dynamic credentials">
 
    - **Role ARN**: (Required) The ARN (Amazon Resource Name) role that is attached to the EC2 instance that the self-managed worker runs on.
@@ -95,6 +94,12 @@ The required fields for creating a storage bucket depend on whether you configur
 
 <Tabs>
 <Tab heading="Static credentials">
+
+<Note>
+
+  The preferred way to authenticate to the S3 bucket is by using dynamic credentials. The example below uses static credentials instead.
+
+</Note>
 
 1. Log in to Boundary.
 1. Use the following command to create a storage bucket in Boundary:
@@ -160,6 +165,76 @@ The required fields for creating a storage bucket depend on whether you configur
       For more information, refer to the AWS documentation for [Logging IAM and AWS STS API calls with AWS CloudTrail](https://docs.aws.amazon.com/IAM/   latest/UserGuide/cloudtrail-integration.html).
       - `role_tags`: (Optional) An object with key-value pair attributes that is passed when you assume an IAM role.
       For more information, refer to the AWS documentation for [Passing session tags in AWS STS](https://docs.aws.amazon.com/IAM/latest/UserGuide/   id_session-tags.html).
+
+</Tab>
+</Tabs>
+
+</Tab>
+<Tab heading="Terraform" group="terraform">
+
+The HCL code for creating a storage bucket is different depending on whether you configured the AWS S3 bucket with static or dynamic credentials.
+
+<Tabs>
+<Tab heading="Static credentials">
+
+<Note>
+
+  The preferred way to authenticate to the S3 bucket is by using dynamic credentials. The code below uses static credentials instead.
+
+</Note>
+
+Apply the following Terraform policy:
+
+```hcl
+resource "boundary_storage_bucket" "aws_static_credentials_example" {
+  name            = "My aws storage bucket with static credentials"
+  description     = "My first storage bucket"
+  scope_id    = "o_1234567890"
+  plugin_name     = "aws"
+  bucket_name = "mybucket1"
+  attributes_json = jsonencode({ "region" = "us-east-1" })
+
+  # recommended to pass in aws secrets using a file() or using environment variables
+  # the secrets below must be generated in aws using an iam user with programmatic access
+  secrets_json = jsonencode({
+    "access_key_id"     = "aws_access_key_id_value",
+    "secret_access_key" = "aws_secret_access_key_value"
+  })
+  worker_filter = "\"dev\" in \"/tags/type\""
+}
+
+output "storage_bucket_id" {
+  value = boundary_storage_bucket.aws_static_credentials_example.id
+}
+```
+
+</Tab>
+<Tab heading="Dynamic credentials">
+
+Apply the following Terraform policy:
+
+```hcl
+resource "boundary_storage_bucket" "aws_dynamic_credentials_example" {
+  name        = "My aws storage bucket with dynamic credentials"
+  description = "My first storage bucket"
+  scope_id    = "o_1234567890"
+  plugin_name = "aws"
+  bucket_name = "mybucket1"
+
+  # the role_arn value should be the same arn used in the instance profile attached to the ec2 instance
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
+  attributes_json = jsonencode({
+    "region"                      = "us-east-1"
+    "role_arn"                    = "arn:aws:iam::123456789012:role/S3Access"
+    "disable_credential_rotation" = true
+  })
+  worker_filter = "\"dev\" in \"/tags/type\""
+}
+
+output "storage_bucket_id" {
+  value = boundary_storage_bucket.aws_dynamic_credentials_example.id
+}
+```
 
 </Tab>
 </Tabs>

--- a/website/content/docs/configuration/session-recording/enable-session-recording.mdx
+++ b/website/content/docs/configuration/session-recording/enable-session-recording.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # Enable session recording on a target
 
-<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary Plus or Boundary Enterprise</a></EnterpriseAlert>
 
 You must enable session recording for any targets that you want to record sessions on.
 When you [create a storage bucket](/boundary/docs/configuration/session-recording/create-storage-bucket), Boundary provides you with an ID.
@@ -56,15 +56,15 @@ The following setting is required for session recording:
 1. Click **Save**.
 
 </Tab>
-<Tab heading="CLI">
+<Tab heading="CLI" group="cli">
 
 1. Log in to Boundary.
 1. Do one of the following:
 
    - To enable an existing SSH target for session recording, run the following commmand:
 
-      ```bash
-      boundary targets update ssh -scope-id p_1234567890 -id tssh_1234567890 -enable-session-recording true -storage-bucket-id sb_1234567890
+      ```shell-session
+      $ boundary targets update ssh -scope-id p_1234567890 -id tssh_1234567890 -enable-session-recording true -storage-bucket-id sb_1234567890
       ```
 
       Make sure to add the `-enable-session-recording true` flag to turn on session recording for the target.
@@ -72,8 +72,8 @@ The following setting is required for session recording:
 
    - To create a new target and enable it for session recording, run the following command:
 
-      ```bash
-      boundary targets create ssh -scope-id p_1234567890 -default -port 22 -name test1 -address 99.12.345.67 -enable-session-recording true -storage-bucket-id sb_1234567890
+      ```shell-session
+      $ boundary targets create ssh -scope-id p_1234567890 -default -port 22 -name test1 -address 99.12.345.67 -enable-session-recording true -storage-bucket-id sb_1234567890
       ```
 
       Make sure to add the `-enable-session-recording true` flag to turn on session recording for the target.
@@ -81,6 +81,27 @@ The following setting is required for session recording:
       You can configure any other [target attributes](/boundary/docs/concepts/domain-model/targets).
 
       You can now view the target from the **Targets** page in the Boundary console.
+
+</Tab>
+<Tab heading="Terraform" group="terraform">
+
+Apply the following Terraform policy:
+
+```hcl
+resource "boundary_target" "address_foo" {
+  name         = "address_foo"
+  description  = "Foo target with an address"
+  type         = "tcp"
+  default_port = "22"
+  scope_id     = boundary_scope.project.id
+  address      = "127.0.0.1"
+
+  # Add the next two lines to an existing target to enable session recording.
+  # Modify the value of storage_bucket_id as appropriate
+  enable_session_recording = true
+  storage_bucket_id        = boundary_storage_bucket.aws_example.id
+}
+```
 
 </Tab>
 </Tabs>

--- a/website/content/docs/configuration/session-recording/index.mdx
+++ b/website/content/docs/configuration/session-recording/index.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # Overview
 
-<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary Plus or Boundary Enterprise</a></EnterpriseAlert>
 
 Boundary provides auditing capabilities using a feature called session recording.
 

--- a/website/content/docs/configuration/session-recording/update-storage-policy.mdx
+++ b/website/content/docs/configuration/session-recording/update-storage-policy.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # Update storage bucket policies
 
-<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
+<EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary Plus or Boundary Enterprise</a></EnterpriseAlert>
 
 A [storage policy][] codifies [storage bucket][] lifecycle management for [session recordings][].
 
@@ -35,7 +35,7 @@ The policies mentioned here demonstrate how to apply an updated storage policy t
 
 ## Storage policy changes
 
-A storage policy defines how long the recording within a scope should retain its session recordings. 
+A storage policy defines how long the recording within a scope should retain its session recordings.
 
 Over time, you may update storage policies to reflect new organizational requirements, compliance changes, or cost management strategies. While updated policies automatically apply to new session recordings within the scopes associated with that policy, existing recordings maintain the previous policies unless you apply the new policy directly to those recordings.
 
@@ -111,6 +111,25 @@ The following is an example of updating the `soc2-policy` policy.
        -delete-after-days 2757 \
        -delete-after-overridable false
    ```
+
+</Tab>
+<Tab heading="Terraform" group="terraform">
+
+Due to the declarative nature of Terraform, you update policies by modifying your existing Terraform configuration. To perform the requested changes, update your existing block of code as shown below, and then execute `terraform apply`.
+
+```hcl
+resource "boundary_policy_storage" "example" {
+  name = "soc2-policy"
+  v2"
+  scope_id = data.boundary_scope.org.id
+
+  retain_for_days = 2557
+  retain_for_overridable = false
+
+  delete_after_days = 2757
+  delete_after_overridable = false
+}
+```
 
 </Tab>
 <Tab heading="API call using cURL" group="api">
@@ -261,6 +280,11 @@ In the event that an updated policy should be retroactively applied to existing 
    </CodeBlockConfig>
 
    Verify that the `Delete After` attribute reflects the updated storage policy.
+
+</Tab>
+<Tab heading="Terraform" group="terraform">
+
+Once the policy changes have been applied with Terraform, you can reapply the policy as needed by following the CLI instructions in this section.
 
 </Tab>
 <Tab heading="API call using cURL" group="api">


### PR DESCRIPTION
The backports failed on #4556 . This PR backports those changes to the `stable-website` branch.

* added sample terraform code to create storage bucket configuration

* added terraform sample code for target configuration

* Added HCP Boundary Plus as requirement in the note

* added sample TF code to configure a storage policy

* added group attributes to tabs

* added terraform tab for updating a storage policy

* formatting and style guide changes

* docs: Lowercase credential types

* docs: Apply active voice

* docs: Close prefix

---------