### PR TITLE
chore: Add permissions to CI user

### DIFF
--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -143,6 +143,7 @@ data "aws_iam_policy_document" "enos_policy_document" {
       "elasticloadbalancing:DescribeTargetGroups",
       "elasticloadbalancing:DescribeTargetHealth",
       "elasticloadbalancing:ModifyListener",
+      "elasticloadbalancing:ModifyListenerAttributes",
       "elasticloadbalancing:ModifyLoadBalancerAttributes",
       "elasticloadbalancing:ModifyRule",
       "elasticloadbalancing:ModifyTargetGroup",


### PR DESCRIPTION
Observed some e2e test failures due to the following
> Error: modifying ELBv2 Listener (arn:aws:elasticloadbalancing:us-east-1:173905499206:listener/app/boundary-alb-zynxjceb/e115653ecf1ea789/25bae502218ed4b1) attributes: operation error Elastic Load Balancing v2: ModifyListenerAttributes, https response error StatusCode: 403, RequestID: a8f01fe5-6a15-4de7-beb5-4630fca0f4c4, api error AccessDenied: User: arn:aws:sts::173905499206:assumed-role/github_actions-boundary_enterprise_ci/GitHubActions is not authorized to perform: elasticloadbalancing:ModifyListenerAttributes on resource: arn:aws:elasticloadbalancing:us-east-1:173905499206:listener/app/boundary-alb-zynxjceb/e115653ecf1ea789/25bae502218ed4b1 because no identity-based policy allows the elasticloadbalancing:ModifyListenerAttributes action

This PR updates the terraform to update the CI user to include the missing permission. The terraform changes have already been applied to the users.

https://hashicorp.atlassian.net/browse/ICU-16240