### PR TITLE
feat(workers): add VerifyKnownWorkers repo function

### DIFF
--- a/internal/daemon/cluster/handlers/worker_service.go
+++ b/internal/daemon/cluster/handlers/worker_service.go
@@ -193,12 +193,12 @@ func (ws *workerServiceServer) Status(ctx context.Context, req *pbs.StatusReques
 
 	authorizedDownstreams := &pbs.AuthorizedDownstreamWorkerList{}
 	if len(req.GetConnectedWorkerPublicIds()) > 0 {
-		knownConnectedWorkers, err := serverRepo.ListWorkers(ctx, []string{scope.Global.String()}, server.WithWorkerPool(req.GetConnectedWorkerPublicIds()), server.WithLiveness(-1))
+		knownConnectedWorkers, err := serverRepo.VerifyKnownWorkers(ctx, req.GetConnectedWorkerPublicIds())
 		if err != nil {
 			event.WriteError(ctx, op, err, event.WithInfoMsg("error getting known connected worker ids"))
 			return &pbs.StatusResponse{}, status.Errorf(codes.Internal, "Error getting known connected worker ids: %v", err)
 		}
-		authorizedDownstreams.WorkerPublicIds = server.WorkerList(knownConnectedWorkers).PublicIds()
+		authorizedDownstreams.WorkerPublicIds = knownConnectedWorkers
 	}
 
 	if len(req.GetConnectedUnmappedWorkerKeyIdentifiers()) > 0 {

--- a/internal/daemon/controller/tickers.go
+++ b/internal/daemon/controller/tickers.go
@@ -12,9 +12,7 @@ import (
 	"github.com/hashicorp/boundary/internal/daemon/cluster"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/event"
-	"github.com/hashicorp/boundary/internal/server"
 	"github.com/hashicorp/boundary/internal/server/store"
-	"github.com/hashicorp/boundary/internal/types/scope"
 )
 
 // In the future we could make this configurable
@@ -198,12 +196,12 @@ func (c *Controller) startWorkerConnectionMaintenanceTicking(cancelCtx context.C
 						event.WriteError(cancelCtx, op, err, event.WithInfoMsg("error fetching server repository for cluster connection maintenance"))
 						break
 					}
-					knownWorker, err := serverRepo.ListWorkers(cancelCtx, []string{scope.Global.String()}, server.WithWorkerPool(connectionState.WorkerIds()), server.WithLiveness(-1))
+					knownWorkers, err := serverRepo.VerifyKnownWorkers(cancelCtx, connectionState.WorkerIds())
 					if err != nil {
 						event.WriteError(cancelCtx, op, err, event.WithInfoMsg("couldn't get known workers from repo"))
 						break
 					}
-					connectionState.DisconnectMissingWorkers(server.WorkerList(knownWorker).PublicIds())
+					connectionState.DisconnectMissingWorkers(knownWorkers)
 				}
 
 				if len(connectionState.UnmappedKeyIds()) > 0 {

--- a/internal/server/query.go
+++ b/internal/server/query.go
@@ -73,6 +73,12 @@ const (
 		where worker_key_identifier = @worker_key_identifier
 	`
 
+	verifyKnownWorkersQuery = `
+		select public_id 
+		  from server_worker 
+		 where public_id in (?);
+	`
+
 	getWorkerAuthsByWorkerIdQuery = `
 		select * 
 		  from worker_auth_authorized 


### PR DESCRIPTION
The repository function VerifyKnownWorkers replaces the use of ListWorkers in two instances where we are only concerned in confirming the existence of workers