### PR TITLE
fix(db): remove old rewrapping-job table

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/90/01_drop_kms_rewrapping_table.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/90/01_drop_kms_rewrapping_table.up.sql
@@ -1,0 +1,9 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+  -- the storage_plugin_storage_bucket_secret table was replaced by storage_bucket_credential_managed_secret
+  -- in migration 88/01_storage_bucket_credential.up.sql.
+  -- the storage_plugin_storage_bucket_secret-rewrapping-job was replaced by storage_bucket_credential_managed_secret-rewrapping-job.
+  delete from job where name = 'storage_plugin_storage_bucket_secret-rewrapping-job';
+commit;


### PR DESCRIPTION
# Summary

The `storage_plugin_storage_bucket_secret-rewrapping-job` table needs to be dropped because the `storage_plugin_storage_bucket_secret` table no longer exists and was replaced by the `storage_bucket_credential_managed_secret` table.