### PR TITLE
chore(enos): Add ipv6 cleanup permission

### DIFF
--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -119,6 +119,7 @@ data "aws_iam_policy_document" "enos_policy_document" {
       "ec2:RevokeSecurityGroupIngress",
       "ec2:RunInstances",
       "ec2:TerminateInstances",
+      "ec2:UnassignIpv6Addresses",
       "elasticloadbalancing:AddTags",
       "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
       "elasticloadbalancing:AttachLoadBalancerToSubnets",


### PR DESCRIPTION
When working on e2e tests for ipv6 environments, CI was running into the following error
```
Error: unassigning EC2 Instance (i-053b6fe8a0a671961) IPv6 addresses: operation error EC2: UnassignIpv6Addresses, https response error StatusCode: 403, RequestID: a94a192e-ae2c-4023-91e6-cc51a7fd0a4d, api error UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:sts::173905499206:assumed-role/github_actions-boundary_enterprise_ci/GitHubActions is not authorized to perform: ec2:UnassignIpv6Addresses on resource: arn:aws:ec2:us-east-1:173905499206:network-interface/eni-03717530bd76ef50d because no identity-based policy allows the ec2:UnassignIpv6Addresses action.
```

This PR updates the Terraform files that manage the policy used by the CI user. Note: the CI user itself already has this change applied to it. 