### PR TITLE
fix(authtokens): set parent scope ID for auth token resource

### DIFF
--- a/internal/daemon/controller/handlers/authtokens/authtoken_service.go
+++ b/internal/daemon/controller/handlers/authtokens/authtoken_service.go
@@ -457,6 +457,8 @@ func newOutputOpts(ctx context.Context, item *authtoken.AuthToken, scopeInfoMap 
 	}
 	res.Id = item.GetPublicId()
 	res.ScopeId = item.GetScopeId()
+	res.ParentScopeId = scopeInfoMap[item.GetScopeId()].GetParentScopeId()
+
 	authorizedActions := authResults.FetchActionSetForId(ctx, item.GetPublicId(), IdActions, auth.WithResource(&res))
 	if len(authorizedActions) == 0 {
 		return nil, false

--- a/internal/daemon/controller/handlers/authtokens/grants_test.go
+++ b/internal/daemon/controller/handlers/authtokens/grants_test.go
@@ -1,8 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package authtokens_test
 
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
@@ -12,7 +17,6 @@ import (
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // TestGrants_ReadActions tests read actions to assert that grants are being applied properly

--- a/internal/daemon/controller/handlers/authtokens/grants_test.go
+++ b/internal/daemon/controller/handlers/authtokens/grants_test.go
@@ -1,0 +1,126 @@
+package authtokens_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/authtoken"
+	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	at "github.com/hashicorp/boundary/internal/daemon/controller/handlers/authtokens"
+	"github.com/hashicorp/boundary/internal/db"
+	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// TestGrants_ReadActions tests read actions to assert that grants are being applied properly
+//
+//	 Role - which scope the role is created in
+//			- global level
+//			- org level
+//			- project level
+//		Grant - what IAM grant scope is set for the permission
+//			- global: descendant
+//			- org: children
+//			- project
+//		Scopes [resource]:
+//			- global [globalGroup]
+//				- org1 [org1Group]
+//					- proj1 [proj1Group]
+//				- org2 [org2Group]
+//					- proj2 [proj2Group]
+//					- proj3 [proj3Group]
+func TestGrants_ReadActions(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	kmsCache := kms.TestKms(t, conn, wrap)
+
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	atRepoFn := func() (*authtoken.Repository, error) { return atRepo, nil }
+
+	s, err := at.NewService(ctx, atRepoFn, iamRepoFn, 1000)
+
+	require.NoError(t, err)
+
+	org1, _ := iam.TestScopes(t, iamRepo)
+	org2, _ := iam.TestScopes(t, iamRepo)
+
+	globalAT := authtoken.TestAuthToken(t, conn, kmsCache, globals.GlobalPrefix)
+	org1AT := authtoken.TestAuthToken(t, conn, kmsCache, org1.GetPublicId())
+	org2AT := authtoken.TestAuthToken(t, conn, kmsCache, org2.GetPublicId())
+
+	t.Run("List", func(t *testing.T) {
+		testcases := []struct {
+			name          string
+			input         *pbs.ListAuthTokensRequest
+			rolesToCreate []authtoken.TestRoleGrantsForToken
+			wantErr       error
+			wantIDs       []string
+		}{
+			{
+				name: "global role grant this and children returns global and org groups",
+				input: &pbs.ListAuthTokensRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=auth-token;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				},
+				wantErr: nil,
+				wantIDs: []string{globalAT.PublicId, org1AT.PublicId, org2AT.PublicId},
+			},
+			{
+				name: "org role grant this and children returns org groups",
+				input: &pbs.ListAuthTokensRequest{
+					ScopeId:   org1.PublicId,
+					Recursive: true,
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  org1.PublicId,
+						GrantStrings: []string{"ids=*;type=auth-token;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				},
+				wantErr: nil,
+				wantIDs: []string{org1AT.PublicId},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
+				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				got, finalErr := s.ListAuthTokens(fullGrantAuthCtx, tc.input)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, finalErr, tc.wantErr)
+					return
+				}
+				require.NoError(t, finalErr)
+				var gotIDs []string
+				for _, g := range got.Items {
+					fmt.Println("ID:", g.GetId(), "Scope:", g.GetScopeId())
+					gotIDs = append(gotIDs, g.GetId())
+				}
+
+				for _, id := range tc.wantIDs {
+					require.Contains(t, gotIDs, id)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
Set Scope ID for resources when performing final auth check in `newOutputOpt`