### PR TITLE
docs: add note about MacOS 15.1, 15.2 incompatibility

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -516,6 +516,11 @@ $ boundary client-agent pause
 
 Follow the troubleshooting steps to understand why the Client Agent is not able to reach the controller.
 
+#### sendmsg: broken pipe
+
+On MacOS versions 15.1 and 15.2, the firewall may incorrectly block the Client Agent from sending DNS responses. To resolve this issue,
+upgrade to MacOS version 15.3 or later.
+
 #### WARNING! Remote host indentification has changed! It is possible that someone is doing something nasty!
 
 This error arises when you use an alias to connect to an SSH target after the first successful connection using that alias. The issue occurs because Boundary workers generate a new host key on every new SSH connection. You can safely ignore the warning using the `StrictHostKeyChecking=no` command line option:

--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -38,6 +38,7 @@ Refer to the following table for known issues that may affect the public beta:
 | Single-word aliases do not work on Windows | If you create an alias consisting of a single word without a dot (`.`), the alias will not work on Windows. |
 | Windows installer does not support partial installations | The Windows installer fails to start the Client Agent if the Desktop client is not installed at the same time. |
 | Alias connection failures inside containers/VMs | Using transparent sessions rely on network access to the local network of the computer the Client Agent is running on. Network enclaves such as those created by Docker containers and VMs cannot reach this network. |
+| DNS lookup is broken on MacOS 15.1 and 15.2 | MacOS 15.1 and 15.2 may incorrectly block DNS lookups for the Client Agent. This issue is resolved in MacOS 15.3 and later. |
 
 ## More information
 


### PR DESCRIPTION
On MacOS 15.1 and 15.2, some users report that all their DNS responses incur the error `sendmsg: broken pipe`