### PR TITLE
docs: add macOS Internet Sharing and Parallels Desktop conflicts for Boundary Client Agent

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -537,6 +537,12 @@ Docker Desktop sometimes creates a local DNS listener that prevents the Client A
 If you run Docker Desktop 4.26 or later, you must clear the `Use kernel networking for UDP` option.
 Otherwise, the Client Agent refuses to start.
 
+### Internet Sharing (macOS)
+Enabling Internet Sharing on macOS causes the system's DNS resolver (`mDNSResponder`) to bind to all interfaces on port 53, preventing the Client Agent from starting. Disable Internet Sharing before running the Client Agent.
+
+### Parallels Desktop (macOS VM on macOS Host)
+Running a macOS VM in Parallels Desktop with shared networking causes the system's DNS resolver (`mDNSResponder`) to bind to all interfaces, blocking port 53 and preventing the Client Agent from starting.
+
 ### Palo Alto Networking Global Protect VPN
 
 If you are unable to establish a transparent session while using the Palo Alto Networking Global Protect VPN, you may need to explicitly specify a network interface and the upstream DNS server(s) to use.

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -537,11 +537,14 @@ Docker Desktop sometimes creates a local DNS listener that prevents the Client A
 If you run Docker Desktop 4.26 or later, you must clear the `Use kernel networking for UDP` option.
 Otherwise, the Client Agent refuses to start.
 
-### Internet Sharing (macOS)
-Enabling Internet Sharing on macOS causes the system's DNS resolver (`mDNSResponder`) to bind to all interfaces on port 53, preventing the Client Agent from starting. Disable Internet Sharing before running the Client Agent.
+### Internet Sharing (MacOS)
+Enabling Internet Sharing on MacOS causes the system's DNS resolver (`mDNSResponder`) to bind to all interfaces on port 53, preventing the Client Agent from starting. Disable Internet Sharing before running the Client Agent.
 
-### Parallels Desktop (macOS VM on macOS Host)
-Running a macOS VM in Parallels Desktop with shared networking causes the system's DNS resolver (`mDNSResponder`) to bind to all interfaces, blocking port 53 and preventing the Client Agent from starting.
+### Parallels Desktop (MacOS VM on MacOS Host)
+Running a MacOS VM in Parallels Desktop with shared networking causes the system's DNS resolver (`mDNSResponder`) to bind to all interfaces, blocking port 53 and preventing the Client Agent from starting.
+
+**Workaround:** Configure Parallels Desktop to use a different network mode.
+Go to **Hardware > Network > Source**, and select an alternative network configuration such as **Host-Only, Default Adapter, or Wi-Fi** instead of Shared Network.
 
 ### Palo Alto Networking Global Protect VPN
 

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -538,13 +538,14 @@ If you run Docker Desktop 4.26 or later, you must clear the `Use kernel networki
 Otherwise, the Client Agent refuses to start.
 
 ### Internet Sharing (MacOS)
-Enabling Internet Sharing on MacOS causes the system's DNS resolver (`mDNSResponder`) to bind to all interfaces on port 53, preventing the Client Agent from starting. Disable Internet Sharing before running the Client Agent.
+Enabling **Internet Sharing** on MacOS causes the system's DNS resolver (`mDNSResponder`) to bind to all interfaces on port 53, preventing the Client Agent from starting. Disable **Internet Sharing** before you run the Client Agent.
 
 ### Parallels Desktop (MacOS VM on MacOS Host)
 Running a MacOS VM in Parallels Desktop with shared networking causes the system's DNS resolver (`mDNSResponder`) to bind to all interfaces, blocking port 53 and preventing the Client Agent from starting.
 
-**Workaround:** Configure Parallels Desktop to use a different network mode.
-Go to **Hardware > Network > Source**, and select an alternative network configuration such as **Host-Only, Default Adapter, or Wi-Fi** instead of Shared Network.
+As a workaround, you can configure Parallels Desktop to use a different network mode.
+Select an alternative network configuration such as **Host-Only**, **Default Adapter**, or **Wi-Fi** instead of **Shared Network**.
+Refer to the Parallels Desktop documentation for more information.
 
 ### Palo Alto Networking Global Protect VPN
 


### PR DESCRIPTION
Updated the "Conflicting Software" section in the Boundary Client Agent documentation to include issues caused by macOS Internet Sharing and Parallels Desktop (macOS VM with shared networking). These configurations cause the system's DNS resolver to bind to port 53, preventing the Client Agent from starting.