### PR TITLE
chore(e2e): Modify bucket object expiration policy to 7 days

### DIFF
--- a/enos/modules/aws_bucket/main.tf
+++ b/enos/modules/aws_bucket/main.tf
@@ -22,7 +22,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "example" {
   rule {
     id = "file_retention"
     expiration {
-      days = 30
+      days = 7
     }
     status = "Enabled"
   }


### PR DESCRIPTION
This PR updates the s3 bucket configuration to use  an object expiration policy of 7 days.