### PR TITLE
fix(token): utilize a more accurate comparison method

### DIFF
--- a/internal/authtoken/repository.go
+++ b/internal/authtoken/repository.go
@@ -5,6 +5,7 @@ package authtoken
 
 import (
 	"context"
+	"crypto/subtle"
 	"database/sql"
 	"fmt"
 	"time"
@@ -240,7 +241,7 @@ func (r *Repository) ValidateToken(ctx context.Context, id, token string, opt ..
 		return nil, nil
 	}
 
-	if retAT.GetToken() != token {
+	if subtle.ConstantTimeCompare([]byte(retAT.GetToken()), []byte(token)) == 0 {
 		return nil, nil
 	}
 	// retAT.Token set to empty string so the value is not returned as described in the methods' doc.


### PR DESCRIPTION
# Summary

Use a constant-time method for comparing secrets. Such an operation will scan the entirety of both strings to be compared rather than returning early as soon as a character is encountered that does not match.