### PR TITLE
chore(e2e): Set up ec2 instance storage with encryption

### DIFF
--- a/enos/modules/aws_boundary/boundary-instances.tf
+++ b/enos/modules/aws_boundary/boundary-instances.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "controller" {
     volume_type = var.controller_ebs_type
     throughput  = var.controller_ebs_throughput
     tags        = local.common_tags
+    encrypted   = true
   }
 
   tags = merge(local.common_tags,
@@ -50,6 +51,7 @@ resource "aws_instance" "worker" {
     volume_type = var.worker_ebs_type
     throughput  = var.worker_ebs_throughput
     tags        = local.common_tags
+    encrypted   = true
   }
 
   tags = merge(local.common_tags,

--- a/enos/modules/aws_worker/main.tf
+++ b/enos/modules/aws_worker/main.tf
@@ -152,6 +152,7 @@ resource "aws_instance" "worker" {
     volume_type = var.ebs_type
     throughput  = var.ebs_throughput
     tags        = local.common_tags
+    encrypted   = true
   }
 
   tags = merge(


### PR DESCRIPTION
This PR modifies the terraform modules used in end-to-end testing to enable encryption for an ec2 instance's `root_block_device` (i.e. the root storage) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance). This addresses a minor security warning that discovered that some volumes were not encrypted at rest. While these instances are only used for tests and are short-lived (get destroyed immediately), it wasn't difficult to address the warning. 

https://hashicorp.atlassian.net/browse/ICU-16596