### PR TITLE
feat: Validate LDAP URL port number

### DIFF
--- a/internal/daemon/controller/handlers/authmethods/ldap.go
+++ b/internal/daemon/controller/handlers/authmethods/ldap.go
@@ -8,7 +8,9 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"math"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/boundary/internal/auth/ldap"
@@ -295,6 +297,12 @@ func validateLdapAttributes(ctx context.Context, attrs *pb.LdapAuthMethodAttribu
 			}
 			if u.Scheme != "ldap" && u.Scheme != "ldaps" {
 				badUrlMsgs = append(badUrlMsgs, fmt.Sprintf("%s scheme in url %q is not either ldap or ldaps", u.Scheme, u.String()))
+			}
+			if u.Port() != "" {
+				port, err := strconv.Atoi(u.Port())
+				if err != nil || port > math.MaxUint16 {
+					badUrlMsgs = append(badUrlMsgs, fmt.Sprintf("port %s in url %s is not valid", u.Port(), u.String()))
+				}
 			}
 		}
 		if len(badUrlMsgs) > 0 {

--- a/internal/daemon/controller/handlers/authmethods/ldap_test.go
+++ b/internal/daemon/controller/handlers/authmethods/ldap_test.go
@@ -821,6 +821,56 @@ func Test_UpdateLdap(t *testing.T) {
 			err:         handlers.ApiErrorWithCode(codes.NotFound),
 			errContains: "no changes were made to the existing AuthMethod",
 		},
+		{
+			name: "valid-port-number",
+			req: &pbs.UpdateAuthMethodRequest{
+				UpdateMask: &field_mask.FieldMask{
+					Paths: []string{"attributes.urls"},
+				},
+				Item: &pb.AuthMethod{
+					Attrs: &pb.AuthMethod_LdapAuthMethodsAttributes{
+						LdapAuthMethodsAttributes: &pb.LdapAuthMethodAttributes{
+							Urls: []string{"ldaps://ldap2:8156"},
+						},
+					},
+				},
+			},
+			res: &pbs.UpdateAuthMethodResponse{
+				Item: &pb.AuthMethod{
+					ScopeId:     o.GetPublicId(),
+					Version:     2,
+					Name:        &wrapperspb.StringValue{Value: "default"},
+					Description: &wrapperspb.StringValue{Value: "default"},
+					Type:        ldap.Subtype.String(),
+					Attrs: &pb.AuthMethod_LdapAuthMethodsAttributes{
+						LdapAuthMethodsAttributes: &pb.LdapAuthMethodAttributes{
+							Urls:  []string{"ldaps://ldap2:8156"},
+							State: "active-private",
+						},
+					},
+					Scope:                       defaultScopeInfo,
+					AuthorizedActions:           ldapAuthorizedActions,
+					AuthorizedCollectionActions: authorizedCollectionActions,
+				},
+			},
+		},
+		{
+			name: "invalid-port-number",
+			req: &pbs.UpdateAuthMethodRequest{
+				UpdateMask: &field_mask.FieldMask{
+					Paths: []string{"attributes.urls"},
+				},
+				Item: &pb.AuthMethod{
+					Attrs: &pb.AuthMethod_LdapAuthMethodsAttributes{
+						LdapAuthMethodsAttributes: &pb.LdapAuthMethodAttributes{
+							Urls: []string{"ldaps://ldap2:9999999"},
+						},
+					},
+				},
+			},
+			err:         handlers.ApiErrorWithCode(codes.InvalidArgument),
+			errContains: "port 9999999 in url ldaps://ldap2:9999999 is not valid",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Add validation for the port number in LDAP URLs. If a port number is provided, it is checked to ensure it is a valid integer and within the valid range. This validation helps prevent errors when configuring LDAP authentication.