### PR TITLE
test(e2e): Address flake in search test

### DIFF
--- a/testing/internal/e2e/tests/base/search_test.go
+++ b/testing/internal/e2e/tests/base/search_test.go
@@ -102,6 +102,17 @@ func TestCliSearch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get current number of targets
+	// Do a force-refresh first to ensure cache has the latest information
+	output = e2e.RunCommand(ctx, "boundary",
+		e2e.WithArgs(
+			"search",
+			"-resource", "targets",
+			"-force-refresh", "true",
+			"-format", "json",
+		),
+	)
+	require.NoError(t, output.Err, string(output.Stderr))
+
 	var currentCount int
 	err = backoff.RetryNotify(
 		func() error {
@@ -301,19 +312,61 @@ func TestCliSearch(t *testing.T) {
 
 	// Log back in and confirm search works
 	boundary.AuthenticateAdminCli(t, ctx)
-	output = e2e.RunCommand(ctx, "boundary",
-		e2e.WithArgs(
-			"search",
-			"-resource", "targets",
-			"-format", "json",
-			"-query", fmt.Sprintf(`name %% "%s" and scope_id = "%s"`, targetPrefix, projectId),
-		),
+	err = backoff.RetryNotify(
+		func() error {
+			output := e2e.RunCommand(ctx, "boundary",
+				e2e.WithArgs(
+					"search",
+					"-resource", "targets",
+					"-format", "json",
+					"-query", fmt.Sprintf(`name %% "%s" and scope_id = "%s"`, targetPrefix, projectId),
+				),
+			)
+			if output.Err != nil {
+				outputStatus := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("cache", "status", "-format", "json"))
+				t.Log("Printing cache status...")
+				t.Log(string(outputStatus.Stdout))
+				var statusResult clientcache.StatusResult
+				err = json.Unmarshal(outputStatus.Stdout, &statusResult)
+				if err != nil {
+					return backoff.Permanent(err)
+				}
+
+				outputLog := e2e.RunCommand(ctx, "cat", e2e.WithArgs(statusResult.Item.LogLocation))
+				t.Log("Printing cache log...")
+				t.Log(string(outputLog.Stdout))
+
+				// BUG: It seems like there's some weird interaction where
+				// occasionally, the cache fails to update after authentication
+				// on Linux environments
+				boundary.AuthenticateAdminCli(t, ctx)
+
+				return errors.New(string(output.Stderr))
+			}
+
+			searchResult := clientcache.SearchResult{}
+			err := json.Unmarshal(output.Stdout, &searchResult)
+			if err != nil {
+				return backoff.Permanent(err)
+			}
+
+			if len(searchResult.Item.Targets) != len(targetIds) {
+				return errors.New(
+					fmt.Sprintf(
+						"Search did not return expected number of targets, EXPECTED: %d, ACTUAL: %d",
+						len(targetIds),
+						len(searchResult.Item.Targets),
+					),
+				)
+			}
+
+			return nil
+		},
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 5),
+		func(err error, td time.Duration) {
+			t.Logf("%s. Retrying...", err.Error())
+		},
 	)
-	require.NoError(t, output.Err, string(output.Stderr))
-	searchResult = clientcache.SearchResult{}
-	err = json.Unmarshal(output.Stdout, &searchResult)
-	require.NoError(t, err)
-	require.Len(t, searchResult.Item.Targets, len(targetIds))
 
 	// Restart cache and confirm search works
 	t.Log("Restarting cache...")

--- a/testing/internal/e2e/tests/base/search_test.go
+++ b/testing/internal/e2e/tests/base/search_test.go
@@ -336,9 +336,10 @@ func TestCliSearch(t *testing.T) {
 				t.Log("Printing cache log...")
 				t.Log(string(outputLog.Stdout))
 
-				// BUG: It seems like there's some weird interaction where
+				// BUG WORKAROUND: It seems like there's some weird interaction where
 				// occasionally, the cache fails to update after authentication
 				// on Linux environments
+				// https://hashicorp.atlassian.net/browse/ICU-16595
 				boundary.AuthenticateAdminCli(t, ctx)
 
 				return errors.New(string(output.Stderr))


### PR DESCRIPTION
Observed this failure on `release/0.19.x`
```
│ === RUN   TestCliSearch
│     search_test.go:40: Stopping cache...
│     search_test.go:58: Waiting for cache to start...
│     search_test.go:76: ***"error":"The cache process is not running."***. Retrying...
│     scope.go:85: Created Org Id: o_lrIyDpJGjn
│     scope.go:127: Created Project Id: p_AQhm9lWozC
│     search_test.go:150: Creating targets...
│     search_test.go:170: Listing targets...
│     search_test.go:183: Waiting for client cache to populate data...
│     search_test.go:232: Did not see expected number of targets in status, EXPECTED: 13, ACTUAL: 2. Retrying...
│     search_test.go:227: Found 13 target(s)
│     search_test.go:239: Searching targets...
│     search_test.go:312: 
│         	Error Trace:	/src/boundary/testing/internal/e2e/tests/base/search_test.go:312
│         	Error:      	Received unexpected error:
│         	            	exit status 1
│         	Test:       	TestCliSearch
│         	Messages:   	***"context":"Error from cache when performing search","status_code":403,"api_error":***"kind":"Forbidden","message":"Forbidden"***
│ --- FAIL: TestCliSearch (16.69s)
```

The current theory is that there's some interaction where the cache doesn't always update successfully on Linux environments. This PR adds a retry to the cache search call as well as an extra authentication on each attempt to address the flaky test.

https://hashicorp.atlassian.net/browse/ICU-16573