### PR TITLE
internal/daemon/controller+worker: propagate downstream timeout

### DIFF
--- a/internal/daemon/worker/status_test.go
+++ b/internal/daemon/worker/status_test.go
@@ -24,6 +24,7 @@ func TestWorkerWaitForNextSuccessfulStatusUpdate(t *testing.T) {
 	})
 	err := event.InitSysEventer(testLogger, testLock, "TestWorkerWaitForNextSuccessfulStatusUpdate", event.WithEventerConfig(testConfig))
 	require.NoError(t, err)
+	t.Cleanup(func() { event.TestResetSystEventer(t) })
 	for _, name := range []string{"ok", "timeout"} {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)

--- a/internal/daemon/worker/worker_test.go
+++ b/internal/daemon/worker/worker_test.go
@@ -181,7 +181,7 @@ func TestWorkerNew(t *testing.T) {
 			}
 			if util.IsNil(tt.in.Eventer) {
 				require.NoError(t, event.InitSysEventer(hclog.Default(), &sync.Mutex{}, "worker_test", event.WithEventerConfig(&event.EventerConfig{})))
-				defer event.TestResetSystEventer(t)
+				t.Cleanup(func() { event.TestResetSystEventer(t) })
 				tt.in.Eventer = event.SysEventer()
 			}
 
@@ -332,7 +332,7 @@ func TestSetupWorkerAuthStorage(t *testing.T) {
 
 func Test_Worker_getSessionTls(t *testing.T) {
 	require.NoError(t, event.InitSysEventer(hclog.Default(), &sync.Mutex{}, "worker_test", event.WithEventerConfig(&event.EventerConfig{})))
-	defer event.TestResetSystEventer(t)
+	t.Cleanup(func() { event.TestResetSystEventer(t) })
 
 	conf := &Config{
 		Server: &base.Server{


### PR DESCRIPTION
Propagate the downstream worker timeout into the downstream receiver and downstream ticker so we have a configurable consistent timeout value to use for worker to worker interactions.

Also change the atomic.Pointer to an atomic.Int64 for consistency with other values.