### PR TITLE
Add rule to suppress CVE-2025-47268

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -25,6 +25,11 @@ container {
 				#
 				# Boundary does not utilize GnuPG to import certificates.
 				"CVE-2025-30258",
+
+				# iputils@20240905-r0 https://nvd.nist.gov/vuln/detail/CVE-2025-47268
+				#
+				# Boundary does not utilize ping in iputils.
+				"CVE-2025-47268"
 			]
 		}
 	}


### PR DESCRIPTION
```
found reported vulnerability CVE-2025-47268 from Alpine Linux's Security Issue Tracker in iputils@20240905-r0
        /lib/apk/db/installed:1:1
```

https://nvd.nist.gov/vuln/detail/CVE-2025-47268

> ping in iputils through 20240905 allows a denial of service (application error or incorrect data collection) via a crafted ICMP Echo Reply packet, because of a signed 64-bit integer overflow in timestamp multiplication.
>
> Base Score: [6.5 MEDIUM](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2025-47268&vector=AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L&version=3.1&source=MITRE)