### PR TITLE
docs: Update release notes

### DIFF
--- a/website/content/docs/release-notes/v0_17_0.mdx
+++ b/website/content/docs/release-notes/v0_17_0.mdx
@@ -309,6 +309,24 @@ description: >-
     </td>
   </tr>
 
+   <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.17.0 - 0.17.4
+    <br /><br />
+    (Fixed in Boundary Enterprise and HCP Boundary 0.17.5)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Canceled SSH connections cause performance issues
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    When an SSH connection was canceled, it could cause a spike in CPU usage. In some cases, egress workers become unresponsive, leading to performance issues. The issue occurred when the connection context was canceled at specific times in the process, creating a busy loop that prevented workers from completing tasks.
+    <br/><br />
+    This issue is resolved in Boundary Enterprise and HCP Boundary version 0.17.5. Workers no longer end up in a busy loop when SSH connections are canceled.
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
 
   </tbody>
 </table>

--- a/website/content/docs/release-notes/v0_18_0.mdx
+++ b/website/content/docs/release-notes/v0_18_0.mdx
@@ -326,5 +326,23 @@ description: >-
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.17.0 - 0.18.3
+    <br /><br />
+    (Fixed in Boundary Enterprise and HCP Boundary 0.18.4)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Canceled SSH connections cause performance issues
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    When an SSH connection was canceled, it could cause a spike in CPU usage. In some cases, egress workers become unresponsive, leading to performance issues. The issue occurred when the connection context was canceled at specific times in the process, creating a busy loop that prevented workers from completing tasks.
+    <br/><br />
+    This issue is resolved in Boundary Enterprise and HCP Boundary version 0.18.4. Workers no longer end up in a busy loop when SSH connections are canceled.
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
   </tbody>
 </table>

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -279,12 +279,13 @@ description: >-
     CVE-2025-22873
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    The version of Go that was used in Boundary release 0.19.x contained a security vulnerability. It was possible to improperly access the parent directory of an os.Root by opening a filename ending in "../". For example, Root.Open("../") would open the parent directory of the Root. This escape only permits opening the parent directory itself, not ancestors of the parent or files contained within the parent.
-    <br /><br />In the new version of Go, Root now correctly returns an error. Boundary release 0.19.2 was updated to use the new version. This issue is resolved.
+    The version of Go that was used in Boundary release 0.19.x contained a security vulnerability. Although this vulnerability did not affect Boundary, release 0.19.2 was updated to use a new version of Go.
     <br/><br />
     Learn more:
     <br /><br />
     <a href="https://github.com/golang/go/issues/73555">CVE-2025-22873</a>
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
     </td>
   </tr>
 

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -269,5 +269,24 @@ description: >-
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.0
+    <br /><br />
+    (Fixed in 0.19.2)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    CVE-2025-22873
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    The version of Go that was used in Boundary release 0.19.x contained a security vulnerability. It was possible to improperly access the parent directory of an os.Root by opening a filename ending in "../". For example, Root.Open("../") would open the parent directory of the Root. This escape only permits opening the parent directory itself, not ancestors of the parent or files contained within the parent.
+    <br /><br />In the new version of Go, Root now correctly returns an error. Boundary release 0.19.2 was updated to use the new version. This issue is resolved.
+    <br/><br />
+    Learn more:
+    <br /><br />
+    <a href="https://github.com/golang/go/issues/73555">CVE-2025-22873</a>
+    </td>
+  </tr>
+
   </tbody>
 </table>

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -228,6 +228,44 @@ description: >-
     However, soft-deleted users were not being properly restored when they logged back in and it affected search capabilities.
     <br/><br />
     This issue is resolved in version 0.19.1. Soft-deleted users are now properly restored as active when they log in again if the refresh token is less than 20 days old.
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.17.0 - 0.19.0
+    <br /><br />
+    (Fixed in 0.19.2)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Canceled SSH connections cause performance issues
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    When an SSH connection was canceled, it could cause a spike in CPU usage. In some cases, egress workers become unresponsive, leading to performance issues. The issue occurred when the connection context was canceled at specific times in the process, creating a busy loop that prevented workers from completing tasks.
+    <br/><br />
+    This issue is resolved in version 0.19.2. Workers no longer enter a busy loop when SSH connections are canceled.
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.0
+    <br /><br />
+    (Fixed in 0.19.2)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Unable to change key type for Vault SSH certificate credential library using the UI
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    When you attempted to change the key type for a Vault SSH certificate credential library using the UI, the update failed.
+    <br/><br />
+    This issue is resolved in version 0.19.2. You can now change the key type using the UI.
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
     </td>
   </tr>
 


### PR DESCRIPTION
This PR updates the 0.19.0 release notes with the fixes for known issues [ICU-16894](https://hashicorp.atlassian.net/browse/ICU-16894) and [ICU-16880](https://hashicorp.atlassian.net/browse/ICU-16880). It also updates the 0.17.0 and 0.18.0 releases with the fix for ICU-16894 since it is being back ported to support N-2 compatibility.

View the updates in the preview deployment:

- [Version 0.17.0 Known issues](https://boundary-esnvlk8zj-hashicorp.vercel.app/boundary/docs/release-notes/v0_17_0#known-issues-and-breaking-changes)
- [Version 0.18.0 Known issues](https://boundary-esnvlk8zj-hashicorp.vercel.app/boundary/docs/release-notes/v0_18_0#known-issues-and-breaking-changes)
- [Version 0.19.0 Known issues](https://boundary-esnvlk8zj-hashicorp.vercel.app/boundary/docs/release-notes/v0_19_0#known-issues-and-breaking-changes)

[ICU-16894]: https://hashicorp.atlassian.net/browse/ICU-16894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ICU-16880]: https://hashicorp.atlassian.net/browse/ICU-16880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ