### PR TITLE
chore: Fail workflow if request does not succeed

### DIFF
--- a/scripts/trigger-merge-to-downstream-gha
+++ b/scripts/trigger-merge-to-downstream-gha
@@ -21,8 +21,9 @@ if [[ -z ${DOWNSTREAM_WORKFLOW} ]]; then
     exit 0
 fi
 
-curl \
+CURL_RESPONSE=$(curl \
   --silent \
+  -w '%{http_code}\n' \
   -X POST \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer ${DOWNSTREAM_TOK}" \
@@ -37,3 +38,14 @@ curl \
   }
 }
 EOF
+)
+echo $CURL_RESPONSE
+
+# Get the first digit of the status code (get the last word of the last line,
+# and then get the first character of that word)
+CURL_STATUS_CODE=$(echo "$CURL_RESPONSE" | tail -n1 | awk '{print $NF}' | cut -c1)
+
+if [[ $CURL_STATUS_CODE -ne 2 ]]; then
+  echo "ERROR: failed to trigger downstream workflow"
+  exit 1
+fi


### PR DESCRIPTION
The `trigger-merge-to-downstream` workflow had been failing for quite some time, but the workflow was still returning success. As a result, automatic merges from `boundary` to `boundary-enterprise` were not happening and there was no notification of a problem. Example: https://github.com/hashicorp/boundary/actions/runs/9843985789/job/27176402958

This PR makes an adjustment to the script to return a non-zero exit code if the curl request to the downstream repo returns a non 2xx exit code.

Testing locally
```
❯ bash trigger-merge-to-downstream-gha main
{ "message": "Resource not accessible by personal access token", "documentation_url": "https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event", "status": "403" } 403
ERROR: failed to trigger downstream workflow
```

https://hashicorp.atlassian.net/browse/ICU-14358