### PR TITLE
chore: update boundary-plugin-gcp dependency to latest version

### DIFF
--- a/plugins/boundary/mains/gcp/go.mod
+++ b/plugins/boundary/mains/gcp/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/boundary/plugins/boundary/mains/gcp
 go 1.23.1
 
 require (
-	github.com/hashicorp/boundary-plugin-gcp v0.0.0-20241120152221-baa2c7a2e742
+	github.com/hashicorp/boundary-plugin-gcp v0.0.0-20241217192246-c04cb367abb4
 	github.com/hashicorp/boundary/sdk v0.0.47
 )
 

--- a/plugins/boundary/mains/gcp/go.sum
+++ b/plugins/boundary/mains/gcp/go.sum
@@ -88,6 +88,8 @@ github.com/googleapis/gax-go/v2 v2.13.0 h1:yitjD5f7jQHhyDsnhKEBU52NdvvdSeGzlAnDP
 github.com/googleapis/gax-go/v2 v2.13.0/go.mod h1:Z/fvTZXF8/uw7Xu5GuslPw+bplx6SS338j1Is2S+B7A=
 github.com/hashicorp/boundary-plugin-gcp v0.0.0-20241120152221-baa2c7a2e742 h1:c4pftmjCNl8E58gxRo1pNmY63pGVz8qHDejeKKDtq34=
 github.com/hashicorp/boundary-plugin-gcp v0.0.0-20241120152221-baa2c7a2e742/go.mod h1:HC8FEkYf/kC0m1w0UiGcxDG6DsmEaVSNDSqFPWyspHc=
+github.com/hashicorp/boundary-plugin-gcp v0.0.0-20241217192246-c04cb367abb4 h1:TeL1WtjoBqIcJEy6HacPd1UPBUDGBv4mzwj/4hov1tE=
+github.com/hashicorp/boundary-plugin-gcp v0.0.0-20241217192246-c04cb367abb4/go.mod h1:3Azvm9j8CHcmBAIX8T0plHLNgwVfkucPM73McKjQx1o=
 github.com/hashicorp/boundary/sdk v0.0.47 h1:h5AXOASS2duHkCYEmNKnI9AR6YBZxD7VbFPV8BoE0z0=
 github.com/hashicorp/boundary/sdk v0.0.47/go.mod h1:9iOT7kDM6mYcSkKxNuZlv8rP7U5BG1kXoevjLLL8lNQ=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
bump GCP plugin version to the latest