### PR TITLE
cmd/connect: Ensure passthroughArgs are at the end.

### DIFF
--- a/internal/cmd/commands/connect/connect.go
+++ b/internal/cmd/commands/connect/connect.go
@@ -686,7 +686,7 @@ func (c *Command) handleExec(clientProxy *apiproxy.ClientProxy, passthroughArgs 
 		return
 	}
 
-	args = append(passthroughArgs, args...)
+	args = append(args, passthroughArgs...)
 
 	stringReplacer := func(in, typ, replacer string) string {
 		for _, style := range []string{


### PR DESCRIPTION
The documentation suggests that any arguments supplied after a `--` will be appended to the end of the command.  This is not the case with current released builds, where boundary appends further information relevant to the connection type onto the end of the command.

This commit changes the argument order to match what the docs detail where anything after `--` is passed through unmodified to the command that's being started as a child of the boundary process.  Notably, this is important for tools that expect boundary to behave like the tool that its wrapping, since with the reversed argument ordering commands that work without boundary break when it is introduced.