### PR TITLE
feat: Disable path length fallback

### DIFF
--- a/internal/daemon/controller/gateway.go
+++ b/internal/daemon/controller/gateway.go
@@ -65,6 +65,7 @@ func newGrpcGatewayMux() *runtime.ServeMux {
 		}),
 		runtime.WithErrorHandler(handlers.ErrorHandler()),
 		runtime.WithForwardResponseOption(handlers.OutgoingResponseFilter),
+		runtime.WithDisablePathLengthFallback(),
 	)
 }
 


### PR DESCRIPTION
Add `WithDisablePathLengthFallback()` runtime option to the grpc-gateway mux HTTP server. This prevents the issue where the request method can be overridden with a `X-HTTP-Method-Override` header.