### PR TITLE
GCP Target User Label Fix

### DIFF
--- a/enos/modules/gcp_target/main.tf
+++ b/enos/modules/gcp_target/main.tf
@@ -125,7 +125,7 @@ resource "google_compute_instance" "boundary_target" {
     "project" : "enos",
     "project_name" : "qti-enos-boundary",
     "environment" : var.environment,
-    "enos_user" : replace(var.enos_user, "/[\\W]+/", ""),
+    "enos_user" : replace(lower(var.enos_user), "/[\\W]+/", ""),
     "filter_label_1" : random_id.filter_label1.hex
     "filter_label_2" : random_id.filter_label2.hex
   })


### PR DESCRIPTION
# Overview
Fixing minor issue where when creating a target in GCP a label called `enos_user` is attached that's based on your Github handle. In the case that the name contains a capital letter it will [fail](https://github.com/hashicorp/boundary/actions/runs/13902731594/job/38899093541#step:35:62) based on the GCP api, to resolve this I've premptivily lowercased the provider variable for `enos_user` to account for this. 