### PR TITLE
docs: clarify behavior of launchctl stop and unload for client agent

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -277,7 +277,7 @@ If you want to disable the Boundary Client Agent, you can stop it with the follo
 $ sudo launchctl unload -w /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
 ```
 
-Unloading the Boundary client agent removes its launch daemon configuration. To restart the agent, use:
+Unloading the Boundary Client Agent removes its launch daemon configuration. To restart the Client Agent, use:
 
 ```shell-session
 $ sudo launchctl load -w /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -274,14 +274,12 @@ If you want to disable the Boundary Client Agent, you can stop it with the follo
 <Tab heading="MacOS" group="macos">
 
 ```shell-session
-$ sudo launchctl stop com.hashicorp.boundary.boundary-client-agent
+$ sudo launchctl unload -w /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
 ```
 
 <Note>
 
-Stopping the Boundary client agent using `launchctl stop` only halts it temporarily, as the `StartInterval` setting causes it to restart automatically after 60 seconds.
-
-**To disable it permanently**, you must unload the service using `launchctl unload`. Unloading not only stops the agent but also removes its configuration from `launchd`. To restart the agent after unloading, you must reload it using `launchctl load`, as the `start` command will not work in this case.
+Unloading the Boundary client agent removes its launch daemon configuration. To restart the agent, use `sudo launchctl load ...`
 
 </Note>
 

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -277,6 +277,14 @@ If you want to disable the Boundary Client Agent, you can stop it with the follo
 $ sudo launchctl stop com.hashicorp.boundary.boundary-client-agent
 ```
 
+<Note>
+
+Stopping the Boundary client agent using `launchctl stop` only halts it temporarily, as the `StartInterval` setting causes it to restart automatically after 60 seconds.
+
+**To disable it permanently**, you must unload the service using `launchctl unload`. Unloading not only stops the agent but also removes its configuration from `launchd`. To restart the agent after unloading, you must reload it using `launchctl load`, as the `start` command will not work in this case.
+
+</Note>
+
 </Tab>
 <Tab heading="Windows" group="windows">
 

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -277,11 +277,11 @@ If you want to disable the Boundary Client Agent, you can stop it with the follo
 $ sudo launchctl unload -w /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
 ```
 
-<Note>
+Unloading the Boundary client agent removes its launch daemon configuration. To restart the agent, use:
 
-Unloading the Boundary client agent removes its launch daemon configuration. To restart the agent, use `sudo launchctl load ...`
-
-</Note>
+```shell-session
+$ sudo launchctl load -w /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
+```
 
 </Tab>
 <Tab heading="Windows" group="windows">


### PR DESCRIPTION
This pull request updates the macOS client agent documentation to clarify the behavior of `launchctl stop` and `launchctl unload`. It adds a note explaining that `launchctl stop` stops the agent temporarily, but the agent will automatically restart after 60 seconds due to the `StartInterval` setting. Additionally, the update provides information on using `launchctl unload` to permanently disable the client agent, in case users need to do so for specific reasons.