### PR TITLE
docs: Update caveats about HCP and TTL

### DIFF
--- a/website/content/docs/concepts/iam.mdx
+++ b/website/content/docs/concepts/iam.mdx
@@ -54,14 +54,11 @@ With the [OIDC](/boundary/tutorials/identity-management/oidc-auth) and LDAP auth
 as the auth method. The accounts and users are only created once the user authenticates to Boundary for the first time.
 The same applies to OIDC/LDAP [managed groups](/boundary/tutorials/identity-management/oidc-idp-groups).
 
-<Note>
-
 You can configure the `max_age` in the [OIDC attributes](/boundary/docs/concepts/domain-model/auth-methods#oidc-auth-method-attributes) to indicate to the OIDC provider how much time is allowed to pass until a user is challenged to authenticate again.
 However, the user will not be prompted to authenticate until the controller's `auth_token_time_to_live` [parameter](/boundary/docs/configuration/controller#auth_token_time_to_live) has expired.
 The default value is 7 days.
-At this time, HCP Boundary users cannot configure the `auth_token_time_to_live` for a controller, so that value always equals the default of 7 days.
 
-</Note>
+To configure time to live in HCP Boundary, refer to [Configure authentication time to live](/hcp/docs/boundary/configure-ttl).
 
 ### Grant permissions
 When setting up access controls for a user, it is important to first consider which scope(s) the user needs access to. Roles give users permission to perform actions through grants strings.

--- a/website/content/docs/configuration/controller.mdx
+++ b/website/content/docs/configuration/controller.mdx
@@ -88,8 +88,6 @@ description will be read.
   to all tokens from all auth methods). Valid time units are anything specified by Golang's
   [ParseDuration()](https://golang.org/pkg/time/#ParseDuration) method. Default is 7 days.
 
-  Note that you cannot set a maximum time to live for auth tokens in HCP Boundary at this time. For HCP Boundary, all auth tokens' maximum time to live equal the default of 7 days.
-
 - `auth_token_time_to_stale` - Maximum time of inactivity for all auth tokens globally (pertains
   to all tokens from all auth methods). Valid time units are anything specified by Golang's
   [ParseDuration()](https://golang.org/pkg/time/#ParseDuration) method. Default is 1 day.


### PR DESCRIPTION
A new feature will allow HCP Boundary users to set time to live and time to stale for auth tokens. This PR updates/removes some caveats where we said this wasn't possible and links out to the new HCP doc.

View the updates in the preview deployment:

- [Configure users - OIDC/LDAP](https://boundary-f83zh2dk3-hashicorp.vercel.app/boundary/docs/concepts/iam#configure-users-oidc-ldap) 
- [Controller > `auth_token_time_to_live`](https://boundary-f83zh2dk3-hashicorp.vercel.app/boundary/docs/configuration/controller#auth_token_time_to_live) - Deleted a reference here


**This PR should be merged AFTER HCP-Docs PR [#1213](https://github.com/hashicorp/hcp-docs/pull/1213)**