### PR TITLE
chore(e2e): Update vault addresses in AWS scenarios

### DIFF
--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -158,7 +158,8 @@ scenario "e2e_aws_base_with_vault" {
       target_address           = step.create_target.target_private_ips[0]
       target_user              = "ubuntu"
       target_port              = "22"
-      vault_addr               = step.create_vault_cluster.instance_public_ips[0]
+      vault_addr               = step.create_vault_cluster.instance_addresses[0]
+      vault_addr_internal      = step.create_vault_cluster.instance_addresses[0]
       vault_root_token         = step.create_vault_cluster.vault_root_token
       aws_region               = var.aws_region
       max_page_size            = step.create_boundary_cluster.max_page_size

--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -200,7 +200,8 @@ scenario "e2e_ui_aws" {
       target_address            = step.create_targets_with_tag.target_private_ips[0]
       target_user               = "ubuntu"
       target_port               = "22"
-      vault_addr                = step.create_vault_cluster.instance_public_ips[0]
+      vault_addr                = step.create_vault_cluster.instance_addresses[0]
+      vault_addr_internal       = step.create_vault_cluster.instance_addresses[0]
       vault_root_token          = step.create_vault_cluster.vault_root_token
       aws_access_key_id         = step.iam_setup.access_key_id
       aws_secret_access_key     = step.iam_setup.secret_access_key

--- a/enos/modules/aws_vault/outputs.tf
+++ b/enos/modules/aws_vault/outputs.tf
@@ -16,6 +16,11 @@ output "instance_private_ips" {
   value       = [for instance in aws_instance.vault_instance : instance.private_ip]
 }
 
+output "instance_addresses" {
+  description = "Addresses of Vault instances"
+  value       = [for instance in aws_instance.vault_instance : "http://${instance.public_ip}:8200"]
+}
+
 output "key_id" {
   value = data.aws_kms_key.kms_key.id
 }


### PR DESCRIPTION
This PR updates additional e2e test modules based on some changes by the [e2e vault oidc test PR](https://github.com/hashicorp/boundary/pull/5384/files). It modifies the AWS-based scenarios to pass a full address with a schema.