### PR TITLE
Backport Correct Static Creds indentation (#2561) - 0.19.0

### DIFF
--- a/website/content/docs/concepts/domain-model/credential-stores.mdx
+++ b/website/content/docs/concepts/domain-model/credential-stores.mdx
@@ -169,9 +169,9 @@ $ curl https://boundaryproject.io/data/vault/boundary-controller-policy.hcl -O -
 $ vault policy write boundary-controller boundary-controller-policy.hcl
 ```
 
-### Static credential store
+## Static credential store
 
-A static credential store allows user-supplied credentials to be managed by Boundary. Credentials are encrypted and stored directly in Boundary. Currently, the static credential store can hold credentials of type `username_password`.
+A static credential store allows user-supplied credentials to be managed by Boundary. Credentials are encrypted and stored directly in Boundary. Currently, the static credential store can hold credentials of types `username_password`, `ssh_private_key`, and `json`.
 
 [token_requirements]: /boundary/docs/concepts/domain-model/credential-stores#vault-token-requirements
 [token_policy]: /boundary/docs/concepts/domain-model/credential-stores#vault-boundary-controller-policy


### PR DESCRIPTION
Backport PR failed for #2561

* Correct Static Creds indentation

* Update website/content/docs/concepts/domain-model/credential-stores.mdx

Co-authored-by: Robin Beck <stellarsquall@users.noreply.github.com>

---------

Co-authored-by: Dan Heath <76443935+Dan-Heath@users.noreply.github.com>
Co-authored-by: Robin Beck <stellarsquall@users.noreply.github.com>