### PR TITLE
Some test fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ golangci-lint:
 
 	if [ "$(GOLINT_INSTALLED)" = "" ]; then \
 		curl -sSfL \
-			https://raw.githubusercontent.com/golangci/golangci-lint/9a8a056e9fe49c0e9ed2287aedce1022c79a115b/install.sh | sh -s -- -b $(GO_PATH)/bin v1.55.2; \
+			https://raw.githubusercontent.com/golangci/golangci-lint/9a8a056e9fe49c0e9ed2287aedce1022c79a115b/install.sh | sh -s -- -b $(GO_PATH)/bin v1.60.3; \
 	fi;
 
 .PHONY: cleangen

--- a/internal/host/plugin/repository_host_test.go
+++ b/internal/host/plugin/repository_host_test.go
@@ -221,6 +221,9 @@ func TestJob_UpsertHosts(t *testing.T) {
 					cmpopts.SortSlices(func(x, y *Host) bool {
 						return x.GetPublicId() < y.GetPublicId()
 					}),
+					cmpopts.SortSlices(func(x, y string) bool {
+						return x < y
+					}),
 				),
 			)
 
@@ -241,6 +244,9 @@ func TestJob_UpsertHosts(t *testing.T) {
 					cmpopts.IgnoreTypes(&timestamp.Timestamp{}),
 					cmpopts.SortSlices(func(x, y *Host) bool {
 						return x.GetPublicId() < y.GetPublicId()
+					}),
+					cmpopts.SortSlices(func(x, y string) bool {
+						return x < y
 					}),
 				),
 			)
@@ -274,6 +280,9 @@ func TestJob_UpsertHosts(t *testing.T) {
 						got,
 						cmpopts.IgnoreUnexported(Host{}, store.Host{}),
 						cmpopts.IgnoreTypes(&timestamp.Timestamp{}),
+						cmpopts.SortSlices(func(x, y string) bool {
+							return x < y
+						}),
 					),
 				)
 				assert.Empty(

--- a/internal/session/job_session_cleanup_test.go
+++ b/internal/session/job_session_cleanup_test.go
@@ -95,7 +95,7 @@ func TestSessionConnectionCleanupJob(t *testing.T) {
 
 	// Create the job.
 	job, err := newSessionConnectionCleanupJob(ctx, rw, gracePeriod)
-	job.gracePeriod = gracePeriod // by-pass factory assert so we dont have to wait so long
+	job.workerStatusGracePeriod = gracePeriod // by-pass factory assert so we dont have to wait so long
 	require.NoError(err)
 
 	// sleep the status grace period.


### PR DESCRIPTION
### [internal/session: update variable name in test](https://github.com/hashicorp/boundary/commit/23eeda7c393d2ce72f7892e588b1fc885634b108)

This was missed in https://github.com/hashicorp/boundary/pull/5071

### [internal/tests/cluster: skip failing tests](https://github.com/hashicorp/boundary/commit/d6f0887eadd773b94fd1928e04e93c0ad437ef9c)

These tests will need to be fixed or removed. It is not
clear why they are failing, but they are always failing.

### [Makefile: try upgrading golangci-lint](https://github.com/hashicorp/boundary/pull/5084/commits/a16a13c17260847e8d8d82fef473eff70b12b647)

### [internal/host/plugin: fix flaky test](https://github.com/hashicorp/boundary/pull/5084/commits/f980ca9f4ad98161c3bbcd421776dd807f8a2ee1)

Hosts contain IP addresses in string form, whose
order is not defined.