### PR TITLE
docs: Fixes examples for alias_refresh_interval & dns_request_timeout

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -99,14 +99,14 @@ The configuration file contains the following fields:
 
    Example:
    ```hcl
-   alias_refresh_interval=60s
+   alias_refresh_interval="60s"
    ```
 
 - `dns_request_timeout` - Specifies for how long the Client Agent DNS request handling, including any recursion, is allowed to run before it is canceled.
 
    Example:
    ```hcl
-   dns_request_timeout=300s
+   dns_request_timeout="300s"
    ```
 
 - `interface_to_use` - Specifies the interface to use instead of the default.
@@ -523,7 +523,7 @@ upgrade to MacOS version 15.3 or later.
 
 It may be neccessary to explicitly allow the `boundary-client-agent` process access to incoming network connections.
 
-From the Firewall options in System Settings, toggle the `boundary-client-agent' to **Allow incoming connections**.  
+From the Firewall options in System Settings, toggle the `boundary-client-agent' to **Allow incoming connections**.
 
 #### WARNING! Remote host indentification has changed! It is possible that someone is doing something nasty!
 

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -523,7 +523,7 @@ upgrade to MacOS version 15.3 or later.
 
 It may be neccessary to explicitly allow the `boundary-client-agent` process access to incoming network connections.
 
-From the Firewall options in System Settings, toggle the `boundary-client-agent' to **Allow incoming connections**.
+From the Firewall options in System Settings, toggle the `boundary-client-agent` to **Allow incoming connections**.
 
 #### WARNING! Remote host indentification has changed! It is possible that someone is doing something nasty!
 


### PR DESCRIPTION
- Issue: Client agent does not start if the given example configurations are used.
- Both the parameters are parsed using `parseutil.ParseDurationSecond`, which parses a duration from a string or numeric value into a time.Duration.
- When units are missing (such as when a numeric type is provided), the duration is assumed to be in seconds.
- Since providing a time format is more readable, updating the example to the corrected string version.
- Providing a string example configuration is more suitable than providing a number example like `alias_refresh_interval=60`; where it is automatically assumed to be seconds, and can become confusing for the consumers.