### PR TITLE
feat(server): refactor LookupWorkerByName to be a test method

### DIFF
--- a/internal/cmd/commands/server/worker_initial_upstreams_reload_test.go
+++ b/internal/cmd/commands/server/worker_initial_upstreams_reload_test.go
@@ -99,7 +99,7 @@ pollFirstController:
 		case <-timeout.C:
 			t.Fatalf("timeout wait for worker to connect to first controller")
 		case <-poll.C:
-			w, err = serversRepo.LookupWorkerByName(testController.Context(), "test")
+			w, err = server.TestLookupWorkerByName(testController.Context(), t, "test", serversRepo)
 			require.NoError(err)
 			if w != nil {
 				switch {
@@ -135,7 +135,7 @@ pollForNoStatus:
 			poll.Stop()
 			break pollForNoStatus
 		case <-poll.C:
-			w, err = serversRepo.LookupWorkerByName(testController2.Context(), "test")
+			w, err = server.TestLookupWorkerByName(testController2.Context(), t, "test", serversRepo)
 			require.NoError(err)
 			if w != nil {
 				switch {
@@ -170,7 +170,7 @@ pollSecondController:
 		case <-timeout.C:
 			t.Fatalf("timeout wait for worker to connect to second controller")
 		case <-poll.C:
-			w, err = serversRepo.LookupWorkerByName(testController2.Context(), "test")
+			w, err = server.TestLookupWorkerByName(testController2.Context(), t, "test", serversRepo)
 			require.NoError(err)
 			if w != nil {
 				switch {

--- a/internal/cmd/commands/server/worker_tags_reload_test.go
+++ b/internal/cmd/commands/server/worker_tags_reload_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/boundary/internal/server"
 	"github.com/hashicorp/boundary/testing/controller"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-kms-wrapping/v2/aead"
@@ -101,7 +102,7 @@ func TestServer_ReloadWorkerTags(t *testing.T) {
 		t.Helper()
 		serversRepo, err := testController.Controller().ServersRepoFn()
 		require.NoError(err)
-		w, err := serversRepo.LookupWorkerByName(testController.Context(), name)
+		w, err := server.TestLookupWorkerByName(testController.Context(), t, name, serversRepo)
 		require.NoError(err)
 		require.NotNil(w)
 		v, ok := w.CanonicalTags()[key]

--- a/internal/daemon/cluster/handlers/worker_service_status_test.go
+++ b/internal/daemon/cluster/handlers/worker_service_status_test.go
@@ -1368,7 +1368,7 @@ func TestWorkerOperationalStatus(t *testing.T) {
 			}
 			require.NoError(err)
 			require.NotNil(got)
-			repoWorker, err := serverRepo.LookupWorkerByName(ctx, worker1.Name)
+			repoWorker, err := server.TestLookupWorkerByName(ctx, t, worker1.Name, serverRepo)
 			require.NoError(err)
 			assert.Equal(tc.wantState, repoWorker.OperationalState)
 		})
@@ -1537,7 +1537,7 @@ func TestWorkerLocalStorageStateStatus(t *testing.T) {
 			}
 			require.NoError(err)
 			require.NotNil(got)
-			repoWorker, err := serverRepo.LookupWorkerByName(ctx, worker1.Name)
+			repoWorker, err := server.TestLookupWorkerByName(ctx, t, worker1.Name, serverRepo)
 			require.NoError(err)
 			assert.Equal(tc.wantState, repoWorker.LocalStorageState)
 		})

--- a/internal/server/repository_worker.go
+++ b/internal/server/repository_worker.go
@@ -65,52 +65,6 @@ func (r *Repository) DeleteWorker(ctx context.Context, publicId string, _ ...Opt
 	return rowsDeleted, nil
 }
 
-// LookupWorkerByName returns the worker with the provided name. In the event
-// that no worker is found that matches then nil, nil will be returned.
-func (r *Repository) LookupWorkerByName(ctx context.Context, name string) (*Worker, error) {
-	const op = "server.(Repository).LookupWorkerByName"
-	switch {
-	case name == "":
-		return nil, errors.New(ctx, errors.InvalidParameter, op, "name is empty")
-	}
-	w, err := lookupWorkerByName(ctx, r.reader, name)
-	if err != nil {
-		return nil, errors.Wrap(ctx, err, op)
-	}
-	if w == nil {
-		return nil, nil
-	}
-	w.RemoteStorageStates, err = r.ListWorkerStorageBucketCredentialState(ctx, w.GetPublicId())
-	if err != nil {
-		return nil, errors.Wrap(ctx, err, op)
-	}
-	return w, nil
-}
-
-func lookupWorkerByName(ctx context.Context, reader db.Reader, name string) (*Worker, error) {
-	const op = "server.lookupWorkerByName"
-	switch {
-	case isNil(reader):
-		return nil, errors.New(ctx, errors.InvalidParameter, op, "reader is nil")
-	case name == "":
-		return nil, errors.New(ctx, errors.InvalidParameter, op, "name is empty")
-	}
-
-	wAgg := &workerAggregate{}
-	err := reader.LookupWhere(ctx, &wAgg, "name = ?", []any{name})
-	if err != nil {
-		if errors.IsNotFoundError(err) {
-			return nil, nil
-		}
-		return nil, errors.Wrap(ctx, err, op)
-	}
-	w, err := wAgg.toWorker(ctx)
-	if err != nil {
-		return nil, errors.Wrap(ctx, err, op)
-	}
-	return w, nil
-}
-
 func (r *Repository) LookupWorkerIdByKeyId(ctx context.Context, keyId string) (string, error) {
 	const op = "server.(Repository).LookupWorkerIdByKeyId"
 	switch {

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -212,3 +212,15 @@ func TestPkiWorker(t *testing.T, conn *db.DB, wrapper wrapping.Wrapper, opt ...O
 	require.NoError(t, err)
 	return wrk
 }
+
+// TestLookupWorkerByName looks up a worker by name
+func TestLookupWorkerByName(ctx context.Context, t *testing.T, name string, serversRepo *Repository) (*Worker, error) {
+	workers, err := serversRepo.ListWorkers(ctx, []string{"global"})
+	require.NoError(t, err)
+	for _, w := range workers {
+		if w.GetName() == name {
+			return w, nil
+		}
+	}
+	return nil, nil
+}


### PR DESCRIPTION
Removed LookupWorkerByName and replaced it with a test method; since this method is used in tests where there are very few workers, the logic was simplified.