### PR TITLE
api: remove items deleted during refresh pagination

### DIFF
--- a/api/accounts/account.gen.go
+++ b/api/accounts/account.gen.go
@@ -351,9 +351,6 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "accounts", nil, apiOpts...)
 		if err != nil {
@@ -391,9 +388,8 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Account that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -402,21 +398,26 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a Account has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/aliases/alias.gen.go
+++ b/api/aliases/alias.gen.go
@@ -357,9 +357,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Alia
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "aliases", nil, apiOpts...)
 		if err != nil {
@@ -397,9 +394,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Alia
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Alias that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -408,21 +404,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Alia
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a Alias has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/authmethods/authmethods.gen.go
+++ b/api/authmethods/authmethods.gen.go
@@ -357,9 +357,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "auth-methods", nil, apiOpts...)
 		if err != nil {
@@ -397,9 +394,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any AuthMethod that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -408,21 +404,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a AuthMethod has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -242,9 +242,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "auth-tokens", nil, apiOpts...)
 		if err != nil {
@@ -282,9 +279,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any AuthToken that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -293,21 +289,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a AuthToken has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/credentiallibraries/credential_library.gen.go
+++ b/api/credentiallibraries/credential_library.gen.go
@@ -357,9 +357,6 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "credential-libraries", nil, apiOpts...)
 		if err != nil {
@@ -397,9 +394,8 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any CredentialLibrary that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -408,21 +404,26 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a CredentialLibrary has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/credentials/credential.gen.go
+++ b/api/credentials/credential.gen.go
@@ -355,9 +355,6 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "credentials", nil, apiOpts...)
 		if err != nil {
@@ -395,9 +392,8 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Credential that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -406,21 +402,26 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a Credential has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/credentialstores/credential_store.gen.go
+++ b/api/credentialstores/credential_store.gen.go
@@ -356,9 +356,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "credential-stores", nil, apiOpts...)
 		if err != nil {
@@ -396,9 +393,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any CredentialStore that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -407,21 +403,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a CredentialStore has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/groups/group.gen.go
+++ b/api/groups/group.gen.go
@@ -350,9 +350,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "groups", nil, apiOpts...)
 		if err != nil {
@@ -390,9 +387,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Group that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -401,21 +397,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a Group has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/hostcatalogs/host_catalog.gen.go
+++ b/api/hostcatalogs/host_catalog.gen.go
@@ -361,9 +361,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "host-catalogs", nil, apiOpts...)
 		if err != nil {
@@ -401,9 +398,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any HostCatalog that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -412,21 +408,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a HostCatalog has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/hosts/host.gen.go
+++ b/api/hosts/host.gen.go
@@ -357,9 +357,6 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "hosts", nil, apiOpts...)
 		if err != nil {
@@ -397,9 +394,8 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Host that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -408,21 +404,26 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a Host has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/hostsets/host_set.gen.go
+++ b/api/hostsets/host_set.gen.go
@@ -355,9 +355,6 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "host-sets", nil, apiOpts...)
 		if err != nil {
@@ -395,9 +392,8 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any HostSet that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -406,21 +402,26 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a HostSet has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/policies/policy.gen.go
+++ b/api/policies/policy.gen.go
@@ -355,9 +355,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Poli
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "policies", nil, apiOpts...)
 		if err != nil {
@@ -395,9 +392,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Poli
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Policy that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -406,21 +402,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Poli
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a Policy has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/roles/role.gen.go
+++ b/api/roles/role.gen.go
@@ -353,9 +353,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "roles", nil, apiOpts...)
 		if err != nil {
@@ -393,9 +390,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Role that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -404,21 +400,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a Role has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/scopes/scope.gen.go
+++ b/api/scopes/scope.gen.go
@@ -351,9 +351,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Scop
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "scopes", nil, apiOpts...)
 		if err != nil {
@@ -391,9 +388,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Scop
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Scope that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -402,21 +398,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Scop
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a Scope has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/sessionrecordings/session_recording.gen.go
+++ b/api/sessionrecordings/session_recording.gen.go
@@ -249,9 +249,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "session-recordings", nil, apiOpts...)
 		if err != nil {
@@ -289,9 +286,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any SessionRecording that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -300,21 +296,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a SessionRecording has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/sessions/session.gen.go
+++ b/api/sessions/session.gen.go
@@ -209,9 +209,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "sessions", nil, apiOpts...)
 		if err != nil {
@@ -249,9 +246,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Session that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -260,21 +256,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a Session has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/storagebuckets/storage_bucket.gen.go
+++ b/api/storagebuckets/storage_bucket.gen.go
@@ -359,9 +359,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Stor
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "storage-buckets", nil, apiOpts...)
 		if err != nil {
@@ -399,9 +396,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Stor
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any StorageBucket that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -410,21 +406,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Stor
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a StorageBucket has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/targets/target.gen.go
+++ b/api/targets/target.gen.go
@@ -369,9 +369,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "targets", nil, apiOpts...)
 		if err != nil {
@@ -409,9 +406,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Target that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -420,21 +416,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a Target has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/users/custom.go
+++ b/api/users/custom.go
@@ -64,9 +64,6 @@ func (c *Client) ListResolvableAliases(ctx context.Context, userId string, opt .
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("users/%s:list-resolvable-aliases", url.PathEscape(userId)), nil, apiOpts...)
 		if err != nil {
@@ -104,9 +101,8 @@ func (c *Client) ListResolvableAliases(ctx context.Context, userId string, opt .
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Alias that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -115,21 +111,26 @@ func (c *Client) ListResolvableAliases(ctx context.Context, userId string, opt .
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If an Alias has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/users/user.gen.go
+++ b/api/users/user.gen.go
@@ -354,9 +354,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*User
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "users", nil, apiOpts...)
 		if err != nil {
@@ -394,9 +391,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*User
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any User that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -405,21 +401,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*User
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a User has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/api/workers/worker.gen.go
+++ b/api/workers/worker.gen.go
@@ -410,9 +410,6 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Work
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "workers", nil, apiOpts...)
 		if err != nil {
@@ -450,9 +447,8 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Work
 				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any Worker that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -461,21 +457,26 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Work
 			break
 		}
 	}
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a Worker has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
 	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
 			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -279,9 +279,6 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 	for i, item := range target.Items {
 		idToIndex[item.Id] = i
 	}
-	// Removed IDs in the response may contain duplicates,
-	// maintain a set to avoid returning duplicates to the user.
-	removedIds := map[string]struct{}{}
 	for {
 		req, err := c.client.NewRequest(ctx, "GET", "{{ .CollectionPath }}", nil, apiOpts...)
 		if err != nil {
@@ -316,12 +313,11 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 				target.Items[i] = item
 			} else {
 				target.Items = append(target.Items, item)
-				idToIndex[item.Id] = len(target.Items)-1
+				idToIndex[item.Id] = len(target.Items) - 1
 			}
 		}
-		for _, removedId := range page.RemovedIds {
-			removedIds[removedId] = struct{}{}
-		}
+		// RemovedIds contain any {{ .Name }} that were deleted since the last response.
+		target.RemovedIds = append(target.RemovedIds, page.RemovedIds...)
 		target.EstItemCount = page.EstItemCount
 		target.ListToken = page.ListToken
 		target.ResponseType = page.ResponseType
@@ -330,21 +326,26 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 			break
 		}
 	}
-	for _, removedId := range  target.RemovedIds {
+	// For now, removedIds will only be populated if this pagination cycle was the result of a
+	// "refresh" operation (i.e., the caller provided a list token option to this call).
+	//
+	// Sort to make response deterministic
+	slices.Sort(target.RemovedIds)
+	// Remove any duplicates
+	target.RemovedIds = slices.Compact(target.RemovedIds)
+	// Remove items that were deleted since the end of the last iteration.
+	// If a {{ .Name }} has been updated and subsequently removed, we don't want
+	// it to appear both in the Items and RemovedIds, so we remove it from the Items.
+	for _, removedId := range target.RemovedIds {
 		if i, ok := idToIndex[removedId]; ok {
 			// Remove the item at index i without preserving order
 			// https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
-			target.Items[i] = target.Items[len(target.Items)-1] 
+			target.Items[i] = target.Items[len(target.Items)-1]
 			target.Items = target.Items[:len(target.Items)-1]
-			// Update the index of the last element
+			// Update the index of the previously last element
 			idToIndex[target.Items[i].Id] = i
 		}
 	}
-	for deletedId := range removedIds {
-		target.RemovedIds = append(target.RemovedIds, deletedId)
-	}
-	// Sort to make response deterministic
-	slices.Sort(target.RemovedIds)
 	// Since we paginated to the end, we can avoid confusion
 	// for the user by setting the estimated item count to the
 	// length of the items slice. If we don't set this here, it


### PR DESCRIPTION
The API automatically paginates to the end of a pagination, and would take into account any items updated and subsequently removed since the last pagination. It now also removes any items removed during the current pagination.

This also clarifies the behavior of `removed_ids` during initial pagination (the only pagination supported by the CLI).