### PR TITLE
Client agent docs updates

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -532,7 +532,7 @@ override_upstream_dns_servers = [
 ]
 ```
 
-### Primary network interfaces
+#### Primary network interfaces
 
 By default, the Client Agent creates IPs on the primary network interface to serve its DNS server.
 Refer to the tabs below for possible conflicts for each supported operating system.

--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -88,6 +88,7 @@ Refer to the following table for known issues that may affect the public beta:
 | Boundary Client Agent resumes on reboot | If the Client Agent is paused and the machine is rebooted, the Client Agent will be resumed after the reboot. |
 | Single-word aliases do not work on Windows | If you create an alias consisting of a single word without a dot (`.`), the alias will not work on Windows. |
 | Windows installer does not support partial installations | The Windows installer fails to start the Client Agent if the Desktop client is not installed at the same time. |
+| Alias connection failures inside containers/VMs | Using transparent sessions rely on network access to the local network of the computer the Client Agent is running on. Network enclaves such as those created by Docker containers and VMs cannot reach this network. |
 
 ## More information
 


### PR DESCRIPTION
### [docs/client-agent: indent PAN docs correctly](https://github.com/hashicorp/boundary/commit/adb627f465de6c1d9bc03eff8fb7f3d6284ab8a0)

Identifying the primary network interface is a sub-heading under the
PAN troubleshooting section.

### [docs/transparent-sessions: add known issue around containers/VMs](https://github.com/hashicorp/boundary/commit/ad9890d6df81f9135e5ded07047c0b4fb3b30cd7)

VMs/containers that do not have access to the local network cannot
use aliases through transparent sessions.