### PR TITLE
fix(enos): bump default db version to new required minimum

### DIFF
--- a/enos/modules/aws_boundary/variables.tf
+++ b/enos/modules/aws_boundary/variables.tf
@@ -139,7 +139,7 @@ variable "db_class" {
 variable "db_version" {
   description = "AWS RDS DBS engine version (for postgres/mysql)"
   type        = string
-  default     = "15.6"
+  default     = "15.7"
 }
 
 variable "db_engine" {


### PR DESCRIPTION
# Summary

AWS stopped supporting PostgresSQL 15.6 as of today. I bumped the default version to 15.7