### PR TITLE
Update Conditional On Unit Tests

### DIFF
--- a/internal/iam/repository_principal_role_test.go
+++ b/internal/iam/repository_principal_role_test.go
@@ -141,20 +141,13 @@ func TestRepository_AddPrincipalRoles(t *testing.T) {
 				if tt.args.wantUserIds {
 					userIds = createUsersFn(orgs)
 					u := TestUser(t, repo, staticOrg.PublicId)
-					if roleId == orgRole.PublicId {
-						userIds = append(userIds, u.PublicId)
-					} else {
-						userIds = append(userIds, u.PublicId)
-					}
+					userIds = append(userIds, u.PublicId)
+
 				}
 				if tt.args.wantGroupIds {
 					groupIds = createGrpsFn(orgs, projects)
 					g := TestGroup(t, conn, staticProj.PublicId)
-					if roleId == projRole.PublicId {
-						groupIds = append(groupIds, g.PublicId)
-					} else {
-						groupIds = append(groupIds, g.PublicId)
-					}
+					groupIds = append(groupIds, g.PublicId)
 				}
 				if len(tt.args.specificUserIds) > 0 {
 					userIds = tt.args.specificUserIds


### PR DESCRIPTION
# Overview
- Remove conditional from the `TestRepository_AddPrincipalRoles` to append to the `groupIds` and `userIds` slices as the logic would always occur regardless of the conditional. 