### PR TITLE
docs: Fix broken anchor link in Credential management

### DIFF
--- a/website/content/docs/concepts/credential-management.mdx
+++ b/website/content/docs/concepts/credential-management.mdx
@@ -10,7 +10,7 @@ description: |-
 When users connect to a remote machine, they typically need a set of credentials for authentication.
 After they connect to the machine, they may also require another set of credentials to access services or other machines within the network.
 
-There are two credential management paradigms in Boundary, [credential brokering](#credential-brokering) and [credential injection](#credential-injection-hcp-only).
+There are two credential management paradigms in Boundary, [credential brokering](#credential-brokering) and [credential injection](#credential-injection).
 
 To configure credential brokering or credential injection with static credentials, refer to [Manage static credentials with Boundary](/boundary/docs/configuration/credential-management/static-cred-boundary) and [Manage static credentials with Vault](/boundary/docs/configuration/credential-management/static-cred-vault).
 

--- a/website/content/docs/concepts/credential-management.mdx
+++ b/website/content/docs/concepts/credential-management.mdx
@@ -12,7 +12,7 @@ After they connect to the machine, they may also require another set of credenti
 
 There are two credential management paradigms in Boundary, [credential brokering](#credential-brokering) and [credential injection](#credential-injection).
 
-To configure credential brokering or credential injection with static credentials, refer to [Manage static credentials with Boundary](/boundary/docs/configuration/credential-management/static-cred-boundary) and [Manage static credentials with Vault](/boundary/docs/configuration/credential-management/static-cred-vault).
+To configure credential brokering or credential injection with static credentials, refer to [Create a static credential store](/boundary/docs/configuration/credential-management/static-cred-boundary) and [Create a Vault credential store](/boundary/docs/configuration/credential-management/static-cred-vault).
 
 ## Credential brokering
 


### PR DESCRIPTION
Fixes an old broken anchor link. This is from when titles used to include "HCP only" instead of using the banner.

[Test the update in the preview deployment](https://boundary-r0oo7hcy2-hashicorp.vercel.app/boundary/docs/concepts/credential-management)

<img width="722" alt="image" src="https://github.com/user-attachments/assets/46cfedb2-4542-44d6-92c5-f61489a2bca0">
