### PR TITLE
Return HTTP 400 status for inactive OIDC auth methods

### DIFF
--- a/internal/daemon/controller/handlers/authmethods/oidc.go
+++ b/internal/daemon/controller/handlers/authmethods/oidc.go
@@ -178,7 +178,14 @@ func (s Service) authenticateOidcStart(ctx context.Context, req *pbs.Authenticat
 	}
 
 	authUrl, tokenId, err := oidc.StartAuth(ctx, s.oidcRepoFn, req.GetAuthMethodId(), opts...)
-	if err != nil {
+	switch {
+	case errors.Match(errors.T(errors.AuthMethodInactive), err):
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.FailedPrecondition, "Cannot start authentication against an inactive OIDC auth method")
+	case errors.Match(errors.T(errors.RecordNotFound), err):
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.NotFound, "Auth method %s was not found", req.GetAuthMethodId())
+	case errors.Match(errors.T(errors.InvalidParameter), err):
+		return nil, handlers.ApiErrorWithCodeAndMessage(codes.InvalidArgument, err.Error())
+	case err != nil:
 		event.WriteError(ctx, op, err, event.WithInfoMsg("error starting the oidc authentication flow"))
 		return nil, handlers.ApiErrorWithCodeAndMessage(codes.Internal, "Error generating parameters for starting the OIDC flow. See the controller's log for more information.")
 	}


### PR DESCRIPTION
This commit modifies the OIDC authentication start method to return a 400 (Bad Request) error if a client attempts to start the authentication flow against an OIDC auth method that is set to inactive. This is something we noticed in our error logs in HCP Boundary that is impacting our SLOs.

Previously this returned its own error code which is mapped to a 500 response. Tests have been updated to catch this new scenario.