### PR TITLE
chore: Install tools if cache restore fails

### DIFF
--- a/.github/workflows/test-race.yml
+++ b/.github/workflows/test-race.yml
@@ -132,6 +132,7 @@ jobs:
           go-version: "${{ needs.setup.outputs.go-version }}"
           cache: false
       - name: Set up Go modules cache
+        id: go-cache
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
@@ -142,6 +143,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go
           fail-on-cache-miss: false
+      - name: Install tools if cache restore fails
+        if: steps.go-cache.outputs.cache-hit != 'true'
+        run: |
+          go mod download
+          make tools
       - name: Set up plugin cache
         id: plugin-cache
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,7 @@ jobs:
           go-version: "${{ needs.setup.outputs.go-version }}"
           cache: false
       - name: Set up Go modules cache
+        id: go-cache
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
@@ -142,6 +143,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go
           fail-on-cache-miss: false
+      - name: Install tools if cache restore fails
+        if: steps.go-cache.outputs.cache-hit != 'true'
+        run: |
+          go mod download
+          make tools
       - name: Set up plugin cache
         id: plugin-cache
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2


### PR DESCRIPTION
This PR updates the unit test workflow to resolve an error when the cache restores to fail. Here is an example run: https://github.com/hashicorp/boundary/actions/runs/12439588543/job/34735079491.

When the cache fails to restore, the pipeline does not have access to the `tparse` tool, resulting in the error
```
Run nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
go test "./..." -tags="" -v -json -cover -timeout 40m | tparse -follow
/bin/sh: 1: tparse: not found
```

This PR adds a step to install tools if the restore happens to fail.