### PR TITLE
ListResolvableAliasesPermissions Hotfix

### DIFF
--- a/internal/alias/target/repository_alias_list_resolvable.go
+++ b/internal/alias/target/repository_alias_list_resolvable.go
@@ -73,6 +73,10 @@ func (r *Repository) listResolvableAliases(ctx context.Context, permissions []pe
 		return nil, time.Time{}, errors.New(ctx, errors.InvalidParameter, op, "missing permissions")
 	}
 
+	// This condition checks if there are no direct IDs, no direct scope IDs, and no child scopes,
+	// while also ensuring that the "allDescendants" flag is not set, and if so returns early.
+	// An example scenario that can cause this is when a role on the global scope grants a user
+	// access to list aliases and read targets, but only within the global scope and its immediate children.
 	directIds, directScopeIds, childAllScopes, allDescendants := splitPermissions(permissions)
 	if !allDescendants && len(directIds) == 0 && len(directScopeIds) == 0 && len(childAllScopes) == 0 {
 		return []*Alias{}, time.Time{}, nil
@@ -151,10 +155,6 @@ func (r *Repository) listResolvableAliasesRefresh(ctx context.Context, updatedAf
 	}
 
 	directIds, directScopeIds, childAllScopes, allDescendants := splitPermissions(permissions)
-
-	if !allDescendants && len(directIds) == 0 && len(directScopeIds) == 0 && len(childAllScopes) == 0 {
-		return []*Alias{}, time.Time{}, nil
-	}
 
 	opts, err := getOpts(opt...)
 	if err != nil {
@@ -236,9 +236,6 @@ func (r *Repository) listRemovedResolvableAliasIds(ctx context.Context, since ti
 	}
 
 	directIds, directScopeIds, childAllScopes, allDescendants := splitPermissions(permissions)
-	if !allDescendants && len(directIds) == 0 && len(directScopeIds) == 0 && len(childAllScopes) == 0 {
-		return []string{}, time.Time{}, nil
-	}
 
 	var args []any
 	var destinationIdClauses []string

--- a/internal/alias/target/repository_alias_list_resolvable.go
+++ b/internal/alias/target/repository_alias_list_resolvable.go
@@ -74,6 +74,9 @@ func (r *Repository) listResolvableAliases(ctx context.Context, permissions []pe
 	}
 
 	directIds, directScopeIds, childAllScopes, allDescendants := splitPermissions(permissions)
+	if !allDescendants && len(directIds) == 0 && len(directScopeIds) == 0 && len(childAllScopes) == 0 {
+		return []*Alias{}, time.Time{}, nil
+	}
 
 	opts, err := getOpts(opt...)
 	if err != nil {
@@ -148,6 +151,10 @@ func (r *Repository) listResolvableAliasesRefresh(ctx context.Context, updatedAf
 	}
 
 	directIds, directScopeIds, childAllScopes, allDescendants := splitPermissions(permissions)
+
+	if !allDescendants && len(directIds) == 0 && len(directScopeIds) == 0 && len(childAllScopes) == 0 {
+		return []*Alias{}, time.Time{}, nil
+	}
 
 	opts, err := getOpts(opt...)
 	if err != nil {
@@ -229,6 +236,9 @@ func (r *Repository) listRemovedResolvableAliasIds(ctx context.Context, since ti
 	}
 
 	directIds, directScopeIds, childAllScopes, allDescendants := splitPermissions(permissions)
+	if !allDescendants && len(directIds) == 0 && len(directScopeIds) == 0 && len(childAllScopes) == 0 {
+		return []string{}, time.Time{}, nil
+	}
 
 	var args []any
 	var destinationIdClauses []string

--- a/internal/alias/target/repository_alias_list_resolvable.go
+++ b/internal/alias/target/repository_alias_list_resolvable.go
@@ -73,11 +73,11 @@ func (r *Repository) listResolvableAliases(ctx context.Context, permissions []pe
 		return nil, time.Time{}, errors.New(ctx, errors.InvalidParameter, op, "missing permissions")
 	}
 
+	directIds, directScopeIds, childAllScopes, allDescendants := splitPermissions(permissions)
 	// This condition checks if there are no direct IDs, no direct scope IDs, and no child scopes,
 	// while also ensuring that the "allDescendants" flag is not set, and if so returns early.
 	// An example scenario that can cause this is when a role on the global scope grants a user
 	// access to list aliases and read targets, but only within the global scope and its immediate children.
-	directIds, directScopeIds, childAllScopes, allDescendants := splitPermissions(permissions)
 	if !allDescendants && len(directIds) == 0 && len(directScopeIds) == 0 && len(childAllScopes) == 0 {
 		return []*Alias{}, time.Time{}, nil
 	}

--- a/internal/alias/target/service_list_resolvable_ext_test.go
+++ b/internal/alias/target/service_list_resolvable_ext_test.go
@@ -88,6 +88,27 @@ func TestService_ListResolvableAliases(t *testing.T) {
 			All:          true,
 		},
 	}
+
+	// Test the scenario where permissions are provided to the ListResolvableAliases service,
+	// but none of the permissions include grant scopes corresponding to scopes of which targets reside.
+	noTargetScopePerms := []perms.Permission{
+		{
+			RoleScopeId:  scope.Global.String(),
+			GrantScopeId: globals.GrantScopeChildren,
+			Resource:     resource.Target,
+			Action:       action.ListResolvableAliases,
+			OnlySelf:     false,
+			All:          true,
+		},
+		{
+			RoleScopeId:  scope.Global.String(),
+			GrantScopeId: scope.Global.String(),
+			Resource:     resource.Target,
+			Action:       action.ListResolvableAliases,
+			OnlySelf:     false,
+			All:          true,
+		},
+	}
 	// Reverse since we read items in descending order (newest first)
 	slices.Reverse(byScopeResources)
 
@@ -158,6 +179,13 @@ func TestService_ListResolvableAliases(t *testing.T) {
 			t.Parallel()
 			_, err := target.ListResolvableAliases(ctx, []byte("some hash"), 1, repo, nil)
 			require.ErrorContains(t, err, "missing target permissions")
+		})
+		t.Run("no valid target permissions", func(t *testing.T) {
+			t.Parallel()
+			res, err := target.ListResolvableAliases(ctx, []byte("some hash"), 1, repo, noTargetScopePerms)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.Empty(t, res.Items)
 		})
 	})
 	t.Run("ListPage validation", func(t *testing.T) {

--- a/internal/perms/acl.go
+++ b/internal/perms/acl.go
@@ -468,21 +468,12 @@ func (a ACL) ListResolvableAliasesPermissions(requestedType resource.Type, actio
 				// so skip it
 				continue
 			}
-		default:
-			// Since direct grants must be the same scope or downstream, the
-			// only possibility left for a children grant is that the parent is
-			// global and the grant is on the org -- if it was for projects it
-			// would need to be a descendants grant
-			if _, ok := childrenScopes[scope.Global.String()]; ok {
-				// We already looked at this scope in the children grants, so skip it
-				continue
-			}
 		}
-
 		if a.buildPermission(&scopes.ScopeInfo{Id: grantScopeId}, requestedType, actions, false, &p) {
 			perms = append(perms, p)
 		}
 	}
+
 	return perms
 }
 

--- a/internal/perms/acl.go
+++ b/internal/perms/acl.go
@@ -468,6 +468,15 @@ func (a ACL) ListResolvableAliasesPermissions(requestedType resource.Type, actio
 				// so skip it
 				continue
 			}
+		case p.RoleScopeId == scope.Global.String() && strings.HasPrefix(grantScopeId, scope.Org.Prefix()):
+			// Handle the case where the parent scope is global, and the grant is at the org level.
+			// Direct grants must either match the parent scope or be downstream. This condition
+			// accounts for a scenario where a child grant exists at the org level while the parent
+			// is global. If the grant were for projects, it would require a descendants grant instead.
+			// Skip processing if the current scope is already accounted for in the childrenScopes map.
+			if _, ok := childrenScopes[p.RoleScopeId]; ok {
+				continue
+			}
 		}
 		if a.buildPermission(&scopes.ScopeInfo{Id: grantScopeId}, requestedType, actions, false, &p) {
 			perms = append(perms, p)

--- a/internal/perms/acl_test.go
+++ b/internal/perms/acl_test.go
@@ -830,7 +830,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: globals.GrantScopeDescendants,
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -856,7 +855,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: globals.GrantScopeDescendants,
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -864,7 +862,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: "global",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -899,7 +896,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: "global",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -925,7 +921,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: globals.GrantScopeChildren,
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -951,7 +946,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: "global",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -959,7 +953,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: globals.GrantScopeChildren,
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -967,7 +960,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: "p_1",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1115,7 +1107,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleParentScopeId: scope.Global.String(),
 					grantScope:        globals.GrantScopeChildren,
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1124,7 +1115,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleParentScopeId: scope.Global.String(),
 					grantScope:        "o_2",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1162,7 +1152,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleParentScopeId: scope.Global.String(),
 					grantScope:        globals.GrantScopeChildren,
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1171,7 +1160,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleParentScopeId: scope.Global.String(),
 					grantScope:        "o_1",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1209,7 +1197,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleParentScopeId: scope.Global.String(),
 					grantScope:        globals.GrantScopeChildren,
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1218,7 +1205,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleParentScopeId: scope.Global.String(),
 					grantScope:        "o_1",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1227,7 +1213,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleParentScopeId: "o_1",
 					grantScope:        "p_1a",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1236,7 +1221,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleParentScopeId: "o_1",
 					grantScope:        "p_1b",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1245,7 +1229,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleParentScopeId: "o_2",
 					grantScope:        "p_2",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},

--- a/internal/perms/acl_test.go
+++ b/internal/perms/acl_test.go
@@ -1003,7 +1003,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: "global",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1011,7 +1010,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: "p_1",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1046,7 +1044,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: "global",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1054,7 +1051,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: "o_1",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},
@@ -1062,7 +1058,6 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					roleScope:  "global",
 					grantScope: "p_1",
 					grants: []string{
-						"type=target;actions=list",
 						"ids=ttcp_1234567890;actions=read",
 					},
 				},

--- a/internal/perms/acl_test.go
+++ b/internal/perms/acl_test.go
@@ -872,6 +872,15 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 			expPermissions: []Permission{
 				{
 					RoleScopeId:  scope.Global.String(),
+					GrantScopeId: scope.Global.String(),
+					Resource:     resource.Target,
+					Action:       action.ListResolvableAliases,
+					ResourceIds:  []string{"ttcp_1234567890"},
+					All:          false,
+					OnlySelf:     false,
+				},
+				{
+					RoleScopeId:  scope.Global.String(),
 					GrantScopeId: globals.GrantScopeDescendants,
 					Resource:     resource.Target,
 					Action:       action.ListResolvableAliases,
@@ -879,6 +888,23 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					All:          false,
 					OnlySelf:     false,
 				},
+			},
+		},
+		{
+			name:         "global_with_this_no_descendants",
+			resourceType: resource.Target,
+			actionSet:    action.NewActionSet(action.Read, action.Cancel),
+			aclGrants: []scopeGrant{
+				{
+					roleScope:  "global",
+					grantScope: "global",
+					grants: []string{
+						"type=target;actions=list",
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+			},
+			expPermissions: []Permission{
 				{
 					RoleScopeId:  scope.Global.String(),
 					GrantScopeId: scope.Global.String(),
@@ -908,6 +934,169 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 				{
 					RoleScopeId:  scope.Global.String(),
 					GrantScopeId: globals.GrantScopeChildren,
+					Resource:     resource.Target,
+					Action:       action.ListResolvableAliases,
+					ResourceIds:  []string{"ttcp_1234567890"},
+					All:          false,
+					OnlySelf:     false,
+				},
+			},
+		},
+		{
+			name:         "global_with_this_with_valid_children_and_direct_grant",
+			resourceType: resource.Target,
+			actionSet:    action.NewActionSet(action.Read, action.Cancel),
+			aclGrants: []scopeGrant{
+				{
+					roleScope:  "global",
+					grantScope: "global",
+					grants: []string{
+						"type=target;actions=list",
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+				{
+					roleScope:  "global",
+					grantScope: globals.GrantScopeChildren,
+					grants: []string{
+						"type=target;actions=list",
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+				{
+					roleScope:  "global",
+					grantScope: "p_1",
+					grants: []string{
+						"type=target;actions=list",
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+			},
+			expPermissions: []Permission{
+				{
+					RoleScopeId:  scope.Global.String(),
+					GrantScopeId: scope.Global.String(),
+					Resource:     resource.Target,
+					Action:       action.ListResolvableAliases,
+					ResourceIds:  []string{"ttcp_1234567890"},
+					All:          false,
+					OnlySelf:     false,
+				},
+				{
+					RoleScopeId:  scope.Global.String(),
+					GrantScopeId: globals.GrantScopeChildren,
+					Resource:     resource.Target,
+					Action:       action.ListResolvableAliases,
+					ResourceIds:  []string{"ttcp_1234567890"},
+					All:          false,
+					OnlySelf:     false,
+				},
+				{
+					RoleScopeId:  scope.Global.String(),
+					GrantScopeId: "p_1",
+					Resource:     resource.Target,
+					Action:       action.ListResolvableAliases,
+					ResourceIds:  []string{"ttcp_1234567890"},
+					All:          false,
+					OnlySelf:     false,
+				},
+			},
+		},
+		{
+			name:         "global_with_this_with_and_direct_grant",
+			resourceType: resource.Target,
+			actionSet:    action.NewActionSet(action.Read, action.Cancel),
+			aclGrants: []scopeGrant{
+				{
+					roleScope:  "global",
+					grantScope: "global",
+					grants: []string{
+						"type=target;actions=list",
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+				{
+					roleScope:  "global",
+					grantScope: "p_1",
+					grants: []string{
+						"type=target;actions=list",
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+			},
+			expPermissions: []Permission{
+				{
+					RoleScopeId:  scope.Global.String(),
+					GrantScopeId: scope.Global.String(),
+					Resource:     resource.Target,
+					Action:       action.ListResolvableAliases,
+					ResourceIds:  []string{"ttcp_1234567890"},
+					All:          false,
+					OnlySelf:     false,
+				},
+				{
+					RoleScopeId:  scope.Global.String(),
+					GrantScopeId: "p_1",
+					Resource:     resource.Target,
+					Action:       action.ListResolvableAliases,
+					ResourceIds:  []string{"ttcp_1234567890"},
+					All:          false,
+					OnlySelf:     false,
+				},
+			},
+		},
+		{
+			name:         "global_with_this_with_multiple_direct_grants",
+			resourceType: resource.Target,
+			actionSet:    action.NewActionSet(action.Read, action.Cancel),
+			aclGrants: []scopeGrant{
+				{
+					roleScope:  "global",
+					grantScope: "global",
+					grants: []string{
+						"type=target;actions=list",
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+				{
+					roleScope:  "global",
+					grantScope: "o_1",
+					grants: []string{
+						"type=target;actions=list",
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+				{
+					roleScope:  "global",
+					grantScope: "p_1",
+					grants: []string{
+						"type=target;actions=list",
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+			},
+			expPermissions: []Permission{
+				{
+					RoleScopeId:  scope.Global.String(),
+					GrantScopeId: scope.Global.String(),
+					Resource:     resource.Target,
+					Action:       action.ListResolvableAliases,
+					ResourceIds:  []string{"ttcp_1234567890"},
+					All:          false,
+					OnlySelf:     false,
+				},
+				{
+					RoleScopeId:  scope.Global.String(),
+					GrantScopeId: "o_1",
+					Resource:     resource.Target,
+					Action:       action.ListResolvableAliases,
+					ResourceIds:  []string{"ttcp_1234567890"},
+					All:          false,
+					OnlySelf:     false,
+				},
+				{
+					RoleScopeId:  scope.Global.String(),
+					GrantScopeId: "p_1",
 					Resource:     resource.Target,
 					Action:       action.ListResolvableAliases,
 					ResourceIds:  []string{"ttcp_1234567890"},
@@ -1112,7 +1301,7 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 
 			acl := NewACL(grants...)
 			perms := acl.ListResolvableAliasesPermissions(tt.resourceType, tt.actionSet)
-			require.ElementsMatch(t, tt.expPermissions, perms)
+			assert.ElementsMatch(t, tt.expPermissions, perms)
 		})
 	}
 }


### PR DESCRIPTION
# Overview
Refactor `ACL` function `ListResolvableAliasesPermissions` to handle direct child scopes (e.g., global → org → project) correctly in the scenario a direct grant is given to a scope under your children, and prevent `500` errors when resolving aliases without proper scope permissions where the current only existing alias type,`Target`, lives.

# Changes 
- In the `ListResolvableAliasesPermissions` function for the `ACL`, the default case was removed and replaced with for edge case for a `global` scoped role with the `children` grant scope:
  ```go
  default:
	  // Since direct grants must be the same scope or downstream, the
	  // only possibility left for a children grant is that the parent is
	  // global and the grant is on the org -- if it was for projects it
	  // would need to be a descendants grant
	  if _, ok := childrenScopes[scope.Global.String()]; ok {
		  // We already looked at this scope in the children grants, so skip it
		  continue
	  }
  ```
  This was part of the [switch](https://github.com/hashicorp/boundary/blob/288fa91f7bce9a3bf26330acbc6d2ba45b02e8b4/internal/perms/acl.go#L452) statement within the [scopeMap](https://github.com/hashicorp/boundary/blob/288fa91f7bce9a3bf26330acbc6d2ba45b02e8b4/internal/perms/acl.go#L437) loop. The [replacement](https://github.com/hashicorp/boundary/blob/f15a7e71b9dc74d45dea229d28601c8f3e922b98/internal/perms/acl.go#L471-L472) addresses a scenario where a globally scoped role provides children scopes but can also directly grant permissions to projects under its children. The previous logic skipped these cases where you can assign scopes that live under your direct children, resulting in permissions not being built for projects where targets reside.

- For the functions [listResolvableAliases](https://github.com/hashicorp/boundary/blob/17b9224fa26c93c23efa0c0a60a838d57f2a382d/internal/alias/target/repository_alias_list_resolvable.go#L123), a condition was modified to handle an edge case where permissions derived from the `ACL` do not include any scopes under which the current target resources reside. In such cases, we now return no data for the end user as this is possible given the available permission slice returned from the `ACL`.