### PR TITLE
Added new remove the requirement for inbound network rules section

### DIFF
--- a/website/content/docs/concepts/connection-workflows/multi-hop.mdx
+++ b/website/content/docs/concepts/connection-workflows/multi-hop.mdx
@@ -17,9 +17,9 @@ across multiple networks to form reverse proxy connections between the user and 
 ## Remove the requirement for inbound network rules
 
 With a multi-hop deployment, all connections are initiated outbound from the most downstream worker in the chain. When the connection is established between the workers, the proxied connections go over the established connection.
-These persistent TCP connections result in the requirement for only outbound connectivity. 
+These persistent TCP connections result in the requirement for only outbound connectivity.
 
-In the scenario where there may be a firewall(s) sitting inbetween ingress and egress workers, organizations do not need to create additional inbound rules to facilitate a Boundary multi-hop deployment. This not only helps to
+In the scenario where there may be a firewall(s) sitting between ingress and egress workers, organizations do not need to create additional inbound rules to facilitate a Boundary multi-hop deployment. This not only helps to
 simplify existing infrastructure configuration within your environment, but also ensures that your current security posture is not weakened or compromised.
 
 ## Multi-hop worker types

--- a/website/content/docs/concepts/connection-workflows/multi-hop.mdx
+++ b/website/content/docs/concepts/connection-workflows/multi-hop.mdx
@@ -14,6 +14,16 @@ inbound traffic to route through multiple network enclaves to reach the target s
 Multi-hop sessions allow you to chain together two or more workers
 across multiple networks to form reverse proxy connections between the user and the target, even in complex networks with strict outbound-only policies.
 
+## Remove the requirement for inbound network rules
+
+With a multi-hop deployment, all connections are initiated outbound from the most downstream worker in the chain. When the connection is established between the workers, the proxied connections go over the established connection.
+These persistent TCP connections result in the requirement for only outbound connectivity. 
+
+In the scenario where there may be a firewall(s) sitting inbetween ingress and egress workers, organizations do not need to create additional inbound rules to facilitate a Boundary multi-hop deployment. This not only helps to
+simplify existing infrastructure configuration within your environment, but also ensures that your current security posture is not weakened or compromised.
+
+## Multi-hop worker types
+
 In multi-hop scenarios, there are typically three types of workers:
 1. **Ingress worker** - An ingress worker is a worker that is accessible by the client. The client initiates the connection to the ingress worker.
 1. **Intermediary worker** - An optional intermediary worker sits between ingress and egress workers as part of a multi-hop chain. There can be multiple intermediary workers as part of a multi-hop chain.

--- a/website/content/docs/concepts/connection-workflows/multi-hop.mdx
+++ b/website/content/docs/concepts/connection-workflows/multi-hop.mdx
@@ -16,7 +16,7 @@ across multiple networks to form reverse proxy connections between the user and 
 
 ## Inbound network rules
 
-With a multi-hop deployment, all connections are initiated outbound from the most downstream worker in the chain. When the connection is established between the workers, the proxied connections go over the established connection.
+With a multi-hop deployment, all connections are initiated outbound from the most downstream worker in the chain. After Boundary establishes the initial connection between the workers, it uses the established connection for any subsequent connections.
 These persistent TCP connections result in the requirement for only outbound connectivity.
 
 If you have one or more firewalls sitting between the ingress and egress workers, you do not need to create additional inbound networking rules to facilitate a Boundary multi-hop deployment. This not only helps to

--- a/website/content/docs/concepts/connection-workflows/multi-hop.mdx
+++ b/website/content/docs/concepts/connection-workflows/multi-hop.mdx
@@ -20,7 +20,7 @@ With a multi-hop deployment, all connections are initiated outbound from the mos
 These persistent TCP connections result in the requirement for only outbound connectivity.
 
 If you have one or more firewalls sitting between the ingress and egress workers, you do not need to create additional inbound networking rules to facilitate a Boundary multi-hop deployment. This not only helps to
-simplify existing infrastructure configuration within your environment, but also ensures that your current security posture is not weakened or compromised.
+simplify your infrastructure configuration, but also ensures that your security posture is not weakened or compromised.
 
 ## Multi-hop worker types
 

--- a/website/content/docs/concepts/connection-workflows/multi-hop.mdx
+++ b/website/content/docs/concepts/connection-workflows/multi-hop.mdx
@@ -19,7 +19,7 @@ across multiple networks to form reverse proxy connections between the user and 
 With a multi-hop deployment, all connections are initiated outbound from the most downstream worker in the chain. When the connection is established between the workers, the proxied connections go over the established connection.
 These persistent TCP connections result in the requirement for only outbound connectivity.
 
-In the scenario where there may be a firewall(s) sitting between ingress and egress workers, organizations do not need to create additional inbound rules to facilitate a Boundary multi-hop deployment. This not only helps to
+If you have one or more firewalls sitting between the ingress and egress workers, you do not need to create additional inbound networking rules to facilitate a Boundary multi-hop deployment. This not only helps to
 simplify existing infrastructure configuration within your environment, but also ensures that your current security posture is not weakened or compromised.
 
 ## Multi-hop worker types

--- a/website/content/docs/concepts/connection-workflows/multi-hop.mdx
+++ b/website/content/docs/concepts/connection-workflows/multi-hop.mdx
@@ -14,7 +14,7 @@ inbound traffic to route through multiple network enclaves to reach the target s
 Multi-hop sessions allow you to chain together two or more workers
 across multiple networks to form reverse proxy connections between the user and the target, even in complex networks with strict outbound-only policies.
 
-## Remove the requirement for inbound network rules
+## Inbound network rules
 
 With a multi-hop deployment, all connections are initiated outbound from the most downstream worker in the chain. When the connection is established between the workers, the proxied connections go over the established connection.
 These persistent TCP connections result in the requirement for only outbound connectivity.


### PR DESCRIPTION
I was unaware until a few weeks ago, after speaking with @jefferai about the pure power of mhop and outbound connectivity. A question that comes up often is that if you have a mhop deployment and maybe a firewall in between, my understanding was that you would have to allow inbound connectivity to the egress worker associated with the target. After speaking with engineering, this is not the case. 

I believe most, if not all of the field are unaware of this and it is a powerful feature. I think more needs to be made of it to highlight this. Certainly colleagues I've spoken to are unaware of it.

This PR is a draft for further review and discussion.