### PR TITLE
chore: remove dead target service code

### DIFF
--- a/internal/daemon/controller/handlers/targets/target_service.go
+++ b/internal/daemon/controller/handlers/targets/target_service.go
@@ -36,7 +36,6 @@ import (
 	"github.com/hashicorp/boundary/internal/pagination"
 	"github.com/hashicorp/boundary/internal/perms"
 	"github.com/hashicorp/boundary/internal/requests"
-	"github.com/hashicorp/boundary/internal/server"
 	"github.com/hashicorp/boundary/internal/session"
 	"github.com/hashicorp/boundary/internal/target"
 	"github.com/hashicorp/boundary/internal/types/action"
@@ -56,28 +55,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-const (
-	credentialDomain = "credential"
-	hostDomain       = "host"
-)
-
-// extraWorkerFilterFunc takes in a set of workers and returns another set,
-// after any filtering it wishes to perform. When calling one of these
-// functions, the current set should be passed in and the returned set should be
-// used if there is no error; it is up to the filter writer to ensure that what
-// is returned, if no filtering is desired, is the input set.
-//
-// This is generally used to take in a set selected already from the database
-// and possible filtered via target worker filters and provide additional
-// filtering capabilities on those remaining workers.
-type extraWorkerFilterFunc func(ctx context.Context, workers []*server.Worker, host, port string) ([]*server.Worker, error)
-
 var (
-	// ExtraWorkerFilters contains any custom worker filters that should be
-	// layered in at session authorization time. These will be executed in-order
-	// with the results from one fed into the next.
-	ExtraWorkerFilters []extraWorkerFilterFunc
-
 	// IdActions contains the set of actions that can be performed on
 	// individual resources
 	IdActions = action.NewActionSet(


### PR DESCRIPTION
Removing dead code. 

`ExtraWorkerFilters` was last used in 0.11
The consts were replaced with `globals.ResourceInfoFromPrefix` in 0.15