### PR TITLE
chore(e2e): Update AWS service user with required permission

### DIFF
--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -228,6 +228,7 @@ data "aws_iam_policy_document" "enos_policy_document" {
       "s3:HeadBucket",
       "s3:PutBucket*",
       "s3:ListBucket",
+      "s3:PutLifecycleConfiguration",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
This PR updates the terraform that manages the AWS service user used by CI with a new permission. This was needed after an update to the s3 bucket module that added an expiration date for objects in the bucket.

The change has already been applied to the service user and has resolved the failing e2e tests. This PR is just checking in those changes.