### PR TITLE
fix(daemon): set correct permissions on cache.db file

### DIFF
--- a/internal/clientcache/internal/daemon/server.go
+++ b/internal/clientcache/internal/daemon/server.go
@@ -567,6 +567,20 @@ func defaultDbUrl(ctx context.Context, opt ...Option) (string, error) {
 		return "", errors.Wrap(ctx, err, op)
 	}
 	fileName := filepath.Join(dotDir, dbFileName)
+	if _, err := os.Stat(fileName); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", errors.Wrap(ctx, err, op)
+		}
+		file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE, 0o600)
+		if err != nil {
+			return "", errors.Wrap(ctx, err, op)
+		}
+		defer file.Close()
+	}
+	err = os.Chmod(fileName, 0o600)
+	if err != nil {
+		return "", errors.Wrap(ctx, err, op)
+	}
 	return fmt.Sprintf("%s%s", fileName, fkPragma), nil
 }
 


### PR DESCRIPTION
# Summary

Updated the client cache to create the database file with 0600 permissions. The third-party SQLite driver in use does not support specifying permissions for a new database file. It was necessary to create an empty database on disk with the correct permissions and then reopen it using the SQLite driver.

Note, this fix only applies to the default DB path `.boundary/cache.db`.