### PR TITLE
Restore soft deleted users on authentication

### DIFF
--- a/internal/clientcache/internal/cache/refresh.go
+++ b/internal/clientcache/internal/cache/refresh.go
@@ -94,7 +94,7 @@ func (r *RefreshService) cleanAndPickAuthTokens(ctx context.Context, u *user) (m
 				if err := r.repo.deleteKeyringToken(ctx, *kt); err != nil {
 					return nil, errors.Wrap(ctx, err, op, errors.WithMsg("for user %q, auth token %q", u.Id, t.Id))
 				}
-			case at != nil:
+			default:
 				_, err := r.repo.tokenReadFromBoundaryFn(ctx, u.Address, at.Token)
 				var apiErr *api.Error
 				switch {

--- a/internal/clientcache/internal/cache/refresh.go
+++ b/internal/clientcache/internal/cache/refresh.go
@@ -101,7 +101,7 @@ func (r *RefreshService) cleanAndPickAuthTokens(ctx context.Context, u *user) (m
 					if err := r.repo.deleteKeyringToken(ctx, *kt); err != nil {
 						return nil, errors.Wrap(ctx, err, op, errors.WithMsg("for user %q, auth token %q", u.Id, t.Id))
 					}
-					event.WriteSysEvent(ctx, op, "Removed auth token from cache because it was not found to be valid in boundary", "auth token id", at.Id)
+					event.WriteSysEvent(ctx, op, "Removed auth token from db because it was not found to be valid in boundary", "auth token id", at.Id)
 					continue
 				case err != nil:
 					event.WriteError(ctx, op, err, event.WithInfoMsg("validating keyring stored token against boundary", "auth token id", at.Id))
@@ -116,7 +116,7 @@ func (r *RefreshService) cleanAndPickAuthTokens(ctx context.Context, u *user) (m
 				switch {
 				case err != nil && (api.ErrUnauthorized.Is(err) || api.ErrNotFound.Is(err)):
 					r.repo.idToKeyringlessAuthToken.Delete(t.Id)
-					event.WriteSysEvent(ctx, op, "Removed auth token from cache because it was not found to be valid in boundary", "auth token id", at.Id)
+					event.WriteSysEvent(ctx, op, "Removed auth token from in memory cache because it was not found to be valid in boundary", "auth token id", at.Id)
 					if err := r.repo.cleanExpiredOrOrphanedAuthTokens(ctx); err != nil {
 						return nil, errors.Wrap(ctx, err, op, errors.WithMsg("for user %q, auth token %q", u.Id, t.Id))
 					}

--- a/internal/clientcache/internal/cache/repository_token.go
+++ b/internal/clientcache/internal/cache/repository_token.go
@@ -51,7 +51,8 @@ func upsertUserAndAuthToken(ctx context.Context, reader db.Reader, writer db.Wri
 		}
 		onConflict := &db.OnConflict{
 			Target: db.Columns{"id"},
-			Action: db.DoNothing(true),
+			// Unset the deleted_at column if it was set to un-delete the user
+			Action: db.SetColumnValues(map[string]any{"deleted_at": "infinity"}),
 		}
 		if err := writer.Create(ctx, u, db.WithOnConflict(onConflict)); err != nil {
 			return errors.Wrap(ctx, err, op)


### PR DESCRIPTION
This PR contains a potential fix for the issue of deleted auth tokens preventing re-authentication (introduced with https://github.com/hashicorp/boundary/pull/5173). The biggest change is that previously, if a soft-deleted user authenticated, it would remain soft-deleted. Now we restore the user on authentication.

It also contains some tidying of the token error handling.