### PR TITLE
Docs: AssumeRole examples fixes

### DIFF
--- a/website/content/docs/concepts/host-discovery/aws.mdx
+++ b/website/content/docs/concepts/host-discovery/aws.mdx
@@ -285,12 +285,12 @@ Apply the following Terraform policy:
 
     attributes_json = jsonencode({
       "region" = "eu-west-2",
-      "disable_credential_rotation" = true })
-    secrets_json = jsonencode({
+      "disable_credential_rotation" = true,
       "role_arn" = "AWS_ROLE_ARN_VALUE",
       "role_external_id" = "AWS_ROLE_EXTERNAL_ID_VALUE",
       "role_session_name" = "AWS_ROLE_SESSION_NAME_VALUE",
-      "role_tags" = "AWS_ROLE_TAGS_VALUE"})
+      "role_tags" = "AWS_ROLE_TAGS_VALUE"
+      })
   }
   ```
 

--- a/website/content/docs/concepts/host-discovery/aws.mdx
+++ b/website/content/docs/concepts/host-discovery/aws.mdx
@@ -82,24 +82,20 @@ Perform the following steps to set up a host catalog using [AssumeRole](https://
 
 1. Deploy a self-managed worker in your AWS account. The worker must be in the same VPC as the hosts you want to access using the dynamic host catalog. Consider [adding worker tags](/boundary/docs/concepts/filtering/worker-tags) to make it easier to route traffic through it using a worker filter later on.
 
-1. Create an IAM role with the `AmazonEC2ReadOnlyAccess` policy attached. This policy should match the following:
+1. Create an IAM role with the `AmazonEC2ReadOnlyAccess` policy attached, or define a custom policy with the `ec2:DescribeInstances` action allowed for all resources. This policy should contain the following, at least:
 
    ```json
    {
-       "Version": "2012-10-17",
-       "Statement": [
-           {
-               "Effect": "Allow",
-               "Action": [
-                   "sts:AssumeRole"
-               ],
-               "Principal": {
-                   "Service": [
-                       "ec2.amazonaws.com"
-                   ]
-               }
-           }
-       ]
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Action": [
+           "ec2:DescribeInstances"
+         ],
+         "Effect": "Allow",
+         "Resource": "*"
+       }
+     ]
    }
    ```
 


### PR DESCRIPTION
This PR corrects mistakes in the AWS AssumeRole usage doc examples.

- Fix terraform example, which incorrectly shows role attributes as `secrets_json`
- Fix role policy example, which shows the trusted identity policy, instead of the `ec2:DescribeInstances` policy required