### PR TITLE
fix(worker): set session.CloseCallTimeout to non-zero value

### DIFF
--- a/internal/daemon/worker/worker.go
+++ b/internal/daemon/worker/worker.go
@@ -485,7 +485,7 @@ func (w *Worker) Reload(ctx context.Context, newConf *config.Config) {
 
 	w.parseAndStoreTags(newConf.Worker.Tags)
 
-	switch newConf.Worker.SuccessfulControllerRPCGracePeriod {
+	switch newConf.Worker.SuccessfulControllerRPCGracePeriodDuration {
 	case 0:
 		w.successfulRoutingInfoGracePeriod.Store(int64(server.DefaultLiveness))
 		w.successfulSessionInfoGracePeriod.Store(int64(server.DefaultLiveness))


### PR DESCRIPTION
# Summary

The variable `newConf.Worker.SuccessfulControllerRPCGracePeriod` is a any type, which defaults to nil. The case statement would then match on the default case, where the `SuccessfulControllerRPCGracePeriodDuration` was not set. This would then have a cascading affect of causing immediate timeouts for anything that was referencing the `session.CloseCallTimeout` variable.