### PR TITLE
Two fixes in our Go API code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,28 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## Next
 
+## 0.17.2 (Unreleased)
+
+### Changes
+
+* The Go API properly uses the passed in value for `WithRecursive` and
+  `WithSkipCurlOutput` instead of always setting to true regardless of the
+  passed-in value. ([PR](https://github.com/hashicorp/boundary/pull/5066))
+
 ## 0.17.1 (2024/08/21)
 
 ### New and Improved
 
-* Add `GetDownstreamWorkersTimeout` config option which represents the period of time (as a duration) timeout
-  for GetDownstreamWorkers call in DownstreamWorkerTicker. This is currently not documented and considered internal.
-  ([PR](https://github.com/hashicorp/boundary/pull/5007))
+* Add `GetDownstreamWorkersTimeout` config option which represents the period of
+  time (as a duration) timeout for GetDownstreamWorkers call in
+  DownstreamWorkerTicker. This is currently not documented and considered
+  internal. ([PR](https://github.com/hashicorp/boundary/pull/5007))
 
 ### Bug Fixes
 
 * Fixed issue where storage policies were not deleted when scopes are deleted
   ([PR](https://github.com/hashicorp/boundary/pull/5014))
-* Contains Bug Fixes from 0.16.3 
+* Contains Bug Fixes from 0.16.3
 
 ### Security
 
@@ -26,40 +35,52 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### New and Improved
 
-* Add `GetDownstreamWorkersTimeout` config option which represents the period of time (as a duration) timeout
-  for GetDownstreamWorkers call in DownstreamWorkerTicker. This is currently not documented and considered internal.
-  ([PR](https://github.com/hashicorp/boundary/pull/5007))
+* Add `GetDownstreamWorkersTimeout` config option which represents the period of
+  time (as a duration) timeout for GetDownstreamWorkers call in
+  DownstreamWorkerTicker. This is currently not documented and considered
+  internal. ([PR](https://github.com/hashicorp/boundary/pull/5007))
 
 ### Bug Fixes
 
-* Minio large file support: Disable multipart uploads via minio to fix an issue where the file checksum is set incorrectly on each part 
-  of the upload, causing it to fail. This change fixes file uploads larger than 16MB and limits upload sizes to 5GB.
-  ([PR](https://github.com/hashicorp/boundary/pull/5013)) and ([PR](https://github.com/hashicorp/boundary-plugin-minio/pull/21))
-* Resolved an issue where session authorization was returning a `401` if the alias is non-existent or the alias does not resolve to anything.
-  A `404` status code is now returned.
+* Minio large file support: Disable multipart uploads via minio to fix an issue
+  where the file checksum is set incorrectly on each part of the upload, causing
+  it to fail. This change fixes file uploads larger than 16MB and limits upload
+  sizes to 5GB. ([PR](https://github.com/hashicorp/boundary/pull/5013)) and
+  ([PR](https://github.com/hashicorp/boundary-plugin-minio/pull/21))
+* Resolved an issue where session authorization was returning a `401` if the
+  alias is non-existent or the alias does not resolve to anything. A `404`
+  status code is now returned.
   ([PR](https://github.com/hashicorp/boundary/pull/5006)))
 
 ### Security
 
-* curl (enterprise): The curl binary is no longer included in the published Docker container images for Boundary Enterprise to address the 
-  CVE-2024-7264 vulnerability.
+* curl (enterprise): The curl binary is no longer included in the published
+  Docker container images for Boundary Enterprise to address the CVE-2024-7264
+  vulnerability.
   [CVE-2024-7264](https://github.com/advisories/GHSA-97c4-2w4v-c7r8)  
 
 ## 0.17.0 (2024/07/17)
 
 ### New and Improved
 
-* SBC (Storage Bucket Credential): This release introduces, SBC, a resource that represents credentials for 
-authentication and authorization with an external object store. There are two SBC types, managed secret and environmental.
-([PR](https://github.com/hashicorp/boundary/pull/4933)), ([PR](https://github.com/hashicorp/boundary-plugin-minio/pull/18)) and ([PR](https://github.com/hashicorp/boundary-plugin-aws/pull/46))
-  * SBC State: This release introduces, SBC State, which represents the ability for a worker to perform a specific action 
-  using the storage bucket. SBC permission types (write, read, & delete) represent an action that is required for the 
-  storage bucket to do as a routine task on an external object store. Each permission type has a permission state 
-  (ok, error, unknown). 
-  * SBC Worker Filtering: For protocol aware workers that require interaction with an external storage service, the 
-  workers will be filtered by the SBC state depending on the action and permission required.
-* ui: Add multiple grant scope support for roles ([PR](https://github.com/hashicorp/boundary-ui/pull/2388))
-* ui: Add API tags support for workers and improve worker filtering for targets ([PR](https://github.com/hashicorp/boundary-ui/pull/2393))
+* SBC (Storage Bucket Credential): This release introduces, SBC, a resource that
+represents credentials for authentication and authorization with an external
+object store. There are two SBC types, managed secret and environmental.
+([PR](https://github.com/hashicorp/boundary/pull/4933)),
+([PR](https://github.com/hashicorp/boundary-plugin-minio/pull/18)) and
+([PR](https://github.com/hashicorp/boundary-plugin-aws/pull/46))
+  * SBC State: This release introduces, SBC State, which represents the ability
+  for a worker to perform a specific action using the storage bucket. SBC
+  permission types (write, read, & delete) represent an action that is required
+  for the storage bucket to do as a routine task on an external object store.
+  Each permission type has a permission state (ok, error, unknown). 
+  * SBC Worker Filtering: For protocol aware workers that require interaction
+  with an external storage service, the workers will be filtered by the SBC
+  state depending on the action and permission required.
+* ui: Add multiple grant scope support for roles
+  ([PR](https://github.com/hashicorp/boundary-ui/pull/2388))
+* ui: Add API tags support for workers and improve worker filtering for targets
+  ([PR](https://github.com/hashicorp/boundary-ui/pull/2393))
 
 ### Bug Fixes
 
@@ -67,16 +88,23 @@ authentication and authorization with an external object store. There are two SB
 
 ### New and Improved
 
-* Updated Minio plugin to allow for potential use with other S3-compatible storage providers.
-([PR](https://github.com/hashicorp/boundary-plugin-minio/pull/16)) and ([PR](https://github.com/hashicorp/boundary-plugin-minio/pull/17))
+* Updated Minio plugin to allow for potential use with other S3-compatible
+storage providers.
+([PR](https://github.com/hashicorp/boundary-plugin-minio/pull/16)) and
+([PR](https://github.com/hashicorp/boundary-plugin-minio/pull/17))
 
 ### Bug Fixes
-* Fixed a bug where a worker credential rotation request suceeded on the controller but the response to the worker was lost.
-This resulted in the controller using a separate set of credentials than the worker, causing the worker to be unable to connect 
-to the controller. The fix implements the new nodeenrollment library NodeIdLoader interface, which ensures that on store, 
-if worker NodeInformation has a previous key set, the worker will check and correct its stored credential set to match. 
-LodeNodeInformation was also updated to fix a bug where in this split credential scenario, the current credential key was
-assumed to be the incoming worker key, which caused the wrong key information to be populated for the key id.
+
+* Fixed a bug where a worker credential rotation request suceeded on the
+controller but the response to the worker was lost. This resulted in the
+controller using a separate set of credentials than the worker, causing the
+worker to be unable to connect to the controller. The fix implements the new
+nodeenrollment library NodeIdLoader interface, which ensures that on store, if
+worker NodeInformation has a previous key set, the worker will check and correct
+its stored credential set to match. LodeNodeInformation was also updated to fix
+a bug where in this split credential scenario, the current credential key was
+assumed to be the incoming worker key, which caused the wrong key information to
+be populated for the key id.
 ([PR](https://github.com/hashicorp/boundary/pull/4870))
 
 ### New and Improved
@@ -137,17 +165,24 @@ assumed to be the incoming worker key, which caused the wrong key information to
 
 ### New and Improved
 
-* Target aliases have been added: You can now create an alias for a target.
-  In most situations where you would use a target id, you can now instead use
-  the alias value. Create an alias with
-  `boundary aliases create target -value example.boundary -destination-id ttcp_1234567890`
-  and connect to a target using an alias using `boundary connect example.boundary`
-* Worker local storage state: Self managed workers that are configured to be used for
-  session recordings will report the state of the its disk space. To learn more about this
-  new feature, refer to the [documentation](http://developer.hashicorp.com/boundary/docs/configuration/session-recording/create-storage-bucket#local-storage).
-* MinIO storage plugin: You can now create a storage bucket that allows Boundary to interoperate
-  with a MinIO cluster for Session Recording storage. This includes some added functionality such
-  as credential rotation and credential management. To learn more about the plugin, refer to the [readme](https://github.com/hashicorp/boundary-plugin-minio?tab=readme-ov-file#minio-plugin-for-hashicorp-boundary). *Note:* Due to a library incompatibility, this release is not yet compatible with the `netbsd` operating system. Please refer to the following [documentation](http://developer.hashicorp.com/boundary/docs/configuration/session-recording/create-storage-bucket) to learn how to create a storage bucket.
+* Target aliases have been added: You can now create an alias for a target. In
+  most situations where you would use a target id, you can now instead use the
+  alias value. Create an alias with `boundary aliases create target -value
+  example.boundary -destination-id ttcp_1234567890` and connect to a target
+  using an alias using `boundary connect example.boundary`
+* Worker local storage state: Self managed workers that are configured to be
+  used for session recordings will report the state of the its disk space. To
+  learn more about this new feature, refer to the
+  [documentation](http://developer.hashicorp.com/boundary/docs/configuration/session-recording/create-storage-bucket#local-storage).
+* MinIO storage plugin: You can now create a storage bucket that allows Boundary
+  to interoperate with a MinIO cluster for Session Recording storage. This
+  includes some added functionality such as credential rotation and credential
+  management. To learn more about the plugin, refer to the
+  [readme](https://github.com/hashicorp/boundary-plugin-minio?tab=readme-ov-file#minio-plugin-for-hashicorp-boundary).
+  *Note:* Due to a library incompatibility, this release is not yet compatible
+  with the `netbsd` operating system. Please refer to the following
+  [documentation](http://developer.hashicorp.com/boundary/docs/configuration/session-recording/create-storage-bucket)
+  to learn how to create a storage bucket.
 * ui: Add UI support for filtering and pagination
   ([PR](https://github.com/hashicorp/boundary-ui/pull/2237))
 * ui: Add UI support for MinIO (Enterprise and HCP Boundary only)

--- a/api/accounts/account.gen.go
+++ b/api/accounts/account.gen.go
@@ -53,7 +53,7 @@ type AccountDeleteResult struct {
 }
 
 // GetItem will always be nil for AccountDeleteResult
-func (n AccountDeleteResult) GetItem() interface{} {
+func (n AccountDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/accounts/ldap_account_attributes.gen.go
+++ b/api/accounts/ldap_account_attributes.gen.go
@@ -18,7 +18,7 @@ type LdapAccountAttributes struct {
 	MemberOfGroups []string `json:"member_of_groups,omitempty"`
 }
 
-func AttributesMapToLdapAccountAttributes(in map[string]interface{}) (*LdapAccountAttributes, error) {
+func AttributesMapToLdapAccountAttributes(in map[string]any) (*LdapAccountAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/accounts/oidc_account_attributes.gen.go
+++ b/api/accounts/oidc_account_attributes.gen.go
@@ -19,7 +19,7 @@ type OidcAccountAttributes struct {
 	UserinfoClaims map[string]interface{} `json:"userinfo_claims,omitempty"`
 }
 
-func AttributesMapToOidcAccountAttributes(in map[string]interface{}) (*OidcAccountAttributes, error) {
+func AttributesMapToOidcAccountAttributes(in map[string]any) (*OidcAccountAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/accounts/option.gen.go
+++ b/api/accounts/option.gen.go
@@ -20,7 +20,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -30,7 +30,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -69,7 +69,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -118,9 +118,9 @@ func WithOidcAccountIssuer(inIssuer string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["issuer"] = inIssuer
 		o.postMap["attributes"] = val
 	}
@@ -130,9 +130,9 @@ func DefaultOidcAccountIssuer() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["issuer"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -142,9 +142,9 @@ func WithLdapAccountLoginName(inLoginName string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["login_name"] = inLoginName
 		o.postMap["attributes"] = val
 	}
@@ -154,9 +154,9 @@ func DefaultLdapAccountLoginName() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["login_name"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -166,9 +166,9 @@ func WithPasswordAccountLoginName(inLoginName string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["login_name"] = inLoginName
 		o.postMap["attributes"] = val
 	}
@@ -178,9 +178,9 @@ func DefaultPasswordAccountLoginName() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["login_name"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -202,9 +202,9 @@ func WithPasswordAccountPassword(inPassword string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["password"] = inPassword
 		o.postMap["attributes"] = val
 	}
@@ -214,9 +214,9 @@ func DefaultPasswordAccountPassword() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["password"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -226,9 +226,9 @@ func WithOidcAccountSubject(inSubject string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["subject"] = inSubject
 		o.postMap["attributes"] = val
 	}
@@ -238,9 +238,9 @@ func DefaultOidcAccountSubject() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["subject"] = nil
 		o.postMap["attributes"] = val
 	}

--- a/api/accounts/password_account_attributes.gen.go
+++ b/api/accounts/password_account_attributes.gen.go
@@ -15,7 +15,7 @@ type PasswordAccountAttributes struct {
 	Password  string `json:"password,omitempty"`
 }
 
-func AttributesMapToPasswordAccountAttributes(in map[string]interface{}) (*PasswordAccountAttributes, error) {
+func AttributesMapToPasswordAccountAttributes(in map[string]any) (*PasswordAccountAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/aliases/alias.gen.go
+++ b/api/aliases/alias.gen.go
@@ -54,7 +54,7 @@ type AliasDeleteResult struct {
 }
 
 // GetItem will always be nil for AliasDeleteResult
-func (n AliasDeleteResult) GetItem() interface{} {
+func (n AliasDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/aliases/option.gen.go
+++ b/api/aliases/option.gen.go
@@ -21,7 +21,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -32,7 +32,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -74,7 +74,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -99,7 +99,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 

--- a/api/aliases/target_alias_attributes.gen.go
+++ b/api/aliases/target_alias_attributes.gen.go
@@ -14,7 +14,7 @@ type TargetAliasAttributes struct {
 	AuthorizeSessionArguments *AuthorizeSessionArguments `json:"authorize_session_arguments,omitempty"`
 }
 
-func AttributesMapToTargetAliasAttributes(in map[string]interface{}) (*TargetAliasAttributes, error) {
+func AttributesMapToTargetAliasAttributes(in map[string]any) (*TargetAliasAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/authmethods/authmethods.gen.go
+++ b/api/authmethods/authmethods.gen.go
@@ -54,7 +54,7 @@ type AuthMethodDeleteResult struct {
 }
 
 // GetItem will always be nil for AuthMethodDeleteResult
-func (n AuthMethodDeleteResult) GetItem() interface{} {
+func (n AuthMethodDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/authmethods/ldap_auth_method_attributes.gen.go
+++ b/api/authmethods/ldap_auth_method_attributes.gen.go
@@ -38,7 +38,7 @@ type LdapAuthMethodAttributes struct {
 	DereferenceAliases       string   `json:"dereference_aliases,omitempty"`
 }
 
-func AttributesMapToLdapAuthMethodAttributes(in map[string]interface{}) (*LdapAuthMethodAttributes, error) {
+func AttributesMapToLdapAuthMethodAttributes(in map[string]any) (*LdapAuthMethodAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/authmethods/oidc_auth_method_attributes.gen.go
+++ b/api/authmethods/oidc_auth_method_attributes.gen.go
@@ -29,7 +29,7 @@ type OidcAuthMethodAttributes struct {
 	Prompts                           []string `json:"prompts,omitempty"`
 }
 
-func AttributesMapToOidcAuthMethodAttributes(in map[string]interface{}) (*OidcAuthMethodAttributes, error) {
+func AttributesMapToOidcAuthMethodAttributes(in map[string]any) (*OidcAuthMethodAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/authmethods/option.gen.go
+++ b/api/authmethods/option.gen.go
@@ -21,7 +21,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -32,7 +32,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -74,7 +74,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -99,7 +99,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 
@@ -107,9 +107,9 @@ func WithLdapAuthMethodAccountAttributeMaps(inAccountAttributeMaps []string) Opt
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["account_attribute_maps"] = inAccountAttributeMaps
 		o.postMap["attributes"] = val
 	}
@@ -119,9 +119,9 @@ func DefaultLdapAuthMethodAccountAttributeMaps() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["account_attribute_maps"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -131,9 +131,9 @@ func WithOidcAuthMethodAccountClaimMaps(inAccountClaimMaps []string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["account_claim_maps"] = inAccountClaimMaps
 		o.postMap["attributes"] = val
 	}
@@ -143,9 +143,9 @@ func DefaultOidcAuthMethodAccountClaimMaps() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["account_claim_maps"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -155,9 +155,9 @@ func WithOidcAuthMethodAllowedAudiences(inAllowedAudiences []string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["allowed_audiences"] = inAllowedAudiences
 		o.postMap["attributes"] = val
 	}
@@ -167,9 +167,9 @@ func DefaultOidcAuthMethodAllowedAudiences() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["allowed_audiences"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -179,9 +179,9 @@ func WithLdapAuthMethodAnonGroupSearch(inAnonGroupSearch bool) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["anon_group_search"] = inAnonGroupSearch
 		o.postMap["attributes"] = val
 	}
@@ -191,9 +191,9 @@ func DefaultLdapAuthMethodAnonGroupSearch() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["anon_group_search"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -203,9 +203,9 @@ func WithOidcAuthMethodApiUrlPrefix(inApiUrlPrefix string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["api_url_prefix"] = inApiUrlPrefix
 		o.postMap["attributes"] = val
 	}
@@ -215,9 +215,9 @@ func DefaultOidcAuthMethodApiUrlPrefix() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["api_url_prefix"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -239,9 +239,9 @@ func WithLdapAuthMethodBindDn(inBindDn string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["bind_dn"] = inBindDn
 		o.postMap["attributes"] = val
 	}
@@ -251,9 +251,9 @@ func DefaultLdapAuthMethodBindDn() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["bind_dn"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -263,9 +263,9 @@ func WithLdapAuthMethodBindPassword(inBindPassword string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["bind_password"] = inBindPassword
 		o.postMap["attributes"] = val
 	}
@@ -275,9 +275,9 @@ func DefaultLdapAuthMethodBindPassword() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["bind_password"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -287,9 +287,9 @@ func WithLdapAuthMethodCertificates(inCertificates []string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["certificates"] = inCertificates
 		o.postMap["attributes"] = val
 	}
@@ -299,9 +299,9 @@ func DefaultLdapAuthMethodCertificates() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["certificates"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -311,9 +311,9 @@ func WithOidcAuthMethodClaimsScopes(inClaimsScopes []string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["claims_scopes"] = inClaimsScopes
 		o.postMap["attributes"] = val
 	}
@@ -323,9 +323,9 @@ func DefaultOidcAuthMethodClaimsScopes() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["claims_scopes"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -335,9 +335,9 @@ func WithLdapAuthMethodClientCertificate(inClientCertificate string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_certificate"] = inClientCertificate
 		o.postMap["attributes"] = val
 	}
@@ -347,9 +347,9 @@ func DefaultLdapAuthMethodClientCertificate() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_certificate"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -359,9 +359,9 @@ func WithLdapAuthMethodClientCertificateKey(inClientCertificateKey string) Optio
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_certificate_key"] = inClientCertificateKey
 		o.postMap["attributes"] = val
 	}
@@ -371,9 +371,9 @@ func DefaultLdapAuthMethodClientCertificateKey() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_certificate_key"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -383,9 +383,9 @@ func WithOidcAuthMethodClientId(inClientId string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_id"] = inClientId
 		o.postMap["attributes"] = val
 	}
@@ -395,9 +395,9 @@ func DefaultOidcAuthMethodClientId() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_id"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -407,9 +407,9 @@ func WithOidcAuthMethodClientSecret(inClientSecret string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_secret"] = inClientSecret
 		o.postMap["attributes"] = val
 	}
@@ -419,9 +419,9 @@ func DefaultOidcAuthMethodClientSecret() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_secret"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -431,9 +431,9 @@ func WithLdapAuthMethodDereferenceAliases(inDereferenceAliases string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["dereference_aliases"] = inDereferenceAliases
 		o.postMap["attributes"] = val
 	}
@@ -443,9 +443,9 @@ func DefaultLdapAuthMethodDereferenceAliases() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["dereference_aliases"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -467,9 +467,9 @@ func WithOidcAuthMethodDisableDiscoveredConfigValidation(inDisableDiscoveredConf
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["disable_discovered_config_validation"] = inDisableDiscoveredConfigValidation
 		o.postMap["attributes"] = val
 	}
@@ -479,9 +479,9 @@ func DefaultOidcAuthMethodDisableDiscoveredConfigValidation() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["disable_discovered_config_validation"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -491,9 +491,9 @@ func WithLdapAuthMethodDiscoverDn(inDiscoverDn bool) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["discover_dn"] = inDiscoverDn
 		o.postMap["attributes"] = val
 	}
@@ -503,9 +503,9 @@ func DefaultLdapAuthMethodDiscoverDn() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["discover_dn"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -515,9 +515,9 @@ func WithOidcAuthMethodDryRun(inDryRun bool) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["dry_run"] = inDryRun
 		o.postMap["attributes"] = val
 	}
@@ -527,9 +527,9 @@ func DefaultOidcAuthMethodDryRun() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["dry_run"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -539,9 +539,9 @@ func WithLdapAuthMethodEnableGroups(inEnableGroups bool) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["enable_groups"] = inEnableGroups
 		o.postMap["attributes"] = val
 	}
@@ -551,9 +551,9 @@ func DefaultLdapAuthMethodEnableGroups() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["enable_groups"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -563,9 +563,9 @@ func WithLdapAuthMethodGroupAttr(inGroupAttr string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["group_attr"] = inGroupAttr
 		o.postMap["attributes"] = val
 	}
@@ -575,9 +575,9 @@ func DefaultLdapAuthMethodGroupAttr() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["group_attr"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -587,9 +587,9 @@ func WithLdapAuthMethodGroupDn(inGroupDn string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["group_dn"] = inGroupDn
 		o.postMap["attributes"] = val
 	}
@@ -599,9 +599,9 @@ func DefaultLdapAuthMethodGroupDn() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["group_dn"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -611,9 +611,9 @@ func WithLdapAuthMethodGroupFilter(inGroupFilter string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["group_filter"] = inGroupFilter
 		o.postMap["attributes"] = val
 	}
@@ -623,9 +623,9 @@ func DefaultLdapAuthMethodGroupFilter() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["group_filter"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -635,9 +635,9 @@ func WithOidcAuthMethodIdpCaCerts(inIdpCaCerts []string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["idp_ca_certs"] = inIdpCaCerts
 		o.postMap["attributes"] = val
 	}
@@ -647,9 +647,9 @@ func DefaultOidcAuthMethodIdpCaCerts() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["idp_ca_certs"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -659,9 +659,9 @@ func WithLdapAuthMethodInsecureTls(inInsecureTls bool) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["insecure_tls"] = inInsecureTls
 		o.postMap["attributes"] = val
 	}
@@ -671,9 +671,9 @@ func DefaultLdapAuthMethodInsecureTls() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["insecure_tls"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -683,9 +683,9 @@ func WithOidcAuthMethodIssuer(inIssuer string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["issuer"] = inIssuer
 		o.postMap["attributes"] = val
 	}
@@ -695,9 +695,9 @@ func DefaultOidcAuthMethodIssuer() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["issuer"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -707,9 +707,9 @@ func WithOidcAuthMethodMaxAge(inMaxAge uint32) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["max_age"] = inMaxAge
 		o.postMap["attributes"] = val
 	}
@@ -719,9 +719,9 @@ func DefaultOidcAuthMethodMaxAge() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["max_age"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -731,9 +731,9 @@ func WithLdapAuthMethodMaximumPageSize(inMaximumPageSize uint32) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["maximum_page_size"] = inMaximumPageSize
 		o.postMap["attributes"] = val
 	}
@@ -743,9 +743,9 @@ func DefaultLdapAuthMethodMaximumPageSize() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["maximum_page_size"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -755,9 +755,9 @@ func WithPasswordAuthMethodMinLoginNameLength(inMinLoginNameLength uint32) Optio
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["min_login_name_length"] = inMinLoginNameLength
 		o.postMap["attributes"] = val
 	}
@@ -767,9 +767,9 @@ func DefaultPasswordAuthMethodMinLoginNameLength() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["min_login_name_length"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -779,9 +779,9 @@ func WithPasswordAuthMethodMinPasswordLength(inMinPasswordLength uint32) Option 
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["min_password_length"] = inMinPasswordLength
 		o.postMap["attributes"] = val
 	}
@@ -791,9 +791,9 @@ func DefaultPasswordAuthMethodMinPasswordLength() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["min_password_length"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -815,9 +815,9 @@ func WithOidcAuthMethodPrompts(inPrompts []string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["prompts"] = inPrompts
 		o.postMap["attributes"] = val
 	}
@@ -827,9 +827,9 @@ func DefaultOidcAuthMethodPrompts() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["prompts"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -839,9 +839,9 @@ func WithOidcAuthMethodSigningAlgorithms(inSigningAlgorithms []string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["signing_algorithms"] = inSigningAlgorithms
 		o.postMap["attributes"] = val
 	}
@@ -851,9 +851,9 @@ func DefaultOidcAuthMethodSigningAlgorithms() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["signing_algorithms"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -863,9 +863,9 @@ func WithLdapAuthMethodStartTls(inStartTls bool) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["start_tls"] = inStartTls
 		o.postMap["attributes"] = val
 	}
@@ -875,9 +875,9 @@ func DefaultLdapAuthMethodStartTls() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["start_tls"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -887,9 +887,9 @@ func WithLdapAuthMethodState(inState string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["state"] = inState
 		o.postMap["attributes"] = val
 	}
@@ -899,9 +899,9 @@ func DefaultLdapAuthMethodState() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["state"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -911,9 +911,9 @@ func WithLdapAuthMethodUpnDomain(inUpnDomain string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["upn_domain"] = inUpnDomain
 		o.postMap["attributes"] = val
 	}
@@ -923,9 +923,9 @@ func DefaultLdapAuthMethodUpnDomain() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["upn_domain"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -935,9 +935,9 @@ func WithLdapAuthMethodUrls(inUrls []string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["urls"] = inUrls
 		o.postMap["attributes"] = val
 	}
@@ -947,9 +947,9 @@ func DefaultLdapAuthMethodUrls() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["urls"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -959,9 +959,9 @@ func WithLdapAuthMethodUseTokenGroups(inUseTokenGroups bool) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["use_token_groups"] = inUseTokenGroups
 		o.postMap["attributes"] = val
 	}
@@ -971,9 +971,9 @@ func DefaultLdapAuthMethodUseTokenGroups() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["use_token_groups"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -983,9 +983,9 @@ func WithLdapAuthMethodUserAttr(inUserAttr string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["user_attr"] = inUserAttr
 		o.postMap["attributes"] = val
 	}
@@ -995,9 +995,9 @@ func DefaultLdapAuthMethodUserAttr() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["user_attr"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -1007,9 +1007,9 @@ func WithLdapAuthMethodUserDn(inUserDn string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["user_dn"] = inUserDn
 		o.postMap["attributes"] = val
 	}
@@ -1019,9 +1019,9 @@ func DefaultLdapAuthMethodUserDn() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["user_dn"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -1031,9 +1031,9 @@ func WithLdapAuthMethodUserFilter(inUserFilter string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["user_filter"] = inUserFilter
 		o.postMap["attributes"] = val
 	}
@@ -1043,9 +1043,9 @@ func DefaultLdapAuthMethodUserFilter() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["user_filter"] = nil
 		o.postMap["attributes"] = val
 	}

--- a/api/authmethods/password_auth_method_attributes.gen.go
+++ b/api/authmethods/password_auth_method_attributes.gen.go
@@ -15,7 +15,7 @@ type PasswordAuthMethodAttributes struct {
 	MinPasswordLength  uint32 `json:"min_password_length,omitempty"`
 }
 
-func AttributesMapToPasswordAuthMethodAttributes(in map[string]interface{}) (*PasswordAuthMethodAttributes, error) {
+func AttributesMapToPasswordAuthMethodAttributes(in map[string]any) (*PasswordAuthMethodAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -51,7 +51,7 @@ type AuthTokenDeleteResult struct {
 }
 
 // GetItem will always be nil for AuthTokenDeleteResult
-func (n AuthTokenDeleteResult) GetItem() interface{} {
+func (n AuthTokenDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/authtokens/option.gen.go
+++ b/api/authtokens/option.gen.go
@@ -21,7 +21,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -32,7 +32,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -64,7 +64,7 @@ func getOpts(opt ...Option) (options, []api.Option) {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -89,6 +89,6 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }

--- a/api/billing/option.gen.go
+++ b/api/billing/option.gen.go
@@ -21,7 +21,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -31,7 +31,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -70,7 +70,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 

--- a/api/credentiallibraries/credential_library.gen.go
+++ b/api/credentiallibraries/credential_library.gen.go
@@ -54,7 +54,7 @@ type CredentialLibraryDeleteResult struct {
 }
 
 // GetItem will always be nil for CredentialLibraryDeleteResult
-func (n CredentialLibraryDeleteResult) GetItem() interface{} {
+func (n CredentialLibraryDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/credentiallibraries/option.gen.go
+++ b/api/credentiallibraries/option.gen.go
@@ -20,7 +20,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -30,7 +30,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -69,7 +69,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -94,9 +94,9 @@ func WithVaultSSHCertificateCredentialLibraryAdditionalValidPrincipals(inAdditio
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["additional_valid_principals"] = inAdditionalValidPrincipals
 		o.postMap["attributes"] = val
 	}
@@ -106,9 +106,9 @@ func DefaultVaultSSHCertificateCredentialLibraryAdditionalValidPrincipals() Opti
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["additional_valid_principals"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -154,9 +154,9 @@ func WithVaultSSHCertificateCredentialLibraryCriticalOptions(inCriticalOptions m
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["critical_options"] = inCriticalOptions
 		o.postMap["attributes"] = val
 	}
@@ -166,9 +166,9 @@ func DefaultVaultSSHCertificateCredentialLibraryCriticalOptions() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["critical_options"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -190,9 +190,9 @@ func WithVaultSSHCertificateCredentialLibraryExtensions(inExtensions map[string]
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["extensions"] = inExtensions
 		o.postMap["attributes"] = val
 	}
@@ -202,9 +202,9 @@ func DefaultVaultSSHCertificateCredentialLibraryExtensions() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["extensions"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -214,9 +214,9 @@ func WithVaultCredentialLibraryHttpMethod(inHttpMethod string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["http_method"] = inHttpMethod
 		o.postMap["attributes"] = val
 	}
@@ -226,9 +226,9 @@ func DefaultVaultCredentialLibraryHttpMethod() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["http_method"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -238,9 +238,9 @@ func WithVaultCredentialLibraryHttpRequestBody(inHttpRequestBody string) Option 
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["http_request_body"] = inHttpRequestBody
 		o.postMap["attributes"] = val
 	}
@@ -250,9 +250,9 @@ func DefaultVaultCredentialLibraryHttpRequestBody() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["http_request_body"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -262,9 +262,9 @@ func WithVaultSSHCertificateCredentialLibraryKeyBits(inKeyBits uint32) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["key_bits"] = inKeyBits
 		o.postMap["attributes"] = val
 	}
@@ -274,9 +274,9 @@ func DefaultVaultSSHCertificateCredentialLibraryKeyBits() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["key_bits"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -286,9 +286,9 @@ func WithVaultSSHCertificateCredentialLibraryKeyId(inKeyId string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["key_id"] = inKeyId
 		o.postMap["attributes"] = val
 	}
@@ -298,9 +298,9 @@ func DefaultVaultSSHCertificateCredentialLibraryKeyId() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["key_id"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -310,9 +310,9 @@ func WithVaultSSHCertificateCredentialLibraryKeyType(inKeyType string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["key_type"] = inKeyType
 		o.postMap["attributes"] = val
 	}
@@ -322,9 +322,9 @@ func DefaultVaultSSHCertificateCredentialLibraryKeyType() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["key_type"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -346,9 +346,9 @@ func WithVaultCredentialLibraryPath(inPath string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["path"] = inPath
 		o.postMap["attributes"] = val
 	}
@@ -358,9 +358,9 @@ func WithVaultSSHCertificateCredentialLibraryPath(inPath string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["path"] = inPath
 		o.postMap["attributes"] = val
 	}
@@ -370,9 +370,9 @@ func WithVaultSSHCertificateCredentialLibraryTtl(inTtl string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["ttl"] = inTtl
 		o.postMap["attributes"] = val
 	}
@@ -382,9 +382,9 @@ func DefaultVaultSSHCertificateCredentialLibraryTtl() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["ttl"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -394,9 +394,9 @@ func WithVaultSSHCertificateCredentialLibraryUsername(inUsername string) Option 
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["username"] = inUsername
 		o.postMap["attributes"] = val
 	}

--- a/api/credentiallibraries/vault_credential_library_attributes.gen.go
+++ b/api/credentiallibraries/vault_credential_library_attributes.gen.go
@@ -16,7 +16,7 @@ type VaultCredentialLibraryAttributes struct {
 	HttpRequestBody string `json:"http_request_body,omitempty"`
 }
 
-func AttributesMapToVaultCredentialLibraryAttributes(in map[string]interface{}) (*VaultCredentialLibraryAttributes, error) {
+func AttributesMapToVaultCredentialLibraryAttributes(in map[string]any) (*VaultCredentialLibraryAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/credentiallibraries/vault_ssh_certificate_credential_library_attributes.gen.go
+++ b/api/credentiallibraries/vault_ssh_certificate_credential_library_attributes.gen.go
@@ -22,7 +22,7 @@ type VaultSSHCertificateCredentialLibraryAttributes struct {
 	AdditionalValidPrincipals []string          `json:"additional_valid_principals,omitempty"`
 }
 
-func AttributesMapToVaultSSHCertificateCredentialLibraryAttributes(in map[string]interface{}) (*VaultSSHCertificateCredentialLibraryAttributes, error) {
+func AttributesMapToVaultSSHCertificateCredentialLibraryAttributes(in map[string]any) (*VaultSSHCertificateCredentialLibraryAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/credentials/credential.gen.go
+++ b/api/credentials/credential.gen.go
@@ -52,7 +52,7 @@ type CredentialDeleteResult struct {
 }
 
 // GetItem will always be nil for CredentialDeleteResult
-func (n CredentialDeleteResult) GetItem() interface{} {
+func (n CredentialDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/credentials/json_attributes.gen.go
+++ b/api/credentials/json_attributes.gen.go
@@ -15,7 +15,7 @@ type JsonAttributes struct {
 	ObjectHmac string                 `json:"object_hmac,omitempty"`
 }
 
-func AttributesMapToJsonAttributes(in map[string]interface{}) (*JsonAttributes, error) {
+func AttributesMapToJsonAttributes(in map[string]any) (*JsonAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/credentials/option.gen.go
+++ b/api/credentials/option.gen.go
@@ -20,7 +20,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -30,7 +30,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -69,7 +69,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -130,9 +130,9 @@ func WithJsonCredentialObject(inObject map[string]interface{}) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["object"] = inObject
 		o.postMap["attributes"] = val
 	}
@@ -142,9 +142,9 @@ func WithUsernamePasswordCredentialPassword(inPassword string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["password"] = inPassword
 		o.postMap["attributes"] = val
 	}
@@ -154,9 +154,9 @@ func WithSshPrivateKeyCredentialPrivateKey(inPrivateKey string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["private_key"] = inPrivateKey
 		o.postMap["attributes"] = val
 	}
@@ -166,9 +166,9 @@ func WithSshPrivateKeyCredentialPrivateKeyPassphrase(inPrivateKeyPassphrase stri
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["private_key_passphrase"] = inPrivateKeyPassphrase
 		o.postMap["attributes"] = val
 	}
@@ -178,9 +178,9 @@ func DefaultSshPrivateKeyCredentialPrivateKeyPassphrase() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["private_key_passphrase"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -190,9 +190,9 @@ func WithSshPrivateKeyCredentialUsername(inUsername string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["username"] = inUsername
 		o.postMap["attributes"] = val
 	}
@@ -202,9 +202,9 @@ func WithUsernamePasswordCredentialUsername(inUsername string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["username"] = inUsername
 		o.postMap["attributes"] = val
 	}

--- a/api/credentials/ssh_private_key_attributes.gen.go
+++ b/api/credentials/ssh_private_key_attributes.gen.go
@@ -18,7 +18,7 @@ type SshPrivateKeyAttributes struct {
 	PrivateKeyPassphraseHmac string `json:"private_key_passphrase_hmac,omitempty"`
 }
 
-func AttributesMapToSshPrivateKeyAttributes(in map[string]interface{}) (*SshPrivateKeyAttributes, error) {
+func AttributesMapToSshPrivateKeyAttributes(in map[string]any) (*SshPrivateKeyAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/credentials/username_password_attributes.gen.go
+++ b/api/credentials/username_password_attributes.gen.go
@@ -16,7 +16,7 @@ type UsernamePasswordAttributes struct {
 	PasswordHmac string `json:"password_hmac,omitempty"`
 }
 
-func AttributesMapToUsernamePasswordAttributes(in map[string]interface{}) (*UsernamePasswordAttributes, error) {
+func AttributesMapToUsernamePasswordAttributes(in map[string]any) (*UsernamePasswordAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/credentialstores/credential_store.gen.go
+++ b/api/credentialstores/credential_store.gen.go
@@ -53,7 +53,7 @@ type CredentialStoreDeleteResult struct {
 }
 
 // GetItem will always be nil for CredentialStoreDeleteResult
-func (n CredentialStoreDeleteResult) GetItem() interface{} {
+func (n CredentialStoreDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/credentialstores/option.gen.go
+++ b/api/credentialstores/option.gen.go
@@ -21,7 +21,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -32,7 +32,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -74,7 +74,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -99,7 +99,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 
@@ -107,9 +107,9 @@ func WithVaultCredentialStoreAddress(inAddress string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["address"] = inAddress
 		o.postMap["attributes"] = val
 	}
@@ -131,9 +131,9 @@ func WithVaultCredentialStoreCaCert(inCaCert string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["ca_cert"] = inCaCert
 		o.postMap["attributes"] = val
 	}
@@ -143,9 +143,9 @@ func DefaultVaultCredentialStoreCaCert() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["ca_cert"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -155,9 +155,9 @@ func WithVaultCredentialStoreClientCertificate(inClientCertificate string) Optio
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_certificate"] = inClientCertificate
 		o.postMap["attributes"] = val
 	}
@@ -167,9 +167,9 @@ func DefaultVaultCredentialStoreClientCertificate() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_certificate"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -179,9 +179,9 @@ func WithVaultCredentialStoreClientCertificateKey(inClientCertificateKey string)
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_certificate_key"] = inClientCertificateKey
 		o.postMap["attributes"] = val
 	}
@@ -191,9 +191,9 @@ func DefaultVaultCredentialStoreClientCertificateKey() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["client_certificate_key"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -227,9 +227,9 @@ func WithVaultCredentialStoreNamespace(inNamespace string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["namespace"] = inNamespace
 		o.postMap["attributes"] = val
 	}
@@ -239,9 +239,9 @@ func DefaultVaultCredentialStoreNamespace() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["namespace"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -251,9 +251,9 @@ func WithVaultCredentialStoreTlsServerName(inTlsServerName string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["tls_server_name"] = inTlsServerName
 		o.postMap["attributes"] = val
 	}
@@ -263,9 +263,9 @@ func DefaultVaultCredentialStoreTlsServerName() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["tls_server_name"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -275,9 +275,9 @@ func WithVaultCredentialStoreTlsSkipVerify(inTlsSkipVerify bool) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["tls_skip_verify"] = inTlsSkipVerify
 		o.postMap["attributes"] = val
 	}
@@ -287,9 +287,9 @@ func DefaultVaultCredentialStoreTlsSkipVerify() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["tls_skip_verify"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -299,9 +299,9 @@ func WithVaultCredentialStoreToken(inToken string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["token"] = inToken
 		o.postMap["attributes"] = val
 	}
@@ -311,9 +311,9 @@ func WithVaultCredentialStoreWorkerFilter(inWorkerFilter string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["worker_filter"] = inWorkerFilter
 		o.postMap["attributes"] = val
 	}
@@ -323,9 +323,9 @@ func DefaultVaultCredentialStoreWorkerFilter() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["worker_filter"] = nil
 		o.postMap["attributes"] = val
 	}

--- a/api/credentialstores/vault_credential_store_attributes.gen.go
+++ b/api/credentialstores/vault_credential_store_attributes.gen.go
@@ -25,7 +25,7 @@ type VaultCredentialStoreAttributes struct {
 	TokenStatus              string `json:"token_status,omitempty"`
 }
 
-func AttributesMapToVaultCredentialStoreAttributes(in map[string]interface{}) (*VaultCredentialStoreAttributes, error) {
+func AttributesMapToVaultCredentialStoreAttributes(in map[string]any) (*VaultCredentialStoreAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/groups/group.gen.go
+++ b/api/groups/group.gen.go
@@ -52,7 +52,7 @@ type GroupDeleteResult struct {
 }
 
 // GetItem will always be nil for GroupDeleteResult
-func (n GroupDeleteResult) GetItem() interface{} {
+func (n GroupDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/groups/option.gen.go
+++ b/api/groups/option.gen.go
@@ -21,7 +21,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -32,7 +32,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -74,7 +74,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -99,7 +99,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 

--- a/api/hostcatalogs/host_catalog.gen.go
+++ b/api/hostcatalogs/host_catalog.gen.go
@@ -58,7 +58,7 @@ type HostCatalogDeleteResult struct {
 }
 
 // GetItem will always be nil for HostCatalogDeleteResult
-func (n HostCatalogDeleteResult) GetItem() interface{} {
+func (n HostCatalogDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/hostcatalogs/option.gen.go
+++ b/api/hostcatalogs/option.gen.go
@@ -22,7 +22,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -33,7 +33,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -75,7 +75,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -100,7 +100,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 

--- a/api/hosts/host.gen.go
+++ b/api/hosts/host.gen.go
@@ -59,7 +59,7 @@ type HostDeleteResult struct {
 }
 
 // GetItem will always be nil for HostDeleteResult
-func (n HostDeleteResult) GetItem() interface{} {
+func (n HostDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/hosts/option.gen.go
+++ b/api/hosts/option.gen.go
@@ -20,7 +20,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -30,7 +30,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -69,7 +69,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -94,9 +94,9 @@ func WithStaticHostAddress(inAddress string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["address"] = inAddress
 		o.postMap["attributes"] = val
 	}
@@ -106,9 +106,9 @@ func DefaultStaticHostAddress() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["address"] = nil
 		o.postMap["attributes"] = val
 	}

--- a/api/hosts/static_host_attributes.gen.go
+++ b/api/hosts/static_host_attributes.gen.go
@@ -14,7 +14,7 @@ type StaticHostAttributes struct {
 	Address string `json:"address,omitempty"`
 }
 
-func AttributesMapToStaticHostAttributes(in map[string]interface{}) (*StaticHostAttributes, error) {
+func AttributesMapToStaticHostAttributes(in map[string]any) (*StaticHostAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/hostsets/host_set.gen.go
+++ b/api/hostsets/host_set.gen.go
@@ -57,7 +57,7 @@ type HostSetDeleteResult struct {
 }
 
 // GetItem will always be nil for HostSetDeleteResult
-func (n HostSetDeleteResult) GetItem() interface{} {
+func (n HostSetDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/hostsets/option.gen.go
+++ b/api/hostsets/option.gen.go
@@ -20,7 +20,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -30,7 +30,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -69,7 +69,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 

--- a/api/managedgroups/ldap_managed_group_attributes.gen.go
+++ b/api/managedgroups/ldap_managed_group_attributes.gen.go
@@ -14,7 +14,7 @@ type LdapManagedGroupAttributes struct {
 	GroupNames []string `json:"group_names,omitempty"`
 }
 
-func AttributesMapToLdapManagedGroupAttributes(in map[string]interface{}) (*LdapManagedGroupAttributes, error) {
+func AttributesMapToLdapManagedGroupAttributes(in map[string]any) (*LdapManagedGroupAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/managedgroups/managedgroups.gen.go
+++ b/api/managedgroups/managedgroups.gen.go
@@ -53,7 +53,7 @@ type ManagedGroupDeleteResult struct {
 }
 
 // GetItem will always be nil for ManagedGroupDeleteResult
-func (n ManagedGroupDeleteResult) GetItem() interface{} {
+func (n ManagedGroupDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/managedgroups/oidc_managed_group_attributes.gen.go
+++ b/api/managedgroups/oidc_managed_group_attributes.gen.go
@@ -14,7 +14,7 @@ type OidcManagedGroupAttributes struct {
 	Filter string `json:"filter,omitempty"`
 }
 
-func AttributesMapToOidcManagedGroupAttributes(in map[string]interface{}) (*OidcManagedGroupAttributes, error) {
+func AttributesMapToOidcManagedGroupAttributes(in map[string]any) (*OidcManagedGroupAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/managedgroups/option.gen.go
+++ b/api/managedgroups/option.gen.go
@@ -20,7 +20,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -30,7 +30,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -69,7 +69,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -118,9 +118,9 @@ func WithOidcManagedGroupFilter(inFilter string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["filter"] = inFilter
 		o.postMap["attributes"] = val
 	}
@@ -130,9 +130,9 @@ func WithLdapManagedGroupGroupNames(inGroupNames []string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["group_names"] = inGroupNames
 		o.postMap["attributes"] = val
 	}
@@ -142,9 +142,9 @@ func DefaultLdapManagedGroupGroupNames() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["group_names"] = nil
 		o.postMap["attributes"] = val
 	}

--- a/api/policies/option.gen.go
+++ b/api/policies/option.gen.go
@@ -21,7 +21,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -32,7 +32,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -74,7 +74,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -99,7 +99,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 

--- a/api/policies/policy.gen.go
+++ b/api/policies/policy.gen.go
@@ -52,7 +52,7 @@ type PolicyDeleteResult struct {
 }
 
 // GetItem will always be nil for PolicyDeleteResult
-func (n PolicyDeleteResult) GetItem() interface{} {
+func (n PolicyDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/policies/storage_policy_attributes.gen.go
+++ b/api/policies/storage_policy_attributes.gen.go
@@ -15,7 +15,7 @@ type StoragePolicyAttributes struct {
 	DeleteAfter *StoragePolicyDeleteAfter `json:"delete_after,omitempty"`
 }
 
-func AttributesMapToStoragePolicyAttributes(in map[string]interface{}) (*StoragePolicyAttributes, error) {
+func AttributesMapToStoragePolicyAttributes(in map[string]any) (*StoragePolicyAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/roles/option.gen.go
+++ b/api/roles/option.gen.go
@@ -21,7 +21,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -32,7 +32,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -74,7 +74,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -99,7 +99,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 

--- a/api/roles/role.gen.go
+++ b/api/roles/role.gen.go
@@ -55,7 +55,7 @@ type RoleDeleteResult struct {
 }
 
 // GetItem will always be nil for RoleDeleteResult
-func (n RoleDeleteResult) GetItem() interface{} {
+func (n RoleDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/scopes/option.gen.go
+++ b/api/scopes/option.gen.go
@@ -22,7 +22,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -33,7 +33,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -75,7 +75,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -100,7 +100,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 

--- a/api/scopes/scope.gen.go
+++ b/api/scopes/scope.gen.go
@@ -53,7 +53,7 @@ type ScopeDeleteResult struct {
 }
 
 // GetItem will always be nil for ScopeDeleteResult
-func (n ScopeDeleteResult) GetItem() interface{} {
+func (n ScopeDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/sessionrecordings/json_credential_attributes.gen.go
+++ b/api/sessionrecordings/json_credential_attributes.gen.go
@@ -14,7 +14,7 @@ type JsonCredentialAttributes struct {
 	ObjectHmac string `json:"object_hmac,omitempty"`
 }
 
-func AttributesMapToJsonCredentialAttributes(in map[string]interface{}) (*JsonCredentialAttributes, error) {
+func AttributesMapToJsonCredentialAttributes(in map[string]any) (*JsonCredentialAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/sessionrecordings/option.gen.go
+++ b/api/sessionrecordings/option.gen.go
@@ -20,7 +20,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -31,7 +31,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -63,7 +63,7 @@ func getOpts(opt ...Option) (options, []api.Option) {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -79,6 +79,6 @@ func WithListToken(listToken string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }

--- a/api/sessionrecordings/session_recording.gen.go
+++ b/api/sessionrecordings/session_recording.gen.go
@@ -58,7 +58,7 @@ type SessionRecordingDeleteResult struct {
 }
 
 // GetItem will always be nil for SessionRecordingDeleteResult
-func (n SessionRecordingDeleteResult) GetItem() interface{} {
+func (n SessionRecordingDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/sessionrecordings/ssh_private_key_credential_attributes.gen.go
+++ b/api/sessionrecordings/ssh_private_key_credential_attributes.gen.go
@@ -16,7 +16,7 @@ type SshPrivateKeyCredentialAttributes struct {
 	PrivateKeyPassphraseHmac string `json:"private_key_passphrase_hmac,omitempty"`
 }
 
-func AttributesMapToSshPrivateKeyCredentialAttributes(in map[string]interface{}) (*SshPrivateKeyCredentialAttributes, error) {
+func AttributesMapToSshPrivateKeyCredentialAttributes(in map[string]any) (*SshPrivateKeyCredentialAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/sessionrecordings/ssh_target_attributes.gen.go
+++ b/api/sessionrecordings/ssh_target_attributes.gen.go
@@ -15,7 +15,7 @@ type SshTargetAttributes struct {
 	DefaultClientPort uint32 `json:"default_client_port,omitempty"`
 }
 
-func AttributesMapToSshTargetAttributes(in map[string]interface{}) (*SshTargetAttributes, error) {
+func AttributesMapToSshTargetAttributes(in map[string]any) (*SshTargetAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/sessionrecordings/static_host_attributes.gen.go
+++ b/api/sessionrecordings/static_host_attributes.gen.go
@@ -14,7 +14,7 @@ type StaticHostAttributes struct {
 	Address string `json:"address,omitempty"`
 }
 
-func AttributesMapToStaticHostAttributes(in map[string]interface{}) (*StaticHostAttributes, error) {
+func AttributesMapToStaticHostAttributes(in map[string]any) (*StaticHostAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/sessionrecordings/username_password_credential_attributes.gen.go
+++ b/api/sessionrecordings/username_password_credential_attributes.gen.go
@@ -15,7 +15,7 @@ type UsernamePasswordCredentialAttributes struct {
 	PasswordHmac string `json:"password_hmac,omitempty"`
 }
 
-func AttributesMapToUsernamePasswordCredentialAttributes(in map[string]interface{}) (*UsernamePasswordCredentialAttributes, error) {
+func AttributesMapToUsernamePasswordCredentialAttributes(in map[string]any) (*UsernamePasswordCredentialAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/sessionrecordings/vault_credential_library_attributes.gen.go
+++ b/api/sessionrecordings/vault_credential_library_attributes.gen.go
@@ -16,7 +16,7 @@ type VaultCredentialLibraryAttributes struct {
 	HttpRequestBody string `json:"http_request_body,omitempty"`
 }
 
-func AttributesMapToVaultCredentialLibraryAttributes(in map[string]interface{}) (*VaultCredentialLibraryAttributes, error) {
+func AttributesMapToVaultCredentialLibraryAttributes(in map[string]any) (*VaultCredentialLibraryAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/sessionrecordings/vault_credential_store_attributes.gen.go
+++ b/api/sessionrecordings/vault_credential_store_attributes.gen.go
@@ -18,7 +18,7 @@ type VaultCredentialStoreAttributes struct {
 	WorkerFilter  string `json:"worker_filter,omitempty"`
 }
 
-func AttributesMapToVaultCredentialStoreAttributes(in map[string]interface{}) (*VaultCredentialStoreAttributes, error) {
+func AttributesMapToVaultCredentialStoreAttributes(in map[string]any) (*VaultCredentialStoreAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/sessionrecordings/vault_ssh_certificate_credential_library_attributes.gen.go
+++ b/api/sessionrecordings/vault_ssh_certificate_credential_library_attributes.gen.go
@@ -21,7 +21,7 @@ type VaultSSHCertificateCredentialLibraryAttributes struct {
 	AdditionalValidPrincipals []string          `json:"additional_valid_principals,omitempty"`
 }
 
-func AttributesMapToVaultSSHCertificateCredentialLibraryAttributes(in map[string]interface{}) (*VaultSSHCertificateCredentialLibraryAttributes, error) {
+func AttributesMapToVaultSSHCertificateCredentialLibraryAttributes(in map[string]any) (*VaultSSHCertificateCredentialLibraryAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/sessions/option.gen.go
+++ b/api/sessions/option.gen.go
@@ -22,7 +22,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -33,7 +33,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -75,7 +75,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -100,7 +100,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 

--- a/api/sessions/session.gen.go
+++ b/api/sessions/session.gen.go
@@ -60,7 +60,7 @@ type SessionDeleteResult struct {
 }
 
 // GetItem will always be nil for SessionDeleteResult
-func (n SessionDeleteResult) GetItem() interface{} {
+func (n SessionDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/storagebuckets/option.gen.go
+++ b/api/storagebuckets/option.gen.go
@@ -22,7 +22,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -33,7 +33,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -75,7 +75,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -100,7 +100,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 

--- a/api/storagebuckets/storage_bucket.gen.go
+++ b/api/storagebuckets/storage_bucket.gen.go
@@ -61,7 +61,7 @@ type StorageBucketDeleteResult struct {
 }
 
 // GetItem will always be nil for StorageBucketDeleteResult
-func (n StorageBucketDeleteResult) GetItem() interface{} {
+func (n StorageBucketDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/targets/option.gen.go
+++ b/api/targets/option.gen.go
@@ -21,7 +21,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -32,7 +32,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -74,7 +74,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -99,7 +99,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 
@@ -149,9 +149,9 @@ func WithSshTargetDefaultClientPort(inDefaultClientPort uint32) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["default_client_port"] = inDefaultClientPort
 		o.postMap["attributes"] = val
 	}
@@ -161,9 +161,9 @@ func DefaultSshTargetDefaultClientPort() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["default_client_port"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -173,9 +173,9 @@ func WithTcpTargetDefaultClientPort(inDefaultClientPort uint32) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["default_client_port"] = inDefaultClientPort
 		o.postMap["attributes"] = val
 	}
@@ -185,9 +185,9 @@ func DefaultTcpTargetDefaultClientPort() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["default_client_port"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -197,9 +197,9 @@ func WithSshTargetDefaultPort(inDefaultPort uint32) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["default_port"] = inDefaultPort
 		o.postMap["attributes"] = val
 	}
@@ -209,9 +209,9 @@ func DefaultSshTargetDefaultPort() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["default_port"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -221,9 +221,9 @@ func WithTcpTargetDefaultPort(inDefaultPort uint32) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["default_port"] = inDefaultPort
 		o.postMap["attributes"] = val
 	}
@@ -233,9 +233,9 @@ func DefaultTcpTargetDefaultPort() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["default_port"] = nil
 		o.postMap["attributes"] = val
 	}
@@ -269,9 +269,9 @@ func WithSshTargetEnableSessionRecording(inEnableSessionRecording bool) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["enable_session_recording"] = inEnableSessionRecording
 		o.postMap["attributes"] = val
 	}
@@ -359,9 +359,9 @@ func WithSshTargetStorageBucketId(inStorageBucketId string) Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["storage_bucket_id"] = inStorageBucketId
 		o.postMap["attributes"] = val
 	}
@@ -371,9 +371,9 @@ func DefaultSshTargetStorageBucketId() Option {
 	return func(o *options) {
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["storage_bucket_id"] = nil
 		o.postMap["attributes"] = val
 	}

--- a/api/targets/ssh_target_attributes.gen.go
+++ b/api/targets/ssh_target_attributes.gen.go
@@ -17,7 +17,7 @@ type SshTargetAttributes struct {
 	EnableSessionRecording bool   `json:"enable_session_recording,omitempty"`
 }
 
-func AttributesMapToSshTargetAttributes(in map[string]interface{}) (*SshTargetAttributes, error) {
+func AttributesMapToSshTargetAttributes(in map[string]any) (*SshTargetAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/targets/target.gen.go
+++ b/api/targets/target.gen.go
@@ -66,7 +66,7 @@ type TargetDeleteResult struct {
 }
 
 // GetItem will always be nil for TargetDeleteResult
-func (n TargetDeleteResult) GetItem() interface{} {
+func (n TargetDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/targets/tcp_target_attributes.gen.go
+++ b/api/targets/tcp_target_attributes.gen.go
@@ -15,7 +15,7 @@ type TcpTargetAttributes struct {
 	DefaultClientPort uint32 `json:"default_client_port,omitempty"`
 }
 
-func AttributesMapToTcpTargetAttributes(in map[string]interface{}) (*TcpTargetAttributes, error) {
+func AttributesMapToTcpTargetAttributes(in map[string]any) (*TcpTargetAttributes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}

--- a/api/users/option.gen.go
+++ b/api/users/option.gen.go
@@ -21,7 +21,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -32,7 +32,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -74,7 +74,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -99,7 +99,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 

--- a/api/users/user.gen.go
+++ b/api/users/user.gen.go
@@ -56,7 +56,7 @@ type UserDeleteResult struct {
 }
 
 // GetItem will always be nil for UserDeleteResult
-func (n UserDeleteResult) GetItem() interface{} {
+func (n UserDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/api/workers/option.gen.go
+++ b/api/workers/option.gen.go
@@ -21,7 +21,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap                 map[string]interface{}
+	postMap                 map[string]any
 	queryMap                map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput      bool
@@ -32,7 +32,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap:  make(map[string]interface{}),
+		postMap:  make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -74,7 +74,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -99,7 +99,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 

--- a/api/workers/worker.gen.go
+++ b/api/workers/worker.gen.go
@@ -63,7 +63,7 @@ type WorkerDeleteResult struct {
 }
 
 // GetItem will always be nil for WorkerDeleteResult
-func (n WorkerDeleteResult) GetItem() interface{} {
+func (n WorkerDeleteResult) GetItem() any {
 	return nil
 }
 

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -748,7 +748,7 @@ type {{ .Name }}DeleteResult struct {
 }
 
 // GetItem will always be nil for {{ .Name }}DeleteResult
-func (n {{ .Name }}DeleteResult) GetItem() interface{} {
+func (n {{ .Name }}DeleteResult) GetItem() any {
 	return nil
 }
 
@@ -839,7 +839,7 @@ import (
 type Option func(*options)
 
 type options struct {
-	postMap map[string]interface{}
+	postMap map[string]any
 	queryMap map[string]string
 	withAutomaticVersioning bool
 	withSkipCurlOutput bool
@@ -850,7 +850,7 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{
-		postMap: make(map[string]interface{}),
+		postMap: make(map[string]any),
 		queryMap: make(map[string]string),
 	}
 }
@@ -894,7 +894,7 @@ func WithAutomaticVersioning(enable bool) Option {
 // Useful for when we need to look up versions.
 func WithSkipCurlOutput(skip bool) Option {
 	return func(o *options) {
-		o.withSkipCurlOutput = true
+		o.withSkipCurlOutput = skip
 	}
 }
 
@@ -921,7 +921,7 @@ func WithFilter(filter string) Option {
 // resource
 func WithRecursive(recurse bool) Option {
 	return func(o *options) {
-		o.withRecursive = true
+		o.withRecursive = recurse
 	}
 }
 {{ end }}
@@ -935,9 +935,9 @@ func With{{ $subtypeName }}{{ $field.Name }}(in{{ $field.Name }} {{ $field.Field
 	return func(o *options) {		{{ if ( not ( eq $subtypeName "" ) ) }}
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["{{ $field.ProtoName }}"] = in{{ $field.Name }}
 		o.postMap["attributes"] = val
 		{{ else if $field.Query }}
@@ -951,9 +951,9 @@ func Default{{ $subtypeName }}{{ $field.Name }}() Option {
 	return func(o *options) {		{{ if ( not ( eq $subtypeName "" ) ) }}
 		raw, ok := o.postMap["attributes"]
 		if !ok {
-			raw = interface{}(map[string]interface{}{})
+			raw = any(map[string]any{})
 		}
-		val := raw.(map[string]interface{})
+		val := raw.(map[string]any)
 		val["{{ $field.ProtoName }}"] = nil
 		o.postMap["attributes"] = val
 		{{ else }}
@@ -971,7 +971,7 @@ var mapstructureConversionTemplate = template.Must(template.New("").Funcs(
 		"kebabCase":       kebabCase,
 	},
 ).Parse(`
-func AttributesMapTo{{ .Name }}(in map[string]interface{}) (*{{ .Name }}, error) {
+func AttributesMapTo{{ .Name }}(in map[string]any) (*{{ .Name }}, error) {
 	if in == nil {
 		return nil, fmt.Errorf("nil input map")
 	}


### PR DESCRIPTION
* Replace `interface{}` with `any`
* For options that are bools, don't always set true; set to the actual value passed in (some options already behaved this way, but they all should)