### PR TITLE
Migrate Controller Repo Usage From Store To Server

### DIFF
--- a/internal/daemon/cluster/handlers/worker_service_status_test.go
+++ b/internal/daemon/cluster/handlers/worker_service_status_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/server"
-	"github.com/hashicorp/boundary/internal/server/store"
 	"github.com/hashicorp/boundary/internal/session"
 	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/internal/target/tcp"
@@ -49,10 +48,8 @@ func TestStatus(t *testing.T) {
 
 	serverRepo, err := server.NewRepository(ctx, rw, rw, kms)
 	require.NoError(t, err)
-	c := &store.Controller{
-		PrivateId: "test_controller1",
-		Address:   "127.0.0.1",
-	}
+
+	c := server.NewController("test_controller1", server.WithAddress("127.0.0.1"))
 	_, err = serverRepo.UpsertController(ctx, c)
 	require.NoError(t, err)
 
@@ -483,10 +480,7 @@ func TestStatusSessionClosed(t *testing.T) {
 
 	serverRepo, err := server.NewRepository(ctx, rw, rw, kms)
 	require.NoError(t, err)
-	c := &store.Controller{
-		PrivateId: "test_controller1",
-		Address:   "127.0.0.1",
-	}
+	c := server.NewController("test_controller1", server.WithAddress("127.0.0.1"))
 	_, err = serverRepo.UpsertController(ctx, c)
 	require.NoError(t, err)
 
@@ -676,10 +670,7 @@ func TestStatusDeadConnection(t *testing.T) {
 	serverRepo, err := server.NewRepository(ctx, rw, rw, kms)
 	require.NoError(t, err)
 
-	c := &store.Controller{
-		PrivateId: "test_controller1",
-		Address:   "127.0.0.1",
-	}
+	c := server.NewController("test_controller1", server.WithAddress("127.0.0.1"))
 	_, err = serverRepo.UpsertController(ctx, c)
 	require.NoError(t, err)
 
@@ -831,10 +822,7 @@ func TestStatusWorkerWithKeyId(t *testing.T) {
 	serverRepo, err := server.NewRepository(ctx, rw, rw, kms)
 	require.NoError(t, err)
 
-	c := &store.Controller{
-		PrivateId: "test_controller1",
-		Address:   "127.0.0.1",
-	}
+	c := server.NewController("test_controller1", server.WithAddress("127.0.0.1"))
 	_, err = serverRepo.UpsertController(ctx, c)
 	require.NoError(t, err)
 
@@ -1034,10 +1022,7 @@ func TestStatusAuthorizedWorkers(t *testing.T) {
 	serverRepo, err := server.NewRepository(ctx, rw, rw, kmsCache)
 	require.NoError(t, err)
 
-	c := &store.Controller{
-		PrivateId: "test_controller1",
-		Address:   "127.0.0.1",
-	}
+	c := server.NewController("test_controller1", server.WithAddress("127.0.0.1"))
 	_, err = serverRepo.UpsertController(ctx, c)
 	require.NoError(t, err)
 
@@ -1240,10 +1225,7 @@ func TestWorkerOperationalStatus(t *testing.T) {
 	serverRepo, err := server.NewRepository(ctx, rw, rw, kms)
 	require.NoError(t, err)
 
-	c := &store.Controller{
-		PrivateId: "test_controller1",
-		Address:   "127.0.0.1",
-	}
+	c := server.NewController("test_controller1", server.WithAddress("127.0.0.1"))
 	_, err = serverRepo.UpsertController(ctx, c)
 	require.NoError(t, err)
 
@@ -1357,10 +1339,7 @@ func TestWorkerLocalStorageStateStatus(t *testing.T) {
 	serverRepo, err := server.NewRepository(ctx, rw, rw, kms)
 	require.NoError(t, err)
 
-	c := &store.Controller{
-		PrivateId: "test_controller1",
-		Address:   "127.0.0.1",
-	}
+	c := server.NewController("test_controller1", server.WithAddress("127.0.0.1"))
 	_, err = serverRepo.UpsertController(ctx, c)
 	require.NoError(t, err)
 

--- a/internal/daemon/cluster/handlers/worker_service_test.go
+++ b/internal/daemon/cluster/handlers/worker_service_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/server"
-	"github.com/hashicorp/boundary/internal/server/store"
 	"github.com/hashicorp/boundary/internal/session"
 	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/internal/target/tcp"
@@ -1015,10 +1014,7 @@ func TestSessionInfo(t *testing.T) {
 
 				serverRepo, err := server.NewRepository(ctx, rw, rw, testKms)
 				require.NoError(err)
-				c := &store.Controller{
-					PrivateId: "test_controller1",
-					Address:   "127.0.0.1",
-				}
+				c := server.NewController("test_controller1", server.WithAddress("127.0.0.1"))
 				_, err = serverRepo.UpsertController(ctx, c)
 				require.NoError(err)
 
@@ -1158,10 +1154,7 @@ func TestRoutingInfo(t *testing.T) {
 	_ = server.TestPkiWorker(t, conn, wrapper, server.WithTestPkiWorkerAuthorizedKeyId(&w2KeyId))
 	w3 := server.TestKmsWorker(t, conn, wrapper, server.WithName("testworker3"))
 
-	c := &store.Controller{
-		PrivateId: "test_controller1",
-		Address:   "1.2.3.4",
-	}
+	c := server.NewController("test_controller1", server.WithAddress("1.2.3.4"))
 	_, err = serverRepo.UpsertController(ctx, c)
 	require.NoError(t, err)
 

--- a/internal/daemon/controller/tickers.go
+++ b/internal/daemon/controller/tickers.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/boundary/internal/daemon/cluster"
 	"github.com/hashicorp/boundary/internal/errors"
 	"github.com/hashicorp/boundary/internal/event"
-	"github.com/hashicorp/boundary/internal/server/store"
+	"github.com/hashicorp/boundary/internal/server"
 )
 
 // In the future we could make this configurable
@@ -46,10 +46,15 @@ func (c *Controller) startStatusTicking(cancelCtx context.Context) {
 
 func (c *Controller) upsertController(ctx context.Context) error {
 	const op = "controller.(Controller).upsertController"
-	controller := &store.Controller{
-		PrivateId: c.conf.RawConfig.Controller.Name,
-		Address:   c.conf.RawConfig.Controller.PublicClusterAddr,
+	var opts []server.Option
+	if c.conf.RawConfig.Controller.Description != "" {
+		opts = append(opts, server.WithDescription(c.conf.RawConfig.Controller.Description))
 	}
+	if c.conf.RawConfig.Controller.PublicClusterAddr != "" {
+		opts = append(opts, server.WithAddress(c.conf.RawConfig.Controller.PublicClusterAddr))
+	}
+
+	controller := server.NewController(c.conf.RawConfig.Controller.Name, opts...)
 	repo, err := c.ServersRepoFn()
 	if err != nil {
 		return errors.Wrap(ctx, err, op, errors.WithMsg("error fetching repository for status upsert"))
@@ -65,10 +70,14 @@ func (c *Controller) upsertController(ctx context.Context) error {
 
 func (c *Controller) updateController(ctx context.Context) error {
 	const op = "controller.(Controller).updateController"
-	controller := &store.Controller{
-		PrivateId: c.conf.RawConfig.Controller.Name,
-		Address:   c.conf.RawConfig.Controller.PublicClusterAddr,
+	var opts []server.Option
+	if c.conf.RawConfig.Controller.Description != "" {
+		opts = append(opts, server.WithDescription(c.conf.RawConfig.Controller.Description))
 	}
+	if c.conf.RawConfig.Controller.PublicClusterAddr != "" {
+		opts = append(opts, server.WithAddress(c.conf.RawConfig.Controller.PublicClusterAddr))
+	}
+	controller := server.NewController(c.conf.RawConfig.Controller.Name, opts...)
 	repo, err := c.ServersRepoFn()
 	if err != nil {
 		return errors.Wrap(ctx, err, op, errors.WithMsg("error fetching repository for status update"))

--- a/internal/scheduler/job/testing.go
+++ b/internal/scheduler/job/testing.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/boundary/internal/server/store"
-
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/server"
@@ -100,7 +98,7 @@ func testRunWithUpdateTime(conn *db.DB, pluginId, name, cId string, updateTime t
 	return run, nil
 }
 
-func testController(t *testing.T, conn *db.DB, wrapper wrapping.Wrapper, opt ...testOption) *store.Controller {
+func testController(t *testing.T, conn *db.DB, wrapper wrapping.Wrapper, opt ...testOption) *server.Controller {
 	t.Helper()
 	ctx := context.Background()
 	rw := db.New(conn)
@@ -117,10 +115,7 @@ func testController(t *testing.T, conn *db.DB, wrapper wrapping.Wrapper, opt ...
 		require.NoError(t, err)
 		privateId = "test-job-server-" + id
 	}
-	controller := &store.Controller{
-		PrivateId: privateId,
-		Address:   "127.0.0.1",
-	}
+	controller := server.NewController(privateId, server.WithAddress("127.0.0.1"))
 	_, err = serversRepo.UpsertController(ctx, controller)
 	require.NoError(t, err)
 	return controller

--- a/internal/scheduler/testing.go
+++ b/internal/scheduler/testing.go
@@ -5,11 +5,10 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/hashicorp/boundary/internal/server/store"
 
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/iam"
@@ -38,10 +37,8 @@ func TestScheduler(t testing.TB, conn *db.DB, wrapper wrapping.Wrapper, opt ...O
 
 	id, err := uuid.GenerateUUID()
 	require.NoError(t, err)
-	controller := &store.Controller{
-		PrivateId: "test-job-server-" + id,
-		Address:   "127.0.0.1",
-	}
+
+	controller := server.NewController(fmt.Sprintf("test-server-job%s", id), server.WithAddress("127.0.0.1"))
 	_, err = serversRepo.UpsertController(ctx, controller)
 	require.NoError(t, err)
 

--- a/internal/server/controller.go
+++ b/internal/server/controller.go
@@ -5,8 +5,10 @@ package server
 
 import "github.com/hashicorp/boundary/internal/server/store"
 
-// Controllers are a server that provider user auth to a client and contain the permissions and resources.
-// Additionally controllers communicate with external services such as databases, KMS, idp, plugins, etc.
+// Controller is a server that is responsible for understanding configuration,
+// authenticating and authorizing users, and serving user API requests (e.g. to
+// initiate a session). They also assign tasks to workers (session handling,
+// session recording parsing, etc.).
 type Controller struct {
 	*store.Controller
 }

--- a/internal/server/controller.go
+++ b/internal/server/controller.go
@@ -1,0 +1,27 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package server
+
+import "github.com/hashicorp/boundary/internal/server/store"
+
+// Controllers are a server that provider user auth to a client and contain the permissions and resources.
+// Additionally controllers communicate with external services such as databases, KMS, idp, plugins, etc.
+type Controller struct {
+	*store.Controller
+}
+
+// NewController returns a new controller. Valid options are WithAddress and WithDescription.
+// All other options are ignored.
+func NewController(privateId string, opt ...Option) *Controller {
+	opts := GetOpts(opt...)
+	controller := &Controller{
+		Controller: &store.Controller{
+			PrivateId:   privateId,
+			Address:     opts.withAddress,
+			Description: opts.withDescription,
+		},
+	}
+
+	return controller
+}

--- a/internal/server/repository_controller.go
+++ b/internal/server/repository_controller.go
@@ -9,17 +9,16 @@ import (
 
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/errors"
-	"github.com/hashicorp/boundary/internal/server/store"
 )
 
-func (r *Repository) ListControllers(ctx context.Context, opt ...Option) ([]*store.Controller, error) {
+func (r *Repository) ListControllers(ctx context.Context, opt ...Option) ([]*Controller, error) {
 	return r.listControllersWithReader(ctx, r.reader, opt...)
 }
 
 // listControllersWithReader will return a listing of resources and honor the
 // WithLimit option or the repo defaultLimit. It accepts a reader, allowing it
 // to be used within a transaction or without.
-func (r *Repository) listControllersWithReader(ctx context.Context, reader db.Reader, opt ...Option) ([]*store.Controller, error) {
+func (r *Repository) listControllersWithReader(ctx context.Context, reader db.Reader, opt ...Option) ([]*Controller, error) {
 	opts := GetOpts(opt...)
 	liveness := opts.withLiveness
 	if liveness == 0 {
@@ -31,7 +30,7 @@ func (r *Repository) listControllersWithReader(ctx context.Context, reader db.Re
 		where = fmt.Sprintf("update_time > now() - interval '%d seconds'", uint32(liveness.Seconds()))
 	}
 
-	var controllers []*store.Controller
+	var controllers []*Controller
 	if err := reader.SearchWhere(
 		ctx,
 		&controllers,
@@ -45,7 +44,7 @@ func (r *Repository) listControllersWithReader(ctx context.Context, reader db.Re
 	return controllers, nil
 }
 
-func (r *Repository) UpsertController(ctx context.Context, controller *store.Controller) (int, error) {
+func (r *Repository) UpsertController(ctx context.Context, controller *Controller) (int, error) {
 	const op = "server.(Repository).UpsertController"
 
 	if controller == nil {
@@ -78,7 +77,7 @@ func (r *Repository) UpsertController(ctx context.Context, controller *store.Con
 	return int(rowsUpdated), nil
 }
 
-func (r *Repository) UpdateController(ctx context.Context, controller *store.Controller) (int, error) {
+func (r *Repository) UpdateController(ctx context.Context, controller *Controller) (int, error) {
 	const op = "server.(Repository).UpdateController"
 
 	if controller == nil {

--- a/internal/session/service_statistics_test.go
+++ b/internal/session/service_statistics_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/server"
-	"github.com/hashicorp/boundary/internal/server/store"
 	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/internal/target/tcp"
 	"github.com/stretchr/testify/assert"
@@ -32,10 +31,8 @@ func TestCloseOrphanedConnections(t *testing.T) {
 	require.NoError(t, err)
 
 	serverRepo, _ := server.NewRepository(context.Background(), rw, rw, testKms)
-	_, err = serverRepo.UpsertController(context.Background(), &store.Controller{
-		PrivateId: "test_controller1",
-		Address:   "127.0.0.1",
-	})
+	c := server.NewController("test_controller1", server.WithAddress("127.0.0.1"))
+	_, err = serverRepo.UpsertController(context.Background(), c)
 	require.NoError(t, err)
 
 	cases := []struct {
@@ -450,10 +447,8 @@ func TestUpdateConnectionBytesUpDown(t *testing.T) {
 	require.NoError(t, err)
 
 	serverRepo, _ := server.NewRepository(context.Background(), rw, rw, testKms)
-	_, err = serverRepo.UpsertController(context.Background(), &store.Controller{
-		PrivateId: "test_controller1",
-		Address:   "127.0.0.1",
-	})
+	c := server.NewController("test_controller1", server.WithAddress("127.0.0.1"))
+	_, err = serverRepo.UpsertController(context.Background(), c)
 	require.NoError(t, err)
 
 	t.Run("nil connection repo", func(t *testing.T) {

--- a/internal/session/service_worker_status_report_test.go
+++ b/internal/session/service_worker_status_report_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/server"
-	"github.com/hashicorp/boundary/internal/server/store"
 	"github.com/hashicorp/boundary/internal/session"
 	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/internal/target/tcp"
@@ -30,10 +29,8 @@ func TestWorkerStatusReport(t *testing.T) {
 	org, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
 
 	serverRepo, _ := server.NewRepository(ctx, rw, rw, kms)
-	_, err := serverRepo.UpsertController(ctx, &store.Controller{
-		PrivateId: "test_controller1",
-		Address:   "127.0.0.1",
-	})
+	c := server.NewController("test_controller1", server.WithAddress("127.0.0."))
+	_, err := serverRepo.UpsertController(ctx, c)
 	require.NoError(t, err)
 
 	repo, err := session.NewRepository(ctx, rw, rw, kms)


### PR DESCRIPTION
# Overview
- Normally we don't use `store` structs directly for exported methods as part of a repo. This updates the server controller to use it's domain package instead which itself embeds the store. 

This PR was created as a result of the discussion [here](https://github.com/hashicorp/boundary/pull/5602#discussion_r1999418660). 