### PR TITLE
docs: Update session recording docs with asciicast info

### DIFF
--- a/website/content/docs/operations/session-recordings/index.mdx
+++ b/website/content/docs/operations/session-recordings/index.mdx
@@ -42,15 +42,12 @@ You should be aware of the following security concerns that could result from th
 
 - asciicast only includes the last value that you send in the header, any previous values are overwritten.
 An attacker may be able to use a malicious shell value at the beginning of a session, and then switch to `shell=/bin/bash` at the end of the session to conceal the malicious activity.
-Boundary displays a warning when a user provides multiple environment requests to set the shell variable.
 
 - asciicast does not display other variables such as `path` in the header, but they can cause drastic changes to code execution during the SSH session.
 An attacker could change the `path` variable to point to a malicious program or change the beahvior of a normal program so that it performs a malicious action.
-Boundary displays a warning when a request that is recorded in the BSR file is not included in the asciicast.
 
 - asciicast silently ignores any requests that do not have an explicit handler, even though they may cause signficant changes to code execution during the SSH session.
 An attacker could execute malicious code using a request without an explicit handler.
-Boundary displays a warning when a request that is recorded in the BSR file is not included in the asciicast.
 
 ## Next steps
 

--- a/website/content/docs/operations/session-recordings/index.mdx
+++ b/website/content/docs/operations/session-recordings/index.mdx
@@ -19,15 +19,40 @@ Recorded sessions are stored in an external storage bucket that you create.
 Storing session recordings in a system external to Boundary means those recordings can be accessed, modified, deleted, and even restored independently of Boundary.
 You can view any sessions that Boundary recorded in your storage provider or via the CLI.
 
+## asciicast
+
 When you view recorded sessions using the CLI or Admin UI, Boundary can convert the recording into other formats for playback.
 Currently Boundary supports converting the recording of an individual SSH channel into an [asciicast](https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md) format to play back an interactive SSH session.
+
+### Limitations
 
 The asciicast format is well suited for the playback of interactive shell activity.
 However, some aspects of the recording cannot be translated into asciicast.
 For example, if an SSH session uses the `RemoteCommand` option, or is used to `exec` a command, the command is not displayed in the asciicast.
 The output of the command may be displayed, though.
+
 If you use SSH for something other than an interactive shell, such as for file transfer, X11 forwarding, or port forwarding, Boundary does not attempt to create an asciicast.
 In all cases, the SSH session is still recorded in the [BSR file](/boundary/docs/concepts/auditing/#bsr-directory-structure) and you can view the BSR file in the external storage bucket.
+
+### Security
+
+When a worker converts an SSH recording into the BSR file, it iterates through each of the requests in the recording and displays some of them to the user.
+If you use an environment request to set the shell variable, the request is included in the asciicast header.
+You should be aware of the following security concerns that could result from this behavior:
+
+- asciicast only includes the last value that you send in the header, any previous values are overwritten.
+An attacker may be able to use a malicious shell value at the beginning of a session, and then switch to `shell=/bin/bash` at the end of the session to conceal the malicious activity.
+Boundary displays a warning when a user provides multiple environment requests to set the shell variable.
+
+- asciicast does not display other variables such as `path` in the header, but they can cause drastic changes to code execution during the SSH session.
+An attacker could change the `path` variable to point to a malicious program or change the beahvior of a normal program so that it performs a malicious action.
+Boundary displays a warning when a request that is recorded in the BSR file is not included in the asciicast.
+
+- asciicast silently ignores any requests that do not have an explicit handler, even though they may cause signficant changes to code execution during the SSH session.
+An attacker could execute malicious code using a request without an explicit handler.
+Boundary displays a warning when a request that is recorded in the BSR file is not included in the asciicast.
+
+## Next steps
 
 For more information about working with recorded sessions, refer to the following topics:
 

--- a/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
+++ b/website/content/docs/operations/session-recordings/manage-recorded-sessions.mdx
@@ -9,19 +9,10 @@ description: |-
 
 <EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
+Boundary converts recorded sessions into an asciicast format so that you can play back interactive SSH sessions.
+Make sure to refer to the [asciicast](/boundary/docs/operations/session-recordings#asciicast) section to understand potential limitations to the asciicast format.
+
 You can view a list of all recorded sessions, or if you know the ID of a specific recorded session, you can find any channels associated with that recording.
-
-<Note>
-
-The asciicast format is well suited for the playback of interactive shell activity.
-However, some aspects of the recording cannot be translated into asciicast.
-For example, if an SSH session uses the `RemoteCommand` option, or is used to `exec` a command, the command is not displayed in the asciicast.
-The output of the command may be displayed, though.
-If you use SSH for something other than an interactive shell, such as for file transfer, X11 forwarding, or port forwarding, Boundary does not attempt to create an asciicast.
-
-In all cases, the SSH session is still recorded in the [BSR file](/boundary/docs/concepts/auditing/#bsr-directory-structure) and you can view the BSR file in the external storage bucket.
-
-</Note>
 
 <Tabs>
 <Tab heading="CLI">


### PR DESCRIPTION
[ICU-15008](https://hashicorp.atlassian.net/browse/ICU-15008) document ToB findings regarding using asciicast for session recording. View the following updates in the preview deployment:

- Added a new section **asciicast** to the [Recorded sessions operations](https://boundary-4o7k6eaa6-hashicorp.vercel.app/boundary/docs/operations/session-recordings) topic and merged in some existing asciicast info.
- Deleted the note regarding asciicast format limitations and instead included a link back to the new section in the [Find and view recorded sessions](https://boundary-4o7k6eaa6-hashicorp.vercel.app/boundary/docs/operations/session-recordings/manage-recorded-sessions) topic.

[ICU-15008]: https://hashicorp.atlassian.net/browse/ICU-15008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ