### PR TITLE
chore(e2e): Increase worker instance size

### DIFF
--- a/enos/modules/aws_boundary/variables.tf
+++ b/enos/modules/aws_boundary/variables.tf
@@ -25,7 +25,7 @@ variable "worker_count" {
 variable "worker_instance_type" {
   description = "EC2 Instance type"
   type        = string
-  default     = "t2.micro"
+  default     = "t2.small"
 }
 
 variable "worker_type_tags" {
@@ -72,7 +72,7 @@ variable "controller_count" {
 variable "controller_instance_type" {
   description = "EC2 Instance type"
   type        = string
-  default     = "t2.micro"
+  default     = "t2.small"
 }
 
 variable "controller_ebs_iops" {

--- a/enos/modules/aws_worker/main.tf
+++ b/enos/modules/aws_worker/main.tf
@@ -10,6 +10,7 @@ terraform {
 }
 
 data "enos_environment" "current" {}
+data "aws_caller_identity" "current" {}
 
 locals {
   selected_az = data.aws_availability_zones.available.names[random_integer.az.result]
@@ -144,7 +145,7 @@ resource "aws_instance" "worker" {
   tags = merge(
     local.common_tags,
     {
-      Name = "${var.name_prefix}-boundary-worker",
+      Name = "${var.name_prefix}-boundary-worker-${split(":", data.aws_caller_identity.current.user_id)[1]}",
     },
   )
 }

--- a/enos/modules/aws_worker/variables.tf
+++ b/enos/modules/aws_worker/variables.tf
@@ -31,7 +31,7 @@ variable "ubuntu_ami_id" {
 variable "worker_instance_type" {
   description = "The EC2 Instance type to be used for the worker's node"
   type        = string
-  default     = "t2.micro"
+  default     = "t2.small"
 }
 
 variable "ssh_aws_keypair" {


### PR DESCRIPTION
This PR updates the e2e test suite to increase the size of the AWS worker instances. There were some AWS SDK updates that increased memory usage on workers, causing them to crash (and subsequently result in e2e test failures). This PR will resolve those failures in boundary-enterprise.

https://hashicorp.atlassian.net/browse/ICU-15786