### PR TITLE
test(e2e): Fix failure in migration test

### DIFF
--- a/testing/internal/e2e/infra/docker.go
+++ b/testing/internal/e2e/infra/docker.go
@@ -172,7 +172,7 @@ func StartBoundary(t testing.TB, pool *dockertest.Pool, network *dockertest.Netw
 		Mounts:       []string{path.Dir(boundaryConfigFilePath) + ":/boundary/"},
 		Name:         "boundary",
 		Networks:     []*dockertest.Network{network},
-		ExposedPorts: []string{"9200", "9201", "9202", "9203"},
+		ExposedPorts: []string{"9200/tcp", "9201/tcp", "9202/tcp", "9203/tcp"},
 		PortBindings: map[docker.Port][]docker.PortBinding{
 			"9200/tcp": {{HostIP: "localhost", HostPort: "9200/tcp"}},
 			"9201/tcp": {{HostIP: "localhost", HostPort: "9201/tcp"}},
@@ -212,7 +212,7 @@ func StartVault(t testing.TB, pool *dockertest.Pool, network *dockertest.Network
 		},
 		Name:         "vault",
 		Networks:     []*dockertest.Network{network},
-		ExposedPorts: []string{"8200"},
+		ExposedPorts: []string{"8200/tcp"},
 		PortBindings: map[docker.Port][]docker.PortBinding{
 			"8200/tcp": {{HostIP: "localhost", HostPort: "8210/tcp"}},
 		},

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -181,16 +181,17 @@ func setupEnvironment(t testing.TB, c *config, boundaryRepo, boundaryTag string)
 
 	t.Log("Waiting for Boundary to finish loading...")
 	err = pool.Retry(func() error {
-		response, err := http.Get(b.UriLocalhost)
+		response, err := http.Get(fmt.Sprintf("%s/health", b.UriLocalhost))
 		if err != nil {
-			t.Logf("Could not access Boundary URL: %s. Retrying...", err.Error())
+			t.Logf("Could not access health endpoint: %s. Retrying...", err.Error())
 			return err
 		}
 
 		if response.StatusCode != http.StatusOK {
-			return fmt.Errorf("Could not connect to %s. Status Code: %d", b.UriLocalhost, response.StatusCode)
+			return fmt.Errorf("Health check returned an error. Status Code: %d", response.StatusCode)
 		}
 
+		response.Body.Close()
 		return nil
 	})
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/database/testdata/boundary-config.hcl
+++ b/testing/internal/e2e/tests/database/testdata/boundary-config.hcl
@@ -91,7 +91,7 @@ events {
     ]
 
     file {
-      path      = "/logs"
+      path      = "/boundary/logs"
       file_name = "audit.log"
     }
 


### PR DESCRIPTION
This PR addresses an e2e test failure that started appearing around October 14, 2024. The PR adjusts the test to wait for the controller to finish starting up before proceeding.  

https://hashicorp.atlassian.net/browse/ICU-15656