### PR TITLE
docs: Explain auth token TTL's impact on OIDC

### DIFF
--- a/website/content/docs/concepts/domain-model/auth-methods.mdx
+++ b/website/content/docs/concepts/domain-model/auth-methods.mdx
@@ -80,6 +80,8 @@ The OIDC auth method has the following additional attributes:
   users to reauthenticate, and an unset `maxAge` results in a Terraform value of
   -1 and the default TTL of the chosen OIDC is used.
 
+  If you set a `max_age` value, it works in conjunction with the [`auth_token_time_to_live` parameter](/boundary/docs/configuration/controller#auth_token_time_to_live) set on the controller. Users are not challenged to authenticate again by the provider until the `auth_token_time_to_live` value has expired, even if the `max_age` expires first.
+
 - `prompt` (optional) If you configure this attribute, the OIDC authorization server prompts users for reauthentication, account selection, or consent when they log in.
 You can optionally configure one or more of the following additional attributes to customize the behavior of the authentication process:
    - `none` (optional) The authorization server does not display any authentication or consent prompts.

--- a/website/content/docs/concepts/iam.mdx
+++ b/website/content/docs/concepts/iam.mdx
@@ -54,6 +54,15 @@ With the [OIDC](/boundary/tutorials/identity-management/oidc-auth) and LDAP auth
 as the auth method. The accounts and users are only created once the user authenticates to Boundary for the first time.
 The same applies to OIDC/LDAP [managed groups](/boundary/tutorials/identity-management/oidc-idp-groups).
 
+<Note>
+
+You can configure the `max_age` in the [OIDC attributes](/boundary/docs/concepts/domain-model/auth-methods#oidc-auth-method-attributes) to indicate to the OIDC provider how much time is allowed to pass until a user is challenged to authenticate again.
+However, the user will not be prompted to authenticate until the controller's `auth_token_time_to_live` [parameter](/boundary/docs/configuration/controller#auth_token_time_to_live) has expired.
+The default value is 7 days.
+At this time, HCP Boundary users cannot configure the `auth_token_time_to_live` for a controller, so that value always equals the default of 7 days.
+
+</Note>
+
 ### Grant permissions
 When setting up access controls for a user, it is important to first consider which scope(s) the user needs access to. Roles give users permission to perform actions through grants strings.
 It is recommended to add the user to a group, and then add the group to the role(s), instead of adding the user directly to the role(s). This way, you can manage multiple users at the same time, and it is easier to

--- a/website/content/docs/configuration/controller.mdx
+++ b/website/content/docs/configuration/controller.mdx
@@ -87,6 +87,8 @@ description will be read.
   to all tokens from all auth methods). Valid time units are anything specified by Golang's
   [ParseDuration()](https://golang.org/pkg/time/#ParseDuration) method. Default is 7 days.
 
+  Note that you cannot set a maximum time to live for auth tokens in HCP Boundary at this time. For HCP Boundary, all auth tokens' maximum time to live equal the default of 7 days.
+
 - `auth_token_time_to_stale` - Maximum time of inactivity for all auth tokens globally (pertains
   to all tokens from all auth methods). Valid time units are anything specified by Golang's
   [ParseDuration()](https://golang.org/pkg/time/#ParseDuration) method. Default is 1 day.


### PR DESCRIPTION
We currently do not document the impact the auth token's time-to-live, as set on the controller, has on authentication using an OIDC provider. This recently led to confusion for a customer. This PR attempts to clarify the relationship between the auth token's time-to-live and the OIDC `max_age` attribute.

I added additional text to the domain model topic for auth methods to clarify the `max_age` attribute:

https://boundary-qwmqisfb9-hashicorp.vercel.app/boundary/docs/concepts/domain-model/auth-methods#max_age

I also updated the controller configuration topic to clarify the time-to-live setting:

https://boundary-qwmqisfb9-hashicorp.vercel.app/boundary/docs/configuration/controller#auth_token_time_to_live

Finally, I added a note to the conceptual IAM topic (I am not sure if this is the best place for this info):

https://boundary-qwmqisfb9-hashicorp.vercel.app/boundary/docs/concepts/iam#configure-users-oidc-ldap

