### PR TITLE
docs: Update link in 0.17.0 release notes

### DIFF
--- a/website/content/docs/release-notes/v0_17_0.mdx
+++ b/website/content/docs/release-notes/v0_17_0.mdx
@@ -47,7 +47,7 @@ description: |-
     <td style={{verticalAlign: 'middle'}}>
       You can now assign a single role to multiple scopes, making it easier to grant permissions to users who must access resources across multiple scopes. You can also configure children scopes to inherit roles.
       <br /><br />
-      Learn more:&nbsp;<a href="/boundary/docs/concepts/security/permissions">Permissions in Boundary</a>.
+      Learn more:&nbsp;<a href="/boundary/docs/configuration/identity-access-management">Permissions in Boundary</a>.
     </td>
   </tr>
 

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -200,11 +200,6 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/boundary/docs/concepts/security/permissions',
-    destination: '/boundary/docs/configuration/identity-access-management',
-    permanent: true,
-  },
-  {
     source: '/boundary/docs/concepts/security/permissions/assignable-permissions',
     destination: '/boundary/docs/configuration/identity-access-management/assignable-permisisons',
     permanent: true,
@@ -212,6 +207,11 @@ module.exports = [
   {
     source: '/boundary/docs/concepts/security/permissions/permission-grant-formats',
     destination: '/boundary/docs/configuration/identity-access-management/permission-grant-formats',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/concepts/security/permissions',
+    destination: '/boundary/docs/configuration/identity-access-management',
     permanent: true,
   },
 ]


### PR DESCRIPTION
Fixes the link to the Permissions in Boundary topic from the 0.17.0 release notes:

https://boundary-dacg2gu3q-hashicorp.vercel.app/boundary/docs/release-notes/v0_17_0