### PR TITLE
docs: Update 0.18.x release notes

### DIFF
--- a/website/content/docs/release-notes/v0_18_0.mdx
+++ b/website/content/docs/release-notes/v0_18_0.mdx
@@ -44,10 +44,10 @@ description: >-
 
 <tr>
     <td style={{verticalAlign: 'middle'}}>
-    Go version 1.23.3 x509 key pair behavior changes
+    Go version 1.23 x509 key pair behavior changes
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Boundary version 0.18.2 uses Go version 1.23.3, which introduced a new x509 key pair behavior. Some VPN implementations struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.2 controllers or workers being unable to establish SSH connections. As a workaround, you can revert back to the previous key pair behavior.
+    Boundary version 0.18.x uses Go version 1.23, which introduced a new x509 key pair behavior. Some VPN implementations struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.x controllers or workers being unable to establish SSH connections. As a workaround, you can revert back to the previous key pair behavior.
     <br /><br />
     Learn more:&nbsp; <a href="#known-issues-and-breaking-changes">Known issues and breaking changes </a>
     </td>
@@ -242,13 +242,13 @@ description: >-
 
   <tr>
     <td style={{verticalAlign: 'middle'}}>
-    0.18.2
+    0.18.x
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Boundary version 0.18.2 controllers or workers are unable to establish SSH connections using the <code>boundary connect ssh</code> command
+    Boundary version 0.18.x controllers or workers are unable to establish SSH connections using the <code>boundary connect ssh</code> command
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Boundary version 0.18.2 uses Go version 1.23.3, which introduced a new x509 key pair behavior. Some VPN implementations struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.2 controllers or workers being unable to establish SSH connections.
+    Boundary version 0.18.x uses Go version 1.23, which introduced a new x509 key pair behavior. Some VPN implementations struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.x controllers or workers being unable to establish SSH connections.
     <br /><br />
     As a workaround, you can revert back to the previous key pair behavior by adding the <code>tlskyber=0</code> and <code>x509keypairleaf=0</code> parameters to the GODEBUG environment variable before the <code>boundary connect ssh command</code>. For example:
     <br /><br />

--- a/website/content/docs/release-notes/v0_18_0.mdx
+++ b/website/content/docs/release-notes/v0_18_0.mdx
@@ -44,10 +44,10 @@ description: >-
 
 <tr>
     <td style={{verticalAlign: 'middle'}}>
-    Go version 1.23 x509 key pair behavior changes
+    Go version 1.23 TLS handshake behavior changes
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Boundary version 0.18.x uses Go version 1.23, which introduced a new TLS handshake behavior. Some VPN providers struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.x controllers, workers or clients being unable to establish connections. As a workaround, you can revert back to the previous TLS handshake behavior.
+    Boundary version 0.18.x uses Go version 1.23, which introduced a new TLS handshake behavior. Some VPN providers struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.x controllers, workers, or clients being unable to establish connections. As a workaround, you can revert back to the previous TLS handshake behavior.
     <br /><br />
     Learn more:&nbsp; <a href="#known-issues-and-breaking-changes">Known issues and breaking changes </a>
     </td>
@@ -245,16 +245,16 @@ description: >-
     0.18.x
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Boundary version 0.18.x CLI is unable to establish connections using the <code>boundary connect</code> command.
+    Boundary version 0.18.x CLI is unable to establish connections using the <code>boundary connect</code> command
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Boundary version 0.18.x uses Go version 1.23, which introduced a new TLS handshake behavior. Some VPN providers struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.x controllers, workers or clients being unable to establish connections. As a workaround, you can revert back to the previous TLS handshake behavior.
+    Boundary version 0.18.x uses Go version 1.23, which introduced a new TLS handshake behavior. Some VPN providers struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.x controllers, workers, or clients being unable to establish connections. As a workaround, you can revert back to the previous TLS handshake behavior.
     <br /><br />
-    As a workaround, you can revert back to the previous TLS handshake behavior by adding the <code>tlskyber=0</code> parameters to the GODEBUG environment variable before the <code>boundary connect</code> command. For example:
+    To revert back to the previous TLS handshake behavior, add the <code>tlskyber=0</code> parameters to the GODEBUG environment variable before the <code>boundary connect</code> command. For example:
     <br /><br />
     <code>GODEBUG=tlskyber=0 boundary connect ssh -target-id &lt;ID&gt;</code>
     <br /><br />
-    Learn more: <a href="https://tip.golang.org/doc/go1.23">Go 1.23 Release Notes</a>
+    Learn more: <a href="https://github.com/golang/go/issues/70047">Go issue #70047</a> and <a href="https://tip.golang.org/doc/go1.23">Go 1.23 Release Notes</a>
     <br /><br />
     </td>
   </tr>

--- a/website/content/docs/release-notes/v0_18_0.mdx
+++ b/website/content/docs/release-notes/v0_18_0.mdx
@@ -41,6 +41,18 @@ description: >-
     Learn more:&nbsp; <a href="#known-issues-and-breaking-changes">Known issues and breaking changes </a>
     </td>
   </tr>
+
+<tr>
+    <td style={{verticalAlign: 'middle'}}>
+    Go version 1.23.3 x509 key pair behavior changes
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Boundary version 0.18.2 uses Go version 1.23.3, which introduced a new x509 key pair behavior. Some VPN implementations struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.2 controllers or workers being unable to establish SSH connections. As a workaround, you can revert back to the previous key pair behavior.
+    <br /><br />
+    Learn more:&nbsp; <a href="#known-issues-and-breaking-changes">Known issues and breaking changes </a>
+    </td>
+  </tr>
+
   </tbody>
 </table>
 
@@ -225,6 +237,25 @@ description: >-
     Learn more: <a href="https://discuss.hashicorp.com/t/hcsec-2024-28-boundary-controller-incorrectly-handles-http-requests-on-initialization-which-may-lead-to-a-denial-of-service">HCSEC-2024-28: Boundary controller incorrectly handles http requests on initialization which may lead to a denial of service</a>
     <br /><br />
     <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.18.2
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Boundary version 0.18.2 controllers or workers are unable to establish SSH connections using the <code>boundary connect ssh</code> command
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Boundary version 0.18.2 uses Go version 1.23.3, which introduced a new x509 key pair behavior. Some VPN implementations struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.2 controllers or workers being unable to establish SSH connections.
+    <br /><br />
+    As a workaround, you can revert back to the previous key pair behavior by adding the <code>tlskyber=0</code> and <code>x509keypairleaf=0</code> parameters to the GODEBUG environment variable before the <code>boundary connect ssh command</code>. For example:
+    <br /><br />
+    <code>GODEBUG=tlskyber=0,x509keypairleaf=0 boundary connect ssh -target-id&lt;ID&gt;</code>
+    <br /><br />
+    Learn more: <a href="https://tip.golang.org/doc/go1.23">Go 1.23 Release Notes</a>
+    <br /><br />
     </td>
   </tr>
 

--- a/website/content/docs/release-notes/v0_18_0.mdx
+++ b/website/content/docs/release-notes/v0_18_0.mdx
@@ -47,7 +47,7 @@ description: >-
     Go version 1.23 x509 key pair behavior changes
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Boundary version 0.18.x uses Go version 1.23, which introduced a new x509 key pair behavior. Some VPN implementations struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.x controllers or workers being unable to establish SSH connections. As a workaround, you can revert back to the previous key pair behavior.
+    Boundary version 0.18.x uses Go version 1.23, which introduced a new TLS handshake behavior. Some VPN providers struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.x controllers, workers or clients being unable to establish connections. As a workaround, you can revert back to the previous TLS handshake behavior.
     <br /><br />
     Learn more:&nbsp; <a href="#known-issues-and-breaking-changes">Known issues and breaking changes </a>
     </td>
@@ -245,14 +245,14 @@ description: >-
     0.18.x
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Boundary version 0.18.x controllers or workers are unable to establish SSH connections using the <code>boundary connect ssh</code> command
+    Boundary version 0.18.x CLI is unable to establish connections using the <code>boundary connect</code> command.
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Boundary version 0.18.x uses Go version 1.23, which introduced a new x509 key pair behavior. Some VPN implementations struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.x controllers or workers being unable to establish SSH connections.
+    Boundary version 0.18.x uses Go version 1.23, which introduced a new TLS handshake behavior. Some VPN providers struggle with the TLS handshake being sent over 2 frames instead of 1, which can lead to Boundary version 0.18.x controllers, workers or clients being unable to establish connections. As a workaround, you can revert back to the previous TLS handshake behavior.
     <br /><br />
-    As a workaround, you can revert back to the previous key pair behavior by adding the <code>tlskyber=0</code> and <code>x509keypairleaf=0</code> parameters to the GODEBUG environment variable before the <code>boundary connect ssh command</code>. For example:
+    As a workaround, you can revert back to the previous TLS handshake behavior by adding the <code>tlskyber=0</code> parameters to the GODEBUG environment variable before the <code>boundary connect</code> command. For example:
     <br /><br />
-    <code>GODEBUG=tlskyber=0,x509keypairleaf=0 boundary connect ssh -target-id&lt;ID&gt;</code>
+    <code>GODEBUG=tlskyber=0 boundary connect ssh -target-id &lt;ID&gt;</code>
     <br /><br />
     Learn more: <a href="https://tip.golang.org/doc/go1.23">Go 1.23 Release Notes</a>
     <br /><br />


### PR DESCRIPTION
Go version 1.23 added a new TLS handshake behavior. Some VPN providers struggle with the new behavior, and it may prevent 0.18.x Boundary clients from connecting. This PR adds a workaround to the known issues for 0.18.x that allows users to invoke the old TLS handshake behavior:

[View the update in the preview deployment](https://boundary-9ues2v8a8-hashicorp.vercel.app/boundary/docs/release-notes/v0_18_0)