### PR TITLE
internal/event: avoid reusing canceled context

### DIFF
--- a/internal/event/eventer.go
+++ b/internal/event/eventer.go
@@ -794,14 +794,18 @@ func (e *Eventer) ReleaseGate() error {
 		if qe == nil {
 			continue // we may have already sent this but gotten errors later
 		}
+		ctx, cancel := newSendCtx(qe.ctx)
+		if cancel != nil {
+			defer cancel()
+		}
 		var queuedOp string
 		switch t := qe.event.(type) {
 		case *sysEvent:
 			queuedOp = "system"
-			writeErr = e.writeSysEvent(qe.ctx, t, WithNoGateLocking(true))
+			writeErr = e.writeSysEvent(ctx, t, WithNoGateLocking(true))
 		case *err:
 			queuedOp = "error"
-			writeErr = e.writeError(qe.ctx, t, WithNoGateLocking(true))
+			writeErr = e.writeError(ctx, t, WithNoGateLocking(true))
 		default:
 			// Have no idea what this is and shouldn't have gotten in here to
 			// begin with, so just continue, and log it


### PR DESCRIPTION
Don't error in ReleaseGate if the context used for the original event has been cancelled. Any error in ReleaseGate causes the controller to terminate its startup. If a user was trying to send a request to the Boundary controller as it started up, the context tied to the request would be reused to attempt logging the observation associated with the request after the logging gate was released. This would always fail, as the context associated with the request was canceled.

We now use a new context timeout for events logged after the release gate is released, if the original context was canceled.

Fixes ICU-15809