### PR TITLE
docs: Update permissions concepts

### DIFF
--- a/website/content/docs/configuration/identity-access-management/assignable-permissions.mdx
+++ b/website/content/docs/configuration/identity-access-management/assignable-permissions.mdx
@@ -96,8 +96,8 @@ They include `id`, `scope_id`, `scope`, `name`, and `description`.
 
 ## Resources
 
-Refer to [Resource tables](/boundary/docs/concepts/security/resource-table) for lists of the available permissions per resource type.
+Refer to [Resource tables](/boundary/docs/configuration/identity-access-management/resource-table) for lists of the available permissions per resource type.
 
 ## Next steps
 
-Refer to [Permission grant formats](/boundary/docs/configuration/permissions/permission-grant-formats) for more information about configuring grant strings and examples of grant string formats.
+Refer to [Permission grant formats](/boundary/docs/configuration/identity-access-management/permission-grant-formats) for more information about configuring grant strings and examples of grant string formats.

--- a/website/content/docs/configuration/identity-access-management/index.mdx
+++ b/website/content/docs/configuration/identity-access-management/index.mdx
@@ -79,6 +79,7 @@ that originate from all matching roles.
 
 ## Next steps
 
-1. Refer to [Assignable permissions](/boundary/docs/configuration/permissions/assignable-permissions) for more information about the permissions you can assign to Boundary principals.
-1. Refer to [Permission grant formats](/boundary/docs/configuration/permissions/permission-grant-formats) for more information about configuring grant strings and to view examples.
+1. Refer to [Assignable permissions](/boundary/docs/configuration/identity-access-management/assignable-permissions) for more information about the permissions you can assign to Boundary principals.
+1. Refer to [Permission grant formats](/boundary/docs/configuration/identity-access-management/permission-grant-formats) for more information about configuring grant strings and to view examples.
+1. Refer to the [Resource table](/boundary/docs/configuration/identity-access-management/resource-table) for a cheat sheet to help you manage your permissions.
 1. Refer to the manage roles documentation for more information.

--- a/website/content/docs/configuration/identity-access-management/permission-grant-formats.mdx
+++ b/website/content/docs/configuration/identity-access-management/permission-grant-formats.mdx
@@ -10,7 +10,7 @@ description: |-
 Each grant string is a mapping that describes a resource or set of resources and
 the permissions that should be granted on them.
 
-Refer to [Assignable permissons](/boundary/docs/configuration/permissions/assignable-permissions) for more information about the permissions you can include in grants.
+Refer to [Assignable permissons](/boundary/docs/configuration/identity-access-management/assignable-permissions) for more information about the permissions you can include in grants.
 
 A grant string has a form similar to:
 
@@ -140,6 +140,10 @@ The following templates substitute a given value into the ID field of the grant 
   method to change their own password.
 - `{{.User.Id}}`: The substituted value is the user ID associated with the token
   used to perform the action.
+
+## Resources
+
+Refer to [Resource tables](/boundary/docs/configuration/identity-access-management/resource-table) for lists of the available permissions per resource type.
 
 ## Next steps
 

--- a/website/content/docs/configuration/identity-access-management/resource-table.mdx
+++ b/website/content/docs/configuration/identity-access-management/resource-table.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # Resource tables
 
-The following tables work as a quick cheat-sheet to help you manage your
+The following tables work as a quick cheat sheet to help you manage your
 permissions. Note that the tables are not exhaustive; for brevity they do _not_ show
 wildcard or templated grant strings.
 

--- a/website/content/docs/configuration/permissions/assignable-permissions.mdx
+++ b/website/content/docs/configuration/permissions/assignable-permissions.mdx
@@ -7,69 +7,97 @@ description: |-
 
 # Assignable permissions
 
+<!---
 Resources identified by the ID/Type selectors have permissions granted to the
 user in the form of actions and visibility (via `output_fields`). Each of these
 is detailed in the subsections below.
+--->
+
+You can grant users permissions to any Boundary resources that are identified by ID or Type selectors.
+Permissions are comprised of actions and visibility.
+You can also use `output_fields` to configure fine-grained control over the visibility of data that is returned to users.
 
 ## Actions
 
-Actions convey the ability to perform some action against a resource or
-collection. Many of these are common CRUD actions (`create`, `read`, `update`,
-`delete`) but many resources also specify actions specific to their type; for
-instance, a `target` has an `authorize-session` action to allow you to request
-making a connection to that target, and `auth-method` resources have an
-`authenticate` action to allow you to authenticate to Boundary. For the most
-part these are straightforward, however there are a couple of special cases to
-know.
+Actions convey the ability to perform some operation against a resource or
+collection.
+They include common CRUD operations (`create`, `read`, `update`,
+`delete`), but some resources also have actions that are specific to their type.
+
+For example, a `target` has an `authorize-session` action that allows you to request
+making a connection to that target.
+The `auth-method` resources have an `authenticate` action that allows you to authenticate to Boundary.
+Most actions represent common operations, however there are some special cases to note.
 
 ### Subactions
 
-Some subactions are supported. These actions have a format
-`top_level_action:subaction`, such as `read:self`. Being granted the top level
-action infers being granted all subactions. Thus, if a grant conveys `read`, it
-also matches the API actions `read` and `read:self`. However, if a grant conveys
-`read:self`, it will match the API action `read:self` but will not match `read`.
+Some subactions are also supported. Subactions have a format
+`top_level_action:subaction`, such as `read:self`.
+When you grant a top level action to a principal, they also inherit all subactions.
+
+For example, if a grant conveys `read`, it also matches the API actions `read` and `read:self`.
+However, if a grant conveys `read:self`, it does not grant the top-level action `read`.
 
 ### The `no-op` action and listing visibility
 
-There is an action that can be granted called `no-op`. As might be apparent,
-`no-op` is not used for any real action in Boundary; the purpose of this action
-is for listing visibility. Boundary only shows resources in the output of a
-`list` action for which a user has at least one granted action. Thus, without
-`no-op`, in order for a resource to be visible in a `list` action, a different
-action such as `read` would have to be granted to a user. This could result in
-exposing more information than desired, especially in the case of listing scopes
-and authentication methods so that users can perform initial authentication to
-Boundary (that is, granting access to `u_anon`).
+Boundary contains a `no-op` action that is not used for any real operations.
+However, you can use the `no-op` action for listing visibility.
 
-By granting the `no-op` action to users, they can see the resources in the
-output of a list command without needing other capability grants as well.
+When a user runs a `list` operation, Boundary only shows the resources for which a user has been granted at least one action.
+Without the `no-op` action, you would have to grant the user another action such as `read` to ensure they could view the resource.
+Granting additional actions to users could result in exposing more information to the user than intended.
+This is especially true for listing scopes and authentication methods, such as when users perform the initial authentication to Boundary.
+
+Instead, you can grant the `no-op` action to users to ensure that they can view the output of a list command, without granting them other unnecessary actions.
 
 ## Anonymous user restrictions
 
-Starting in Boundary 0.9.0, there are severe limits placed on the actions
-allowed to be assigned to the anonymous user `u_anon`. This is meant to avoid
-situations where an operator accidentally or mistakenly adds the anonymous user
-to a role that provides more privileges than might be intended for
-unauthenticated users.
+There are limits to the actions that you can assign to the anonymous user `u_anon`.
+The limitations are meant to prevent you from accidentally adding the anonymous user to a role that provides more privileges than you would intend to grant to an unauthenticated user.
 
-The set of actions is currently restricted to listing scopes and auth methods
-and authentication to auth methods (plus `no-op` actions for listing
-visibility). If further use-cases arise from user feedback this list can be
-expanded.
+For anonymous users, actions are restricted to listing scopes and auth methods,
+and authentication to auth methods.
+You can also grant the `no-op` action for listing visibility.
 
-Note: there is no special error message returned when access is denied due to it
-being disallowed to the anonymous user. It is still possible to assign grants to
-a role on which the anonymous user is a principal that can never match the
-anonymous user. In the future this may change, but trying to limit this
-introduces other restrictions on reasonable administrative workflows so an
-acceptable set of tradeoffs would need to be figured out.
+Boundary does not return a special error message when access is denied to an action because it is not allowed for an anonymous user.
+You can still assign grants to a role on which the anonymous user is a principal, but they can never match the anonymous user.
 
 ## Output fields
 
-Grant strings can contain an `output_fields` field. This allows fine-grained
-control over visibility of data returned to users.
+Grant strings can contain an `output_fields` value. This setting gives you fine-grained
+control over the visibility of data returned to users.
 
+The `output_fields` reference the field names of the JSON object reponse.
+They are composed just like other parts of the RBAC model, and are action-specific.
+For example, the following grant:
+
+`ids=*;type=auth-methods;actions=list,no-op;output_fields=scope_id,name,description`
+
+results in the three identified output fields (scope ID, name, and description) applying to any `list` and `no-op` actions for all auth methods in the scope.
+If a user performed a `list` operation under this example grant, each item returned would only have the three fields populated: `scope_id`, `name`, and `description`.
+Any other actions, such as `read` or `update`, would be unaffected and would return the default information.
+
+This grant:
+
+`ids=*;type=auth-methods;output_fields=id`
+
+means that only the `id` will be returned for any action performed against auth methods in this scope.
+
+Grants are composable.
+Therefore, if both of the example grants above are added, the final set of output fields would be `id`, `scope_id`, `name`, and `description` for the `list` and `no-op` actions.
+For all other actions, the output field would be `id`.
+
+### Default output fields
+
+If none of the grants applicable to the resource or action for a given request contain `output_fields` definitions, Boundary uses the defaults.
+The defaults are implemented using the internal values for `output_fields` and vary based on whether the user is anonymous:
+
+- If the user is anonymous: Boundary returns a useful, but restricted set of fields.
+They include `id`, `scope_id`, `scope`, `name`, and `description`.
+- If the user is authenticated: Boundary returns the full set of fields.
+
+
+<!---
 In many cases, `output_fields` will not need to be set directly. However, an
 example in the form of some history helps provide some context as to when this
 might be useful.
@@ -135,3 +163,5 @@ grants start specifying output fields, it is composed from an empty set and thus
 nothing is contained unless explicitly specified. (An actual empty set is not
 currently supported, as we don't perform validation on the values given.
 However, this means setting `output_fields=none` is functionally equivalent!)
+
+--->

--- a/website/content/docs/configuration/permissions/assignable-permissions.mdx
+++ b/website/content/docs/configuration/permissions/assignable-permissions.mdx
@@ -8,8 +8,12 @@ description: |-
 # Assignable permissions
 
 You can grant users permissions to any Boundary resources that are identified by ID or Type selectors.
-Permissions are comprised of actions and visibility.
-You can also use `output_fields` to configure fine-grained control over the visibility of data that is returned to users.
+There are two types of assigned permissions:
+
+- An `actions` field indicating which actions to allow the client to perform on
+  the resources matched by `id` and `type`
+- An `output_fields` field indicating which top-level fields to return in the
+  response.
 
 ## Actions
 
@@ -44,7 +48,7 @@ This is especially true for listing scopes and authentication methods, such as w
 
 Instead, you can grant the `no-op` action to users to ensure that they can view the output of a list command, without granting them other unnecessary actions.
 
-## Anonymous user restrictions
+### Anonymous user restrictions
 
 There are limits to the actions that you can assign to the anonymous user `u_anon`.
 The limitations are meant to prevent you from accidentally adding the anonymous user to a role that provides more privileges than you would intend to grant to an unauthenticated user.
@@ -83,9 +87,17 @@ For all other actions, the output field would be `id`.
 
 ### Default output fields
 
-If none of the grants applicable to the resource or action for a given request contain `output_fields` definitions, Boundary uses the defaults.
-The defaults are implemented using the internal values for `output_fields` and vary based on whether the user is anonymous:
+If none of the grants applicable to the resource or action for a given request contain `output_fields` definitions, Boundary uses the default settings.
+The default settings vary based on whether the user is anonymous:
 
-- If the user is anonymous: Boundary returns a useful, but restricted set of fields.
+- If the user is anonymous, Boundary returns a restricted set of fields.
 They include `id`, `scope_id`, `scope`, `name`, and `description`.
-- If the user is authenticated: Boundary returns the full set of fields.
+- If the user is authenticated, Boundary returns the full set of fields.
+
+## Resources
+
+Refer to [Resource tables](/boundary/docs/concepts/security/resource-table) for a table of the available permissions per resource type.
+
+## Next steps
+
+Refer to [Permission grant formats](/boundary/docs/configuration/permissions/permission-grant-formats) for more information about configuring grant strings and examples of grant string formats.

--- a/website/content/docs/configuration/permissions/assignable-permissions.mdx
+++ b/website/content/docs/configuration/permissions/assignable-permissions.mdx
@@ -7,12 +7,6 @@ description: |-
 
 # Assignable permissions
 
-<!---
-Resources identified by the ID/Type selectors have permissions granted to the
-user in the form of actions and visibility (via `output_fields`). Each of these
-is detailed in the subsections below.
---->
-
 You can grant users permissions to any Boundary resources that are identified by ID or Type selectors.
 Permissions are comprised of actions and visibility.
 You can also use `output_fields` to configure fine-grained control over the visibility of data that is returned to users.
@@ -95,73 +89,3 @@ The defaults are implemented using the internal values for `output_fields` and v
 - If the user is anonymous: Boundary returns a useful, but restricted set of fields.
 They include `id`, `scope_id`, `scope`, `name`, and `description`.
 - If the user is authenticated: Boundary returns the full set of fields.
-
-
-<!---
-In many cases, `output_fields` will not need to be set directly. However, an
-example in the form of some history helps provide some context as to when this
-might be useful.
-
-In Boundary 0.2.0, we restricted the set of fields returned for some `list`
-calls (those on the `scopes` and `auth-methods` collections) to a small set if
-the user was the anonymous user `u_anon`. Although default behavior in Boundary
-was to display all resource fields when listing, because the default was also to
-allow anonymous access to perform `list` on scopes and auth methods (in order to
-discover auth methods and then authenticate to them), returning all
-configuration information for all scopes and auth methods felt like it was
-publicly disclosing more information to users than might be desired.
-
-At the same time, this was not an ideal solution for two reasons:
-
-1. There is no one-size-fits-all security policy, and what we thought were
-   reasonable defaults may not work in all situations
-
-2. It made the scopes and auth methods listing behavior work differently from
-   any other `list` action, which is not ideal
-
-As a result, we decided to approach this problem the same way we normally try to
-within Boundary: set resonable defaults, but give the administrator ultimate
-control.
-
-The resulting behavior is as follows: `output_fields` references the field names
-of the JSON object response, composes just like other parts of the RBAC model,
-and are action-specific. That is, a grant like:
-
-`ids=*;type=auth-methods;actions=list,no-op;output_fields=scope_id,name,description`
-
-will, if all by itself, result in those three identified output fields applying
-to `list` (and `no-op`) actions for all auth methods in the scope. Thus when
-performing a `list`, each item returned will have only those three fields
-populated. Any other actions (like `read` or `update`) are unaffected and will
-use defaults.
-
-A grant like:
-
-`ids=*;type=auth-methods;output_fields=id`
-
-will, if all by itself, result in _any_ action against auth methods in the scope
-having only `id` returned.
-
-However, if both of the above grants are included, since grants are composable
-the final set of output fields will be `id,scope_id,name,description` for `list`
-(and `no-op`) actions, and `id` for all other actions.
-
-If, after the grants are composed for a given request, none of the grants
-applicable to the resource/action contain `output_fields` definitions, the
-defaults are used. These defaults are implemented using internal values for
-`output_fields` and vary based on whether the user is the anonymous user:
-
-- If the user is the anonymous user, a useful but restricted set of fields is
-  returned. This includes `id`, `scope_id`, `scope`, `name`, `description`, and a
-  few more.
-
-- If the user is any authenticated user, the full set of fields is returned
-
-To think about it a different way, empty `output_fields`, after grant
-composition, is equivalent to using Boundary's default; however the moment that
-grants start specifying output fields, it is composed from an empty set and thus
-nothing is contained unless explicitly specified. (An actual empty set is not
-currently supported, as we don't perform validation on the values given.
-However, this means setting `output_fields=none` is functionally equivalent!)
-
---->

--- a/website/content/docs/configuration/permissions/assignable-permissions.mdx
+++ b/website/content/docs/configuration/permissions/assignable-permissions.mdx
@@ -96,7 +96,7 @@ They include `id`, `scope_id`, `scope`, `name`, and `description`.
 
 ## Resources
 
-Refer to [Resource tables](/boundary/docs/concepts/security/resource-table) for a table of the available permissions per resource type.
+Refer to [Resource tables](/boundary/docs/concepts/security/resource-table) for lists of the available permissions per resource type.
 
 ## Next steps
 

--- a/website/content/docs/configuration/permissions/index.mdx
+++ b/website/content/docs/configuration/permissions/index.mdx
@@ -9,7 +9,7 @@ description: |-
 
 Boundary's permissions model is a composable, RBAC, allow-only model that
 attempts to marry flexibility with usability.
-The following pages discuss the permission model's fundamental concepts, provide examples of the specific forms of allowed grants, and contain a table that acts as an easy cheat sheet to help you craft roles.
+The following pages discuss the permission model's fundamental concepts, provide examples of the specific forms of allowed grants, and contain a table that acts as a cheat sheet to help you craft roles.
 
 Boundary's [domain model](/boundary/docs/concepts/domain-model) is based on resource
 types. You can implement resource types directly, such as with targets, or they can be
@@ -19,43 +19,37 @@ catalog is a concrete type.
 
 From a permissions standpoint, all actions take place against directly
 implemented or abstract types. There may be actions that are only implemented by
-some concrete types (e.g., not all `auth-method` implementations will support a
-`change-password` action), but the permissions model still defines these
-capabilities at the abstract type level. This helps keep the overall system
-relatively simple and predictable.
+some concrete types, for example, not all `auth-method` implementations support a
+`change-password` action. But the permissions model still defines these
+capabilities at the abstract type level.
 
 At a very high level, permissions within Boundary are declared via grant strings
 and mapped to users via roles.
 
 ## Grant strings
 
+Each grant string is a mapping that describes a resource or set of resources and
+the permissions that should be granted on them.
+
 A grant string has a form similar to:
 
 `ids=<id>;type=<type>;actions=<action list>;output_fields=<fields list>`
 
-Each grant string is a mapping that describes a resource or set of resources and
-the permissions that should be granted on them.
+Selectors are used to indicate the resources on which the grant should apply,
+using specific IDs or wildcard IDs and type selectors.
 
-There are currently two types of selectors:
+You can supply grant strings using a human-friendly string syntax or using JSON.
 
-- An `id` field that indicates a specific resource or a wildcard to match all
+### Assigned permissions
 
-- A `type` field that indicates a specific resource type or a wildcard to match
-  all; this might also be used to grant permissions on collections of resources
-
-Selectors are used to indicate which resources on which the grant should apply,
-using specific IDs or wildcard IDs and type selectors. (The acceptable grant
-string formats are detailed later on this page.)
-
-Additionally, there are two types of assigned permissions:
+You can grant users permissions to any Boundary resources that are identified by ID or Type selectors.
+There are two types of assigned permissions:
 
 - An `actions` field indicating which actions to allow the client to perform on
   the resources matched by `id` and `type`
 
 - An `output_fields` field indicating which top-level fields to return in the
-  response (0.2.1+)
-
-You can supply grant strings using a human-friendly string syntax or using JSON.
+  response.
 
 ## Roles
 
@@ -63,7 +57,7 @@ Roles map grant strings to principals, which are users, groups, and managed grou
 Every role assigns grants within a scope, as determined by the role's grant scope IDs.
 
 You can assign roles to multiple scopes to grant permissions to users who need access to resources across multiple scopes.
-You can also configure child scopes to inherit roles from parents.
+Child scopes can inherit roles from parents.
 For example, the global scope could have multiple child scopes called "orgs".
 When you create a role in the global scope, you can configure it to apply to those children org scopes.
 
@@ -74,12 +68,9 @@ A role provides grants for a request if the grant scope ID matches the request's
 scope ID and one or more of the following are true:
 
 - The user's ID is contained in the principal IDs set on the role
-
 - A group the user belongs to is contained in the principal IDs set on the role
-
 - The user is logged in and the `u_auth` user is contained in the principal IDs
   set on the role
-
 - The role contains the `u_anon` user in the in the principal IDs set on the
   role
 
@@ -88,6 +79,6 @@ that originate from all matching roles.
 
 ## Next steps
 
-Refer to the [assignable permissions](/boundary/docs/configuration/permissions/assignable-permissions) documentation for more information about the permissions you can assign to Boundary principals.
-
-Refer to the [permission grant formats](/boundary/docs/configuration/permissions/permission-grant-formats) documentation for more information about configuring grant strings and examples.
+1. Refer to [Assignable permissions](/boundary/docs/configuration/permissions/assignable-permissions) for more information about the permissions you can assign to Boundary principals.
+1. Refer to [Permission grant formats](/boundary/docs/configuration/permissions/permission-grant-formats) for more information about configuring grant strings and to view examples.
+1. Refer to the manage roles documentation for more information.

--- a/website/content/docs/configuration/permissions/index.mdx
+++ b/website/content/docs/configuration/permissions/index.mdx
@@ -8,15 +8,13 @@ description: |-
 # Permissions in Boundary
 
 Boundary's permissions model is a composable, RBAC, allow-only model that
-attempts to marry flexibility with usability. This page discusses the permission
-model's fundamental concepts, provides examples of the specific forms of allowed
-grants, and contains a table that acts as an easy cheat sheet to help those new
-to its grant syntax with crafting roles.
+attempts to marry flexibility with usability.
+The following pages discuss the permission model's fundamental concepts, provide examples of the specific forms of allowed grants, and contain a table that acts as an easy cheat sheet to help you craft roles.
 
 Boundary's [domain model](/boundary/docs/concepts/domain-model) is based on resource
-types. These can be implemented directly, such as with targets, or they can be
-abstract types that are implemented by concrete types within the system. As an
-example of the latter, a host catalog is an abstract type and a Static host
+types. You can implement resource types directly, such as with targets, or they can be
+abstract types that you implement using concrete types within the system. As an
+example of the latter, a host catalog is an abstract type and a static host
 catalog is a concrete type.
 
 From a permissions standpoint, all actions take place against directly
@@ -57,7 +55,7 @@ Additionally, there are two types of assigned permissions:
 - An `output_fields` field indicating which top-level fields to return in the
   response (0.2.1+)
 
-Grant strings can be supplied via a human-friendly string syntax or via JSON.
+You can supply grant strings using a human-friendly string syntax or using JSON.
 
 ## Roles
 
@@ -87,3 +85,9 @@ scope ID and one or more of the following are true:
 
 Roles are composable; a user's final set of grants will be composed of grants
 that originate from all matching roles.
+
+## Next steps
+
+Refer to the [assignable permissions](/boundary/docs/configuration/permissions/assignable-permissions) documentation for more information about the permissions you can assign to Boundary principals.
+
+Refer to the [permission grant formats](/boundary/docs/configuration/permissions/permission-grant-formats) documentation for more information about configuring grant strings and examples.

--- a/website/content/docs/configuration/permissions/permission-grant-formats.mdx
+++ b/website/content/docs/configuration/permissions/permission-grant-formats.mdx
@@ -7,45 +7,45 @@ description: |-
 
 # Permission grant formats
 
-Because of the aforementioned properties of the permissions model, grants are
-relatively simple. All grants take one of four forms. These examples use the
-canonical string syntax; the JSON equivalents are simply an object with a string
+All grants take one of four forms. The following examples use the
+canonical string syntax.
+The JSON equivalents are an object with a string
 `id` value, a string `type` value, a string array `actions` value, and a string
 array `output_fields` value.
 
-~> `output_fields` is omitted in most example below for brevity but are valid
-in all of them. It is also valid in each case to omit `actions` and specify
-_only_ `output_fields`.
+In the examples below, `output_fields` is omitted for brevity, but they are valid for each example.
+It is also valid to omit `actions` and only specify `output_fields`.
 
 ## ID only
 
-This is the simplest form: for a given specific resource, allow these actions.
-Example:
+The simplest form of grant allows the specified actions for a given resource.
+Refer to the following example:
 
 `ids=hsst_1234567890;actions=read,update`
 
-This grants `read` and `update` actions to that single resource. It is invalid
-to specify `create` or `list` as actions in this format, as this format
-explicitly identifies a resource, whereas those actions operate exclusively on
-collections.
+This example grants `read` and `update` actions to the resource `hsst_1234567890`. It is invalid
+to specify `create` or `list` as actions in this format, because this format
+explicitly identifies a resource.
+The `create` and `list` actions are only supported for collections.
 
 ## Type only
 
-For a given type, allow these actions. Example:
+You can configure a grant to allow the specified actions for a given type.
+Refer to the following example:
 
 `type=host-catalog;actions=create,list`
 
 Because type specifies only a collection as opposed to specific resources within
 that collection, only collection actions are allowed in this format. Currently,
-this is `create` and `list`.
+this includes the `create` and `list` actions.
 
-There is one additional restriction: this is only valid against "top-level"
-resource types, which currently are:
+There is one additional restriction: this grant format is only valid against "top-level"
+resource types, which include:
 
-- Auth Methods
-- Auth Tokens
+- Auth methods
+- Auth tokens
 - Groups
-- Host Catalogs
+- Host catalogs
 - Roles
 - Scopes
 - Sessions
@@ -53,55 +53,60 @@ resource types, which currently are:
 - Users
 
 The reason for this is that other types of resources are contained within one of
-these resource types; for instance, accounts are instantiated within an auth
-method. To specify actions against those, you must also specify to which
-specific containing resource you want the grants to apply. This can be done with
-the pinned format shown below.
+these resource types.
+For example, accounts are instantiated within an auth
+method. To specify actions against an auth method, you must also specify the
+specific containing resource you want to apply the grants to.
+You can update those resources using the pinned format shown below.
 
 ## Pinned ID
 
-This form "pins" actions to a non-top-level type within a specific ID. It's
-easiest to explain with an example:
+This form "pins" actions to a non-top-level type within a specific ID.
+Refer to the following example:
 
 `ids=hcst_1234567890;type=host-set;actions=create,read,update`
 
 In this example, the user is able to create, read, or update host sets within
-the scope, but _only the host sets belonging to host catalog hcst_1234567890_.
+the scope, but only the host sets belonging to host catalog `hcst_1234567890`.
 Pinning is essentially a way to use top-level resources to create mini
 permission boundaries for their subordinate resources.
 
 ## Wildcards
 
-Various wildcard possibilities are allowed:
+You can use wildcards in grants.
+Refer to the following sections for the various wildcard possibilities that are supported.
 
 ### Wildcard ID
 
-When just the ID is `*`, it matches all IDs of the given type. This can be used
-with both top-level resource types and not. Example:
+When just the ID is `*`, it matches all IDs of the given type. You can use this grant format
+with both top-level resource types and non-top-level resource types.
+Refer to the following example:
 
 `ids=*;type=host-set;actions=create,read,update,set-hosts`
 
 ### Wildcard type
 
-For non-top-level resources with pinned IDs, the `type` can be a wildcard:
+For non-top-level resources with pinned IDs, the `type` can be a wildcard.
+Refer to the following example:
 
 `ids=hcst_1234567890;type=*;actions=create,read,update`
 
-This would allow `create`, `read`, and `update` actions for all types of
-subordinate resources (in this case host sets and hosts) underneath the host
+This grant format would allow `create`, `read`, and `update` actions for all types of
+subordinate resources underneath the host
 catalog with ID `hcst_1234567890`.
+In this example, that would include host sets and hosts.
 
 ### Wildcard ID and type
 
-If ID and type are both a wildcard, the grant is essentially a catch-all that
-will match any resource of any type within the scope and allow the given
-actions.
+If the ID and type are both wildcards, the grant is essentially a catch-all that matches any resource of any type within the scope and allows the given actions.
+Refer to the following example:
 
 `ids=*;type=*;actions=read,list`
 
 ### Wildcard ID, type, and actions
 
-Finally, ID, type, and actions can all be wildcards:
+ID, type, and actions can all be wildcards.
+Refer to the following example:
 
 `ids=*;type=*;actions=*`
 
@@ -109,22 +114,13 @@ Such a grant is essentially a full administrator grant for a scope.
 
 ## Templates
 
-A few template possibilities exist, which will at grant evaluation time
-substitute the given value into the ID field of the grant string:
+A few template possibilities exist for grants.
+The following templates substitute a given value into the ID field of the grant string at evaluation time:
 
 - `{{.Account.Id}}`: The substituted value is the account ID associated with the
   token used to perform the action. As an example,
   `ids={{.Account.Id}};actions=read,change-password"` is one of Boundary's
   default grants to allow users that have authenticated with the Password auth
   method to change their own password.
-  - **NOTE**: Prior to Boundary 0.11.1, `{{account.id}}` must be used instead.
-    Boundary 0.11.1+ changes this for consistency with other places within
-    Boundary that are gaining templating support, but supports both formats for
-    backwards compatibility.
-
 - `{{.User.Id}}`: The substituted value is the user ID associated with the token
   used to perform the action.
-  - **NOTE**: Prior to Boundary 0.11.1, `{{user.id}}` must be used instead.
-    Boundary 0.11.1+ changes this for consistency with other places within
-    Boundary that are gaining templating support, but supports both formats for
-    backwards compatibility.

--- a/website/content/docs/configuration/permissions/permission-grant-formats.mdx
+++ b/website/content/docs/configuration/permissions/permission-grant-formats.mdx
@@ -7,14 +7,30 @@ description: |-
 
 # Permission grant formats
 
-All grants take one of four forms. The following examples use the
-canonical string syntax.
-The JSON equivalents are an object with a string
-`id` value, a string `type` value, a string array `actions` value, and a string
-array `output_fields` value.
+Each grant string is a mapping that describes a resource or set of resources and
+the permissions that should be granted on them.
 
-In the examples below, `output_fields` is omitted for brevity, but they are valid for each example.
-It is also valid to omit `actions` and only specify `output_fields`.
+Refer to [Assignable permissons](/boundary/docs/configuration/permissions/assignable-permissions) for more information about the permissions you can include in grants.
+
+A grant string has a form similar to:
+
+`ids=<id>;type=<type>;actions=<action list>;output_fields=<fields list>`
+
+There are two types of selectors:
+
+- An `id` field that indicates a specific resource or a wildcard to match all
+- A `type` field that indicates a specific resource type or a wildcard to match
+  all; this might also be used to grant permissions on collections of resources
+
+Selectors are used to indicate the resources on which the grant should apply,
+using specific IDs or wildcard IDs and type selectors.
+
+You can supply grant strings using a human-friendly string syntax or using JSON.
+The following examples use the canonical string syntax.
+The JSON equivalents are an object with a string `id` value, a string `type` value, a string array `actions` value, and a string array `output_fields` value.
+
+In the following examples, `output_fields` is omitted for brevity, but they are valid for each example.
+It is also valid to omit `actions` and specify only `output_fields`.
 
 ## ID only
 
@@ -124,3 +140,7 @@ The following templates substitute a given value into the ID field of the grant 
   method to change their own password.
 - `{{.User.Id}}`: The substituted value is the user ID associated with the token
   used to perform the action.
+
+## Next steps
+
+Refer to Manage roles to map grant strings to principals using roles.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -260,10 +260,6 @@
           {
             "title": "Connections/TLS",
             "path": "concepts/security/connections-tls"
-          },
-          {
-            "title": "Resource tables",
-            "path": "concepts/security/resource-table"
           }
         ]
       },
@@ -503,19 +499,23 @@
         ]
       },
       {
-        "title": "Permissions",
+        "title": "Identity and access management",
         "routes": [
           {
             "title": "Overview",
-            "path": "configuration/permissions"
+            "path": "configuration/identity-access-management"
           },
           {
             "title": "Assignable permissions",
-            "path": "configuration/permissions/assignable-permissions"
+            "path": "configuration/identity-access-management/assignable-permissions"
           },
           {
             "title": "Permission grant formats",
-            "path": "configuration/permissions/permission-grant-formats"
+            "path": "configuration/identity-access-management/permission-grant-formats"
+          },
+          {
+            "title": "Resource table",
+            "path": "configuration/identity-access-management/resource-table"
           }
         ]
       },

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -196,22 +196,22 @@ module.exports = [
   },
   {
     source: '/boundary/docs/concepts/security/permissions/resource-table',
-    destination: '/boundary/docs/concepts/security/resource-table',
+    destination: '/boundary/docs/configuration/identity-access-management/resource-table',
     permanent: true,
   },
   {
     source: '/boundary/docs/concepts/security/permissions',
-    destination: '/boundary/docs/configuration/permissions',
+    destination: '/boundary/docs/configuration/identity-access-management',
     permanent: true,
   },
   {
     source: '/boundary/docs/concepts/security/permissions/assignable-permissions',
-    destination: '/boundarydocs/configuration/permissions/assignable-permisisons',
+    destination: '/boundarydocs/configuration/identity-access-management/assignable-permisisons',
     permanent: true,
   },
   {
     source: '/boundary/docs/concepts/security/permissions/permission-grant-formats',
-    destination: '/boundary/docs/configuration/permissions/permission-grant-formats',
+    destination: '/boundary/docs/configuration/identity-access-management/permission-grant-formats',
     permanent: true,
   },
 ]


### PR DESCRIPTION
Updates to the following concept topics for clarity/conciseness and to streamline workflow to the updated manage roles usage docs:

- [Permissions in Boundary](https://boundary-aw4ad8712-hashicorp.vercel.app/boundary/docs/configuration/identity-access-management)
- [Assignable permissions](https://boundary-aw4ad8712-hashicorp.vercel.app/boundary/docs/configuration/identity-access-management/assignable-permissions)
- [Permission grant formats](https://boundary-aw4ad8712-hashicorp.vercel.app/boundary/docs/configuration/identity-access-management/permission-grant-formats)
- [Resource table](https://boundary-aw4ad8712-hashicorp.vercel.app/boundary/docs/configuration/identity-access-management/resource-table)