### PR TITLE
PSA-1311 - update scan workflow conditions

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,7 +12,10 @@ on:
 jobs:
   scan:
     runs-on: ${{ fromJSON(vars.RUNNER_LARGE) }}
-    if: ${{ github.actor != 'dependabot[bot]' || github.actor != 'hc-github-team-secure-boundary' }}
+    if: |
+      ! github.event.pull_request.head.repo.fork &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'hc-github-team-secure-boundary'
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 


### PR DESCRIPTION
Fix the workflow conditional for when to run the security scanner workflow:

- `! github.event.pull_request.head.repo.fork` don't run on community pr forks
- `github.actor != 'dependabot[bot]'` don't run for dependabot
- `github.actor != 'hc-github-team-secure-boundary'` don't run for boundary bot