### PR TITLE
test(asciicast): Update expected value due to encoding change

### DIFF
--- a/internal/bsr/convert/internal/asciicast/asciicast_test.go
+++ b/internal/bsr/convert/internal/asciicast/asciicast_test.go
@@ -144,7 +144,7 @@ func TestEventMarshal(t *testing.T) {
 		{
 			"backspace",
 			mustEvent(t, asciicast.Output, 0.1, []byte("\b\x1b[K")),
-			[]byte(`[0.1,"o","\u0008\u001b[K"]`),
+			[]byte(`[0.1,"o","\b\u001b[K"]`),
 			nil,
 		},
 		{


### PR DESCRIPTION
This fixes the following test error
```
 --- FAIL: TestEventMarshal (0.00s)
  --- FAIL: TestEventMarshal/backspace (0.00s)

    asciicast_test.go:166: 
        	Error Trace:	/home/runner/actions-runner/_work/boundary-enterprise/boundary-enterprise/internal/bsr/convert/internal/asciicast/asciicast_test.go:166
        	Error:      	Not equal: 
        	            	expected: []byte{0x5b, 0x30, 0x2e, 0x31, 0x2c, 0x22, 0x6f, 0x22, 0x2c, 0x22, 0x5c, 0x75, 0x30, 0x30, 0x30, 0x38, 0x5c, 0x75, 0x30, 0x30, 0x31, 0x62, 0x5b, 0x4b, 0x22, 0x5d}
        	            	actual  : []byte{0x5b, 0x30, 0x2e, 0x31, 0x2c, 0x22, 0x6f, 0x22, 0x2c, 0x22, 0x5c, 0x62, 0x5c, 0x75, 0x30, 0x30, 0x31, 0x62, 0x5b, 0x4b, 0x22, 0x5d}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	-([]uint8) (len=26) {
        	            	- 00000000  5b 30 2e 31 2c 22 6f 22  2c 22 5c 75 30 30 30 38  |[0.1,"o","\u0008|
        	            	- 00000010  5c 75 30 30 31 62 5b 4b  22 5d                    |\u001b[K"]|
        	            	+([]uint8) (len=22) {
        	            	+ 00000000  5b 30 2e 31 2c 22 6f 22  2c 22 5c 62 5c 75 30 30  |[0.1,"o","\b\u00|
        	            	+ 00000010  31 62 5b 4b 22 5d                                 |1b[K"]|
        	            	 }
        	Test:       	TestEventMarshal/backspace
```