### PR TITLE
Indexes and trigger changes to improve performance

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/81/01_deleted_tables_and_triggers.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/81/01_deleted_tables_and_triggers.up.sql
@@ -308,6 +308,7 @@ begin;
     'affected by the trigger and the current timestamp. It is used to populate rows '
     'of the deleted tables.';
 
+  -- Removed in 91/05_deletion_tables_view and replaced with a view.
   create function get_deletion_tables() returns setof name
   as $$
     select c.relname

--- a/internal/db/schema/migrations/oss/postgres/91/02_indexes_fk_delete.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/91/02_indexes_fk_delete.up.sql
@@ -1,0 +1,46 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+  -- Index to help when setting target_id to null on a session
+  -- when the corresponding target is deleted.
+  drop index if exists session_target_id_ix;
+  create index session_target_id_ix
+            on session (target_id);
+
+  -- Index to help when setting auth_token_id to null on a session
+  -- when the corresponding auth_token is deleted.
+  drop index if exists session_auth_token_id_ix;
+  create index session_auth_token_id_ix
+            on session (auth_token_id);
+
+  -- Index to help when setting session_id to null on a credential_vault_credential
+  -- when the corresponding session is deleted.
+  drop index if exists credential_vault_credential_session_id_ix;
+  create index credential_vault_credential_session_id_ix
+            on credential_vault_credential (session_id);
+
+  -- Index to help delete cascade of session_worker_protocol
+  -- when the corresponding session is deleted.
+  drop index if exists session_worker_protocol_session_id_ix;
+  create index session_worker_protocol_session_id_ix
+            on session_worker_protocol (session_id);
+
+  -- Index to help when setting session_id to null on recording_connection
+  -- when the corresponding session is deleted.
+  drop index if exists recording_connection_session_id_ix;
+  create index recording_connection_session_id_ix
+            on recording_connection (session_id);
+
+  -- Index to help delete of terminated sessions.
+  drop index if exists session_state_state_start_time_ix;
+  create index session_state_state_terminated_start_time_ix
+            on session_state (state, start_time)
+         where state = 'terminated';
+
+  analyze session,
+          credential_vault_credential,
+          session_worker_protocol,
+          recording_connection,
+          session_state;
+commit;

--- a/internal/db/schema/migrations/oss/postgres/91/03_indexes_grants_query.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/91/03_indexes_grants_query.up.sql
@@ -1,0 +1,39 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+  -- For each of these tables, swap the ordering of the
+  -- columns in the index for the primary key.
+  -- This helps the grants query that contains
+  -- several where clauses on what is currently the second
+  -- column in these indexes. By swapping the order, this
+  -- will make it more likely that the query planner will
+  -- choose to use the index.
+  -- See: https://www.postgresql.org/docs/current/indexes-multicolumn.html
+
+      alter table auth_oidc_managed_group_member_account
+  drop constraint auth_oidc_managed_group_member_account_pkey,
+  add primary key (member_id, managed_group_id);
+
+      alter table iam_managed_group_role
+  drop constraint iam_managed_group_role_pkey,
+  add primary key (principal_id, role_id);
+
+      alter table iam_group_member_user
+  drop constraint iam_group_member_user_pkey,
+  add primary key (member_id, group_id);
+
+      alter table iam_group_role
+  drop constraint iam_group_role_pkey,
+  add primary key (principal_id, role_id);
+
+      alter table iam_user_role
+  drop constraint iam_user_role_pkey,
+  add primary key (principal_id, role_id);
+
+  analyze auth_oidc_managed_group_member_account,
+          iam_managed_group_role,
+          iam_group_member_user,
+          iam_group_role,
+          iam_user_role;
+commit;

--- a/internal/db/schema/migrations/oss/postgres/91/04_insert_session_delete_on_statement.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/91/04_insert_session_delete_on_statement.up.sql
@@ -1,0 +1,25 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+  create function bulk_insert_deleted_ids() returns trigger
+  as $$
+  begin
+    execute format('insert into %I (public_id, delete_time)
+                         select o.public_id, now()
+                           from old_table o;',
+                   tg_argv[0]);
+    return null;
+  end;
+  $$ language plpgsql;
+  comment on function bulk_insert_deleted_ids is
+    'bulk_insert_deleted_ids is a function that inserts records into the table '
+    'specified by the first trigger argument. It takes the public IDs from the '
+    'set of rows that where deleted and the current timestamp.';
+
+  drop trigger insert_deleted_id on session;
+  create trigger bulk_insert_deleted_ids
+    after delete on session
+    referencing old table as old_table
+    for each statement execute function bulk_insert_deleted_ids('session_deleted');
+commit;

--- a/internal/db/schema/migrations/oss/postgres/91/05_deletion_tables_view.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/91/05_deletion_tables_view.up.sql
@@ -1,0 +1,18 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+  -- Originially added in 81/01_deleted_tables_and_triggers.up.sql
+  -- This is being replaced with a view.
+  drop function get_deletion_tables;
+
+  -- This view uses the pg_catalog to find all tables that end in _deleted and are visibile.
+  -- See: https://www.postgresql.org/docs/current/catalog-pg-class.html
+  --      https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-INFO-SCHEMA
+  create view deletion_table as
+    select c.relname as tablename
+      from pg_catalog.pg_class c
+     where c.relkind in ('r') -- r = ordinary table
+       and c.relname operator(pg_catalog.~) '^(.+_deleted)$' collate pg_catalog.default
+       and pg_catalog.pg_table_is_visible(c.oid);
+commit;

--- a/internal/pagination/purge/purge_test.go
+++ b/internal/pagination/purge/purge_test.go
@@ -26,7 +26,7 @@ func TestPurgeTables(t *testing.T) {
 		t.Errorf("error getting db connection %s", err)
 	}
 
-	rows, err := db.Query("select get_deletion_tables()")
+	rows, err := db.Query("select tablename from deletion_table")
 	if err != nil {
 		t.Errorf("unable to query for deletion tables %s", err)
 	}

--- a/internal/pagination/purge/query.go
+++ b/internal/pagination/purge/query.go
@@ -5,7 +5,8 @@ package purge
 
 const (
 	getDeletionTablesQuery = `
-select get_deletion_tables();
+select tablename
+  from deletion_table;
 `
 	deleteQueryTemplate = `
 delete from %s where delete_time < now() - interval '30 days'


### PR DESCRIPTION
This PR adds several performance related changes in the form of indexes,
and changes to a delete trigger to run more efficiently. These
improvements should help with several operations, notably:

- The grants query used to fetch grants for a user for controller API
  requests.
- Deletion of targets, auth tokens, and sessions.

See the individual commits for additional details.