### PR TITLE
chore(e2e): Add audit logs to aws boundary instances

### DIFF
--- a/enos/modules/aws_boundary/boundary-instances.tf
+++ b/enos/modules/aws_boundary/boundary-instances.tf
@@ -89,6 +89,11 @@ resource "enos_remote_exec" "update_path_controller" {
   }
 }
 
+locals {
+  audit_log_directory = "/var/log/boundary"
+  service_user        = "boundary"
+}
+
 resource "enos_file" "controller_config" {
   depends_on  = [enos_bundle_install.controller]
   destination = "/etc/boundary/boundary.hcl"
@@ -107,6 +112,7 @@ resource "enos_file" "controller_config" {
     cluster_port            = var.listener_cluster_port
     region                  = var.aws_region
     max_page_size           = var.max_page_size
+    audit_log_dir           = local.audit_log_directory
   })
   for_each = toset([for idx in range(var.controller_count) : tostring(idx)])
 
@@ -154,6 +160,25 @@ resource "enos_boundary_start" "controller_start" {
   ]
 }
 
+resource "enos_remote_exec" "create_controller_audit_log_dir" {
+  depends_on = [
+    enos_boundary_start.controller_start
+  ]
+  for_each = toset([for idx in range(var.controller_count) : tostring(idx)])
+
+  environment = {
+    LOG_DIR      = local.audit_log_directory
+    SERVICE_USER = local.service_user
+  }
+
+  scripts = [abspath("${path.module}/scripts/create-audit-log-dir.sh")]
+
+  transport = {
+    ssh = {
+      host = aws_instance.controller[tonumber(each.value)].public_ip
+    }
+  }
+}
 resource "enos_bundle_install" "worker" {
   depends_on = [aws_instance.worker]
   for_each   = toset([for idx in range(var.worker_count) : tostring(idx)])
@@ -188,7 +213,6 @@ resource "enos_remote_exec" "update_path_worker" {
   }
 }
 
-
 resource "enos_file" "worker_config" {
   depends_on  = [enos_bundle_install.worker]
   destination = "/etc/boundary/boundary.hcl"
@@ -196,11 +220,11 @@ resource "enos_file" "worker_config" {
     id                     = each.value
     kms_key_id             = data.aws_kms_key.kms_key.id,
     controller_ips         = jsonencode(aws_instance.controller.*.private_ip),
-    public_addr            = aws_instance.worker.0.public_ip
+    public_addr            = aws_instance.worker[tonumber(each.value)].public_ip
     region                 = var.aws_region
     type                   = jsonencode(var.worker_type_tags)
     recording_storage_path = var.recording_storage_path
-
+    audit_log_dir          = local.audit_log_directory
   })
   for_each = toset([for idx in range(var.worker_count) : tostring(idx)])
 
@@ -220,6 +244,26 @@ resource "enos_boundary_start" "worker_start" {
   config_path            = "/etc/boundary"
   license                = var.boundary_license
   recording_storage_path = var.recording_storage_path != "" ? var.recording_storage_path : null
+
+  transport = {
+    ssh = {
+      host = aws_instance.worker[tonumber(each.value)].public_ip
+    }
+  }
+}
+
+resource "enos_remote_exec" "create_worker_audit_log_dir" {
+  depends_on = [
+    enos_boundary_start.worker_start,
+  ]
+  for_each = toset([for idx in range(var.worker_count) : tostring(idx)])
+
+  environment = {
+    LOG_DIR      = local.audit_log_directory
+    SERVICE_USER = local.service_user
+  }
+
+  scripts = [abspath("${path.module}/scripts/create-audit-log-dir.sh")]
 
   transport = {
     ssh = {

--- a/enos/modules/aws_boundary/scripts/create-audit-log-dir.sh
+++ b/enos/modules/aws_boundary/scripts/create-audit-log-dir.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -eux
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$LOG_DIR" ]] && fail "LOG_DIR env variable has not been set"
+[[ -z "$SERVICE_USER" ]] && fail "SERVICE_USER env variable has not been set"
+
+function retry {
+  local retries=$1
+  shift
+  local count=0
+
+  until "$@"; do
+    exit=$?
+    wait=10
+    count=$((count + 1))
+
+    if [ "$count" -lt "$retries" ]; then
+      sleep "$wait"
+    else
+      return "$exit"
+    fi
+  done
+
+  return 0
+}
+
+retry 7 id -a "$SERVICE_USER"
+
+sudo mkdir -p "$LOG_DIR"
+sudo chown -R "$SERVICE_USER":"$SERVICE_USER" "$LOG_DIR"

--- a/enos/modules/aws_boundary/templates/controller.hcl
+++ b/enos/modules/aws_boundary/templates/controller.hcl
@@ -55,3 +55,44 @@ kms "awskms" {
   region     = "${region}"
   kms_key_id = "${kms_key_id}"
 }
+
+events {
+  audit_enabled        = true
+  observations_enabled = true
+  sysevents_enabled    = true
+
+  sink "stderr" {
+    name        = "all-events"
+    description = "All events sent to stderr"
+    event_types = ["*"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+      "\"/data/request_info/path\" contains \"/health\"",
+    ]
+  }
+
+  sink {
+    name        = "audit-sink"
+    description = "Audit sent to a file"
+    event_types = ["audit"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+    ]
+
+    file {
+      path      = "${audit_log_dir}"
+      file_name = "audit.log"
+    }
+
+    audit_config {
+      audit_filter_overrides {
+        secret    = "encrypt"
+        sensitive = "hmac-sha256"
+      }
+    }
+  }
+}

--- a/enos/modules/aws_boundary/templates/controller_bsr.hcl
+++ b/enos/modules/aws_boundary/templates/controller_bsr.hcl
@@ -61,3 +61,44 @@ kms "awskms" {
   region     = "${region}"
   kms_key_id = "${kms_key_id}"
 }
+
+events {
+  audit_enabled        = true
+  observations_enabled = true
+  sysevents_enabled    = true
+
+  sink "stderr" {
+    name        = "all-events"
+    description = "All events sent to stderr"
+    event_types = ["*"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+      "\"/data/request_info/path\" contains \"/health\"",
+    ]
+  }
+
+  sink {
+    name        = "audit-sink"
+    description = "Audit sent to a file"
+    event_types = ["audit"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+    ]
+
+    file {
+      path      = "${audit_log_dir}"
+      file_name = "audit.log"
+    }
+
+    audit_config {
+      audit_filter_overrides {
+        secret    = "encrypt"
+        sensitive = "hmac-sha256"
+      }
+    }
+  }
+}

--- a/enos/modules/aws_boundary/templates/worker.hcl
+++ b/enos/modules/aws_boundary/templates/worker.hcl
@@ -29,3 +29,44 @@ kms "awskms" {
   region     = "${region}"
   kms_key_id = "${kms_key_id}"
 }
+
+events {
+  audit_enabled        = true
+  observations_enabled = true
+  sysevents_enabled    = true
+
+  sink "stderr" {
+    name        = "all-events"
+    description = "All events sent to stderr"
+    event_types = ["*"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+      "\"/data/request_info/path\" contains \"/health\"",
+    ]
+  }
+
+  sink {
+    name        = "audit-sink"
+    description = "Audit sent to a file"
+    event_types = ["audit"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+    ]
+
+    file {
+      path      = "${audit_log_dir}"
+      file_name = "audit.log"
+    }
+
+    audit_config {
+      audit_filter_overrides {
+        secret    = "encrypt"
+        sensitive = "hmac-sha256"
+      }
+    }
+  }
+}

--- a/enos/modules/aws_boundary/templates/worker_bsr.hcl
+++ b/enos/modules/aws_boundary/templates/worker_bsr.hcl
@@ -31,3 +31,44 @@ kms "awskms" {
   region     = "${region}"
   kms_key_id = "${kms_key_id}"
 }
+
+events {
+  audit_enabled        = true
+  observations_enabled = true
+  sysevents_enabled    = true
+
+  sink "stderr" {
+    name        = "all-events"
+    description = "All events sent to stderr"
+    event_types = ["*"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+      "\"/data/request_info/path\" contains \"/health\"",
+    ]
+  }
+
+  sink {
+    name        = "audit-sink"
+    description = "Audit sent to a file"
+    event_types = ["audit"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+    ]
+
+    file {
+      path      = "${audit_log_dir}"
+      file_name = "audit.log"
+    }
+
+    audit_config {
+      audit_filter_overrides {
+        secret    = "encrypt"
+        sensitive = "hmac-sha256"
+      }
+    }
+  }
+}

--- a/enos/modules/aws_worker/scripts/create-audit-log-dir.sh
+++ b/enos/modules/aws_worker/scripts/create-audit-log-dir.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -eux
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$LOG_DIR" ]] && fail "LOG_DIR env variable has not been set"
+[[ -z "$SERVICE_USER" ]] && fail "SERVICE_USER env variable has not been set"
+
+function retry {
+  local retries=$1
+  shift
+  local count=0
+
+  until "$@"; do
+    exit=$?
+    wait=10
+    count=$((count + 1))
+
+    if [ "$count" -lt "$retries" ]; then
+      sleep "$wait"
+    else
+      return "$exit"
+    fi
+  done
+
+  return 0
+}
+
+retry 7 id -a "$SERVICE_USER"
+
+sudo mkdir -p "$LOG_DIR"
+sudo chown -R "$SERVICE_USER":"$SERVICE_USER" "$LOG_DIR"

--- a/enos/modules/aws_worker/templates/worker.hcl
+++ b/enos/modules/aws_worker/templates/worker.hcl
@@ -29,3 +29,44 @@ kms "awskms" {
   region     = "${region}"
   kms_key_id = "${kms_key_id}"
 }
+
+events {
+  audit_enabled        = true
+  observations_enabled = true
+  sysevents_enabled    = true
+
+  sink "stderr" {
+    name        = "all-events"
+    description = "All events sent to stderr"
+    event_types = ["*"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+      "\"/data/request_info/path\" contains \"/health\"",
+    ]
+  }
+
+  sink {
+    name        = "audit-sink"
+    description = "Audit sent to a file"
+    event_types = ["audit"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+    ]
+
+    file {
+      path      = "${audit_log_dir}"
+      file_name = "audit.log"
+    }
+
+    audit_config {
+      audit_filter_overrides {
+        secret    = "encrypt"
+        sensitive = "hmac-sha256"
+      }
+    }
+  }
+}

--- a/enos/modules/aws_worker/templates/worker_bsr.hcl
+++ b/enos/modules/aws_worker/templates/worker_bsr.hcl
@@ -31,3 +31,44 @@ kms "awskms" {
   region     = "${region}"
   kms_key_id = "${kms_key_id}"
 }
+
+events {
+  audit_enabled        = true
+  observations_enabled = true
+  sysevents_enabled    = true
+
+  sink "stderr" {
+    name        = "all-events"
+    description = "All events sent to stderr"
+    event_types = ["*"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+      "\"/data/request_info/path\" contains \"/health\"",
+    ]
+  }
+
+  sink {
+    name        = "audit-sink"
+    description = "Audit sent to a file"
+    event_types = ["audit"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+    ]
+
+    file {
+      path      = "${audit_log_dir}"
+      file_name = "audit.log"
+    }
+
+    audit_config {
+      audit_filter_overrides {
+        secret    = "encrypt"
+        sensitive = "hmac-sha256"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR updates the e2e test suite to enable audit logs on AWS-based boundary instances. Audit logs will be sent to both
- stderr
- /var/log/boundary/audit.log

The bash script was borrowed from vault's implementation: https://github.com/hashicorp/vault/blob/main/enos/modules/vault_cluster/scripts/create-audit-log-dir.sh

https://hashicorp.atlassian.net/browse/ICU-14089