### PR TITLE
adds target aliases and transparent sessions usage docs

### DIFF
--- a/website/content/docs/concepts/aliases.mdx
+++ b/website/content/docs/concepts/aliases.mdx
@@ -8,29 +8,39 @@ description: |-
 # Aliases
 
 An alias is a globally unique, DNS-like string that is associated with a destination resource.
+
 You can establish a session to a target by referencing its alias, instead of having to provide a target ID or target name and scope ID.
+
 For example, if you have an alias `boundary.dev`, you can use it to connect to a target with the following command: `boundary connect ssh boundary.dev`.
 
 ## Background
 
 When you create a resource in Boundary, it assigns the resource a randomly generated identifier.
+
 You must use those IDs to perform actions in Boundary.
 
 When you connect to a target using the terminal, you must reference the target ID or target name and scope name.
+
 As an example, to SSH to a target, you can execute the command `boundary connect ssh -target-id ttcp_123456789`.
+
 Since it can be difficult to remember the unique IDs, users frequently have to look up the identifiers for any resources they want to operate on.
 
 Aliases simplify this process.
+
 When you create an alias and associate it with a target, you can later use the alias `value` instead of the target ID in commands.
+
 Boundary automatically resolves to the target that the alias references.
 
 ## Permissions
 
 The existence of an alias for a Boundary resource does not change how permissions function.
+
 Anyone can attempt to use an alias to access a target, but if you do not have permission to access the target, the attempt fails.
+
 You can create an alias for a target, even if you do not have permission to access the target.
 
 Separating the permissions from aliases and destination resources means a different set of people can manage the aliases than the people who have permission to operate on targets.
+
 For example, you may have a project with a sensitive set of targets.
 You can configure Boundary to allow a select few users to manage those targets, while a different group of users manage the aliases.
 
@@ -43,7 +53,9 @@ Examples of valid aliases include `database.boundary` and `webserver.boundary`.
 ### Single word aliases and transparent sessions
 
 HashiCorp recommends that you do not use single-word aliases such as `webserver` as opposed to `webserver.boundary`, because single-word aliases do not work intuitively on Windows.
+
 Windows DNS resolution does not support resolving unqualified single word DNS hostnames.
+
 You can make the hostname fully qualified, but is not intuitive to most users.
 
 For example the following hostname works:
@@ -65,221 +77,10 @@ See the [transparent sessions](/boundary/docs/concepts/transparent-sessions) doc
 ## Scopes
 
 You can only create aliases in the `global` scope.
+
 However, you can associate aliases with targets or hosts from any scope.
 Support for additional resource types may be added in the future.
 
 If you delete a project, Boundary clears the `destination_id` parameter for any aliases that resolve to targets in that project, so that they no longer function.
 
-## Connect to a target using an alias
-
-Whenever you could use the `-id` flag or `-target` flag in the CLI, you can substitute an alias.
-
-For example, you can use the following command to connect to an SSH target with the ID `ttcp_1234567890`:
-
-```shell-session
-$ boundary connect ssh -target -id ttcp_1234567890
-```
-
-If you configured an alias named `example.alias.boundary` for the target, you could alternatively use the following command to connect to the target:
-
-```shell-session
-$ boundary connect ssh example.alias.boundary
-```
-
-## Create aliases
-
-There are multiple ways that you can create aliases and associate them with targets in Boundary.
-
-You can:
-
-- [Create an alias for an existing target](#create-an-alias-for-an-existing-target)
-- [Create an alias during target creation](#create-an-alias-during-target-creation)
-- [Associate an existing alias with a target](#associate-an-existing-alias-with-a-target)
-
-### Create an alias for an existing target
-
-You can create a new alias and associate it with an existing target at the same time.
-Complete the following steps to create a new alias and associate it with a target:
-
-<Tabs>
-<Tab heading="UI" group="ui">
-
-1. Log in to Boundary.
-1. Select **Aliases** in the navigation pane.
-1. Click **New Alias**.
-1. Complete the following fields:
-   - **Name**: (Optional) Enter an optional name for the alias to use for identification purposes.
-   - **Description**: (Optional) Enter an optional description for the alias to use for identification purposes.
-   - **Type**: Select **Target**.
-   At this time, targets are the only Boundary resources that supports aliasing.
-   - **Alias Value**: Enter the string that you want to use as the alias to represent the target.
-   An alias's value can be a hostname or a DNS-like string.
-   - **Target ID**: (Optional) Specify any targets you want to associate with the alias.
-   - **Host ID**: (Optional) Enter an optional host ID, if you would like to specify that the alias always uses the same host when you use it to connect to a target.
-1. Click **Save**.
-
-</Tab>
-<Tab heading="CLI" group="cli">
-
-1. Log in to Boundary.
-1. Use the following command to create an alias:
-
-   ```shell-session
-   $ boundary aliases create target \
-       -description 'This is an example alias for target tcp_1234567890' \
-       -destination-id tcp_1234567890 \
-       -name Example Boundary alias \
-       -scope-id global \
-       -value example.alias.boundary \
-       -authorize-session-host-id hst_1234567890
-   ```
-
-   You can use any of the following [attributes](/boundary/docs/concepts/domain-model/aliases) when you create an alias:
-
-   - `-description=<string>` - Specifies the optional description you want to use for identification purposes.
-   - `-destination-id=<string>` - Specifies the ID of the target that the alias references.
-   - `-name=<string>` - Specifies the optional name you want to use to describe the alias for identification purposes.
-   - `-scope-id=<string>` - Scope in which to create the alias. The default is `global`.
-   You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
-   At this time, aliases are only supported for the global scope.
-   - `-value=<string>` - Specifies the string that you want to use as the alias to represent the target.
-   The alias `value` can be a hostname or a DNS-like string.
-   - `-authorize-session-host-id=<string>` - Optionally indicates the host ID to use when you use the alias to authorize a session.
-
-</Tab>
-</Tabs>
-
-### Create an alias during target creation
-
-You can create a new target and new alias at the same time and associate the two.
-
-Complete the following steps to create a new target and new alias at the same time:
-
-<Tabs>
-<Tab heading="UI" group="ui">
-
-1. Log in to Boundary.
-1. Select **Targets** in the navigation pane.
-1. Click **New Target**.
-1. Complete the following fields:
-   - **Name**: Enter the target name for identification purposes.
-   - **Description**: (Optional) Enter an optional description for identification purposes.
-   - **Type**: Select the target type.
-   You can create SSH or TCP targets.
-   - **Target Address**: (Optional) Enter a valid IP address or DNS name.
-   Alternatively, you can configure host catalogs and host sets.
-   - **Default Port**: (Optional) Enter an optional default port for the target to use for connections.
-   - **Default Client Port**: (Optional) Enter an optional local proxy port on which to listen when a session is started on a client.
-   - **Maximum Duration**: (Optional) Enter an optional maximum duration for sessions on this target, in seconds.
-   - **Maximum Connection**: (Optional) Enter the maximum number of connections allowed per session on this target.
-   For unlimited connections, enter `-1`.
-   - **Workers**: (Optional) Select whether you want the worker to function as an ingress and/or egress worker.
-   - **Aliases**: (Optional) Enter the value fpr any aliases you want to associate with this target, and then click **Add**.
-   An alias's value can be a hostname or a DNS-like string.
-   You can associate multiple aliases with a target.
-1. Click **Save**.
-
-</Tab>
-<Tab heading="CLI" group="cli">
-
-1. Log in to Boundary.
-1. Use the following command to create a target:
-
-   ```shell-session
-   $ boundary targets create ssh \
-       -description 'This is an example ssh target' \
-       -name Example Boundary SSH target \
-       -scope-id global \
-       -with-alias-authorize-session-host-id hst_1234567890 \
-       -with-alias-scope-id global \
-       -with-alias-value example.alias.boundary
-   ```
-
-   You can use any of the following [attributes](/boundary/docs/concepts/domain-model/targets) when you create a target:
-
-    - `description` - (optional)
-     An optional description that you can use for identification purposes.
-   - `name` - (required)
-     The `name` must be unique within the target's project.
-   - `scope-id` - (required)
-     The scope in which to create the target.
-     The default is `global`.
-     You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
-   - `-address=<string>` - An optional valid network address for the target to connect to.
-     You cannot use an address alongside host sources.
-   - `-default-client-port=<string>` - The default client port on the target.
-   - `-default-port=<string>` - The default port on the target.
-     If you do not specify a default port, Boundary uses port 22.
-   - `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
-   - `-enable-session-recording=<string>` - A Boolean expression you can use to enable session recording for the target.
-   - `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
-   - `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.
-A value of `-1` means the connections are unlimited.
-   - `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
-     You can specify an integer number of seconds or a duration string.
-   - `-storage-bucket-id=<string>` - The public ID of the storage bucket to associate with the target.
-   - `-with-alias-authorize-session-host-id=<string>` - The host ID that an alias uses to authorize sessions for the target.
-   - `-with-aliasscope-id=<string>` - The scope ID that you want to create the target and alias in.
-     The default is `global`.
-     At this time, aliases are only supported for the global scope.
-   - `-with-alias-value=<string>` - The value of the alias that you want to use to represent the target.
-     Use this parameter to create the alias and target, and associate them with each other, at the same time.
-
-     Note that you can create SSH or TCP [target types](/boundary/docs/concepts/domain-model/targets#target-types).
-     The example command in this section creates an SSH target.
-
-</Tab>
-</Tabs>
-
-### Associate an existing alias with a target
-
-If you already created an alias, you can update it with an existing target.
-Complete the following steps to add an alias to a target:
-
-<Tabs>
-<Tab heading="UI" group="ui">
-
-1. Log in to Boundary.
-1. Select **Targets** in the navigation pane.
-1. Select the target you want to add an alias to.
-1. Under the **Aliases** heading in the right sidebar, click **Add an alias**.
-1. Complete the following fields:
-   - **Name**: (Optional) Enter an optional name for the alias to use for identification purposes.
-   - **Description**: (Optional) Enter an optional description for the alias to use for identification purposes.
-   - **Type**: Select **Target**.
-   At this time, targets are the only Boundary resources that supports aliasing.
-   - **Alias Value**: Enter the alias value you want to use in commands to represent the target.
-   An alias's value can be a hostname or a DNS-like string.
-   - **Target ID**: This field contains the ID of the target you selected to add an alias to.
-   It is read only.
-   - **Host ID**: (Optional) Enter an optional host ID, if you would like to specify that the alias always uses the same host when you use it to connect to a target.
-1. Click **Save**.
-
-</Tab>
-<Tab heading="CLI" group="cli">
-
-1. Log in to Boundary.
-1. Use the following command to create an alias:
-
-   ```shell-session
-   $ boundary aliases update target \
-       -destination-id tcp_1234567890 \
-       -id alt_1234567890 \
-       -authorize-session-host-id hst_1234567890
-   ```
-
-   You can use any of the following [attributes](/boundary/docs/concepts/domain-model/aliases) when you update an alias:
-
-   - `-description=<string>` - Specifies the optional description you want to use for identification purposes.
-   - `-destination-id=<string>` - Specifies the ID of the target that the alias references.
-   - `id=<string>` - Specifies the ID of the alias you want to update.
-   - `-name=<string>` - Specifies the optional name you want to use to describe the alias for identification purposes.
-   - `-scope-id=<string>` - Scope in which to create the alias. The default is `global`.
-   You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
-   At this time, aliases are only supported for the global scope.
-   - `-value=<string>` - Specifies the string that you want to use as the alias to represent the target.
-   The alias `value` must comply with DNS naming rules.
-   - `-authorize-session-host-id=<string>` - Optionally indicates the host ID to use when you use the alias to authorize a session.
-
-</Tab>
-</Tabs>
+Refer to the [Configure aliases and transparent sessions](/boundary/docs/configuration/target-aliases) pages to learn more.

--- a/website/content/docs/concepts/aliases.mdx
+++ b/website/content/docs/concepts/aliases.mdx
@@ -7,42 +7,25 @@ description: |-
 
 # Aliases
 
-An alias is a globally unique, DNS-like string that is associated with a destination resource.
-
-You can establish a session to a target by referencing its alias, instead of having to provide a target ID or target name and scope ID.
+An alias is a globally unique, DNS-like string that is associated with a destination resource. You can establish a session to a target by referencing its alias, instead of having to provide a target ID or target name and scope ID.
 
 For example, if you have an alias `boundary.dev`, you can use it to connect to a target with the following command: `boundary connect ssh boundary.dev`.
 
 ## Background
 
-When you create a resource in Boundary, it assigns the resource a randomly generated identifier.
-
-You must use those IDs to perform actions in Boundary.
-
-When you connect to a target using the terminal, you must reference the target ID or target name and scope name.
+When you create a resource in Boundary, it assigns the resource a randomly generated identifier. You must use those IDs to perform actions in Boundary. When you connect to a target using the terminal, you must reference the target ID or target name and scope name.
 
 As an example, to SSH to a target, you can execute the command `boundary connect ssh -target-id ttcp_123456789`.
 
 Since it can be difficult to remember the unique IDs, users frequently have to look up the identifiers for any resources they want to operate on.
 
-Aliases simplify this process.
-
-When you create an alias and associate it with a target, you can later use the alias `value` instead of the target ID in commands.
-
-Boundary automatically resolves to the target that the alias references.
+Aliases simplify this process. When you create an alias and associate it with a target, you can later use the alias `value` instead of the target ID in commands. Boundary automatically resolves to the target that the alias references.
 
 ## Permissions
 
-The existence of an alias for a Boundary resource does not change how permissions function.
+The existence of an alias for a Boundary resource does not change how permissions function. Anyone can attempt to use an alias to access a target, but if you do not have permission to access the target, the attempt fails. You can create an alias for a target, even if you do not have permission to access the target.
 
-Anyone can attempt to use an alias to access a target, but if you do not have permission to access the target, the attempt fails.
-
-You can create an alias for a target, even if you do not have permission to access the target.
-
-Separating the permissions from aliases and destination resources means a different set of people can manage the aliases than the people who have permission to operate on targets.
-
-For example, you may have a project with a sensitive set of targets.
-You can configure Boundary to allow a select few users to manage those targets, while a different group of users manage the aliases.
+Separating the permissions from aliases and destination resources means a different set of people can manage the aliases than the people who have permission to operate on targets. For example, you may have a project with a sensitive set of targets. You can configure Boundary to allow a select few users to manage those targets, while a different group of users manage the aliases.
 
 ## Naming conventions
 
@@ -54,9 +37,7 @@ Examples of valid aliases include `database.boundary` and `webserver.boundary`.
 
 HashiCorp recommends that you do not use single-word aliases such as `webserver` as opposed to `webserver.boundary`, because single-word aliases do not work intuitively on Windows.
 
-Windows DNS resolution does not support resolving unqualified single word DNS hostnames.
-
-You can make the hostname fully qualified, but is not intuitive to most users.
+Windows DNS resolution does not support resolving unqualified single word DNS hostnames. You can make the hostname fully qualified, but is not intuitive to most users.
 
 For example the following hostname works:
 
@@ -72,14 +53,11 @@ ssh mytarget
 
 For this reason, if you expect any Windows users to use an alias, it contains a dot (`.`) anywhere in the value.
 
-See the [transparent sessions](/boundary/docs/concepts/transparent-sessions) documentation for more information.
+Refer to the [transparent sessions](/boundary/docs/concepts/transparent-sessions) documentation for more information.
 
 ## Scopes
 
-You can only create aliases in the `global` scope.
-
-However, you can associate aliases with targets or hosts from any scope.
-Support for additional resource types may be added in the future.
+You can only create aliases in the `global` scope. However, you can associate aliases with targets or hosts from any scope. Support for additional resource types may be added in the future.
 
 If you delete a project, Boundary clears the `destination_id` parameter for any aliases that resolve to targets in that project, so that they no longer function.
 

--- a/website/content/docs/concepts/aliases.mdx
+++ b/website/content/docs/concepts/aliases.mdx
@@ -51,7 +51,7 @@ But this hostname does not work:
 ssh mytarget
 ```
 
-For this reason, if you expect any Windows users to use an alias, it contains a dot (`.`) anywhere in the value.
+For this reason, if you expect any Windows users to use an alias, it should contain a dot (`.`) anywhere in the value.
 
 Refer to the [transparent sessions](/boundary/docs/concepts/transparent-sessions) documentation for more information.
 

--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -27,7 +27,7 @@ Boundary provides OS notifications to make it clear when you connect to a target
 
 Boundary supports Windows and MacOS for the transparent sessions public beta.
 
-Refer to the [Configure transparent sessions](/docs/boundary/configuration/target-aliases/transparent-sessions) page to get started.
+Refer to the [Configure transparent sessions](/boundary/docs/configuration/target-aliases/transparent-sessions) page to get started.
 
 ## Known issues
 

--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -12,67 +12,22 @@ description: |-
 @include 'alerts/beta.mdx'
 
 Transparent sessions shift Boundary from an active connection model to a passive connection model.
+
 Boundary operates in the background instead of requiring you to remember specific resource IDs or ephemeral ports to connect to targets.
+
 As long as Boundary authenticates a user and the user is authorized to access the target, Boundary intercepts the DNS call and routes traffic through a session automatically.
 
 Transparent sessions require [aliases](/boundary/docs/concepts/aliases) and the [Boundary Client Agent](/boundary/docs/api-clients/client-agent).
 
 The Boundary Desktop client facilitates quick target discovery and session establishment using your preferred client.
+
 If you configure aliases for your targets, install the Boundary Client Agent, and ensure you are authenticated to the cluster, connections are transparent to the user.
+
 Boundary provides OS notifications to make it clear when you connect to a target using a transparent session.
 
 Boundary supports Windows and MacOS for the transparent sessions public beta.
 
-## Requirements
-
-Before you configure transparent sessions, you must:
-
-- Ensure that the Boundary CLI and Boundary Desktop are not installed in the environment in which you want to run the transparent sessions beta.
-- Download the appropriate Boundary installer for your Windows or MacOS environment from the [releases](https://releases.hashicorp.com/boundary-installer) page.
-
-## Install clients
-
-Complete the following steps to install the Boundary Client Agent, CLI, and Desktop client:
-
-1. Install Boundary using the installer.
-Make sure to select the options **Boundary Client Agent**, **CLI**, and **Desktop**.
-1. Open the CLI and type the following command to confirm that the version is 0.18.0:
-   ```shell-session
-   $ boundary version
-   ```
-1. In the CLI, run the status command to confirm that the Boundary Client Agent has started:
-
-   ```shell-session
-   $ boundary client-agent status
-   ```
-
-## Configure targets
-
-The following section details how to configure targets and test the transparent sessions public beta feature.
-
-If you use a cluster that was created earlier than release 0.16.0, you must add the grant `list-resolvable-aliases` so that the client agent can populate the local alias cache.
-As an example, you could add the grant `type=user;actions=list-resolvable-aliases;ids=*`.
-
-Complete the following steps to configure targets and test transparent sessions:
-
-1. Authenticate to Boundary using the CLI or Desktop client.
-1. [Create a new target with an alias](/boundary/docs/concepts/aliases#create-an-alias-during-target-creation) or [create an alias for an existing target](/boundary/docs/concepts/aliases#create-an-alias-for-an-existing-target).
-Ensure that you have authorization to establish a session to the target.
-1. Open the client of your choice and [connect to your target using the alias](/boundary/docs/concepts/aliases#connect-to-a-target-using-an-alias).
-
-   Boundary routes your session using the Boundary Client Agent.
-   You can validate that Boundary routed the session by looking at the **Sessions** page in the Desktop client, by typing `boundary sessions list -recursive` in the CLI, or by looking at sessions managed by the Client Agent using `boundary client-agent sessions`.
-
-   <Note>
-
-   The Client Agent periodically requests an updated list of aliases from the controller, so the alias may not work immediately after you create it.
-   It should not take longer than 2 minutes for the alias to be updated in the Client Agent. If you still see connection issues after 2 minutes,
-   follow the troubleshooting steps in [the Client Agent troubleshooting guide](/boundary/docs/api-clients/client-agent#troubleshooting).
-
-   </Note>
-
-When you have validated that transparent sessions work, you can create and establish transparent sessions to other services.
-Make a list of the services you use, add these resources to Boundary as targets, and create workers as needed for network partitions.
+Refer to the [Configure transparent sessions](/docs/boundary/configuration/target-aliases/transparent-sessions) page to get started.
 
 ## Known issues
 
@@ -96,3 +51,4 @@ Refer to the following topics for more information:
 
 - [Aliases](/boundary/docs/concepts/aliases)
 - [Boundary Client Agent](/boundary/docs/api-clients/client-agent)
+- [Configure transparent sessions](/boundary/docs/configuration/target-aliases/transparent-sessions)

--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -11,19 +11,13 @@ description: |-
 
 @include 'alerts/beta.mdx'
 
-Transparent sessions shift Boundary from an active connection model to a passive connection model.
-
-Boundary operates in the background instead of requiring you to remember specific resource IDs or ephemeral ports to connect to targets.
+Transparent sessions shift Boundary from an active connection model to a passive connection model. Boundary operates in the background instead of requiring you to remember specific resource IDs or ephemeral ports to connect to targets.
 
 As long as Boundary authenticates a user and the user is authorized to access the target, Boundary intercepts the DNS call and routes traffic through a session automatically.
 
 Transparent sessions require [aliases](/boundary/docs/concepts/aliases) and the [Boundary Client Agent](/boundary/docs/api-clients/client-agent).
 
-The Boundary Desktop client facilitates quick target discovery and session establishment using your preferred client.
-
-If you configure aliases for your targets, install the Boundary Client Agent, and ensure you are authenticated to the cluster, connections are transparent to the user.
-
-Boundary provides OS notifications to make it clear when you connect to a target using a transparent session.
+The Boundary Desktop client facilitates quick target discovery and session establishment using your preferred client. If you configure aliases for your targets, install the Boundary Client Agent, and ensure you are authenticated to the cluster, connections are transparent to the user. Boundary provides OS notifications to make it clear when you connect to a target using a transparent session.
 
 Boundary supports Windows and MacOS for the transparent sessions public beta.
 

--- a/website/content/docs/configuration/target-aliases/connect-target-alias.mdx
+++ b/website/content/docs/configuration/target-aliases/connect-target-alias.mdx
@@ -1,0 +1,30 @@
+---
+layout: docs
+page_title: Overview
+description: >-
+  Learn how to connect to a target configured with an alias.
+---
+
+After you [Create a target alias](/boundary/docs/configuration/target-aliases/create-target-alias), you can refer to the alias when establishing sessions.
+
+With aliases, you don't have to specify the target ID, target name, or scope when connecting with Boundary. Target aliases are also required to use [transparent sessions](/boundary/docs/configuration/target-aliases/transparent-sessions).
+
+# Connect to a target using an alias
+
+You can substitute an alias whenever you could use the `-id` flag or `-target` flag in the CLI.
+
+For example, you can use the following command to connect to an SSH target with the ID `ttcp_1234567890`:
+
+```shell-session
+$ boundary connect ssh -target -id ttcp_1234567890
+```
+
+If you configured an alias named `example.alias.boundary` for the target, you can now use the alias to connect to the target:
+
+```shell-session
+$ boundary connect ssh example.alias.boundary
+```
+
+Aliases are globally unique, so you don't need to specify the scope to connect to the target.
+
+After verifying that you can connect to the target using an alias, you can try to connect to the target using [transparent sessions](/boundary/docs/configuration/target-aliases/transparent-sessions). <sup>HCP/ENT</sup>

--- a/website/content/docs/configuration/target-aliases/connect-target-alias.mdx
+++ b/website/content/docs/configuration/target-aliases/connect-target-alias.mdx
@@ -5,9 +5,9 @@ description: >-
   Learn how to connect to a target configured with an alias.
 ---
 
-After you [Create a target alias](/boundary/docs/configuration/target-aliases/create-target-alias), you can refer to the alias when establishing sessions.
+After you [Create a target alias](/boundary/docs/configuration/target-aliases/create-target-alias), you can refer to the alias when you establish sessions.
 
-With aliases, you don't have to specify the target ID, target name, or scope when connecting with Boundary. Target aliases are also required to use [transparent sessions](/boundary/docs/configuration/target-aliases/transparent-sessions).
+With aliases, you don't have to specify the target ID, target name, or scope when you connect with Boundary. Target aliases are also required to use [transparent sessions](/boundary/docs/configuration/target-aliases/transparent-sessions).
 
 # Connect to a target using an alias
 
@@ -27,4 +27,4 @@ $ boundary connect ssh example.alias.boundary
 
 Aliases are globally unique, so you don't need to specify the scope to connect to the target.
 
-After verifying that you can connect to the target using an alias, you can try to connect to the target using [transparent sessions](/boundary/docs/configuration/target-aliases/transparent-sessions). <sup>HCP/ENT</sup>
+After you verify that you can connect to the target using an alias, you can try to connect to the target using [transparent sessions](/boundary/docs/configuration/target-aliases/transparent-sessions). <sup>HCP/ENT</sup>

--- a/website/content/docs/configuration/target-aliases/create-target-alias.mdx
+++ b/website/content/docs/configuration/target-aliases/create-target-alias.mdx
@@ -12,6 +12,7 @@ You can create aliases and associate them with targets using the following metho
 - [Create an alias for an existing target](#create-an-alias-for-an-existing-target)
 - [Create an alias during target creation](#create-an-alias-during-target-creation)
 - [Associate an existing alias with a target](#associate-an-existing-alias-with-a-target)
+- [Create multiple target aliases: An example](#create-multiple-aliases-for-a-single-target)
 
 ## Create an alias for an existing target
 

--- a/website/content/docs/configuration/target-aliases/create-target-alias.mdx
+++ b/website/content/docs/configuration/target-aliases/create-target-alias.mdx
@@ -17,7 +17,7 @@ You can create aliases and associate them with targets using the following metho
 
 You can create a new alias and associate it with an existing target at the same time.
 
-When creating the target alias, you can choose from the following methods:
+When you create the target alias, you can choose from the following methods:
 
 - Create the alias without adding a target
 - Create the alias for one or more targets

--- a/website/content/docs/configuration/target-aliases/create-target-alias.mdx
+++ b/website/content/docs/configuration/target-aliases/create-target-alias.mdx
@@ -210,19 +210,19 @@ If you [created an alias](#create-an-alias-for-an-existing-target) without assoc
 
 ## Create multiple aliases for a single target
 
-Target aliases point directly to the target they are associated with. Targets can be assigned a host set or a direct target address.
+Target aliases point directly to the target they are associated with. You can assign targets a host set or a direct target address.
 
 [Host sets](/boundary/docs/concepts/domain-model/host-sets) are sets of functionally equivalent hosts, and are commonly used for deployments at scale. A target assigned a host set will select a host from the host set at random when Boundary establishes a connection.
 
-[Direct target addresses](/boundary/docs/concepts/domain-model/targets#address) are assigned directly to the target, and refer directly to a network resource, like an IP address. Boundary will only connect to this address when establishing a connection.
+You assign [direct target addresses](/boundary/docs/concepts/domain-model/targets#address) directly to the target. They refer to a specific network resource, like an IP address. Boundary only connects to the direct target address when it establishes a connection to the associated target.
 
-When you create a target alias, it can also be assigned a specific host. This is useful if you want to avoid creating multiple targets for specific hosts using direct target addresses. 
+When you create a target alias, you can also assign it to a specific host. Assigning an alias to a specific host is useful if you want to avoid creating multiple targets for specific hosts using direct target addresses. 
 
-For example, two aliases could be created for the same target that has been assigned a host set. One alias could refer to the target itself, and would randomly select a host to connect to for a session. Another alias could point to the same target, but also be assigned a host ID that Boundary should use for a session.
+For example, you could create two aliases for the same target that has been assigned a host set. One alias could refer to the target itself, and would allow Boundary to randomly select a host to connect to for a session. Another alias could point to the same target, but you could assign a host ID that Boundary should use for a session.
 
 ### Example
 
-You may wish to create aliases that point to the same target, but that specify which host should be used when establishing a session.
+You may want to create aliases that point to the same target, but that specify which host Boundary should use when it establishes a session.
 
 In this example, you set up three aliases for the same target:
 
@@ -354,9 +354,9 @@ Create the `linux-dev-servers` target.
 </Tab>
 </Tabs>
 
-Next, create two additional aliases for the target:
+Next, create two additional aliases for the target.
 
-1. `eng.app-servers.linux-dev.dev-040` for the host `dev-040`
+Create `eng.app-servers.linux-dev.dev-040` for the host `dev-040`:
 
    <Tabs>
    <Tab heading="UI" group="ui">
@@ -436,7 +436,7 @@ Next, create two additional aliases for the target:
    </Tab>
    </Tabs>
 
-1. `eng.app-servers.linux-dev.dev-041` for the host `dev-041`
+Then create `eng.app-servers.linux-dev.dev-041` for the host `dev-041`.
 
    <Tabs>
    <Tab heading="UI" group="ui">
@@ -518,7 +518,7 @@ Next, create two additional aliases for the target:
 
 You can now use the aliases to connect to the targets in different contexts.
 
-The Boundary Desktop Client app will list the `linux-dev-servers` target and its aliases under the **Aliases** column.
+The Boundary Desktop Client lists the `linux-dev-servers` target and its aliases under the **Aliases** column.
 
 When you click **Connect**, a list of the hosts available for the connection appears in the **Quick Connect** box.
 
@@ -528,7 +528,7 @@ To establish a connection to any `linux-dev` host using the CLI, use the `eng.ap
 $ boundary connect ssh eng.app-servers.linux-dev 
 ```
 
-This will randomly select a host from the `linux-dev-servers` host set attached to the `linux-dev-servers` target.
+This command randomly selects a host from the `linux-dev-servers` host set attached to the `linux-dev-servers` target.
 
 To establish a connection to a specific host, connect to its target alias instead:
 

--- a/website/content/docs/configuration/target-aliases/create-target-alias.mdx
+++ b/website/content/docs/configuration/target-aliases/create-target-alias.mdx
@@ -249,6 +249,12 @@ And the following host set and hosts exist:
 
 Because the `linux-dev-servers` hosts are functionally equivalent, you can create a single target for the  host set, and create an alias for the target.
 
+We recommend creating DNS-like aliases to ensure consistent naming conventions. In this example, an alias pattern might be:
+
+`hostname.host-set.project.org`
+
+For the `linux-dev-servers` target, create the alias `linux-dev.app-servers.eng`.
+
 <Tabs>
 <Tab heading="UI" group="ui">
 
@@ -260,10 +266,10 @@ Create the `linux-dev-servers` target.
 1. Click **New Target**.
 1. Complete the following fields:
    - **Name**: `linux-dev-servers`
-   - **Description**: `engineering.app-servers linux-dev`
+   - **Description**: `linux-dev.app-servers.eng target`
    - **Type**: SSH
    - **Default Port**: `22`
-   - **Aliases**: `eng.app-servers.linux-dev`
+   - **Aliases**: `linux-dev.app-servers.eng`
 1. Click **Save**.
 
 Then add the `linux-dev-servers` host set to the new `linux-dev-servers` target.
@@ -279,16 +285,16 @@ Then add the `linux-dev-servers` host set to the new `linux-dev-servers` target.
 Create the `linux-dev-servers` target.
 
 1. Log in to Boundary.
-1. Use the following command to create the `linux-dev-servers` target with alias `eng.app-servers.linux-dev`:
+1. Use the following command to create the `linux-dev-servers` target with alias `linux-dev.app-servers.eng`:
 
    ```shell-session
    $ boundary targets create ssh \
-       -description 'engineering.app-servers linux-dev' \
+       -description 'linux-dev.app-servers.eng target' \
        -name linux-dev-servers \
        -scope-id p_3ECODJDbXV \
        -default-port 22 \
        -with-alias-scope-id global \
-       -with-alias-value eng.app-servers.linux-dev
+       -with-alias-value linux-dev.app-servers.eng
    ```
 
    Example output:
@@ -297,16 +303,16 @@ Create the `linux-dev-servers` target.
    
    ```shell-session
    $ boundary targets create ssh \
-       -description 'engineering.app-servers linux-dev' \
+       -description 'linux-dev.app-servers.eng target' \
        -name linux-dev-servers \
        -scope-id p_pj6UUPVJT3 \
        -default-port 22 \
        -with-alias-scope-id global \
-       -with-alias-value eng.app-servers.linux-dev
+       -with-alias-value linux-dev.app-servers.eng
     
     Target information:
       Created Time:               Thu, 14 Nov 2024 13:39:36 MST
-      Description:                engineering.app-servers linux-dev
+      Description:                linux-dev.app-servers.eng target
       ID:                         tssh_lhH5pa425G
       Name:                       linux-dev-servers
       Session Connection Limit:   -1
@@ -336,7 +342,7 @@ Create the `linux-dev-servers` target.
     
       Aliases:
         ID:                       alt_CkC6wGKLWW
-        Value:                    eng.app-servers.linux-dev
+        Value:                    linux-dev.app-servers.eng
     
       Attributes:
         Default Port:             22
@@ -354,9 +360,9 @@ Create the `linux-dev-servers` target.
 </Tab>
 </Tabs>
 
-Next, create two additional aliases for the target.
+Next, create two more aliases for the target.
 
-Create `eng.app-servers.linux-dev.dev-040` for the host `dev-040`:
+Create the `dev-040.linux-dev.app-servers.eng` alias for the host `dev-040`:
 
    <Tabs>
    <Tab heading="UI" group="ui">
@@ -366,9 +372,9 @@ Create `eng.app-servers.linux-dev.dev-040` for the host `dev-040`:
    1. Click **New Alias**.
    1. Complete the following fields:
       - **Name**: `dev-040`
-      - **Description**: `Target alias for engineering.app-servers linux-dev dev-040`
+      - **Description**: `Target alias for dev-040.linux-dev.app-servers.eng`
       - **Type**: `Target`
-      - **Alias Value**: `eng.app-servers.linux-dev.dev-040`
+      - **Alias Value**: `dev-040.linux-dev.app-servers.eng`
       - **Target ID**: `tssh_lhH5pa425G`
       - **Host ID**: `hst_7wGXkF8e0Q`
    1. Click **Save**.
@@ -381,11 +387,11 @@ Create `eng.app-servers.linux-dev.dev-040` for the host `dev-040`:
    
       ```shell-session
       $ boundary aliases create target \
-          -description 'Target alias for engineering.app-servers linux-dev dev-040' \
+          -description 'Target alias for dev-040.linux-dev.app-servers.eng' \
           -destination-id tssh_lhH5pa425G \
           -name dev-040 \
           -scope-id global \
-          -value eng.app-servers.linux-dev.dev-040 \
+          -value dev-040.linux-dev.app-servers.eng \
           -authorize-session-host-id hst_7wGXkF8e0Q
       ```
 
@@ -395,22 +401,22 @@ Create `eng.app-servers.linux-dev.dev-040` for the host `dev-040`:
       
       ```shell-session
       $ boundary aliases create target \
-             -description 'Target alias for engineering.app-servers linux-dev   dev-040' \
+             -description 'Target alias for dev-040.linux-dev.app-servers.eng' \
              -destination-id tssh_lhH5pa425G \
              -name dev-040 \
              -scope-id global \
-             -value eng.app-servers.linux-dev.dev-040 \
+             -value dev-040.linux-dev.app-servers.eng \
              -authorize-session-host-id hst_7wGXkF8e0Q
        
        Alias information:
          Created Time:        Thu, 14 Nov 2024 13:55:41 MST
-         Description:         Target alias for engineering.app-servers linux-dev dev-040
+         Description:         Target alias for dev-040.linux-dev.app-servers.eng
          Destination ID:      tssh_lhH5pa425G
          ID:                  alt_QeCGTcvlq2
          Name:                dev-040
          Type:                target
          Updated Time:        Thu, 14 Nov 2024 13:55:41 MST
-         Value:               eng.app-servers.linux-dev.dev-040
+         Value:               dev-040.linux-dev.app-servers.eng
          Version:             1
        
          Scope:
@@ -436,7 +442,7 @@ Create `eng.app-servers.linux-dev.dev-040` for the host `dev-040`:
    </Tab>
    </Tabs>
 
-Then create `eng.app-servers.linux-dev.dev-041` for the host `dev-041`.
+Then create the `dev-041.linux-dev.app-servers.eng` alias for the host `dev-041`.
 
    <Tabs>
    <Tab heading="UI" group="ui">
@@ -446,9 +452,9 @@ Then create `eng.app-servers.linux-dev.dev-041` for the host `dev-041`.
    1. Click **New Alias**.
    1. Complete the following fields:
       - **Name**: `dev-041`
-      - **Description**: `Target alias for engineering.app-servers linux-dev dev-040`
+      - **Description**: `Target alias for dev-041.linux-dev.app-servers.eng`
       - **Type**: `Target`
-      - **Alias Value**: `eng.app-servers.linux-dev.dev-041`
+      - **Alias Value**: `dev-041.linux-dev.app-servers.eng`
       - **Target ID**: `tssh_lhH5pa425G`
       - **Host ID**: `hst_7wGXkF8e0Q`
    1. Click **Save**.
@@ -461,11 +467,11 @@ Then create `eng.app-servers.linux-dev.dev-041` for the host `dev-041`.
    
       ```shell-session
       $ boundary aliases create target \
-          -description 'Target alias for engineering.app-servers linux-dev dev-041' \
+          -description 'Target alias for dev-041.linux-dev.app-servers.eng' \
           -destination-id tssh_lhH5pa425G \
           -name dev-041 \
           -scope-id global \
-          -value eng.app-servers.linux-dev.dev-041 \
+          -value dev-041.linux-dev.app-servers.eng \
           -authorize-session-host-id hst_zlRwMMPKwp
       ```
 
@@ -475,22 +481,22 @@ Then create `eng.app-servers.linux-dev.dev-041` for the host `dev-041`.
       
       ```shell-session
       $ boundary aliases create target \
-             -description 'Target alias for engineering.app-servers linux-dev   dev-041' \
+             -description 'Target alias for dev-041.linux-dev.app-servers.eng' \
              -destination-id tssh_lhH5pa425G \
              -name dev-041 \
              -scope-id global \
-             -value eng.app-servers.linux-dev.dev-041 \
+             -value dev-041.linux-dev.app-servers.eng \
              -authorize-session-host-id hst_zlRwMMPKwp
        
        Alias information:
          Created Time:        Thu, 14 Nov 2024 14:00:13 MST
-         Description:         Target alias for engineering.app-servers linux-dev dev-040
+         Description:         Target alias for dev-040.linux-dev.app-servers.eng
          Destination ID:      tssh_lhH5pa425G
          ID:                  alt_X5MRXRSi7t
          Name:                dev-041
          Type:                target
          Updated Time:        Thu, 14 Nov 2024 14:00:13 MST
-         Value:               eng.app-servers.linux-dev.dev-041
+         Value:               dev-041.linux-dev.app-servers.eng
          Version:             1
        
          Scope:
@@ -522,10 +528,10 @@ The Boundary Desktop Client lists the `linux-dev-servers` target and its aliases
 
 When you click **Connect**, a list of the hosts available for the connection appears in the **Quick Connect** box.
 
-To establish a connection to any `linux-dev` host using the CLI, use the `eng.app-servers.linux-dev` alias:
+To establish a connection to any `linux-dev` host using the CLI, use the `linux-dev.app-servers.eng` alias:
 
 ```shell-session
-$ boundary connect ssh eng.app-servers.linux-dev 
+$ boundary connect ssh linux-dev.app-servers.eng
 ```
 
 This command randomly selects a host from the `linux-dev-servers` host set attached to the `linux-dev-servers` target.
@@ -533,7 +539,7 @@ This command randomly selects a host from the `linux-dev-servers` host set attac
 To establish a connection to a specific host, connect to its target alias instead:
 
 ```shell-session
-$ boundary connect ssh eng.app-servers.linux-dev.dev-041
+$ boundary connect ssh dev-041.linux-dev.app-servers.eng
 ```
 
 This alias still points to the `linux-dev-servers` target, but will only create a session with the `dev-041` host.

--- a/website/content/docs/configuration/target-aliases/create-target-alias.mdx
+++ b/website/content/docs/configuration/target-aliases/create-target-alias.mdx
@@ -351,11 +351,11 @@ Create the `linux-dev-servers` target.
    
    </CodeBlockConfig>
 
-   Then add the `linux-dev-servers` host set (ID `hsst_56oiL0WaKu`) to the new `linux-dev-servers` target (ID `tssh_lhH5pa425G`).
+Then add the `linux-dev-servers` host set (ID `hsst_56oiL0WaKu`) to the new `linux-dev-servers` target (ID `tssh_lhH5pa425G`).
 
-   ```shell-session
-   $ boundary targets add-host-sources -id tssh_lhH5pa425G -host-source hsst_56oiL0WaKu
-   ```
+```shell-session
+$ boundary targets add-host-sources -id tssh_lhH5pa425G -host-sourchsst_56oiL0WaKu
+```
 
 </Tab>
 </Tabs>
@@ -364,163 +364,163 @@ Next, create two more aliases for the target.
 
 Create the `dev-040.linux-dev.app-servers.eng` alias for the host `dev-040`:
 
-   <Tabs>
-   <Tab heading="UI" group="ui">
-   
-   1. Log in to Boundary. Navigate to the `global` scope
-   1. Select **Aliases** in the navigation pane.
-   1. Click **New Alias**.
-   1. Complete the following fields:
-      - **Name**: `dev-040`
-      - **Description**: `Target alias for dev-040.linux-dev.app-servers.eng`
-      - **Type**: `Target`
-      - **Alias Value**: `dev-040.linux-dev.app-servers.eng`
-      - **Target ID**: `tssh_lhH5pa425G`
-      - **Host ID**: `hst_7wGXkF8e0Q`
-   1. Click **Save**.
-   
-   </Tab>
-   <Tab heading="CLI" group="cli">
-   
-   1. Log in to Boundary.
-   1. Use the following command to create an alias for host `dev-040:
-   
-      ```shell-session
-      $ boundary aliases create target \
-          -description 'Target alias for dev-040.linux-dev.app-servers.eng' \
-          -destination-id tssh_lhH5pa425G \
-          -name dev-040 \
-          -scope-id global \
-          -value dev-040.linux-dev.app-servers.eng \
-          -authorize-session-host-id hst_7wGXkF8e0Q
-      ```
+<Tabs>
+<Tab heading="UI" group="ui">
 
-      Example output:
-      
-      <CodeBlockConfig hideClipboard>
-      
-      ```shell-session
-      $ boundary aliases create target \
-             -description 'Target alias for dev-040.linux-dev.app-servers.eng' \
-             -destination-id tssh_lhH5pa425G \
-             -name dev-040 \
-             -scope-id global \
-             -value dev-040.linux-dev.app-servers.eng \
-             -authorize-session-host-id hst_7wGXkF8e0Q
-       
-       Alias information:
-         Created Time:        Thu, 14 Nov 2024 13:55:41 MST
-         Description:         Target alias for dev-040.linux-dev.app-servers.eng
-         Destination ID:      tssh_lhH5pa425G
-         ID:                  alt_QeCGTcvlq2
-         Name:                dev-040
-         Type:                target
-         Updated Time:        Thu, 14 Nov 2024 13:55:41 MST
-         Value:               dev-040.linux-dev.app-servers.eng
-         Version:             1
-       
-         Scope:
-           ID:                global
-           Name:              global
-           Type:              global
-       
-         Authorized Actions:
-           no-op
-           read
-           update
-           delete
-       
-         Attributes:
-           authorize_session_arguments:
-           {
-           "host_id": "hst_7wGXkF8e0Q"
-           }
-      ```
-      
-      </CodeBlockConfig>
-   
-   </Tab>
-   </Tabs>
+1. Log in to Boundary. Navigate to the `global` scope.
+1. Select **Aliases** in the navigation pane.
+1. Click **New Alias**.
+1. Complete the following fields:
+   - **Name**: `dev-040`
+   - **Description**: `Target alias for dev-040.linux-dev.app-servers.eng`
+   - **Type**: `Target`
+   - **Alias Value**: `dev-040.linux-dev.app-servers.eng`
+   - **Target ID**: `tssh_lhH5pa425G`
+   - **Host ID**: `hst_7wGXkF8e0Q`
+1. Click **Save**.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+1. Log in to Boundary.
+1. Use the following command to create an alias for host `dev-040:
+
+  ```shell-session
+  $ boundary aliases create target \
+      -description 'Target alias for dev-040.linux-dev.app-servers.eng' \
+      -destination-id tssh_lhH5pa425G \
+      -name dev-040 \
+      -scope-id global \
+      -value dev-040.linux-dev.app-servers.eng \
+      -authorize-session-host-id hst_7wGXkF8e0Q
+  ```
+
+  Example output:
+  
+  <CodeBlockConfig hideClipboard>
+  
+  ```shell-session
+  $ boundary aliases create target \
+        -description 'Target alias for dev-040.linux-dev.app-servers.eng' \
+        -destination-id tssh_lhH5pa425G \
+        -name dev-040 \
+        -scope-id global \
+        -value dev-040.linux-dev.app-servers.eng \
+        -authorize-session-host-id hst_7wGXkF8e0Q
+  
+  Alias information:
+    Created Time:        Thu, 14 Nov 2024 13:55:41 MST
+    Description:         Target alias for dev-040.linux-dev.app-servers.eng
+    Destination ID:      tssh_lhH5pa425G
+    ID:                  alt_QeCGTcvlq2
+    Name:                dev-040
+    Type:                target
+    Updated Time:        Thu, 14 Nov 2024 13:55:41 MST
+    Value:               dev-040.linux-dev.app-servers.eng
+    Version:             1
+  
+    Scope:
+      ID:                global
+      Name:              global
+      Type:              global
+  
+    Authorized Actions:
+      no-op
+      read
+      update
+      delete
+  
+    Attributes:
+      authorize_session_arguments:
+      {
+      "host_id": "hst_7wGXkF8e0Q"
+      }
+  ```
+  
+  </CodeBlockConfig>
+
+</Tab>
+</Tabs>
 
 Then create the `dev-041.linux-dev.app-servers.eng` alias for the host `dev-041`.
 
-   <Tabs>
-   <Tab heading="UI" group="ui">
-   
-   1. Log in to Boundary. Navigate to the `global` scope
-   1. Select **Aliases** in the navigation pane.
-   1. Click **New Alias**.
-   1. Complete the following fields:
-      - **Name**: `dev-041`
-      - **Description**: `Target alias for dev-041.linux-dev.app-servers.eng`
-      - **Type**: `Target`
-      - **Alias Value**: `dev-041.linux-dev.app-servers.eng`
-      - **Target ID**: `tssh_lhH5pa425G`
-      - **Host ID**: `hst_7wGXkF8e0Q`
-   1. Click **Save**.
-   
-   </Tab>
-   <Tab heading="CLI" group="cli">
-   
-   1. Log in to Boundary.
-   1. Use the following command to create an alias for host `dev-041`:
-   
-      ```shell-session
-      $ boundary aliases create target \
+<Tabs>
+<Tab heading="UI" group="ui">
+
+1. Log in to Boundary. Navigate to the `global` scope.
+1. Select **Aliases** in the navigation pane.
+1. Click **New Alias**.
+1. Complete the following fields:
+   - **Name**: `dev-041`
+   - **Description**: `Target alias for dev-041.linux-dev.app-servers.eng`
+   - **Type**: `Target`
+   - **Alias Value**: `dev-041.linux-dev.app-servers.eng`
+   - **Target ID**: `tssh_lhH5pa425G`
+   - **Host ID**: `hst_7wGXkF8e0Q`
+1. Click **Save**.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+1. Log in to Boundary.
+1. Use the following command to create an alias for host `dev-041`:
+
+  ```shell-session
+  $ boundary aliases create target \
+      -description 'Target alias for dev-041.linux-dev.app-servers.eng' \
+      -destination-id tssh_lhH5pa425G \
+      -name dev-041 \
+      -scope-id global \
+      -value dev-041.linux-dev.app-servers.eng \
+      -authorize-session-host-id hst_zlRwMMPKwp
+  ```
+
+  Example output:
+  
+  <CodeBlockConfig hideClipboard>
+  
+  ```shell-session
+  $ boundary aliases create target \
           -description 'Target alias for dev-041.linux-dev.app-servers.eng' \
           -destination-id tssh_lhH5pa425G \
           -name dev-041 \
           -scope-id global \
           -value dev-041.linux-dev.app-servers.eng \
           -authorize-session-host-id hst_zlRwMMPKwp
-      ```
+    
+    Alias information:
+      Created Time:        Thu, 14 Nov 2024 14:00:13 MST
+      Description:         Target alias for dev-040.linux-dev.app-servers.eng
+      Destination ID:      tssh_lhH5pa425G
+      ID:                  alt_X5MRXRSi7t
+      Name:                dev-041
+      Type:                target
+      Updated Time:        Thu, 14 Nov 2024 14:00:13 MST
+      Value:               dev-041.linux-dev.app-servers.eng
+      Version:             1
+    
+      Scope:
+        ID:                global
+        Name:              global
+        Type:              global
+    
+      Authorized Actions:
+        no-op
+        read
+        update
+        delete
+    
+      Attributes:
+        authorize_session_arguments:
+        {
+        "host_id": "hst_zlRwMMPKwp"
+        }                                                                                                             
+  ```
+  
+  </CodeBlockConfig>
 
-      Example output:
-      
-      <CodeBlockConfig hideClipboard>
-      
-      ```shell-session
-      $ boundary aliases create target \
-             -description 'Target alias for dev-041.linux-dev.app-servers.eng' \
-             -destination-id tssh_lhH5pa425G \
-             -name dev-041 \
-             -scope-id global \
-             -value dev-041.linux-dev.app-servers.eng \
-             -authorize-session-host-id hst_zlRwMMPKwp
-       
-       Alias information:
-         Created Time:        Thu, 14 Nov 2024 14:00:13 MST
-         Description:         Target alias for dev-040.linux-dev.app-servers.eng
-         Destination ID:      tssh_lhH5pa425G
-         ID:                  alt_X5MRXRSi7t
-         Name:                dev-041
-         Type:                target
-         Updated Time:        Thu, 14 Nov 2024 14:00:13 MST
-         Value:               dev-041.linux-dev.app-servers.eng
-         Version:             1
-       
-         Scope:
-           ID:                global
-           Name:              global
-           Type:              global
-       
-         Authorized Actions:
-           no-op
-           read
-           update
-           delete
-       
-         Attributes:
-           authorize_session_arguments:
-           {
-           "host_id": "hst_zlRwMMPKwp"
-           }                                                                                                             
-      ```
-      
-      </CodeBlockConfig>
-   
-   </Tab>
-   </Tabs>
+</Tab>
+</Tabs>
 
 You can now use the aliases to connect to the targets in different contexts.
 

--- a/website/content/docs/configuration/target-aliases/create-target-alias.mdx
+++ b/website/content/docs/configuration/target-aliases/create-target-alias.mdx
@@ -1,0 +1,538 @@
+---
+layout: docs
+page_title: Create target aliases
+description: >-
+  Learn how to create a target alias for an existing target, or assign one during target creation.
+---
+
+# Create target aliases
+
+You can create aliases and associate them with targets using the following methods:
+
+- [Create an alias for an existing target](#create-an-alias-for-an-existing-target)
+- [Create an alias during target creation](#create-an-alias-during-target-creation)
+- [Associate an existing alias with a target](#associate-an-existing-alias-with-a-target)
+
+## Create an alias for an existing target
+
+You can create a new alias and associate it with an existing target at the same time.
+
+When creating the target alias, you can choose from the following methods:
+
+- Create the alias without adding a target
+- Create the alias for one or more targets
+- Create the alias with an optional host ID
+
+Complete the following steps to create a new alias and associate it with a target:
+
+<Tabs>
+<Tab heading="UI" group="ui">
+
+1. Log in to Boundary.
+1. Select **Aliases** in the navigation pane.
+1. Click **New Alias**.
+1. Complete the following fields:
+   - **Name**: (Optional) Enter an optional name for the alias to use for identification purposes.
+   - **Description**: (Optional) Enter an optional description for the alias to use for identification purposes.
+   - **Type**: Select **Target**.
+   At this time, targets are the only Boundary resources that supports aliasing.
+   - **Alias Value**: Enter the string that you want to use as the alias to represent the target.
+   An alias's value can be a hostname or a DNS-like string.
+   - **Target ID**: (Optional) Specify any targets you want to associate with the alias.
+   - **Host ID**: (Optional) Enter an optional host ID, if you would like to specify that the alias always uses the same host when you use it to connect to a target.
+1. Click **Save**.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+1. Log in to Boundary.
+1. Use the following command to create an alias:
+
+   ```shell-session
+   $ boundary aliases create target \
+       -description 'This is an example alias for target tcp_1234567890' \
+       -destination-id tcp_1234567890 \
+       -name Example Boundary alias \
+       -scope-id global \
+       -value example.alias.boundary \
+       -authorize-session-host-id hst_1234567890
+   ```
+
+   You can use any of the following [attributes](/boundary/docs/concepts/domain-model/aliases) when you create an alias:
+
+   - `-description=<string>` - Specifies the optional description you want to use for identification purposes.
+   - `-destination-id=<string>` - Specifies the ID of the target that the alias references.
+   - `-name=<string>` - Specifies the optional name you want to use to describe the alias for identification purposes.
+   - `-scope-id=<string>` - Scope in which to create the alias. The default is `global`.
+   You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
+   At this time, aliases are only supported for the global scope.
+   - `-value=<string>` - Specifies the string that you want to use as the alias to represent the target.
+   The alias `value` can be a hostname or a DNS-like string.
+   - `-authorize-session-host-id=<string>` - Optionally indicates the host ID to use when you use the alias to authorize a session.
+
+</Tab>
+</Tabs>
+
+## Create an alias during target creation
+
+You can create a new target and new alias at the same time and associate the two.
+
+Complete the following steps to create a new target and new alias at the same time:
+
+<Tabs>
+<Tab heading="UI" group="ui">
+
+1. Log in to Boundary.
+1. Select **Targets** in the navigation pane.
+1. Click **New Target**.
+1. Complete the following fields:
+   - **Name**: Enter the target name for identification purposes.
+   - **Description**: (Optional) Enter an optional description for identification purposes.
+   - **Type**: Select the target type.
+   You can create SSH or TCP targets.
+   - **Target Address**: (Optional) Enter a valid IP address or DNS name.
+   Alternatively, you can configure host catalogs and host sets.
+   - **Default Port**: (Optional) Enter an optional default port for the target to use for connections.
+   - **Default Client Port**: (Optional) Enter an optional local proxy port on which to listen when a session is started on a client.
+   - **Maximum Duration**: (Optional) Enter an optional maximum duration for sessions on this target, in seconds.
+   - **Maximum Connection**: (Optional) Enter the maximum number of connections allowed per session on this target.
+   For unlimited connections, enter `-1`.
+   - **Workers**: (Optional) Select whether you want the worker to function as an ingress and/or egress worker.
+   - **Aliases**: (Optional) Enter the value fpr any aliases you want to associate with this target, and then click **Add**.
+   An alias's value can be a hostname or a DNS-like string.
+   You can associate multiple aliases with a target.
+1. Click **Save**.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+1. Log in to Boundary.
+1. Use the following command to create a target:
+
+   ```shell-session
+   $ boundary targets create ssh \
+       -description 'This is an example ssh target' \
+       -name Example Boundary SSH target \
+       -scope-id global \
+       -with-alias-authorize-session-host-id hst_1234567890 \
+       -with-alias-scope-id global \
+       -with-alias-value example.alias.boundary
+   ```
+
+   You can use any of the following [attributes](/boundary/docs/concepts/domain-model/targets) when you create a target:
+
+    - `description` - (optional)
+     An optional description that you can use for identification purposes.
+   - `name` - (required)
+     The `name` must be unique within the target's project.
+   - `scope-id` - (required)
+     The scope in which to create the target.
+     The default is `global`.
+     You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
+   - `-address=<string>` - An optional valid network address for the target to connect to.
+     You cannot use an address alongside host sources.
+   - `-default-client-port=<string>` - The default client port on the target.
+   - `-default-port=<string>` - The default port on the target.
+     If you do not specify a default port, Boundary uses port 22.
+   - `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
+   - `-enable-session-recording=<string>` - A Boolean expression you can use to enable session recording for the target.
+   - `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
+   - `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.
+A value of `-1` means the connections are unlimited.
+   - `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
+     You can specify an integer number of seconds or a duration string.
+   - `-storage-bucket-id=<string>` - The public ID of the storage bucket to associate with the target.
+   - `-with-alias-authorize-session-host-id=<string>` - The host ID that an alias uses to authorize sessions for the target.
+   - `-with-aliasscope-id=<string>` - The scope ID that you want to create the target and alias in.
+     The default is `global`.
+     At this time, aliases are only supported for the global scope.
+   - `-with-alias-value=<string>` - The value of the alias that you want to use to represent the target.
+     Use this parameter to create the alias and target, and associate them with each other, at the same time.
+
+     Note that you can create SSH or TCP [target types](/boundary/docs/concepts/domain-model/targets#target-types).
+     The example command in this section creates an SSH target.
+
+</Tab>
+</Tabs>
+
+## Associate an existing alias with a target
+
+If you [created an alias](#create-an-alias-for-an-existing-target) without associating it with a target, you can update it with an existing target at a later time. Complete the following steps to add an alias to a target:
+
+<Tabs>
+<Tab heading="UI" group="ui">
+
+1. Log in to Boundary.
+1. Select **Targets** in the navigation pane.
+1. Select the target you want to add an alias to.
+1. Under the **Aliases** heading in the right sidebar, click **Add an alias**.
+1. Complete the following fields:
+   - **Name**: (Optional) Enter an optional name for the alias to use for identification purposes.
+   - **Description**: (Optional) Enter an optional description for the alias to use for identification purposes.
+   - **Type**: Select **Target**.
+   At this time, targets are the only Boundary resources that supports aliasing.
+   - **Alias Value**: Enter the alias value you want to use in commands to represent the target.
+   An alias's value can be a hostname or a DNS-like string.
+   - **Target ID**: This field contains the ID of the target you selected to add an alias to.
+   It is read only.
+   - **Host ID**: (Optional) Enter an optional host ID, if you would like to specify that the alias always uses the same host when you use it to connect to a target.
+1. Click **Save**.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+1. Log in to Boundary.
+1. Use the following command to create an alias:
+
+   ```shell-session
+   $ boundary aliases update target \
+       -destination-id tcp_1234567890 \
+       -id alt_1234567890 \
+       -authorize-session-host-id hst_1234567890
+   ```
+
+   You can use any of the following [attributes](/boundary/docs/concepts/domain-model/aliases) when you update an alias:
+
+   - `-description=<string>` - Specifies the optional description you want to use for identification purposes.
+   - `-destination-id=<string>` - Specifies the ID of the target that the alias references.
+   - `id=<string>` - Specifies the ID of the alias you want to update.
+   - `-name=<string>` - Specifies the optional name you want to use to describe the alias for identification purposes.
+   - `-scope-id=<string>` - Scope in which to create the alias. The default is `global`.
+   You can also specify the scope using the BOUNDARY_SCOPE_ID environment variable.
+   At this time, aliases are only supported for the global scope.
+   - `-value=<string>` - Specifies the string that you want to use as the alias to represent the target.
+   The alias `value` must comply with DNS naming rules.
+   - `-authorize-session-host-id=<string>` - Optionally indicates the host ID to use when you use the alias to authorize a session.
+
+</Tab>
+</Tabs>
+
+## Create multiple aliases for a single target
+
+Target aliases point directly to the target they are associated with. Targets can be assigned a host set or a direct target address.
+
+[Host sets](/boundary/docs/concepts/domain-model/host-sets) are sets of functionally equivalent hosts, and are commonly used for deployments at scale. A target assigned a host set will select a host from the host set at random when Boundary establishes a connection.
+
+[Direct target addresses](/boundary/docs/concepts/domain-model/targets#address) are assigned directly to the target, and refer directly to a network resource, like an IP address. Boundary will only connect to this address when establishing a connection.
+
+When you create a target alias, it can also be assigned a specific host. This is useful if you want to avoid creating multiple targets for specific hosts using direct target addresses. 
+
+For example, two aliases could be created for the same target that has been assigned a host set. One alias could refer to the target itself, and would randomly select a host to connect to for a session. Another alias could point to the same target, but also be assigned a host ID that Boundary should use for a session.
+
+### Example
+
+You may wish to create aliases that point to the same target, but that specify which host should be used when establishing a session.
+
+In this example, you set up three aliases for the same target:
+
+1. A target alias without a host specified
+1. A target alias with a host ID specified
+1. A target alias with a different host ID specified
+
+<Note>
+
+  This example uses SSH target types, which are only available in HCP Boundary and Boundary Enterprise. This process also works for any other target type, including the TCP target type available in Boundary Community Edition.
+
+</Note>
+
+For this example, assume that the following scopes exist:
+
+- Org: `engineering`, ID `o_2drCWvp3Oc`
+- Project: `app-servers`, ID `p_3ECODJDbXV`
+
+And the following host set and hosts exist:
+
+- Host set: `linux-dev-servers`, ID `hsst_56oiL0WaKu`
+- Host: `dev-040`, ID `hst_7wGXkF8e0Q`
+- Host: `dev-041`, ID `hst_zlRwMMPKwp`
+
+Because the `linux-dev-servers` hosts are functionally equivalent, you can create a single target for the  host set, and create an alias for the target.
+
+<Tabs>
+<Tab heading="UI" group="ui">
+
+Create the `linux-dev-servers` target.
+
+1. Log in to Boundary.
+1. Select the 'engineering' org and the `app-servers` project.
+1. Select **Targets** in the navigation pane.
+1. Click **New Target**.
+1. Complete the following fields:
+   - **Name**: `linux-dev-servers`
+   - **Description**: `engineering.app-servers linux-dev`
+   - **Type**: SSH
+   - **Default Port**: `22`
+   - **Aliases**: `eng.app-servers.linux-dev`
+1. Click **Save**.
+
+Then add the `linux-dev-servers` host set to the new `linux-dev-servers` target.
+
+1. Click on the **Host Sources** tab.
+1. Click **Add Host Sources**.
+1. Select the `linux-dev-servers` host set.
+1. Click **Add Host Sources**.
+
+</Tab>
+<Tab heading="CLI" group="cli">
+
+Create the `linux-dev-servers` target.
+
+1. Log in to Boundary.
+1. Use the following command to create the `linux-dev-servers` target with alias `eng.app-servers.linux-dev`:
+
+   ```shell-session
+   $ boundary targets create ssh \
+       -description 'engineering.app-servers linux-dev' \
+       -name linux-dev-servers \
+       -scope-id p_3ECODJDbXV \
+       -default-port 22 \
+       -with-alias-scope-id global \
+       -with-alias-value eng.app-servers.linux-dev
+   ```
+
+   Example output:
+   
+   <CodeBlockConfig hideClipboard>
+   
+   ```shell-session
+   $ boundary targets create ssh \
+       -description 'engineering.app-servers linux-dev' \
+       -name linux-dev-servers \
+       -scope-id p_pj6UUPVJT3 \
+       -default-port 22 \
+       -with-alias-scope-id global \
+       -with-alias-value eng.app-servers.linux-dev
+    
+    Target information:
+      Created Time:               Thu, 14 Nov 2024 13:39:36 MST
+      Description:                engineering.app-servers linux-dev
+      ID:                         tssh_lhH5pa425G
+      Name:                       linux-dev-servers
+      Session Connection Limit:   -1
+      Session Max Seconds:        28800
+      Type:                       ssh
+      Updated Time:               Thu, 14 Nov 2024 13:39:36 MST
+      Version:                    1
+    
+      Scope:
+        ID:                       p_3ECODJDbXV
+        Name:                     app-servers
+        Parent Scope ID:          o_2drCWvp3Oc
+        Type:                     project
+    
+      Authorized Actions:
+        remove-host-sources
+        remove-credential-sources
+        authorize-session
+        delete
+        set-credential-sources
+        no-op
+        read
+        update
+        add-host-sources
+        set-host-sources
+        add-credential-sources
+    
+      Aliases:
+        ID:                       alt_CkC6wGKLWW
+        Value:                    eng.app-servers.linux-dev
+    
+      Attributes:
+        Default Port:             22
+        Enable Session Recording: false
+   ```
+   
+   </CodeBlockConfig>
+
+   Then add the `linux-dev-servers` host set (ID `hsst_56oiL0WaKu`) to the new `linux-dev-servers` target (ID `tssh_lhH5pa425G`).
+
+   ```shell-session
+   $ boundary targets add-host-sources -id tssh_lhH5pa425G -host-source hsst_56oiL0WaKu
+   ```
+
+</Tab>
+</Tabs>
+
+Next, create two additional aliases for the target:
+
+1. `eng.app-servers.linux-dev.dev-040` for the host `dev-040`
+
+   <Tabs>
+   <Tab heading="UI" group="ui">
+   
+   1. Log in to Boundary. Navigate to the `global` scope
+   1. Select **Aliases** in the navigation pane.
+   1. Click **New Alias**.
+   1. Complete the following fields:
+      - **Name**: `dev-040`
+      - **Description**: `Target alias for engineering.app-servers linux-dev dev-040`
+      - **Type**: `Target`
+      - **Alias Value**: `eng.app-servers.linux-dev.dev-040`
+      - **Target ID**: `tssh_lhH5pa425G`
+      - **Host ID**: `hst_7wGXkF8e0Q`
+   1. Click **Save**.
+   
+   </Tab>
+   <Tab heading="CLI" group="cli">
+   
+   1. Log in to Boundary.
+   1. Use the following command to create an alias for host `dev-040:
+   
+      ```shell-session
+      $ boundary aliases create target \
+          -description 'Target alias for engineering.app-servers linux-dev dev-040' \
+          -destination-id tssh_lhH5pa425G \
+          -name dev-040 \
+          -scope-id global \
+          -value eng.app-servers.linux-dev.dev-040 \
+          -authorize-session-host-id hst_7wGXkF8e0Q
+      ```
+
+      Example output:
+      
+      <CodeBlockConfig hideClipboard>
+      
+      ```shell-session
+      $ boundary aliases create target \
+             -description 'Target alias for engineering.app-servers linux-dev   dev-040' \
+             -destination-id tssh_lhH5pa425G \
+             -name dev-040 \
+             -scope-id global \
+             -value eng.app-servers.linux-dev.dev-040 \
+             -authorize-session-host-id hst_7wGXkF8e0Q
+       
+       Alias information:
+         Created Time:        Thu, 14 Nov 2024 13:55:41 MST
+         Description:         Target alias for engineering.app-servers linux-dev dev-040
+         Destination ID:      tssh_lhH5pa425G
+         ID:                  alt_QeCGTcvlq2
+         Name:                dev-040
+         Type:                target
+         Updated Time:        Thu, 14 Nov 2024 13:55:41 MST
+         Value:               eng.app-servers.linux-dev.dev-040
+         Version:             1
+       
+         Scope:
+           ID:                global
+           Name:              global
+           Type:              global
+       
+         Authorized Actions:
+           no-op
+           read
+           update
+           delete
+       
+         Attributes:
+           authorize_session_arguments:
+           {
+           "host_id": "hst_7wGXkF8e0Q"
+           }
+      ```
+      
+      </CodeBlockConfig>
+   
+   </Tab>
+   </Tabs>
+
+1. `eng.app-servers.linux-dev.dev-041` for the host `dev-041`
+
+   <Tabs>
+   <Tab heading="UI" group="ui">
+   
+   1. Log in to Boundary. Navigate to the `global` scope
+   1. Select **Aliases** in the navigation pane.
+   1. Click **New Alias**.
+   1. Complete the following fields:
+      - **Name**: `dev-041`
+      - **Description**: `Target alias for engineering.app-servers linux-dev dev-040`
+      - **Type**: `Target`
+      - **Alias Value**: `eng.app-servers.linux-dev.dev-041`
+      - **Target ID**: `tssh_lhH5pa425G`
+      - **Host ID**: `hst_7wGXkF8e0Q`
+   1. Click **Save**.
+   
+   </Tab>
+   <Tab heading="CLI" group="cli">
+   
+   1. Log in to Boundary.
+   1. Use the following command to create an alias for host `dev-041`:
+   
+      ```shell-session
+      $ boundary aliases create target \
+          -description 'Target alias for engineering.app-servers linux-dev dev-041' \
+          -destination-id tssh_lhH5pa425G \
+          -name dev-041 \
+          -scope-id global \
+          -value eng.app-servers.linux-dev.dev-041 \
+          -authorize-session-host-id hst_zlRwMMPKwp
+      ```
+
+      Example output:
+      
+      <CodeBlockConfig hideClipboard>
+      
+      ```shell-session
+      $ boundary aliases create target \
+             -description 'Target alias for engineering.app-servers linux-dev   dev-041' \
+             -destination-id tssh_lhH5pa425G \
+             -name dev-041 \
+             -scope-id global \
+             -value eng.app-servers.linux-dev.dev-041 \
+             -authorize-session-host-id hst_zlRwMMPKwp
+       
+       Alias information:
+         Created Time:        Thu, 14 Nov 2024 14:00:13 MST
+         Description:         Target alias for engineering.app-servers linux-dev dev-040
+         Destination ID:      tssh_lhH5pa425G
+         ID:                  alt_X5MRXRSi7t
+         Name:                dev-041
+         Type:                target
+         Updated Time:        Thu, 14 Nov 2024 14:00:13 MST
+         Value:               eng.app-servers.linux-dev.dev-041
+         Version:             1
+       
+         Scope:
+           ID:                global
+           Name:              global
+           Type:              global
+       
+         Authorized Actions:
+           no-op
+           read
+           update
+           delete
+       
+         Attributes:
+           authorize_session_arguments:
+           {
+           "host_id": "hst_zlRwMMPKwp"
+           }                                                                                                             
+      ```
+      
+      </CodeBlockConfig>
+   
+   </Tab>
+   </Tabs>
+
+You can now use the aliases to connect to the targets in different contexts.
+
+The Boundary Desktop Client app will list the `linux-dev-servers` target and its aliases under the **Aliases** column.
+
+When you click **Connect**, a list of the hosts available for the connection appears in the **Quick Connect** box.
+
+To establish a connection to any `linux-dev` host using the CLI, use the `eng.app-servers.linux-dev` alias:
+
+```shell-session
+$ boundary connect ssh eng.app-servers.linux-dev 
+```
+
+This will randomly select a host from the `linux-dev-servers` host set attached to the `linux-dev-servers` target.
+
+To establish a connection to a specific host, connect to its target alias instead:
+
+```shell-session
+$ boundary connect ssh eng.app-servers.linux-dev.dev-041
+```
+
+This alias still points to the `linux-dev-servers` target, but will only create a session with the `dev-041` host.

--- a/website/content/docs/configuration/target-aliases/create-target-alias.mdx
+++ b/website/content/docs/configuration/target-aliases/create-target-alias.mdx
@@ -212,7 +212,7 @@ If you [created an alias](#create-an-alias-for-an-existing-target) without assoc
 
 Target aliases point directly to the target they are associated with. You can assign targets a host set or a direct target address.
 
-[Host sets](/boundary/docs/concepts/domain-model/host-sets) are sets of functionally equivalent hosts, and are commonly used for deployments at scale. A target assigned a host set will select a host from the host set at random when Boundary establishes a connection.
+[Host sets](/boundary/docs/concepts/domain-model/host-sets) are sets of functionally equivalent hosts, and are commonly used for deployments at scale.  When Boundary authorizes a session, a target assigned a host set will select a host from the host set at random to use for all connections for the session.
 
 You assign [direct target addresses](/boundary/docs/concepts/domain-model/targets#address) directly to the target. They refer to a specific network resource, like an IP address. Boundary only connects to the direct target address when it establishes a connection to the associated target.
 

--- a/website/content/docs/configuration/target-aliases/index.mdx
+++ b/website/content/docs/configuration/target-aliases/index.mdx
@@ -7,9 +7,9 @@ description: >-
 
 # Overview
 
-Target aliases simplify the connection workflow end users by allowing targets to be referenced by a globally unique DNS-like string.
+Target aliases simplify the connection workflow for end users by allowing them to reference targets using a globally unique DNS-like string.
 
-Without aliases, connecting to an end target requires referencing the target ID, or a combination of target name and scope:
+Without aliases, connecting to an end target requires you to reference the target ID, or a combination of target name and scope:
 
 ```shell-session
 $ boundary connect ssh -target-id ttcp_1234567890
@@ -32,4 +32,4 @@ To set up a target alias:
 1. [Create a target alias](/boundary/docs/configuration/target-aliases/create-target-alias)
 1. [Connect to a target using an alias](/boundary/docs/configuration/target-aliases/connect-target-alias)
 
-After setting up a target alias, you can optionally [Configure transparent sessions for end users](/boundary/docs/configuration/target-aliases/transparent-sessions). <sup>HCP/ENT</sup>
+After you set up a target alias, you can optionally [Configure transparent sessions for end users](/boundary/docs/configuration/target-aliases/transparent-sessions). <sup>HCP/ENT</sup>

--- a/website/content/docs/configuration/target-aliases/index.mdx
+++ b/website/content/docs/configuration/target-aliases/index.mdx
@@ -1,0 +1,35 @@
+---
+layout: docs
+page_title: Overview
+description: >-
+  Learn how to configure aliases and transparent sessions to enhance end-user workflows and simplify target access.
+---
+
+# Overview
+
+Target aliases simplify the connection workflow end users by allowing targets to be referenced by a globally unique DNS-like string.
+
+Without aliases, connecting to an end target requires referencing the target ID, or a combination of target name and scope:
+
+```shell-session
+$ boundary connect ssh -target-id ttcp_1234567890
+```
+
+```shell-session
+$ boundary connect ssh -target-name sql-database -target-scope-name -staging
+```
+
+With target aliases, a single globally referenced value is assigned to a target, simplifying connection workflows and enabling transparent sessions for Enterprise and HCP end users.
+
+```shell-session
+$ boundary connect ssh sql-database-staging
+```
+
+## Configure target aliases
+
+To set up a target alias:
+
+1. [Create a target alias](/boundary/docs/configuration/target-aliases/create-target-alias)
+1. [Connect to a target using an alias](/boundary/docs/configuration/target-aliases/connect-target-alias)
+
+After setting up a target alias, you can optionally [Configure transparent sessions for end users](/boundary/docs/configuration/target-aliases/transparent-sessions). <sup>HCP/ENT</sup>

--- a/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
+++ b/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
@@ -38,9 +38,15 @@ Make sure to select the options **Boundary Client Agent**, **CLI**, and **Deskto
 
 The following section details how to configure targets and test the transparent sessions public beta feature.
 
-If you use a cluster that was created earlier than release 0.16.0, you must add the grant `list-resolvable-aliases` so that the client agent can populate the local alias cache.
+<Tip>
 
-As an example, you could add the grant `type=user;actions=list-resolvable-aliases;ids=*`.
+  If you use a cluster that was created earlier than release 0.16.0, you must add the grant `list-resolvable-aliases` so that the client agent can populate the local alias cache.
+
+  As an example, you could add the grant:
+   
+  `type=user;actions=list-resolvable-aliases;ids=*`.
+
+</Tip>
 
 Complete the following steps to configure targets and test transparent sessions:
 

--- a/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
+++ b/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
@@ -63,30 +63,30 @@ When you have validated that transparent sessions work, you can create and estab
 
 To establish transparent sessions to other services:
 
-1. Make a list of the services you use
-1. Create workers as needed for network partitions
-1. Add the services to Boundary as targets
-1. [Create aliases for the targets](/boundary/docs/configuration/target-aliases/create-target-alias)
-1. Connect to the target using your client of choice
+1. Make a list of the services you use.
+1. Create workers as needed for network partitions.
+1. Add the services to Boundary as targets.
+1. [Create aliases for the targets](/boundary/docs/configuration/target-aliases/create-target-alias).
+1. Connect to the target using your client of choice.
 
 ## Connect using transparent sessions
 
-Without transparent sessions, clients must use the [Boundary connect helpers](/boundary/docs/concepts/connection-workflows) to establish a session:
+Without transparent sessions, you must use the [Boundary connect helpers](/boundary/docs/concepts/connection-workflows) to establish a session:
 
 ```shell-session
 $ boundary connect ssh -target-name sql-database -target-scope-name -staging
 ```
 
-Or use the Boundary Desktop Client app to start a session, and connect on a local port supplied by Boundary:
+Alternatively, you can use the Boundary Desktop Client to start a session, and connect on a local port supplied by Boundary:
 
 ```shell-session
 $ ssh 127.0.0.1 -p 55374
 ```
 
-With transparent sessions, the target alias is used as the address to esablish a session. If the [client agent is running](#install-the-boundary-clients), you can use the alias to start a session:
+With transparent sessions, you use the target alias as the address to establish a session. If the [client agent is running](#install-the-boundary-clients), you can use the alias to start a session:
 
 ```shell-session
 $ ssh my.alias.name
 ```
 
-Boundary will then start the session as usual, and broker or inject any credentials you have configured.
+Boundary starts the session as usual, and brokers or injects any credentials you have configured.

--- a/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
+++ b/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
@@ -1,0 +1,92 @@
+---
+layout: docs
+page_title: Configure transparent sessions
+description: >-
+  Learn how to configure transparent sessions to enhance end-user workflows and simplify target access.
+---
+
+# Configure transparent sessions
+
+@include 'alerts/enterprise-only.mdx'
+
+@include 'alerts/beta.mdx'
+
+## Requirements
+
+Before you configure transparent sessions, you must:
+
+- Ensure that the Boundary CLI and Boundary Desktop are not installed in the environment in which you want to run the transparent sessions beta.
+- Download the appropriate Boundary installer for your Windows or MacOS environment from the [Install Boundary](/boundary/install#installer) page or the [releases](https://releases.hashicorp.com/boundary-installer) page.
+
+## Install the Boundary clients
+
+Complete the following steps to install the Boundary Client Agent, CLI, and Desktop client:
+
+1. Install Boundary using the installer.
+Make sure to select the options **Boundary Client Agent**, **CLI**, and **Desktop**.
+1. Open the CLI and type the following command to confirm that the version is 0.18.0:
+   ```shell-session
+   $ boundary version
+   ```
+1. In the CLI, run the status command to confirm that the Boundary Client Agent has started:
+
+   ```shell-session
+   $ boundary client-agent status
+   ```
+
+## Configure targets
+
+The following section details how to configure targets and test the transparent sessions public beta feature.
+
+If you use a cluster that was created earlier than release 0.16.0, you must add the grant `list-resolvable-aliases` so that the client agent can populate the local alias cache.
+
+As an example, you could add the grant `type=user;actions=list-resolvable-aliases;ids=*`.
+
+Complete the following steps to configure targets and test transparent sessions:
+
+1. Authenticate to Boundary using the CLI or Desktop client.
+1. [Create a new target with an alias](/boundary/docs/concepts/aliases#create-an-alias-during-target-creation) or [create an alias for an existing target](/boundary/docs/concepts/aliases#create-an-alias-for-an-existing-target).
+Ensure that you have authorization to establish a session to the target.
+1. Open the client of your choice and [connect to your target using the alias](/boundary/docs/concepts/aliases#connect-to-a-target-using-an-alias).
+
+   Boundary routes your session using the Boundary Client Agent.
+   You can validate that Boundary routed the session by looking at the **Sessions** page in the Desktop client, by typing `boundary sessions list -recursive` in the CLI, or by looking at sessions managed by the Client Agent using `boundary client-agent sessions`.
+
+   <Note>
+
+   The Client Agent periodically requests an updated list of aliases from the controller, so the alias may not work immediately after you create it.
+   The alias should be updated in the Client Agent within 2 minutes. If you still see connection issues after 2 minutes, follow the troubleshooting steps in [the Client Agent troubleshooting guide](/boundary/docs/api-clients/client-agent#troubleshooting).
+
+   </Note>
+
+When you have validated that transparent sessions work, you can create and establish transparent sessions to other services.
+
+To establish transparent sessions to other services:
+
+1. Make a list of the services you use
+1. Create workers as needed for network partitions
+1. Add the services to Boundary as targets
+1. [Create aliases for the targets](/boundary/docs/configuration/target-aliases/create-target-alias)
+1. Connect to the target using your client of choice
+
+## Connect using transparent sessions
+
+Without transparent sessions, clients must use the [Boundary connect helpers](/boundary/docs/concepts/connection-workflows) to establish a session:
+
+```shell-session
+$ boundary connect ssh -target-name sql-database -target-scope-name -staging
+```
+
+Or use the Boundary Desktop Client app to start a session, and connect on a local port supplied by Boundary:
+
+```shell-session
+$ ssh 127.0.0.1 -p 55374
+```
+
+With transparent sessions, the target alias is used as the address to esablish a session. If the [client agent is running](#install-the-boundary-clients), you can use the alias to start a session:
+
+```shell-session
+$ ssh my.alias.name
+```
+
+Boundary will then start the session as usual, and broker or inject any credentials you have configured.

--- a/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
+++ b/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
@@ -83,7 +83,7 @@ Alternatively, you can use the Boundary Desktop Client to start a session, and c
 $ ssh 127.0.0.1 -p 55374
 ```
 
-With transparent sessions, you use the target alias as the address to establish a session. If the [client agent is running](#install-the-boundary-clients), you can use the alias to start a session:
+With transparent sessions, you use the target alias as the address to establish a session. If the [client agent is running](#install-the-boundary-clients) and you have authenticated using the CLI or Boundary Desktop Client, you can use the alias to start a session:
 
 ```shell-session
 $ ssh my.alias.name

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -584,6 +584,32 @@
         ]
       },
       {
+        "title": "Aliases and transparent sessions",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "configuration/target-aliases"
+          },
+          {
+            "title": "Create a target alias",
+            "path": "configuration/target-aliases/create-target-alias"
+          },
+          {
+            "title": "Connect using a target alias",
+            "path": "configuration/target-aliases/connect-target-alias"
+          },          
+          {
+            "title": "Connect using transparent sessions",
+            "badge": {
+              "text": "HCP/ENT BETA",
+              "type": "outlined",
+              "color": "neutral"
+            },
+            "path": "configuration/target-aliases/transparent-sessions"
+          }
+        ]
+      },
+      {
         "title": "Events",
         "routes": [
           {


### PR DESCRIPTION
[Aliases and transparent sessions overview](https://boundary-1mnmk7a65-hashicorp.vercel.app//boundary/docs/configuration/target-aliases)
[Aliases concepts page](https://boundary-1mnmk7a65-hashicorp.vercel.app/boundary/docs/concepts/aliases)
[Transparent sessions concepts page](https://boundary-1mnmk7a65-hashicorp.vercel.app/boundary/docs/concepts/transparent-sessions)

This PR adds usage docs for target aliases and transparent sessions.

- Adds new configuration/target-aliases book
  - Overview
  - Create target aliases
  - Connect to a target using an alias
  - Configure transparent sessions
- Migrates appropriate usage docs content from Concepts pages to the usage docs
- Adds a new configuration example for targets with a host ID specified