### PR TITLE
chore: Clarify GrantHash behavior when there are no GrantTuples

### DIFF
--- a/internal/daemon/controller/auth/auth_test.go
+++ b/internal/daemon/controller/auth/auth_test.go
@@ -341,5 +341,5 @@ func TestGrantsHash(t *testing.T) {
 	hash3, err := res.GrantsHash(ctx)
 	require.NoError(t, err)
 	assert.False(t, bytes.Equal(hash1, hash3))
-	assert.False(t, bytes.Equal(hash1, hash3))
+	assert.False(t, bytes.Equal(hash2, hash3))
 }

--- a/internal/daemon/controller/auth/auth_test.go
+++ b/internal/daemon/controller/auth/auth_test.go
@@ -342,4 +342,13 @@ func TestGrantsHash(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, bytes.Equal(hash1, hash3))
 	assert.False(t, bytes.Equal(hash2, hash3))
+
+	// Recreate auth result with no grants, should return a slice of empty bytes
+	res.grants = nil
+	hash4, err := res.GrantsHash(ctx)
+	require.NoError(t, err)
+	assert.False(t, bytes.Equal(hash1, hash4))
+	assert.False(t, bytes.Equal(hash2, hash4))
+	assert.False(t, bytes.Equal(hash3, hash4))
+	assert.True(t, bytes.Equal([]byte{0, 0, 0, 0, 0, 0, 0, 0}, hash4))
 }

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -53,9 +53,10 @@ type GrantTuple struct {
 type GrantTuples []GrantTuple
 
 // GrantsHash returns a stable hash of all the grants in the GrantTuples.
+//
+// In the event that GrantTuples is nil, return a slice of empty bytes: []byte{0,0,0,0,0,0,0,0}
 func (g GrantTuples) GrantHash(ctx context.Context) ([]byte, error) {
 	const op = "perms.(GrantTuples).GrantHash"
-	// TODO: Should this return an error when the GrantTuples is empty?
 	var values []string
 	for _, grant := range g {
 		values = append(values, grant.Grant, grant.RoleId, grant.GrantScopeId)

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -207,9 +207,7 @@ func (g Grant) clone() *Grant {
 	}
 	if outFields, hasSetFields := g.OutputFields.Fields(); hasSetFields {
 		fieldsToAdd := make([]string, 0, len(outFields))
-		for _, v := range outFields {
-			fieldsToAdd = append(fieldsToAdd, v)
-		}
+		fieldsToAdd = append(fieldsToAdd, outFields...)
 		ret.OutputFields = ret.OutputFields.AddFields(fieldsToAdd)
 	}
 	return ret

--- a/internal/perms/grants_test.go
+++ b/internal/perms/grants_test.go
@@ -1083,6 +1083,18 @@ func TestHasActionOrSubaction(t *testing.T) {
 	}
 }
 
+func Test_HasNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	var gt GrantTuples
+
+	hash, err := gt.GrantHash(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 0}, hash)
+}
+
 func FuzzParse(f *testing.F) {
 	ctx := context.Background()
 	tc := []string{


### PR DESCRIPTION
- Add clarifying comment to `GrantHash` --> if GrantTuples is nil, return a slice of empty bytes: `[]byte{0000 0000}`
- Enforce this behavior with additional test cases