### PR TITLE
feat(loopback): support dynamic credentials

### DIFF
--- a/internal/plugin/loopback/const.go
+++ b/internal/plugin/loopback/const.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package loopback
+
+const (
+	// ConstDynamicCredentials should be used as a key for an storage bucket attribute, to mock dynamic credentials.
+	ConstDynamicCredentials = "dynamic_credentials"
+)


### PR DESCRIPTION
# Summary

Currently, the AWS plugin for storage supports using both static(IAM User) and dynamic(Instance Profile) credentials. This PR is updating the loopback plugin mimic dynamic credentials, allowing us to add more unit tests for storage.