### PR TITLE
Test: GrantsForUser for Accounts for various user to role relationships

### DIFF
--- a/internal/iam/repository_role_grant_ext_test.go
+++ b/internal/iam/repository_role_grant_ext_test.go
@@ -414,7 +414,7 @@ func TestGrantsForUser(t *testing.T) {
 	repo := iam.TestRepo(t, conn, wrap)
 
 	// Test against each resource
-	for _, r := range []resource.Type{resource.Group} {
+	for _, r := range []resource.Type{resource.Group, resource.Account} {
 		t.Run(fmt.Sprintf("[Resource: %s] [User Association]", r), func(t *testing.T) {
 			// Create a couple users to test direct associations
 			user := iam.TestUser(t, repo, "global")

--- a/internal/iam/repository_role_grant_ext_test.go
+++ b/internal/iam/repository_role_grant_ext_test.go
@@ -414,7 +414,7 @@ func TestGrantsForUser(t *testing.T) {
 	repo := iam.TestRepo(t, conn, wrap)
 
 	// Test against each resource
-	for _, r := range []resource.Type{resource.Group, resource.Account} {
+	for _, r := range []resource.Type{resource.Group, resource.Account, resource.Target} {
 		t.Run(fmt.Sprintf("[Resource: %s] [User Association]", r), func(t *testing.T) {
 			// Create a couple users to test direct associations
 			user := iam.TestUser(t, repo, "global")


### PR DESCRIPTION
Refactored the existing GrantsForUser tests from #5443. The logic between these tests is mostly the same -- the only variables are:
1. The resource being tested
2. The method of association (direct vs group vs managed group)

As a result, it made sense to refactor the existing three tests into one. Now passing in a **principal** (the thing being associated to roles), and a **role association function** (tells us how to associate the principal to its roles)
 
___

Note: The tests for `resource.Account` will not pass until the GrantsForUser refactor is complete. In its current state, `GrantsForUser()` returns _all_ grants for a user. After the refactor, it'll return a subset of grants based on some new parameters (i.e. resource type, request scope, recursive option). Until then, tests for `resource.Account` will return roles for _all_ scopes even though `resource.Account` can only exist at the Global and Org scopes.
