### PR TITLE
fix(db): return expected rows err for migration logs

### DIFF
--- a/internal/db/schema/internal/postgres/postgres.go
+++ b/internal/db/schema/internal/postgres/postgres.go
@@ -475,7 +475,7 @@ func (p *Postgres) GetMigrationLog(ctx context.Context, opt ...log.Option) ([]*l
 		entries = append(entries, e)
 	}
 	if rows.Err() != nil {
-		return nil, errors.Wrap(ctx, err, op)
+		return nil, errors.Wrap(ctx, rows.Err(), op)
 	}
 	opts := log.GetOpts(opt...)
 	if opts.WithDeleteLog {


### PR DESCRIPTION
# Summary

Errors encountered during database migrations applied through the database init and database migrate commands do not display the correct error messages. This issue arises from an incorrect variable reference in the GetMigrationLog function.