### PR TITLE
refact(worker): export api and config tags

### DIFF
--- a/internal/server/repository_worker.go
+++ b/internal/server/repository_worker.go
@@ -726,7 +726,7 @@ func (r *Repository) AddWorkerTags(ctx context.Context, workerId string, workerV
 		return nil, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("no worker found with public id %s", workerId))
 	}
 
-	newTags := append(worker.apiTags, tags...)
+	newTags := append(worker.ApiTags, tags...)
 	_, err = r.writer.DoTx(ctx, db.StdRetryCnt, db.ExpBackoff{}, func(reader db.Reader, w db.Writer) error {
 		worker := worker.clone()
 		worker.PublicId = workerId

--- a/internal/server/worker_tags_test.go
+++ b/internal/server/worker_tags_test.go
@@ -639,7 +639,7 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 	worker, err = repo.LookupWorker(context.Background(), worker.PublicId)
 	require.NoError(err)
 	assert.Equal(uint32(2), worker.Version)
-	assert.Equal(len(manyTags), len(worker.apiTags))
+	assert.Equal(len(manyTags), len(worker.ApiTags))
 
 	// Delete a valid tag from worker
 	rowsDeleted, err = repo.DeleteWorkerTags(context.Background(), worker.PublicId, worker.Version, []*Tag{
@@ -650,8 +650,8 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 	worker, err = repo.LookupWorker(context.Background(), worker.PublicId)
 	require.NoError(err)
 	assert.Equal(uint32(3), worker.Version)
-	assert.Contains(worker.apiTags, &Tag{Key: "key", Value: "value"})
-	assert.Contains(worker.apiTags, &Tag{Key: "key2", Value: "value2"})
+	assert.Contains(worker.ApiTags, &Tag{Key: "key", Value: "value"})
+	assert.Contains(worker.ApiTags, &Tag{Key: "key2", Value: "value2"})
 
 	// Add another valid tag to worker
 	_, err = repo.AddWorkerTags(context.Background(), worker.PublicId, worker.Version, []*Tag{
@@ -661,8 +661,8 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 	worker, err = repo.LookupWorker(context.Background(), worker.PublicId)
 	require.NoError(err)
 	assert.Equal(uint32(4), worker.Version)
-	assert.Contains(worker.apiTags, &Tag{Key: "key!", Value: "value!"})
-	assert.Equal(3, len(worker.apiTags))
+	assert.Contains(worker.ApiTags, &Tag{Key: "key!", Value: "value!"})
+	assert.Equal(3, len(worker.ApiTags))
 
 	// Set all tags to nil
 	set, err = repo.SetWorkerTags(context.Background(), worker.PublicId, worker.Version, nil)
@@ -671,8 +671,8 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 	worker, err = repo.LookupWorker(context.Background(), worker.PublicId)
 	require.NoError(err)
 	assert.Equal(uint32(5), worker.Version)
-	assert.Equal(Tags(nil), worker.apiTags)
-	assert.Equal(0, len(worker.apiTags))
+	assert.Equal(Tags(nil), worker.ApiTags)
+	assert.Equal(0, len(worker.ApiTags))
 
 	// Ensure config tags are untouched
 	for _, ct := range []*Tag{
@@ -681,9 +681,9 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 		{Key: "key3", Value: "value3"},
 		{Key: "key?", Value: "value?"},
 	} {
-		assert.Contains(worker.configTags, ct)
+		assert.Contains(worker.ConfigTags, ct)
 	}
-	assert.Equal(4, len(worker.configTags))
+	assert.Equal(4, len(worker.ConfigTags))
 
 	// Go full circle
 	_, err = repo.AddWorkerTags(context.Background(), worker.PublicId, worker.Version, manyTags)
@@ -691,8 +691,8 @@ func TestRepository_WorkerTagsConsequent(t *testing.T) {
 	worker, err = repo.LookupWorker(context.Background(), worker.PublicId)
 	require.NoError(err)
 	assert.Equal(uint32(6), worker.Version)
-	assert.Equal(len(manyTags), len(worker.apiTags))
+	assert.Equal(len(manyTags), len(worker.ApiTags))
 	for _, t := range manyTags {
-		assert.Contains(worker.apiTags, t)
+		assert.Contains(worker.ApiTags, t)
 	}
 }

--- a/internal/server/worker_test.go
+++ b/internal/server/worker_test.go
@@ -24,12 +24,12 @@ import (
 
 func TestWorkerCanonicalTags(t *testing.T) {
 	w := NewWorker(scope.Global.String())
-	w.apiTags = []*Tag{
+	w.ApiTags = []*Tag{
 		{Key: "key", Value: "apis unique"},
 		{Key: "key", Value: "shared"},
 		{Key: "key2", Value: "apis key2 unique"},
 	}
-	w.configTags = []*Tag{
+	w.ConfigTags = []*Tag{
 		{Key: "key", Value: "configs unique"},
 		{Key: "key", Value: "shared"},
 		{Key: "key3", Value: "configs key3 unique"},
@@ -120,8 +120,8 @@ func TestWorkerAggregate(t *testing.T) {
 		assert.Equal(t, uint32(1), got.GetVersion())
 		assert.NotNil(t, got.GetLastStatusTime())
 		assert.NotNil(t, got.GetReleaseVersion())
-		assert.Empty(t, got.apiTags)
-		assert.Equal(t, got.configTags, Tags{{Key: "key", Value: "val"}})
+		assert.Empty(t, got.ApiTags)
+		assert.Equal(t, got.ConfigTags, Tags{{Key: "key", Value: "val"}})
 	})
 
 	t.Run("Worker with many config tag", func(t *testing.T) {
@@ -151,8 +151,8 @@ func TestWorkerAggregate(t *testing.T) {
 
 		got := getAggWorker(id)
 		require.NotNil(t, got.GetLastStatusTime())
-		assert.Empty(t, got.apiTags)
-		assert.ElementsMatch(t, got.configTags, []*Tag{
+		assert.Empty(t, got.ApiTags)
+		assert.ElementsMatch(t, got.ConfigTags, []*Tag{
 			{Key: "key", Value: "val"},
 			{Key: "key", Value: "val2"},
 			{Key: "key2", Value: "val2"},
@@ -180,7 +180,7 @@ func TestWorkerAggregate(t *testing.T) {
 		assert.Equal(t, uint32(1), got.GetVersion())
 		assert.NotNil(t, got.GetLastStatusTime())
 		assert.Empty(t, got.GetConfigTags())
-		assert.Equal(t, got.apiTags, Tags{{Key: "key", Value: "val"}})
+		assert.Equal(t, got.ApiTags, Tags{{Key: "key", Value: "val"}})
 	})
 
 	// Worker with mix of tag sources
@@ -211,11 +211,11 @@ func TestWorkerAggregate(t *testing.T) {
 
 		got := getAggWorker(id)
 		require.NotNil(t, got.GetLastStatusTime())
-		assert.ElementsMatch(t, got.apiTags, []*Tag{
+		assert.ElementsMatch(t, got.ApiTags, []*Tag{
 			{Key: "key", Value: "val2"},
 			{Key: "key2", Value: "val2"},
 		})
-		assert.ElementsMatch(t, got.configTags, []*Tag{
+		assert.ElementsMatch(t, got.ConfigTags, []*Tag{
 			{Key: "key", Value: "val"},
 		})
 	})


### PR DESCRIPTION
Exporting API and Config tags will allow them to be populated by queries defined in query.go for use in domain functions.