### PR TITLE
fix(event): Prevent eventer data races by removing shallow object copy

### DIFF
--- a/internal/event/eventer.go
+++ b/internal/event/eventer.go
@@ -852,14 +852,13 @@ func (e *Eventer) StandardWriter(ctx context.Context, typ Type) (io.Writer, erro
 	if err := typ.Validate(); err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
-	newEventer := *e
 	ctx, err := NewEventerContext(ctx, e)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 	return &logAdapter{
 		ctxWithEventer: ctx,
-		e:              &newEventer,
+		e:              e,
 		emitEventType:  typ,
 	}, nil
 }


### PR DESCRIPTION
This issue was surfaced through other changes (PR 5137).

Given that the eventer works in a singleton pattern (see sysEventer global variable), performing this shallow object copy can cause a data race because the copy operation reads the underlying eventer data structures. At the same time, given the global nature of this eventer, other goroutines can be writing to those same data structures.

Since we're already using a singleton pattern in this package, and given that the current copy operation is shallow, copying the object doesn't seem necessary, so this commit changes `StandardWriter` to build the `logAdapter` with the `e` eventer directly instead of copying it.