### PR TITLE
chore: bump sdk & api deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
-	github.com/hashicorp/boundary/api v0.0.50
-	github.com/hashicorp/boundary/sdk v0.0.48
+	github.com/hashicorp/boundary/api v0.0.54
+	github.com/hashicorp/boundary/sdk v0.0.50
 	github.com/hashicorp/cap v0.5.1-0.20240315182732-faa330bfb8df
 	github.com/hashicorp/dawdle v0.5.0
 	github.com/hashicorp/eventlogger v0.2.9


### PR DESCRIPTION
Post-release step: Bump`sdk` and `api` based off `0.19.0` release