### PR TITLE
chore: Update boundary-plugin-gcp to version v0.1.0

### DIFF
--- a/plugins/boundary/mains/gcp/go.mod
+++ b/plugins/boundary/mains/gcp/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/boundary/plugins/boundary/mains/gcp
 go 1.23.1
 
 require (
-	github.com/hashicorp/boundary-plugin-gcp v0.0.0-20250109165213-bcb928e4f9af
+	github.com/hashicorp/boundary-plugin-gcp v0.1.0
 	github.com/hashicorp/boundary/sdk v0.0.47
 )
 

--- a/plugins/boundary/mains/gcp/go.sum
+++ b/plugins/boundary/mains/gcp/go.sum
@@ -86,8 +86,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.3 h1:QRje2j5GZimBzlbhGA2
 github.com/googleapis/enterprise-certificate-proxy v0.3.3/go.mod h1:YKe7cfqYXjKGpGvmSg28/fFvhNzinZQm8DGnaburhGA=
 github.com/googleapis/gax-go/v2 v2.13.0 h1:yitjD5f7jQHhyDsnhKEBU52NdvvdSeGzlAnDPT0hH1s=
 github.com/googleapis/gax-go/v2 v2.13.0/go.mod h1:Z/fvTZXF8/uw7Xu5GuslPw+bplx6SS338j1Is2S+B7A=
-github.com/hashicorp/boundary-plugin-gcp v0.0.0-20250109165213-bcb928e4f9af h1:/HZf9ZuMRIPLvPaGZdNH4PourMp8ikuchaAoi2tBIME=
-github.com/hashicorp/boundary-plugin-gcp v0.0.0-20250109165213-bcb928e4f9af/go.mod h1:l15UQaKEEcppwrFGGVNBBVmAZqN5HaOk29dh5uVVztQ=
+github.com/hashicorp/boundary-plugin-gcp v0.1.0 h1:fIq07J0byp3qJ7aCC+oN+hLt11V5kjgzj3HpOa6r32o=
+github.com/hashicorp/boundary-plugin-gcp v0.1.0/go.mod h1:l15UQaKEEcppwrFGGVNBBVmAZqN5HaOk29dh5uVVztQ=
 github.com/hashicorp/boundary/sdk v0.0.47 h1:h5AXOASS2duHkCYEmNKnI9AR6YBZxD7VbFPV8BoE0z0=
 github.com/hashicorp/boundary/sdk v0.0.47/go.mod h1:9iOT7kDM6mYcSkKxNuZlv8rP7U5BG1kXoevjLLL8lNQ=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
Update the GCP plugin dependency to point the latest released version