### PR TITLE
ci(security-scanner): Suppress GHSA-29qp-crvh-w22m

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -30,6 +30,7 @@ binary {
 		suppress {
 			vulnerabilities = [
 				"GO-2025-3408", # yamux@v0.1.1
+				"GHSA-29qp-crvh-w22m", # yamux@v0.1.1
 			]
 		}
 	}


### PR DESCRIPTION
There is currently not a fix for GHSA-29qp-crvh-w22m. Adding the vulnerability to the suppress list for now