### PR TITLE
bosorawis sql split global grants scope table

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
@@ -78,7 +78,7 @@ begin;
       'update_iam_role_table_update_time is used to automatically update the update_time '
       'of the base table whenever one of the subtype iam_role tables are updated';
 
-  create function delete_base_iam_role() returns trigger
+  create function delete_iam_role_subtype() returns trigger
   as $$
   begin
     delete from iam_role
@@ -86,8 +86,8 @@ begin;
     return null; -- result is ignored since this is an after trigger
   end;
     $$ language plpgsql;
-    comment on function delete_base_iam_role() is
-      'delete_base_iam_role is used to automatically delete associated iam_role entry'
+    comment on function delete_iam_role_subtype() is
+      'delete_iam_role_subtype is used to automatically delete associated iam_role entry'
       'since domain implementation performs deletion on the child table which does not cleanup the base iam_role table ';
 
   -- global iam_role must have a scope_id of global.
@@ -138,10 +138,10 @@ begin;
     for each row execute procedure insert_role_subtype();
 
   create trigger insert_grant_scope_update_time before insert on iam_role_global
-    for each row execute procedure insert_grant_scope_update_time();  
+    for each row execute procedure insert_grant_scope_update_time();
 
   create trigger insert_grant_this_role_scope_update_time before insert on iam_role_global
-    for each row execute procedure insert_grant_this_role_scope_update_time();  
+    for each row execute procedure insert_grant_this_role_scope_update_time();
 
   create trigger update_iam_role_global_grant_scope_update_time before update on iam_role_global
     for each row execute procedure insert_grant_scope_update_time();
@@ -152,8 +152,8 @@ begin;
   create trigger update_iam_role_global_base_table_update_time after update on iam_role_global
     for each row execute procedure update_iam_role_table_update_time();
 
-  create trigger delete_base_iam_role after delete on iam_role_global
-    for each row execute procedure delete_base_iam_role();
+  create trigger delete_iam_role_subtype after delete on iam_role_global
+    for each row execute procedure delete_iam_role_subtype();
 
   create trigger default_create_time_column before insert on iam_role_global
     for each row execute procedure default_create_time();
@@ -161,7 +161,7 @@ begin;
   create trigger update_time_column before update on iam_role_global
     for each row execute procedure update_time_column();
 
-  create trigger update_version_column after update on iam_role_global 
+  create trigger update_version_column after update on iam_role_global
     for each row execute procedure update_version_column();
 
   create trigger immutable_columns before update on iam_role_global

--- a/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
@@ -81,7 +81,8 @@ begin;
   create function delete_iam_role_subtype() returns trigger
   as $$
   begin
-    delete from iam_role
+    delete
+      from iam_role
     where public_id = old.public_id;
     return null; -- result is ignored since this is an after trigger
   end;

--- a/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
@@ -203,7 +203,7 @@ begin;
     for each row execute procedure default_create_time();
 
   create trigger immutable_columns before update on iam_role_global_individual_org_grant_scope
-    for each row execute procedure immutable_columns('role_id', 'grant_scope', 'scope_id', 'create_time');
+    for each row execute procedure immutable_columns('role_id', 'scope_id', 'create_time');
 
   create table iam_role_global_individual_project_grant_scope (
     role_id wt_role_id
@@ -244,7 +244,7 @@ begin;
     for each row execute procedure default_create_time();
 
   create trigger immutable_columns before update on iam_role_global_individual_project_grant_scope
-    for each row execute procedure immutable_columns('role_id', 'grant_scope', 'scope_id', 'create_time');
+    for each row execute procedure immutable_columns('role_id', 'scope_id', 'create_time');
 
 
 commit;

--- a/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
@@ -197,7 +197,7 @@ begin;
     primary key(role_id, scope_id)
   );
   comment on table iam_role_global_individual_org_grant_scope is
-    'iam_role_global_individual_org_grant_scope is a list of individually granted org scope to global roles with grant_scope of individual.';
+    'iam_role_global_individual_org_grant_scope is a list of individually granted org scope to global roles with grant_scope individual.';
 
   create trigger default_create_time_column before insert on iam_role_global_individual_org_grant_scope
     for each row execute procedure default_create_time();
@@ -238,7 +238,7 @@ begin;
     primary key(role_id, scope_id)
   );
   comment on table iam_role_global_individual_project_grant_scope is
-    'iam_role_global_individual_project_grant_scope is a list of individually granted project scope table to global role with grant_scope of individual or children.';
+    'iam_role_global_individual_project_grant_scope is a list of individually granted project scope table to global role with grant_scope individual or children.';
 
   create trigger default_create_time_column before insert on iam_role_global_individual_project_grant_scope
     for each row execute procedure default_create_time();

--- a/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
@@ -66,7 +66,7 @@ begin;
     'of the subtype table whenever the grant_this_role_scope column is updated';
 
 
-  create function delete_individual_role_grant_scope() returns trigger
+  create function delete_global_role_individual_role_grant_scope() returns trigger
   as $$
   begin
     if new.grant_scope = 'children' then
@@ -81,8 +81,8 @@ begin;
     return new;
   end;
   $$ language plpgsql;
-  comment on function delete_individual_role_grant_scope() is
-    'delete_individual_role_grant_scope deletes individual role grants from '
+  comment on function delete_global_role_individual_role_grant_scope() is
+    'delete_global_role_individual_role_grant_scope deletes individual role grants from '
     'iam_role_global_individual_org_grant_scope and iam_role_global_individual_project_grant_scope to remove '
     'redundant grants';
 
@@ -158,8 +158,8 @@ begin;
   create trigger immutable_columns before update on iam_role_global
     for each row execute procedure immutable_columns('scope_id', 'create_time');
 
-  create trigger delete_individual_grant_scopes before update on iam_role_global
-    for each row execute procedure delete_individual_role_grant_scope('scope_id', 'create_time');
+  create trigger delete_global_role_individual_grant_scopes before update on iam_role_global
+    for each row execute procedure delete_global_role_individual_role_grant_scope();
 
 
   create table iam_role_global_individual_org_grant_scope (

--- a/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/100/01_iam_role_global.up.sql
@@ -187,7 +187,7 @@ begin;
        constraint only_individual_grant_scope_allowed
          check(
           grant_scope = 'individual'
-        ),
+        ), 
     constraint iam_role_global_grant_scope_fkey
       foreign key (role_id, grant_scope)
       references iam_role_global(public_id, grant_scope)
@@ -197,7 +197,7 @@ begin;
     primary key(role_id, scope_id)
   );
   comment on table iam_role_global_individual_org_grant_scope is
-    'iam_role_global_individual_org_grant_scope is a list of individually granted org scope to global roles with grant_scope individual.';
+    'iam_role_global_individual_org_grant_scope is a list of individually granted org scope to global roles with grant_scope of individual.';
 
   create trigger default_create_time_column before insert on iam_role_global_individual_org_grant_scope
     for each row execute procedure default_create_time();
@@ -238,7 +238,7 @@ begin;
     primary key(role_id, scope_id)
   );
   comment on table iam_role_global_individual_project_grant_scope is
-    'iam_role_global_individual_project_grant_scope is a list of individually granted project scope table to global role with grant_scope individual or children.';
+    'iam_role_global_individual_project_grant_scope is a list of individually granted project scope table to global role with grant_scope of individual or children.';
 
   create trigger default_create_time_column before insert on iam_role_global_individual_project_grant_scope
     for each row execute procedure default_create_time();

--- a/internal/db/schema/migrations/oss/postgres/100/02_iam_role_org.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/100/02_iam_role_org.up.sql
@@ -74,8 +74,8 @@ begin;
   create trigger update_iam_role_org_base_table_update_time after update on iam_role_org
     for each row execute procedure update_iam_role_table_update_time();
 
-  create trigger delete_base_iam_role after delete on iam_role_org
-    for each row execute procedure delete_base_iam_role();
+  create trigger delete_iam_role_subtype after delete on iam_role_org
+    for each row execute procedure delete_iam_role_subtype();
 
   create trigger default_create_time_column before insert on iam_role_org
     for each row execute procedure default_create_time();

--- a/internal/db/schema/migrations/oss/postgres/100/02_iam_role_org.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/100/02_iam_role_org.up.sql
@@ -87,7 +87,7 @@ begin;
     for each row execute procedure update_version_column();
 
   create trigger immutable_columns before update on iam_role_org
-    for each row execute procedure immutable_columns('scope_id', 'create_time', 'grant_scope');
+    for each row execute procedure immutable_columns('scope_id', 'create_time');
 
   create table iam_role_org_individual_grant_scope (
     role_id wt_role_id

--- a/internal/db/schema/migrations/oss/postgres/100/02_iam_role_org.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/100/02_iam_role_org.up.sql
@@ -24,23 +24,6 @@ begin;
     ('individual');       
 
 
-  create function delete_org_role_individual_role_grant_scope() returns trigger
-  as $$
-  begin
-    if new.grant_scope = 'children' then
-      delete from iam_role_org_individual_grant_scope
-        where role_id = new.public_id;
-    end if;
-    return new;
-  end;
-  $$ language plpgsql;
-  comment on function delete_org_role_individual_role_grant_scope() is
-    'delete_org_role_individual_role_grant_scope deletes individual role grants from '
-    'iam_role_org_individual_grant_scope to remove redundant grants';
-
-
-
-
   create table iam_role_org (
     public_id wt_role_id primary key
       constraint iam_role_fkey
@@ -88,11 +71,11 @@ begin;
   create trigger update_iam_role_org_grant_this_role_scope_update_time before update on iam_role_org
     for each row execute procedure insert_grant_this_role_scope_update_time();
 
-  create trigger update_iam_role_table_update_time after update on iam_role_org
+  create trigger update_iam_role_org_base_table_update_time after update on iam_role_org
     for each row execute procedure update_iam_role_table_update_time();
 
-  create trigger delete_iam_role_subtype after delete on iam_role_org
-    for each row execute procedure delete_iam_role_subtype();
+  create trigger delete_base_iam_role after delete on iam_role_org
+    for each row execute procedure delete_base_iam_role();
 
   create trigger default_create_time_column before insert on iam_role_org
     for each row execute procedure default_create_time();
@@ -104,10 +87,7 @@ begin;
     for each row execute procedure update_version_column();
 
   create trigger immutable_columns before update on iam_role_org
-    for each row execute procedure immutable_columns('scope_id', 'create_time');
-
-  create trigger delete_org_role_individual_grant_scopes before update on iam_role_org
-    for each row execute procedure delete_org_role_individual_role_grant_scope();
+    for each row execute procedure immutable_columns('scope_id', 'create_time', 'grant_scope');
 
   create table iam_role_org_individual_grant_scope (
     role_id wt_role_id

--- a/internal/db/schema/migrations/oss/postgres/100/03_iam_role_project.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/100/03_iam_role_project.up.sql
@@ -34,14 +34,14 @@ begin;
   create trigger update_time_column before update on iam_role_project
     for each row execute procedure update_time_column();
 
-  create trigger update_iam_role_table_update_time after update on iam_role_project
-    for each row execute procedure update_iam_role_table_update_time();
-
   create trigger update_version_column after update on iam_role_project
     for each row execute procedure update_version_column();
 
-  create trigger delete_iam_role_subtype after delete on iam_role_project
-    for each row execute procedure delete_iam_role_subtype();
+  create trigger update_iam_role_project_base_table_update_time after update on iam_role_project
+    for each row execute procedure update_iam_role_table_update_time();
+
+  create trigger delete_base_iam_role after delete on iam_role_project
+    for each row execute procedure delete_base_iam_role();
 
   create trigger immutable_columns before update on iam_role_project
     for each row execute procedure immutable_columns('scope_id', 'create_time');

--- a/internal/db/schema/migrations/oss/postgres/100/03_iam_role_project.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/100/03_iam_role_project.up.sql
@@ -40,8 +40,8 @@ begin;
   create trigger update_iam_role_project_base_table_update_time after update on iam_role_project
     for each row execute procedure update_iam_role_table_update_time();
 
-  create trigger delete_base_iam_role after delete on iam_role_project
-    for each row execute procedure delete_base_iam_role();
+  create trigger delete_iam_role_subtype after delete on iam_role_project
+    for each row execute procedure delete_iam_role_subtype();
 
   create trigger immutable_columns before update on iam_role_project
     for each row execute procedure immutable_columns('scope_id', 'create_time');

--- a/internal/db/sqltest/tests/iam/iam_role_global.sql
+++ b/internal/db/sqltest/tests/iam/iam_role_global.sql
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
 begin;
-  select plan(30);
+  select plan(34);
   select wtt_load('widgets', 'iam');
 
   --------------------------------------------------------------------------------

--- a/internal/db/sqltest/tests/iam/iam_role_global.sql
+++ b/internal/db/sqltest/tests/iam/iam_role_global.sql
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
 begin;
-  select plan(54);
+  select plan(44);
   select wtt_load('widgets', 'iam');
 
   --------------------------------------------------------------------------------
@@ -370,15 +370,6 @@ begin;
         ('r_6666666666', 'global', true, 'individual');
   select lives_ok('insert_valid_global_role_individual_grants');
 
-  -- create a row in iam_role_global_individual_org_grant_scope with grant_scope=individual
-  prepare insert_valid_org_scope_to_individual_grants as
-    insert into iam_role_global_individual_org_grant_scope
-        (role_id, grant_scope, scope_id)
-    values
-        ('r_6666666666', 'individual', 'o_____widget');
-  select lives_ok('insert_valid_org_scope_to_individual_grants');
-
-
   -- create a row in iam_role_global_individual_project_grant_scope with grant_scope=individual
   prepare insert_valid_project_scope_to_individual_grants as
     insert into iam_role_global_individual_project_grant_scope
@@ -396,53 +387,12 @@ begin;
   
   -- verify that iam_role_global.grant_scope is updated to children
   select is(count(*), 1::bigint) from iam_role_global where public_id = 'r_6666666666' and grant_scope = 'children';
-    -- check that the update cascaded to iam_role_global_individual_project_grant_scope
+  -- check that the update cascaded to iam_role_global_individual_project_grant_scope and iam_role_global_individual_org_grant_scope
   -- and that the grant_scope is now children
-  select is(count(*), 0::bigint) from iam_role_global_individual_org_grant_scope where role_id = 'r_6666666666';
   select is(count(*), 1::bigint) from iam_role_global_individual_project_grant_scope where role_id = 'r_6666666666' and scope_id = 'p____bwidget' and grant_scope = 'children';
 
 
-  -- 4l) update to iam_role_global.grant_scope from individual to descendants cascades also
-  -- deletes all individual grant scopes in iam_role_global_individual_org_grant_scope and iam_role_global_individual_project_grant_scope
-  prepare insert_r7_valid_global_role_individual_grants as
-    insert into iam_role_global 
-        (public_id, scope_id, grant_this_role_scope, grant_scope)
-    values
-        ('r_7777777777', 'global', true, 'individual');
-  select lives_ok('insert_r7_valid_global_role_individual_grants');
-
-  -- create a row in iam_role_global_individual_org_grant_scope with grant_scope=individual
-  prepare insert_valid_org_scope_to_individual_grants_for_r7 as
-    insert into iam_role_global_individual_org_grant_scope
-        (role_id, grant_scope, scope_id)
-    values
-        ('r_7777777777', 'individual', 'o_____widget');
-  select lives_ok('insert_valid_org_scope_to_individual_grants_for_r7');
-
-
-  -- create a row in iam_role_global_individual_project_grant_scope with grant_scope=individual
-  prepare insert_valid_project_scope_to_individual_grants_for_r7 as
-    insert into iam_role_global_individual_project_grant_scope
-        (role_id, grant_scope, scope_id)
-    values
-        ('r_7777777777', 'individual', 'p____bwidget');
-  select lives_ok('insert_valid_project_scope_to_individual_grants_for_r7');
-
-  -- take away children grants by updating to iam_role_global to individual
-  prepare update_grant_scope_to_descendants as
-    update iam_role_global
-        set grant_scope = 'descendants'
-      where public_id = 'r_7777777777';
-    select lives_ok('update_grant_scope_to_descendants');
-
-  -- verify that iam_role_global.grant_scope is updated to descendants
-  select is(count(*), 1::bigint) from iam_role_global where public_id = 'r_7777777777' and grant_scope = 'descendants';
-  -- check that the update deletes all individual grant scopes in iam_role_global_individual_org_grant_scope and iam_role_global_individual_project_grant_scope
-  select is(count(*), 0::bigint) from iam_role_global_individual_org_grant_scope where role_id = 'r_7777777777';
-  select is(count(*), 0::bigint) from iam_role_global_individual_project_grant_scope where role_id = 'r_7777777777';
-
-
-  -- 4m) update to iam_role_global.grant_scope from children to individual sets
+  -- 4l) update to iam_role_global.grant_scope from children to individual sets
   -- individually granted project scope in iam_role_global_individual_project_grant_scope grant_scope to children
   prepare insert_r8_valid_global_scope_to_individual_grants as
     insert into iam_role_global 
@@ -469,7 +419,6 @@ begin;
   -- verify that iam_role_global.grant_scope is updated to individual
   select is(count(*), 1::bigint) from iam_role_global where public_id = 'r_8888888888' and grant_scope = 'individual';
   -- check that the update deletes all individual grant scopes in iam_role_global_individual_org_grant_scope and iam_role_global_individual_project_grant_scope
-  select is(count(*), 0::bigint) from iam_role_global_individual_org_grant_scope where role_id = 'r_8888888888';
   select is(count(*), 1::bigint) from iam_role_global_individual_project_grant_scope where role_id = 'r_8888888888' and grant_scope = 'individual' and scope_id = 'p____bwidget';
 
   select * from finish();

--- a/internal/db/sqltest/tests/iam/iam_role_global.sql
+++ b/internal/db/sqltest/tests/iam/iam_role_global.sql
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
 begin;
-  select plan(51);
+  select plan(54);
   select wtt_load('widgets', 'iam');
 
   --------------------------------------------------------------------------------
@@ -394,7 +394,9 @@ begin;
       where public_id = 'r_6666666666';
     select lives_ok('update_grant_scope_to_children');
   
-  -- check that the update cascaded to iam_role_global_individual_project_grant_scope
+  -- verify that iam_role_global.grant_scope is updated to children
+  select is(count(*), 1::bigint) from iam_role_global where public_id = 'r_6666666666' and grant_scope = 'children';
+    -- check that the update cascaded to iam_role_global_individual_project_grant_scope
   -- and that the grant_scope is now children
   select is(count(*), 0::bigint) from iam_role_global_individual_org_grant_scope where role_id = 'r_6666666666';
   select is(count(*), 1::bigint) from iam_role_global_individual_project_grant_scope where role_id = 'r_6666666666' and scope_id = 'p____bwidget' and grant_scope = 'children';
@@ -432,7 +434,9 @@ begin;
         set grant_scope = 'descendants'
       where public_id = 'r_7777777777';
     select lives_ok('update_grant_scope_to_descendants');
-  
+
+  -- verify that iam_role_global.grant_scope is updated to descendants
+  select is(count(*), 1::bigint) from iam_role_global where public_id = 'r_7777777777' and grant_scope = 'descendants';
   -- check that the update deletes all individual grant scopes in iam_role_global_individual_org_grant_scope and iam_role_global_individual_project_grant_scope
   select is(count(*), 0::bigint) from iam_role_global_individual_org_grant_scope where role_id = 'r_7777777777';
   select is(count(*), 0::bigint) from iam_role_global_individual_project_grant_scope where role_id = 'r_7777777777';
@@ -462,6 +466,8 @@ begin;
       where public_id = 'r_8888888888';
     select lives_ok('update_r8_grant_scope_to_individual');
   
+  -- verify that iam_role_global.grant_scope is updated to individual
+  select is(count(*), 1::bigint) from iam_role_global where public_id = 'r_8888888888' and grant_scope = 'individual';
   -- check that the update deletes all individual grant scopes in iam_role_global_individual_org_grant_scope and iam_role_global_individual_project_grant_scope
   select is(count(*), 0::bigint) from iam_role_global_individual_org_grant_scope where role_id = 'r_8888888888';
   select is(count(*), 1::bigint) from iam_role_global_individual_project_grant_scope where role_id = 'r_8888888888' and grant_scope = 'individual' and scope_id = 'p____bwidget';

--- a/internal/db/sqltest/tests/iam/iam_role_global.sql
+++ b/internal/db/sqltest/tests/iam/iam_role_global.sql
@@ -171,7 +171,7 @@ begin;
         'foreign key also enforces matching grant_scope=individual in iam_role_global'
   );
 
-  -- 3f) insert into iam_role_global_individual_org_grant_scope when role grant_scope is descendants is not allowed
+  -- 3g) insert into iam_role_global_individual_org_grant_scope when role grant_scope is descendants is not allowed
   -- r_1111111111 is a global role with grant_scope=descendants
   prepare iam_role_global_individual_org_grant_scope_role_descendants as
     insert into iam_role_global_individual_org_grant_scope
@@ -185,7 +185,7 @@ begin;
   );
 
 
-  -- 3g) insert into iam_role_global_individual_org_grant_scope when role grant_scope is children is not allowed
+  -- 3h) insert into iam_role_global_individual_org_grant_scope when role grant_scope is children is not allowed
   -- r_2222222222 is a global role with grant_scope=children
   prepare iam_role_global_individual_org_grant_scope_role_children as
     insert into iam_role_global_individual_org_grant_scope
@@ -199,7 +199,7 @@ begin;
   );
 
 
-  --3g) insert entry with role_id that does not exist in iam_role_global
+  --3i) insert entry with role_id that does not exist in iam_role_global
   prepare insert_invalid_role_id as
     insert into iam_role_global_individual_org_grant_scope
         (role_id, grant_scope, scope_id)
@@ -211,7 +211,7 @@ begin;
     'foreign key enforces that role exists in iam_role_global'
   );
 
-  -- 3h) insert into iam_role_global_individual_org_grant_scope when role grant_scope is 'individual'
+  -- 3j) insert into iam_role_global_individual_org_grant_scope when role grant_scope is 'individual'
   -- r_3333333333 is a global role with grant_scope=individual
   prepare insert_valid_individual_org_scope as
     insert into iam_role_global_individual_org_grant_scope

--- a/internal/db/sqltest/tests/iam/iam_role_global.sql
+++ b/internal/db/sqltest/tests/iam/iam_role_global.sql
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
 begin;
-  select plan(14);
+  select plan(30);
   select wtt_load('widgets', 'iam');
 
   --------------------------------------------------------------------------------
@@ -10,15 +10,23 @@ begin;
   --------------------------------------------------------------------------------
 
   -- 1a) insert a valid row -> should succeed and insert_role_subtype trigger
+  -- r_1111111111 is a global role with grant_scope=descendants
+  -- r_2222222222 is a global role with grant_scope=children
+  -- r_3333333333 is a global role with grant_scope=individual
   prepare insert_valid_global_role as
     insert into iam_role_global 
         (public_id, scope_id, grant_this_role_scope, grant_scope)
     values
-        ('r_1111111111', 'global', true, 'children');
+        ('r_1111111111', 'global', true, 'descendants'),
+        ('r_2222222222', 'global', true, 'children'),
+        ('r_3333333333', 'global', true, 'individual');
   select lives_ok('insert_valid_global_role');
+
 
   -- verify it also created a row in base iam_role
   select is(count(*), 1::bigint) from iam_role where public_id = 'r_1111111111';
+  select is(count(*), 1::bigint) from iam_role where public_id = 'r_2222222222';
+  select is(count(*), 1::bigint) from iam_role where public_id = 'r_3333333333';
 
   -- 1b) try duplicate (public_id, grant_scope) => unique violation
   prepare insert_dup_public_id_grant_scope as
@@ -60,87 +68,297 @@ begin;
   -- 2) testing insert_grant_scope_update_time trigger
   --------------------------------------------------------------------------------
 
-  -- 2b) insert a new row (grant_this_role_scope, grant_scope) => should initialize
+  -- 2a) insert a new row (grant_this_role_scope, grant_scope) => should initialize
   prepare insert_with_grant_scope_update_time_set as
     insert into iam_role_global 
         (public_id, scope_id, grant_scope, grant_scope_update_time)
     values 
-        ('r_2222222222', 'global', 'descendants', null);
+        ('r_4444444444', 'global', 'descendants', null);
   select lives_ok('insert_with_grant_scope_update_time_set');
 
-  -- 2c) check if grant_scope_update_time is set
+  -- 2b) check if grant_scope_update_time is set
   select is(
-    (select grant_scope_update_time is not null from iam_role_global where public_id = 'r_2222222222'),
+    (select grant_scope_update_time is not null from iam_role_global where public_id = 'r_4444444444'),
     true,
     'grant_scope_update_time should be set with the default timestamp right after insert'
   );
 
-  -- 2d) update grant_this_role_scope => trigger should update grant_scope_update_time timestamp
+  -- 2c) update grant_this_role_scope => trigger should update grant_scope_update_time timestamp
   prepare update_grant_this_role_scope as
     update iam_role_global
        set grant_this_role_scope = true
-     where public_id = 'r_2222222222';
+     where public_id = 'r_4444444444';
   select lives_ok('update_grant_this_role_scope');
   select is(
-    (select grant_scope_update_time is not null from iam_role_global where public_id = 'r_2222222222'),
+    (select grant_scope_update_time is not null from iam_role_global where public_id = 'r_4444444444'),
     true,
     'grant_scope_update_time should be set with the default timestamp right after insert'
   );
 
   --------------------------------------------------------------------------------
-  -- 3) testing iam_role_global_individual_grant_scope table constraints
+  -- 3) testing iam_role_global_individual_org_grant_scope table constraints
   --------------------------------------------------------------------------------
  
-  --3a) insert invalid row: grant_scope != 'individual'
-  prepare insert_invalid_individual_grant_scope as
-    insert into iam_role_global_individual_grant_scope
-        (role_id, scope_id, grant_scope)
+  -- 3a) insert invalid row: grant_scope = 'descendants'
+  prepare insert_invalid_individual_org_grant_scope_descendants as
+    insert into iam_role_global_individual_org_grant_scope
+        (role_id, grant_scope, scope_id)
     values
-        ('r_3333333333', 'descendants', 'global');
+        ('r_3333333333', 'descendants', 'p____bwidget');
   select throws_like(
-    'insert_invalid_individual_grant_scope',
-    'new row for relation "iam_role_global_individual_grant_scope" violates check constraint "only_individual_grant_scope_allowed"',
+    'insert_invalid_individual_org_grant_scope_descendants',
+    'new row for relation "iam_role_global_individual_org_grant_scope" violates check constraint "only_individual_grant_scope_allowed"',
     'check(grant_scope = "individual") is enforced'
   );
 
-  -- 3b) insert invalid row with a scope_id that is not global
-  prepare insert_invalid_iam_role_global_individual_grant_scope as
-    insert into iam_role_global_individual_grant_scope
+  -- 3b) insert invalid row: grant_scope = 'children'
+  prepare insert_invalid_individual_org_grant_scope_children as
+    insert into iam_role_global_individual_org_grant_scope
         (role_id, grant_scope, scope_id)
     values
-        ('r_1111111111', 'individual', 'o_1111111111');
+        ('r_3333333333', 'children', 'p____bwidget');
   select throws_like(
-        'insert_invalid_iam_role_global_individual_grant_scope',
-        'insert or update on table "iam_role_global_individual_grant_scope" violates foreign key constraint "iam_scope_fkey"',
+    'insert_invalid_individual_org_grant_scope_children',
+    'new row for relation "iam_role_global_individual_org_grant_scope" violates check constraint "only_individual_grant_scope_allowed"',
+    'check(grant_scope = "individual") is enforced'
+  );
+
+  -- 3c) insert invalid row with a scope_id that is not global
+  prepare insert_invalid_iam_role_global_individual_org_grant_scope as
+    insert into iam_role_global_individual_org_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_3333333333', 'individual', 'o_1111111111');
+  select throws_like(
+        'insert_invalid_iam_role_global_individual_org_grant_scope',
+        'insert or update on table "iam_role_global_individual_org_grant_scope" violates foreign key constraint "iam_scope_org_fkey"',
         'foreign key also enforces matching grant_scope=individual in iam_role_global'
   );
 
-  -- 3c) insert invalid row where scope_id is 'global'
+  -- 3d) insert invalid row where scope_id is 'global'
   prepare insert_iam_role_global_individual_scope_id as
-    insert into iam_role_global_individual_grant_scope
+    insert into iam_role_global_individual_org_grant_scope
         (role_id, grant_scope, scope_id)
     values
-        ('r_1111111111', 'individual', 'global');
+        ('r_3333333333', 'individual', 'global');
   select throws_like(
         'insert_iam_role_global_individual_scope_id',
-        'new row for relation "iam_role_global_individual_grant_scope" violates check constraint "scope_id_is_not_global"',
+        'insert or update on table "iam_role_global_individual_org_grant_scope" violates foreign key constraint "iam_scope_org_fkey"',
         'check(scope_id != ''global'') is enforced'
   );
 
-  -- 3d) insert valid iam_role_global_individual_grant_scope
-  prepare insert_global_role_for_individual_scope as
-    insert into iam_role_global 
-        (public_id, scope_id, grant_scope)
+  -- 3e) insert invalid row where scope_id is a project
+  prepare insert_invalid_project_into_individual_org_scope as
+    insert into iam_role_global_individual_org_grant_scope
+        (role_id, grant_scope, scope_id)
     values
-        ('r_3333333333', 'global', 'individual');
-  select lives_ok('insert_global_role_for_individual_scope');
+        ('r_3333333333', 'individual', 'p____bwidgetp____bwidget');
+  select throws_like(
+        'insert_iam_role_global_individual_scope_id',
+        'insert or update on table "iam_role_global_individual_org_grant_scope" violates foreign key constraint "iam_scope_org_fkey"',
+        'foreign key also enforces matching grant_scope=individual in iam_role_global'
+  );
 
+  -- 3f) insert into iam_role_global_individual_org_grant_scope when role grant_scope is 'children'
+  prepare insert_invalid_individual_org_scope as
+    insert into iam_role_global_individual_org_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_2222222222', 'individual', 'o_____widget');
+  select throws_like(
+        'insert_invalid_individual_org_scope',
+        'insert or update on table "iam_role_global_individual_org_grant_scope" violates foreign key constraint "iam_role_global_grant_scope_fkey"',
+        'foreign key also enforces matching grant_scope=individual in iam_role_global'
+  );
+
+  -- 3f) insert into iam_role_global_individual_org_grant_scope when role grant_scope is descendants is not allowed
+  -- r_1111111111 is a global role with grant_scope=descendants
+  prepare iam_role_global_individual_org_grant_scope_role_descendants as
+    insert into iam_role_global_individual_org_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_1111111111', 'individual', 'o_____widget');
+  select throws_like(
+        'iam_role_global_individual_org_grant_scope_role_descendants',
+        'insert or update on table "iam_role_global_individual_org_grant_scope" violates foreign key constraint "iam_role_global_grant_scope_fkey"',
+        'foreign key also enforces matching grant_scope=individual in iam_role_global'
+  );
+
+
+  -- 3g) insert into iam_role_global_individual_org_grant_scope when role grant_scope is children is not allowed
+  -- r_2222222222 is a global role with grant_scope=children
+  prepare iam_role_global_individual_org_grant_scope_role_children as
+    insert into iam_role_global_individual_org_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_2222222222', 'individual', 'o_____widget');
+  select throws_like(
+        'iam_role_global_individual_org_grant_scope_role_children',
+        'insert or update on table "iam_role_global_individual_org_grant_scope" violates foreign key constraint "iam_role_global_grant_scope_fkey"',
+        'foreign key also enforces matching grant_scope=individual in iam_role_global'
+  );
+
+
+  --3g) insert entry with role_id that does not exist in iam_role_global
+  prepare insert_invalid_role_id as
+    insert into iam_role_global_individual_org_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_1231231231', 'individual', 'p____bwidget');
+  select throws_like(
+    'insert_invalid_role_id',
+    'insert or update on table "iam_role_global_individual_org_grant_scope" violates foreign key constraint "iam_role_global_fkey"',
+    'foreign key enforces that role exists in iam_role_global'
+  );
+
+  -- 3h) insert into iam_role_global_individual_org_grant_scope when role grant_scope is 'individual'
+  -- r_3333333333 is a global role with grant_scope=individual
   prepare insert_valid_individual_org_scope as
-    insert into iam_role_global_individual_grant_scope
+    insert into iam_role_global_individual_org_grant_scope
         (role_id, grant_scope, scope_id)
     values
         ('r_3333333333', 'individual', 'o_____widget');
   select lives_ok('insert_valid_individual_org_scope');
+
+
+
+  --------------------------------------------------------------------------------
+  -- 4) testing iam_role_global_individual_project_grant_scope table constraints
+  --------------------------------------------------------------------------------
+ 
+  -- 4a) insert invalid row: grant_scope = 'descendants'
+  prepare insert_invalid_individual_project_grant_scope_descendants as
+    insert into iam_role_global_individual_project_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_3333333333', 'descendants', 'p____bwidget');
+  select throws_like(
+    'insert_invalid_individual_project_grant_scope_descendants',
+    'new row for relation "iam_role_global_individual_project_grant_scope" violates check constraint "only_individual_or_children_grant_scope_allowed"',
+    'check(grant_scope in ["children", "individual"]) is enforced'
+  );
+
+  -- 4b) insert invalid row: grant_scope = 'children'
+  prepare insert_invalid_individual_project_grant_scope_children as
+    insert into iam_role_global_individual_project_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_3333333333', 'children', 'p____bwidget');
+  select throws_like(
+    'insert_invalid_individual_project_grant_scope_children',
+    'insert or update on table "iam_role_global_individual_project_grant_scope" violates foreign key constraint "iam_role_global_grant_scope_fkey"',
+    'foreign key to grant_scope in iam_role_global is enforced'
+  );
+
+  -- 4c) insert invalid row with a scope_id project does not exist
+  prepare insert_invalid_iam_role_global_individual_project_grant_scope as
+    insert into iam_role_global_individual_project_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_3333333333', 'individual', 'p_1111111111');
+  select throws_like(
+        'insert_invalid_iam_role_global_individual_project_grant_scope',
+        'insert or update on table "iam_role_global_individual_project_grant_scope" violates foreign key constraint "iam_scope_project_fkey"',
+        'foreign key also enforces matching grant_scope=individual in iam_role_global'
+  );
+
+  -- 4d) insert invalid row where scope_id is 'global'
+  prepare insert_invalid_project_grant_scope_global as
+    insert into iam_role_global_individual_project_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_3333333333', 'individual', 'global');
+  select throws_like(
+        'insert_invalid_project_grant_scope_global',
+        'insert or update on table "iam_role_global_individual_project_grant_scope" violates foreign key constraint "iam_scope_project_fkey"',
+        'check(scope_id != ''global'') is enforced'
+  );
+
+  -- 4e) insert invalid row where scope_id is an org
+  prepare insert_invalid_org_into_individual_proj_scope as
+    insert into iam_role_global_individual_project_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_3333333333', 'individual', 'o_____widget');
+  select throws_like(
+        'insert_invalid_org_into_individual_proj_scope',
+        'insert or update on table "iam_role_global_individual_project_grant_scope" violates foreign key constraint "iam_scope_project_fkey"',
+        'foreign key enforces that scope_id is a project scope'
+  );
+
+  -- 4f) insert into iam_role_global_individual_project_grant_scope when role grant_scope is descendants is not allowed
+  -- r_1111111111 is a global role with grant_scope=descendants
+  prepare iam_role_global_individual_project_grant_scope_role_descendants as
+    insert into iam_role_global_individual_project_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_1111111111', 'individual', 'p_____widget');
+  select throws_like(
+        'iam_role_global_individual_project_grant_scope_role_descendants',
+        'insert or update on table "iam_role_global_individual_project_grant_scope" violates foreign key constraint "iam_scope_project_fkey"',
+        'foreign key enforces that scope_id is a project scope'
+  );
+
+  -- 4g) insert entry with role_id that does not exist in iam_role_global
+  prepare insert_invalid_role_id_proj_grants_scope as
+    insert into iam_role_global_individual_project_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_1231231231', 'individual', 'p____bwidget');
+  select throws_like(
+    'insert_invalid_role_id_proj_grants_scope',
+    'insert or update on table "iam_role_global_individual_project_grant_scope" violates foreign key constraint "iam_role_global_fkey"',
+    'foreign key enforces that role exists in iam_role_global'
+  );
+
+
+  -- 4h) insert into iam_role_global_individual_project_grant_scope when role grant_scope is 'children' is valid
+  -- r_2222222222 is a global role with grant_scope=children
+  prepare insert_valid_individual_project_scope_children_grants as
+    insert into iam_role_global_individual_project_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_2222222222', 'children', 'p____bwidget');
+  select lives_ok('insert_valid_individual_project_scope_children_grants');
+
+  -- 4i) insert into iam_role_global_individual_project_grant_scope when role grant_scope is 'individual'
+  -- r_3333333333 is a global role with grant_scope=individual
+  prepare insert_valid_individual_project_scope as
+    insert into iam_role_global_individual_project_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_3333333333', 'individual', 'p____bwidget');
+  select lives_ok('insert_valid_individual_project_scope');
+
+
+
+  -- 4j) update to iam_role_global.grant_scope from children to individual cascades to iam_role_global_individual_project_grant_scope.grant_scope
+  -- r_5555555555 is a global role with grant_scope=children
+  prepare insert_valid_global_role_children_grants as
+    insert into iam_role_global 
+        (public_id, scope_id, grant_this_role_scope, grant_scope)
+    values
+        ('r_5555555555', 'global', true, 'children');
+  select lives_ok('insert_valid_global_role_children_grants');
+
+  -- create a row in iam_role_global_individual_project_grant_scope with grant_scope=children
+  prepare insert_valid_project_scope_to_children_grants as
+    insert into iam_role_global_individual_project_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_5555555555', 'children', 'p____bwidget');
+  select lives_ok('insert_valid_project_scope_to_children_grants');
+
+  -- take away children grants by updating to iam_role_global to individual
+  prepare update_grant_scope_to_individual as
+    update iam_role_global
+        set grant_scope = 'individual'
+      where public_id = 'r_5555555555';
+    select lives_ok('update_grant_scope_to_individual');
+  
+  -- check that the update cascaded to iam_role_global_individual_project_grant_scope
+  -- and that the grant_scope is now individual
+  select is(count(*), 1::bigint) from iam_role_global_individual_project_grant_scope where role_id = 'r_5555555555' and grant_scope = 'individual';
 
   select * from finish();
 rollback;

--- a/internal/db/sqltest/tests/iam/iam_role_org.sql
+++ b/internal/db/sqltest/tests/iam/iam_role_org.sql
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
 begin;
-  select plan(16);
+  select plan(22);
   select wtt_load('widgets', 'iam');
 
   ------------------------------------------------------------------------------
@@ -97,19 +97,66 @@ begin;
     'grant_scope_update_time should be set right after insert if the trigger sets it'
   );
 
-  -- 2b) update grant_this_role_scope => trigger should update grant_scope_update_time
+  -- 2b) update grant_this_role_scope => trigger should update grant_this_role_scope_update_time
+  
+  -- update grant_this_role_scope_update_time to default
+  prepare reset_grant_this_role_scope_update_time as
+    update iam_role_org
+       set grant_this_role_scope_update_time = '1970-01-01 00:00:00'
+     where public_id = 'r_org_2222222222';
+  select lives_ok('reset_grant_this_role_scope_update_time');
+
   prepare update_grant_this_role_scope as
     update iam_role_org
-       set grant_this_role_scope = false
+       set grant_this_role_scope = true
      where public_id = 'r_org_2222222222';
   select lives_ok('update_grant_this_role_scope');
+
+  select is(
+    (select grant_this_role_scope_update_time is not null
+       from iam_role_org
+      where public_id = 'r_org_2222222222'),
+    true,
+    'grant_this_role_scope_update_time should be updated after changing grant_this_role_scope'
+  );
+
+  select is(
+    (select grant_this_role_scope_update_time > NOW() - INTERVAL '1 minute'
+       from iam_role_org
+      where public_id = 'r_org_2222222222'),
+    true,
+    'grant_this_role_scope_update_time should be updated after changing grant_this_role_scope'
+  );
+
+
+  -- 2c) update grant_scope => trigger should update grant_this_role_scope_update_time
+  
+  prepare reset_grant_scope_update_time as
+    update iam_role_org
+       set grant_scope_update_time = '1970-01-01 00:00:00'
+     where public_id = 'r_org_2222222222';
+  select lives_ok('reset_grant_scope_update_time');
+
+  prepare update_grant_scope as
+    update iam_role_org
+       set grant_scope = 'children'
+     where public_id = 'r_org_2222222222';
+  select lives_ok('update_grant_scope');
 
   select is(
     (select grant_scope_update_time is not null
        from iam_role_org
       where public_id = 'r_org_2222222222'),
     true,
-    'grant_scope_update_time should be updated after changing grant_this_role_scope'
+    'grant_scope_update_time should be updated after changing grant_scope'
+  );
+
+  select is(
+    (select grant_scope_update_time > NOW() - INTERVAL '1 minute'
+       from iam_role_org
+      where public_id = 'r_org_2222222222'),
+    true,
+    'grant_scope_update_time should be updated after changing grant_scope'
   );
 
   ------------------------------------------------------------------------------

--- a/internal/db/sqltest/tests/iam/iam_role_org.sql
+++ b/internal/db/sqltest/tests/iam/iam_role_org.sql
@@ -121,7 +121,7 @@ begin;
   );
 
   select is(
-    (select grant_this_role_scope_update_time > NOW() - INTERVAL '1 minute'
+    (select grant_this_role_scope_update_time = now()
        from iam_role_org
       where public_id = 'r_org_2222222222'),
     true,
@@ -152,7 +152,7 @@ begin;
   );
 
   select is(
-    (select grant_scope_update_time > NOW() - INTERVAL '1 minute'
+    (select grant_scope_update_time = now()
        from iam_role_org
       where public_id = 'r_org_2222222222'),
     true,

--- a/internal/db/sqltest/tests/iam/iam_role_org.sql
+++ b/internal/db/sqltest/tests/iam/iam_role_org.sql
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
 begin;
-  select plan(16);
+  select plan(21);
   select wtt_load('widgets', 'iam');
 
   ------------------------------------------------------------------------------
@@ -166,6 +166,35 @@ begin;
     'project scope_id invalid_project not found in org',
     'ensure_project_belongs_to_role_org trigger enforces matching org'
   );
+
+  -- 3f) switch from individual to children deletes redundant grants scope in iam_role_org_individual_grant_scope
+  prepare insert_r4_valid_org_scope_role as
+    insert into iam_role_org 
+        (public_id, scope_id, grant_this_role_scope, grant_scope)
+    values
+        ('r_4444444444', 'o_____widget', true, 'individual');
+  select lives_ok('insert_r4_valid_org_scope_role');
+
+  -- create a row in iam_role_org_individual_grant_scope with grant_scope=individual
+  prepare insert_r4_valid_project_scope as
+    insert into iam_role_org_individual_grant_scope
+        (role_id, grant_scope, scope_id)
+    values
+        ('r_4444444444', 'individual', 'p____bwidget');
+  select lives_ok('insert_r4_valid_project_scope');
+
+  -- change grannt_scope from individual to children
+  prepare update_r4_grant_scope_to_children as
+    update iam_role_org
+        set grant_scope = 'children'
+      where public_id = 'r_4444444444';
+    select lives_ok('update_r4_grant_scope_to_children');
+  
+  -- check that the iam_role_org.grant_scope is updated to children
+  select is(count(*), 1::bigint) from iam_role_org where public_id = 'r_4444444444' and grant_scope = 'children';
+  -- check that the update deletes all individual grant scopes in iam_role_org_individual_grant_scope
+  select is(count(*), 0::bigint) from iam_role_org_individual_grant_scope where role_id = 'r_4444444444';
+
 
   select * from finish();
 rollback;


### PR DESCRIPTION
Split `iam_role_global_individual_grant_scope` to `iam_role_global_individual_org_grant_scope` and `iam_role_global_individual_project_grant_scope` and allow `children` to be used in `iam_role_global_individual_project_grant_scope.grant_scope` to support use case where roles at global scope are granted `children` and individual projects grants. 

Add triggers to 

- propagate changing `iam_role_global_individual_project_grant_scope.grant_scope` from `children` to `individual` and vice-versa when `iam_role_global.grant_scope` is updated
- add trigger to delete all `iam_role_global_individual_project_grant_scope` and `iam_role_global_individual_org_grant_scope` when a `iam_role_global.grant_scope` is changed to `descendants`
- add trigger to delete all `iam_role_global_individual_org_grant_scope` when a `iam_role_global.grant_scope` is changed to `children` 
- add trigger to delete all `iam_role_org_individual_grant_scope` when a `iam_role_org.grant_scope` is changed to `children` 

