### PR TITLE
chore(e2e): Add note for modifying `/etc/hosts`

### DIFF
--- a/enos/README.md
+++ b/enos/README.md
@@ -57,6 +57,16 @@ See [enos.vars.hcl](./enos.vars.hcl) for complete descriptions of each variable.
 You can either modify `enos.vars.hcl` directly or create your own copy at
 `enos-local.vars.hcl` which gets ignored by git.
 
+### System File Modifications
+
+For docker-based scenarios, you will need to modify `/etc/hosts` to include the
+following lines
+```
+127.0.0.1       localhost       boundary
+127.0.0.1       localhost       worker
+127.0.0.1       localhost       vault
+```
+
 ## Executing Scenarios
 From the `enos` directory:
 


### PR DESCRIPTION
This PR updates the enos readme to include a note for modifying `/etc/hosts`. This is needed when using docker-based scenarios to allow the use of container names in addresses. 