### PR TITLE
chore(hcp): Update use of license module

### DIFF
--- a/enos/ci/hcp-resources/main.tf
+++ b/enos/ci/hcp-resources/main.tf
@@ -67,7 +67,7 @@ module "find_azs" {
 module "license" {
   source = "../../modules/read_license"
 
-  file_name = abspath(local.license_path)
+  license_path = abspath(local.license_path)
 }
 
 module "iam_user" {


### PR DESCRIPTION
This PR updates a Terraform file to update a usage of a module based on some changes from a different PR. This Terraform file is used to generate resources for HCP long-lived tests.