### PR TITLE
dependabot: add go modules, groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,245 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: "daily"
+      # Check for updates to GitHub Actions every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all GitHub Actions updates into a single PR
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/api"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/sdk"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/plugins/kms/mains/ocikms"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/plugins/kms/mains/awskms/"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/plugins/kms/mains/azurekeyvault/"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/plugins/kms/mains/transit/"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/plugins/kms/mains/gcpkms/"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/plugins/kms/mains/alicloudkms/"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/plugins/boundary/mains/gcp"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/plugins/boundary/mains/azure"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/plugins/boundary/mains/aws"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "gomod"
+    directory: "/plugins/boundary/mains/minio"
+    schedule:
+      # Check for updates to Go modules every Sunday
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # Group all Go module updates into one PR for version updates
+      # and one for security updates.
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"


### PR DESCRIPTION
Trying to decipher https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference and https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates to let us group dependabot PRs into three groups:

1. Github Actions updates
1. Go version updates
1. Go security updates

No real way to test this other than merging it and checking for new PRs on Sunday 🤷🏻 . I'll open similar PRs for other repos if this one works.
