### PR TITLE
Remove web team from CODEOWNERS for content directories

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,11 @@
 # the repo, unless a later match takes precedence.
 * @hashicorp/boundary
 
-# engineering and web presence get notified of, and can approve changes to web tooling, but not content.
+# web presence and education
+
+/website/       @hashicorp/boundary-education-approvers @hashicorp/web-presence @hashicorp/boundary
+
+# engineering and web presence get notified of, and can approve changes to, web tooling, but not content.
 
 /website/ @hashicorp/web-presence @hashicorp/boundary
 /website/data/
@@ -11,6 +15,6 @@
 
 # education and engineering get notified of, and can approve changes to web content.
 
-/website/data/		@hashicorp/team-docs-packer-and-terraform @hashicorp/boundary
-/website/public/		@hashicorp/team-docs-packer-and-terraform @hashicorp/boundary
-/website/content/	@hashicorp/team-docs-packer-and-terraform @hashicorp/boundary
+/website/data/		    @hashicorp/boundary-education-approvers @hashicorp/boundary
+/website/public/		@hashicorp/boundary-education-approvers @hashicorp/boundary
+/website/content/	    @hashicorp/boundary-education-approvers @hashicorp/boundary

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,15 @@
 # the repo, unless a later match takes precedence.
 * @hashicorp/boundary
 
-# web presence and education
+# engineering and web presence get notified of, and can approve changes to web tooling, but not content.
 
-/website/       @hashicorp/boundary-education-approvers @hashicorp/web-presence @hashicorp/boundary
+/website/ @hashicorp/web-presence @hashicorp/boundary
+/website/data/
+/website/public/
+/website/content/
+
+# education and engineering get notified of, and can approve changes to web content.
+
+/website/data/		@hashicorp/team-docs-packer-and-terraform @hashicorp/boundary
+/website/public/		@hashicorp/team-docs-packer-and-terraform @hashicorp/boundary
+/website/content/	@hashicorp/team-docs-packer-and-terraform @hashicorp/boundary

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,10 +2,6 @@
 # the repo, unless a later match takes precedence.
 * @hashicorp/boundary
 
-# web presence and education
-
-/website/       @hashicorp/boundary-education-approvers @hashicorp/web-presence @hashicorp/boundary
-
 # engineering and web presence get notified of, and can approve changes to, web tooling, but not content.
 
 /website/ @hashicorp/web-presence @hashicorp/boundary


### PR DESCRIPTION
The web team was getting a lot of noise from my recent code owner changes, so we decided together to remove them from the CODEOWNERS for docs content directories. Please let me know if you have questions. 