### PR TITLE
test(cluster): split tests between parallel and sequential packages

### DIFF
--- a/internal/daemon/controller/testing.go
+++ b/internal/daemon/controller/testing.go
@@ -529,7 +529,6 @@ func NewTestController(t testing.TB, opts *TestControllerOpts) *TestController {
 	var err error
 	tc.c, err = New(ctx, conf)
 	if err != nil {
-		tc.Shutdown()
 		t.Fatal(err)
 	}
 
@@ -552,7 +551,6 @@ func NewTestController(t testing.TB, opts *TestControllerOpts) *TestController {
 
 	if !opts.DisableAutoStart {
 		if err := tc.c.Start(); err != nil {
-			tc.Shutdown()
 			t.Fatal(err)
 		}
 	}

--- a/internal/daemon/worker/testing.go
+++ b/internal/daemon/worker/testing.go
@@ -72,6 +72,9 @@ func (tw *TestWorker) Name() string {
 func (tw *TestWorker) UpstreamAddrs() []string {
 	var addrs []string
 	lastStatus := tw.w.LastStatusSuccess()
+	if lastStatus == nil {
+		return addrs
+	}
 	for _, v := range lastStatus.GetCalculatedUpstreams() {
 		addrs = append(addrs, v.Address)
 	}
@@ -360,7 +363,6 @@ func NewTestWorker(t testing.TB, opts *TestWorkerOpts) *TestWorker {
 
 	tw.w, err = New(ctx, conf)
 	if err != nil {
-		tw.Shutdown()
 		t.Fatal(err)
 	}
 
@@ -387,7 +389,6 @@ func NewTestWorker(t testing.TB, opts *TestWorkerOpts) *TestWorker {
 
 	if !opts.DisableAutoStart {
 		if err := tw.w.Start(); err != nil {
-			tw.Shutdown()
 			t.Fatal(err)
 		}
 	}

--- a/internal/tests/cluster/parallel/anon_listing_test.go
+++ b/internal/tests/cluster/parallel/anon_listing_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package parallel
 
 import (
 	"testing"
@@ -15,6 +15,8 @@ import (
 )
 
 func TestAnonListing(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	logger := hclog.New(&hclog.LoggerOptions{
 		Level: hclog.Trace,
@@ -28,7 +30,6 @@ func TestAnonListing(t *testing.T) {
 		InitialResourcesSuffix: "1234567890",
 		Logger:                 logger,
 	})
-	defer c1.Shutdown()
 
 	// Anon user has list and read permissions on scopes by default,
 	// verify that list scopes returns expected scope without setting token

--- a/internal/tests/cluster/parallel/doc.go
+++ b/internal/tests/cluster/parallel/doc.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+/*
+This package includes a set of tests that run in parallel.
+A test should only be added to this package if it can be
+completely isolated from other tests that currently exist
+in this package. If a test is consistently failing due to
+not having an isolated environment, it should be moved to
+the adjacent "sequential" package.
+*/
+
+package parallel

--- a/internal/tests/cluster/parallel/ipv6_listener_test.go
+++ b/internal/tests/cluster/parallel/ipv6_listener_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package parallel
 
 import (
 	"context"
@@ -20,6 +20,7 @@ import (
 
 func TestIPv6Listener(t *testing.T) {
 	t.Parallel()
+
 	require := require.New(t)
 	logger := hclog.New(&hclog.LoggerOptions{
 		Level: hclog.Trace,
@@ -32,13 +33,11 @@ func TestIPv6Listener(t *testing.T) {
 		Config: conf,
 		Logger: logger.Named("c1"),
 	})
-	defer c1.Shutdown()
 
 	c2 := c1.AddClusterControllerMember(t, &controller.TestControllerOpts{
 		Config: conf,
 		Logger: c1.Config().Logger.ResetNamed("c2"),
 	})
-	defer c2.Shutdown()
 
 	wg := new(sync.WaitGroup)
 	wg.Add(2)
@@ -61,7 +60,6 @@ func TestIPv6Listener(t *testing.T) {
 		InitialUpstreams: append(c1.ClusterAddrs(), c2.ClusterAddrs()...),
 		Logger:           logger.Named("w1"),
 	})
-	defer w1.Shutdown()
 
 	wg.Add(2)
 	go func() {

--- a/internal/tests/cluster/parallel/multi_controller_worker_test.go
+++ b/internal/tests/cluster/parallel/multi_controller_worker_test.go
@@ -1,10 +1,10 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package parallel
 
 import (
-	"context"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -14,12 +14,12 @@ import (
 	"github.com/hashicorp/boundary/internal/daemon/worker"
 	"github.com/hashicorp/boundary/internal/tests/helper"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-secure-stdlib/strutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMultiControllerMultiWorkerConnections(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	logger := hclog.New(&hclog.LoggerOptions{
 		Level: hclog.Trace,
@@ -32,12 +32,10 @@ func TestMultiControllerMultiWorkerConnections(t *testing.T) {
 		Config: conf,
 		Logger: logger.Named("c1"),
 	})
-	defer c1.Shutdown()
 
 	c2 := c1.AddClusterControllerMember(t, &controller.TestControllerOpts{
 		Logger: c1.Config().Logger.ResetNamed("c2"),
 	})
-	defer c2.Shutdown()
 
 	wg := new(sync.WaitGroup)
 	wg.Add(2)
@@ -56,7 +54,6 @@ func TestMultiControllerMultiWorkerConnections(t *testing.T) {
 		InitialUpstreams: append(c1.ClusterAddrs(), c2.ClusterAddrs()...),
 		Logger:           logger.Named("w1"),
 	})
-	defer w1.Shutdown()
 
 	wg.Add(2)
 	go func() {
@@ -72,7 +69,6 @@ func TestMultiControllerMultiWorkerConnections(t *testing.T) {
 	w2 := w1.AddClusterWorkerMember(t, &worker.TestWorkerOpts{
 		Logger: logger.Named("w2"),
 	})
-	defer w2.Shutdown()
 
 	wg.Add(2)
 	go func() {
@@ -98,53 +94,47 @@ func TestMultiControllerMultiWorkerConnections(t *testing.T) {
 	}()
 	wg.Wait()
 
-	w1 = worker.NewTestWorker(t, &worker.TestWorkerOpts{
+	w3 := worker.NewTestWorker(t, &worker.TestWorkerOpts{
 		WorkerAuthKms:    c1.Config().WorkerAuthKms,
 		InitialUpstreams: c1.ClusterAddrs(),
-		Logger:           logger.Named("w1"),
+		Logger:           logger.Named("w3"),
 	})
-	defer w1.Shutdown()
 
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		helper.ExpectWorkers(t, c1, w1, w2)
+		helper.ExpectWorkers(t, c1, w2, w3)
 	}()
 	go func() {
 		defer wg.Done()
-		helper.ExpectWorkers(t, c2, w1, w2)
+		helper.ExpectWorkers(t, c2, w2, w3)
 	}()
 	wg.Wait()
 
 	require.NoError(c2.Controller().Shutdown())
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		helper.ExpectWorkers(t, c1, w1, w2)
-	}()
-	wg.Wait()
+	helper.ExpectWorkers(t, c1, w2, w3)
 
-	c2 = c1.AddClusterControllerMember(t, &controller.TestControllerOpts{
-		Logger: c1.Config().Logger.ResetNamed("c2"),
+	c3 := c1.AddClusterControllerMember(t, &controller.TestControllerOpts{
+		Logger: c1.Config().Logger.ResetNamed("c3"),
 	})
-	defer c2.Shutdown()
 
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		helper.ExpectWorkers(t, c1, w1, w2)
+		helper.ExpectWorkers(t, c1, w2, w3)
 	}()
 	go func() {
 		defer wg.Done()
-		helper.ExpectWorkers(t, c2, w1, w2)
+		helper.ExpectWorkers(t, c3, w2, w3)
 	}()
 	wg.Wait()
 }
 
 func TestWorkerAppendInitialUpstreams(t *testing.T) {
-	ctx := context.Background()
-	require, assert := require.New(t), assert.New(t)
+	t.Parallel()
+
+	require := require.New(t)
 	logger := hclog.New(&hclog.LoggerOptions{
 		Level: hclog.Trace,
 	})
@@ -156,7 +146,6 @@ func TestWorkerAppendInitialUpstreams(t *testing.T) {
 		Config: conf,
 		Logger: logger.Named("c1"),
 	})
-	defer c1.Shutdown()
 
 	helper.ExpectWorkers(t, c1)
 
@@ -167,31 +156,29 @@ func TestWorkerAppendInitialUpstreams(t *testing.T) {
 		Logger:                              logger.Named("w1"),
 		SuccessfulStatusGracePeriodDuration: 1 * time.Second,
 	})
-	defer w1.Shutdown()
 
 	// Wait for worker to send status
-	cancelCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	t.Cleanup(cancel)
-	for {
-		select {
-		case <-time.After(500 * time.Millisecond):
-		case <-cancelCtx.Done():
-			require.FailNow("No worker found after 10 seconds")
-		}
-		successSent := w1.Worker().LastStatusSuccess()
-		if successSent != nil {
-			break
-		}
-	}
 	helper.ExpectWorkers(t, c1, w1)
 
 	// Upstreams should be equivalent to the controller cluster addr after status updates
-	assert.Equal(c1.ClusterAddrs(), w1.Worker().LastStatusSuccess().LastCalculatedUpstreams)
+	require.Eventually(func() bool {
+		if w1.Worker().LastStatusSuccess() == nil {
+			return false
+		}
+		return slices.Equal(c1.ClusterAddrs(), w1.Worker().LastStatusSuccess().LastCalculatedUpstreams)
+	}, 4*time.Second, 250*time.Millisecond)
 
 	// Bring down the controller
-	c1.Shutdown()
-	time.Sleep(3 * time.Second) // Wait a little longer than the grace period
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c1.Shutdown()
+	}()
 
 	// Upstreams should now match initial upstreams
-	assert.True(strutil.EquivalentSlices(initialUpstreams, w1.Worker().LastStatusSuccess().LastCalculatedUpstreams))
+	require.Eventually(func() bool {
+		return slices.Equal(initialUpstreams, w1.Worker().LastStatusSuccess().LastCalculatedUpstreams)
+	}, 4*time.Second, 250*time.Millisecond)
+	wg.Wait()
 }

--- a/internal/tests/cluster/parallel/package_registry_test.go
+++ b/internal/tests/cluster/parallel/package_registry_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package parallel
 
 import (
 	// Enable tcp target support.

--- a/internal/tests/cluster/parallel/recursive_anon_listing_test.go
+++ b/internal/tests/cluster/parallel/recursive_anon_listing_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package parallel
 
 import (
 	"strings"
@@ -16,9 +16,10 @@ import (
 
 // This test validates the fix for ICU-2301
 func TestListAnonymousRecursing(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	tc := controller.NewTestController(t, nil)
-	defer tc.Shutdown()
 
 	client := tc.Client()
 	token := tc.Token()

--- a/internal/tests/cluster/parallel/unix_listener_test.go
+++ b/internal/tests/cluster/parallel/unix_listener_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package parallel
 
 import (
 	"bytes"
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/scopes"
@@ -23,6 +22,8 @@ import (
 )
 
 func TestUnixListener(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	buf := new(bytes.Buffer)
 	logger := hclog.New(&hclog.LoggerOptions{
@@ -73,7 +74,6 @@ func TestUnixListener(t *testing.T) {
 			},
 		},
 	})
-	defer c1.Shutdown()
 
 	helper.ExpectWorkers(t, c1)
 
@@ -86,19 +86,17 @@ func TestUnixListener(t *testing.T) {
 		InitialUpstreams: c1.ClusterAddrs(),
 		Logger:           logger.Named("w1"),
 	})
-	defer w1.Shutdown()
 
-	time.Sleep(10 * time.Second)
 	helper.ExpectWorkers(t, c1, w1)
 
 	require.NoError(w1.Worker().Shutdown())
-	time.Sleep(10 * time.Second)
+
 	helper.ExpectWorkers(t, c1)
 
 	require.NoError(c1.Controller().Shutdown())
-	c1 = controller.NewTestController(t, &controller.TestControllerOpts{
+	c2 := controller.NewTestController(t, &controller.TestControllerOpts{
 		Config:                        conf,
-		Logger:                        logger.Named("c1"),
+		Logger:                        logger.Named("c2"),
 		DisableOidcAuthMethodCreation: true,
 		EventerConfig: &event.EventerConfig{
 			ObservationsEnabled: true,
@@ -118,15 +116,13 @@ func TestUnixListener(t *testing.T) {
 			},
 		},
 	})
-	defer c1.Shutdown()
 
-	time.Sleep(10 * time.Second)
-	helper.ExpectWorkers(t, c1)
+	helper.ExpectWorkers(t, c2)
 
 	client, err := api.NewClient(nil)
 	require.NoError(err)
 
-	addrs := c1.ApiAddrs()
+	addrs := c2.ApiAddrs()
 	require.Len(addrs, 1)
 
 	require.NoError(client.SetAddr(addrs[0]))

--- a/internal/tests/cluster/sequential/doc.go
+++ b/internal/tests/cluster/sequential/doc.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+/*
+This package includes a set of tests that run sequentially.
+A test should be added to this package if it needs to be completely
+isolated from other tests. Newly added tests should not enable the
+testing parallel option. Please include a comment in the unit test
+that explains why the test must be ran sequentially. Tests that can
+be ran in parallel should be moved to the adjacent "parallel" package.
+*/
+
+package sequential

--- a/internal/tests/cluster/sequential/package_registry_test.go
+++ b/internal/tests/cluster/sequential/package_registry_test.go
@@ -1,0 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package sequential
+
+import (
+	// Enable tcp target support.
+	_ "github.com/hashicorp/boundary/internal/daemon/controller/handlers/targets/tcp"
+	_ "github.com/hashicorp/boundary/internal/target/tcp"
+)

--- a/internal/tests/cluster/sequential/session_cleanup_test.go
+++ b/internal/tests/cluster/sequential/session_cleanup_test.go
@@ -1,11 +1,12 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package sequential
 
 import (
 	"context"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -107,7 +108,7 @@ func testWorkerSessionCleanupSingle(burdenCase timeoutBurdenType) func(t *testin
 		)
 		require.NoError(err)
 		t.Cleanup(func() {
-			proxy.Close()
+			_ = proxy.Close()
 		})
 		require.NotEmpty(t, proxy.ListenerAddr())
 
@@ -118,10 +119,6 @@ func testWorkerSessionCleanupSingle(burdenCase timeoutBurdenType) func(t *testin
 			SuccessfulStatusGracePeriodDuration: workerGracePeriod(burdenCase),
 		})
 
-		err = w1.Worker().WaitForNextSuccessfulStatusUpdate()
-		require.NoError(err)
-		err = c1.WaitForNextWorkerStatusUpdate(w1.Name())
-		require.NoError(err)
 		helper.ExpectWorkers(t, c1, w1)
 
 		// Use an independent context for test things that take a context so
@@ -237,8 +234,18 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 			PublicClusterAddr:               pl2.Addr().String(),
 			WorkerStatusGracePeriodDuration: controllerGracePeriod(burdenCase),
 		})
-		helper.ExpectWorkers(t, c1)
-		helper.ExpectWorkers(t, c2)
+
+		wg := new(sync.WaitGroup)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			helper.ExpectWorkers(t, c1)
+		}()
+		go func() {
+			defer wg.Done()
+			helper.ExpectWorkers(t, c2)
+		}()
+		wg.Wait()
 
 		// *************
 		// ** Proxy 1 **
@@ -251,7 +258,7 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 		)
 		require.NoError(err)
 		t.Cleanup(func() {
-			p1.Close()
+			_ = p1.Close()
 		})
 		require.NotEmpty(t, p1.ListenerAddr())
 
@@ -266,7 +273,7 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 		)
 		require.NoError(err)
 		t.Cleanup(func() {
-			p2.Close()
+			_ = p2.Close()
 		})
 		require.NotEmpty(t, p2.ListenerAddr())
 
@@ -283,15 +290,16 @@ func testWorkerSessionCleanupMulti(burdenCase timeoutBurdenType) func(t *testing
 		// currently-unknown reason the next successful status update fails
 		// because it's not sent before the context times out.
 		time.Sleep(5 * time.Second)
-
-		err = w1.Worker().WaitForNextSuccessfulStatusUpdate()
-		require.NoError(err)
-		err = c1.WaitForNextWorkerStatusUpdate(w1.Name())
-		require.NoError(err)
-		err = c2.WaitForNextWorkerStatusUpdate(w1.Name())
-		require.NoError(err)
-		helper.ExpectWorkers(t, c1, w1)
-		helper.ExpectWorkers(t, c2, w1)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			helper.ExpectWorkers(t, c1, w1)
+		}()
+		go func() {
+			defer wg.Done()
+			helper.ExpectWorkers(t, c2, w1)
+		}()
+		wg.Wait()
 
 		// Use an independent context for test things that take a context so
 		// that we aren't tied to any timeouts in the controller, etc. This

--- a/internal/tests/cluster/sequential/worker_bytesupdown_test.go
+++ b/internal/tests/cluster/sequential/worker_bytesupdown_test.go
@@ -1,41 +1,40 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package sequential
 
 import (
 	"context"
 	"net"
 	"testing"
 
+	"github.com/hashicorp/boundary/api/sessions"
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/boundary/internal/cmd/config"
 	"github.com/hashicorp/boundary/internal/daemon/controller"
 	tg "github.com/hashicorp/boundary/internal/daemon/controller/handlers/targets"
 	"github.com/hashicorp/boundary/internal/daemon/worker"
-	"github.com/hashicorp/boundary/internal/event"
 	"github.com/hashicorp/boundary/internal/tests/helper"
 	"github.com/hashicorp/dawdle"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 )
 
-func TestWorkerSessionProxyMultipleConnections(t *testing.T) {
-	const op = "cluster.TestWorkerSessionMultipleConnections"
+func TestWorkerBytesUpDown(t *testing.T) {
+	require := require.New(t)
 
 	// This prevents us from running tests in parallel.
 	tg.SetupSuiteTargetFilters(t)
 
-	require := require.New(t)
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:  t.Name(),
 		Level: hclog.Trace,
 	})
 
-	pl, err := net.Listen("tcp", "[::1]:")
+	conf, err := config.DevController(config.WithIPv6Enabled(true))
 	require.NoError(err)
 
-	conf, err := config.DevController(config.WithIPv6Enabled(true))
+	pl, err := net.Listen("tcp", "[::1]:")
 	require.NoError(err)
 
 	// update cluster listener to utilize proxy listener address
@@ -51,7 +50,6 @@ func TestWorkerSessionProxyMultipleConnections(t *testing.T) {
 		Logger:                          logger.Named("c1"),
 		WorkerStatusGracePeriodDuration: helper.DefaultWorkerStatusGracePeriod,
 	})
-	t.Cleanup(c1.Shutdown)
 
 	helper.ExpectWorkers(t, c1)
 
@@ -63,19 +61,16 @@ func TestWorkerSessionProxyMultipleConnections(t *testing.T) {
 		dawdle.WithWbufSize(256),
 	)
 	require.NoError(err)
-	t.Cleanup(func() {
-		proxy.Close()
-	})
 	require.NotEmpty(t, proxy.ListenerAddr())
+	t.Cleanup(func() { _ = proxy.Close() })
 
 	w1 := worker.NewTestWorker(t, &worker.TestWorkerOpts{
 		WorkerAuthKms:                       c1.Config().WorkerAuthKms,
 		InitialUpstreams:                    []string{proxy.ListenerAddr()},
 		Logger:                              logger.Named("w1"),
-		SuccessfulStatusGracePeriodDuration: helper.DefaultWorkerStatusGracePeriod,
+		SuccessfulStatusGracePeriodDuration: helper.DefaultSuccessfulStatusGracePeriod,
 		EnableIPv6:                          true,
 	})
-	t.Cleanup(w1.Shutdown)
 
 	helper.ExpectWorkers(t, c1, w1)
 
@@ -96,34 +91,54 @@ func TestWorkerSessionProxyMultipleConnections(t *testing.T) {
 	ts := helper.NewTestTcpServer(t)
 	require.NotNil(t, ts)
 	t.Cleanup(ts.Close)
-	t.Logf("test server listening on port %d", ts.Port())
-
 	tgt, err = tcl.Update(ctx, tgt.Item.Id, tgt.Item.Version, targets.WithTcpTargetDefaultPort(ts.Port()), targets.WithSessionConnectionLimit(-1))
 	require.NoError(err)
 	require.NotNil(tgt)
 
-	// Authorize and connect
+	// Authorize a session, connect and send/recv some traffic
 	workerInfo := []*targets.WorkerInfo{
 		{
 			Address: w1.ProxyAddrs()[0],
 		},
 	}
 	sess := helper.NewTestSession(ctx, t, tcl, "ttcp_1234567890", helper.WithWorkerInfo(workerInfo))
-	sConn := sess.Connect(ctx, t)
+	conn := sess.Connect(ctx, t)
+	conn.TestSendRecvAll(t)
 
-	// Run initial send/receive test, make sure things are working
-	event.WriteSysEvent(ctx, op, "running initial send/recv test for initial connection")
-	sConn.TestSendRecvAll(t)
+	// Wait for next status and then check DB for bytes up and down
+	helper.ExpectWorkers(t, c1, w1)
 
-	// Create another connection for this session
-	sConn2 := sess.Connect(ctx, t)
-	// Ensure second connection works
-	event.WriteSysEvent(ctx, op, "running initial send/recv test for second connection")
-	sConn2.TestSendRecvAll(t)
+	dbConns1, err := c1.ConnectionsRepo().ListConnectionsBySessionId(ctx, sess.SessionId)
+	require.NoError(err)
+	require.Len(dbConns1, 1)
+	require.NotZero(dbConns1[0].BytesUp)
+	require.NotZero(dbConns1[0].BytesDown)
 
-	// Create another connection for this session
-	sConn3 := sess.Connect(ctx, t)
-	// Ensure second connection works
-	event.WriteSysEvent(ctx, op, "running initial send/recv test for third connection")
-	sConn3.TestSendRecvAll(t)
+	// Also check the connection data via the API
+	sc := sessions.NewClient(c1.Client())
+	apiRes1, err := sc.Read(ctx, sess.SessionId)
+	require.NoError(err)
+	require.Len(apiRes1.Item.Connections, 1)
+	require.NotZero(apiRes1.Item.Connections[0].BytesUp)
+	require.NotZero(apiRes1.Item.Connections[0].BytesDown)
+
+	// Send/recv some more traffic, close connection, wait for the next status
+	// update and check everything again.
+	conn.TestSendRecvAll(t)
+	require.NoError(conn.Close())
+	helper.ExpectWorkers(t, c1, w1)
+
+	dbConns2, err := c1.ConnectionsRepo().ListConnectionsBySessionId(ctx, sess.SessionId)
+	require.NoError(err)
+	require.Len(dbConns2, 1)
+	require.Greater(dbConns2[0].BytesUp, dbConns1[0].BytesUp)
+	require.Greater(dbConns2[0].BytesDown, dbConns1[0].BytesDown)
+	require.NotEmpty(dbConns2[0].ClosedReason)
+
+	apiRes2, err := sc.Read(ctx, sess.SessionId)
+	require.NoError(err)
+	require.Len(apiRes2.Item.Connections, 1)
+	require.Greater(apiRes2.Item.Connections[0].BytesUp, apiRes1.Item.Connections[0].BytesUp)
+	require.Greater(apiRes2.Item.Connections[0].BytesDown, apiRes1.Item.Connections[0].BytesDown)
+	require.NotEmpty(apiRes2.Item.Connections[0].ClosedReason)
 }

--- a/internal/tests/cluster/sequential/worker_tagging_test.go
+++ b/internal/tests/cluster/sequential/worker_tagging_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package sequential
 
 import (
 	"testing"
@@ -33,7 +33,6 @@ func TestWorkerTagging(t *testing.T) {
 		InitialResourcesSuffix: "1234567890",
 		Logger:                 logger.Named("c1"),
 	})
-	defer c1.Shutdown()
 
 	ctx := c1.Context()
 
@@ -62,9 +61,7 @@ func TestWorkerTagging(t *testing.T) {
 		InitialUpstreams: c1.ClusterAddrs(),
 		Logger:           logger.Named("w1"),
 	})
-	defer w1.Shutdown()
 	w1Addr := w1.ProxyAddrs()[0]
-	w1.Worker().WaitForNextSuccessfulStatusUpdate()
 
 	// Worker 2
 	conf, err = config.DevWorker()
@@ -80,9 +77,7 @@ func TestWorkerTagging(t *testing.T) {
 		InitialUpstreams: c1.ClusterAddrs(),
 		Logger:           logger.Named("w2"),
 	})
-	defer w2.Shutdown()
 	w2Addr := w2.ProxyAddrs()[0]
-	w2.Worker().WaitForNextSuccessfulStatusUpdate()
 
 	// Worker 3
 	conf, err = config.DevWorker()
@@ -98,10 +93,7 @@ func TestWorkerTagging(t *testing.T) {
 		InitialUpstreams: c1.ClusterAddrs(),
 		Logger:           logger.Named("w3"),
 	})
-	defer w3.Shutdown()
 	w3Addr := w3.ProxyAddrs()[0]
-
-	w3.Worker().WaitForNextSuccessfulStatusUpdate()
 
 	helper.ExpectWorkers(t, c1, w1, w2, w3)
 

--- a/internal/tests/cluster/sequential/x509_verification_test.go
+++ b/internal/tests/cluster/sequential/x509_verification_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package cluster
+package sequential
 
 import (
 	"bytes"
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"sync"
 	"testing"
-	"time"
 
 	apiproxy "github.com/hashicorp/boundary/api/proxy"
 	"github.com/hashicorp/boundary/api/targets"
@@ -64,10 +63,6 @@ func TestCustomX509Verification_Client(t *testing.T) {
 	})
 
 	// Give time for it to connect
-	time.Sleep(10 * time.Second)
-
-	err = w1.Worker().WaitForNextSuccessfulStatusUpdate()
-	req.NoError(err)
 	helper.ExpectWorkers(t, c1, w1)
 
 	// Connect target
@@ -233,10 +228,7 @@ func testCustomX509Verification_Server(ec event.TestConfig, certPool *x509.CertP
 		w1.Worker().TestOverrideX509VerifyDnsName = dnsName
 
 		// Give time for it to connect
-		time.Sleep(10 * time.Second)
-
-		err = w1.Worker().WaitForNextSuccessfulStatusUpdate()
-		req.NoError(err)
+		helper.ExpectWorkers(t, c1, w1)
 
 		// Connect target
 		client := c1.Client()


### PR DESCRIPTION
# Summary

There are a number of tests in the cluster package that must run sequentially (due to global variables that are being manipulated), but there are also many tests that can run in parallel. The golang sdk does not allow us to configure how we want to run these tests in a specific order. Therefore, I split the tests into two sub packages. This has greatly improved the runtime of the tests, without introducing flaky behaviors.

Before:
<img width="1081" alt="Screenshot 2024-12-18 at 2 25 05 PM" src="https://github.com/user-attachments/assets/9c2e52a9-3031-4cb5-9ca9-51056cf1e21a" />

After:
<img width="1076" alt="Screenshot 2024-12-18 at 2 24 42 PM" src="https://github.com/user-attachments/assets/e7acde0e-74ac-48fb-b10d-cc03311ea791" />
