### PR TITLE
chore(e2e): Added support for boundary license to be an env for enos

### DIFF
--- a/enos/ci/hcp-resources/main.tf
+++ b/enos/ci/hcp-resources/main.tf
@@ -43,7 +43,6 @@ locals {
   egress_tag = "egress"
 
   license_path      = abspath(var.boundary_license_path)
-  license           = var.boundary_license
   boundary_zip_path = abspath(var.boundary_zip_path)
 
   cluster_tag     = "boundary_hcp_testing"

--- a/enos/ci/hcp-resources/main.tf
+++ b/enos/ci/hcp-resources/main.tf
@@ -43,6 +43,7 @@ locals {
   egress_tag = "egress"
 
   license_path      = abspath(var.boundary_license_path)
+  license           = var.boundary_license
   boundary_zip_path = abspath(var.boundary_zip_path)
 
   cluster_tag     = "boundary_hcp_testing"

--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -17,7 +17,7 @@ scenario "e2e_aws_base_with_vault" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
+    license                  = var.boundary_license
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     build_path = {
       "local" = "/tmp",

--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -17,6 +17,7 @@ scenario "e2e_aws_base_with_vault" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     build_path = {
       "local" = "/tmp",

--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -17,7 +17,6 @@ scenario "e2e_aws_base_with_vault" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                  = var.boundary_license
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     build_path = {
       "local" = "/tmp",
@@ -47,6 +46,7 @@ scenario "e2e_aws_base_with_vault" {
 
     variables {
       license_path = local.license_path
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -17,7 +17,7 @@ scenario "e2e_aws_base" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
+    license                  = var.boundary_license
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     build_path = {
       "local" = "/tmp",

--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -17,6 +17,7 @@ scenario "e2e_aws_base" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     build_path = {
       "local" = "/tmp",

--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -17,7 +17,6 @@ scenario "e2e_aws_base" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir     = abspath(var.boundary_install_dir)
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                  = var.boundary_license
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     build_path = {
       "local" = "/tmp",
@@ -47,6 +46,7 @@ scenario "e2e_aws_base" {
 
     variables {
       license_path = local.license_path
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -20,7 +20,6 @@ scenario "e2e_aws" {
     boundary_install_dir     = abspath(var.boundary_install_dir)
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     boundary_license_path    = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                  = var.boundary_license
     vault_license_path       = abspath(var.vault_license_path != null ? var.vault_license_path : joinpath(path.root, "./support/vault.hclic"))
 
     build_path = {
@@ -52,6 +51,7 @@ scenario "e2e_aws" {
 
     variables {
       license_path = local.boundary_license_path
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -20,7 +20,7 @@ scenario "e2e_aws" {
     boundary_install_dir     = abspath(var.boundary_install_dir)
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     boundary_license_path    = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
+    license                  = var.boundary_license
     vault_license_path       = abspath(var.vault_license_path != null ? var.vault_license_path : joinpath(path.root, "./support/vault.hclic"))
 
     build_path = {

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -20,6 +20,7 @@ scenario "e2e_aws" {
     boundary_install_dir     = abspath(var.boundary_install_dir)
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     boundary_license_path    = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
     vault_license_path       = abspath(var.vault_license_path != null ? var.vault_license_path : joinpath(path.root, "./support/vault.hclic"))
 
     build_path = {

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -13,6 +13,7 @@ scenario "e2e_database" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
 
     tags = merge({
       "Project Name" : var.project_name

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -13,7 +13,6 @@ scenario "e2e_database" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                  = var.boundary_license
 
     tags = merge({
       "Project Name" : var.project_name
@@ -27,7 +26,8 @@ scenario "e2e_database" {
     module    = module.read_license
 
     variables {
-      license_path = local.license_path
+      license_path = local.license_path      
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -13,7 +13,7 @@ scenario "e2e_database" {
     aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
+    license                  = var.boundary_license
 
     tags = merge({
       "Project Name" : var.project_name

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -26,7 +26,7 @@ scenario "e2e_database" {
     module    = module.read_license
 
     variables {
-      license_path = local.license_path      
+      license_path = local.license_path
       license      = var.boundary_license
     }
   }

--- a/enos/enos-scenario-e2e-docker-base-plus.hcl
+++ b/enos/enos-scenario-e2e-docker-base-plus.hcl
@@ -21,7 +21,6 @@ scenario "e2e_docker_base_plus" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
 
     network_cluster = "e2e_cluster"
 
@@ -69,7 +68,8 @@ scenario "e2e_docker_base_plus" {
     module    = module.read_license
 
     variables {
-      license_path = local.license_path
+      license_path = local.license_path      
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-docker-base-plus.hcl
+++ b/enos/enos-scenario-e2e-docker-base-plus.hcl
@@ -21,6 +21,7 @@ scenario "e2e_docker_base_plus" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
 
     network_cluster = "e2e_cluster"
 

--- a/enos/enos-scenario-e2e-docker-base-plus.hcl
+++ b/enos/enos-scenario-e2e-docker-base-plus.hcl
@@ -68,7 +68,7 @@ scenario "e2e_docker_base_plus" {
     module    = module.read_license
 
     variables {
-      license_path = local.license_path      
+      license_path = local.license_path
       license      = var.boundary_license
     }
   }

--- a/enos/enos-scenario-e2e-docker-base-with-gcp.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-gcp.hcl
@@ -21,6 +21,7 @@ scenario "e2e_docker_base_with_gcp" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
     gcp_private_key            = var.gcp_private_key_path != null ? file(var.gcp_private_key_path) : var.gcp_private_key
 
     network_cluster = "e2e_gcp"

--- a/enos/enos-scenario-e2e-docker-base-with-gcp.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-gcp.hcl
@@ -21,7 +21,6 @@ scenario "e2e_docker_base_with_gcp" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
     gcp_private_key            = var.gcp_private_key_path != null ? file(var.gcp_private_key_path) : var.gcp_private_key
 
     network_cluster = "e2e_gcp"
@@ -71,6 +70,7 @@ scenario "e2e_docker_base_with_gcp" {
 
     variables {
       license_path = local.license_path
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-docker-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-vault.hcl
@@ -23,6 +23,7 @@ scenario "e2e_docker_base_with_vault" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
 
     network_cluster = "e2e_cluster"
 

--- a/enos/enos-scenario-e2e-docker-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-vault.hcl
@@ -23,7 +23,6 @@ scenario "e2e_docker_base_with_vault" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
 
     network_cluster = "e2e_cluster"
 
@@ -72,6 +71,7 @@ scenario "e2e_docker_base_with_vault" {
 
     variables {
       license_path = local.license_path
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-docker-base-with-worker.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-worker.hcl
@@ -22,7 +22,6 @@ scenario "e2e_docker_base_with_worker" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
 
     network_cluster  = "e2e_cluster"
     network_host     = "e2e_host"
@@ -87,6 +86,7 @@ scenario "e2e_docker_base_with_worker" {
 
     variables {
       license_path = local.license_path
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-docker-base-with-worker.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-worker.hcl
@@ -22,6 +22,7 @@ scenario "e2e_docker_base_with_worker" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
 
     network_cluster  = "e2e_cluster"
     network_host     = "e2e_host"

--- a/enos/enos-scenario-e2e-docker-base.hcl
+++ b/enos/enos-scenario-e2e-docker-base.hcl
@@ -21,6 +21,7 @@ scenario "e2e_docker_base" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
 
     network_cluster = "e2e_cluster"
 

--- a/enos/enos-scenario-e2e-docker-base.hcl
+++ b/enos/enos-scenario-e2e-docker-base.hcl
@@ -21,7 +21,6 @@ scenario "e2e_docker_base" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
 
     network_cluster = "e2e_cluster"
 
@@ -70,6 +69,7 @@ scenario "e2e_docker_base" {
 
     variables {
       license_path = local.license_path
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-docker-worker-registration-controller-led.hcl
+++ b/enos/enos-scenario-e2e-docker-worker-registration-controller-led.hcl
@@ -22,7 +22,6 @@ scenario "e2e_docker_worker_registration_controller_led" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
 
     network_cluster  = "e2e_cluster"
     network_host     = "e2e_host"
@@ -87,6 +86,7 @@ scenario "e2e_docker_worker_registration_controller_led" {
 
     variables {
       license_path = local.license_path
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-docker-worker-registration-controller-led.hcl
+++ b/enos/enos-scenario-e2e-docker-worker-registration-controller-led.hcl
@@ -22,6 +22,7 @@ scenario "e2e_docker_worker_registration_controller_led" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
 
     network_cluster  = "e2e_cluster"
     network_host     = "e2e_host"

--- a/enos/enos-scenario-e2e-docker-worker-registration-worker-led.hcl
+++ b/enos/enos-scenario-e2e-docker-worker-registration-worker-led.hcl
@@ -22,7 +22,6 @@ scenario "e2e_docker_worker_registration_worker_led" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
 
     network_cluster  = "e2e_cluster"
     network_host     = "e2e_host"
@@ -87,6 +86,7 @@ scenario "e2e_docker_worker_registration_worker_led" {
 
     variables {
       license_path = local.license_path
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-docker-worker-registration-worker-led.hcl
+++ b/enos/enos-scenario-e2e-docker-worker-registration-worker-led.hcl
@@ -22,6 +22,7 @@ scenario "e2e_docker_worker_registration_worker_led" {
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
 
     network_cluster  = "e2e_cluster"
     network_host     = "e2e_host"

--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -17,7 +17,7 @@ scenario "e2e_ui_aws" {
     aws_ssh_private_key_path  = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir      = abspath(var.boundary_install_dir)
     license_path              = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
+    license                   = var.boundary_license
     local_boundary_dir        = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_ui_src_dir = var.local_boundary_ui_src_dir != null ? abspath(var.local_boundary_ui_src_dir) : null
     build_path = {

--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -17,6 +17,7 @@ scenario "e2e_ui_aws" {
     aws_ssh_private_key_path  = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir      = abspath(var.boundary_install_dir)
     license_path              = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
     local_boundary_dir        = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_ui_src_dir = var.local_boundary_ui_src_dir != null ? abspath(var.local_boundary_ui_src_dir) : null
     build_path = {

--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -17,7 +17,6 @@ scenario "e2e_ui_aws" {
     aws_ssh_private_key_path  = abspath(var.aws_ssh_private_key_path)
     boundary_install_dir      = abspath(var.boundary_install_dir)
     license_path              = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                   = var.boundary_license
     local_boundary_dir        = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_ui_src_dir = var.local_boundary_ui_src_dir != null ? abspath(var.local_boundary_ui_src_dir) : null
     build_path = {
@@ -48,6 +47,7 @@ scenario "e2e_ui_aws" {
 
     variables {
       license_path = local.license_path
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-ui-docker.hcl
+++ b/enos/enos-scenario-e2e-ui-docker.hcl
@@ -21,7 +21,6 @@ scenario "e2e_ui_docker" {
     local_boundary_ui_src_dir  = var.local_boundary_ui_src_dir != null ? abspath(var.local_boundary_ui_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    license                    = var.boundary_license
 
     network_cluster = "e2e_cluster"
 
@@ -70,6 +69,7 @@ scenario "e2e_ui_docker" {
 
     variables {
       license_path = local.license_path
+      license      = var.boundary_license
     }
   }
 

--- a/enos/enos-scenario-e2e-ui-docker.hcl
+++ b/enos/enos-scenario-e2e-ui-docker.hcl
@@ -21,6 +21,7 @@ scenario "e2e_ui_docker" {
     local_boundary_ui_src_dir  = var.local_boundary_ui_src_dir != null ? abspath(var.local_boundary_ui_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
     license_path               = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    license                    = var.boundary_license
 
     network_cluster = "e2e_cluster"
 

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -175,6 +175,12 @@ variable "boundary_license_path" {
   default     = null
 }
 
+variable "boundary_license" {
+  description = "Boundary license"
+  type        = string
+  default     = null
+}
+
 variable "vault_license_path" {
   description = "Vault license path"
   type        = string

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -39,6 +39,8 @@
 // ENTERPRISE ONLY
 // Path to a license file
 // boundary_license_path = "./support/boundary.hclic"
+// Directly set the boundary license. Overrides boundary license file.
+// boundary_license = ""
 
 // ==============================================================================
 // OPTIONAL VARIABLES

--- a/enos/modules/read_license/main.tf
+++ b/enos/modules/read_license/main.tf
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 variable "license_path" {}
+variable "license" {}
 
 output "license" {
-  value = file(var.license_path)
+  value = var.license != null ? var.license : file(var.license_path)
 }

--- a/enos/modules/read_license/main.tf
+++ b/enos/modules/read_license/main.tf
@@ -1,8 +1,16 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-variable "license_path" {}
-variable "license" {}
+
+# Loads boundary license from file or environment variable
+# If license is null or unsuplied then the license is returned from the file at license_path
+variable "license_path" {
+  description = "Path to the boundary license file"
+}
+variable "license" {
+  description = "Boundary license" 
+  default = null
+}
 
 output "license" {
   value = var.license != null ? var.license : file(var.license_path)

--- a/enos/modules/read_license/main.tf
+++ b/enos/modules/read_license/main.tf
@@ -8,8 +8,8 @@ variable "license_path" {
   description = "Path to the boundary license file"
 }
 variable "license" {
-  description = "Boundary license" 
-  default = null
+  description = "Boundary license"
+  default     = null
 }
 
 output "license" {

--- a/enos/modules/read_license/main.tf
+++ b/enos/modules/read_license/main.tf
@@ -3,7 +3,7 @@
 
 
 # Loads boundary license from file or environment variable
-# If license is null or unsuplied then the license is returned from the file at license_path
+# If license is null or not provided, then the license is returned from the file at license_path
 variable "license_path" {
   description = "Path to the boundary license file"
 }


### PR DESCRIPTION
Created an environment variable that allows you to pass in the boundary license for boundary enterprise without using a file. 
Note that the license in the env will overwrite the license in the file. 

Jira - https://hashicorp.atlassian.net/browse/ICU-16630

Testing - 
Tested a couple different scenarios with the license as an env, license in the file and both envs being set 