### PR TITLE
Change reqScope parameter type from `Scope` to `string`

### DIFF
--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -334,7 +334,7 @@ const (
           on roles_with_grants.role_id = iam_role_global.public_id
         join iam_role_global_individual_org_grant_scope individual
           on individual.role_id = iam_role_global.public_id
-       where individual.scope_id = @request_scope
+       where individual.scope_id = @request_scope_id
     ),
     org_roles_this_grant_scope as (
       select iam_role_org.public_id            as role_id,
@@ -346,7 +346,7 @@ const (
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_org.public_id
        where iam_role_org.grant_this_role_scope
-         and iam_role_org.scope_id = @request_scope
+         and iam_role_org.scope_id = @request_scope_id
     ),
     global_and_org_roles as (
       select role_id,
@@ -406,7 +406,7 @@ const (
           on roles_with_grants.role_id = iam_role_global.public_id
         join iam_role_global_individual_project_grant_scope individual
           on individual.role_id = iam_role_global.public_id
-       where individual.scope_id = @request_scope
+       where individual.scope_id = @request_scope_id
     ),
     org_roles_with_children_grant_scopes as (
       select iam_role_org.public_id            as role_id,
@@ -419,7 +419,7 @@ const (
           on roles_with_grants.role_id = iam_role_org.public_id
         join iam_scope_project
           on iam_scope_project.parent_id = iam_role_org.scope_id
-         and iam_scope_project.scope_id = @request_scope
+         and iam_scope_project.scope_id = @request_scope_id
        where iam_role_org.grant_scope = 'children'
     ),
     org_roles_with_individual_grant_scopes as (
@@ -433,7 +433,7 @@ const (
           on roles_with_grants.role_id = iam_role_org.public_id
         join iam_role_org_individual_grant_scope individual
           on individual.role_id = iam_role_org.public_id
-       where individual.scope_id = @request_scope
+       where individual.scope_id = @request_scope_id
     ),
     project_roles_this_grant_scope as (
       select iam_role_project.public_id        as role_id,
@@ -447,7 +447,7 @@ const (
         join iam_scope_project
           on iam_scope_project.scope_id = iam_role_project.scope_id
        where iam_role_project.grant_this_role_scope
-         and iam_role_project.scope_id = @request_scope
+         and iam_role_project.scope_id = @request_scope_id
     ),
     all_roles as (
       select role_id,

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -569,22 +569,20 @@ func (r *Repository) grantsForUserGlobalResources(
 		sql.Named("resources", pq.Array(resources)),
 	)
 
-	var grants []grantsForUserResults
+	var grants []perms.GrantTuple
 	rows, err := r.reader.Query(ctx, grantsForUserGlobalResourcesQuery, args)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var g grantsForUserResults
+		var g perms.GrantTuple
 		if err := rows.Scan(
-			&g.roleId,
-			&g.roleScopeId,
-			&g.roleParentScopeId,
-			&g.grantScope,
-			&g.grantThisRoleScope,
-			pq.Array(&g.individualGrantScopes),
-			pq.Array(&g.canonicalGrants),
+			&g.RoleId,
+			&g.RoleScopeId,
+			&g.RoleParentScopeId,
+			&g.GrantScopeId,
+			&g.Grant,
 		); err != nil {
 			return nil, errors.Wrap(ctx, err, op)
 		}
@@ -593,22 +591,7 @@ func (r *Repository) grantsForUserGlobalResources(
 	if err := rows.Err(); err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
-
-	ret := make(perms.GrantTuples, 0)
-	for _, grant := range grants {
-		for _, canonicalGrant := range grant.canonicalGrants {
-			gt := perms.GrantTuple{
-				RoleId:            grant.roleId,
-				RoleScopeId:       grant.roleScopeId,
-				RoleParentScopeId: grant.roleParentScopeId,
-				GrantScopeId:      grant.roleScopeId, // use "global" for all global grants
-				Grant:             canonicalGrant,
-			}
-			ret = append(ret, gt)
-		}
-	}
-
-	return ret, nil
+	return grants, nil
 }
 
 // grantsForUserOrgResources returns the grants for the user for resources that can

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -615,17 +615,16 @@ func (r *Repository) grantsForUserGlobalResources(
 // only be org scoped.
 func (r *Repository) grantsForUserOrgResources(
 	ctx context.Context,
-	userId string,
+	userId,
+	reqScopeId string,
 	res resource.Type,
-	reqScope Scope,
 	opt ...Option,
 ) (perms.GrantTuples, error) {
 	const op = "iam.(Repository).grantsForUserOrgResources"
 	if userId == "" {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing user id")
 	}
-	requestScope := reqScope.GetPublicId()
-	if requestScope == "" {
+	if reqScopeId == "" {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing request scope id")
 	}
 
@@ -645,7 +644,7 @@ func (r *Repository) grantsForUserOrgResources(
 	args = append(args,
 		sql.Named("user_ids", pq.Array(userIds)),
 		sql.Named("resources", pq.Array(resources)),
-		sql.Named("request_scope", requestScope),
+		sql.Named("request_scope_id", reqScopeId),
 	)
 
 	var grants []perms.GrantTuple
@@ -677,17 +676,16 @@ func (r *Repository) grantsForUserOrgResources(
 // only be project scoped.
 func (r *Repository) grantsForUserProjectResources(
 	ctx context.Context,
-	userId string,
+	userId,
+	reqScopeId string,
 	res resource.Type,
-	reqScope Scope,
 	opt ...Option,
 ) (perms.GrantTuples, error) {
 	const op = "iam.(Repository).grantsForUserProjectResources"
 	if userId == "" {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing user id")
 	}
-	requestScope := reqScope.GetPublicId()
-	if requestScope == "" {
+	if reqScopeId == "" {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing request scope id")
 	}
 
@@ -707,7 +705,7 @@ func (r *Repository) grantsForUserProjectResources(
 	args = append(args,
 		sql.Named("user_ids", pq.Array(userIds)),
 		sql.Named("resources", pq.Array(resources)),
-		sql.Named("request_scope", requestScope),
+		sql.Named("request_scope_id", reqScopeId),
 	)
 
 	var grants []perms.GrantTuple


### PR DESCRIPTION
- Changing the type of the `reqScope` parameter from `Scope` to `string`
- Simplify `grantsForUserGlobalResourcesQuery` & its repo function. Now querying directly into `perms.GrantTuple`