### PR TITLE
test(e2e): Add increased retries in bytes up/down tests due to worker status report changes

### DIFF
--- a/testing/internal/e2e/tests/base/bytes_up_down_empty_test.go
+++ b/testing/internal/e2e/tests/base/bytes_up_down_empty_test.go
@@ -6,10 +6,14 @@ package base_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/boundary/api/sessions"
+	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/testing/internal/e2e"
 	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
 	"github.com/stretchr/testify/assert"
@@ -17,7 +21,7 @@ import (
 )
 
 // TestCliBytesUpDownEmpty uses the cli to verify that the bytes_up/bytes_down fields of a
-// session correctly increase when data is transmitting during a session.
+// session do not change when no data is transmitted during a session.
 func TestCliBytesUpDownEmpty(t *testing.T) {
 	e2e.MaybeSkipTest(t)
 	c, err := loadTestConfig()
@@ -35,17 +39,13 @@ func TestCliBytesUpDownEmpty(t *testing.T) {
 	})
 	projectId, err := boundary.CreateProjectCli(t, ctx, orgId)
 	require.NoError(t, err)
-	hostCatalogId, err := boundary.CreateHostCatalogCli(t, ctx, projectId)
-	require.NoError(t, err)
-	hostSetId, err := boundary.CreateHostSetCli(t, ctx, hostCatalogId)
-	require.NoError(t, err)
-	hostId, err := boundary.CreateHostCli(t, ctx, hostCatalogId, c.TargetAddress)
-	require.NoError(t, err)
-	err = boundary.AddHostToHostSetCli(t, ctx, hostSetId, hostId)
-	require.NoError(t, err)
-	targetId, err := boundary.CreateTargetCli(t, ctx, projectId, c.TargetPort)
-	require.NoError(t, err)
-	err = boundary.AddHostSourceToTargetCli(t, ctx, targetId, hostSetId)
+	targetId, err := boundary.CreateTargetCli(
+		t,
+		ctx,
+		projectId,
+		c.TargetPort,
+		target.WithAddress(c.TargetAddress),
+	)
 	require.NoError(t, err)
 
 	// Create a session where no additional commands are run
@@ -72,43 +72,53 @@ func TestCliBytesUpDownEmpty(t *testing.T) {
 
 	session := boundary.WaitForSessionCli(t, ctx, projectId)
 	assert.Equal(t, targetId, session.TargetId)
-	assert.Equal(t, hostId, session.HostId)
-
-	// Confirm that bytesUp and bytesDown do not change
-	bytesUp := 0
-	bytesDown := 0
 
 	// Wait until bytes up and down is greater than 0
 	t.Log("Waiting for bytes_up/bytes_down to be greater than 0...")
-	for i := 0; i < 3; i++ {
-		output := e2e.RunCommand(ctx, "boundary",
-			e2e.WithArgs("sessions", "read", "-id", session.Id, "-format", "json"),
-		)
-		require.NoError(t, output.Err, string(output.Stderr))
-		var newSessionReadResult sessions.SessionReadResult
-		err = json.Unmarshal(output.Stdout, &newSessionReadResult)
-		require.NoError(t, err)
+	bytesUp := 0
+	bytesDown := 0
+	err = backoff.RetryNotify(
+		func() error {
+			output := e2e.RunCommand(ctx, "boundary",
+				e2e.WithArgs("sessions", "read", "-id", session.Id, "-format", "json"),
+			)
+			if output.Err != nil {
+				return backoff.Permanent(errors.New(string(output.Stderr)))
+			}
+			var newSessionReadResult sessions.SessionReadResult
+			err = json.Unmarshal(output.Stdout, &newSessionReadResult)
+			if err != nil {
+				return backoff.Permanent(err)
+			}
 
-		if len(newSessionReadResult.Item.Connections) > 0 {
+			if len(newSessionReadResult.Item.Connections) == 0 {
+				return fmt.Errorf("no connections found in session")
+			}
+
 			bytesUp = int(newSessionReadResult.Item.Connections[0].BytesUp)
 			bytesDown = int(newSessionReadResult.Item.Connections[0].BytesDown)
-			t.Logf("bytes_up: %d, bytes_down: %d", bytesUp, bytesDown)
-
-			if bytesUp > 0 && bytesDown > 0 {
-				break
+			if !(bytesUp > 0 && bytesDown > 0) {
+				return fmt.Errorf(
+					"bytes_up: %d, bytes_down: %d, bytes_up or bytes_down is not greater than 0",
+					bytesUp,
+					bytesDown,
+				)
 			}
-		} else {
-			t.Log("No connections found in session. Retrying...")
-		}
 
-		time.Sleep(2 * time.Second)
-	}
-	require.Greater(t, bytesUp, 0)
-	require.Greater(t, bytesDown, 0)
+			t.Logf("bytes_up: %d, bytes_down: %d", bytesUp, bytesDown)
+			return nil
+		},
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
+		func(err error, td time.Duration) {
+			t.Logf("%s. Retrying...", err.Error())
+		},
+	)
+	require.NoError(t, err)
 
-	t.Log("Reading bytes_up/bytes_down values...")
-	for i := 0; i < 3; i++ {
-		time.Sleep(2 * time.Second)
+	// Confirm that bytesUp and bytesDown do not change
+	t.Log("Verifying bytes_up/bytes_down values do not change...")
+	for i := 0; i < 5; i++ {
+		time.Sleep(3 * time.Second)
 
 		output := e2e.RunCommand(ctx, "boundary",
 			e2e.WithArgs("sessions", "read", "-id", session.Id, "-format", "json"),
@@ -117,14 +127,11 @@ func TestCliBytesUpDownEmpty(t *testing.T) {
 		var newSessionReadResult sessions.SessionReadResult
 		err = json.Unmarshal(output.Stdout, &newSessionReadResult)
 		require.NoError(t, err)
-		bytesUp = int(newSessionReadResult.Item.Connections[0].BytesUp)
-		bytesDown = int(newSessionReadResult.Item.Connections[0].BytesDown)
+		newBytesUp := int(newSessionReadResult.Item.Connections[0].BytesUp)
+		newBytesDown := int(newSessionReadResult.Item.Connections[0].BytesDown)
+		t.Logf("bytes_up: %d, bytes_down: %d", newBytesUp, newBytesDown)
 
-		if i != 1 {
-			require.Equal(t, bytesUp, int(newSessionReadResult.Item.Connections[0].BytesUp))
-			require.Equal(t, bytesDown, int(newSessionReadResult.Item.Connections[0].BytesDown))
-		}
-
-		t.Logf("bytes_up: %d, bytes_down: %d", bytesUp, bytesDown)
+		require.Equal(t, bytesUp, newBytesUp)
+		require.Equal(t, bytesDown, newBytesDown)
 	}
 }


### PR DESCRIPTION
This PR updates the bytes up/down tests due to some upcoming changes to worker status reporting. Bytes up/down information will be sent up every 15 seconds, which caused some flakiness in these tests (the tests currently only check up to 6 seconds).

```
=== RUN   TestCliBytesUpDownEmpty
    scope.go:85: Created Org Id: o_0FgXGDvowH
    scope.go:127: Created Project Id: p_eMqKDSVfJn
    target.go:127: Created Target: ttcp_jPWTLvmYmv
    session.go:25: Waiting for session to appear...
    bytes_up_down_empty_test.go:55: Starting session...
    session.go:60: No items are appearing in the session list. Retrying...
    session.go:48: Found 1 session(s)
    session.go:55: Created Session: s_hh4zZEtfzn
    bytes_up_down_empty_test.go:77: Waiting for bytes_up/bytes_down to be greater than 0...
    bytes_up_down_empty_test.go:108: bytes_up: 3705, bytes_down: 4273
    bytes_up_down_empty_test.go:119: Verifying bytes_up/bytes_down values do not change...
    bytes_up_down_empty_test.go:135: bytes_up: 3705, bytes_down: 4273
    bytes_up_down_empty_test.go:135: bytes_up: 3705, bytes_down: 4273
    bytes_up_down_empty_test.go:135: bytes_up: 3705, bytes_down: 4273
    bytes_up_down_empty_test.go:135: bytes_up: 3705, bytes_down: 4273
    bytes_up_down_empty_test.go:135: bytes_up: 3705, bytes_down: 4273
--- PASS: TestCliBytesUpDownEmpty (22.93s)
=== RUN   TestCliBytesUpDownTransferData
    scope.go:85: Created Org Id: o_WLUFlS3Xx0
    scope.go:127: Created Project Id: p_Q9xvhoKA4i
    target.go:127: Created Target: ttcp_vywhl0r1I4
    session.go:25: Waiting for session to appear...
    bytes_up_down_test.go:58: Starting session...
    session.go:60: No items are appearing in the session list. Retrying...
    session.go:48: Found 1 session(s)
    session.go:55: Created Session: s_63mKatLQqb
    session.go:71: Waiting for session to be active...
    bytes_up_down_test.go:81: Waiting for bytes_up/bytes_down to be greater than 0...
    bytes_up_down_test.go:112: bytes_up: 3649, bytes_down: 4325
    bytes_up_down_test.go:123: Waiting for bytes_up/bytes_down to increase...
    bytes_up_down_test.go:159: bytes_up: 3649, bytes_down: 4325, bytes_up/bytes_down is not greater than previous value. Retrying...
    bytes_up_down_test.go:159: bytes_up: 3649, bytes_down: 4457, bytes_up/bytes_down is not greater than previous value. Retrying...
    bytes_up_down_test.go:154: bytes_up: 3745, bytes_down: 4713
--- PASS: TestCliBytesUpDownTransferData (14.64s)
```

https://hashicorp.atlassian.net/browse/ICU-16156