### PR TITLE
docs: Manually backport 0.18.0 updates

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -532,7 +532,7 @@ override_upstream_dns_servers = [
 ]
 ```
 
-### Primary network interfaces
+#### Primary network interfaces
 
 By default, the Client Agent creates IPs on the primary network interface to serve its DNS server.
 Refer to the tabs below for possible conflicts for each supported operating system.

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -170,32 +170,35 @@ By default, it is located in the following directory:
 
    `/Library/Application Support/HashiCorp/Boundary/boundary-client-agent.hcl`
 
-1. Change the configuration settings.
-1. Save the file and restart the Client Agent with the following commands:
+1. Change the configuration settings, and save the file.
+
+   You must restart the Client Agent to update some configuration settings.
+   However, when you restart the Client Agent, it closes any existing sessions.
+   Other configuration settings can be updated by only reloading the configuration file, which does not affect any existing sessions.
+
+1. Either restart the Client Agent or reload the configuration file.
+
+   You can update any configuration value by restarting the Client Agent with the following commands, however it will close any existing sessions:
 
    ```shell-session
    $ sudo launchctl stop com.hashicorp.boundary.boundary-client-agent
    $ sudo launchctl start com.hashicorp.boundary.boundary-client-agent
    ```
 
-You can change some configuration values without restarting the Client Agent.
-These values include:
+   Alternatively, you can update the following configuration values by reloading the configuration file, which will not disrupt any existing sessions:
 
-- `dns_request_timeout`
-- `log_file`
-- `log_level`
-- `state_file`
-- `override_upstream_dns_servers`
-- `v4_prefix`
+   - `dns_request_timeout`
+   - `log_file`
+   - `log_level`
+   - `state_file`
+   - `override_upstream_dns_servers`
+   - `v4_prefix`
 
-To update the other values, you must reload the configuration.
-To reload the configuration, update the configuration file, and then use the following command:
+   Run the following command to reload the configuration file:
 
-```shell-session
-$ sudo pkill -1 boundary-client-agent
-```
-
-This command sends a SIGHUP signal to the Client Agent, which causes it to reload the configuration file.
+   ```shell-session
+   $ sudo pkill -1 boundary-client-agent
+   ```
 
 </Tab>
 <Tab heading="Windows" group="windows">
@@ -204,18 +207,19 @@ This command sends a SIGHUP signal to the Client Agent, which causes it to reloa
 By default, it is located in the following directory:
 
    `C:\Program Files\Hashicorp Boundary\boundary-client-agent.hcl`
-1. Change the configuration settings.
-1. Save the file and restart the Client Agent with the following commands:
+
+1. Change the configuration settings, and save the file.
+1. Run the following commands to restart the Client Agent.
 
    ```shell-session
    net stop BoundaryClientAgent
    net start BoundaryClientAgent
    ```
 
+   Note that when you restart the Client Agent, it closes any existing sessions.
+
 </Tab>
 </Tabs>
-
-Note that when you restart the Client Agent, it closes any existing sessions.
 
 ## Manage the Client Agent
 

--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -28,7 +28,7 @@ Boundary supports Windows and MacOS for the transparent sessions public beta.
 Before you configure transparent sessions, you must:
 
 - Ensure that the Boundary CLI and Boundary Desktop are not installed in the environment in which you want to run the transparent sessions beta.
-- Download the appropriate installer for your Windows or MacOS environment from the [downloads](/boundary/install) page.
+- Download the appropriate Boundary installer for your Windows or MacOS environment from the [releases](https://releases.hashicorp.com/boundary-installer) page.
 
 ## Install clients
 

--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -88,6 +88,7 @@ Refer to the following table for known issues that may affect the public beta:
 | Boundary Client Agent resumes on reboot | If the Client Agent is paused and the machine is rebooted, the Client Agent will be resumed after the reboot. |
 | Single-word aliases do not work on Windows | If you create an alias consisting of a single word without a dot (`.`), the alias will not work on Windows. |
 | Windows installer does not support partial installations | The Windows installer fails to start the Client Agent if the Desktop client is not installed at the same time. |
+| Alias connection failures inside containers/VMs | Using transparent sessions rely on network access to the local network of the computer the Client Agent is running on. Network enclaves such as those created by Docker containers and VMs cannot reach this network. |
 
 ## More information
 


### PR DESCRIPTION
The automatic backports to the `release/0.18.x` branch are failing when we backport to the stable website. This PR manually cherry-picks the most recent docs updates to the `release/0.18.x` branch. This PR supersedes the following auto-generated backport PRs which all failed:

- #5185 
- #5182
- #5178 