### PR TITLE
docs: Clarify credential store behavior

### DIFF
--- a/website/content/docs/concepts/domain-model/credential-stores.mdx
+++ b/website/content/docs/concepts/domain-model/credential-stores.mdx
@@ -18,7 +18,7 @@ to the minimum necessary for the project it is in.
 Credential stores either generate or store credentials, depending on the type:
 
 - Vault credential stores contain [credential libraries][].
-   You use credential libraries to issue credentials.
+   Targets use credential libraries to issue credentials for sessions.
 
 - Static credential stores contain credentials, not credential libraries.
    When you use static credential stores, the credentials are stored directly in Boundary.

--- a/website/content/docs/concepts/domain-model/credential-stores.mdx
+++ b/website/content/docs/concepts/domain-model/credential-stores.mdx
@@ -15,7 +15,7 @@ It belongs to a [project][] and supports the
 by providing mechanisms to limit the [credentials][] it can access
 to the minimum necessary for the project it is in.
 
-Credential stores either generate or store credentials, depending on the type:
+Credential stores contain either credential libraries or credentials, depending on the type:
 
 - Vault credential stores contain [credential libraries][].
    Targets use credential libraries to issue credentials for sessions.

--- a/website/content/docs/concepts/domain-model/credential-stores.mdx
+++ b/website/content/docs/concepts/domain-model/credential-stores.mdx
@@ -8,20 +8,27 @@ description: >-
 # Credential stores
 
 A credential store is a resource
-that can retrieve, store, and potentially generate [credentials][]
+that can retrieve [credentials][]
 of differing types and differing access levels.
 It belongs to a [project][] and supports the
 [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege)
 by providing mechanisms to limit the [credentials][] it can access
 to the minimum necessary for the project it is in.
-A credential store can also contain [credential libraries][].
+
+Credential stores either generate or store credentials, depending on the type:
+
+- Vault credential stores contain [credential libraries][].
+   You use credential libraries to issue credentials.
+
+- Static credential stores contain credentials, not credential libraries.
+   When you use static credential stores, the credentials are stored directly in Boundary.
 
 ## Attributes
 
 A credential store has the following configurable attributes:
 
 - `name` - (optional)
-  If set, the `name` must be unique within the credential store's [project][].
+  If set, the `name` must be unique within the credential store's project.
 
 - `description` - (optional)
 
@@ -63,7 +70,7 @@ A Vault credential store has the following additional attributes:
   This allows the use of private Vault instances with Boundary. Workers
   deployed in the same network as a private Vault instance can access and relay
   Vault requests to Boundary controllers.
-  ~> **Note:** A worker that matches the worker filter must exist before defining the Vault credential store, as it
+  A worker that matches the worker filter must exist before defining the Vault credential store, as it
   will perform the Vault calls needed to set up the credential store with Boundary.
 
 ### Static credential store attributes
@@ -99,7 +106,7 @@ All tokens must also have the capabilities of the
 ### Vault policies
 
 The credential store's token must have the capabilities to issue credentials for
-each of it's [credential libraries][] plus the capabilities of the
+each of its credential libraries plus the capabilities of the
 [Vault Boundary Controller Policy][token_policy] described below.
 
 We recommend creating a unique Vault policy for each Vault credential store that


### PR DESCRIPTION
From a Slack conversation:

https://hashicorp.slack.com/archives/C016ZKNM05T/p1744743081610239

The description of how credential libraries interact with credential stores in this topic is unclear. We mention that credential stores can store or generate credentials, but those functions are specific to the static and Vault types respectively. We should clarify how those 2 credential store types differ.

Additionally, I deleted some redundant links, removed a broken note, and fixed a typo.

View the update in the preview deployment:

[Credential stores](https://boundary-e66kan0aw-hashicorp.vercel.app/boundary/docs/concepts/domain-model/credential-stores)