### PR TITLE
fix(accounts): bug grants filter children accounts

### DIFF
--- a/internal/daemon/controller/handlers/accounts/account_service.go
+++ b/internal/daemon/controller/handlers/accounts/account_service.go
@@ -1488,9 +1488,10 @@ func validateSetPasswordRequest(ctx context.Context, req *pbs.SetPasswordRequest
 
 func newOutputOpts(ctx context.Context, item auth.Account, authMethodId string, authResults requestauth.VerifyResults) ([]handlers.Option, bool) {
 	res := perms.Resource{
-		ScopeId: authResults.Scope.Id,
-		Type:    resource.Account,
-		Pin:     authMethodId,
+		ScopeId:       authResults.Scope.Id,
+		ParentScopeId: authResults.Scope.ParentScopeId,
+		Type:          resource.Account,
+		Pin:           authMethodId,
 	}
 	res.Id = item.GetPublicId()
 	authorizedActions := authResults.FetchActionSetForId(ctx, item.GetPublicId(), IdActions[globals.ResourceInfoFromPrefix(item.GetPublicId()).Subtype], requestauth.WithResource(&res)).Strings()

--- a/internal/daemon/controller/handlers/accounts/grants_test.go
+++ b/internal/daemon/controller/handlers/accounts/grants_test.go
@@ -1,0 +1,109 @@
+package accounts_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/auth/ldap"
+	"github.com/hashicorp/boundary/internal/auth/oidc"
+	"github.com/hashicorp/boundary/internal/auth/password"
+	"github.com/hashicorp/boundary/internal/authtoken"
+	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/accounts"
+	"github.com/hashicorp/boundary/internal/db"
+	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListPassword_Grants(t *testing.T) {
+	ctx := context.TODO()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	kms := kms.TestKms(t, conn, wrap)
+	iamRepo, err := iam.NewRepository(ctx, rw, rw, kms)
+	require.NoError(t, err)
+	pwRepoFn := func() (*password.Repository, error) {
+		return password.NewRepository(ctx, rw, rw, kms)
+	}
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		return oidc.NewRepository(ctx, rw, rw, kms)
+	}
+
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		return ldap.NewRepository(ctx, rw, rw, kms)
+	}
+
+	org, proj := iam.TestScopes(t, iam.TestRepo(t, conn, wrap))
+	orgAM := password.TestAuthMethod(t, conn, org.GetPublicId())
+	projAM := password.TestAuthMethod(t, conn, proj.GetPublicId())
+	orgPWAccounts := password.TestMultipleAccounts(t, conn, orgAM.GetPublicId(), 3)
+	projPWAccounts := password.TestMultipleAccounts(t, conn, projAM.GetPublicId(), 3)
+
+	testcases := []struct {
+		name           string
+		roleRequest    []authtoken.TestRoleGrantsForToken
+		input          *pbs.ListAccountsRequest
+		wantAccountIDs []string
+		wantErr        error
+	}{
+		{
+			name: "children grants global scope list org accounts return org accounts",
+			input: &pbs.ListAccountsRequest{
+				AuthMethodId: orgAM.PublicId,
+				PageSize:     100,
+			},
+			roleRequest: []authtoken.TestRoleGrantsForToken{
+				{
+					RoleScopeID:  globals.GlobalPrefix,
+					GrantStrings: []string{"ids=*;type=*;actions=list,read"},
+					GrantScopes:  []string{globals.GrantScopeChildren},
+				},
+			},
+			wantAccountIDs: []string{orgPWAccounts[0].PublicId, orgPWAccounts[1].PublicId, orgPWAccounts[2].PublicId},
+			wantErr:        nil,
+		},
+		{
+			name: "children grants org scope list project accounts return project accounts",
+			input: &pbs.ListAccountsRequest{
+				AuthMethodId: projAM.PublicId,
+				PageSize:     100,
+			},
+			roleRequest: []authtoken.TestRoleGrantsForToken{
+				{
+					RoleScopeID:  org.GetPublicId(),
+					GrantStrings: []string{"ids=*;type=*;actions=list,read"},
+					GrantScopes:  []string{globals.GrantScopeChildren},
+				},
+			},
+			wantAccountIDs: []string{projPWAccounts[0].PublicId, projPWAccounts[1].PublicId, projPWAccounts[2].PublicId},
+			wantErr:        nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := accounts.NewService(ctx, pwRepoFn, oidcRepoFn, ldapRepoFn, 1000)
+			require.NoError(t, err, "Couldn't create new user service.")
+			tok := authtoken.TestAuthTokenWithRoles(t, conn, kms, globals.GlobalPrefix, tc.roleRequest)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			got, gErr := s.ListAccounts(fullGrantAuthCtx, tc.input)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, gErr)
+			require.Len(t, got.Items, len(orgPWAccounts))
+			var gotIDs []string
+			for _, item := range got.Items {
+				gotIDs = append(gotIDs, item.Id)
+			}
+			require.ElementsMatch(t, tc.wantAccountIDs, gotIDs)
+		})
+	}
+
+}

--- a/internal/daemon/controller/handlers/accounts/grants_test.go
+++ b/internal/daemon/controller/handlers/accounts/grants_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package accounts_test
 
 import (
@@ -105,5 +108,4 @@ func TestListPassword_Grants(t *testing.T) {
 			require.ElementsMatch(t, tc.wantAccountIDs, gotIDs)
 		})
 	}
-
 }


### PR DESCRIPTION
fix children grants filtering out results because `parentScopeId` isn't passed into the permissions engine during the output filtering
