### PR TITLE
Resolve Scope Name For Target Authorize Session

### DIFF
--- a/internal/cmd/commands/targetscmd/funcs.go
+++ b/internal/cmd/commands/targetscmd/funcs.go
@@ -315,6 +315,9 @@ func extraFlagsHandlingFuncImpl(c *Command, _ *base.FlagSets, opts *[]targets.Op
 	if strutil.StrListContains(flagsMap[c.Func], "scope-id") && c.FlagScopeId != "" {
 		*opts = append(*opts, targets.WithScopeId(c.FlagScopeId))
 	}
+	if strutil.StrListContains(flagsMap[c.Func], "scope-name") && c.FlagScopeName != "" {
+		*opts = append(*opts, targets.WithScopeName(c.FlagScopeName))
+	}
 
 	switch c.Func {
 	case "add-host-sources", "remove-host-sources":


### PR DESCRIPTION
# Overview
Resolve issue facing `boundary targtes authorize-session` where the flag for `-scope-name` was never being set and thus always threw exception `{“error”:“Error trying to authorize-session a session against target: empty targetId value and no combination of target name and scope ID/name passed into AuthorizeSession request”}`