### PR TITLE
e2e: replace '%s' with %q

### DIFF
--- a/testing/internal/e2e/helpers.go
+++ b/testing/internal/e2e/helpers.go
@@ -133,7 +133,7 @@ func WithEnv(name string, value string) Option {
 func MaybeSkipTest(t testing.TB) {
 	if _, ok := os.LookupEnv(EnvToCheckSkip); !ok {
 		t.Skipf(
-			"Skipping test because environment variable '%s' is not set. This is needed for e2e tests.",
+			"Skipping test because environment variable %q is not set. This is needed for e2e tests.",
 			EnvToCheckSkip,
 		)
 	}
@@ -144,7 +144,7 @@ func MaybeSkipSlowTest(t testing.TB) {
 	MaybeSkipTest(t)
 	if _, ok := os.LookupEnv(EnvToCheckSlowSkip); !ok {
 		t.Skipf(
-			"Skipping test because environment variable '%s' is not set. This is needed for slow e2e tests.",
+			"Skipping test because environment variable %q is not set. This is needed for slow e2e tests.",
 			EnvToCheckSlowSkip,
 		)
 	}

--- a/testing/internal/e2e/tests/base/auth_token_delete_test.go
+++ b/testing/internal/e2e/tests/base/auth_token_delete_test.go
@@ -85,6 +85,6 @@ func TestUserIsLoggedOutWhenAuthTokenIsDeletedCli(t *testing.T) {
 	)
 
 	// Expect error as the user got logged out
-	require.Error(t, output.Err, fmt.Sprintf("User '%s' is still logged in", testAccountName))
+	require.Error(t, output.Err, fmt.Sprintf("User %q is still logged in", testAccountName))
 	t.Log("Successfully verified that token name is invalid")
 }

--- a/testing/internal/e2e/tests/base/credential_store_test.go
+++ b/testing/internal/e2e/tests/base/credential_store_test.go
@@ -142,7 +142,7 @@ func TestCliStaticCredentialStore(t *testing.T) {
 				e2e.WithArgs("credential-stores", "read", "-id", storeId, "-format", "json"),
 			)
 			if output.Err == nil {
-				return fmt.Errorf("Deleted credential can still be read: '%s'", output.Stdout)
+				return fmt.Errorf("Deleted credential can still be read: %q", output.Stdout)
 			}
 
 			var response boundary.CliError


### PR DESCRIPTION
%q handles quotes inside the quoted strings better.