### PR TITLE
test(cluster): split tests to improve parallelism

### DIFF
--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -529,7 +529,6 @@ func NewTestController(t testing.TB, opts *TestControllerOpts) *TestController {
 	var err error
 	tc.c, err = New(ctx, conf)
 	if err != nil {
-		tc.Shutdown()
 		t.Fatal(err)
 	}
 
@@ -552,7 +551,6 @@ func NewTestController(t testing.TB, opts *TestControllerOpts) *TestController {
 
 	if !opts.DisableAutoStart {
 		if err := tc.c.Start(); err != nil {
-			tc.Shutdown()
 			t.Fatal(err)
 		}
 	}

--- a/internal/daemon/worker/testing.go
+++ b/internal/daemon/worker/testing.go
@@ -72,6 +72,9 @@ func (tw *TestWorker) Name() string {
 func (tw *TestWorker) UpstreamAddrs() []string {
 	var addrs []string
 	lastStatus := tw.w.LastStatusSuccess()
+	if lastStatus == nil {
+		return addrs
+	}
 	for _, v := range lastStatus.GetCalculatedUpstreams() {
 		addrs = append(addrs, v.Address)
 	}
@@ -360,7 +363,6 @@ func NewTestWorker(t testing.TB, opts *TestWorkerOpts) *TestWorker {
 
 	tw.w, err = New(ctx, conf)
 	if err != nil {
-		tw.Shutdown()
 		t.Fatal(err)
 	}
 
@@ -387,7 +389,6 @@ func NewTestWorker(t testing.TB, opts *TestWorkerOpts) *TestWorker {
 
 	if !opts.DisableAutoStart {
 		if err := tw.w.Start(); err != nil {
-			tw.Shutdown()
 			t.Fatal(err)
 		}
 	}

--- a/internal/tests/cluster/parallel/anon_listing_test.go
+++ b/internal/tests/cluster/parallel/anon_listing_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package parallel
 
 import (
 	"testing"
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAnonListing(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	logger := hclog.New(&hclog.LoggerOptions{
 		Level: hclog.Trace,
@@ -28,7 +29,6 @@ func TestAnonListing(t *testing.T) {
 		InitialResourcesSuffix: "1234567890",
 		Logger:                 logger,
 	})
-	defer c1.Shutdown()
 
 	// Anon user has list and read permissions on scopes by default,
 	// verify that list scopes returns expected scope without setting token

--- a/internal/tests/cluster/parallel/doc.go
+++ b/internal/tests/cluster/parallel/doc.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+/*
+This package includes a set of tests that run in parallel.
+A test should only be added to this package if it can be
+completely isolated from other tests that currently exist
+in this package. If a test is consistently failing due to
+not having an isolated environment, it should be moved to
+the adjacent "sequential" package.
+*/
+
+package parallel

--- a/internal/tests/cluster/parallel/ipv6_listener_test.go
+++ b/internal/tests/cluster/parallel/ipv6_listener_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package parallel
 
 import (
 	"context"
@@ -32,13 +32,11 @@ func TestIPv6Listener(t *testing.T) {
 		Config: conf,
 		Logger: logger.Named("c1"),
 	})
-	defer c1.Shutdown()
 
 	c2 := c1.AddClusterControllerMember(t, &controller.TestControllerOpts{
 		Config: conf,
 		Logger: c1.Config().Logger.ResetNamed("c2"),
 	})
-	defer c2.Shutdown()
 
 	wg := new(sync.WaitGroup)
 	wg.Add(2)
@@ -61,7 +59,6 @@ func TestIPv6Listener(t *testing.T) {
 		InitialUpstreams: append(c1.ClusterAddrs(), c2.ClusterAddrs()...),
 		Logger:           logger.Named("w1"),
 	})
-	defer w1.Shutdown()
 
 	wg.Add(2)
 	go func() {

--- a/internal/tests/cluster/parallel/package_registry_test.go
+++ b/internal/tests/cluster/parallel/package_registry_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package parallel
 
 import (
 	// Enable tcp target support.

--- a/internal/tests/cluster/parallel/recursive_anon_listing_test.go
+++ b/internal/tests/cluster/parallel/recursive_anon_listing_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package parallel
 
 import (
 	"strings"
@@ -16,9 +16,9 @@ import (
 
 // This test validates the fix for ICU-2301
 func TestListAnonymousRecursing(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	tc := controller.NewTestController(t, nil)
-	defer tc.Shutdown()
 
 	client := tc.Client()
 	token := tc.Token()

--- a/internal/tests/cluster/sequential/doc.go
+++ b/internal/tests/cluster/sequential/doc.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+/*
+This package includes a set of tests that run sequentially.
+A test should be added to this package if it needs to be completely
+isolated from other tests. Newly added tests should not enable the
+testing parallel option. Please include a comment in the unit test
+that explains why the test must be ran sequentially. Tests that can
+be ran in parallel should be moved to the adjacent "parallel" package.
+*/
+
+package sequential

--- a/internal/tests/cluster/sequential/package_registry_test.go
+++ b/internal/tests/cluster/sequential/package_registry_test.go
@@ -1,0 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package sequential
+
+import (
+	// Enable tcp target support.
+	_ "github.com/hashicorp/boundary/internal/daemon/controller/handlers/targets/tcp"
+	_ "github.com/hashicorp/boundary/internal/target/tcp"
+)

--- a/internal/tests/cluster/sequential/session_cleanup_test.go
+++ b/internal/tests/cluster/sequential/session_cleanup_test.go
@@ -1,11 +1,12 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package sequential
 
 import (
 	"context"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -107,7 +108,7 @@ func testWorkerSessionCleanupSingle(burdenCase timeoutBurdenType) func(t *testin
 		)
 		require.NoError(err)
 		t.Cleanup(func() {
-			proxy.Close()
+			_ = proxy.Close()
 		})
 		require.NotEmpty(t, proxy.ListenerAddr())
 
@@ -117,11 +118,6 @@ func testWorkerSessionCleanupSingle(burdenCase timeoutBurdenType) func(t *testin
 			Logger:                              logger.Named("w1"),
 			SuccessfulStatusGracePeriodDuration: workerGracePeriod(burdenCase),
 		})
-
-		err = w1.Worker().WaitForNextSuccessfulStatusUpdate()
-		require.NoError(err)
-		err = c1.WaitForNextWorkerStatusUpdate(w1.Name())
-		require.NoError(err)
 		helper.ExpectWorkers(t, c1, w1)
 
 		// Use an independent context for test things that take a context so
@@ -163,7 +159,6 @@ func testWorkerSessionCleanupSingle(burdenCase timeoutBurdenType) func(t *testin
 			// Wait on worker, then check controller
 			sess.ExpectConnectionStateOnWorker(ctx, t, w1, session.StatusClosed)
 			sess.ExpectConnectionStateOnController(ctx, t, c1.Controller().ConnectionRepoFn, session.StatusConnected)
-
 		default:
 			// Should be closed on both worker and controller. Wait on
 			// worker then check controller.
@@ -237,8 +232,18 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 			PublicClusterAddr:               pl2.Addr().String(),
 			WorkerStatusGracePeriodDuration: controllerGracePeriod(burdenCase),
 		})
-		helper.ExpectWorkers(t, c1)
-		helper.ExpectWorkers(t, c2)
+
+		wg := new(sync.WaitGroup)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			helper.ExpectWorkers(t, c1)
+		}()
+		go func() {
+			defer wg.Done()
+			helper.ExpectWorkers(t, c2)
+		}()
+		wg.Wait()
 
 		// *************
 		// ** Proxy 1 **
@@ -251,7 +256,7 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 		)
 		require.NoError(err)
 		t.Cleanup(func() {
-			p1.Close()
+			_ = p1.Close()
 		})
 		require.NotEmpty(t, p1.ListenerAddr())
 
@@ -266,7 +271,7 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 		)
 		require.NoError(err)
 		t.Cleanup(func() {
-			p2.Close()
+			_ = p2.Close()
 		})
 		require.NotEmpty(t, p2.ListenerAddr())
 
@@ -279,19 +284,17 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 			Logger:                              logger.Named("w1"),
 			SuccessfulStatusGracePeriodDuration: workerGracePeriod(burdenCase),
 		})
-		// Worker needs some extra time to become ready, otherwise for a
-		// currently-unknown reason the next successful status update fails
-		// because it's not sent before the context times out.
-		time.Sleep(5 * time.Second)
 
-		err = w1.Worker().WaitForNextSuccessfulStatusUpdate()
-		require.NoError(err)
-		err = c1.WaitForNextWorkerStatusUpdate(w1.Name())
-		require.NoError(err)
-		err = c2.WaitForNextWorkerStatusUpdate(w1.Name())
-		require.NoError(err)
-		helper.ExpectWorkers(t, c1, w1)
-		helper.ExpectWorkers(t, c2, w1)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			helper.ExpectWorkers(t, c1, w1)
+		}()
+		go func() {
+			defer wg.Done()
+			helper.ExpectWorkers(t, c2, w1)
+		}()
+		wg.Wait()
 
 		// Use an independent context for test things that take a context so
 		// that we aren't tied to any timeouts in the controller, etc. This
@@ -327,16 +330,14 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 		// successful status report to ensure this.
 		event.WriteSysEvent(ctx, op, "pausing link to controller #1")
 		p1.Pause()
-		err = w1.Worker().WaitForNextSuccessfulStatusUpdate()
-		require.NoError(err)
+		helper.ExpectWorkers(t, c2, w1)
 		sConn.TestSendRecvAll(t)
 
 		// Resume first controller, pause second. This one should work too.
 		event.WriteSysEvent(ctx, op, "pausing link to controller #2, resuming #1")
 		p1.Resume()
 		p2.Pause()
-		err = w1.Worker().WaitForNextSuccessfulStatusUpdate()
-		require.NoError(err)
+		helper.ExpectWorkers(t, c1, w1)
 		sConn.TestSendRecvAll(t)
 
 		// Kill the first controller connection again. This one should fail
@@ -366,6 +367,7 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 		event.WriteSysEvent(ctx, op, "resuming connections to both controllers")
 		p1.Resume()
 		p2.Resume()
+
 		err = w1.Worker().WaitForNextSuccessfulStatusUpdate()
 		require.NoError(err)
 

--- a/internal/tests/cluster/sequential/worker_bytesupdown_test.go
+++ b/internal/tests/cluster/sequential/worker_bytesupdown_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package sequential
 
 import (
 	"context"

--- a/internal/tests/cluster/sequential/worker_proxy_test.go
+++ b/internal/tests/cluster/sequential/worker_proxy_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package sequential
 
 import (
 	"context"
@@ -51,7 +51,6 @@ func TestWorkerSessionProxyMultipleConnections(t *testing.T) {
 		Logger:                          logger.Named("c1"),
 		WorkerStatusGracePeriodDuration: helper.DefaultWorkerStatusGracePeriod,
 	})
-	t.Cleanup(c1.Shutdown)
 
 	helper.ExpectWorkers(t, c1)
 
@@ -63,9 +62,7 @@ func TestWorkerSessionProxyMultipleConnections(t *testing.T) {
 		dawdle.WithWbufSize(256),
 	)
 	require.NoError(err)
-	t.Cleanup(func() {
-		proxy.Close()
-	})
+	t.Cleanup(func() { _ = proxy.Close() })
 	require.NotEmpty(t, proxy.ListenerAddr())
 
 	w1 := worker.NewTestWorker(t, &worker.TestWorkerOpts{
@@ -75,7 +72,6 @@ func TestWorkerSessionProxyMultipleConnections(t *testing.T) {
 		SuccessfulStatusGracePeriodDuration: helper.DefaultWorkerStatusGracePeriod,
 		EnableIPv6:                          true,
 	})
-	t.Cleanup(w1.Shutdown)
 
 	helper.ExpectWorkers(t, c1, w1)
 

--- a/internal/tests/cluster/sequential/worker_tagging_test.go
+++ b/internal/tests/cluster/sequential/worker_tagging_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package sequential
 
 import (
 	"testing"
@@ -33,7 +33,6 @@ func TestWorkerTagging(t *testing.T) {
 		InitialResourcesSuffix: "1234567890",
 		Logger:                 logger.Named("c1"),
 	})
-	defer c1.Shutdown()
 
 	ctx := c1.Context()
 
@@ -62,7 +61,6 @@ func TestWorkerTagging(t *testing.T) {
 		InitialUpstreams: c1.ClusterAddrs(),
 		Logger:           logger.Named("w1"),
 	})
-	defer w1.Shutdown()
 	w1Addr := w1.ProxyAddrs()[0]
 	w1.Worker().WaitForNextSuccessfulStatusUpdate()
 
@@ -80,7 +78,6 @@ func TestWorkerTagging(t *testing.T) {
 		InitialUpstreams: c1.ClusterAddrs(),
 		Logger:           logger.Named("w2"),
 	})
-	defer w2.Shutdown()
 	w2Addr := w2.ProxyAddrs()[0]
 	w2.Worker().WaitForNextSuccessfulStatusUpdate()
 
@@ -98,7 +95,6 @@ func TestWorkerTagging(t *testing.T) {
 		InitialUpstreams: c1.ClusterAddrs(),
 		Logger:           logger.Named("w3"),
 	})
-	defer w3.Shutdown()
 	w3Addr := w3.ProxyAddrs()[0]
 
 	w3.Worker().WaitForNextSuccessfulStatusUpdate()

--- a/internal/tests/cluster/sequential/x509_verification_test.go
+++ b/internal/tests/cluster/sequential/x509_verification_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package sequential
 
 import (
 	"bytes"
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"sync"
 	"testing"
-	"time"
 
 	apiproxy "github.com/hashicorp/boundary/api/proxy"
 	"github.com/hashicorp/boundary/api/targets"
@@ -62,12 +61,6 @@ func TestCustomX509Verification_Client(t *testing.T) {
 		InitialUpstreams: c1.ClusterAddrs(),
 		Logger:           logger.Named("w1"),
 	})
-
-	// Give time for it to connect
-	time.Sleep(10 * time.Second)
-
-	err = w1.Worker().WaitForNextSuccessfulStatusUpdate()
-	req.NoError(err)
 	helper.ExpectWorkers(t, c1, w1)
 
 	// Connect target
@@ -232,11 +225,7 @@ func testCustomX509Verification_Server(ec event.TestConfig, certPool *x509.CertP
 		w1.Worker().TestOverrideX509VerifyCertPool = certPool
 		w1.Worker().TestOverrideX509VerifyDnsName = dnsName
 
-		// Give time for it to connect
-		time.Sleep(10 * time.Second)
-
-		err = w1.Worker().WaitForNextSuccessfulStatusUpdate()
-		req.NoError(err)
+		helper.ExpectWorkers(t, c1, w1)
 
 		// Connect target
 		client := c1.Client()


### PR DESCRIPTION
# Summary

There are a number of tests in the cluster package that must run sequentially (due to global variables that are being manipulated), but there are also many tests that can run in parallel. The golang sdk does not allow us to configure how we want to run these tests in a specific order. Therefore, I split the tests into two sub packages. This has greatly improved the runtime of the tests, without introducing flaky behaviors.

Before:
<img width="1081" alt="Screenshot 2024-12-18 at 2 25 05 PM" src="https://github.com/user-attachments/assets/f4b067db-fa66-45fa-87d2-90f6f027c868" />

After:
<img width="1076" alt="Screenshot 2024-12-18 at 2 24 42 PM" src="https://github.com/user-attachments/assets/3f0035b9-cdd5-4023-a9b2-542cae41448f" />
