### PR TITLE
test(bats): Added bats tests for generic commands

### DIFF
--- a/internal/tests/cli/boundary/_generics.bash
+++ b/internal/tests/cli/boundary/_generics.bash
@@ -1,0 +1,18 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+export UPDATE_NAME='update'
+
+function generic_read() {
+    boundary read $1 -format json
+}
+
+function generic_update_name() {
+    local id=$1
+    local name=$2
+    boundary update $id -name $name
+}
+
+function generic_delete() {
+    boundary delete $1
+}

--- a/internal/tests/cli/boundary/_generics.bash
+++ b/internal/tests/cli/boundary/_generics.bash
@@ -14,5 +14,5 @@ function generic_update_name() {
 }
 
 function generic_delete() {
-    boundary delete $1
+    boundary delete $1 -format json
 }

--- a/internal/tests/cli/boundary/generic.bats
+++ b/internal/tests/cli/boundary/generic.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+load _auth
+load _helpers
+load _targets
+load _generics
+
+
+@test "boundary/generic: can login as admin user" {
+  run login $DEFAULT_LOGIN
+  [ "$status" -eq 0 ]
+}
+
+
+@test "boundary/generic: admin user can create target" {
+  run create_tcp_target $DEFAULT_P_ID 22 $TGT_NAME
+  echo $output
+  [ "$status" -eq 0 ]
+}
+
+@test "boundary/generic: admin user can read target with generic read" {
+    local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run generic_read $id
+    echo $output
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/generic: admin user can update target with generic update" {
+    local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+    run generic_update_name $id $UPDATE_NAME
+    echo $output
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/generic: admin user can check that the update worked with generic read" {
+    local id=$(target_id_from_name $DEFAULT_P_ID $UPDATE_NAME)
+    echo $id
+    run generic_read $id
+    echo $output
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary/generic: admin user can delete target with generic delete" {
+    local id=$(target_id_from_name $DEFAULT_P_ID $UPDATE_NAME)
+    run generic_delete $id
+    run has_status_code "$output" "204"
+    echo $output
+}

--- a/internal/tests/cli/boundary/generic.bats
+++ b/internal/tests/cli/boundary/generic.bats
@@ -6,11 +6,10 @@ load _targets
 load _generics
 
 
-@test "boundary/generic: can login as admin user" {
+@test "boundary/generic: can log in as admin user" {
   run login $DEFAULT_LOGIN
   [ "$status" -eq 0 ]
 }
-
 
 @test "boundary/generic: admin user can create target" {
   run create_tcp_target $DEFAULT_P_ID 22 $TGT_NAME
@@ -19,30 +18,32 @@ load _generics
 }
 
 @test "boundary/generic: admin user can read target with generic read" {
-    local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run generic_read $id
-    echo $output
-    [ "$status" -eq 0 ]
+  local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+  run generic_read $id
+  echo $output
+  [ "$status" -eq 0 ]
 }
 
 @test "boundary/generic: admin user can update target with generic update" {
-    local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
-    run generic_update_name $id $UPDATE_NAME
-    echo $output
-    [ "$status" -eq 0 ]
+  local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
+  run generic_update_name $id $UPDATE_NAME
+  echo $output
+  [ "$status" -eq 0 ]
 }
 
 @test "boundary/generic: admin user can check that the update worked with generic read" {
-    local id=$(target_id_from_name $DEFAULT_P_ID $UPDATE_NAME)
-    echo $id
-    run generic_read $id
-    echo $output
-    [ "$status" -eq 0 ]
+  local id=$(target_id_from_name $DEFAULT_P_ID $UPDATE_NAME)
+  echo $id
+  run generic_read $id
+  echo $output
+  [ "$status" -eq 0 ]
 }
 
 @test "boundary/generic: admin user can delete target with generic delete" {
-    local id=$(target_id_from_name $DEFAULT_P_ID $UPDATE_NAME)
-    run generic_delete $id
-    run has_status_code "$output" "204"
-    echo $output
+  local id=$(target_id_from_name $DEFAULT_P_ID $UPDATE_NAME)
+  run generic_delete $id
+  echo $output
+  [ "$status" -eq 0 ]
+  run has_status_code "$output" "204"
+  [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Bats test for generic boundary commands using targets

Commands tested

Boundary read
Boundary update
Boundary delete

Test output 

generic.bats
 ✓ boundary/generic: can login as admin user
 ✓ boundary/generic: admin user can create target
 ✓ boundary/generic: admin user can read target with generic read
 ✓ boundary/generic: admin user can update target with generic update
 ✓ boundary/generic: admin user can check that the update worked with generic read
 ✓ boundary/generic: admin user can delete target with generic delete

6 tests, 0 failures