### PR TITLE
docs/client-agent: add warning about MacOS 15

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -523,6 +523,8 @@ upgrade to MacOS version 15.3 or later.
 
 It may be neccessary to explicitly allow the `boundary-client-agent` process access to incoming network connections.
 
+From the Firewall options in System Settings, toggle the `boundary-client-agent' to **Allow incoming connections**.  
+
 #### WARNING! Remote host indentification has changed! It is possible that someone is doing something nasty!
 
 This error arises when you use an alias to connect to an SSH target after the first successful connection using that alias. The issue occurs because Boundary workers generate a new host key on every new SSH connection. You can safely ignore the warning using the `StrictHostKeyChecking=no` command line option:

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -521,6 +521,8 @@ Follow the troubleshooting steps to understand why the Client Agent is not able 
 On MacOS versions 15.1 and 15.2, the firewall may incorrectly block the Client Agent from sending DNS responses. To resolve this issue,
 upgrade to MacOS version 15.3 or later.
 
+It may be neccessary to explicitly allow the `boundary-client-agent` process access to incoming network connections.
+
 #### WARNING! Remote host indentification has changed! It is possible that someone is doing something nasty!
 
 This error arises when you use an alias to connect to an SSH target after the first successful connection using that alias. The issue occurs because Boundary workers generate a new host key on every new SSH connection. You can safely ignore the warning using the `StrictHostKeyChecking=no` command line option:


### PR DESCRIPTION
MacOS 15.3 has been known to sometimes block users from using the client agent altogether. Explicitly allowing it access to incoming network connections resolves the issue.