### PR TITLE
Restrict cache results to 250 entries by default

### DIFF
--- a/internal/clientcache/internal/cache/consts.go
+++ b/internal/clientcache/internal/cache/consts.go
@@ -1,0 +1,17 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+/*
+Package cache contains the domain logic for the client cache.
+*/
+package cache
+
+const (
+	// defaultLimitedResultSetSize is the default number of results to
+	// return when limiting
+	defaultLimitedResultSetSize = 250
+
+	// unlimitedMaxResultSetSize is the value to use when we want to return all
+	// results
+	unlimitedMaxResultSetSize = -1
+)

--- a/internal/clientcache/internal/cache/options_test.go
+++ b/internal/clientcache/internal/cache/options_test.go
@@ -22,7 +22,8 @@ func Test_GetOpts(t *testing.T) {
 		opts, err := getOpts()
 		require.NoError(t, err)
 		testOpts := options{
-			withDbType: dbw.Sqlite,
+			withDbType:           dbw.Sqlite,
+			withMaxResultSetSize: defaultLimitedResultSetSize,
 		}
 		assert.Equal(t, opts, testOpts)
 	})
@@ -92,5 +93,17 @@ func Test_GetOpts(t *testing.T) {
 		testOpts := getDefaultOptions()
 		testOpts.withIgnoreSearchStaleness = true
 		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("withMaxResultSetSize", func(t *testing.T) {
+		opts, err := getOpts(WithMaxResultSetSize(defaultLimitedResultSetSize))
+		require.NoError(t, err)
+		testOpts := getDefaultOptions()
+		testOpts.withMaxResultSetSize = defaultLimitedResultSetSize
+		assert.Equal(t, opts, testOpts)
+		opts, err = getOpts(WithMaxResultSetSize(0))
+		require.Nil(t, err)
+		assert.Equal(t, opts, testOpts)
+		_, err = getOpts(WithMaxResultSetSize(-2))
+		require.Error(t, err)
 	})
 }

--- a/internal/clientcache/internal/daemon/404_handler.go
+++ b/internal/clientcache/internal/daemon/404_handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 // new404Func creates a handler that returns a custom 404 error message.
-func new404Func(ctx context.Context) http.HandlerFunc {
+func new404Func(_ context.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		writeError(w, "Not found", http.StatusNotFound)
 	}


### PR DESCRIPTION
A query parameter `max_result_set_size` can be specified to set a per-request limit, with `-1` meaning all values. If there were more entries than the max size used for the request, an `incomplete` boolean is set in the response.