### PR TITLE
test(e2e): Add support for an hcp worker

### DIFF
--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -192,3 +192,11 @@ variable "go_version" {
   type        = string
   default     = ""
 }
+
+variable "hcp_boundary_cluster_id" {
+  description = "ID of the Boundary cluster in HCP"
+  type        = string
+  default     = ""
+  // If using HCP int, ensure that the cluster id starts with "int-"
+  // Example: "int-19283a-123123-..."
+}

--- a/enos/modules/aws_boundary/outputs.tf
+++ b/enos/modules/aws_boundary/outputs.tf
@@ -225,3 +225,10 @@ output "pet_id" {
   description = "The ID of the random_pet used in this module"
   value       = random_pet.default.id
 }
+
+output "worker_tokens" {
+  description = "If available, worker tokens used to register to Boundary"
+  value = try([
+    for token in enos_remote_exec.get_worker_token : trimspace(token.stdout)
+  ], null)
+}

--- a/enos/modules/aws_boundary/security-groups.tf
+++ b/enos/modules/aws_boundary/security-groups.tf
@@ -88,7 +88,7 @@ resource "aws_security_group" "boundary_alb_sg" {
       cidr_blocks = flatten([
         formatlist("%s/32", data.enos_environment.localhost.public_ipv4_addresses),
         join(",", data.aws_vpc.infra.cidr_block_associations.*.cidr_block),
-        format("%s/32", aws_instance.controller.0.public_ip),
+        try(format("%s/32", aws_instance.controller.0.public_ip), []),
         formatlist("%s/32", var.alb_sg_additional_ips)
       ])
       description      = ingress.key

--- a/enos/modules/aws_boundary/templates/worker_hcp_bsr.hcl
+++ b/enos/modules/aws_boundary/templates/worker_hcp_bsr.hcl
@@ -1,0 +1,63 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+listener "tcp" {
+  purpose = "proxy"
+  tls_disable = true
+  address = "0.0.0.0"
+}
+
+hcp_boundary_cluster_id = "${hcp_boundary_cluster_id}"
+
+worker {
+  public_addr = "${public_addr}"
+
+  tags {
+    type   = ${type}
+    region = ["${region}"]
+  }
+
+  auth_storage_path = "/tmp/boundary/worker"
+  recording_storage_path = "${recording_storage_path}"
+}
+
+events {
+  audit_enabled        = true
+  observations_enabled = true
+  sysevents_enabled    = true
+
+  sink "stderr" {
+    name        = "all-events"
+    description = "All events sent to stderr"
+    event_types = ["*"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+      "\"/data/request_info/path\" contains \"/health\"",
+    ]
+  }
+
+  sink {
+    name        = "audit-sink"
+    description = "Audit sent to a file"
+    event_types = ["audit"]
+    format      = "cloudevents-json"
+
+    deny_filters = [
+      "\"/data/request_info/method\" contains \"Status\"",
+    ]
+
+    file {
+      path      = "${audit_log_dir}"
+      file_name = "audit.log"
+    }
+
+    audit_config {
+      audit_filter_overrides {
+        secret    = "encrypt"
+        sensitive = "hmac-sha256"
+      }
+    }
+  }
+}

--- a/enos/modules/aws_boundary/variables.tf
+++ b/enos/modules/aws_boundary/variables.tf
@@ -370,3 +370,11 @@ variable "recording_storage_path" {
   type        = string
   default     = ""
 }
+
+variable "hcp_boundary_cluster_id" {
+  description = "ID of the Boundary cluster in HCP"
+  type        = string
+  default     = ""
+  // If using HCP int, ensure that the cluster id starts with "int-"
+  // Example: "int-19283a-123123-..."
+}

--- a/enos/modules/aws_iam_setup/main.tf
+++ b/enos/modules/aws_iam_setup/main.tf
@@ -73,8 +73,7 @@ output "access_key_id" {
 }
 
 output "secret_access_key" {
-  value     = aws_iam_access_key.boundary.secret
-  sensitive = true
+  value = nonsensitive(aws_iam_access_key.boundary.secret)
 }
 
 output "user_name" {


### PR DESCRIPTION
This PR updates the e2e test suite to add support for an hcp worker. 
- Update `aws_boundary` module to support having a `controller_count` of 0 (we're using a HCP controller)
- Add variable to pass in a HCP cluster id
- Extract worker tokens from workers

There will be a follow-up PR in `boundary-enterprise` to add a scenario for setting up HCP Session Recording resources.

https://hashicorp.atlassian.net/browse/ICU-14433