### PR TITLE
test(host): validate ipv6 address for hosts

### DIFF
--- a/internal/host/plugin/job_set_sync_test.go
+++ b/internal/host/plugin/job_set_sync_test.go
@@ -6,6 +6,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -198,7 +199,7 @@ func TestSetSyncJob_Run(t *testing.T) {
 			Hosts: []*plgpb.ListHostsResponseHost{
 				{
 					ExternalId:  "first",
-					IpAddresses: []string{fmt.Sprintf("10.0.0.%d", *counter)},
+					IpAddresses: []string{fmt.Sprintf("10.0.0.%d", *counter), testGetIpv6Address(t)},
 					DnsNames:    []string{"foo.com"},
 					SetIds:      setIds,
 				},
@@ -225,6 +226,13 @@ func TestSetSyncJob_Run(t *testing.T) {
 	assert.Len(hosts, 1)
 	for _, host := range hosts {
 		assert.Equal(uint32(1), host.Version)
+		require.Len(host.IpAddresses, 2)
+		ipv4 := net.ParseIP(host.IpAddresses[0])
+		require.NotNil(ipv4)
+		require.NotNil(ipv4.To4())
+		ipv6 := net.ParseIP(host.IpAddresses[1])
+		require.NotNil(ipv6)
+		require.NotNil(ipv6.To16())
 	}
 
 	require.NoError(rw.LookupByPublicId(ctx, hsa))

--- a/internal/host/plugin/repository_host_test.go
+++ b/internal/host/plugin/repository_host_test.go
@@ -163,7 +163,7 @@ func TestJob_UpsertHosts(t *testing.T) {
 			in: func() *input {
 				ph := phs[1]
 				e := exp[1]
-				newIp := testGetIpAddress(t)
+				newIp := testGetIpv4Address(t)
 				newName := testGetDnsName(t)
 				ph.IpAddresses = append(ph.IpAddresses, newIp)
 				e.IpAddresses = append(e.IpAddresses, newIp)

--- a/internal/host/plugin/testing.go
+++ b/internal/host/plugin/testing.go
@@ -165,7 +165,8 @@ func TestExternalHosts(t testing.TB, catalog *HostCatalog, setIds []string, coun
 		externalId, err := base62.Random(10)
 		require.NoError(err)
 
-		ipStr := testGetIpAddress(t)
+		ipv4Str := testGetIpv4Address(t)
+		ipv6Str := testGetIpv6Address(t)
 		dnsName := testGetDnsName(t)
 
 		rh := &plgpb.ListHostsResponseHost{
@@ -173,7 +174,7 @@ func TestExternalHosts(t testing.TB, catalog *HostCatalog, setIds []string, coun
 			Name:        base62.MustRandom(10),
 			Description: base62.MustRandom(10),
 			SetIds:      setIds[0 : i+1],
-			IpAddresses: []string{ipStr},
+			IpAddresses: []string{ipv4Str, ipv6Str},
 			DnsNames:    []string{dnsName},
 		}
 		retRH = append(retRH, rh)
@@ -190,7 +191,7 @@ func TestExternalHosts(t testing.TB, catalog *HostCatalog, setIds []string, coun
 				CatalogId:   catalog.PublicId,
 				PublicId:    publicId,
 				ExternalId:  externalId,
-				IpAddresses: []string{ipStr},
+				IpAddresses: []string{ipv4Str, ipv6Str},
 				DnsNames:    []string{dnsName},
 				Version:     1,
 			},
@@ -217,7 +218,7 @@ func testGetDnsName(t testing.TB) string {
 	return fmt.Sprintf("%s.example.com", dnsName)
 }
 
-func testGetIpAddress(t testing.TB) string {
+func testGetIpv4Address(t testing.TB) string {
 	ipBytes := make([]byte, 4)
 	for {
 		lr := io.LimitReader(rand.Reader, 4)
@@ -228,6 +229,21 @@ func testGetIpAddress(t testing.TB) string {
 		v4 := ip.To4()
 		if v4 != nil {
 			return v4.String()
+		}
+	}
+}
+
+func testGetIpv6Address(t testing.TB) string {
+	ipBytes := make([]byte, 16)
+	for {
+		lr := io.LimitReader(rand.Reader, 16)
+		n, err := lr.Read(ipBytes)
+		require.NoError(t, err)
+		require.Equal(t, n, 16)
+		ip := net.IP(ipBytes)
+		v6 := ip.To16()
+		if v6 != nil {
+			return v6.String()
 		}
 	}
 }

--- a/internal/host/static/repository_host_test.go
+++ b/internal/host/static/repository_host_test.go
@@ -70,7 +70,7 @@ func TestRepository_CreateHost(t *testing.T) {
 			wantIsErr: errors.InvalidParameter,
 		},
 		{
-			name: "valid-no-options",
+			name: "valid-ipv4-address",
 			in: &Host{
 				Host: &store.Host{
 					CatalogId: catalog.PublicId,
@@ -81,6 +81,36 @@ func TestRepository_CreateHost(t *testing.T) {
 				Host: &store.Host{
 					CatalogId: catalog.PublicId,
 					Address:   "127.0.0.1",
+				},
+			},
+		},
+		{
+			name: "valid-abbreviated-ipv6-address",
+			in: &Host{
+				Host: &store.Host{
+					CatalogId: catalog.PublicId,
+					Address:   "2001:4860:4860::8888",
+				},
+			},
+			want: &Host{
+				Host: &store.Host{
+					CatalogId: catalog.PublicId,
+					Address:   "2001:4860:4860::8888",
+				},
+			},
+		},
+		{
+			name: "valid-ipv6-address",
+			in: &Host{
+				Host: &store.Host{
+					CatalogId: catalog.PublicId,
+					Address:   "2001:4860:4860:0:0:0:0:8888",
+				},
+			},
+			want: &Host{
+				Host: &store.Host{
+					CatalogId: catalog.PublicId,
+					Address:   "2001:4860:4860:0:0:0:0:8888",
 				},
 			},
 		},
@@ -545,7 +575,7 @@ func TestRepository_UpdateHost(t *testing.T) {
 			wantCount: 1,
 		},
 		{
-			name: "change-address",
+			name: "change-ipv4-address",
 			orig: &Host{
 				Host: &store.Host{
 					Address: "127.0.0.1",
@@ -556,6 +586,38 @@ func TestRepository_UpdateHost(t *testing.T) {
 			want: &Host{
 				Host: &store.Host{
 					Address: "10.0.0.1",
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "change-abbreviated-ipv6-address",
+			orig: &Host{
+				Host: &store.Host{
+					Address: "127.0.0.1",
+				},
+			},
+			chgFn: changeAddress("2001:4860:4860::8888"),
+			masks: []string{"Address"},
+			want: &Host{
+				Host: &store.Host{
+					Address: "2001:4860:4860::8888",
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "change-ipv6-address",
+			orig: &Host{
+				Host: &store.Host{
+					Address: "127.0.0.1",
+				},
+			},
+			chgFn: changeAddress("2001:4860:4860:0:0:0:0:8888"),
+			masks: []string{"Address"},
+			want: &Host{
+				Host: &store.Host{
+					Address: "2001:4860:4860:0:0:0:0:8888",
 				},
 			},
 			wantCount: 1,


### PR DESCRIPTION
# Summary

A new set of tests were added to the create/update repository methods of the static host resource. These tests were added to validate that an IPv6 address can be used by a host. The existing UpsertHost test for the dynamic host resource was updated to validate ensure an IPv6 address can be used by a host.