### PR TITLE
internal/pagination: ensure estimated counts are positive

### DIFF
--- a/internal/pagination/pagination.go
+++ b/internal/pagination/pagination.go
@@ -43,7 +43,7 @@ type ListResponse[T boundary.Resource] struct {
 	// a List call is complete, this number is equal to
 	// the number of items returned. Otherwise, the
 	// estimated count function is consulted for an estimate.
-	EstimatedItemCount int
+	EstimatedItemCount uint
 }
 
 // ListFilterFunc is a callback used to filter out resources that don't match
@@ -329,7 +329,7 @@ func buildListResp[T boundary.Resource](
 	resp := &ListResponse[T]{
 		Items:              items,
 		CompleteListing:    completeListing,
-		EstimatedItemCount: len(items),
+		EstimatedItemCount: uint(len(items)),
 	}
 
 	var err error
@@ -368,10 +368,13 @@ func buildListResp[T boundary.Resource](
 	if !completeListing {
 		// If this was not a complete listing, get an estimate
 		// of the total items from the DB.
-		var err error
-		resp.EstimatedItemCount, err = estimatedCountFn(ctx)
+		estimatedItemCount, err := estimatedCountFn(ctx)
 		if err != nil {
 			return nil, err
+		}
+		// The estimate may be -1 if the count is unknown.
+		if estimatedItemCount >= 0 {
+			resp.EstimatedItemCount = uint(estimatedItemCount)
 		}
 	}
 	return resp, err
@@ -394,10 +397,13 @@ func buildListPageResp[T boundary.Resource](
 		DeletedIds:      deletedIds,
 	}
 
-	var err error
-	resp.EstimatedItemCount, err = estimatedCountFn(ctx)
+	estimatedItemCount, err := estimatedCountFn(ctx)
 	if err != nil {
 		return nil, err
+	}
+	// The estimate may be -1 if the count is unknown.
+	if estimatedItemCount >= 0 {
+		resp.EstimatedItemCount = uint(estimatedItemCount)
 	}
 	var lastItem boundary.Resource
 	if len(items) > 0 {

--- a/internal/pagination/plugin/pagination_plugin.go
+++ b/internal/pagination/plugin/pagination_plugin.go
@@ -318,7 +318,7 @@ func buildListResp[T boundary.Resource](
 	resp := &pagination.ListResponse[T]{
 		Items:              items,
 		CompleteListing:    completeListing,
-		EstimatedItemCount: len(items),
+		EstimatedItemCount: uint(len(items)),
 	}
 
 	var err error
@@ -357,10 +357,13 @@ func buildListResp[T boundary.Resource](
 	if !completeListing {
 		// If this was not a complete listing, get an estimate
 		// of the total items from the DB.
-		var err error
-		resp.EstimatedItemCount, err = estimatedCountFn(ctx)
+		estimatedItemCount, err := estimatedCountFn(ctx)
 		if err != nil {
 			return nil, err
+		}
+		// The estimate may be -1 if the count is unknown.
+		if estimatedItemCount >= 0 {
+			resp.EstimatedItemCount = uint(estimatedItemCount)
 		}
 	}
 	return resp, err
@@ -383,10 +386,13 @@ func buildListPageResp[T boundary.Resource](
 		DeletedIds:      deletedIds,
 	}
 
-	var err error
-	resp.EstimatedItemCount, err = estimatedCountFn(ctx)
+	estimatedItemCount, err := estimatedCountFn(ctx)
 	if err != nil {
 		return nil, err
+	}
+	// The estimate may be -1 if the count is unknown.
+	if estimatedItemCount >= 0 {
+		resp.EstimatedItemCount = uint(estimatedItemCount)
 	}
 	var lastItem boundary.Resource
 	if len(items) > 0 {


### PR DESCRIPTION
Previously, the estimated item count returned from the pagination library could be negative, as the estimated item count functions exported by the various resource repositories rely on the postgres pg_class table of estimate row counts, which can be negative [1].

This negative integer was converted to a uint32 in the service layer, leading to very large numbers being returned by the API.

We now ensure that only 0 or a positive number can be returned in the estimated item count, 0 when the server would otherwise have returned -1.

1: https://www.postgresql.org/docs/current/catalog-pg-class.html