### PR TITLE
chore(e2e): Add object expiration policy to s3 bucket

### DIFF
--- a/enos/modules/aws_bucket/main.tf
+++ b/enos/modules/aws_bucket/main.tf
@@ -7,6 +7,17 @@ resource "aws_s3_bucket" "default" {
   bucket_prefix = "enos-${random_pet.default.id}-"
   force_destroy = true
   tags          = local.common_tags
+
+resource "aws_s3_bucket_lifecycle_configuration" "example" {
+  bucket = aws_s3_bucket.default.id
+
+  rule {
+    id = "file_retention"
+    expiration {
+      days = 30
+    }
+    status = "Enabled"
+  }
 }
 
 data "aws_iam_policy_document" "default" {

--- a/enos/modules/aws_bucket/main.tf
+++ b/enos/modules/aws_bucket/main.tf
@@ -3,10 +3,18 @@
 
 resource "random_pet" "default" {}
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_s3_bucket" "default" {
   bucket_prefix = "enos-${random_pet.default.id}-"
   force_destroy = true
-  tags          = local.common_tags
+  tags = merge(
+    local.common_tags,
+    {
+      User = "${split(":", data.aws_caller_identity.current.user_id)[1]}"
+    },
+  )
+}
 
 resource "aws_s3_bucket_lifecycle_configuration" "example" {
   bucket = aws_s3_bucket.default.id


### PR DESCRIPTION
This PR updates the s3 bucket configuration to include an object expiration policy of 30 days. This is more specifically for use in the POC for internal long-running tests against the cloud platform. 

https://hashicorp.atlassian.net/browse/ICU-15062