### PR TITLE
test(e2e): Address flakiness in bytes up/down test

### DIFF
--- a/testing/internal/e2e/tests/base/bytes_up_down_empty_test.go
+++ b/testing/internal/e2e/tests/base/bytes_up_down_empty_test.go
@@ -108,7 +108,7 @@ func TestCliBytesUpDownEmpty(t *testing.T) {
 			t.Logf("bytes_up: %d, bytes_down: %d", bytesUp, bytesDown)
 			return nil
 		},
-		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 6),
 		func(err error, td time.Duration) {
 			t.Logf("%s. Retrying...", err.Error())
 		},

--- a/testing/internal/e2e/tests/base/bytes_up_down_test.go
+++ b/testing/internal/e2e/tests/base/bytes_up_down_test.go
@@ -68,7 +68,7 @@ func TestCliBytesUpDownTransferData(t *testing.T) {
 				"-o", "IdentitiesOnly=yes", // forces the use of the provided key
 				"-p", "{{boundary.port}}", // this is provided by boundary
 				"{{boundary.ip}}",
-				"for i in {1..10}; do pwd; sleep 1s; done",
+				"for i in {1..30}; do pwd; sleep 1s; done",
 			),
 		)
 	}()
@@ -143,7 +143,7 @@ func TestCliBytesUpDownTransferData(t *testing.T) {
 			newBytesUp = int(newSessionReadResult.Item.Connections[0].BytesUp)
 			newBytesDown = int(newSessionReadResult.Item.Connections[0].BytesDown)
 
-			if !(newBytesDown > bytesDown) || !(newBytesUp > bytesUp) {
+			if !(newBytesDown > bytesDown) {
 				return fmt.Errorf(
 					"bytes_up: %d, bytes_down: %d, bytes_up/bytes_down is not greater than previous value",
 					newBytesUp,
@@ -154,7 +154,7 @@ func TestCliBytesUpDownTransferData(t *testing.T) {
 			t.Logf("bytes_up: %d, bytes_down: %d", newBytesUp, newBytesDown)
 			return nil
 		},
-		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 6),
 		func(err error, td time.Duration) {
 			t.Logf("%s. Retrying...", err.Error())
 		},


### PR DESCRIPTION
This PR is a follow-up to https://github.com/hashicorp/boundary/pull/5424.

This PR attempts to resolve flakiness in the e2e test `TestCliBytesUpDownTransferData`. The test occasionally fails for the following reason
```
│     bytes_up_down_test.go:81: Waiting for bytes_up/bytes_down to be greater than 0...
│     bytes_up_down_test.go:117: bytes_up: 0, bytes_down: 0, bytes_up or bytes_down is not greater than 0. Retrying...
│     bytes_up_down_test.go:117: bytes_up: 0, bytes_down: 0, bytes_up or bytes_down is not greater than 0. Retrying...
│     bytes_up_down_test.go:112: bytes_up: 4728, bytes_down: 4861
│     bytes_up_down_test.go:123: Waiting for bytes_up/bytes_down to increase...
│     bytes_up_down_test.go:159: bytes_up: 4728, bytes_down: 4861, bytes_up/bytes_down is not greater than previous value. Retrying...
│     bytes_up_down_test.go:159: bytes_up: 4728, bytes_down: 4861, bytes_up/bytes_down is not greater than previous value. Retrying...
│     bytes_up_down_test.go:159: bytes_up: 4728, bytes_down: 4861, bytes_up/bytes_down is not greater than previous value. Retrying...
│     bytes_up_down_test.go:159: bytes_up: 4728, bytes_down: 4861, bytes_up/bytes_down is not greater than previous value. Retrying...
│     bytes_up_down_test.go:159: bytes_up: 4728, bytes_down: 4861, bytes_up/bytes_down is not greater than previous value. Retrying...
│     bytes_up_down_test.go:162:
│         	Error Trace:	/src/boundary/testing/internal/e2e/tests/base/bytes_up_down_test.go:162
│         	Error:      	Received unexpected error:
│         	            	bytes_up: 4728, bytes_down: 4861, bytes_up/bytes_down is not greater than previous value
│         	Test:       	TestCliBytesUpDownTransferData
│ --- FAIL: TestCliBytesUpDownTransferData (45.53s)
```

What I believe is happening
- the test invokes a session for 10s and transmits data during that session
- because of the worker status refactoring changes, bytes up/down information is now sent at a slower rate (every ~15s)
- as a result, it may take longer for the test to detect when bytes up/down is greater than 0 (the initial check). 
- the amount of time it takes can sometimes be about the amount of time that the session is transmitting data for. therefore, when the test is checking to see that bytes up/down is increasing, the session has already expired.

This PR modifies the duration that the session is transmitting for. It also updates the max amount of time to retry to account for the new update rate (~15s)

https://hashicorp.atlassian.net/browse/ICU-16238