### PR TITLE
chore: update security scanner

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -64,7 +64,7 @@ jobs:
         python3 -m pip install semgrep==1.45.0
 
         # CodeQL
-        LATEST=$(gh release list --repo https://github.com/github/codeql-action | cut -f 3 | sort --version-sort | tail -n1)
+        LATEST=$(gh release list --repo https://github.com/github/codeql-action | cut -f 3 | grep codeql-bundle- | sort --version-sort | tail -n1)
         gh release download --repo https://github.com/github/codeql-action --pattern codeql-bundle-linux64.tar.gz "$LATEST"
         tar xf codeql-bundle-linux64.tar.gz -C "$HOME/.bin"
 


### PR DESCRIPTION
The security-scanner started failing with `no assets to download` (see https://github.com/hashicorp/boundary/actions/runs/11485270903/job/31967837536)