### PR TITLE
fix(common) set parent ID before fetching action setsparent ID before fetching action sets

### DIFF
--- a/internal/daemon/controller/common/scopeids/scope_ids.go
+++ b/internal/daemon/controller/common/scopeids/scope_ids.go
@@ -83,9 +83,9 @@ type GetListingResourceInformationOutput struct {
 // resources; the IDs of the resources known to be authorized for that user; and
 // a memoized map of the scopes to their info for populating returned values.
 func GetListingResourceInformation(
-	// The context to use when listing in the DB, if required
+// The context to use when listing in the DB, if required
 	ctx context.Context,
-	// The input struct
+// The input struct
 	input GetListingResourceInformationInput,
 ) (*GetListingResourceInformationOutput, error) {
 	const op = "scopeids.GetListingResourceInformation"
@@ -150,6 +150,7 @@ func GetListingResourceInformation(
 	for _, scp := range scps {
 		scpId := scp.GetPublicId()
 		res.ScopeId = scpId
+		res.ParentScopeId = scp.GetParentId()
 		aSet := input.AuthResults.FetchActionSetForType(ctx,
 			// This is overridden by WithResource
 			resource.Unknown,
@@ -249,11 +250,11 @@ func GetListingResourceInformation(
 //
 // It also populates the scope IDs in the output
 func filterAuthorizedResourceIds(
-	// The context to use when listing in the DB, if required
+// The context to use when listing in the DB, if required
 	ctx context.Context,
-	// The input struct
+// The input struct
 	input GetListingResourceInformationInput,
-	// The scope information to fill out
+// The scope information to fill out
 	output *GetListingResourceInformationOutput,
 ) error {
 	const op = "scopeids.filterAuthorizedResources"
@@ -316,18 +317,18 @@ func (i *GetListingResourceInformationOutput) populateScopeIdsFromScopeResourceM
 // services; services should eventually migrate to
 // GetListingResourceInformation.
 func GetListingScopeIds(
-	// The context to use when listing in the DB, if required
+// The context to use when listing in the DB, if required
 	ctx context.Context,
-	// An IAM repo function to use for a listing call, if required
+// An IAM repo function to use for a listing call, if required
 	repoFn common.IamRepoFactory,
-	// The original auth results from the list command
+// The original auth results from the list command
 	authResults auth.VerifyResults,
-	// The scope ID to use, or to use as the starting point for a recursive
-	// search
+// The scope ID to use, or to use as the starting point for a recursive
+// search
 	rootScopeId string,
-	// The type of resource we are listing
+// The type of resource we are listing
 	typ resource.Type,
-	// Whether or not the search should be recursive
+// Whether or not the search should be recursive
 	recursive bool,
 ) ([]string, map[string]*scopes.ScopeInfo, error) {
 	const op = "scopeids.GetListingScopeIds"

--- a/internal/daemon/controller/common/scopeids/scope_ids.go
+++ b/internal/daemon/controller/common/scopeids/scope_ids.go
@@ -83,9 +83,9 @@ type GetListingResourceInformationOutput struct {
 // resources; the IDs of the resources known to be authorized for that user; and
 // a memoized map of the scopes to their info for populating returned values.
 func GetListingResourceInformation(
-// The context to use when listing in the DB, if required
+	// The context to use when listing in the DB, if required
 	ctx context.Context,
-// The input struct
+	// The input struct
 	input GetListingResourceInformationInput,
 ) (*GetListingResourceInformationOutput, error) {
 	const op = "scopeids.GetListingResourceInformation"
@@ -250,11 +250,11 @@ func GetListingResourceInformation(
 //
 // It also populates the scope IDs in the output
 func filterAuthorizedResourceIds(
-// The context to use when listing in the DB, if required
+	// The context to use when listing in the DB, if required
 	ctx context.Context,
-// The input struct
+	// The input struct
 	input GetListingResourceInformationInput,
-// The scope information to fill out
+	// The scope information to fill out
 	output *GetListingResourceInformationOutput,
 ) error {
 	const op = "scopeids.filterAuthorizedResources"
@@ -317,18 +317,18 @@ func (i *GetListingResourceInformationOutput) populateScopeIdsFromScopeResourceM
 // services; services should eventually migrate to
 // GetListingResourceInformation.
 func GetListingScopeIds(
-// The context to use when listing in the DB, if required
+	// The context to use when listing in the DB, if required
 	ctx context.Context,
-// An IAM repo function to use for a listing call, if required
+	// An IAM repo function to use for a listing call, if required
 	repoFn common.IamRepoFactory,
-// The original auth results from the list command
+	// The original auth results from the list command
 	authResults auth.VerifyResults,
-// The scope ID to use, or to use as the starting point for a recursive
-// search
+	// The scope ID to use, or to use as the starting point for a recursive
+	// search
 	rootScopeId string,
-// The type of resource we are listing
+	// The type of resource we are listing
 	typ resource.Type,
-// Whether or not the search should be recursive
+	// Whether or not the search should be recursive
 	recursive bool,
 ) ([]string, map[string]*scopes.ScopeInfo, error) {
 	const op = "scopeids.GetListingScopeIds"

--- a/internal/daemon/controller/handlers/users/grants_test.go
+++ b/internal/daemon/controller/handlers/users/grants_test.go
@@ -129,7 +129,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 			},
 			{
-				name: "global role grant children list at org returns org user",
+				name: "org role grant children list at org returns forbidden error",
 				input: &pbs.ListUsersRequest{
 					ScopeId:   org2.PublicId,
 					Recursive: true,

--- a/internal/daemon/controller/handlers/users/grants_test.go
+++ b/internal/daemon/controller/handlers/users/grants_test.go
@@ -5,6 +5,7 @@ package users_test
 
 import (
 	"context"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
@@ -126,6 +127,22 @@ func TestGrants_ReadActions(t *testing.T) {
 					org2User1.PublicId,
 					org2User2.PublicId,
 				},
+			},
+			{
+				name: "global role grant children list at org returns org user",
+				input: &pbs.ListUsersRequest{
+					ScopeId:   org2.PublicId,
+					Recursive: true,
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  org2.PublicId,
+						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeChildren},
+					},
+				},
+				wantErr: handlers.ForbiddenError(),
+				wantIDs: nil,
 			},
 		}
 

--- a/internal/daemon/controller/handlers/users/grants_test.go
+++ b/internal/daemon/controller/handlers/users/grants_test.go
@@ -5,13 +5,13 @@ package users_test
 
 import (
 	"context"
-	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
 	talias "github.com/hashicorp/boundary/internal/alias/target"
 	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/users"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"

--- a/internal/daemon/controller/handlers/users/grants_test.go
+++ b/internal/daemon/controller/handlers/users/grants_test.go
@@ -108,6 +108,25 @@ func TestGrants_ReadActions(t *testing.T) {
 					org2User2.PublicId,
 				},
 			},
+			{
+				name: "global role grant children list at org returns org user",
+				input: &pbs.ListUsersRequest{
+					ScopeId:   org2.PublicId,
+					Recursive: true,
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeChildren},
+					},
+				},
+				wantErr: nil,
+				wantIDs: []string{
+					org2User1.PublicId,
+					org2User2.PublicId,
+				},
+			},
 		}
 
 		for _, tc := range testcases {

--- a/internal/daemon/controller/handlers/users/grants_test.go
+++ b/internal/daemon/controller/handlers/users/grants_test.go
@@ -273,22 +273,6 @@ func TestGrants_ReadActions(t *testing.T) {
 				wantIDs: nil,
 			},
 			{
-				name: "org role grant children non-recursive list at global returns forbidden error",
-				input: &pbs.ListUsersRequest{
-					ScopeId:   globals.GlobalPrefix,
-					Recursive: false,
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
-					{
-						RoleScopeID:  org2.PublicId,
-						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeChildren},
-					},
-				},
-				wantErr: handlers.ForbiddenError(),
-				wantIDs: nil,
-			},
-			{
 				name: "no grant recursive list returns forbidden error",
 				input: &pbs.ListUsersRequest{
 					ScopeId:   globals.GlobalPrefix,

--- a/internal/daemon/controller/handlers/users/grants_test.go
+++ b/internal/daemon/controller/handlers/users/grants_test.go
@@ -60,14 +60,18 @@ func TestGrants_ReadActions(t *testing.T) {
 
 	t.Run("List", func(t *testing.T) {
 		testcases := []struct {
-			name          string
-			input         *pbs.ListUsersRequest
-			rolesToCreate []authtoken.TestRoleGrantsForToken
-			wantErr       error
-			wantIDs       []string
+			name  string
+			input *pbs.ListUsersRequest
+			// set this flag when the listing user has permission to list global
+			// AND the test attempts to list users at global scope
+			// users which gets created as a part of token generation
+			includeTestUsers bool
+			rolesToCreate    []authtoken.TestRoleGrantsForToken
+			wantErr          error
+			wantIDs          []string
 		}{
 			{
-				name: "global role grant this and children returns global and org users",
+				name: "global role grant this and children recursive list at global returns global and org users",
 				input: &pbs.ListUsersRequest{
 					ScopeId:   globals.GlobalPrefix,
 					Recursive: true,
@@ -79,7 +83,8 @@ func TestGrants_ReadActions(t *testing.T) {
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
 				},
-				wantErr: nil,
+				includeTestUsers: true,
+				wantErr:          nil,
 				wantIDs: []string{
 					globals.AnyAuthenticatedUserId,
 					globals.AnonymousUserId,
@@ -91,11 +96,12 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 			},
 			{
-				name: "org role grant this and children returns org user",
+				name: "org role grant this and children recursive list at org returns org user",
 				input: &pbs.ListUsersRequest{
 					ScopeId:   org2.PublicId,
 					Recursive: true,
 				},
+				includeTestUsers: false,
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
 						RoleScopeID:  org2.PublicId,
@@ -110,11 +116,12 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 			},
 			{
-				name: "global role grant children list at org returns org user",
+				name: "global role grant children recursive list at org returns org user",
 				input: &pbs.ListUsersRequest{
 					ScopeId:   org2.PublicId,
 					Recursive: true,
 				},
+				includeTestUsers: false,
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
 						RoleScopeID:  globals.GlobalPrefix,
@@ -129,10 +136,131 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 			},
 			{
-				name: "org role grant children list at org returns forbidden error",
+				name: "global role grant children recursive list at global returns all org users",
+				input: &pbs.ListUsersRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				includeTestUsers: false,
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeChildren},
+					},
+				},
+				wantErr: nil,
+				wantIDs: []string{
+					org1User1.PublicId,
+					org2User1.PublicId,
+					org2User2.PublicId,
+				},
+			},
+			{
+				name: "org1 role grant this recursive list at global returns org1 users",
+				input: &pbs.ListUsersRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				includeTestUsers: false,
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  org1.PublicId,
+						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis},
+					},
+				},
+				wantErr: nil,
+				wantIDs: []string{
+					org1User1.PublicId,
+				},
+			},
+			{
+				name: "individual org grant this recursive list at global returns org user",
+				input: &pbs.ListUsersRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				includeTestUsers: false,
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  org1.PublicId,
+						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeID:  org2.PublicId,
+						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis},
+					},
+				},
+				wantErr: nil,
+				wantIDs: []string{
+					org1User1.PublicId,
+					org2User1.PublicId,
+					org2User2.PublicId,
+				},
+			},
+			{
+				name: "global role grant this recursive list at org returns no user",
 				input: &pbs.ListUsersRequest{
 					ScopeId:   org2.PublicId,
 					Recursive: true,
+				},
+				includeTestUsers: false,
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis},
+					},
+				},
+				wantErr: nil,
+				wantIDs: []string{},
+			},
+			{
+				name: "global role grant this recursive list at global returns only global user",
+				input: &pbs.ListUsersRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				includeTestUsers: true,
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeThis},
+					},
+				},
+				wantErr: nil,
+				wantIDs: []string{
+					globals.AnyAuthenticatedUserId,
+					globals.AnonymousUserId,
+					globals.RecoveryUserId,
+					globalUser.PublicId,
+				},
+			},
+			{
+				name: "global role grant children non-recursive list at global returns forbidden error",
+				input: &pbs.ListUsersRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: false,
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeChildren},
+					},
+				},
+				wantErr: handlers.ForbiddenError(),
+				wantIDs: nil,
+			},
+			{
+				name: "org role grant children non-recursive list at global returns forbidden error",
+				input: &pbs.ListUsersRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: false,
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
@@ -144,11 +272,41 @@ func TestGrants_ReadActions(t *testing.T) {
 				wantErr: handlers.ForbiddenError(),
 				wantIDs: nil,
 			},
+			{
+				name: "org role grant children non-recursive list at global returns forbidden error",
+				input: &pbs.ListUsersRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: false,
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeID:  org2.PublicId,
+						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
+						GrantScopes:  []string{globals.GrantScopeChildren},
+					},
+				},
+				wantErr: handlers.ForbiddenError(),
+				wantIDs: nil,
+			},
+			{
+				name: "no grant recursive list returns forbidden error",
+				input: &pbs.ListUsersRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{},
+				wantErr:       handlers.ForbiddenError(),
+				wantIDs:       nil,
+			},
 		}
 
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
 				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
+				t.Cleanup(func() {
+					// deleting user to keep assertions clean since we're listing users over and over
+					_, _ = iamRepo.DeleteUser(ctx, tok.IamUserId)
+				})
 				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
 				got, finalErr := s.ListUsers(fullGrantAuthCtx, tc.input)
 				if tc.wantErr != nil {
@@ -157,7 +315,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				}
 				require.NoError(t, finalErr)
 				var gotIDs []string
-				if tc.input.ScopeId == globals.GlobalPrefix {
+				if tc.includeTestUsers {
 					tc.wantIDs = append(tc.wantIDs, tok.IamUserId)
 				}
 				for _, g := range got.Items {


### PR DESCRIPTION
Fix missing parent Scope ID when calling `FetchActionSetForType`