### PR TITLE
Install boundary docs enhancements

### DIFF
--- a/website/content/docs/install-boundary/configure-controllers.mdx
+++ b/website/content/docs/install-boundary/configure-controllers.mdx
@@ -339,3 +339,9 @@ This allows you to configure targets within those scopes and manage them.
 
 HashiCorp recommends that you use the [KMS recovery workflow](/boundary/docs/install-boundary/initialize#log-in-with-recovery-kms) to log in to Boundary for the first time.
 Refer to [Creating your first login account](/boundary/docs/install-boundary/initialize#create-your-first-login-account) to learn about setting up your first auth method, user, account, and role to log in to Boundary going forward without the recovery KMS workflow.
+
+After configuring the controller, you should:
+
+- [Configure Boundary workers](/boundary/docs/install-boundary/configure-workers)
+- [Initialize Boundary](/boundary/docs/install-boundary/initialize)
+- [Install the Boundary Clients](/boundary/docs/install-boundary/install-clients)

--- a/website/content/docs/install-boundary/configure-workers.mdx
+++ b/website/content/docs/install-boundary/configure-workers.mdx
@@ -535,3 +535,8 @@ name, and admin password when prompted.
 
 </Tab>
 </Tabs>
+
+After configuring workers, you should:
+
+- [Initialize Boundary](/boundary/docs/install-boundary/initialize)
+- [Install the Boundary Clients](/boundary/docs/install-boundary/install-clients)

--- a/website/content/docs/install-boundary/deploy.mdx
+++ b/website/content/docs/install-boundary/deploy.mdx
@@ -205,7 +205,7 @@ binary:
 </Tab>
 </Tabs>
 
-You should install the binary on the controller and worker instances you configure to run in you Boundary environments. 
+You should install the binary on the controller and worker instances you configure to run in your Boundary environments. 
 
 Next, you should:
 

--- a/website/content/docs/install-boundary/deploy.mdx
+++ b/website/content/docs/install-boundary/deploy.mdx
@@ -36,7 +36,7 @@ the service runs.
 
 <Note>
 
-  You must complete the following steps for each Boundary controller and worker
+You must complete the following steps for each Boundary controller and worker
 node that you want to deploy. The binary operates as either a worker or
 controller, depending on the configuration that you generate for the
 Boundary binary.

--- a/website/content/docs/install-boundary/deploy.mdx
+++ b/website/content/docs/install-boundary/deploy.mdx
@@ -10,7 +10,7 @@ description: >-
 To deploy a self-managed Boundary environment you should:
 
 1. Deploy and configure Boundary controllers and workers
-2. Install end user clients
+2. Install end-user clients
 
 This guide outlines the required steps to manually install and configure a
 single HashiCorp Boundary cluster as defined in the [Recommended
@@ -205,7 +205,7 @@ binary:
 </Tab>
 </Tabs>
 
-You should install the binary on the controller and worker instances you are configuring to run in you Boundary environments. 
+You should install the binary on the controller and worker instances you configure to run in you Boundary environments. 
 
 Next, you should:
 

--- a/website/content/docs/install-boundary/deploy.mdx
+++ b/website/content/docs/install-boundary/deploy.mdx
@@ -1,17 +1,26 @@
 ---
 layout: docs
-page_title: Install Boundary
+page_title: Deploy Boundary
 description: >-
- Install a self-managed version of Boundary Enterprise or Community Edition on Ubuntu/Debian, CentOS/RHEL, or Amazon Linux using the binary file.
+ Deploy a self-managed version of Boundary Enterprise or Community Edition on Ubuntu/Debian, CentOS/RHEL, or Amazon Linux by installing the binary file.
 ---
 
-# Install Boundary
+# Deploy Boundary
+
+To deploy a self-managed Boundary environment you should:
+
+1. Deploy and configure Boundary controllers and workers
+2. Install end user clients
 
 This guide outlines the required steps to manually install and configure a
 single HashiCorp Boundary cluster as defined in the [Recommended
 architecture](/boundary/docs/install-boundary/recommended-architecture) topic.
 It assumes you install Boundary on virtual machines (VMs) or bare-metal servers
 running a Debian or Red Hat-based Linux distribution.
+
+You can also deploy Boundary using Terraform. Refer to the [Terraform patterns](/boundary/docs/install-boundary/terraform-patterns) page to learn more.
+
+To learn about installing end-user clients, refer to the [Install Boundary clients](/boundary/docs/install-boundary/install-clients) page.
 
 This document includes general guidance as well as specific recommendations for
 popular cloud infrastructure platforms. These recommendations have also been
@@ -27,10 +36,14 @@ In addition to installing the Boundary binary, the official package also
 provides a systemd service unit, and a local `boundary` user account under which
 the service runs.
 
-You must complete the following steps for each Boundary controller and worker
+<Note>
+
+  You must complete the following steps for each Boundary controller and worker
 node that you want to deploy. The binary operates as either a worker or
-controller, depending on the subsequent configuration that you generate for the
+controller, depending on the configuration that you generate for the
 Boundary binary.
+
+</Note>
 
 The steps vary by Linux distribution.
 
@@ -39,6 +52,7 @@ binary:
 
 <Tabs>
 <Tab heading="Enterprise">
+
 <Tabs>
 <Tab heading="Ubuntu/Debian">
 
@@ -190,3 +204,12 @@ binary:
 </Tabs>
 </Tab>
 </Tabs>
+
+You should install the binary on the controller and worker instances you are configuring to run in you Boundary environments. 
+
+Next, you should:
+
+- [Configure Boundary controllers](/boundary/docs/install-boundary/configure-controllers)
+- [Configure Boundary workers](/boundary/docs/install-boundary/configure-workers)
+- [Initialize Boundary](/boundary/docs/install-boundary/initialize)
+- [Install the Boundary Clients](/boundary/docs/install-boundary/install-clients)

--- a/website/content/docs/install-boundary/deploy.mdx
+++ b/website/content/docs/install-boundary/deploy.mdx
@@ -18,8 +18,6 @@ architecture](/boundary/docs/install-boundary/recommended-architecture) topic.
 It assumes you install Boundary on virtual machines (VMs) or bare-metal servers
 running a Debian or Red Hat-based Linux distribution.
 
-You can also deploy Boundary using Terraform. Refer to the [Terraform patterns](/boundary/docs/install-boundary/terraform-patterns) page to learn more.
-
 To learn about installing end-user clients, refer to the [Install Boundary clients](/boundary/docs/install-boundary/install-clients) page.
 
 This document includes general guidance as well as specific recommendations for

--- a/website/content/docs/install-boundary/index.mdx
+++ b/website/content/docs/install-boundary/index.mdx
@@ -7,8 +7,22 @@ description: >-
 
 # Overview
 
-This section details installing Boundary in a self-managed environment.
+This section details deploying Boundary in a self-managed environment.
 You can use the topics in this section to install the Community Edition or the Enterprise version of Boundary.
 The section also includes reference architecture, system requirement recommendations, and best practices.
 
 To deploy HCP Boundary instead, refer to the [HCP Boundary Get Started section](/boundary/docs/hcp/get-started/deploy-and-login).
+
+This section outlines the following topics for deploying your self-managed environment:
+
+- Architectural considerations
+  - [System requirements](/boundary/docs/install-boundary/architecture/system-requirements)
+  - [Recommended architecture](/boundary/docs/install-boundary/architecture/recommended-architecture)
+  - [Fault tolerance](/boundary/docs/install-boundary/architecture/fault-tolerance)
+  - [High availability](/boundary/docs/install-boundary/architecture/high-availability)
+- [Deploy Boundary](/boundary/docs/install-boundary/deploy)
+- [Configure controllers](/boundary/docs/install-boundary/configure-controllers)
+- [Configure workers](/boundary/docs/install-boundary/configure-workers)
+- [Initialize Boundary](/boundary/docs/install-boundary/initialize)
+- [Install Boundary clients](/boundary/docs/install-boundary/install-clients)
+- [Terraform patterns](/boundary/docs/install-boundary/terraform-patterns)

--- a/website/content/docs/install-boundary/initialize.mdx
+++ b/website/content/docs/install-boundary/initialize.mdx
@@ -10,6 +10,8 @@ description: >-
 This document describes how to access Boundary for the first time and create the necessary resources to log in as a
 user.
 
+You can also initialize and manage Boundary using Terraform. Refer to the [Terraform patterns](/boundary/docs/install-boundary/terraform-patterns) page to learn more.
+
 ## Requirements
 
 Before you initialize Boundary, you should have [initialized a database](/boundary/docs/install-boundary/configure-controllers#initialize-the-database).

--- a/website/content/docs/install-boundary/initialize.mdx
+++ b/website/content/docs/install-boundary/initialize.mdx
@@ -460,3 +460,9 @@ resource "boundary_role" "project_admin" {
 boundary authenticate password \
   -auth-method-id <auth_method_id>
 ```
+
+After initializing Boundary, you should:
+
+Next, you should:
+
+- [Install the Boundary Clients](/boundary/docs/install-boundary/install-clients)

--- a/website/content/docs/install-boundary/install-clients.mdx
+++ b/website/content/docs/install-boundary/install-clients.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Install Boundary clients
 description: >-
- Install the Boundary CLI, Boundary Desktop Client app, or Boundary Installer for Boundary Enterprise or Community Edition on Windows, MacOS, or Linux.
+ Install the Boundary CLI, Boundary Desktop Client app, or Boundary installer for Boundary Enterprise or Community Edition on Windows, MacOS, or Linux.
 ---
 
 # Install Boundary clients
@@ -23,7 +23,7 @@ correct clients:
 
 @include 'alerts/beta.mdx'
 
-The Boundary Installer bundles together the following components:
+The Boundary installer bundles together the following components:
 
 - Boundary binary (CLI)
 - Boundary Desktop Client app
@@ -33,7 +33,7 @@ Download the appropriate Boundary installer for your Windows, MacOS, or Linux en
 
 <Warning>
 
-  Before you launch the Boundary Installer, ensure that you have uninstalled all previous versions of the Boundary binary and Boundary Desktop Client app.
+  Before you launch the Boundary installer, ensure that you have uninstalled all previous versions of the Boundary binary and Boundary Desktop Client app.
 
 </Warning>
 

--- a/website/content/docs/install-boundary/install-clients.mdx
+++ b/website/content/docs/install-boundary/install-clients.mdx
@@ -11,9 +11,9 @@ Boundary end users access infrastructure targets using the Boundary Desktop Clie
 
 This guide outlines the required steps to manually install and configure a Boundary client depending on which distribution of Boundary end-users are accessing.
 
-To learn about installing the Boundary binary when deploying Boundary controllers or workers, refer to the [Deploy Boundary](/boundary/docs/install-boundary/deploy) page.
+To learn about installing the Boundary binary when you deploy Boundary controllers or workers, refer to the [Deploy Boundary](/boundary/docs/install-boundary/deploy) page.
 
-Select your distribution of Boundary, and complete the steps to install the
+Select your Boundary distribution, and complete the steps to install the
 correct clients:
 
 <Tabs>
@@ -33,7 +33,7 @@ Download the appropriate Boundary installer for your Windows, MacOS, or Linux en
 
 <Warning>
 
-  Before launching the Boundary Installer, ensure that you have uninstalled all previous versions of the Boundary binary and Boundary Desktop Client app.
+  Before you launch the Boundary Installer, ensure that you have uninstalled all previous versions of the Boundary binary and Boundary Desktop Client app.
 
 </Warning>
 
@@ -42,7 +42,7 @@ To learn more about installing the Boundary CLI and Boundary Desktop Client app,
 </Tab>
 <Tab heading="Community Edition">
 
-The following components are recommended for end-users:
+We recommend the following components for end users:
 
 - Boundary binary (CLI)
 - Boundary Desktop Client app

--- a/website/content/docs/install-boundary/install-clients.mdx
+++ b/website/content/docs/install-boundary/install-clients.mdx
@@ -9,7 +9,7 @@ description: >-
 
 Boundary end users access infrastructure targets using the Boundary Desktop Client app or the Boundary CLI. Enterprise or HCP Boundary users can use transparent sessions to proxy traffic though the Boundary Client Agent <sup>HCP/ENT</sup>.
 
-This guide outlines the required steps to manually install and configure a Boundary client depending on which distribution of Boundary end-users are accessing.
+This guide outlines the required steps to manually install and configure a Boundary client depending on which distribution of Boundary end users access.
 
 To learn about installing the Boundary binary when you deploy Boundary controllers or workers, refer to the [Deploy Boundary](/boundary/docs/install-boundary/deploy) page.
 

--- a/website/content/docs/install-boundary/install-clients.mdx
+++ b/website/content/docs/install-boundary/install-clients.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Install Boundary clients
 
-Boundary end users access infrastructure targets using the Boundary Desktop Client app or the Boundary CLI. Enterprise or HCP Boundary users can use transparent sessions to proxy traffic though the Boundary Client Agent <sup>HCP/ENT</sup>.
+Boundary end users access infrastructure targets using the Boundary Desktop Client app or the Boundary CLI. Enterprise or HCP Boundary users can use transparent sessions to proxy traffic through the Boundary Client Agent <sup>HCP/ENT</sup>.
 
 This guide outlines the required steps to manually install and configure a Boundary client depending on which distribution of Boundary end users access.
 

--- a/website/content/docs/install-boundary/install-clients.mdx
+++ b/website/content/docs/install-boundary/install-clients.mdx
@@ -21,13 +21,17 @@ correct clients:
 
 @include 'alerts/enterprise-only.mdx'
 
-@include 'alerts/beta.mdx'
+<Note>
+
+  The Boundary installer includes the Boundary Client Agent, which is a beta feature. For production environments, consider downloading the Boundary binary and Boundary Desktop Client directly from the [Install Boundary](/boundary/install) page.
+
+</Note>
 
 The Boundary installer bundles together the following components:
 
 - Boundary binary (CLI)
 - Boundary Desktop Client app
-- Boundary Client Agent <sup>HCP/ENT</sup>
+- Boundary Client Agent <sup>HCP/ENT</sup> <sup>BETA</sup>
 
 Download the appropriate Boundary installer for your Windows, MacOS, or Linux environment from the [Install Boundary](/boundary/install#installer) page or the [releases](https://releases.hashicorp.com/boundary-installer) page. You can also download the components individually, but compatibility is not guaranteed. Refer to the [Supported versions policy](/boundary/docs/enterprise/supported-versions#control-plane-and-client-cli-compatibility) to learn more.
 

--- a/website/content/docs/install-boundary/install-clients.mdx
+++ b/website/content/docs/install-boundary/install-clients.mdx
@@ -1,0 +1,61 @@
+---
+layout: docs
+page_title: Install Boundary clients
+description: >-
+ Install the Boundary CLI, Boundary Desktop Client app, or Boundary Installer for Boundary Enterprise or Community Edition on Windows, MacOS, or Linux.
+---
+
+# Install Boundary clients
+
+Boundary end users access infrastructure targets using the Boundary Desktop Client app or the Boundary CLI. Enterprise or HCP Boundary users can use transparent sessions to proxy traffic though the Boundary Client Agent <sup>HCP/ENT</sup>.
+
+This guide outlines the required steps to manually install and configure a Boundary client depending on which distribution of Boundary end-users are accessing.
+
+To learn about installing the Boundary binary when deploying Boundary controllers or workers, refer to the [Deploy Boundary](/boundary/docs/install-boundary/deploy) page.
+
+Select your distribution of Boundary, and complete the steps to install the
+correct clients:
+
+<Tabs>
+<Tab heading="Enterprise">
+
+@include 'alerts/enterprise-only.mdx'
+
+@include 'alerts/beta.mdx'
+
+The Boundary Installer bundles together the following components:
+
+- Boundary binary (CLI)
+- Boundary Desktop Client app
+- Boundary Client Agent <sup>HCP/ENT</sup>
+
+Download the appropriate Boundary installer for your Windows, MacOS, or Linux environment from the [Install Boundary](/boundary/install#installer) page or the [releases](https://releases.hashicorp.com/boundary-installer) page. You can also download the components individually, but compatibility is not guaranteed. Refer to the [Supported versions policy](/boundary/docs/enterprise/supported-versions#control-plane-and-client-cli-compatibility) to learn more.
+
+<Warning>
+
+  Before launching the Boundary Installer, ensure that you have uninstalled all previous versions of the Boundary binary and Boundary Desktop Client app.
+
+</Warning>
+
+To learn more about installing the Boundary CLI and Boundary Desktop Client app, refer to the [Get started with HCP Boundary](/boundary/tutorials/get-started-hcp) tutorials. 
+
+</Tab>
+<Tab heading="Community Edition">
+
+The following components are recommended for end-users:
+
+- Boundary binary (CLI)
+- Boundary Desktop Client app
+
+Download these components for your Windows, MacOS, or Linux environment from the [Install Boundary](/boundary/install) page or the [HashiCorp releases](https://releases.hashicorp.com/) page. 
+
+<Warning>
+
+Client compatibility is not guaranteed. You should always ensure that your client is compatible with the version of the Boundary control plane you are connecting to. Refer to the [Supported versions policy](/boundary/docs/enterprise/supported-versions#control-plane-and-client-cli-compatibility) to learn more.
+
+</Warning>
+
+To learn more about installing the Boundary CLI and Boundary Desktop Client app, refer to the [Get started with self-managed Boundary](/boundary/tutorials/get-started-community) tutorials. 
+
+</Tab>
+</Tabs>

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -108,8 +108,8 @@
         ]
       },
       {
-        "title": "Install Boundary",
-        "path": "install-boundary/install"
+        "title": "Deploy Boundary",
+        "path": "install-boundary/deploy"
       },
       {
         "title": "Configure controllers",
@@ -122,6 +122,10 @@
       {
         "title": "Initialize Boundary",
         "path": "install-boundary/initialize"
+      },
+      {
+        "title": "Install Boundary clients",
+        "path": "install-boundary/install-clients"
       },
       {
         "title": "Systemd install",

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -94,6 +94,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/install-boundary/install',
+    destination: '/boundary/docs/install-boundary/deploy',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/install-boundary/fault-tolerance',
     destination: '/boundary/docs/install-boundary/architecture/fault-tolerance',
     permanent: true,


### PR DESCRIPTION
[Install clients deploy preview](https://boundary-9cgc3130q-hashicorp.vercel.app/boundary/docs/install-boundary/install-clients)
 
This PR adds enhancements for the Install Boundary docs:

- renames the install-boundary/install page to install-boundary/deploy
- adds appropriate redirects
- adds copy to distinguish between installing the binary and installing the clients 
- adds an install-boundary/clients page to detailing which clients to install based on distribution
- updates copy to include TOC and clear deployment steps