### PR TITLE
DO NOT MERGE: specify tlskyber=0 go to disable two-packet TLS hello

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -17,6 +17,7 @@ project "boundary" {
     release_branches = [
       "main",
       "release/**",
+      "jbrandhorst-downgrade-0.18-go",
     ]
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/boundary
 
 go 1.23.3
 
+godebug tlskyber=0
+
 replace github.com/hashicorp/boundary/api => ./api
 
 replace github.com/hashicorp/boundary/sdk => ./sdk

--- a/plugins/boundary/mains/aws/go.mod
+++ b/plugins/boundary/mains/aws/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/boundary/plugins/boundary/mains/aws
 
 go 1.23.3
 
+godebug tlskyber=0
+
 require (
 	github.com/hashicorp/boundary-plugin-aws v0.4.2
 	github.com/hashicorp/boundary/sdk v0.0.49

--- a/plugins/boundary/mains/azure/go.mod
+++ b/plugins/boundary/mains/azure/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/boundary/plugins/boundary/mains/azure
 
 go 1.23.0
 
+godebug tlskyber=0
+
 require (
 	github.com/hashicorp/boundary-plugin-azure v0.1.3
 	github.com/hashicorp/boundary/sdk v0.0.39

--- a/plugins/boundary/mains/minio/go.mod
+++ b/plugins/boundary/mains/minio/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/boundary/plugins/boundary/mains/minio
 
 go 1.23.0
 
+godebug tlskyber=0
+
 require (
 	github.com/hashicorp/boundary-plugin-minio v0.1.5
 	github.com/hashicorp/boundary/sdk v0.0.43-0.20240717182311-a20aae98794a

--- a/plugins/kms/mains/alicloudkms/go.mod
+++ b/plugins/kms/mains/alicloudkms/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/boundary/plugins/kms/mains/alicloudkms
 
 go 1.23.0
 
+godebug tlskyber=0
+
 require (
 	github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.7
 	github.com/hashicorp/go-kms-wrapping/wrappers/alicloudkms/v2 v2.0.3

--- a/plugins/kms/mains/awskms/go.mod
+++ b/plugins/kms/mains/awskms/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/boundary/plugins/kms/mains/awskms
 
 go 1.23.0
 
+godebug tlskyber=0
+
 require (
 	github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.7
 	github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v2 v2.0.10

--- a/plugins/kms/mains/azurekeyvault/go.mod
+++ b/plugins/kms/mains/azurekeyvault/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/boundary/plugins/kms/mains/azurekeyvault
 
 go 1.23.0
 
+godebug tlskyber=0
+
 require (
 	github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.7
 	github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault/v2 v2.0.11

--- a/plugins/kms/mains/gcpckms/go.mod
+++ b/plugins/kms/mains/gcpckms/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/boundary/plugins/kms/mains/gcpckms
 
 go 1.23.0
 
+godebug tlskyber=0
+
 require (
 	github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.7
 	github.com/hashicorp/go-kms-wrapping/wrappers/gcpckms/v2 v2.0.12

--- a/plugins/kms/mains/ocikms/go.mod
+++ b/plugins/kms/mains/ocikms/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/boundary/plugins/kms/mains/ocikms
 
 go 1.23.0
 
+godebug tlskyber=0
+
 require (
 	github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.7
 	github.com/hashicorp/go-kms-wrapping/wrappers/ocikms/v2 v2.0.8

--- a/plugins/kms/mains/transit/go.mod
+++ b/plugins/kms/mains/transit/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/boundary/plugins/kms/mains/transit
 
 go 1.23.0
 
+godebug tlskyber=0
+
 require (
 	github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.7
 	github.com/hashicorp/go-kms-wrapping/wrappers/transit/v2 v2.0.12


### PR DESCRIPTION
@ajayreshc is the MVP for pointing out this option to me rather than downgrading our Go version