### PR TITLE
Add semgrep rules

### DIFF
--- a/.semgrep/event-with-info-msg.yaml
+++ b/.semgrep/event-with-info-msg.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+rules:
+  - id: with-info-msg-string-interpolation
+    languages:
+      - go
+    severity: ERROR
+    message: Use of WithInfoMsg with string interpolation. WithInfoMsg expects kv
+      tuples.
+    # Source for Go string interpolation verbs:
+    # https://pkg.go.dev/fmt#hdr-Printing.
+    pattern: event.WithInfoMsg("=~/.*%(((\[\d+\])|[\d|\.|#|+|\-| |\*])*)?[s|v|q|d|T|t|b|c|o|O|x|X|U|e|E|f|F|g|G|p].*/",...)

--- a/scan.hcl
+++ b/scan.hcl
@@ -15,7 +15,7 @@ repository {
   plugin "semgrep" {
     use_git_ignore = true
     exclude = ["*_test.go", "website/*", "testing/*"]
-    config = ["p/gosec"]
+    config = ["p/gosec", ".semgrep/"]
   }
   
   plugin "codeql" {


### PR DESCRIPTION
### [Add semgrep rules](https://github.com/hashicorp/boundary/commit/ce476b0aff17acaed7efc9d27f76c289668797d1)

Instrument our security scanner with the ability to use custom semgrep
rules. This is inspired by the HVS teams use of semgrep.

### [semgrep: add rule to detect string interpolation in WithInfoMsg](https://github.com/hashicorp/boundary/commit/428f64fc26298f021e4621d5aa0dd2cd792933af)

The event.WithInfoMsg function expects a set of key value tuples,
but it can easily be misunderstood to accept string interpolation
arguments. This check will error if any string interpolation verbs are
used in calls to event.WithInfoMsg

View this rule in the playground here: https://semgrep.dev/playground/r/YGUpBXB/johan_brandhorst_personal_org.with-info-msg-string-interpolation