### PR TITLE
test (cache/search): fix NewTestServer(...) storage

### DIFF
--- a/internal/clientcache/cmd/search/search_test.go
+++ b/internal/clientcache/cmd/search/search_test.go
@@ -136,9 +136,9 @@ func TestSearch(t *testing.T) {
 		assert.Nil(t, apiErr)
 		assert.NotNil(t, resp)
 		assert.NotNil(t, r)
-		assert.EqualValues(t, r, &daemon.SearchResult{
+		assert.EqualValues(t, &daemon.SearchResult{
 			RefreshStatus: daemon.NotRefreshing,
-		})
+		}, r)
 	})
 
 	t.Run("empty response from query", func(t *testing.T) {

--- a/internal/clientcache/internal/daemon/testing.go
+++ b/internal/clientcache/internal/daemon/testing.go
@@ -37,6 +37,9 @@ func NewTestServer(t *testing.T, cmd Commander, opt ...Option) *TestServer {
 		RecheckSupportInterval: DefaultRecheckSupportInterval,
 		LogWriter:              io.Discard,
 		DotDirectory:           dotDir,
+		// we need to provide this, otherwise it will open a store in the user's
+		// home dir. See db.Open(...)
+		DatabaseUrl: dotDir + "cache.db?_pragma=foreign_keys(1)",
 	}
 
 	s, err := New(ctx, cfg)


### PR DESCRIPTION
Fix ensures that the TestServer returned uses the
correct directory for writing its sqlite files,
which was created via t.TempDir()