### PR TITLE
internal/daemon: simplify time update tests

### DIFF
--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -937,7 +937,7 @@ func (tc *TestController) WaitForNextWorkerStatusUpdate(workerStatusName string)
 			break
 		}
 
-		if waitStatusCurrent.Sub(waitStatusStart) > 0 {
+		if waitStatusCurrent.After(waitStatusStart) {
 			break
 		}
 	}

--- a/internal/daemon/worker/status.go
+++ b/internal/daemon/worker/status.go
@@ -106,7 +106,7 @@ func (w *Worker) WaitForNextSuccessfulStatusUpdate() error {
 			return ctx.Err()
 		}
 
-		if w.lastSuccessfulStatusTime().Sub(waitStatusStart) > 0 {
+		if w.lastSuccessfulStatusTime().After(waitStatusStart) {
 			break
 		}
 	}

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -711,7 +711,7 @@ func (w *Worker) Shutdown() error {
 			break
 		}
 
-		if w.lastSuccessfulStatusTime().Sub(waitStatusStart) > 0 {
+		if w.lastSuccessfulStatusTime().After(waitStatusStart) {
 			break
 		}
 


### PR DESCRIPTION
Using time.After makes the intent clearer