### PR TITLE
test(hostsets): add grants tests

### DIFF
--- a/internal/daemon/controller/handlers/host_sets/grants_test.go
+++ b/internal/daemon/controller/handlers/host_sets/grants_test.go
@@ -817,7 +817,166 @@ func TestGrants_WriteActions(t *testing.T) {
 		}
 	})
 
-	t.Run("Add Host Set Hosts", func(t *testing.T) {})
-	t.Run("Remove Host Set Hosts", func(t *testing.T) {})
+	t.Run("Add Host Set Hosts", func(t *testing.T) {
+		hc := static.TestCatalog(t, conn, proj.PublicId, static.WithName("test catalog"), static.WithDescription("test desc"))
+		hcClone := static.TestCatalog(t, conn, proj.PublicId, static.WithName("clone catalog"), static.WithDescription("clone desc"))
+
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			expected expectedOutput
+		}{
+			{
+				name: "global role grant this can't add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "org role grant this can't add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "project role grant this can add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=add-hosts;output_fields=id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "global role grant this & descendants can add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-set;actions=add-hosts;output_fields=id,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+			},
+			{
+				name: "org role grant this & children can add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=add-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "incorrect grants can't add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=list,create,update,delete;output_fields=id,name,description,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name:     "no grants can't add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, nil),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "global role grant with host-catalog id, add-hosts action, host-set type, and this/children scope allows adding hosts to host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=add-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "org role grant with host-catalog id, add-hosts action, host-set type, and this/children scope allows adding hosts to host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=add-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "project role grant with host-catalog id, add-hosts action, host-set type, and this/children scope allows adding hosts to host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=add-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "project role grant with an unassociated host-catalog id and add-hosts action does not allow adding hosts to host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hcClone.PublicId + ";type=host-set;actions=add-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				hset := static.TestSet(t, conn, hc.PublicId,
+					static.WithName("test name - "+tc.name),
+					static.WithDescription("test description"),
+				)
+				hosts := static.TestHosts(t, conn, hc.GetPublicId(), 2)
+
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				got, err := s.AddHostSetHosts(fullGrantAuthCtx, &pbs.AddHostSetHostsRequest{
+					Id: hset.PublicId,
+					HostIds: []string{
+						hosts[0].PublicId,
+						hosts[1].PublicId,
+					},
+					Version: 1,
+				})
+				if tc.expected.err != nil {
+					require.ErrorIs(t, err, tc.expected.err)
+					return
+				}
+				// check if the output fields are as expected
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, got.Item, tc.expected.outputFields)
+			})
+		}
+	})
+
+	t.Run("Remove Host Set Hosts", func(t *testing.T) {
+
+	})
+
 	t.Run("Set Host Set Hosts", func(t *testing.T) {})
 }

--- a/internal/daemon/controller/handlers/host_sets/grants_test.go
+++ b/internal/daemon/controller/handlers/host_sets/grants_test.go
@@ -818,8 +818,8 @@ func TestGrants_WriteActions(t *testing.T) {
 	})
 
 	t.Run("Add Host Set Hosts", func(t *testing.T) {
-		hc := static.TestCatalog(t, conn, proj.PublicId, static.WithName("test catalog"), static.WithDescription("test desc"))
-		hcClone := static.TestCatalog(t, conn, proj.PublicId, static.WithName("clone catalog"), static.WithDescription("clone desc"))
+		hc := static.TestCatalog(t, conn, proj.PublicId, static.WithName("test add host set hosts catalog"), static.WithDescription("test desc"))
+		hcClone := static.TestCatalog(t, conn, proj.PublicId, static.WithName("clone add host set hosts catalog"), static.WithDescription("clone desc"))
 
 		testcases := []struct {
 			name     string
@@ -975,8 +975,8 @@ func TestGrants_WriteActions(t *testing.T) {
 	})
 
 	t.Run("Remove Host Set Hosts", func(t *testing.T) {
-		hc := static.TestCatalog(t, conn, proj.PublicId, static.WithName("test catalog"), static.WithDescription("test desc"))
-		hcClone := static.TestCatalog(t, conn, proj.PublicId, static.WithName("clone catalog"), static.WithDescription("clone desc"))
+		hc := static.TestCatalog(t, conn, proj.PublicId, static.WithName("test remove host set hosts catalog"), static.WithDescription("test desc"))
+		hcClone := static.TestCatalog(t, conn, proj.PublicId, static.WithName("clone remove host set hosts catalog"), static.WithDescription("clone desc"))
 
 		// We need to create a host set with hosts in order to remove hosts.
 		// As a result, each testcase is granted the `add-hosts` action for our test host-catalog.
@@ -1162,8 +1162,8 @@ func TestGrants_WriteActions(t *testing.T) {
 	})
 
 	t.Run("Set Host Set Hosts", func(t *testing.T) {
-		hc := static.TestCatalog(t, conn, proj.PublicId, static.WithName("test catalog"), static.WithDescription("test desc"))
-		hcClone := static.TestCatalog(t, conn, proj.PublicId, static.WithName("clone catalog"), static.WithDescription("clone desc"))
+		hc := static.TestCatalog(t, conn, proj.PublicId, static.WithName("test set host set hosts catalog"), static.WithDescription("test desc"))
+		hcClone := static.TestCatalog(t, conn, proj.PublicId, static.WithName("clone set host set hosts catalog"), static.WithDescription("clone desc"))
 
 		testcases := []struct {
 			name     string

--- a/internal/daemon/controller/handlers/host_sets/grants_test.go
+++ b/internal/daemon/controller/handlers/host_sets/grants_test.go
@@ -1161,5 +1161,166 @@ func TestGrants_WriteActions(t *testing.T) {
 		}
 	})
 
-	t.Run("Set Host Set Hosts", func(t *testing.T) {})
+	t.Run("Set Host Set Hosts", func(t *testing.T) {
+		hc := static.TestCatalog(t, conn, proj.PublicId, static.WithName("test catalog"), static.WithDescription("test desc"))
+		hcClone := static.TestCatalog(t, conn, proj.PublicId, static.WithName("clone catalog"), static.WithDescription("clone desc"))
+
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			expected expectedOutput
+		}{
+			{
+				name: "global role grant this can't set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "org role grant this can't set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "project role grant this can set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=set-hosts;output_fields=id,host_ids,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "global role grant this & descendants can set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-set;actions=set-hosts;output_fields=id,host_ids,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+			},
+			{
+				name: "org role grant this & children can set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=set-hosts;output_fields=id,host_ids,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "incorrect grants can't set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=list,create,update;output_fields=id,name,description,host_ids,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name:     "no grants can't set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, nil),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "global role grant with host-catalog id, set-hosts action, host-set type, and this/children scope allows setting hosts on host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=set-hosts;output_fields=id,host_ids,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "org role grant with host-catalog id, set-hosts action, host-set type, and this/children scope allows setting hosts on host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=set-hosts;output_fields=id,host_ids,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "project role grant with host-catalog id, set-hosts action, host-set type, and this/children scope allows setting hosts on host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=set-hosts;output_fields=id,host_ids,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "project role grant with an unassociated host-catalog id and set-hosts action does not allow setting hosts on host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hcClone.PublicId + ";type=host-set;actions=set-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				hset := static.TestSet(t, conn, hc.PublicId,
+					static.WithName("test name - "+tc.name),
+					static.WithDescription("test description"),
+				)
+				hosts := static.TestHosts(t, conn, hc.GetPublicId(), 3)
+
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				got, err := s.SetHostSetHosts(fullGrantAuthCtx, &pbs.SetHostSetHostsRequest{
+					Id: hset.PublicId,
+					HostIds: []string{
+						hosts[0].PublicId,
+						hosts[1].PublicId,
+						hosts[2].PublicId,
+					},
+					Version: 1,
+				})
+				if tc.expected.err != nil {
+					require.ErrorIs(t, err, tc.expected.err)
+					return
+				}
+				require.NoError(t, err)
+
+				wantIds := []string{hosts[0].PublicId, hosts[1].PublicId, hosts[2].PublicId}
+				require.ElementsMatch(t, wantIds, got.Item.HostIds)
+
+				// check if the output fields are as expected
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, got.Item, tc.expected.outputFields)
+			})
+		}
+	})
 }

--- a/internal/daemon/controller/handlers/host_sets/grants_test.go
+++ b/internal/daemon/controller/handlers/host_sets/grants_test.go
@@ -616,120 +616,94 @@ func TestGrants_WriteActions(t *testing.T) {
 
 	t.Run("Update", func(t *testing.T) {
 		testcases := []struct {
-			name                        string
-			setupScopesResourcesAndUser func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostSet, func() (*iam.User, auth.Account))
-			expected                    expectedOutput
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			expected expectedOutput
 		}{
 			{
 				name: "global role grant this can't update host-sets",
-				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostSet, func() (*iam.User, auth.Account)) {
-					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
-					hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
-					return hset, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
-						{
-							RoleScopeId: globals.GlobalPrefix,
-							Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
-							GrantScopes: []string{globals.GrantScopeThis},
-						},
-					})
-				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
 				expected: expectedOutput{err: handlers.ForbiddenError()},
 			},
 			{
 				name: "org role grant this can't update host-sets",
-				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostSet, func() (*iam.User, auth.Account)) {
-					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
-					hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
-					return hset, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
-						{
-							RoleScopeId: org.PublicId,
-							Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
-							GrantScopes: []string{globals.GrantScopeThis},
-						},
-					})
-				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
 				expected: expectedOutput{err: handlers.ForbiddenError()},
 			},
 			{
 				name: "project role grant this can update host-sets",
-				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostSet, func() (*iam.User, auth.Account)) {
-					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
-					hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
-					return hset, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
-						{
-							RoleScopeId: proj.PublicId,
-							Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
-							GrantScopes: []string{globals.GrantScopeThis},
-						},
-					})
-				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
 				expected: expectedOutput{outputFields: []string{globals.IdField}},
 			},
 			{
 				name: "global role grant this & descendants can update host-sets",
-				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostSet, func() (*iam.User, auth.Account)) {
-					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
-					hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
-					return hset, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
-						{
-							RoleScopeId: globals.GlobalPrefix,
-							Grants:      []string{"ids=*;type=host-set;actions=update;output_fields=id,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
-							GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
-						},
-					})
-				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-set;actions=update;output_fields=id,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
 				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
 			},
 			{
 				name: "org role grant this & children can update host-sets",
-				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostSet, func() (*iam.User, auth.Account)) {
-					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
-					hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
-					return hset, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
-						{
-							RoleScopeId: org.PublicId,
-							Grants:      []string{"ids=*;type=host-set;actions=update;output_fields=id,scope_id,type,created_time,updated_time"},
-							GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
-						},
-					})
-				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=update;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
 				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
 			},
 			{
 				name: "incorrect grants can't update host-sets",
-				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostSet, func() (*iam.User, auth.Account)) {
-					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
-					hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
-					return hset, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
-						{
-							RoleScopeId: proj.PublicId,
-							Grants:      []string{"ids=*;type=host-set;actions=list,create,delete;output_fields=id,name,description,created_time,updated_time"},
-							GrantScopes: []string{globals.GrantScopeThis},
-						},
-					})
-				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=list,create,delete;output_fields=id,name,description,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
 				expected: expectedOutput{err: handlers.ForbiddenError()},
 			},
 			{
-				name: "no grants can't update host-sets",
-				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostSet, func() (*iam.User, auth.Account)) {
-					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
-					hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
-					return hset, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, nil)
-				},
+				name:     "no grants can't update host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, nil),
 				expected: expectedOutput{err: handlers.ForbiddenError()},
 			},
 		}
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-				original, userFunc := tc.setupScopesResourcesAndUser(t, conn, iamRepo, kmsCache)
-				user, account := userFunc()
+				hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+				hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
+
+				user, account := tc.userFunc()
 				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
 				require.NoError(t, err)
 				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
 
 				got, err := s.UpdateHostSet(fullGrantAuthCtx, &pbs.UpdateHostSetRequest{
-					Id: original.PublicId,
+					Id: hset.PublicId,
 					Item: &pb.HostSet{
 						Name:        &wrappers.StringValue{Value: "updated host set name (" + tc.name + ")"},
 						Description: &wrappers.StringValue{Value: "test desc"},
@@ -748,7 +722,101 @@ func TestGrants_WriteActions(t *testing.T) {
 		}
 	})
 
-	t.Run("Delete", func(t *testing.T) {})
+	t.Run("Delete", func(t *testing.T) {
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			wantErr  error
+		}{
+			{
+				name: "global role grant this can't delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "org role grant this can't delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "project role grant this can delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+			},
+			{
+				name: "global role grant this & descendants can delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-set;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+			},
+			{
+				name: "org role grant this & children can delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+			},
+			{
+				name: "incorrect grants can't delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=list,create,update"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name:     "no grants can't delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, nil),
+				wantErr:  handlers.ForbiddenError(),
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+				hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
+
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				_, err = s.DeleteHostSet(fullGrantAuthCtx, &pbs.DeleteHostSetRequest{Id: hset.PublicId})
+				if tc.wantErr != nil {
+					require.ErrorIs(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
+			})
+		}
+	})
+
 	t.Run("Add Host Set Hosts", func(t *testing.T) {})
 	t.Run("Remove Host Set Hosts", func(t *testing.T) {})
 	t.Run("Set Host Set Hosts", func(t *testing.T) {})

--- a/internal/daemon/controller/handlers/host_sets/grants_test.go
+++ b/internal/daemon/controller/handlers/host_sets/grants_test.go
@@ -5,11 +5,17 @@ package host_sets_test
 
 import (
 	"context"
+	"fmt"
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/auth"
+	"github.com/hashicorp/boundary/internal/auth/oidc"
 	"github.com/hashicorp/boundary/internal/authtoken"
-	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	controllerauth "github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/host_sets"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
@@ -21,6 +27,12 @@ import (
 	plgpb "github.com/hashicorp/boundary/sdk/pbs/plugin"
 	"github.com/stretchr/testify/require"
 )
+
+// expectedOutput consolidates common output fields for the test cases
+type expectedOutput struct {
+	err          error
+	outputFields []string
+}
 
 // TestGrants_ReadActions tests read actions to assert that grants are being applied properly
 //
@@ -41,11 +53,15 @@ func TestGrants_ReadActions(t *testing.T) {
 	conn, _ := db.TestSetup(t, "postgres")
 	wrap := db.TestWrapper(t)
 	rw := db.New(conn)
-	iamRepo := iam.TestRepo(t, conn, wrap)
 	kmsCache := kms.TestKms(t, conn, wrap)
-	sche := scheduler.TestScheduler(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	scheduler := scheduler.TestScheduler(t, conn, wrap)
 	pluginRepoFn := func() (*hostplugin.Repository, error) {
-		return hostplugin.NewRepository(ctx, rw, rw, kmsCache, sche, map[string]plgpb.HostPluginServiceClient{})
+		return hostplugin.NewRepository(ctx, rw, rw, kmsCache, scheduler, map[string]plgpb.HostPluginServiceClient{})
 	}
 	repoFn := func() (*static.Repository, error) {
 		return static.NewRepository(ctx, rw, rw, kmsCache)
@@ -53,88 +69,232 @@ func TestGrants_ReadActions(t *testing.T) {
 	s, err := host_sets.NewService(ctx, repoFn, pluginRepoFn, 1000)
 	require.NoError(t, err)
 
-	org, proj := iam.TestScopes(t, iamRepo)
+	org, proj := iam.TestScopes(t, iamRepo) // TODO: Add a second org/proj scopes? To enforce independent behavior (e.g. grants in org1/proj1 shouldn't be returned when querying org2/proj2)
 
+	// Create five test Host Sets under a test Host Catalog
 	hcs := static.TestCatalogs(t, conn, proj.GetPublicId(), 1)
 	hc := hcs[0]
-
-	hsets := static.TestSets(t, conn, hc.GetPublicId(), 5)
-	var wantHostSets []string
-	for _, h := range hsets {
-		wantHostSets = append(wantHostSets, h.GetPublicId())
+	hsets := make([]*static.HostSet, 5)
+	for i := range cap(hsets) {
+		hsets[i] = static.TestSet(t, conn, hc.PublicId,
+			static.WithName(fmt.Sprintf("test name %d", i)),
+			static.WithDescription(fmt.Sprintf("test description %d", i)),
+		)
 	}
 
 	t.Run("List", func(t *testing.T) {
 		testcases := []struct {
 			name          string
 			input         *pbs.ListHostSetsRequest
-			rolesToCreate []authtoken.TestRoleGrantsForToken
+			userFunc      func() (*iam.User, auth.Account)
 			wantErr       error
-			wantIDs       []string
+			wantOutfields map[string][]string
 		}{
 			{
-				name: "global role grant this returns all created host-set",
+				name: "global role grant this returns 403 because host-sets live on projects",
 				input: &pbs.ListHostSetsRequest{
 					HostCatalogId: hc.GetPublicId(),
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=host-set;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
-				wantErr: nil,
-				wantIDs: wantHostSets,
+				}),
+				wantErr: handlers.ForbiddenError(),
 			},
 			{
-				name: "org role grant this returns all created host-set",
+				name: "org role grant this returns 403 because host-sets live on projects",
 				input: &pbs.ListHostSetsRequest{
 					HostCatalogId: hc.GetPublicId(),
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  org.PublicId,
-						GrantStrings: []string{"ids=*;type=host-set;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+						RoleScopeId: org.GetPublicId(),
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
-				wantErr: nil,
-				wantIDs: wantHostSets,
+				}),
+				wantErr: handlers.ForbiddenError(),
 			},
 			{
-				name: "project role grant this returns all created host-set",
+				name: "project role grant this returns all host-sets on the project",
 				input: &pbs.ListHostSetsRequest{
 					HostCatalogId: hc.GetPublicId(),
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  proj.PublicId,
-						GrantStrings: []string{"ids=*;type=host-set;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis},
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField},
+					hsets[1].GetPublicId(): {globals.IdField},
+					hsets[2].GetPublicId(): {globals.IdField},
+					hsets[3].GetPublicId(): {globals.IdField},
+					hsets[4].GetPublicId(): {globals.IdField},
 				},
-				wantErr: nil,
-				wantIDs: wantHostSets,
+			},
+			{
+				name: "global role grant this & children returns 403 because host-sets live on projects",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "org role grant children returns all host-sets on child projects",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[1].GetPublicId(): {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[2].GetPublicId(): {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[3].GetPublicId(): {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[4].GetPublicId(): {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				},
+			},
+			{
+				name: "global role grant this & descendants returns all host-sets on descendant projects",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[1].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[2].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[3].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[4].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				},
+			},
+			{
+				name: "project role grant this returns all host-sets on the project",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField},
+					hsets[1].GetPublicId(): {globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField},
+					hsets[2].GetPublicId(): {globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField},
+					hsets[3].GetPublicId(): {globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField},
+					hsets[4].GetPublicId(): {globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField},
+				},
+			},
+			{
+				name: "org role grant with host-catalog id, list action, host-set type, and children scope returns all host sets",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=list,no-op;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[1].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[2].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[3].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[4].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				},
+			},
+			{
+				name: "project role grant with host-catalog id, list action, host-set type, and this scope returns all host sets",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=list,no-op;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[1].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[2].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[3].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[4].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				},
 			},
 		}
 
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
-				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				// Call function to create direct/indirect relationship
+				user, account := tc.userFunc()
+
+				// Create auth token for the user
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+
+				// Create auth context from the auth token
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
 				got, finalErr := s.ListHostSets(fullGrantAuthCtx, tc.input)
 				if tc.wantErr != nil {
 					require.ErrorIs(t, finalErr, tc.wantErr)
 					return
 				}
 				require.NoError(t, finalErr)
-				var gotIDs []string
+				var gotIds []string
 				for _, g := range got.Items {
-					gotIDs = append(gotIDs, g.GetId())
+					gotIds = append(gotIds, g.GetId())
+
+					// check if the output fields are as expected
+					if tc.wantOutfields[g.Id] != nil {
+						handlers.TestAssertOutputFields(t, g, tc.wantOutfields[g.Id])
+					}
 				}
-				require.ElementsMatch(t, tc.wantIDs, gotIDs)
+				wantIds := slices.Collect(maps.Keys(tc.wantOutfields))
+				require.ElementsMatch(t, wantIds, gotIds)
 			})
 		}
 	})
+
+	t.Run("Get", func(t *testing.T) {
+		// TODO: Implement
+	})
+}
+
+func TestGrants_WriteActions(t *testing.T) {
+	// ctx, conn, wrap, rw, kmsCache := helper.TestDbCore(t)
+	// iamRepo := iam.TestRepo(t, conn, wrap)
+
+	//TODO: Implement
 }

--- a/internal/host/static/testing.go
+++ b/internal/host/static/testing.go
@@ -88,6 +88,31 @@ func TestHosts(t testing.TB, conn *db.DB, catalogId string, count int) []*Host {
 	return hosts
 }
 
+// TestSet creates a static host set in the provided DB
+// with the provided catalog id. The catalog must have been created
+// previously. Name and description are the only valid options. All other options are
+// ignored. The test will fail if any errors are encountered.
+func TestSet(t testing.TB, conn *db.DB, catalogId string, opt ...Option) *HostSet {
+	t.Helper()
+	ctx := context.Background()
+	assert := assert.New(t)
+
+	set, err := NewHostSet(ctx, catalogId, opt...)
+	assert.NoError(err)
+	assert.NotNil(set)
+
+	id, err := newHostSetId(ctx)
+	assert.NoError(err)
+	assert.NotEmpty(id)
+	set.PublicId = id
+
+	w := db.New(conn)
+	err2 := w.Create(ctx, set)
+	assert.NoError(err2)
+
+	return set
+}
+
 // TestSets creates count number of static host sets in the provided DB
 // with the provided catalog id. The catalog must have been created
 // previously. The test will fail if any errors are encountered.

--- a/internal/host/static/testing.go
+++ b/internal/host/static/testing.go
@@ -12,6 +12,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestCatalog creates a static host catalog to the provided DB
+// with the provided project id.  If any errors are encountered during the creation of
+// the host catalog, the test will fail.
+// Name and description are the only valid options. All other options are
+// ignored.
+func TestCatalog(t testing.TB, conn *db.DB, projectId string, opt ...Option) *HostCatalog {
+	t.Helper()
+	ctx := context.Background()
+	assert := assert.New(t)
+
+	cat, err := NewHostCatalog(ctx, projectId, opt...)
+	assert.NoError(err)
+	assert.NotNil(cat)
+	id, err := newHostCatalogId(ctx)
+	assert.NoError(err)
+	assert.NotEmpty(id)
+	cat.PublicId = id
+
+	w := db.New(conn)
+	err2 := w.Create(ctx, cat)
+	assert.NoError(err2)
+
+	return cat
+}
+
 // TestCatalogs creates count number of static host catalogs to the provided DB
 // with the provided project id.  If any errors are encountered during the creation of
 // the host catalog, the test will fail.


### PR DESCRIPTION
- CRUDL grants tests for host sets
- Added `TestHostSet()` function in order to create test host sets with names & descriptions for validating `output_fields`
- Added `TestHostCatalog()` function in order to create multiple test host catalogs without running into duplicate name errors from the API