### PR TITLE
ci(security-scanner): Suppress GO-2025-3408

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -12,6 +12,7 @@ container {
 		suppress {
 			vulnerabilities = [
 				"CVE-2024-13176", # openssl@3.3.2-r4
+				"GO-2025-3408", # yamux@v0.1.1
 			]
 		}
 	}

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -12,7 +12,6 @@ container {
 		suppress {
 			vulnerabilities = [
 				"CVE-2024-13176", # openssl@3.3.2-r4
-				"GO-2025-3408", # yamux@v0.1.1
 			]
 		}
 	}
@@ -24,4 +23,14 @@ binary {
 	osv          = true
 	oss_index    = true
 	nvd          = true
+
+	# Triage items that are _safe_ to ignore here. Note that this list should be
+	# periodically cleaned up to remove items that are no longer found by the scanner.
+	triage {
+		suppress {
+			vulnerabilities = [
+				"GO-2025-3408", # yamux@v0.1.1
+			]
+		}
+	}
 }


### PR DESCRIPTION
There is currently not a fix for GO-2025-3408. Adding the vulnerability to the suppress list for now

The issue to address the vulnerability is currently open: https://github.com/hashicorp/yamux/issues/142