### PR TITLE
feat: grantsForUser for Global Resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kr/pretty v0.3.1
 	github.com/kr/text v0.2.0
+	github.com/lib/pq v1.10.9
 	github.com/mattn/go-colorable v0.1.13
 	github.com/miekg/dns v1.1.58
 	github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a
@@ -169,7 +170,6 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -211,7 +211,7 @@ const (
     users (id) as (
       select public_id
         from iam_user
-      %s -- anonUser || authUser
+      where public_id = any(@user_ids)
     ),
     user_groups (id) as (
       select group_id
@@ -268,7 +268,7 @@ const (
       join iam_grant
         on iam_grant.canonical_grant        = iam_role_grant.canonical_grant
       where iam_role.public_id in (select role_id from user_group_roles)
-        and iam_grant.resource              = any('{"%s", "unknown", "*"}')
+        and iam_grant.resource              = any(@resources)
    ),
    global_roles as (
       select iam_role_global.public_id             as role_id,

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -259,6 +259,13 @@ const (
       select role_id
         from managed_group_roles
     ),
+    individual_grant_scopes (role_id, scope_id) as (
+      select role_id, scope_id
+        from iam_role_global_individual_org_grant_scope
+      union
+      select role_id, scope_id
+        from iam_role_global_individual_project_grant_scope
+    ),
     roles_with_grants (role_id, canonical_grant) as (
       select iam_role_grant.role_id,
         iam_role_grant.canonical_grant
@@ -282,7 +289,7 @@ const (
       from iam_role_global
       join roles_with_grants
         on roles_with_grants.role_id = iam_role_global.public_id
-      left join iam_role_global_individual_grant_scope individual
+      left join individual_grant_scopes individual
         on roles_with_grants.role_id = individual.role_id
       join iam_scope
         on iam_scope.public_id = iam_role_global.scope_id

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -298,7 +298,7 @@ const (
            role_parent_scope_id,
            grant_scope,
            grant_this_role_scope,
-           null as individual_grant_scopes, -- there can be no individual grants for global roles
+           null as individual_grant_scopes, -- individual grant scopes do not apply to resources in the global scope
            array_agg(distinct(canonical_grant)) as canonical_grants
       from global_roles
      where global_roles.grant_this_role_scope = true

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -286,8 +286,8 @@ const (
    )
    select role_id,
           role_scope_id,
-          grant_scope,
 		      role_parent_scope_id,
+          grant_scope,
           grant_this_role_scope,
           NULL as individual_grant_scopes, -- there can be no individual grants for global roles
           array_agg(distinct(canonical_grant)) filter (where canonical_grant is not null) as canonical_grants -- only include canonical grants if they are not null

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -206,6 +206,104 @@ const (
         on grants.role_id = roles.role_id;
     `
 
+	grantsForUserGlobalResourcesQuery = `
+	with
+    users (id) as (
+      select public_id
+        from iam_user
+      %s -- anonUser || authUser
+    ),
+    user_groups (id) as (
+      select group_id
+        from iam_group_member_user
+       where member_id in (select id from users)
+    ),
+    user_accounts (id) as (
+      select public_id
+        from auth_account
+       where iam_user_id in (select id from users)
+    ),
+    user_oidc_managed_groups (id) as (
+      select managed_group_id
+        from auth_oidc_managed_group_member_account
+       where member_id in (select id from user_accounts)
+    ),
+    user_ldap_managed_groups (id) as (
+      select managed_group_id
+        from auth_ldap_managed_group_member_account
+       where member_id in (select id from user_accounts)
+    ),
+    managed_group_roles (role_id) as (
+      select distinct role_id
+        from iam_managed_group_role
+       where principal_id in (select id from user_oidc_managed_groups)
+          or principal_id in (select id from user_ldap_managed_groups)
+    ),
+    group_roles (role_id) as (
+      select role_id
+        from iam_group_role
+       where principal_id in (select id from user_groups)
+    ),
+    user_roles (role_id) as (
+      select role_id
+        from iam_user_role
+       where principal_id in (select id from users)
+    ),
+    user_group_roles (role_id) as (
+      select role_id
+        from group_roles
+      union
+      select role_id
+        from user_roles
+      union
+      select role_id
+        from managed_group_roles
+    ),
+    roles_with_grants (role_id, canonical_grant) as (
+      select iam_role_grant.role_id,
+        iam_role_grant.canonical_grant
+      from iam_role_grant
+      join iam_role
+        on iam_role.public_id               = iam_role_grant.role_id
+      join iam_grant
+        on iam_grant.canonical_grant        = iam_role_grant.canonical_grant
+      where iam_role.public_id in (select role_id from user_group_roles)
+        and iam_grant.resource              = any('{"%s", "unknown", "*"}')
+   ),
+   global_roles as (
+      select iam_role_global.public_id             as role_id,
+             iam_role_global.scope_id              as role_scope_id,
+             iam_scope.type                        as role_type,
+             'global'                              as role_parent_scope_id, -- manually set to global because we are only looking at global roles and the parent scope is always global
+             iam_role_global.grant_scope           as grant_scope,
+             iam_role_global.grant_this_role_scope as grant_this_role_scope,
+             individual.scope_id                   as individual_grant_scope,
+             roles_with_grants.canonical_grant     as canonical_grant
+      from iam_role_global
+      join roles_with_grants
+        on roles_with_grants.role_id = iam_role_global.public_id
+      left join iam_role_global_individual_grant_scope individual
+        on roles_with_grants.role_id = individual.role_id
+      join iam_scope
+        on iam_scope.public_id = iam_role_global.scope_id
+   )
+   select role_id,
+          role_scope_id,
+          grant_scope,
+		      role_parent_scope_id,
+          grant_this_role_scope,
+          array_agg(distinct(individual_grant_scope)) filter (where individual_grant_scope is not null) as individual_grant_scopes, -- only include individual grant scopes if they are not null
+          array_agg(distinct(canonical_grant)) filter (where canonical_grant is not null)               as canonical_grants -- only include canonical grants if they are not null
+    from global_roles
+   group by (
+          role_id,
+          role_scope_id,
+		      role_parent_scope_id,
+          grant_scope,
+          grant_this_role_scope
+   );
+   `
+
 	estimateCountRoles = `
 		select reltuples::bigint as estimate from pg_class where oid in ('iam_role'::regclass)
 	`

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -207,70 +207,79 @@ const (
     `
 
 	grantsForUserGlobalResourcesQuery = `
-	with
+    with
     users (id) as (
       select public_id
         from iam_user
-      where public_id = any(@user_ids)
+       where public_id = any(@user_ids)
     ),
     user_groups (id) as (
       select group_id
         from iam_group_member_user
-       where member_id in (select id from users)
+       where member_id in (select id
+                             from users)
     ),
     user_accounts (id) as (
       select public_id
         from auth_account
-       where iam_user_id in (select id from users)
+       where iam_user_id in (select id
+                               from users)
     ),
     user_oidc_managed_groups (id) as (
       select managed_group_id
         from auth_oidc_managed_group_member_account
-       where member_id in (select id from user_accounts)
+       where member_id in (select id
+                             from user_accounts)
     ),
     user_ldap_managed_groups (id) as (
       select managed_group_id
         from auth_ldap_managed_group_member_account
-       where member_id in (select id from user_accounts)
+       where member_id in (select id
+                             from user_accounts)
     ),
     managed_group_roles (role_id) as (
       select distinct role_id
         from iam_managed_group_role
-       where principal_id in (select id from user_oidc_managed_groups)
-          or principal_id in (select id from user_ldap_managed_groups)
+       where principal_id in (select id
+                                from user_oidc_managed_groups)
+          or principal_id in (select id
+                                from user_ldap_managed_groups)
     ),
     group_roles (role_id) as (
       select role_id
         from iam_group_role
-       where principal_id in (select id from user_groups)
+       where principal_id in (select id
+                                from user_groups)
     ),
     user_roles (role_id) as (
       select role_id
         from iam_user_role
-       where principal_id in (select id from users)
+       where principal_id in (select id
+                                from users)
     ),
     user_group_roles (role_id) as (
       select role_id
         from group_roles
-      union
+       union
       select role_id
         from user_roles
-      union
+       union
       select role_id
         from managed_group_roles
     ),
     roles_with_grants (role_id, canonical_grant) as (
       select iam_role_grant.role_id,
-        iam_role_grant.canonical_grant
-      from iam_role_grant
-      join iam_role
-        on iam_role.public_id               = iam_role_grant.role_id
-      join iam_grant
-        on iam_grant.canonical_grant        = iam_role_grant.canonical_grant
-      where iam_role.public_id in (select role_id from user_group_roles)
-        and iam_grant.resource              = any(@resources)
-   ),
-   global_roles as (
+             iam_role_grant.canonical_grant
+        from iam_role_grant
+        join iam_role
+          on iam_role.public_id = iam_role_grant.role_id
+        join iam_grant
+          on iam_grant.canonical_grant = iam_role_grant.canonical_grant
+       where iam_role.public_id in (select role_id
+                                      from user_group_roles)
+         and iam_grant.resource = any(@resources)
+    ),
+    global_roles as (
       select iam_role_global.public_id             as role_id,
              iam_role_global.scope_id              as role_scope_id,
              iam_scope.type                        as role_type,
@@ -278,29 +287,27 @@ const (
              iam_role_global.grant_scope           as grant_scope,
              iam_role_global.grant_this_role_scope as grant_this_role_scope,
              roles_with_grants.canonical_grant     as canonical_grant
-      from iam_role_global
-      join roles_with_grants
-        on roles_with_grants.role_id = iam_role_global.public_id
-      join iam_scope
-        on iam_scope.public_id = iam_role_global.scope_id
-   )
-   select role_id,
-          role_scope_id,
-		      role_parent_scope_id,
-          grant_scope,
-          grant_this_role_scope,
-          NULL as individual_grant_scopes, -- there can be no individual grants for global roles
-          array_agg(distinct(canonical_grant)) filter (where canonical_grant is not null) as canonical_grants -- only include canonical grants if they are not null
-   from global_roles
-   where global_roles.grant_this_role_scope = true
-   group by (
-          role_id,
-          role_scope_id,
-		      role_parent_scope_id,
-          grant_scope,
-          grant_this_role_scope
-   );
-   `
+        from iam_role_global
+        join roles_with_grants
+          on roles_with_grants.role_id = iam_role_global.public_id
+        join iam_scope
+          on iam_scope.public_id = iam_role_global.scope_id
+    )
+    select role_id,
+           role_scope_id,
+           role_parent_scope_id,
+           grant_scope,
+           grant_this_role_scope,
+           null as individual_grant_scopes, -- there can be no individual grants for global roles
+           array_agg(distinct(canonical_grant)) as canonical_grants
+      from global_roles
+     where global_roles.grant_this_role_scope = true
+  group by role_id,
+           role_scope_id,
+           role_parent_scope_id,
+           grant_scope,
+           grant_this_role_scope;
+    `
 
 	estimateCountRoles = `
 		select reltuples::bigint as estimate from pg_class where oid in ('iam_role'::regclass)

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -543,7 +543,6 @@ func (r *Repository) grantsForUserGlobalResources(
 	ctx context.Context,
 	userId string,
 	res resource.Type,
-	reqScope Scope,
 	opt ...Option,
 ) (perms.GrantTuples, error) {
 	const op = "iam.(Repository).GrantsForUserGlobalResources"

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -454,11 +454,11 @@ type grantsForUserResults struct {
 	// for itself aka "this" or "individual" scope.
 	grantThisRoleScope bool
 	// individualGrantScopes represents the individual grant scopes for the role.
-	// This is a slice of strings that may be NULL values if the role does
+	// This is a slice of strings that may be empty if the role does
 	// not have individual grants.
 	individualGrantScopes []string
 	// canonicalGrants represents the canonical grants for the role.
-	// This is a slice of strings that may be NULL if the role does
+	// This is a slice of strings that may be empty if the role does
 	// not have canonical grants associated with it.
 	canonicalGrants []string
 }

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -544,7 +544,8 @@ func (r *Repository) grantsForUserGlobalResources(
 	userId string,
 	res resource.Type,
 	reqScope Scope,
-	opt ...Option) (perms.GrantTuples, error) {
+	opt ...Option,
+) (perms.GrantTuples, error) {
 	const op = "iam.(Repository).GrantsForUserGlobalResources"
 	if userId == "" {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing user id")

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -556,7 +556,7 @@ func (r *Repository) grantsForUserGlobalResources(
 	case globals.AnonymousUserId:
 		args = append(args, sql.Named("user_ids", fmt.Sprintf("{ %s }", userId)))
 	default:
-		args = append(args, sql.Named("user_ids", fmt.Sprintf("{ u_anon, u_auth, %s }", userId)))
+		args = append(args, sql.Named("user_ids", fmt.Sprintf("{ %s, %s, %s }", globals.AnonymousUserId, globals.AnyAuthenticatedUserId, userId)))
 	}
 	args = append(args, sql.Named("resources", fmt.Sprintf("{ %s, unknown, * }", res.String())))
 

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -546,7 +546,7 @@ func (r *Repository) grantsForUserGlobalResources(
 	res resource.Type,
 	opt ...Option,
 ) (perms.GrantTuples, error) {
-	const op = "iam.(Repository).GrantsForUserGlobalResources"
+	const op = "iam.(Repository).grantsForUserGlobalResources"
 	if userId == "" {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing user id")
 	}

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -571,8 +571,8 @@ func (r *Repository) grantsForUserGlobalResources(
 		if err := rows.Scan(
 			&g.roleId,
 			&g.roleScopeId,
-			&g.grantScope,
 			&g.roleParentScopeId,
+			&g.grantScope,
 			&g.grantThisRoleScope,
 			pq.Array(&g.individualGrantScopes),
 			pq.Array(&g.canonicalGrants),

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -621,7 +621,7 @@ func (r *Repository) grantsForUserGlobalResources(
 					RoleId:            grant.roleId,
 					RoleScopeId:       grant.roleScopeId,
 					RoleParentScopeId: grant.roleParentScopeId,
-					GrantScopeId:      reqScope.GetPublicId(),
+					GrantScopeId:      grant.grantScope,
 					Grant:             canonicalGrant,
 				}
 				if grant.grantThisRoleScope || gt.GrantScopeId == "" {

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -2496,8 +2496,8 @@ func setupDB_IamRoles(t *testing.T, conn *db.DB) []string {
       (parent_id,      type,      public_id,      name)
     values
       ('global',       'org',     'o_____colors', 'Colors R Us'),
-	  ('o_____colors', 'project', 'p____bcolors', 'Blue Color Mill'),
       ('o_____colors', 'project', 'p____rcolors', 'Red Color Mill'),
+	  ('o_____colors', 'project', 'p____bcolors', 'Blue Color Mill'),
       ('o_____colors', 'project', 'p____gcolors', 'Green Color Mill');
 	`
 	_, err := rw.Exec(ctx, insertScopes, nil)
@@ -2515,13 +2515,22 @@ func setupDB_IamRoles(t *testing.T, conn *db.DB) []string {
 	_, err = rw.Exec(ctx, insertGlobalRoles, nil)
 	require.NoError(err)
 
-	insertIndividualGlobalRoles := `
-	insert into iam_role_global_individual_grant_scope
+	insertIndividualOrgScopeGlobalRoles := `
+	insert into iam_role_global_individual_org_grant_scope
 	  (role_id,        scope_id,   grant_scope)
 	values
 	  ('r_go____name', 'o_____colors', 'individual');
 	`
-	_, err = rw.Exec(ctx, insertIndividualGlobalRoles, nil)
+	_, err = rw.Exec(ctx, insertIndividualOrgScopeGlobalRoles, nil)
+	require.NoError(err)
+
+	insertIndividualProjScopeGlobalRoles := `
+	insert into iam_role_global_individual_project_grant_scope
+	  (role_id,        scope_id,   grant_scope)
+	values
+	  ('r_gp____spec', 'p____gcolors', 'individual');
+	`
+	_, err = rw.Exec(ctx, insertIndividualProjScopeGlobalRoles, nil)
 	require.NoError(err)
 
 	insertRoleGrants := `

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -2456,8 +2456,8 @@ func TestGrantsForUserGlobalResources(t *testing.T) {
 	TestRoleGrant(t, conn, role4.PublicId, "ids=*;type=group;actions=read;output_fields=id")
 
 	// Add user to created roles
-	for _, roleId := range []string{role1.PublicId, role2.PublicId, role3.PublicId, role4.PublicId} {
-		_, err := repo.AddPrincipalRoles(ctx, roleId, 1, []string{user.PublicId})
+	for _, role := range []*Role{role1, role2, role3, role4} {
+		_, err := repo.AddPrincipalRoles(ctx, role.PublicId, role.Version, []string{user.PublicId})
 		require.NoError(t, err)
 	}
 

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -2447,37 +2447,60 @@ func TestGrantsForUserGlobalResources(t *testing.T) {
 
 	globalScope := Scope{Scope: &store.Scope{Type: scope.Global.String(), PublicId: "global"}}
 
-	got, err := repo.grantsForUserGlobalResources(ctx, user.PublicId, resource.Alias, globalScope)
-	require.NoError(t, err)
-	assert.ElementsMatch(t, got, []perms.GrantTuple{
-		{
-			RoleId:            "r_go____name",
-			RoleScopeId:       "global",
-			RoleParentScopeId: "global",
-			GrantScopeId:      "o_____colors",
-			Grant:             "ids=*;type=alias;actions=create,update,read,list",
-		},
-		{
-			RoleId:            "r_go____name",
-			RoleScopeId:       "global",
-			RoleParentScopeId: "global",
-			GrantScopeId:      "o_____colors",
-			Grant:             "ids=*;type=alias;actions=delete",
-		},
-		{
-			RoleId:            "r_gg_____buy",
-			RoleScopeId:       "global",
-			RoleParentScopeId: "global",
-			GrantScopeId:      "global",
-			Grant:             "ids=*;type=*;actions=update",
-		},
-		{
-			RoleId:            "r_gp____spec",
-			RoleScopeId:       "global",
-			RoleParentScopeId: "global",
-			GrantScopeId:      "global",
-			Grant:             "ids=*;type=alias;actions=delete",
-		},
+	t.Run("Alias", func(t *testing.T) {
+		got, err := repo.grantsForUserGlobalResources(ctx, user.PublicId, resource.Alias, globalScope)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, got, []perms.GrantTuple{
+			{
+				RoleId:            "r_go____name",
+				RoleScopeId:       "global",
+				RoleParentScopeId: "global",
+				GrantScopeId:      "o_____colors",
+				Grant:             "ids=*;type=alias;actions=create,update,read,list",
+			},
+			{
+				RoleId:            "r_go____name",
+				RoleScopeId:       "global",
+				RoleParentScopeId: "global",
+				GrantScopeId:      "o_____colors",
+				Grant:             "ids=*;type=alias;actions=delete",
+			},
+			{
+				RoleId:            "r_gg_____buy",
+				RoleScopeId:       "global",
+				RoleParentScopeId: "global",
+				GrantScopeId:      "global",
+				Grant:             "ids=*;type=*;actions=update",
+			},
+			{
+				RoleId:            "r_gp____spec",
+				RoleScopeId:       "global",
+				RoleParentScopeId: "global",
+				GrantScopeId:      "global",
+				Grant:             "ids=*;type=alias;actions=delete",
+			},
+		})
+	})
+
+	t.Run("Group", func(t *testing.T) {
+		got, err := repo.grantsForUserGlobalResources(ctx, user.PublicId, resource.Group, globalScope)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, got, []perms.GrantTuple{
+			{
+				RoleId:            "r_gg____shop",
+				RoleScopeId:       "global",
+				RoleParentScopeId: "global",
+				GrantScopeId:      "global",
+				Grant:             "ids=*;type=group;actions=read;output_fields=id",
+			},
+			{
+				RoleId:            "r_gg_____buy",
+				RoleScopeId:       "global",
+				RoleParentScopeId: "global",
+				GrantScopeId:      "global",
+				Grant:             "ids=*;type=*;actions=update",
+			},
+		})
 	})
 }
 

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -2469,7 +2469,7 @@ func TestGrantsForUserGlobalResources(t *testing.T) {
 				RoleId:            "r_gg_____buy",
 				RoleScopeId:       "global",
 				RoleParentScopeId: "global",
-				GrantScopeId:      "global",
+				GrantScopeId:      "descendants",
 				Grant:             "ids=*;type=*;actions=update",
 			},
 			{
@@ -2497,7 +2497,7 @@ func TestGrantsForUserGlobalResources(t *testing.T) {
 				RoleId:            "r_gg_____buy",
 				RoleScopeId:       "global",
 				RoleParentScopeId: "global",
-				GrantScopeId:      "global",
+				GrantScopeId:      "descendants",
 				Grant:             "ids=*;type=*;actions=update",
 			},
 		})


### PR DESCRIPTION
add query to fetch grants for a user for resources that are only globally scoped

**Note**:
DO NOT MERGE until we can create roles by subType from domain code instead of using `setupDB_IamRoles` to manually insert. `setupDB_IamRoles` was used to just validate the query