### PR TITLE
chore: Handle build-ui case when there's multiple artifacts

### DIFF
--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -37,10 +37,11 @@ if which gh &> /dev/null;  then
     echo "Found gh cli, attempting to download ui assets"
 
     artifact_id=$(gh api "repos/hashicorp/${REPO_NAME}/actions/artifacts" --paginate | \
-        jq ".artifacts[] | select(.workflow_run.head_sha == \"${UI_COMMITISH}\" and .name == \"admin-ui-${UI_EDITION}\")" | \
+        jq ".artifacts[] | select(.workflow_run.head_sha == \"${UI_COMMITISH}f\" and .name == \"admin-ui-${UI_EDITION}\")" | \
+        jq --slurp '.[0]' | \
         jq -r '.id')
 
-    if [[ ${artifact_id} ]]; then
+    if [[ "${artifact_id}" != "null" ]]; then
         echo "Downloading artifact: ${artifact_id} for admin-ui-${UI_EDITION} ${UI_COMMITISH}"
         tmp_dir=$(mktemp -d)
         gh api "repos/hashicorp/${REPO_NAME}/actions/artifacts/${artifact_id}/zip" > "${tmp_dir}/boundary-ui.zip"


### PR DESCRIPTION
`make build-ui` has been failing in `boundary-enterprise` for the following reason
```
❯ make build-ui
./scripts/build-ui.sh
==> Building default UI version from internal/ui/VERSION_ent: b3266a06d02e155773bdf6aab67e4746b4900ffd
Found gh cli, attempting to download ui assets
Downloading artifact: 2426488954
2404259760
2042297073 for admin-ui-ent b3266a06d02e155773bdf6aab67e4746b4900ffd
parse "https://api.github.com/repos/hashicorp/boundary-ui-enterprise/actions/artifacts/2426488954\n2404259760\n2042297073/zip": net/url: invalid control character in URL
make: *** [build-ui] Error 1
```

This is caused by the `gh` command looking artifact ids for a certain commit, which in this case, is returning several artifact ids separated by `\n`. 
```
{
  "id": 2426488954,
  ...
}
{
  "id": 2404259760,
  ...
}
{
  "id": 2042297073,
  ...
}
```

The `gh` command returns several JSON objects, so this PR uses the slurp option to read them all into an array and selects the first one (the output is sorted by `createdAt:descending`).

https://hashicorp.atlassian.net/browse/ICU-16237