### PR TITLE
chore: Modify tparse check

### DIFF
--- a/.github/workflows/test-race.yml
+++ b/.github/workflows/test-race.yml
@@ -143,11 +143,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go
           fail-on-cache-miss: false
-      - name: Install tools if cache restore fails
-        if: steps.go-cache.outputs.cache-hit != 'true'
+      - name: Install tools if tparse doesn't exist
         run: |
-          go mod download
-          make tools
+          if command -v tparse &> /dev/null; then
+            echo "tparse exists"
+          else
+            echo "tparse doesn't exist"
+            go mod download
+            make tools
+          fi
       - name: Set up plugin cache
         id: plugin-cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,11 +143,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go
           fail-on-cache-miss: false
-      - name: Install tools if cache restore fails
-        if: steps.go-cache.outputs.cache-hit != 'true'
+      - name: Install tools if tparse doesn't exist
         run: |
-          go mod download
-          make tools
+          if command -v tparse &> /dev/null; then
+            echo "tparse exists"
+          else
+            echo "tparse doesn't exist"
+            go mod download
+            make tools
+          fi
       - name: Set up plugin cache
         id: plugin-cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0


### PR DESCRIPTION
Someone ran into a case where a unit test run failed due to not having `tparse` even though the cache restore was successful.
![Screenshot 2025-01-08 at 4 46 40 PM](https://github.com/user-attachments/assets/9c9fbcab-d361-4bd4-ab85-5c2ecfd1e186)
https://github.com/hashicorp/boundary/actions/runs/12642066509/job/35225823802

We previously addressed a similar issue with [this PR](https://github.com/hashicorp/boundary/pull/5394), but in that instance, the cache failed to restore.

I haven't been able to find the root cause. Prior to the failing job, [this job](https://github.com/hashicorp/boundary/actions/runs/12623460970/job/35172475947) was the most recent run that used this cache key -- in this case, that job created the cache and ran the tests successfully. I'm not sure how `tparse` ended up missing.

In any event, this PR modifies the workflow to check if `tparse` exists regardless if it restores from the cache successfully.

https://hashicorp.atlassian.net/browse/ICU-16152
