### PR TITLE
docs: Clarify credential workflow for SSH target types

### DIFF
--- a/website/content/docs/concepts/credential-management.mdx
+++ b/website/content/docs/concepts/credential-management.mdx
@@ -88,7 +88,7 @@ The credential injection process works as follows:
     Then the controller passes credentials to the worker.
     The worker authenticates to the target, and the user is then authenticated to the target.
 
-Credential injection is available for the SSH target type, allowing users to inject the following credential types when accessing targets using SSH:
+Credential injection is required for the SSH target type, allowing users to inject the following credential types when they access targets using SSH:
 
 - SSH certificates
 - Usernames and passwords

--- a/website/content/docs/concepts/credential-management.mdx
+++ b/website/content/docs/concepts/credential-management.mdx
@@ -17,7 +17,9 @@ To configure credential brokering or credential injection with static credential
 ## Credential brokering
 
 Credential brokering is the process by which credentials are fetched from a credential store, and then returned back to the user.
+
 The user must already be authorized to connect to a specific target to have credentials for that target brokered back to them.
+
 Credentials are brokered when the session is established.
 
 The credential brokering process works as follows:
@@ -28,10 +30,10 @@ The credential brokering process works as follows:
    The controller fetches credentials from the credential store and passes the credentials to the user.
 1. The user establishes a connection to the session.
 
-    The controller assigns the job to a worker, and the worker establishes a session to the target.
+   The controller assigns the job to a worker, and the worker establishes a session to the target.
 1. The user enters the credentials.
 
-    The user is authenticated to the target.
+   The user is authenticated to the target.
 
 You can attach brokered credentials to either TCP targets or SSH targets.
 Brokered credentials can take the form of a token, username and password, SSH private key, certificate, JSON blob, or an unstructured secret stored in Vault, for example.
@@ -44,6 +46,7 @@ Consider a scenario where a user wants to access a target using SSH.
 
 In this scenario, the user must be authorized to access the target.
 If they are authorized, they can authenticate themselves to the machine using credentials that were brokered, or returned, back to them.
+
 If the user is not authorized to access the target, they will not be able to retrieve brokered credentials for that target.
 
   <img
@@ -72,7 +75,9 @@ Learn more about the [Vault dynamic secrets engine](/vault/docs/secrets).
 <EnterpriseAlert product="boundary">This feature requires <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a></EnterpriseAlert>
 
 Credential injection is the process by which a credential is fetched from a credential store and then passed on to a worker for authentication to a remote machine.
+
 With credential injection, the user never sees the credential required to authenticate to the target.
+
 This provides a passwordless experience for the user, as the worker does both session establishment and authentication to the target on behalf of the user.
 This process differs from credential brokering, where credentials are returned to the user rather than injected into the session on worker nodes.
 
@@ -81,18 +86,20 @@ The credential injection process works as follows:
 1. The user authenticates to Boundary.
 1. The user requests a connection to a target.
 
-    The controller fetches credentials from the credential store.
+   The controller fetches credentials from the credential store.
 1. The user establishes a connection to the session.
 
-    The controller assigns the job to a worker, and the worker establishes a session to the target.
-    Then the controller passes credentials to the worker.
-    The worker authenticates to the target, and the user is then authenticated to the target.
+   The controller assigns the job to a worker, and the worker establishes a session to the target.
+   Then the controller passes credentials to the worker.
+   The worker authenticates to the target, and the user is then authenticated to the target.
 
 Credential injection is required for the SSH target type, allowing users to inject the following credential types when they access targets using SSH:
 
 - SSH certificates
 - Usernames and passwords
 - Usernames and public keys
+
+Additional credentials can be brokered to SSH targets after the session is establised using injected credentials.
 
 ### Security considerations
 

--- a/website/content/docs/configuration/credential-management/configure-credential-brokering.mdx
+++ b/website/content/docs/configuration/credential-management/configure-credential-brokering.mdx
@@ -12,7 +12,8 @@ When you use credential brokering, Boundary returns credentials to the user when
 
 ## Requirements
 
-- You must have an existing target available.
+- You must have an existing target available. To use brokered credentials to connect to a target that runs SSH, you must use a TCP target type.
+
 - You must have configured either a static credential store or a Vault credential store:
 
   - To configure a static credential store, refer to [Create static credential stores](/boundary/docs/configuration/credential-management/static-cred-boundary).
@@ -67,3 +68,11 @@ Complete the following steps to configure credential brokering for a target:
 
 </Tab>
 </Tabs>
+
+## More information
+
+Refer to the following topics for more information:
+
+- [Create static credential stores](/boundary/docs/configuration/credential-management/static-cred-boundary)
+- [Create Vault credential stores](/boundary/docs/configuration/credential-management/static-cred-vault)
+- [Target types](/boundary/docs/concepts/domain-model/targets#target-types)

--- a/website/content/docs/configuration/credential-management/configure-credential-injection.mdx
+++ b/website/content/docs/configuration/credential-management/configure-credential-injection.mdx
@@ -15,7 +15,7 @@ Credential injection provides end users with a passwordless experience when they
 ## Requirements
 
 - This feature requires either <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a>
-- You must have an existing target available. To use injected application credentials to connect to a target that runs SSH, you must use an SSH target type.
+- You must have an existing target available. If you use the SSH target type, the target must be configured with an injected application credential.
 
 - You must have configured either a static credential store or a Vault credential store:
 

--- a/website/content/docs/configuration/credential-management/configure-credential-injection.mdx
+++ b/website/content/docs/configuration/credential-management/configure-credential-injection.mdx
@@ -15,7 +15,8 @@ Credential injection provides end users with a passwordless experience when they
 ## Requirements
 
 - This feature requires either <a href="https://www.hashicorp.com/products/boundary">HCP Boundary or Boundary Enterprise</a>
-- You must have an existing target available.
+- You must have an existing target available. To use injected application credentials to connect to a target that runs SSH, you must use an SSH target type.
+
 - You must have configured either a static credential store or a Vault credential store:
 
   - To configure a static credential store, refer to [Create static credential stores](/boundary/docs/configuration/credential-management/static-cred-boundary).
@@ -71,3 +72,11 @@ Complete the following steps to configure targets with credential injection:
 
 </Tab>
 </Tabs>
+
+## More information
+
+Refer to the following topics for more information:
+
+- [Create static credential stores](/boundary/docs/configuration/credential-management/static-cred-boundary)
+- [Create Vault credential stores](/boundary/docs/configuration/credential-management/static-cred-vault)
+- [Target types](/boundary/docs/concepts/domain-model/targets#target-types)

--- a/website/content/docs/configuration/credential-management/index.mdx
+++ b/website/content/docs/configuration/credential-management/index.mdx
@@ -27,9 +27,14 @@ Boundary can retrieve credentials from the credential stores and present them ba
 
 End users can experience three workflows when they connect to a target. In the first workflow, when an end user connects to a target, Boundary initiates the session, but the end user must know the credentials to authenticate into the session. This workflow is available for testing purposes, but it is not recommended because it places the burden on the users to securely store and manage credentials.
 
-The second workflow uses a feature called credential brokering, where credentials are retrieved from a credentials store and returned back to the end user. The end user then enters the credentials into the session when prompted by the target. This workflow is more secure than the first workflow since credentials are centrally managed through Boundary. For more information, see the [credential brokering](/boundary/docs/concepts/credential-management#credential-brokering) concepts page.
+The second workflow uses a feature called credential brokering, where credentials are retrieved from a credentials store and returned back to the end user. The end user then enters the credentials into the session when prompted by the target. This workflow is more secure than the first workflow since credentials are centrally managed through Boundary. For more information, refer to the the [Credential brokering](/boundary/docs/concepts/credential-management#credential-brokering) concepts page.
 
-The third workflow uses a featured called credential injection, where credentials are retrieved from a credential store and injected directly into the session on behalf of the end user. This workflow is the most secure because credentials are not exposed to the end user, reducing the chances of a leaked credential. This workflow is also more streamlined as the user goes through a passwordless experience.  For more information, see the [credential injection](/boundary/docs/concepts/credential-management#credential-injection) concepts page.
+The third workflow uses a featured called credential injection, where credentials are retrieved from a credential store and injected directly into the session on behalf of the end user. This workflow is the most secure because credentials are not exposed to the end user, reducing the chances of a leaked credential. This workflow is also more streamlined as the user goes through a passwordless experience. For more information, refer to the [Credential injection](/boundary/docs/concepts/credential-management#credential-injection) concepts page.
+
+The type of target you connect to also determines which credential workflows you can configure.
+An SSH target must have at least one injected application credential to establish the SSH connection.
+A TCP target cannot have any injected application credentials.
+For more information, refer to the [Target types](/boundary/docs/concepts/domain-model/targets#target-types) documentation.
 
 ## Next steps
 


### PR DESCRIPTION
The documentation is not clear about the requirement to use injected credentials for SSH target types. This has led to some confusion internally. This PR attempts to connect some dots between target type requirements and the credential brokering/injection workflows.

It contains the following updates:

- In the [Credential injection](https://boundary-khhhe3zpd-hashicorp.vercel.app/boundary/docs/concepts/credential-management#credential-injection) section of the **Credential management** concepts page, I changed "Credential injection is _available_..." to "Credential injection is _required_..."
- In the [End user workflows](https://boundary-khhhe3zpd-hashicorp.vercel.app/boundary/docs/configuration/credential-management#end-user-workflows) section of the credential management **Overview** topic, I added a 4th paragraph that explains that target type has an impact on the credential workflow you can configure.
- In the [Requirements](https://boundary-khhhe3zpd-hashicorp.vercel.app/boundary/docs/configuration/credential-management/configure-credential-brokering#requirements) section of the credential brokering configuration topic, I updated the first bullet to add "To use brokered credentials to connect to a target that runs SSH, you must use a TCP target type. I also added a [More information](https://boundary-khhhe3zpd-hashicorp.vercel.app/boundary/docs/configuration/credential-management/configure-credential-brokering#more-information) section at the bottom of the topic.
- In the [Requirements](https://boundary-khhhe3zpd-hashicorp.vercel.app/boundary/docs/configuration/credential-management/configure-credential-injection#requirements) section of the credential injection configuration topic, I updated the second bullet to add "To use injected application credentials to connect to a target that runs SSH, you must use an SSH target type. I also added a [More information](https://boundary-khhhe3zpd-hashicorp.vercel.app/boundary/docs/configuration/credential-management/configure-credential-injection#more-information) section at the bottom of the topic.