### PR TITLE
docs: Update TS documentation for GA

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -9,8 +9,6 @@ description: >-
 
 @include 'alerts/enterprise-only.mdx'
 
-@include 'alerts/beta.mdx'
-
 The Boundary Client Agent is Boundary's DNS daemon.
 When the Boundary Client Agent runs alongside an authenticated Boundary client, the agent establishes itself as the primary resolver on the system and intercepts DNS requests.
 

--- a/website/content/docs/concepts/connection-workflows/index.mdx
+++ b/website/content/docs/concepts/connection-workflows/index.mdx
@@ -21,8 +21,6 @@ To practice using the `boundary connect` command in a development environment, r
 
 @include 'alerts/enterprise-only.mdx'
 
-@include 'alerts/beta.mdx'
-
 Transparent sessions shift Boundary from an active connection model to a passive connection model.
 Instead of interacting with the Boundary CLI or Desktop client and having to remember specific IDs or ephemeral ports to connect to targets, Boundary operates in the background.
 If a user is authenticated and authorized, Boundary intercepts DNS calls and routes traffic through a session automatically.

--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -9,8 +9,6 @@ description: >-
 
 @include 'alerts/enterprise-only.mdx'
 
-@include 'alerts/beta.mdx'
-
 Transparent sessions shift Boundary from an active connection model to a passive connection model. Boundary operates in the background instead of requiring you to remember specific resource IDs or ephemeral ports to connect to targets.
 
 As long as Boundary authenticates a user and the user is authorized to access the target, Boundary intercepts the DNS call and routes traffic through a session automatically.
@@ -19,13 +17,13 @@ Transparent sessions require [aliases](/boundary/docs/concepts/aliases) and the 
 
 The Boundary Desktop client facilitates quick target discovery and session establishment using your preferred client. If you configure aliases for your targets, install the Boundary Client Agent, and ensure you are authenticated to the cluster, connections are transparent to the user. Boundary provides OS notifications to make it clear when you connect to a target using a transparent session.
 
-Boundary supports Windows and MacOS for the transparent sessions public beta.
+Boundary supports Windows and MacOS for transparent sessions.
 
 Refer to the [Configure transparent sessions](/boundary/docs/configuration/target-aliases/transparent-sessions) page to get started.
 
 ## Known issues
 
-Refer to the following table for known issues that may affect the public beta:
+Refer to the following table for known issues:
 
 | Issue | Description |
 | ----- | ----------- |

--- a/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
+++ b/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
@@ -9,8 +9,6 @@ description: >-
 
 @include 'alerts/enterprise-only.mdx'
 
-@include 'alerts/beta.mdx'
-
 ## Requirements
 
 Before you configure transparent sessions, you must:
@@ -55,7 +53,7 @@ Make sure to select the options **Boundary Client Agent**, **CLI**, and **Deskto
 
 ## Configure targets
 
-The following section details how to configure targets and test the transparent sessions public beta feature.
+The following section details how to configure targets and use transparent sessions.
 
 <Tip>
 

--- a/website/content/docs/install-boundary/install-clients.mdx
+++ b/website/content/docs/install-boundary/install-clients.mdx
@@ -21,17 +21,11 @@ correct clients:
 
 @include 'alerts/enterprise-only.mdx'
 
-<Note>
-
-  The Boundary installer includes the Boundary Client Agent, which is a beta feature. For production environments, consider downloading the Boundary binary and Boundary Desktop Client directly from the [Install Boundary](/boundary/install) page.
-
-</Note>
-
 The Boundary installer bundles together the following components:
 
 - Boundary binary (CLI)
 - Boundary Desktop Client app
-- Boundary Client Agent <sup>HCP/ENT</sup> <sup>BETA</sup>
+- Boundary Client Agent <sup>HCP/ENT</sup>
 
 Download the appropriate Boundary installer for your Windows, MacOS, or Linux environment from the [Install Boundary](/boundary/install#installer) page or the [releases](https://releases.hashicorp.com/boundary-installer) page. You can also download the components individually, but compatibility is not guaranteed. Refer to the [Supported versions policy](/boundary/docs/enterprise/supported-versions#control-plane-and-client-cli-compatibility) to learn more.
 
@@ -41,7 +35,7 @@ Download the appropriate Boundary installer for your Windows, MacOS, or Linux en
 
 </Warning>
 
-To learn more about installing the Boundary CLI and Boundary Desktop Client app, refer to the [Get started with HCP Boundary](/boundary/tutorials/get-started-hcp) tutorials. 
+To learn more about installing the Boundary CLI and Boundary Desktop Client app, refer to the [Get started with HCP Boundary](/boundary/tutorials/get-started-hcp) tutorials.
 
 </Tab>
 <Tab heading="Community Edition">
@@ -51,7 +45,7 @@ We recommend the following components for end users:
 - Boundary binary (CLI)
 - Boundary Desktop Client app
 
-Download these components for your Windows, MacOS, or Linux environment from the [Install Boundary](/boundary/install) page or the [HashiCorp releases](https://releases.hashicorp.com/) page. 
+Download these components for your Windows, MacOS, or Linux environment from the [Install Boundary](/boundary/install) page or the [HashiCorp releases](https://releases.hashicorp.com/) page.
 
 <Warning>
 
@@ -59,7 +53,7 @@ Client compatibility is not guaranteed. You should always ensure that your clien
 
 </Warning>
 
-To learn more about installing the Boundary CLI and Boundary Desktop Client app, refer to the [Get started with self-managed Boundary](/boundary/tutorials/get-started-community) tutorials. 
+To learn more about installing the Boundary CLI and Boundary Desktop Client app, refer to the [Get started with self-managed Boundary](/boundary/tutorials/get-started-community) tutorials.
 
 </Tab>
 </Tabs>

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -202,7 +202,7 @@
       {
         "title": "Transparent sessions",
         "badge": {
-          "text": "HCP/ENT BETA",
+          "text": "HCP/ENT",
           "type": "outlined",
           "color": "neutral"
         },
@@ -609,7 +609,7 @@
           {
             "title": "Connect using transparent sessions",
             "badge": {
-              "text": "HCP/ENT BETA",
+              "text": "HCP/ENT",
               "type": "outlined",
               "color": "neutral"
             },
@@ -1689,7 +1689,7 @@
       {
         "title": "Client Agent",
         "badge": {
-          "text": "HCP/ENT BETA",
+          "text": "HCP/ENT",
           "type": "outlined",
           "color": "neutral"
         },


### PR DESCRIPTION
This PR removes beta tags and references from the transparent sessions documentation. View the updates in the preview deployment:

- [Boundary Client Agent](https://boundary-28vo24gtc-hashicorp.vercel.app/boundary/docs/api-clients/client-agent)
- [Transparent sessions](https://boundary-28vo24gtc-hashicorp.vercel.app/boundary/docs/concepts/transparent-sessions)
- [Configure transparent sessions](https://boundary-28vo24gtc-hashicorp.vercel.app/boundary/docs/configuration/target-aliases/transparent-sessions)
- [Install Boundary clients](https://boundary-28vo24gtc-hashicorp.vercel.app/boundary/docs/install-boundary/install-clients)