### PR TITLE
Dkanney CVE suppression for 0.19.2

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -5,6 +5,29 @@ container {
 	dependencies = true
 	alpine_secdb = true
 	secrets      = false
+
+	# Triage items that are _safe_ to ignore here. Note that this list should be
+	# periodically cleaned up to remove items that are no longer found by the scanner.
+	triage {
+		suppress {
+			vulnerabilities = [
+				# busybox@1.37.0-r12 https://nvd.nist.gov/vuln/detail/CVE-2025-46394
+				#
+				# Boundary does not shell out to the busybox tar program.
+				"CVE-2025-46394", 
+
+				# busybox@1.37.0-r12 https://nvd.nist.gov/vuln/detail/CVE-2024-58251
+				#
+				# Boundary does not shell out to the busybox netstat program.
+				"CVE-2024-58251",
+
+				# gnupg@2.4.7-r0 https://nvd.nist.gov/vuln/detail/CVE-2025-30258
+				#
+				# Boundary does not utilize GnuPG to import certificates.
+				"CVE-2025-30258",
+			]
+		}
+	}
 }
 
 binary {


### PR DESCRIPTION
Suppressing vulnerability warnings from CVEs found in this CRT pipeline: https://github.com/hashicorp/crt-workflows-common/actions/runs/14717736026/job/41305881597

```
## ⚠︎ found reported vulnerability CVE-2025-46394 from Alpine Linux's Security Issue Tracker in busybox@1.37.0-r12
- URI: https://nvd.nist.gov/vuln/detail/CVE-2025-46394
- Description: In tar in BusyBox through 1.37.0, a TAR archive can have filenames hidden from a listing through the use of terminal escape sequences.
- Base Score: 3.2 LOW

## ⚠︎ found reported vulnerability CVE-2024-58251 from Alpine Linux's Security Issue Tracker in busybox@1.37.0-r12
- URI: https://nvd.nist.gov/vuln/detail/CVE-2024-58251
- Description: In netstat in BusyBox through 1.37.0, local users can launch of network application with an argv[0] containing an ANSI terminal escape sequence, leading to a denial of service (terminal locked up) when netstat is used by a victim.
- Base Score: 2.5 LOW

## found reported vulnerability CVE-2025-30258 from Alpine Linux's Security Issue Tracker in gnupg@2.4.7-r0
- URI: https://nvd.nist.gov/vuln/detail/CVE-2025-30258
- Description: In GnuPG before 2.5.5, if a user chooses to import a certificate with certain crafted subkey data that lacks a valid backsig or that has incorrect usage flags, the user loses the ability to verify signatures made from certain other signing keys, aka a "verification DoS."
- Base Score: 2.7 LOW
- Awaiting Analysis: true
```