### PR TITLE
docs: Release notes 07-31

### DIFF
--- a/website/content/docs/commands/sessions/list.mdx
+++ b/website/content/docs/commands/sessions/list.mdx
@@ -38,6 +38,8 @@ We recommend that you use single quotes, because the filters contain double quot
 Refer to the [Filter resource listings documentation](/boundary/docs/concepts/filtering/resource-listing) for more details.
 - `-include-terminated` - If set, Boundary includes terminated sessions in the `list` results.
 The default value is `false`.
+This field has been deprecated and will be removed from a future release.
+Boundary will include terminated sessions in all list results, unless you filter them out.
 - `recursive` - If set, runs the list operation recursively on any child scopes, if the type supports it.
 The default value is `false`.
 - `scope-id=<string>` - The scope from which to list sessions.

--- a/website/content/docs/release-notes/v0_16_0.mdx
+++ b/website/content/docs/release-notes/v0_16_0.mdx
@@ -203,3 +203,53 @@ description: |-
   </tr>
   </tbody>
 </table>
+
+## Feature deprecations and EOL
+
+<table>
+  <thead>
+    <tr>
+      <th style={{verticalAlign: 'middle'}}>EOL</th>
+      <th style={{verticalAlign: 'middle'}}>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      <code>boundary daemon</code> command
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+     The <code>boundary daemon</code> command has been deprecated in favor of the new <code>boundary cache</code> command. The functionality remains the same.
+      <br /><br />
+      Learn more:&nbsp;
+      <a href="/boundary/docs/commands/cache"><code>boundary cache</code></a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      <code>include_terminated</code> field removed
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+     The <code>include_terminated</code> field from the <code>list sessions</code> command has been deprecated and will be removed in an upcoming release. Boundary will return terminated sessions in all list session responses, unless they are filtered out.
+      <br /><br />
+      Learn more:&nbsp;
+      <a href="/boundary/docs/commands/sessions/list#command-options"><code>sessions list</code> command options</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      <code>grant_scope_id</code> field removed from roles
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+     The <code>grant_scope_id</code> field, which was deprecated in release 0.15.0, has been removed from roles. You can now manage roles using the <code>add-grant-scopes</code>, <code>remove-grant-scopes</code>, and <code>set-grant-scopes</code> commands.
+      <br /><br />
+      Learn more:&nbsp;<a href="/boundary/docs/commands/roles/add-grant-scopes"><code>add-grant-scopes</code></a>, <a href="/boundary/docs/commands/roles/remove-grant-scopes"><code>remove-grant-scopes</code></a>, and <a href="/boundary/docs/commands/roles/set-grant-scopes"><code>set-grant-scopes</code></a>
+    </td>
+  </tr>
+
+
+  </tbody>
+</table>

--- a/website/content/docs/release-notes/v0_16_0.mdx
+++ b/website/content/docs/release-notes/v0_16_0.mdx
@@ -232,10 +232,10 @@ description: |-
       <code>include_terminated</code> field removed
     </td>
     <td style={{verticalAlign: 'middle'}}>
-     The <code>include_terminated</code> field from the <code>list sessions</code> command has been deprecated and will be removed in an upcoming release. Boundary will return terminated sessions in all list session responses, unless they are filtered out.
+     The <code>include_terminated</code> field from the <code>list sessions</code> command has been deprecated and will be removed in an upcoming release. Boundary will return terminated sessions in all list session responses, unless they are filtered out using the <code>filter</code> field. For more information, refer to the filter resource documentation.
       <br /><br />
       Learn more:&nbsp;
-      <a href="/boundary/docs/commands/sessions/list#command-options"><code>sessions list</code> command options</a>
+      <a href="/boundary/docs/commands/sessions/list#command-options"><code>sessions list</code> command options</a> and <a href="/boundary/docs/concepts/filtering/resource-listing">Filter resource listings</a>
     </td>
   </tr>
 

--- a/website/content/docs/release-notes/v0_17_0.mdx
+++ b/website/content/docs/release-notes/v0_17_0.mdx
@@ -60,7 +60,7 @@ description: |-
     </td>
     <td style={{verticalAlign: 'middle'}}>
       When you attempt to connect to a target, Boundary randomly selects a worker that has the matching tags to proxy the connection. Before release 0.17.0, unhealthy workers that had issues related to the external storage provider were eligible to proxy connections. The connections would fail, and users had to restart the connection until Boundary selected a healthy worker. <br /><br />
-      In this release, Boundary removes workers from the connection pool if they have issues with the external storage provider for improved worker failure handling.
+      In this release, Boundary removes workers from the pool of available workers if they have issues with the external storage provider for improved worker failure handling.
       <br /><br />
       Learn more:&nbsp;<a href="/boundary/docs/configuration/session-recording/configure-worker-storage">Configure workers for session recording</a>.
     </td>

--- a/website/content/docs/release-notes/v0_17_0.mdx
+++ b/website/content/docs/release-notes/v0_17_0.mdx
@@ -1,0 +1,129 @@
+---
+layout: docs
+page_title: v0.17.0
+description: |-
+  Boundary release notes for v0.17.0
+---
+
+# Boundary 0.17.0 release notes
+
+**GA date:** July 31, 2024
+
+@include 'release-notes/intro.mdx'
+
+## New features
+
+<table>
+  <thead>
+    <tr>
+      <th style={{verticalAlign: 'middle'}}>Feature</th>
+      <th style={{verticalAlign: 'middle'}}>Update</th>
+      <th style={{verticalAlign: 'middle'}}>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      Centralized tag management for workers
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      GA
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+     Prior to this version, if you wanted to edit or update worker tags, you had to do it using the worker configuration file, the CLI, or the API. Now, you can edit worker tags directly in the Boundary UI.
+      <br /><br />
+      Learn more:&nbsp;<a href="/boundary/docs/concepts/filtering/worker-tags">Worker tags</a>.
+    </td>
+  </tr>
+
+   <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      Multi-scope roles and inheritance
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      GA
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      You can now assign a single role to multiple scopes, making it easier to grant permissions to users who must access resources across multiple scopes. You can also configure children scopes to inherit roles.
+      <br /><br />
+      Learn more:&nbsp;<a href="/boundary/docs/concepts/security/permissions">Permissions in Boundary</a>.
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      Improved worker failure handling
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      GA
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      When you attempt to connect to a target, Boundary randomly selects a worker that has the matching tags to proxy the connection. Before release 0.17.0, unhealthy workers that had issues related to the external storage provider were eligible to proxy connections. The connections would fail, and users had to restart the connection until Boundary selected a healthy worker. <br /><br />
+      In this release, Boundary removes workers from the connection pool if they have issues with the external storage provider for improved worker failure handling.
+      <br /><br />
+      Learn more:&nbsp;<a href="/boundary/docs/configuration/session-recording/configure-worker-storage">Configure workers for session recording</a>.
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      S3-compliant storage options for session recording
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      GA
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      As of Boundary 0.16.0, the MinIO plugin made it possible to use MinIO storage as a storage option for session recording. Starting in this release, you can use the MinIO plugin to configure storage using other S3-compliant storage providers.
+      <br /><br />
+      Learn more:&nbsp;<a href="/boundary/docs/configuration/session-recording/storage-providers/configure-s3-compliant">Configure S3-compliant storage for session recording</a>.
+    </td>
+  </tr>
+
+
+  </tbody>
+</table>
+
+## Known issues and breaking changes
+
+<table>
+  <thead>
+    <tr>
+      <th style={{verticalAlign: 'middle'}}>Version</th>
+      <th style={{verticalAlign: 'middle'}}>Issue</th>
+      <th style={{verticalAligh: 'middle'}}>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.13.0+
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Rotation of AWS access and secret keys during a session results in stale recordings
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    In Boundary version 0.13.0+, when you rotate a storage bucket's secrets, any new sessions use the new credentials. However, previously established sessions continue to use the old credentials.
+    <br /><br />
+    As a best practice, administrators should rotate credentials in a phased manner, ensuring that all previously established sessions are completed before revoking the stale credentials.
+    Otherwise, you may end up with recordings that aren't stored in the remote storage bucket, and are unable to be played back.
+    </td>
+  </tr>
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.13.0+
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Unsupported recovery workflow during worker failure
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    If a worker fails during a recording, there is no way to recover the recording. This could happen due to a network connectivity issue or because a worker is scaled down, for example.
+    <br /><br />
+    Learn more:&nbsp;
+    <a href="/boundary/docs/troubleshoot/troubleshoot-recorded-sessions#unsupported-recovery-workflow">Unsupported recovery workflow</a>
+    </td>
+  </tr>
+
+  </tbody>
+</table>

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1758,6 +1758,10 @@
         "path": "release-notes"
       },
       {
+        "title": "v0.17.0",
+        "path": "release-notes/v0_17_0"
+      },
+      {
         "title": "v0.16.0",
         "path": "release-notes/v0_16_0"
       },


### PR DESCRIPTION
Updates the release notes for the 07/31 release. View the updates in the preview deployment:

- [Release 0.16.x feature deprecations and EOL](https://boundary-mni4dnlwa-hashicorp.vercel.app/boundary/docs/release-notes/v0_16_0#feature-deprecations-and-eol) (Per the changelog, these deprecations were made during point releases, but we did not add them to the release notes.)
- Updated [`sessions list` command options](https://boundary-mni4dnlwa-hashicorp.vercel.app/boundary/docs/commands/sessions/list#command-options) to indicate that `include-terminated` is deprecated
- New page [Release 0.17.0](https://boundary-mni4dnlwa-hashicorp.vercel.app/boundary/docs/release-notes/v0_17_0)