### PR TITLE
chore(e2e): Modify gcp label to meet format constraints

### DIFF
--- a/enos/modules/gcp_target/main.tf
+++ b/enos/modules/gcp_target/main.tf
@@ -125,7 +125,7 @@ resource "google_compute_instance" "boundary_target" {
     "project" : "enos",
     "project_name" : "qti-enos-boundary",
     "environment" : var.environment,
-    "enos_user" : var.enos_user,
+    "enos_user" : replace(var.enos_user, "/[\\W]+/", ""),
     "filter_label_1" : random_id.filter_label1.hex
     "filter_label_2" : random_id.filter_label2.hex
   })


### PR DESCRIPTION
This PR updates an e2e test terraform module that is used to create GCP instances. We observed the following error on a run.
```
Error: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.labels': ''. Label value 'hashicorp-tsccr[bot]' violates format constraints. The value can only contain lowercase letters, numeric characters, underscores and dashes. The value can be at most 63 characters long. International characters are allowed., invalid

  with module.create_gcp_target.google_compute_instance.boundary_target[0],
  on ../../modules/gcp_target/main.tf line 96, in resource "google_compute_instance" "boundary_target":
  96: resource "google_compute_instance" "boundary_target" ***
```
https://github.com/hashicorp/boundary/actions/runs/12567797706/job/35034860787?pr=5398

This run came from [here](https://github.com/hashicorp/boundary/pull/5398), where the author is `hashicorp-tsccr[bot]`. This PR modifies the label to remove any characters that don't match `[0-9A-Za-z_]`.