### PR TITLE
docs: Document recorded session max size

### DIFF
--- a/website/content/docs/configuration/session-recording/index.mdx
+++ b/website/content/docs/configuration/session-recording/index.mdx
@@ -32,6 +32,14 @@ When you estimate worker storage requirements, consider the number of concurrent
 
 When you estimate storage requirements for the external storage provider, consider your [storage policy](/boundary/docs/concepts/domain-model/storage-policy) and how long a BSR will be retained in the external storage bucket.
 
+<Warning>
+
+Boundary supports recorded session files up to 5 GB in size.
+If a recorded session file is over 5 GB, the session details show the recording state as `Failed` and you may not be able to play back the session.
+Be careful when you use Secure File Copy (SCP) to transfer large files during a recorded session because it can result in large recorded session files.
+
+</Warning>
+
 ## Enable session recording
 
 To enable session recording, you must:


### PR DESCRIPTION
This PR documents the size limitation for recorded session files. I added this info to the Overview page for configuring session recording in a section named "Storage considerations" since it affects all external storage providers.