### PR TITLE
ci: update the security-scanner gha token

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         repository: hashicorp/security-scanner
-        token: ${{ secrets.HASHIBOT_PRODSEC_GITHUB_TOKEN }}
+        token: ${{ secrets.PRODSEC_SCANNER_READ_ONLY }}
         path: security-scanner
         ref: main
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -64,7 +64,7 @@ jobs:
         python3 -m pip install semgrep==1.45.0
 
         # CodeQL
-        LATEST=$(gh release list --repo https://github.com/github/codeql-action | cut -f 3 | sort --version-sort | tail -n1)
+        LATEST=$(gh release list --repo https://github.com/github/codeql-action | cut -f 3 | grep codeql-bundle- | sort --version-sort | tail -n1)
         gh release download --repo https://github.com/github/codeql-action --pattern codeql-bundle-linux64.tar.gz "$LATEST"
         tar xf codeql-bundle-linux64.tar.gz -C "$HOME/.bin"
 


### PR DESCRIPTION
Using the org level secret instead of the repository one.
Ref: [PSA-1351](https://hashicorp.atlassian.net/browse/PSA-1351)

This would need to be backported in to CE and ENT

[PSA-1351]: https://hashicorp.atlassian.net/browse/PSA-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Also fixing the asset download issue.