### PR TITLE
Fix panic in credential renewal job

### DIFF
--- a/internal/credential/vault/jobs.go
+++ b/internal/credential/vault/jobs.go
@@ -604,6 +604,9 @@ func (r *CredentialRenewalJob) renewCred(ctx context.Context, c *privateCredenti
 	if err != nil {
 		return errors.Wrap(ctx, err, op, errors.WithMsg("unable to renew credential"))
 	}
+	if renewedCred == nil {
+		return errors.New(ctx, errors.Unknown, op, "vault returned empty credential")
+	}
 
 	cred.expiration = time.Duration(renewedCred.LeaseDuration) * time.Second
 	query, values := cred.updateExpirationQuery()


### PR DESCRIPTION
This commit modifies the credential renewal job to handle a case where the `renewLease` method can return `nil, nil`. Currently, a panic is caused by usage of the `renewedCred` variable in this scenario.

This commit adds a nil check and returns an error if the `renewedCred` variable is returned as `nil`.