### PR TITLE
feat(server): create query for list and lookup worker to use

### DIFF
--- a/internal/daemon/controller/handlers/workers/worker_service.go
+++ b/internal/daemon/controller/handlers/workers/worker_service.go
@@ -899,7 +899,7 @@ func (s Service) toProto(ctx context.Context, in *server.Worker, opt ...handlers
 		out.LastStatusTime = in.GetLastStatusTime().GetTimestamp()
 	}
 	if outputFields.Has(globals.ActiveConnectionCountField) {
-		out.ActiveConnectionCount = &wrapperspb.UInt32Value{Value: in.ActiveConnectionCount()}
+		out.ActiveConnectionCount = &wrapperspb.UInt32Value{Value: in.GetActiveConnectionCount()}
 	}
 	if outputFields.Has(globals.ControllerGeneratedActivationToken) && in.ControllerGeneratedActivationToken != "" {
 		out.ControllerGeneratedActivationToken = &wrapperspb.StringValue{Value: in.ControllerGeneratedActivationToken}

--- a/internal/server/query.go
+++ b/internal/server/query.go
@@ -4,6 +4,39 @@
 package server
 
 const (
+	listWorkersQuery = `
+	with connection_count (worker_id, count) as (
+    select worker_id,
+           count(1) as count
+      from session_connection
+      where closed_reason is null
+   group by worker_id
+)
+    select w.public_id,
+           w.scope_id,
+           w.description,
+           w.name,
+           w.address,
+           w.create_time,
+           w.update_time,
+           w.version,
+           w.last_status_time,
+           w.type,
+           w.release_version,
+           w.operational_state,
+           w.local_storage_state,
+           cc.count as active_connection_count,
+           wt.tags as api_tags,
+           ct.tags as config_tags
+      from server_worker w
+ left join (select worker_id, json_agg(json_build_object('key', key, 'value', value)) as tags from server_worker_api_tag group by worker_id) wt
+        on w.public_id = wt.worker_id
+ left join (select worker_id, json_agg(json_build_object('key', key, 'value', value)) as tags from server_worker_config_tag group by worker_id) ct
+        on w.public_id = ct.worker_id
+ left join connection_count as cc
+        on w.public_id = cc.worker_id
+	`
+
 	getStorageBucketCredentialStatesByWorkerId = `
 		select spsb.public_id as storage_bucket_id,
 			   wsbcs.permission_type, wsbcs.state, 

--- a/internal/server/worker.go
+++ b/internal/server/worker.go
@@ -112,10 +112,9 @@ func AttachWorkerIdToState(ctx context.Context, workerId string) (*structpb.Stru
 // authorizing and establishing a session.  It is owned by a scope.
 type Worker struct {
 	*store.Worker
-
-	activeConnectionCount uint32 `gorm:"-"`
-	apiTags               Tags
-	configTags            Tags
+	ApiTags               Tags   `json:"api_tags" gorm:"->"`
+	ConfigTags            Tags   `json:"config_tags" gorm:"->"`
+	ActiveConnectionCount uint32 `gorm:"->"`
 
 	// inputTags is not specified to be api or config tags and is not intended
 	// to be read by clients.  Since config tags and api tags are applied in
@@ -149,7 +148,7 @@ func NewWorker(scopeId string, opt ...Option) *Worker {
 		inputTags: opts.withWorkerTags,
 	}
 	if opts.withTestUseInputTagsAsApiTags {
-		worker.apiTags = worker.inputTags
+		worker.ApiTags = worker.inputTags
 	}
 	return worker
 }
@@ -167,16 +166,16 @@ func (w *Worker) clone() *Worker {
 	cWorker := &Worker{
 		Worker: cw.(*store.Worker),
 	}
-	if w.apiTags != nil {
-		cWorker.apiTags = make([]*Tag, 0, len(w.apiTags))
-		for _, t := range w.apiTags {
-			cWorker.apiTags = append(cWorker.apiTags, &Tag{Key: t.Key, Value: t.Value})
+	if w.ApiTags != nil {
+		cWorker.ApiTags = make([]*Tag, 0, len(w.ApiTags))
+		for _, t := range w.ApiTags {
+			cWorker.ApiTags = append(cWorker.ApiTags, &Tag{Key: t.Key, Value: t.Value})
 		}
 	}
-	if w.configTags != nil {
-		cWorker.configTags = make([]*Tag, 0, len(w.configTags))
-		for _, t := range w.configTags {
-			cWorker.configTags = append(cWorker.configTags, &Tag{Key: t.Key, Value: t.Value})
+	if w.ConfigTags != nil {
+		cWorker.ConfigTags = make([]*Tag, 0, len(w.ConfigTags))
+		for _, t := range w.ConfigTags {
+			cWorker.ConfigTags = append(cWorker.ConfigTags, &Tag{Key: t.Key, Value: t.Value})
 		}
 	}
 	if w.inputTags != nil {
@@ -190,8 +189,8 @@ func (w *Worker) clone() *Worker {
 
 // ActiveConnectionCount is the current number of sessions this worker is handling
 // according to the controllers.
-func (w *Worker) ActiveConnectionCount() uint32 {
-	return w.activeConnectionCount
+func (w *Worker) GetActiveConnectionCount() uint32 {
+	return w.ActiveConnectionCount
 }
 
 // CanonicalTags is the deduplicated set of tags contained on both the resource
@@ -199,10 +198,10 @@ func (w *Worker) ActiveConnectionCount() uint32 {
 // function is guaranteed to return a non-nil map.
 func (w *Worker) CanonicalTags(opt ...Option) map[string][]string {
 	dedupedTags := make(map[Tag]struct{})
-	for _, t := range w.apiTags {
+	for _, t := range w.ApiTags {
 		dedupedTags[*t] = struct{}{}
 	}
-	for _, t := range w.configTags {
+	for _, t := range w.ConfigTags {
 		dedupedTags[*t] = struct{}{}
 	}
 	tags := make(map[string][]string)
@@ -216,7 +215,7 @@ func (w *Worker) CanonicalTags(opt ...Option) map[string][]string {
 // the worker daemon's configuration file.
 func (w *Worker) GetConfigTags() map[string][]string {
 	tags := make(map[string][]string)
-	for _, t := range w.configTags {
+	for _, t := range w.ConfigTags {
 		tags[t.Key] = append(tags[t.Key], t.Value)
 	}
 	return tags
@@ -225,7 +224,7 @@ func (w *Worker) GetConfigTags() map[string][]string {
 // GetApiTags returns the api tags which have been set for this worker.
 func (w *Worker) GetApiTags() map[string][]string {
 	tags := make(map[string][]string)
-	for _, t := range w.apiTags {
+	for _, t := range w.ApiTags {
 		tags[t.Key] = append(tags[t.Key], t.Value)
 	}
 	return tags
@@ -286,10 +285,10 @@ func (a *workerAggregate) toWorker(ctx context.Context) (*Worker, error) {
 			OperationalState:  a.OperationalState,
 			LocalStorageState: a.LocalStorageState,
 		},
-		activeConnectionCount: a.ActiveConnectionCount,
+		ActiveConnectionCount: a.ActiveConnectionCount,
 		RemoteStorageStates:   map[string]*plugin.StorageBucketCredentialState{},
-		apiTags:               a.ApiTags,
-		configTags:            a.WorkerConfigTags,
+		ApiTags:               a.ApiTags,
+		ConfigTags:            a.WorkerConfigTags,
 	}
 
 	return worker, nil

--- a/internal/server/worker_tags_test.go
+++ b/internal/server/worker_tags_test.go
@@ -639,7 +639,7 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 	worker, err = repo.LookupWorker(context.Background(), worker.PublicId)
 	require.NoError(err)
 	assert.Equal(uint32(2), worker.Version)
-	assert.Equal(len(manyTags), len(worker.apiTags))
+	assert.Equal(len(manyTags), len(worker.ApiTags))
 
 	// Delete a valid tag from worker
 	rowsDeleted, err = repo.DeleteWorkerTags(context.Background(), worker.PublicId, worker.Version, []*Tag{
@@ -650,8 +650,8 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 	worker, err = repo.LookupWorker(context.Background(), worker.PublicId)
 	require.NoError(err)
 	assert.Equal(uint32(3), worker.Version)
-	assert.Contains(worker.apiTags, &Tag{Key: "key", Value: "value"})
-	assert.Contains(worker.apiTags, &Tag{Key: "key2", Value: "value2"})
+	assert.Contains(worker.ApiTags, &Tag{Key: "key", Value: "value"})
+	assert.Contains(worker.ApiTags, &Tag{Key: "key2", Value: "value2"})
 
 	// Add another valid tag to worker
 	_, err = repo.AddWorkerTags(context.Background(), worker.PublicId, worker.Version, []*Tag{
@@ -661,8 +661,8 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 	worker, err = repo.LookupWorker(context.Background(), worker.PublicId)
 	require.NoError(err)
 	assert.Equal(uint32(4), worker.Version)
-	assert.Contains(worker.apiTags, &Tag{Key: "key!", Value: "value!"})
-	assert.Equal(3, len(worker.apiTags))
+	assert.Contains(worker.ApiTags, &Tag{Key: "key!", Value: "value!"})
+	assert.Equal(3, len(worker.ApiTags))
 
 	// Set all tags to nil
 	set, err = repo.SetWorkerTags(context.Background(), worker.PublicId, worker.Version, nil)
@@ -671,8 +671,8 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 	worker, err = repo.LookupWorker(context.Background(), worker.PublicId)
 	require.NoError(err)
 	assert.Equal(uint32(5), worker.Version)
-	assert.Equal(Tags(nil), worker.apiTags)
-	assert.Equal(0, len(worker.apiTags))
+	assert.Equal(Tags(nil), worker.ApiTags)
+	assert.Equal(0, len(worker.ApiTags))
 
 	// Ensure config tags are untouched
 	for _, ct := range []*Tag{
@@ -681,9 +681,9 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 		{Key: "key3", Value: "value3"},
 		{Key: "key?", Value: "value?"},
 	} {
-		assert.Contains(worker.configTags, ct)
+		assert.Contains(worker.ConfigTags, ct)
 	}
-	assert.Equal(4, len(worker.configTags))
+	assert.Equal(4, len(worker.ConfigTags))
 
 	// Go full circle
 	_, err = repo.AddWorkerTags(context.Background(), worker.PublicId, worker.Version, manyTags)
@@ -691,8 +691,8 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 	worker, err = repo.LookupWorker(context.Background(), worker.PublicId)
 	require.NoError(err)
 	assert.Equal(uint32(6), worker.Version)
-	assert.Equal(len(manyTags), len(worker.apiTags))
+	assert.Equal(len(manyTags), len(worker.ApiTags))
 	for _, t := range manyTags {
-		assert.Contains(worker.apiTags, t)
+		assert.Contains(worker.ApiTags, t)
 	}
 }

--- a/internal/server/worker_test.go
+++ b/internal/server/worker_test.go
@@ -24,12 +24,12 @@ import (
 
 func TestWorkerCanonicalTags(t *testing.T) {
 	w := NewWorker(scope.Global.String())
-	w.apiTags = []*Tag{
+	w.ApiTags = []*Tag{
 		{Key: "key", Value: "apis unique"},
 		{Key: "key", Value: "shared"},
 		{Key: "key2", Value: "apis key2 unique"},
 	}
-	w.configTags = []*Tag{
+	w.ConfigTags = []*Tag{
 		{Key: "key", Value: "configs unique"},
 		{Key: "key", Value: "shared"},
 		{Key: "key3", Value: "configs key3 unique"},
@@ -120,8 +120,8 @@ func TestWorkerAggregate(t *testing.T) {
 		assert.Equal(t, uint32(1), got.GetVersion())
 		assert.NotNil(t, got.GetLastStatusTime())
 		assert.NotNil(t, got.GetReleaseVersion())
-		assert.Empty(t, got.apiTags)
-		assert.Equal(t, got.configTags, Tags{{Key: "key", Value: "val"}})
+		assert.Empty(t, got.ApiTags)
+		assert.Equal(t, got.ConfigTags, Tags{{Key: "key", Value: "val"}})
 	})
 
 	t.Run("Worker with many config tag", func(t *testing.T) {
@@ -151,8 +151,8 @@ func TestWorkerAggregate(t *testing.T) {
 
 		got := getAggWorker(id)
 		require.NotNil(t, got.GetLastStatusTime())
-		assert.Empty(t, got.apiTags)
-		assert.ElementsMatch(t, got.configTags, []*Tag{
+		assert.Empty(t, got.ApiTags)
+		assert.ElementsMatch(t, got.ConfigTags, []*Tag{
 			{Key: "key", Value: "val"},
 			{Key: "key", Value: "val2"},
 			{Key: "key2", Value: "val2"},
@@ -180,7 +180,7 @@ func TestWorkerAggregate(t *testing.T) {
 		assert.Equal(t, uint32(1), got.GetVersion())
 		assert.NotNil(t, got.GetLastStatusTime())
 		assert.Empty(t, got.GetConfigTags())
-		assert.Equal(t, got.apiTags, Tags{{Key: "key", Value: "val"}})
+		assert.Equal(t, got.ApiTags, Tags{{Key: "key", Value: "val"}})
 	})
 
 	// Worker with mix of tag sources
@@ -211,11 +211,11 @@ func TestWorkerAggregate(t *testing.T) {
 
 		got := getAggWorker(id)
 		require.NotNil(t, got.GetLastStatusTime())
-		assert.ElementsMatch(t, got.apiTags, []*Tag{
+		assert.ElementsMatch(t, got.ApiTags, []*Tag{
 			{Key: "key", Value: "val2"},
 			{Key: "key2", Value: "val2"},
 		})
-		assert.ElementsMatch(t, got.configTags, []*Tag{
+		assert.ElementsMatch(t, got.ConfigTags, []*Tag{
 			{Key: "key", Value: "val"},
 		})
 	})


### PR DESCRIPTION
This PR creates a query for ListWorker and LookupWorker to use and directly populates the worker struct.

A future PR will remove the view the query replicates and remove the use of the workerAggregate struct entirely.