### PR TITLE
fix(api): Prevent memory spike after creating many resources

### DIFF
--- a/api/accounts/account.gen.go
+++ b/api/accounts/account.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -368,7 +369,9 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*Account, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/accounts/account.gen.go
+++ b/api/accounts/account.gen.go
@@ -368,8 +368,7 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 		return target, nil
 	}
 
-	allItems := make([]*Account, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/aliases/alias.gen.go
+++ b/api/aliases/alias.gen.go
@@ -376,8 +376,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Alia
 		return target, nil
 	}
 
-	allItems := make([]*Alias, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/aliases/alias.gen.go
+++ b/api/aliases/alias.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -376,7 +377,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Alia
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*Alias, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/authmethods/authmethods.gen.go
+++ b/api/authmethods/authmethods.gen.go
@@ -376,8 +376,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 		return target, nil
 	}
 
-	allItems := make([]*AuthMethod, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/authmethods/authmethods.gen.go
+++ b/api/authmethods/authmethods.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -376,7 +377,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*AuthMethod, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -261,8 +261,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 		return target, nil
 	}
 
-	allItems := make([]*AuthToken, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/authtokens/authtokens.gen.go
+++ b/api/authtokens/authtokens.gen.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -261,7 +262,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Auth
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*AuthToken, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/credentiallibraries/credential_library.gen.go
+++ b/api/credentiallibraries/credential_library.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -374,7 +375,9 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*CredentialLibrary, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/credentiallibraries/credential_library.gen.go
+++ b/api/credentiallibraries/credential_library.gen.go
@@ -374,8 +374,7 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 		return target, nil
 	}
 
-	allItems := make([]*CredentialLibrary, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/credentials/credential.gen.go
+++ b/api/credentials/credential.gen.go
@@ -372,8 +372,7 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 		return target, nil
 	}
 
-	allItems := make([]*Credential, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/credentials/credential.gen.go
+++ b/api/credentials/credential.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -372,7 +373,9 @@ func (c *Client) List(ctx context.Context, credentialStoreId string, opt ...Opti
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*Credential, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/credentialstores/credential_store.gen.go
+++ b/api/credentialstores/credential_store.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -375,7 +376,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*CredentialStore, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/credentialstores/credential_store.gen.go
+++ b/api/credentialstores/credential_store.gen.go
@@ -375,8 +375,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Cred
 		return target, nil
 	}
 
-	allItems := make([]*CredentialStore, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/groups/group.gen.go
+++ b/api/groups/group.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -369,7 +370,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*Group, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/groups/group.gen.go
+++ b/api/groups/group.gen.go
@@ -369,8 +369,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Grou
 		return target, nil
 	}
 
-	allItems := make([]*Group, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/hostcatalogs/host_catalog.gen.go
+++ b/api/hostcatalogs/host_catalog.gen.go
@@ -381,8 +381,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 		return target, nil
 	}
 
-	allItems := make([]*HostCatalog, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/hostcatalogs/host_catalog.gen.go
+++ b/api/hostcatalogs/host_catalog.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -381,7 +382,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Host
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*HostCatalog, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/hosts/host.gen.go
+++ b/api/hosts/host.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -374,7 +375,9 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*Host, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/hosts/host.gen.go
+++ b/api/hosts/host.gen.go
@@ -374,8 +374,7 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 		return target, nil
 	}
 
-	allItems := make([]*Host, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/hostsets/host_set.gen.go
+++ b/api/hostsets/host_set.gen.go
@@ -372,8 +372,7 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 		return target, nil
 	}
 
-	allItems := make([]*HostSet, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/hostsets/host_set.gen.go
+++ b/api/hostsets/host_set.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -372,7 +373,9 @@ func (c *Client) List(ctx context.Context, hostCatalogId string, opt ...Option) 
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*HostSet, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/managedgroups/managedgroups.gen.go
+++ b/api/managedgroups/managedgroups.gen.go
@@ -368,8 +368,7 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 		return target, nil
 	}
 
-	allItems := make([]*ManagedGroup, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/managedgroups/managedgroups.gen.go
+++ b/api/managedgroups/managedgroups.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -368,7 +369,9 @@ func (c *Client) List(ctx context.Context, authMethodId string, opt ...Option) (
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*ManagedGroup, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/policies/policy.gen.go
+++ b/api/policies/policy.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -374,7 +375,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Poli
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*Policy, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/policies/policy.gen.go
+++ b/api/policies/policy.gen.go
@@ -374,8 +374,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Poli
 		return target, nil
 	}
 
-	allItems := make([]*Policy, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/roles/role.gen.go
+++ b/api/roles/role.gen.go
@@ -372,8 +372,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 		return target, nil
 	}
 
-	allItems := make([]*Role, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/roles/role.gen.go
+++ b/api/roles/role.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -372,7 +373,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Role
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*Role, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/scopes/scope.gen.go
+++ b/api/scopes/scope.gen.go
@@ -370,8 +370,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Scop
 		return target, nil
 	}
 
-	allItems := make([]*Scope, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/scopes/scope.gen.go
+++ b/api/scopes/scope.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -370,7 +371,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Scop
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*Scope, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/sessionrecordings/session_recording.gen.go
+++ b/api/sessionrecordings/session_recording.gen.go
@@ -268,8 +268,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 		return target, nil
 	}
 
-	allItems := make([]*SessionRecording, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/sessionrecordings/session_recording.gen.go
+++ b/api/sessionrecordings/session_recording.gen.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -268,7 +269,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*SessionRecording, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/sessions/session.gen.go
+++ b/api/sessions/session.gen.go
@@ -228,8 +228,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 		return target, nil
 	}
 
-	allItems := make([]*Session, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/sessions/session.gen.go
+++ b/api/sessions/session.gen.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -228,7 +229,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Sess
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*Session, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/storagebuckets/storage_bucket.gen.go
+++ b/api/storagebuckets/storage_bucket.gen.go
@@ -378,8 +378,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Stor
 		return target, nil
 	}
 
-	allItems := make([]*StorageBucket, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/storagebuckets/storage_bucket.gen.go
+++ b/api/storagebuckets/storage_bucket.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -378,7 +379,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Stor
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*StorageBucket, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/targets/target.gen.go
+++ b/api/targets/target.gen.go
@@ -388,8 +388,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 		return target, nil
 	}
 
-	allItems := make([]*Target, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/targets/target.gen.go
+++ b/api/targets/target.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -388,7 +389,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*Targ
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*Target, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/users/user.gen.go
+++ b/api/users/user.gen.go
@@ -373,8 +373,7 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*User
 		return target, nil
 	}
 
-	allItems := make([]*User, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/api/users/user.gen.go
+++ b/api/users/user.gen.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -373,7 +374,9 @@ func (c *Client) List(ctx context.Context, scopeId string, opt ...Option) (*User
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*User, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -295,7 +295,9 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 		return target, nil
 	}
 
-	allItems := target.Items
+	fmt.Fprintln(os.Stderr, "Estimated item count (postgres):", target.EstItemCount)
+	allItems := make([]*{{ .Name }}, 0, target.EstItemCount)
+	allItems = append(allItems, target.Items...)
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
@@ -807,6 +809,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"net/url"
 	"slices"
 	"time"

--- a/internal/api/genapi/templates.go
+++ b/internal/api/genapi/templates.go
@@ -285,7 +285,7 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 
 	// In case we shortcut out due to client directed pagination, ensure these
 	// are set
-{{ if .RecursiveListing }} 
+{{ if .RecursiveListing }}
 	target.recursive = opts.withRecursive
 {{ end }}
 	target.pageSize = opts.withPageSize
@@ -295,8 +295,7 @@ func (c *Client) List(ctx context.Context, {{ .CollectionFunctionArg }} string, 
 		return target, nil
 	}
 
-	allItems := make([]*{{ .Name }}, 0, target.EstItemCount)
-	allItems = append(allItems, target.Items...)
+	allItems := target.Items
 
 	// If there are more results, automatically fetch the rest of the results.
 	// idToIndex keeps a map from the ID of an item to its index in target.Items.
@@ -399,7 +398,7 @@ func (c *Client) ListNextPage(ctx context.Context, currentPage *{{ .Name }}ListR
 	opts, apiOpts := getOpts(opt...)
 	opts.queryMap["{{ snakeCase .CollectionFunctionArg }}"] = currentPage.{{ .CollectionFunctionArg }}
 
-{{ if .RecursiveListing }} 
+{{ if .RecursiveListing }}
 	// Don't require them to re-specify recursive
 	if currentPage.recursive {
 		opts.queryMap["recursive"] = "true"
@@ -446,7 +445,7 @@ func (c *Client) ListNextPage(ctx context.Context, currentPage *{{ .Name }}ListR
 	nextPage.{{ .CollectionFunctionArg }} = currentPage.{{ .CollectionFunctionArg }}
 {{ if .RecursiveListing }}
 	nextPage.recursive = currentPage.recursive
-{{ end }} 
+{{ end }}
 	nextPage.pageSize = currentPage.pageSize
 	// Cache the removed IDs from this page
 	nextPage.allRemovedIds = append(currentPage.allRemovedIds, nextPage.RemovedIds...)
@@ -516,14 +515,14 @@ func (c *Client) Read(ctx context.Context, id string, opt... Option) (*{{ .Name 
 `))
 
 var deleteTemplate = template.Must(template.New("").Parse(`
-func (c *Client) Delete(ctx context.Context, id string, opt... Option) (*{{ .Name }}DeleteResult, error) { 
+func (c *Client) Delete(ctx context.Context, id string, opt... Option) (*{{ .Name }}DeleteResult, error) {
 	if id == "" {
 		return nil, fmt.Errorf("empty id value passed into Delete request")
 	}
 	if c.client == nil {
 		return nil, fmt.Errorf("nil client")
 	}
-	
+
 	opts, apiOpts := getOpts(opt...)
 
 	req, err := c.client.NewRequest(ctx, "DELETE", {{ .ResourcePath }}, nil, apiOpts...)


### PR DESCRIPTION
Recently, pagination end-to-end tests have been consistently failing in `boundary-enterprise` due to an out of memory panic
```
│ === RUN   TestCliPaginateAuthMethods
│     scope.go:85: Created Org Id: o_1eB3coWMK0
│     authmethod.go:35: Created Auth Method: ampw_XXlYygaK0k
│     authmethod.go:35: Created Auth Method: ampw_bPs7brgJ7V
│     authmethod.go:35: Created Auth Method: ampw_4LrkW9cI1b
│     authmethod.go:35: Created Auth Method: ampw_Dbc7emmAbv
│     authmethod.go:35: Created Auth Method: ampw_mHHk4Pxngw
│     authmethod.go:35: Created Auth Method: ampw_h2NishKsBz
│     authmethod.go:35: Created Auth Method: ampw_oWOcPTluZc
│     authmethod.go:35: Created Auth Method: ampw_3N0Cw5KI3g
│     authmethod.go:35: Created Auth Method: ampw_HD5sqrXOkO
│     authmethod.go:35: Created Auth Method: ampw_WLvKjTFuO8
│     authmethod.go:35: Created Auth Method: ampw_K8H6gNEAHs
│     auth_method_password_test.go:185: 
│         	Error Trace:	/src/boundary/testing/internal/e2e/tests/base/auth_method_password_test.go:185
│         	Error:      	Received unexpected error:
│         	            	exit status 2
│         	Test:       	TestCliPaginateAuthMethods
│         	Messages:   	fatal error: runtime: out of memory
│         	            	
│         	            	runtime stack:
│         	            	...
│         	            	goroutine 1 gp=0xc0000061c0 m=6 mp=0xc000500008 [running]:
│         	            	runtime.systemstack_switch()
│         	            		runtime/asm_amd64.s:479 +0x8 fp=0xc000d5b340 sp=0xc000d5b330 pc=0x4772e8
│         	            	runtime.(*mheap).alloc(0x800000000?, 0x400000?, 0x10?)
│         	            		runtime/mheap.go:956 +0x5b fp=0xc000d5b388 sp=0xc000d5b340 pc=0x429a1b
│         	            	runtime.(*mcache).allocLarge(0x1718?, 0x7fffffff0, 0x0)
│         	            		runtime/mcache.go:234 +0x87 fp=0xc000d5b3d8 sp=0xc000d5b388 pc=0x416447
│         	            	runtime.mallocgc(0x7fffffff0, 0x1eb1a80, 0x1)
│         	            		runtime/malloc.go:1177 +0x5d0 fp=0xc000d5b478 sp=0xc000d5b3d8 pc=0x46bd70
│         	            	runtime.makeslice(0xc00047aee8?, 0x1f6ac20?, 0xc000a9e990?)
│         	            		runtime/slice.go:116 +0x49 fp=0xc000d5b4a0 sp=0xc000d5b478 pc=0x473349
│         	            	github.com/hashicorp/boundary/api/authmethods.(*Client).List(0xc000094088, ***0xb249d18, 0xc000bc80f0***, ***0x7fff344fc821, 0xc***, ***0x0, 0x0, 0x0***)
│         	            		github.com/hashicorp/boundary/api@v0.0.50/authmethods/authmethods.gen.go:379 +0x578 fp=0xc000d5b9c0 sp=0xc000d5b4a0 pc=0x18d91f8
│         	            	github.com/hashicorp/boundary/internal/cmd/commands/authmethodscmd.(*Command).Run(0xc000122f60, ***0xc000154150, 0x3, 0x3***)
│         	            		...
```
Example run: https://github.com/hashicorp/boundary-enterprise/actions/runs/13701871710/job/38318300622

This seemed to start happening after some runner changes were made, presumably the changes to use Ubuntu 22.04 runners. In `boundary-enterprise`, this workflow is set to use `RUNNER_LARGE = m5.8xlarge`, but jobs have been choosing to use `m6a.2xlarge`. My guess is that it's due to this: https://hashicorp.atlassian.net/wiki/spaces/IPS/pages/2368864360/Organization+Runner+Groups#Ubuntu-22.04-x64-runners. There is a large memory difference between the instances.
- m5.8xlarge = 128 GiB
- m6a.2xlarge = 32 GiB

Regardless, it was still surprising that tests would still run out of memory on a 32 GiB instance.

Looking at the stack trace, we noticed that it was occurring during an allocation during the a list call. The theory is that this allocation uses an estimate length coming from postgres, and because the test had just created a number of resources in quick succession, the estimate length large enough to run out of memory. This PR modifies how the allocation is done. 

Here is a run in `boundary-enterprise` with these changes that results in a success: https://github.com/hashicorp/boundary-enterprise/actions/runs/13707265684/job/38336012952

https://hashicorp.atlassian.net/browse/ICU-16613