### PR TITLE
chore: Only use dependabot for internal action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,6 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    allow:
+      # Allow updates for internal actions
+      - dependency-name: "hashicorp/*"


### PR DESCRIPTION
This PR updates the dependabot configuration to only provide updates for internal Github Action updates. We have an internal tool to provide security approved 3rd party Action updates, so the PRs generated by dependbot are redundant. 