### PR TITLE
cmd: propagate keyring reading errors

### DIFF
--- a/internal/clientcache/cmd/cache/addtoken.go
+++ b/internal/clientcache/cmd/cache/addtoken.go
@@ -174,7 +174,7 @@ func (c *AddTokenCommand) Add(ctx context.Context, ui cli.Ui, apiClient *api.Cli
 
 		// Try to read the token from the keyring in a best effort way. Ignore
 		// any errors since the keyring may not be present on the system.
-		at := base.ReadTokenFromKeyring(ui, keyringType, tokenName)
+		at, _ := base.ReadTokenFromKeyring(ui, keyringType, tokenName)
 		if at != nil && (token == "" || pa.AuthTokenId == at.Id) {
 			pa.Keyring = &daemon.KeyringToken{
 				KeyringType: keyringType,

--- a/internal/clientcache/internal/cache/repository.go
+++ b/internal/clientcache/internal/cache/repository.go
@@ -20,7 +20,7 @@ const (
 )
 
 // KeyringTokenLookupFn takes a token name and returns the token from the keyring
-type KeyringTokenLookupFn func(keyring string, tokenName string) *authtokens.AuthToken
+type KeyringTokenLookupFn func(keyring string, tokenName string) (*authtokens.AuthToken, error)
 
 // BoundaryTokenReaderFn reads an auth token's resource information from boundary
 type BoundaryTokenReaderFn func(ctx context.Context, addr string, authToken string) (*authtokens.AuthToken, error)

--- a/internal/clientcache/internal/cache/repository_test.go
+++ b/internal/clientcache/internal/cache/repository_test.go
@@ -26,8 +26,8 @@ type ringToken struct {
 // mapBasedAuthTokenKeyringLookup provides a fake KeyringTokenLookupFn that uses
 // the provided map to perform lookups for the tokens
 func mapBasedAuthTokenKeyringLookup(m map[ringToken]*authtokens.AuthToken) KeyringTokenLookupFn {
-	return func(k, t string) *authtokens.AuthToken {
-		return m[ringToken{k, t}]
+	return func(k, t string) (*authtokens.AuthToken, error) {
+		return m[ringToken{k, t}], nil
 	}
 }
 

--- a/internal/clientcache/internal/cache/repository_token_test.go
+++ b/internal/clientcache/internal/cache/repository_token_test.go
@@ -154,6 +154,21 @@ func TestRepository_AddKeyringToken(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("When the keyring function errors", func(t *testing.T) {
+		keyringFn := func(keyring, tokenName string) (*authtokens.AuthToken, error) {
+			return nil, stderrors.New("keyring lookup function failed")
+		}
+		r, err := NewRepository(ctx, s, &sync.Map{}, keyringFn, sliceBasedAuthTokenBoundaryReader(boundaryAuthTokens))
+		require.NoError(t, err)
+
+		err = r.AddKeyringToken(ctx, "address", KeyringToken{
+			KeyringType: "k",
+			TokenName:   "t",
+			AuthTokenId: "at_1",
+		})
+		assert.ErrorContains(t, err, "keyring lookup function failed")
+	})
 }
 
 func TestRepository_AddRawToken(t *testing.T) {

--- a/internal/clientcache/internal/daemon/server.go
+++ b/internal/clientcache/internal/daemon/server.go
@@ -48,7 +48,7 @@ const (
 // and retrieve the keyring and token information used by a command.
 type Commander interface {
 	ClientProvider
-	ReadTokenFromKeyring(keyringType, tokenName string) *authtokens.AuthToken
+	ReadTokenFromKeyring(keyringType, tokenName string) (*authtokens.AuthToken, error)
 }
 
 // ClientProvider is an interface that provides an api.Client

--- a/internal/clientcache/internal/daemon/token_handler_test.go
+++ b/internal/clientcache/internal/daemon/token_handler_test.go
@@ -33,8 +33,8 @@ type ringToken struct {
 // mapBasedAuthTokenKeyringLookup provides a fake KeyringTokenLookupFn that uses
 // the provided map to perform lookups for the tokens
 func mapBasedAuthTokenKeyringLookup(m map[ringToken]*authtokens.AuthToken) cache.KeyringTokenLookupFn {
-	return func(k, t string) *authtokens.AuthToken {
-		return m[ringToken{k, t}]
+	return func(k, t string) (*authtokens.AuthToken, error) {
+		return m[ringToken{k, t}], nil
 	}
 }
 

--- a/internal/cmd/base/base.go
+++ b/internal/cmd/base/base.go
@@ -350,8 +350,10 @@ func (c *Command) Client(opt ...Option) (*api.Client, error) {
 			return nil, err
 		}
 
-		authToken := c.ReadTokenFromKeyring(keyringType, tokenName)
-		if authToken != nil {
+		authToken, err := c.ReadTokenFromKeyring(keyringType, tokenName)
+		if err != nil {
+			c.UI.Error(err.Error())
+		} else {
 			c.client.SetToken(authToken.Token)
 		}
 	}

--- a/internal/cmd/commands/config/token.go
+++ b/internal/cmd/commands/config/token.go
@@ -136,7 +136,11 @@ func (c *TokenCommand) Run(args []string) (ret int) {
 			c.UI.Error(err.Error())
 			return base.CommandCliError
 		}
-		authToken = c.ReadTokenFromKeyring(keyringType, tokenName)
+		authToken, err = c.ReadTokenFromKeyring(keyringType, tokenName)
+		if err != nil {
+			c.UI.Error(err.Error())
+			return base.CommandCliError
+		}
 	} else {
 		// Fallback to env/CLI but we can only get just the token value this way, at
 		// least for now


### PR DESCRIPTION
Reading a token from the keyring can sometimes fail for reasons other than the token not being present in the keyring. This PR introduces a new error used to indicate that the token requested could not be found in the keyring and propagates errors from the keyring up to the caller, so that the caller can act on them.

Additionally, this fixes a bug in the client cache where it would incorrectly assume that a token had been removed from the keyring, when in fact there was an error reading from the keyring.