### PR TITLE
Update Mistake in set-grant-scopes.mdx

### DIFF
--- a/website/content/docs/commands/roles/set-grant-scopes.mdx
+++ b/website/content/docs/commands/roles/set-grant-scopes.mdx
@@ -17,7 +17,7 @@ You can specify multiple grant scopes per role.
 This example sets the complete set of grant scopes on a role with the ID `r_1234567890` in the current scope and any children scopes:
 
 ```shell-session
-$ boundary roles add-grant-scopes -id r_1234567890 -grant-scope-id "this" -grant-scope-id "children"
+$ boundary roles set-grant-scopes -id r_1234567890 -grant-scope-id "this" -grant-scope-id "children"
 ```
 
 ## Usage
@@ -25,7 +25,7 @@ $ boundary roles add-grant-scopes -id r_1234567890 -grant-scope-id "this" -grant
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary roles set-grants [options] [args]
+$ boundary roles set-grant-scopes [options] [args]
 ```
 
 </CodeBlockConfig>


### PR DESCRIPTION
There is an error in the documentation where incorrect commands are listed under set-grant-scopes. The correct commands need to be updated.

For reference, please see: https://developer.hashicorp.com/boundary/docs/commands/roles/set-grant-scopes