### PR TITLE
fix(authmethods): set parent scope ID for auth methods resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   regardless of the value set.
   ([PR](https://github.com/hashicorp/boundary/pull/5385)).
 
+* Fix bug which causes groups in children scope to be filtered out when
+  the scopes are granted access using children keyword.
+  ([PR](https://github.com/hashicorp/boundary/pull/5418)).
+
+
 ### New and Improved
 
 * Introduces soft-delete for users within the client cache.

--- a/internal/authtoken/testing.go
+++ b/internal/authtoken/testing.go
@@ -5,7 +5,6 @@ package authtoken
 
 import (
 	"context"
-	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/go-uuid"
 	"testing"
 
@@ -71,7 +70,7 @@ func TestAuthTokenWithRoles(t testing.TB, conn *db.DB, kms *kms.Kms, scopeId str
 	loginName, err := uuid.GenerateUUID()
 	require.NoError(t, err)
 	acct := password.TestAccount(t, conn, authMethod.GetPublicId(), loginName)
-	user := iam.TestUser(t, iamRepo, globals.GlobalPrefix, iam.WithAccountIds(acct.GetPublicId()))
+	user := iam.TestUser(t, iamRepo, scopeId, iam.WithAccountIds(acct.GetPublicId()))
 	for _, r := range roles {
 		role := iam.TestRoleWithGrants(t, conn, r.RoleScopeID, r.GrantScopes, r.GrantStrings)
 		_ = iam.TestUserRole(t, conn, role.PublicId, user.PublicId)

--- a/internal/authtoken/testing.go
+++ b/internal/authtoken/testing.go
@@ -66,6 +66,8 @@ func TestAuthTokenWithRoles(t testing.TB, conn *db.DB, kms *kms.Kms, scopeId str
 	require.NoError(t, err)
 
 	iamRepo, err := iam.NewRepository(ctx, rw, rw, kms)
+	require.NoError(t, err)
+
 	authMethod := password.TestAuthMethods(t, conn, scopeId, 1)[0]
 
 	loginName, err := uuid.GenerateUUID()
@@ -79,5 +81,4 @@ func TestAuthTokenWithRoles(t testing.TB, conn *db.DB, kms *kms.Kms, scopeId str
 	fullGrantToken, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())
 	require.NoError(t, err)
 	return fullGrantToken
-
 }

--- a/internal/authtoken/testing.go
+++ b/internal/authtoken/testing.go
@@ -5,13 +5,13 @@ package authtoken
 
 import (
 	"context"
-	"github.com/hashicorp/go-uuid"
 	"testing"
 
 	"github.com/hashicorp/boundary/internal/auth/password"
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,7 +48,8 @@ func TestAuthToken(t testing.TB, conn *db.DB, kms *kms.Kms, scopeId string, opt 
 	return at
 }
 
-// TestRoleGrantsForToken
+// TestRoleGrantsForToken contains information used by TestAuthTokenWithRoles to create
+// roles and their associated grants (with grant scopes)
 type TestRoleGrantsForToken struct {
 	RoleScopeID  string
 	GrantStrings []string

--- a/internal/daemon/controller/auth/testing.go
+++ b/internal/daemon/controller/auth/testing.go
@@ -7,18 +7,17 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/boundary/internal/db"
-	"github.com/hashicorp/boundary/internal/iam"
-	"github.com/hashicorp/boundary/internal/kms"
-	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/daemon/controller/common"
+	"github.com/hashicorp/boundary/internal/db"
 	authpb "github.com/hashicorp/boundary/internal/gen/controller/auth"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/requests"
 	"github.com/hashicorp/boundary/internal/server"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/stretchr/testify/require"
 )
 
 // DisabledAuthTestContext is meant for testing, and uses a context that has

--- a/internal/daemon/controller/auth/testing.go
+++ b/internal/daemon/controller/auth/testing.go
@@ -5,12 +5,13 @@ package auth
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/stretchr/testify/require"
-	"testing"
 
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/authtoken"

--- a/internal/daemon/controller/auth/testing.go
+++ b/internal/daemon/controller/auth/testing.go
@@ -5,11 +5,19 @@ package auth
 
 import (
 	"context"
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/stretchr/testify/require"
+	"testing"
 
 	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/daemon/controller/common"
 	authpb "github.com/hashicorp/boundary/internal/gen/controller/auth"
 	"github.com/hashicorp/boundary/internal/requests"
+	"github.com/hashicorp/boundary/internal/server"
 )
 
 // DisabledAuthTestContext is meant for testing, and uses a context that has
@@ -29,4 +37,31 @@ func DisabledAuthTestContext(iamRepoFn common.IamRepoFactory, scopeId string, op
 	reqInfo.Actions = opts.withActions
 	requestContext := context.WithValue(context.Background(), requests.ContextRequestInformationKey, &requests.RequestContext{})
 	return NewVerifierContext(requestContext, iamRepoFn, nil, nil, opts.withKms, &reqInfo)
+}
+
+// TestAuthContextFromToken creates an auth context with provided token
+// This is used in conjunction with TestAuthTokenWithRoles which creates a test token
+func TestAuthContextFromToken(t *testing.T, conn *db.DB, wrap wrapping.Wrapper, token *authtoken.AuthToken, iamRepo *iam.Repository) context.Context {
+	t.Helper()
+	ctx := context.Background()
+	rw := db.New(conn)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	serversRepoFn := func() (*server.Repository, error) {
+		return server.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	atRepoFn := func() (*authtoken.Repository, error) {
+		return atRepo, nil
+	}
+	fullGrantAuthCtx := NewVerifierContext(requests.NewRequestContext(ctx, requests.WithUserId(token.GetIamUserId())),
+		iamRepoFn, atRepoFn, serversRepoFn, kmsCache, &authpb.RequestInfo{
+			PublicId:    token.PublicId,
+			Token:       token.GetToken(),
+			TokenFormat: uint32(AuthTokenTypeBearer),
+		})
+	return fullGrantAuthCtx
 }

--- a/internal/daemon/controller/handlers/authmethods/authmethod_service.go
+++ b/internal/daemon/controller/handlers/authmethods/authmethod_service.go
@@ -1577,6 +1577,7 @@ func newOutputOpts(ctx context.Context, item auth.AuthMethod, scopeInfoMap map[s
 	}
 	res.Id = item.GetPublicId()
 	res.ScopeId = item.GetScopeId()
+	res.ParentScopeId = scopeInfoMap[item.GetScopeId()].GetParentScopeId()
 	authorizedActions := authResults.FetchActionSetForId(ctx, item.GetPublicId(), IdActions[globals.ResourceInfoFromPrefix(item.GetPublicId()).Subtype], requestauth.WithResource(&res)).Strings()
 	if len(authorizedActions) == 0 {
 		return nil, false, nil

--- a/internal/daemon/controller/handlers/authmethods/grants_test.go
+++ b/internal/daemon/controller/handlers/authmethods/grants_test.go
@@ -1,0 +1,143 @@
+package authmethods_test
+
+import (
+	"context"
+
+	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/auth"
+	"github.com/hashicorp/boundary/internal/auth/ldap"
+	"github.com/hashicorp/boundary/internal/auth/oidc"
+	"github.com/hashicorp/boundary/internal/auth/password"
+	"github.com/hashicorp/boundary/internal/authtoken"
+	controllerauth "github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
+
+	"testing"
+
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/authmethods"
+	"github.com/hashicorp/boundary/internal/db"
+	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGrants_ReadActions tests read actions to assert that grants are being applied properly
+func TestGrants_ReadActions(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	rw := db.New(conn)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		return oidc.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		return ldap.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	pwRepoFn := func() (*password.Repository, error) {
+		return password.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	atRepoFn := func() (*authtoken.Repository, error) {
+		return authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	authMethodRepoFn := func() (*auth.AuthMethodRepository, error) {
+		return auth.NewAuthMethodRepository(ctx, rw, rw, kmsCache)
+	}
+
+	s, err := authmethods.NewService(ctx,
+		kmsCache,
+		pwRepoFn,
+		oidcRepoFn,
+		iamRepoFn,
+		atRepoFn,
+		ldapRepoFn,
+		authMethodRepoFn,
+		1000)
+	require.NoError(t, err)
+	org1, _ := iam.TestScopes(t, iamRepo)
+	org2, _ := iam.TestScopes(t, iamRepo)
+
+	pwGlobal := password.TestAuthMethod(t, conn, globals.GlobalPrefix)
+	pwOrg1 := password.TestAuthMethod(t, conn, org1.GetPublicId())
+	pwOrg2 := password.TestAuthMethod(t, conn, org2.GetPublicId())
+
+	t.Run("Get", func(t *testing.T) {
+		testcases := []struct {
+			name             string
+			input            *pbs.ListAuthMethodsRequest
+			amIDExpectErrMap map[string]error
+			rolesToCreate    []authtoken.TestRoleGrantsForToken
+		}{
+			{
+				name: "global role grant this and children returns all auth methods",
+				amIDExpectErrMap: map[string]error{
+					pwGlobal.GetPublicId(): nil,
+					pwOrg1.GetPublicId():   nil,
+					pwOrg2.GetPublicId():   nil,
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				},
+			},
+			{
+				name: "org role grant this and children returns auth methods in org1",
+				input: &pbs.ListAuthMethodsRequest{
+					ScopeId:   org1.PublicId,
+					Recursive: true,
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeChildren},
+					},
+				},
+				amIDExpectErrMap: map[string]error{
+					pwGlobal.GetPublicId(): handlers.ForbiddenError(),
+					pwOrg1.GetPublicId():   nil,
+					pwOrg2.GetPublicId():   nil,
+				},
+			},
+			{
+				name: "no grants return all auth methods",
+				input: &pbs.ListAuthMethodsRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+					PageSize:  500,
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{},
+				amIDExpectErrMap: map[string]error{
+					pwGlobal.GetPublicId(): handlers.ForbiddenError(),
+					pwOrg1.GetPublicId():   handlers.ForbiddenError(),
+					pwOrg2.GetPublicId():   handlers.ForbiddenError(),
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				for amId, wantErr := range tc.amIDExpectErrMap {
+					_, err := s.GetAuthMethod(fullGrantAuthCtx, &pbs.GetAuthMethodRequest{
+						Id: amId,
+					})
+					if wantErr != nil {
+						require.ErrorIs(t, err, wantErr)
+						continue
+					}
+					require.NoError(t, err)
+				}
+			})
+		}
+	})
+}

--- a/internal/daemon/controller/handlers/groups/grants_test.go
+++ b/internal/daemon/controller/handlers/groups/grants_test.go
@@ -5,7 +5,6 @@ package groups_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
@@ -111,7 +110,6 @@ func TestGrants_ReadActions(t *testing.T) {
 				require.NoError(t, finalErr)
 				var gotIDs []string
 				for _, g := range got.Items {
-					fmt.Println(g.GetName())
 					gotIDs = append(gotIDs, g.GetId())
 				}
 				require.ElementsMatch(t, tc.wantIDs, gotIDs)

--- a/internal/daemon/controller/handlers/groups/grants_test.go
+++ b/internal/daemon/controller/handlers/groups/grants_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package groups_test
+
+import (
+	"context"
+	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/kms"
+	"testing"
+
+	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/authtoken"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/groups"
+	"github.com/hashicorp/boundary/internal/db"
+	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGrants_ReadActions tests read actions to assert that grants are being applied properly
+//
+//	 Role - which scope the role is created in
+//			- global level
+//			- org level
+//			- project level
+//		Grant - what IAM grant scope is set for the permission
+//			- global: descendant
+//			- org: children
+//			- project
+//		Scopes [resource]:
+//			- global [globalGroup]
+//				- org1 [org1Group]
+//					- proj1 [proj1Group]
+//				- org2 [org2Group]
+//					- proj2 [proj2Group]
+//					- proj3 [proj3Group]
+func TestGrants_ReadActions(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	kmsCache := kms.TestKms(t, conn, wrap)
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+	org1, _ := iam.TestScopes(t, iamRepo)
+	org2, _ := iam.TestScopes(t, iamRepo)
+
+	globalGroup := iam.TestGroup(t, conn, globals.GlobalPrefix, iam.WithDescription("global"), iam.WithName("global"))
+	org1Group := iam.TestGroup(t, conn, org1.GetPublicId(), iam.WithDescription("org1"), iam.WithName("org1"))
+	org2Group := iam.TestGroup(t, conn, org2.GetPublicId(), iam.WithDescription("org2"), iam.WithName("org2"))
+
+	t.Run("List", func(t *testing.T) {
+		testcases := []struct {
+			name          string
+			input         *pbs.ListGroupsRequest
+			rolesToCreate []authtoken.TestRoleGrantsForToken
+			wantErr       error
+			wantIDs       []string
+		}{
+			{
+				name: "global role grant this and children returns global and org groups",
+				input: &pbs.ListGroupsRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=group;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				},
+				wantErr: nil,
+				wantIDs: []string{globalGroup.PublicId, org1Group.PublicId, org2Group.PublicId},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
+				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				got, finalErr := s.ListGroups(fullGrantAuthCtx, tc.input)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, finalErr, tc.wantErr)
+					return
+				}
+				require.NoError(t, finalErr)
+				var gotIDs []string
+				for _, g := range got.Items {
+					gotIDs = append(gotIDs, g.GetId())
+				}
+				require.ElementsMatch(t, tc.wantIDs, gotIDs)
+			})
+		}
+	})
+
+}

--- a/internal/daemon/controller/handlers/groups/grants_test.go
+++ b/internal/daemon/controller/handlers/groups/grants_test.go
@@ -7,15 +7,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
-	"github.com/hashicorp/boundary/internal/kms"
-
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/authtoken"
+	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/groups"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/daemon/controller/handlers/groups/grants_test.go
+++ b/internal/daemon/controller/handlers/groups/grants_test.go
@@ -5,9 +5,10 @@ package groups_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
 	"github.com/hashicorp/boundary/internal/kms"
-	"testing"
 
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/authtoken"
@@ -97,5 +98,4 @@ func TestGrants_ReadActions(t *testing.T) {
 			})
 		}
 	})
-
 }

--- a/internal/daemon/controller/handlers/groups/group_service.go
+++ b/internal/daemon/controller/handlers/groups/group_service.go
@@ -840,6 +840,7 @@ func newOutputOpts(ctx context.Context, item *iam.Group, scopeInfoMap map[string
 	}
 	res.Id = item.GetPublicId()
 	res.ScopeId = item.GetScopeId()
+	res.ParentScopeId = scopeInfoMap[item.GetScopeId()].GetParentScopeId()
 	authorizedActions := authResults.FetchActionSetForId(ctx, item.GetPublicId(), IdActions, auth.WithResource(&res))
 	if len(authorizedActions) == 0 {
 		return nil, false


### PR DESCRIPTION
- **add utility functions for grants tests**
- **use passed in scopeID to create user**
- **add test for groups list**
- **groups: set ParentScopeId before FetchActionSetForId**
- **add comment to TestRoleGrantsForToken**
- **lint and ran make gen**
- **fix import groups**
- **add an additional test case**
- **remove print**
- **changelog**
- **handlers/authmethods: fix children permission**
