### PR TITLE
test(e2e): Add user name to AWS resources

### DIFF
--- a/enos/modules/aws_boundary/boundary-instances.tf
+++ b/enos/modules/aws_boundary/boundary-instances.tf
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_instance" "controller" {
   count         = var.controller_count
   ami           = var.ubuntu_ami_id
@@ -24,7 +26,7 @@ resource "aws_instance" "controller" {
 
   tags = merge(local.common_tags,
     {
-      Name = "${local.name_prefix}-boundary-controller-${count.index}"
+      Name = "${local.name_prefix}-boundary-controller-${count.index}-${split(":", data.aws_caller_identity.current.user_id)[1]}"
       Type = local.boundary_cluster_tag,
     },
   )
@@ -50,7 +52,7 @@ resource "aws_instance" "worker" {
 
   tags = merge(local.common_tags,
     {
-      Name = "${local.name_prefix}-boundary-worker-${count.index}",
+      Name = "${local.name_prefix}-boundary-worker-${count.index}-${split(":", data.aws_caller_identity.current.user_id)[1]}",
       Type = local.boundary_cluster_tag,
     },
   )

--- a/enos/modules/aws_target/main.tf
+++ b/enos/modules/aws_target/main.tf
@@ -28,6 +28,8 @@ variable "ingress_cidr" {
 
 data "enos_environment" "current" {}
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_security_group" "boundary_target" {
   name_prefix = "boundary-target-sg"
   description = "SSH and boundary Traffic"
@@ -70,7 +72,7 @@ resource "aws_instance" "target" {
   key_name               = var.aws_ssh_keypair_name
 
   tags = merge(var.additional_tags, {
-    "Name" : "boundary-target-${count.index}",
+    "Name" : "boundary-target-${count.index}-${split(":", data.aws_caller_identity.current.user_id)[1]}",
     "Type" : "target",
     "Project" : "Enos",
     "Project Name" : "qti-enos-boundary",

--- a/enos/modules/aws_vault/vault-instances.tf
+++ b/enos/modules/aws_vault/vault-instances.tf
@@ -12,7 +12,7 @@ resource "aws_instance" "vault_instance" {
   tags = merge(
     var.common_tags,
     {
-      Name = "${local.name_suffix}-vault-${var.vault_node_prefix}-${each.key}"
+      Name = "${local.name_suffix}-vault-${var.vault_node_prefix}-${each.key}-${split(":", data.aws_caller_identity.current.user_id)[1]}"
       Type = local.vault_cluster_tag
     },
   )

--- a/enos/modules/aws_vpc/main.tf
+++ b/enos/modules/aws_vpc/main.tf
@@ -55,6 +55,8 @@ locals {
   )
 }
 
+data "aws_caller_identity" "current" {}
+
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -137,7 +139,7 @@ resource "aws_vpc" "vpc" {
   tags = merge(
     local.common_tags,
     {
-      "Name" = var.name
+      "Name" = "${var.name}-${split(":", data.aws_caller_identity.current.user_id)[1]}"
     },
   )
 }


### PR DESCRIPTION
This PR updates several enos modules to add the user's email address to AWS resources in order to make it easier to identify who generated them when looking at the AWS console. This is to assist when investigating who has left lingering resources that can be cleaned up when we are about to reach vpc limits or when costs are high.

Example:
![Screenshot 2024-10-03 at 2 32 07 PM](https://github.com/user-attachments/assets/598391e9-d4be-4c40-aed8-4bf1417daa3a)

https://hashicorp.atlassian.net/browse/ICU-15225