### PR TITLE
chore(e2e): Add encryption to target ec2 instance

### DIFF
--- a/enos/modules/aws_target/main.tf
+++ b/enos/modules/aws_target/main.tf
@@ -129,6 +129,10 @@ resource "aws_instance" "target" {
     "Environment" : var.environment
     "Enos User" : var.enos_user,
   })
+
+  root_block_device {
+    encrypted = true
+  }
 }
 
 resource "enos_remote_exec" "wait" {


### PR DESCRIPTION
This PR is a continuation of https://github.com/hashicorp/boundary/pull/5580

This PR configures encryption on an ec2 instance used as an SSH target. Hopefully, this will fully address that Wiz alert. 