### PR TITLE
chore(e2e): Add required permission to service user

### DIFF
--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -133,6 +133,7 @@ data "aws_iam_policy_document" "enos_policy_document" {
       "elasticloadbalancing:DeleteRule",
       "elasticloadbalancing:DeleteTargetGroup",
       "elasticloadbalancing:DeregisterTargets",
+      "elasticloadbalancing:DescribeListenerAttributes",
       "elasticloadbalancing:DescribeListeners",
       "elasticloadbalancing:DescribeLoadBalancerAttributes",
       "elasticloadbalancing:DescribeLoadBalancers",


### PR DESCRIPTION
Observed that some e2e tests were failing for the following reason
> Error: reading ELBv2 Listener (arn:aws:elasticloadbalancing:us-east-1:271311691044:listener/app/boundary-alb-clerlzdj/2d640b6192460fa9/dadeaa7b29410903) attributes: operation error Elastic Load Balancing v2: DescribeListenerAttributes, https response error StatusCode: 403, RequestID: 04a1faa7-90a5-4b3d-a69f-aae3544ecf38, api error AccessDenied: User: arn:aws:sts::271311691044:assumed-role/github_actions-boundary_ci/GitHubActions is not authorized to perform: elasticloadbalancing:DescribeListenerAttributes because no identity-based policy allows the elasticloadbalancing:DescribeListenerAttributes action

This PR updates some terraform for the CI service user to add the requested permission. This terraform has already been applied to the user and confirmed that it addresses the error.

https://hashicorp.atlassian.net/browse/ICU-15734