### PR TITLE
docs: Note that IPv4 and IPv6 are mandatory

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -17,6 +17,8 @@ When the Boundary Client Agent runs alongside an authenticated Boundary client, 
 If you enter a hostname that matches a Boundary alias that the client is authorized to establish a session to, Boundary automatically generates the session and transparently proxies the connection on your behalf.
 If the Boundary Client Agent cannot find an alias, or if there are any issues with authentication, network connectivity, or latency, the Client Agent defers DNS resolution to the previously configured DNS resolvers.
 
+Note that you must enable both IPv4 and IPv6 protocols for your environment to ensure the Client Agent can start and perform DNS lookups.
+
 ## Security
 
 When you successfully authorize a session on a Boundary controller, the response includes a list of any brokered credentials, which include the decoded secrets.

--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -17,7 +17,11 @@ When the Boundary Client Agent runs alongside an authenticated Boundary client, 
 If you enter a hostname that matches a Boundary alias that the client is authorized to establish a session to, Boundary automatically generates the session and transparently proxies the connection on your behalf.
 If the Boundary Client Agent cannot find an alias, or if there are any issues with authentication, network connectivity, or latency, the Client Agent defers DNS resolution to the previously configured DNS resolvers.
 
-Note that you must enable both IPv4 and IPv6 protocols for your environment to ensure the Client Agent can start and perform DNS lookups.
+<Note>
+
+You must enable both IPv4 and IPv6 protocols for your environment to ensure the Client Agent can start and perform DNS lookups.
+
+</Note>
 
 ## Security
 

--- a/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
+++ b/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
@@ -17,6 +17,7 @@ Before you configure transparent sessions, you must:
 
 - Ensure that the Boundary CLI and Boundary Desktop are not installed in the environment in which you want to run the transparent sessions beta.
 - Download the appropriate Boundary installer for your Windows or MacOS environment from the [Install Boundary](/boundary/install#installer) page or the [releases](https://releases.hashicorp.com/boundary-installer) page.
+- Ensure that both IPv4 and IPv6 protocols are enabled for your environment. The [Client Agent](/boundary/docs/api-clients/client-agent) requires both protocols to start and perform DNS lookups.
 
 ## Install the Boundary clients
 
@@ -43,7 +44,7 @@ The following section details how to configure targets and test the transparent 
   If you use a cluster that was created earlier than release 0.16.0, you must add the grant `list-resolvable-aliases` so that the client agent can populate the local alias cache.
 
   As an example, you could add the grant:
-   
+
   `type=user;actions=list-resolvable-aliases;ids=*`.
 
 </Tip>


### PR DESCRIPTION
From a Slack conversation: https://hashicorp.slack.com/archives/C01AQDJF3SA/p1744830559607819?thread_ts=1744827620.957889&cid=C01AQDJF3SA. 

We should note that both protocols are required by the Client Agent to help alleviate customer confusion.

I added notes in 2 topics. View the updates in the preview deployment:

- [Configure transparent sessions](https://boundary-hr9jwegtk-hashicorp.vercel.app/boundary/docs/configuration/target-aliases/transparent-sessions)
- [Boundary Client Agent](https://boundary-hr9jwegtk-hashicorp.vercel.app/boundary/docs/api-clients/client-agent)