### PR TITLE
internal/scheduler/job: fix test failure

### DIFF
--- a/internal/scheduler/job/repository_job_test.go
+++ b/internal/scheduler/job/repository_job_test.go
@@ -35,7 +35,7 @@ func TestRepository_UpsertJob(t *testing.T) {
 	}
 	tests := []struct {
 		name        string
-		in          args
+		in          *args
 		want        *Job
 		wantErr     bool
 		wantErrCode errors.Code
@@ -44,7 +44,7 @@ func TestRepository_UpsertJob(t *testing.T) {
 		{
 			name:    "missing-name",
 			wantErr: true,
-			in: args{
+			in: &args{
 				description: "description",
 			},
 			wantErrCode: errors.InvalidParameter,
@@ -52,7 +52,7 @@ func TestRepository_UpsertJob(t *testing.T) {
 		},
 		{
 			name: "missing-description",
-			in: args{
+			in: &args{
 				name: "name",
 			},
 			wantErr:     true,
@@ -61,7 +61,7 @@ func TestRepository_UpsertJob(t *testing.T) {
 		},
 		{
 			name: "valid",
-			in: args{
+			in: &args{
 				name:        "name",
 				description: "description",
 			},


### PR DESCRIPTION
This was failing because the compared values weren't pointers. It was probably caused by a depedency version update changing the behavior of this function.