### PR TITLE
docs: Clarify aliases and scopes

### DIFF
--- a/website/content/docs/concepts/aliases.mdx
+++ b/website/content/docs/concepts/aliases.mdx
@@ -41,8 +41,10 @@ Examples of valid aliases include `webserver` and `webserver.boundary`.
 
 ## Scopes
 
-At this time, you can only create aliases in the `global` scope.
-The destination target for an alias can be in any scope, however.
+You can only create aliases in the `global` scope.
+However, you can associate aliases with targets or hosts from any scope.
+Support for additional resource types may be added in the future.
+
 If you delete a project, Boundary clears the `destination_id` parameter for any aliases that resolve to targets in that project, so that they no longer function.
 
 ## Connect to a target using an alias


### PR DESCRIPTION
The phrasing we use to explain how aliases interact wtih scopes is confusing. This PR attempts to clarify how aliases can point to resources in other scopes.

From a Slack conversation:

https://hashicorp.slack.com/archives/C01AQDJF3SA/p1721828305064579
