### PR TITLE
chore: update gcp plugin module name

### DIFF
--- a/plugins/boundary/mains/gcp/go.mod
+++ b/plugins/boundary/mains/gcp/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/boundary/plugins/boundary/mains/aws
+module github.com/hashicorp/boundary/plugins/boundary/mains/gcp
 
 go 1.23.1
 


### PR DESCRIPTION
The module name for `go.mod` should be `gcp` not `aws` since it is in the `gcp` package