### PR TITLE
chore(e2e): Update to use Ubuntu 22

### DIFF
--- a/enos/modules/aws_vpc/main.tf
+++ b/enos/modules/aws_vpc/main.tf
@@ -73,7 +73,7 @@ data "aws_ami" "ubuntu" {
   # Currently latest LTS-1
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-*-server-*"]
   }
 
   filter {

--- a/enos/modules/aws_vpc_ipv6/main.tf
+++ b/enos/modules/aws_vpc_ipv6/main.tf
@@ -108,7 +108,7 @@ data "aws_ami" "ubuntu" {
   # Currently latest LTS-1
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-*-server-*"]
   }
 
   filter {


### PR DESCRIPTION
This PR updates end-to-end test infra to use Ubuntu 22 due to Ubuntu 20 reaching end-of-life. End-to-end tests still pass with this update.

https://hashicorp.atlassian.net/browse/ICU-16897