### PR TITLE
fix(host): set parent scope id for host resource

### DIFF
--- a/internal/daemon/controller/handlers/hosts/grants_test.go
+++ b/internal/daemon/controller/handlers/hosts/grants_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package hosts_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/authtoken"
+	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/hosts"
+	"github.com/hashicorp/boundary/internal/db"
+	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
+	hostplugin "github.com/hashicorp/boundary/internal/host/plugin"
+	"github.com/hashicorp/boundary/internal/host/static"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/scheduler"
+	plgpb "github.com/hashicorp/boundary/sdk/pbs/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGrants_ReadActions tests read actions to assert that grants are being applied properly
+//
+//	 Role - which scope the role is created in
+//			- global level
+//			- org level
+//			- proj level
+//		Grant - what IAM grant scope is set for the permission
+//			- global: descendant
+//			- org: children
+//			- project: this
+//		Scopes [resource]:
+//			- global
+//				- org1
+//					- proj1
+func TestGrants_ReadActions(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	sche := scheduler.TestScheduler(t, conn, wrap)
+	pluginRepoFn := func() (*hostplugin.Repository, error) {
+		return hostplugin.NewRepository(ctx, rw, rw, kmsCache, sche, map[string]plgpb.HostPluginServiceClient{})
+	}
+	repoFn := func() (*static.Repository, error) {
+		return static.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	s, err := hosts.NewService(ctx, repoFn, pluginRepoFn, 1000)
+	require.NoError(t, err)
+
+	org, proj := iam.TestScopes(t, iamRepo)
+
+	hcs := static.TestCatalogs(t, conn, proj.GetPublicId(), 1)
+	hc := hcs[0]
+
+	hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
+	var wantHs []string
+	testHosts := static.TestHosts(t, conn, hc.GetPublicId(), 10)
+	static.TestSetMembers(t, conn, hset.GetPublicId(), testHosts)
+	for _, h := range testHosts {
+		wantHs = append(wantHs, h.GetPublicId())
+	}
+
+	t.Run("List", func(t *testing.T) {
+		testcases := []struct {
+			name          string
+			input         *pbs.ListHostsRequest
+			rolesToCreate []authtoken.TestRoleGrantsForToken
+			wantErr       error
+			wantIDs       []string
+		}{
+			{
+				name: "global role grant this returns all created hosts",
+				input: &pbs.ListHostsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=host;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				},
+				wantErr: nil,
+				wantIDs: wantHs,
+			},
+			{
+				name: "org role grant this returns all created hosts",
+				input: &pbs.ListHostsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  org.PublicId,
+						GrantStrings: []string{"ids=*;type=host;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				},
+				wantErr: nil,
+				wantIDs: wantHs,
+			},
+			{
+				name: "project role grant this returns all created hosts",
+				input: &pbs.ListHostsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  proj.PublicId,
+						GrantStrings: []string{"ids=*;type=host;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis},
+					},
+				},
+				wantErr: nil,
+				wantIDs: wantHs,
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
+				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				got, finalErr := s.ListHosts(fullGrantAuthCtx, tc.input)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, finalErr, tc.wantErr)
+					return
+				}
+				require.NoError(t, finalErr)
+				var gotIDs []string
+				for _, g := range got.Items {
+					gotIDs = append(gotIDs, g.GetId())
+				}
+				require.ElementsMatch(t, tc.wantIDs, gotIDs)
+			})
+		}
+	})
+}

--- a/internal/daemon/controller/handlers/hosts/host_service.go
+++ b/internal/daemon/controller/handlers/hosts/host_service.go
@@ -622,10 +622,11 @@ func toPluginInfo(plg *plugin.Plugin) *plugins.PluginInfo {
 
 func newOutputOpts(ctx context.Context, item host.Host, plg *plugin.Plugin, authResults auth.VerifyResults) ([]handlers.Option, bool) {
 	res := perms.Resource{
-		ScopeId: authResults.Scope.Id,
-		Type:    resource.Host,
-		Pin:     item.GetCatalogId(),
-		Id:      item.GetPublicId(),
+		ScopeId:       authResults.Scope.Id,
+		ParentScopeId: authResults.Scope.ParentScopeId,
+		Type:          resource.Host,
+		Pin:           item.GetCatalogId(),
+		Id:            item.GetPublicId(),
 	}
 	res.Id = item.GetPublicId()
 	idActions := idActionsTypeMap[globals.ResourceInfoFromPrefix(res.Id).Subtype]


### PR DESCRIPTION
set the `ParentScopeId` before fetching authorized actions for host resource