### PR TITLE
docs: Add Desktop fix to known issues 0.15.x and 0.16.x

### DIFF
--- a/website/content/docs/release-notes/v0_15_0.mdx
+++ b/website/content/docs/release-notes/v0_15_0.mdx
@@ -290,6 +290,28 @@ description: |-
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.15.0
+    <br /><br />
+    (Fixed in 0.15.5)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Users cannot log in to Boundary Desktop
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A bug caused Boundary Desktop to incorrectly assume the controller was running an unsupported version. It would prevent users from being able to log in to the Desktop client.
+    <br /><br />
+    Learn more:&nbsp;
+    <br /><br />
+    <a href="https://github.com/hashicorp/boundary/issues/4370">Boundary Desktop issue #4370</a>
+    <br /><br />
+    This issue is fixed in Boundary version 0.15.5.
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
 
 
   </tbody>

--- a/website/content/docs/release-notes/v0_16_0.mdx
+++ b/website/content/docs/release-notes/v0_16_0.mdx
@@ -201,5 +201,27 @@ description: |-
     <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
     </td>
   </tr>
+
+   <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.16.0
+    <br /><br />
+    (Fixed in 0.16.0)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Users cannot log in to Boundary Desktop
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A bug caused Boundary Desktop to incorrectly assume the controller was running an unsupported version. It would prevent users from being able to log in to the Desktop client.
+    <br /><br />
+    Learn more:&nbsp;
+    <br /><br />
+    <a href="https://github.com/hashicorp/boundary/issues/4370">Boundary Desktop issue #4370</a>
+    <br /><br />
+    This issue is fixed in Boundary version 0.16.0.
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This pull request adds info about a Desktop bug that is being fixed for the July 31 release. The fix is being back ported to the 0.15.5 release. It was already back ported to the 0.16.0 release. This pull request adds the issue to the release note's Known issues section for both versions.

View the update in the preview deployment:

- [0.15.x known issues](https://boundary-2h5otc59i-hashicorp.vercel.app/boundary/docs/release-notes/v0_15_0#known-issues-and-breaking-changes)
- [0.16.x known issues](https://boundary-2h5otc59i-hashicorp.vercel.app/boundary/docs/release-notes/v0_16_0#known-issues-and-breaking-changes)