### PR TITLE
docs: add ssh host key error to known issues

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -512,10 +512,10 @@ Follow the troubleshooting steps to understand why the Client Agent is not able 
 
 #### WARNING! Remote host indentification has changed! It is possible that someone is doing something nasty!
 
-This issue typically arises when a user resumes the client-agent after a pause and attempts to connect to a target. 
-The error message is a result of the client-agent detecting a change in the remote host's identity due to change in remote worker IP address.
+This issue arises when using SSH to connect to an SSH target through an alias after the first successful connection to that alias. The issue is due to the way Boundary workers generate a new host key on every new SSH connection. The warning can safely be ignored using the `StrictHostKeyChecking=no` command line option:
 
-HashiCorp advises removing the existing server host key from the `~/.ssh/known_hosts` file.
+```shell-session
+$ ssh -o StrictHostKeyChecking=no targetalias.boundary.dev
 
 ## Conflicting software
 

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -510,6 +510,13 @@ $ boundary client-agent pause
 
 Follow the troubleshooting steps to understand why the Client Agent is not able to reach the controller.
 
+#### WARNING! Remote host indentification has changed! It is possible that someone is doing something nasty!
+
+This issue typically arises when a user resumes the client-agent after a pause and attempts to connect to a target. 
+The error message is a result of the client-agent detecting a change in the remote host's identity due to change in remote worker IP address.
+
+HashiCorp advises removing the existing server host key from the `~/.ssh/known_hosts` file.
+
 ## Conflicting software
 
 Some software is known to cause conflicts with the Boundary Client Agent.
@@ -618,7 +625,7 @@ You must restart the Client Agent for it to update its configuration with the ne
 </Tab>
 </Tabs>
 
-### Cloudflare WARP client
+### Cloudflare WARP client 
 
 The Cloudflare WARP client uses a local DNS server to direct traffic.
 It has built-in checks to prevent it from being run alongside other software that uses the same mechanism.

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -516,6 +516,9 @@ This issue arises when using SSH to connect to an SSH target through an alias af
 
 ```shell-session
 $ ssh -o StrictHostKeyChecking=no targetalias.boundary.dev
+```
+
+You can also remove the existing server host key from the `~/.ssh/known_hosts` file to avoid the error.
 
 ## Conflicting software
 

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -512,7 +512,7 @@ Follow the troubleshooting steps to understand why the Client Agent is not able 
 
 #### WARNING! Remote host indentification has changed! It is possible that someone is doing something nasty!
 
-This issue arises when using SSH to connect to an SSH target through an alias after the first successful connection to that alias. The issue is due to the way Boundary workers generate a new host key on every new SSH connection. The warning can safely be ignored using the `StrictHostKeyChecking=no` command line option:
+This error arises when you use an alias to connect to an SSH target after the first successful connection using that alias. The issue occurs because Boundary workers generate a new host key on every new SSH connection. You can safely ignore the warning using the `StrictHostKeyChecking=no` command line option:
 
 ```shell-session
 $ ssh -o StrictHostKeyChecking=no targetalias.boundary.dev

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -625,7 +625,7 @@ You must restart the Client Agent for it to update its configuration with the ne
 </Tab>
 </Tabs>
 
-### Cloudflare WARP client 
+### Cloudflare WARP client
 
 The Cloudflare WARP client uses a local DNS server to direct traffic.
 It has built-in checks to prevent it from being run alongside other software that uses the same mechanism.


### PR DESCRIPTION
host key error for man in the middle attack is commonly encountered while connecting ssh target, updated docs to help troubleshoot this issue.