### PR TITLE
docs: Update installer download link

### DIFF
--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -28,7 +28,7 @@ Boundary supports Windows and MacOS for the transparent sessions public beta.
 Before you configure transparent sessions, you must:
 
 - Ensure that the Boundary CLI and Boundary Desktop are not installed in the environment in which you want to run the transparent sessions beta.
-- Download the appropriate installer for your Windows or MacOS environment from the [downloads](/boundary/install) page.
+- Download the appropriate Boundary installer for your Windows or MacOS environment from the [releases](releases.hashicorp.com/boundary-installer) page.
 
 ## Install clients
 

--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -28,7 +28,7 @@ Boundary supports Windows and MacOS for the transparent sessions public beta.
 Before you configure transparent sessions, you must:
 
 - Ensure that the Boundary CLI and Boundary Desktop are not installed in the environment in which you want to run the transparent sessions beta.
-- Download the appropriate Boundary installer for your Windows or MacOS environment from the [releases](releases.hashicorp.com/boundary-installer) page.
+- Download the appropriate Boundary installer for your Windows or MacOS environment from the [releases](https://releases.hashicorp.com/boundary-installer) page.
 
 ## Install clients
 


### PR DESCRIPTION
Changes the link to download the boundary installer from the Downloads page to the Releases page.

[View the preview deployment](https://boundary-n9d2uh9pp-hashicorp.vercel.app/boundary/docs/concepts/transparent-sessions)