### PR TITLE
Restrict concurrent password hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 * Fix bug in parsing IPv6 addresses. Previously setting a target address or the
   initial upstream address in the config file would result in a malformed value.
   ([PR](https://github.com/hashicorp/boundary/pull/5221)).
+* Fix an issue where, when starting a session, the connection limit always displays 0.
+  ([PR](https://github.com/hashicorp/boundary/pull/5396)).
 
 ### New and Improved
 
@@ -33,11 +35,16 @@ maintainability of worker queries, and improve DB performance. ([PR](https://git
   and reliability at large scale. Workers older than v0.19.0 will remain supported
   until the release of v0.20.0, in accordance with
   [our worker/controller compatiblity policy](https://developer.hashicorp.com/boundary/docs/enterprise/supported-versions#control-plane-and-worker-compatibility).
+* Add concurrency limit on the password hashing of all password auth methods.
+  ([PR](https://github.com/hashicorp/boundary-plugin-aws/pull/5437)).
 
-### Bug fixes
+  This avoids bursty memory and CPU use during concurrent password auth method
+  authentication attempts. The number of concurrent hashing operations
+  can be set with the new `concurrent_password_hash_workers` configuration
+  value in the controller stanza, or the new 
+  `BOUNDARY_CONTROLLER_CONCURRENT_PASSWORD_HASH_WORKERS` environment variable.
+  The default limit is 1.
 
-* Fix an issue where, when starting a session, the connection limit always displays 0.
-  ([PR](https://github.com/hashicorp/boundary/pull/5396)).
 
 ## 0.18.2 (2024/12/12)
 ### Bug fixes

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/posener/complete v1.2.3
 	github.com/prometheus/client_golang v1.18.0
 	github.com/ryanuber/go-glob v1.0.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/zalando/go-keyring v0.2.3
 	go.uber.org/atomic v1.11.0
 	golang.org/x/crypto v0.31.0
@@ -93,6 +93,7 @@ require (
 	github.com/hashicorp/dbassert v0.0.0-20231012105025-1bc1bd88e22b
 	github.com/hashicorp/go-kms-wrapping/extras/kms/v2 v2.0.0-20241126174344-f3b1a41a15fd
 	github.com/hashicorp/go-rate v0.0.0-20231204194614-cc8d401f70ab
+	github.com/hashicorp/go-secure-stdlib/permitpool v1.0.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/nodeenrollment v0.2.13
 	github.com/jackc/pgx/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,8 @@ github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8 h1:iBt4Ew4XEGLfh6/bPk4rSY
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8/go.mod h1:aiJI+PIApBRQG7FZTEBx5GiiX+HbOHilUdNxUZi4eV0=
 github.com/hashicorp/go-secure-stdlib/password v0.1.3 h1:/2S3qhBDGbI0DoSgSC8m9EaiRelgGrJmApZIDb/8Xv8=
 github.com/hashicorp/go-secure-stdlib/password v0.1.3/go.mod h1:JPOgAG+z70auO30+LCRhvZKxGAh8cfXorXNJWGlFiVQ=
+github.com/hashicorp/go-secure-stdlib/permitpool v1.0.0 h1:U6y5MXGiDVOOtkWJ6o/tu1TxABnI0yKTQWJr7z6BpNk=
+github.com/hashicorp/go-secure-stdlib/permitpool v1.0.0/go.mod h1:ecDb3o+8D4xtP0nTCufJaAVawHavy5M2eZ64Nq/8/LM=
 github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.6 h1:ZYv2XA+tEfFXIToR2jmBgVqQU9gERt0APbWqmUoNGnY=
 github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.6/go.mod h1:ggFN8dlaLWS2R1gymBbCrvXM/bkZP7hEAa4seqDwhyg=
 github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1 h1:SMGUnbpAcat8rIKHkBPjfv81yC46a8eCNZ2hsR2l1EI=
@@ -484,8 +486,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
 github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=

--- a/internal/auth/password/permitpool.go
+++ b/internal/auth/password/permitpool.go
@@ -1,0 +1,59 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package password
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
+)
+
+// resizablePermitPool is a permit pool that can be resized at runtime.
+type resizablePermitPool struct {
+	pool *permitpool.Pool
+	// lock is used to synchronize access to the permit pool
+	// This is an RWMutex to allow an unlimited number of readers
+	// and a single writer, since allowing a single reader or writer
+	// would effectively make the pool useless.
+	lock *sync.RWMutex
+}
+
+// newResizablePermitPool creates a new resizable permit pool with n permits.
+func newResizablePermitPool(n int) *resizablePermitPool {
+	return &resizablePermitPool{
+		pool: permitpool.New(n),
+		lock: &sync.RWMutex{},
+	}
+}
+
+// SetPermit sets the number of permits available in the pool.
+func (r *resizablePermitPool) SetPermits(n int) error {
+	const op = "resizablePermitPool.SetPermits"
+	if n <= 0 {
+		return errors.New(context.Background(), errors.InvalidParameter, op, "n must be greater than 0")
+	}
+	// Taking a write lock ensures there are no currently acquired permits
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.pool = permitpool.New(n)
+	return nil
+}
+
+// Do executes the provided function with a permit acquired from the pool.
+// If the context is canceled while waiting to acquire a permit, an error is returned.
+func (r *resizablePermitPool) Do(ctx context.Context, fn func()) error {
+	const op = "resizablePermitPool.Do"
+	// We need to ensure both the Acquire and Release happen while the read lock is held,
+	// so that the pool cannot be resized in between.
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	if err := r.pool.Acquire(ctx); err != nil {
+		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to acquire permit"))
+	}
+	defer r.pool.Release()
+	fn()
+	return nil
+}

--- a/internal/auth/password/permitpool_test.go
+++ b/internal/auth/password/permitpool_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package password
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPermitPool(t *testing.T) {
+	pool := newResizablePermitPool(1)
+	wg := &sync.WaitGroup{}
+	start := make(chan struct{})
+
+	ctx := context.Background()
+	// Start 5 goroutines all trying to acquire the permit at the same time
+	for i := range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			t.Log("Goroutine " + strconv.Itoa(i) + " starting")
+			err := pool.Do(ctx, func() {
+				// Do some expensive operation
+				time.Sleep(10 * time.Millisecond)
+			})
+			assert.NoError(t, err)
+			t.Log("Goroutine " + strconv.Itoa(i) + " finished")
+		}()
+	}
+
+	// Also start a few goroutines that attempt to resize the pool
+	for i := range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			t.Log("Resizing pool " + strconv.Itoa(i))
+			err := pool.SetPermits(2)
+			t.Log("Resized pool" + strconv.Itoa(i))
+			assert.NoError(t, err)
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/auth/password"
 	"github.com/hashicorp/boundary/internal/cmd/base"
 	"github.com/hashicorp/boundary/internal/cmd/config"
 	"github.com/hashicorp/boundary/internal/cmd/ops"
@@ -868,6 +869,10 @@ func (c *Command) Reload(newConf *config.Config) error {
 		if workerReloadErr != nil {
 			reloadErrors = stderrors.Join(reloadErrors, fmt.Errorf("error encountered reloading worker initial upstreams: %w", workerReloadErr))
 		}
+	}
+
+	if newConf != nil && newConf.Controller != nil && newConf.Controller.ConcurrentPasswordHashWorkers > 0 {
+		reloadErrors = stderrors.Join(reloadErrors, password.SetHashingPermits(int(newConf.Controller.ConcurrentPasswordHashWorkers)))
 	}
 
 	// Send a message that we reloaded. This prevents "guessing" sleep times

--- a/internal/daemon/controller/controller.go
+++ b/internal/daemon/controller/controller.go
@@ -495,6 +495,12 @@ func New(ctx context.Context, conf *Config) (*Controller, error) {
 		event.WriteSysEvent(ctx, op, "unable to ensure worker auth roots exist, may be due to multiple controllers starting at once, continuing")
 	}
 
+	if c.conf.RawConfig.Controller.ConcurrentPasswordHashWorkers > 0 {
+		if err := password.SetHashingPermits(int(c.conf.RawConfig.Controller.ConcurrentPasswordHashWorkers)); err != nil {
+			return nil, fmt.Errorf("unable to set number of concurrent password workers: %w", err)
+		}
+	}
+
 	if graphFactory != nil {
 		boundVer := version.Get().VersionNumber()
 		c.downstreamWorkers, err = graphFactory(ctx, "root", boundVer)


### PR DESCRIPTION
### [internal/auth/password: add resizable pool](https://github.com/hashicorp/boundary/pull/5437/commits/5d3ed2ccb8d6784b63ab7e7d97956bcdd92e9467)
The resizable pool wraps the permit pool with a mutex
to allow it to be resized at runtime.

### [internal/auth/password: add concurrency limit](https://github.com/hashicorp/boundary/pull/5437/commits/e75ce91c84ff1af3b95c8f299b56c33f893a24c1)
The default concurrency limit is 1, and it can be
set using the SetHashingPermits function.

### [internal/cmd/config: allow configuring hashing limits](https://github.com/hashicorp/boundary/pull/5437/commits/724cbb1e12a3fe6a6ed68d001d66bf2e52d94ac8)
The new concurrent_password_hash_workers configuration
value can be used to loosen the constraints on the
password auth method hashing operation.

### [internal/cmd: set password hashing constraints](https://github.com/hashicorp/boundary/pull/5437/commits/8285311bc27b1a06ab530cc7979551bedee24efc)
Sets the password hashing concurrency constraints on
startup and config reload.

### [CHANGELOG: add notice about password concurrency limit](https://github.com/hashicorp/boundary/pull/5437/commits/82356e17f0e9c5d34868a9abc94d92ec6c5c5400)