### PR TITLE
Update controller.mdx - public_cluster_addr

### DIFF
--- a/website/content/docs/configuration/controller.mdx
+++ b/website/content/docs/configuration/controller.mdx
@@ -77,11 +77,12 @@ description will be read.
   optionally port) at which the controller can be reached _by workers_. This will
   be used by workers after initial connection to controllers via the worker's
   `initial_upstreams` block. This defaults to the address of the listener marked for
-  `cluster` purpose. This is especially useful for cloud environments that do not
+  `cluster` purpose. This is used if a load balancer is used in front of multiple Boundary controllers. This is also especially useful for cloud environments that do not
   bind a publicly accessible IP to a NIC on the host directly, such as an Amazon
   EIP. This value can be a direct address string, can refer to a file on disk (file://)
   from which an address will be read; an env var (env://) from which the
-  address will be read; or a [go-sockaddr template](https://godoc.org/github.com/hashicorp/go-sockaddr/template).
+  address will be read; or a [go-sockaddr template](https://godoc.org/github.com/hashicorp/go-sockaddr/template). 
+  Note: The address should not include the protocol prefixes like `http://` or `https://`.
 
 - `auth_token_time_to_live` - Maximum time to live (TTL) for all auth tokens globally (pertains
   to all tokens from all auth methods). Valid time units are anything specified by Golang's


### PR DESCRIPTION
Updating public_cluster_addr to indicate that it is used if a load balancer is used for controllers. Also added a note about not including https:// and http:// in the address