### PR TITLE
Add context timeout/deadline causes

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -729,6 +729,7 @@ func (c *Client) NewRequest(ctx context.Context, method, requestPath string, bod
 // Do takes a properly configured request and applies client configuration to
 // it, returning the response.
 func (c *Client) Do(r *retryablehttp.Request, opt ...Option) (*Response, error) {
+	const op = "api.(Client).Do"
 	opts := getOpts(opt...)
 	c.modifyLock.RLock()
 	limiter := c.config.Limiter
@@ -765,7 +766,11 @@ func (c *Client) Do(r *retryablehttp.Request, opt ...Option) (*Response, error) 
 
 	if timeout != 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
+		ctx, cancel = context.WithTimeoutCause(
+			ctx,
+			timeout,
+			fmt.Errorf("%s: client configured timeout exceeded", op),
+		)
 		// This dance is just to ignore vet warnings; we don't want to cancel
 		// this as it will make reading the response body impossible
 		_ = cancel
@@ -834,6 +839,9 @@ func (c *Client) Do(r *retryablehttp.Request, opt ...Option) (*Response, error) 
 	}
 
 	if err != nil {
+		if ctxCause := context.Cause(ctx); ctxCause != nil {
+			return nil, fmt.Errorf("%w (%w)", err, ctxCause)
+		}
 		if strings.Contains(err.Error(), "tls: oversized") {
 			err = fmt.Errorf(
 				"%w\n\n"+

--- a/internal/clientcache/cmd/cache/wrapper_register.go
+++ b/internal/clientcache/cmd/cache/wrapper_register.go
@@ -80,6 +80,7 @@ func silentUi() *cli.BasicUi {
 // addTokenToCache runs AddTokenCommand with the token used in, or retrieved by
 // the wrapped command.
 func addTokenToCache(ctx context.Context, baseCmd *base.Command, token string) bool {
+	const op = "cache.addTokenToCache"
 	com := AddTokenCommand{Command: base.NewCommand(baseCmd.UI)}
 	client, err := baseCmd.Client()
 	if err != nil {
@@ -95,7 +96,11 @@ func addTokenToCache(ctx context.Context, baseCmd *base.Command, token string) b
 
 	// Since the daemon might have just started, we need to wait until it can
 	// respond to our requests
-	waitCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	waitCtx, cancel := context.WithTimeoutCause(
+		ctx,
+		3*time.Second,
+		fmt.Errorf("%s: daemon startup timeout exceeded", op),
+	)
 	defer cancel()
 	if err := waitForDaemon(waitCtx); err != nil {
 		// TODO: Print the result of this out into a log in the dot directory

--- a/internal/clientcache/internal/cache/refresh.go
+++ b/internal/clientcache/internal/cache/refresh.go
@@ -154,7 +154,11 @@ func (r *RefreshService) RefreshForSearch(ctx context.Context, authTokenid strin
 	const op = "cache.(RefreshService).RefreshForSearch"
 	if r.maxSearchRefreshTimeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, r.maxSearchRefreshTimeout)
+		ctx, cancel = context.WithTimeoutCause(
+			ctx,
+			r.maxSearchRefreshTimeout,
+			fmt.Errorf("%s: search refresh timeout exceeded", op),
+		)
 		defer cancel()
 	}
 	at, err := r.repo.LookupToken(ctx, authTokenid)

--- a/internal/daemon/controller/handler.go
+++ b/internal/daemon/controller/handler.go
@@ -475,7 +475,11 @@ func wrapHandlerWithCommonFuncs(h http.Handler, c *Controller, props HandlerProp
 		w.Header().Set("Cache-Control", "no-store")
 
 		// Start with the request context and our timeout
-		ctx, cancelFunc := context.WithTimeout(r.Context(), maxRequestDuration)
+		ctx, cancelFunc := context.WithTimeoutCause(
+			r.Context(),
+			maxRequestDuration,
+			fmt.Errorf("%s: max request duration exceeded", op),
+		)
 		defer cancelFunc()
 
 		// Add a size limiter if desired

--- a/internal/daemon/controller/interceptor.go
+++ b/internal/daemon/controller/interceptor.go
@@ -494,7 +494,11 @@ func eventsResponseInterceptor(
 func requestMaxDurationInterceptor(_ context.Context, maxRequestDuration time.Duration) grpc.UnaryServerInterceptor {
 	const op = "controller.requestMaxDurationInterceptor"
 	return func(interceptorCtx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		withTimeout, cancel := context.WithTimeout(interceptorCtx, maxRequestDuration)
+		withTimeout, cancel := context.WithTimeoutCause(
+			interceptorCtx,
+			maxRequestDuration,
+			fmt.Errorf("%s: max request duration exceeded", op),
+		)
 		defer cancel()
 		return handler(withTimeout, req)
 	}

--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -888,7 +888,11 @@ func (tc *TestController) WaitForNextWorkerStatusUpdate(workerStatusName string)
 	ctx := context.TODO()
 	event.WriteSysEvent(ctx, op, "waiting for next status report from worker", "worker", workerStatusName)
 	waitStatusStart := time.Now()
-	ctx, cancel := context.WithTimeout(tc.ctx, time.Duration(tc.c.workerStatusGracePeriod.Load()))
+	ctx, cancel := context.WithTimeoutCause(
+		tc.ctx,
+		time.Duration(tc.c.workerStatusGracePeriod.Load()),
+		fmt.Errorf("%s: worker status grace period exceeded", op),
+	)
 	defer cancel()
 	var err error
 	for {

--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -941,7 +941,7 @@ func (tc *TestController) WaitForNextWorkerStatusUpdate(workerStatusName string)
 			break
 		}
 
-		if waitStatusCurrent.Sub(waitStatusStart) > 0 {
+		if waitStatusCurrent.After(waitStatusStart) {
 			break
 		}
 	}

--- a/internal/daemon/worker/handler.go
+++ b/internal/daemon/worker/handler.go
@@ -136,7 +136,7 @@ func (w *Worker) handleProxy(listenerCfg *listenerutil.ListenerConfig, sessionMa
 		// Later calls will cause this to noop if they return a different status
 		defer conn.Close(websocket.StatusNormalClosure, "done")
 
-		connCtx, connCancel := context.WithDeadline(ctx, sess.GetExpiration())
+		connCtx, connCancel := context.WithDeadlineCause(ctx, sess.GetExpiration(), fmt.Errorf("%s: session expiration exceeded", op))
 		defer connCancel()
 
 		var handshake proxy.ClientHandshake

--- a/internal/daemon/worker/listeners.go
+++ b/internal/daemon/worker/listeners.go
@@ -321,6 +321,7 @@ func (w *Worker) stopServersAndListeners() error {
 }
 
 func (w *Worker) stopHttpServer() error {
+	const op = "worker.stopHttpServer"
 	if w.proxyListener == nil {
 		return nil
 	}
@@ -329,7 +330,11 @@ func (w *Worker) stopHttpServer() error {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(w.baseContext, w.proxyListener.Config.MaxRequestDuration)
+	ctx, cancel := context.WithTimeoutCause(
+		w.baseContext,
+		w.proxyListener.Config.MaxRequestDuration,
+		fmt.Errorf("%s: max request duration exceeded", op),
+	)
 	w.proxyListener.HTTPServer.Shutdown(ctx)
 	cancel()
 

--- a/internal/daemon/worker/session/session.go
+++ b/internal/daemon/worker/session/session.go
@@ -503,7 +503,11 @@ func closeConnections(ctx context.Context, sessClient pbs.SessionServiceClient, 
 	// bit of formalization in terms of how we handle timeouts. For now, this
 	// just ensures consistency with the same status call in that it times out
 	// within an adequate period of time.
-	closeConnCtx, closeConnCancel := context.WithTimeout(ctx, time.Duration(CloseCallTimeout.Load()))
+	closeConnCtx, closeConnCancel := context.WithTimeoutCause(
+		ctx,
+		time.Duration(CloseCallTimeout.Load()),
+		fmt.Errorf("%s: close call timeout exceeded", op),
+	)
 	defer closeConnCancel()
 	response, err := closeConnection(closeConnCtx, sessClient, makeCloseConnectionRequest(closeInfo))
 	if err != nil {

--- a/internal/daemon/worker/status.go
+++ b/internal/daemon/worker/status.go
@@ -110,7 +110,7 @@ func (w *Worker) WaitForNextSuccessfulStatusUpdate() error {
 			return ctx.Err()
 		}
 
-		if w.lastSuccessfulStatusTime().Sub(waitStatusStart) > 0 {
+		if w.lastSuccessfulStatusTime().After(waitStatusStart) {
 			break
 		}
 	}

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -715,7 +715,7 @@ func (w *Worker) Shutdown() error {
 			break
 		}
 
-		if w.lastSuccessfulStatusTime().Sub(waitStatusStart) > 0 {
+		if w.lastSuccessfulStatusTime().After(waitStatusStart) {
 			break
 		}
 

--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -703,7 +703,11 @@ func (w *Worker) Shutdown() error {
 	// at our default liveness value, which is also our default status grace
 	// period timeout
 	waitStatusStart := time.Now()
-	nextStatusCtx, nextStatusCancel := context.WithTimeout(w.baseContext, server.DefaultLiveness)
+	nextStatusCtx, nextStatusCancel := context.WithTimeoutCause(
+		w.baseContext,
+		server.DefaultLiveness,
+		fmt.Errorf("%s: liveness timeout exceeded", op),
+	)
 	defer nextStatusCancel()
 	for {
 		if err := nextStatusCtx.Err(); err != nil {
@@ -791,7 +795,11 @@ func (w *Worker) getSessionTls(sessionManager session.Manager) func(hello *tls.C
 			return nil, fmt.Errorf("no last status information found at session acceptance time")
 		}
 
-		timeoutContext, cancel := context.WithTimeout(w.baseContext, session.ValidateSessionTimeout)
+		timeoutContext, cancel := context.WithTimeoutCause(
+			w.baseContext,
+			session.ValidateSessionTimeout,
+			fmt.Errorf("%s: session validation timeout exceeded", op),
+		)
 		defer cancel()
 		sess, err := sessionManager.LoadLocalSession(timeoutContext, sessionId, lastSuccess.GetWorkerId())
 		if err != nil {

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -38,6 +38,10 @@ type Err struct {
 	// Wrapped is the error which this Err wraps and will be nil if there's no
 	// error to wrap.
 	Wrapped error
+
+	// ContextCause will be set if the context provided to the error creation
+	// was Done.
+	ContextCause error
 }
 
 // E creates a new Err with provided code and supports the options of:
@@ -78,6 +82,9 @@ func E(ctx context.Context, opt ...Option) error {
 		Op:      opts.withOp,
 		Wrapped: opts.withErrWrapped,
 		Msg:     fmt.Sprintf(opts.withErrMsg, opts.withErrMsgArgs...),
+	}
+	if ctx != nil {
+		err.ContextCause = context.Cause(ctx)
 	}
 	if opts.withoutEvent {
 		return err
@@ -227,6 +234,9 @@ func (e *Err) Error() string {
 	}
 	if e.Msg != "" {
 		join(&s, ": ", e.Msg)
+	}
+	if e.ContextCause != nil {
+		join(&s, " ", "("+e.ContextCause.Error()+")")
 	}
 
 	var skipInfo bool

--- a/internal/event/context.go
+++ b/internal/event/context.go
@@ -196,7 +196,7 @@ func WriteError(ctx context.Context, caller Op, e error, opt ...Option) {
 			return
 		}
 	}
-	ev, err := newError(caller, e, opt...)
+	ev, err := newError(ctx, caller, e, opt...)
 	if err != nil {
 		eventer.logger.Error(fmt.Sprintf("%s: %v", op, err))
 		eventer.logger.Error(fmt.Sprintf("%s: unable to create new error to write error: %v", op, e))

--- a/internal/event/context.go
+++ b/internal/event/context.go
@@ -363,13 +363,18 @@ func WriteSysEvent(ctx context.Context, caller Op, msg string, args ...any) {
 }
 
 func newSendCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	const op = "event.newSendCtx"
 	var sendCtx context.Context
 	var sendCancel context.CancelFunc
 	switch {
 	case ctx == nil:
 		return context.Background(), nil
 	case ctx.Err() != nil:
-		sendCtx, sendCancel = context.WithTimeout(context.WithoutCancel(ctx), cancelledSendTimeout)
+		sendCtx, sendCancel = context.WithTimeoutCause(
+			context.WithoutCancel(ctx),
+			cancelledSendTimeout,
+			fmt.Errorf("%s: cancelled send timeout exceeded", op),
+		)
 	default:
 		sendCtx = ctx
 	}

--- a/internal/event/context.go
+++ b/internal/event/context.go
@@ -368,15 +368,8 @@ func newSendCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	switch {
 	case ctx == nil:
 		return context.Background(), nil
-	case ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded:
-		sendCtx, sendCancel = context.WithTimeout(context.Background(), cancelledSendTimeout)
-		info, ok := RequestInfoFromContext(ctx)
-		if ok {
-			reqCtx, err := NewRequestInfoContext(sendCtx, info)
-			if err == nil {
-				sendCtx = reqCtx
-			}
-		}
+	case ctx.Err() != nil:
+		sendCtx, sendCancel = context.WithTimeout(context.WithoutCancel(ctx), cancelledSendTimeout)
 	default:
 		sendCtx = ctx
 	}

--- a/internal/event/eventer_retry_test.go
+++ b/internal/event/eventer_retry_test.go
@@ -30,7 +30,7 @@ func TestEventer_retrySend(t *testing.T) {
 	require.NoError(t, err)
 
 	testError := fmt.Errorf("%s: missing operation: %w", "missing operation", ErrInvalidParameter)
-	testEvent, err := newError("TestEventer_retrySend", testError, WithId("test-error"))
+	testEvent, err := newError(ctx, "TestEventer_retrySend", testError, WithId("test-error"))
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/internal/event/eventer_test.go
+++ b/internal/event/eventer_test.go
@@ -304,7 +304,7 @@ func TestEventer_writeError(t *testing.T) {
 	eventer, er := NewEventer(testLogger, testLock, "TestEventer_writeError", testSetup.EventerConfig)
 	require.NoError(t, er)
 
-	testError, er := newError("TestEventer_writeError", fmt.Errorf("%s: no msg: test", ErrIo))
+	testError, er := newError(ctx, "TestEventer_writeError", fmt.Errorf("%s: no msg: test", ErrIo))
 	require.NoError(t, er)
 
 	tests := []struct {

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -499,7 +499,11 @@ func (k *Kms) MonitorTableRewrappingRuns(ctx context.Context, tableName string, 
 		if retErr != nil {
 			// Create new context in case we failed because the context was canceled
 			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel = context.WithTimeoutCause(
+				context.Background(),
+				5*time.Second,
+				fmt.Errorf("%s: exec timeout exceeded", op),
+			)
 			defer cancel()
 		}
 		// Update the progress of this run

--- a/internal/tests/helper/testing_helper.go
+++ b/internal/tests/helper/testing_helper.go
@@ -122,7 +122,11 @@ func (s *TestSession) ExpectConnectionStateOnController(
 	require := require.New(t)
 	assert := assert.New(t)
 
-	ctx, cancel := context.WithTimeout(ctx, expectConnectionStateOnControllerTimeout)
+	ctx, cancel := context.WithTimeoutCause(
+		ctx,
+		expectConnectionStateOnControllerTimeout,
+		errors.New("connection state on controller timeout exceeded"),
+	)
 	defer cancel()
 
 	// This is just for initialization of the actual state set.
@@ -188,7 +192,11 @@ func (s *TestSession) ExpectConnectionStateOnWorker(
 	require := require.New(t)
 	assert := assert.New(t)
 
-	ctx, cancel := context.WithTimeout(ctx, expectConnectionStateOnWorkerTimeout)
+	ctx, cancel := context.WithTimeoutCause(
+		ctx,
+		expectConnectionStateOnWorkerTimeout,
+		errors.New("connection state on worker timeout exceeded"),
+	)
 	defer cancel()
 
 	// This is just for initialization of the actual state set.


### PR DESCRIPTION
### [internal/event: simplify new ctx creation](https://github.com/hashicorp/boundary/commit/31b29bda2b043611669c731b6b632937a4349fbb)

If the input context is done, we construct a new context
with a new timeout. Make use of context.WithoutCancel
to simplify the logic for adding existing context values
into this new context.

### [internal/errors: add ctx cancel cause](https://github.com/hashicorp/boundary/commit/a0c853fc27a263d9412a04952c125f6ff0600ec0)

Adds the context cancel cause to the error, if set. This can
provide useful error information to debugging efforts
when a context cancellation error happens.

### [internal/event: include context cancel cause in event](https://github.com/hashicorp/boundary/commit/2c870e73cf8729d3ef71aa28ab8db2bbc1afba3e)

The context cancel cause can be a great way to understand
why a context was canceled.

### [all: add cancellation causes to timeouts](https://github.com/hashicorp/boundary/commit/bf52575a996bf5903bf87789966104a6d2d71959) 

The new WithTimeoutCause and WithDeadlineCause functions
allow us to decorate contexts with metadata surrounding
a specific timeout or deadline. Combined with the automatic
discovery of the context cause in the errors and event
packages, we should get much more information about
context cancellations.

### [internal/daemon: simplify time update tests](https://github.com/hashicorp/boundary/commit/a8cc893cf1f9d32312b4570cb7e68ae0b7c862e4)

Using time.After makes the intent clearer