### PR TITLE
fix(target): Assign session connection limit to SessionAuthorization.ConnectionLimit

### DIFF
--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -1214,6 +1214,7 @@ func (s Service) AuthorizeSession(ctx context.Context, req *pbs.AuthorizeSession
 		HostSetId:          hostSetId,
 		Endpoint:           endpointUrl.String(),
 		Credentials:        creds,
+		ConnectionLimit:    t.GetSessionConnectionLimit(),
 	}
 
 	ret.SessionRecordingId, err = SessionRecordingFn(


### PR DESCRIPTION
- We weren’t assigning the session connection limit we got from the DB to the `ConnectionLimit` field on the `SessionAuthorization` response object before returning from `AuthorizeSession` [[link](https://github.com/hashicorp/boundary-enterprise/blob/62c41191ffce6ab68fbed810559dd857fa8a2528/internal/daemon/controller/handlers/targets/target_service.go#L1203)]. As a result, the connection limit has a default value of `0` when the connect cmd prints the session info
- We _do_ assign `ConnectionLimit` in a similar object, `SessionAuthorizationData`, but it gets marshalled into an auth token. Instead of decoding & unmarshalling the entire `SessionAuthorizationData` payload for the connection limit, I decided to just copy its value onto the `SessionAuthorization` struct.