### PR TITLE
test(e2e): Skip pagination tests until large estimated count bug is addressed

### DIFF
--- a/testing/internal/e2e/tests/base/paginate_account_test.go
+++ b/testing/internal/e2e/tests/base/paginate_account_test.go
@@ -25,6 +25,7 @@ import (
 // all accounts in a single invocation.
 func TestCliPaginateAccounts(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -125,6 +126,7 @@ func TestCliPaginateAccounts(t *testing.T) {
 // all accounts in a single invocation.
 func TestApiPaginateAccounts(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_auth_token_test.go
+++ b/testing/internal/e2e/tests/base/paginate_auth_token_test.go
@@ -25,6 +25,7 @@ import (
 // all auth tokens in a single invocation.
 func TestCliPaginateAuthTokens(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -134,6 +135,7 @@ func TestCliPaginateAuthTokens(t *testing.T) {
 // all auth tokens in a single invocation.
 func TestApiPaginateAuthTokens(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_credential_store_test.go
+++ b/testing/internal/e2e/tests/base/paginate_credential_store_test.go
@@ -23,6 +23,7 @@ import (
 // all credential stores in a single invocation.
 func TestCliPaginateCredentialStores(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -117,6 +118,7 @@ func TestCliPaginateCredentialStores(t *testing.T) {
 // all credential stores in a single invocation.
 func TestApiPaginateCredentialStores(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_credential_test.go
+++ b/testing/internal/e2e/tests/base/paginate_credential_test.go
@@ -23,6 +23,7 @@ import (
 // all credentials in a single invocation.
 func TestCliPaginateCredentials(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -129,6 +130,7 @@ func TestCliPaginateCredentials(t *testing.T) {
 // all Credentials in a single invocation.
 func TestApiPaginateCredentials(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_group_test.go
+++ b/testing/internal/e2e/tests/base/paginate_group_test.go
@@ -23,6 +23,7 @@ import (
 // all groups in a single invocation.
 func TestCliPaginateGroups(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -115,6 +116,7 @@ func TestCliPaginateGroups(t *testing.T) {
 // all groups in a single invocation.
 func TestApiPaginateGroups(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_host_catalog_test.go
+++ b/testing/internal/e2e/tests/base/paginate_host_catalog_test.go
@@ -23,6 +23,7 @@ import (
 // all host catalogs in a single invocation.
 func TestCliPaginateHostCatalogs(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -117,6 +118,7 @@ func TestCliPaginateHostCatalogs(t *testing.T) {
 // all host catalogs in a single invocation.
 func TestApiPaginateHostCatalogs(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_host_set_test.go
+++ b/testing/internal/e2e/tests/base/paginate_host_set_test.go
@@ -23,6 +23,7 @@ import (
 // all host sets in a single invocation.
 func TestCliPaginateHostSets(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -119,6 +120,7 @@ func TestCliPaginateHostSets(t *testing.T) {
 // all host sets in a single invocation.
 func TestApiPaginateHostSets(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_host_test.go
+++ b/testing/internal/e2e/tests/base/paginate_host_test.go
@@ -23,6 +23,7 @@ import (
 // all hosts in a single invocation.
 func TestCliPaginateHosts(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -119,6 +120,7 @@ func TestCliPaginateHosts(t *testing.T) {
 // all hosts in a single invocation.
 func TestApiPaginateHosts(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_managed_group_test.go
+++ b/testing/internal/e2e/tests/base/paginate_managed_group_test.go
@@ -24,6 +24,7 @@ import (
 // all managed groups in a single invocation.
 func TestCliPaginateManagedGroups(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -124,6 +125,7 @@ func TestCliPaginateManagedGroups(t *testing.T) {
 // all managedgroups in a single invocation.
 func TestApiPaginateManagedGroups(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_role_test.go
+++ b/testing/internal/e2e/tests/base/paginate_role_test.go
@@ -23,6 +23,7 @@ import (
 // all roles in a single invocation.
 func TestCliPaginateRoles(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -120,6 +121,7 @@ func TestCliPaginateRoles(t *testing.T) {
 // all roles in a single invocation.
 func TestApiPaginateRoles(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_scope_test.go
+++ b/testing/internal/e2e/tests/base/paginate_scope_test.go
@@ -21,6 +21,7 @@ import (
 // all scopes in a single invocation.
 func TestCliPaginateScopes(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -113,6 +114,7 @@ func TestCliPaginateScopes(t *testing.T) {
 // all scopes in a single invocation.
 func TestApiPaginateScopes(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_session_test.go
+++ b/testing/internal/e2e/tests/base/paginate_session_test.go
@@ -22,6 +22,7 @@ import (
 // canceled sessions is not included.
 func TestCliPaginateSessions(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -105,6 +106,7 @@ func TestCliPaginateSessions(t *testing.T) {
 // canceled sessions is not included.
 func TestApiPaginateSessions(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_target_test.go
+++ b/testing/internal/e2e/tests/base/paginate_target_test.go
@@ -25,6 +25,7 @@ import (
 // all targets in a single invocation.
 func TestCliPaginateTargets(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -127,6 +128,7 @@ func TestCliPaginateTargets(t *testing.T) {
 // all targets in a single invocation.
 func TestApiPaginateTargets(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 

--- a/testing/internal/e2e/tests/base/paginate_user_test.go
+++ b/testing/internal/e2e/tests/base/paginate_user_test.go
@@ -23,6 +23,7 @@ import (
 // all users in a single invocation.
 func TestCliPaginateUsers(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 
@@ -115,6 +116,7 @@ func TestCliPaginateUsers(t *testing.T) {
 // all users in a single invocation.
 func TestApiPaginateUsers(t *testing.T) {
 	e2e.MaybeSkipTest(t)
+	e2e.MaybeSkipSlowTest(t)
 	c, err := loadTestConfig()
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR skips the pagination e2e tests until the "large estimated count" bug is addressed: https://hashicorp.atlassian.net/browse/ICU-16649. Since that bug is causing OOM on the runner (in boundary-enterprise), the idea is to disable the tests triggering the OOM so that we can at least get the other tests to execute. (This borrows the "SkipSlowTest" method to avoid needing to create another method).

There will be another PR on boundary-enterprise to skip any enterprise-specific pagination tests.

