### PR TITLE
feat: grantsForUser for recursive Project resources

### DIFF
--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -580,7 +580,7 @@ const (
            canonical_grant;
     `
 
-	grantsForUserProjectResourcesGlobalScopeQuery = resourceRoleGrantsForUsers + `,
+	grantsForUserProjectResourcesGlobalScopeRecursiveQuery = resourceRoleGrantsForUsers + `,
     global_roles_with_descendant_grant_scopes as (
       select iam_role_global.public_id         as role_id,
              iam_role_global.scope_id          as role_scope_id,
@@ -689,7 +689,7 @@ const (
            canonical_grant;
     `
 
-	grantsForUserProjectResourcesOrgScopeQuery = resourceRoleGrantsForUsers + `,
+	grantsForUserProjectResourcesOrgScopeRecursiveQuery = resourceRoleGrantsForUsers + `,
     org_roles_with_children_grant_scopes as (
       select iam_role_org.public_id            as role_id,
              iam_role_org.scope_id             as role_scope_id,

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -580,6 +580,115 @@ const (
            canonical_grant;
     `
 
+	grantsForUserProjectResourcesGlobalScopeQuery = resourceRoleGrantsForUsers + `,
+    global_roles_with_descendant_grant_scopes as (
+      select iam_role_global.public_id         as role_id,
+             iam_role_global.scope_id          as role_scope_id,
+             'global'                          as role_parent_scope_id,
+             iam_role_global.grant_scope       as grant_scope,
+             roles_with_grants.canonical_grant as canonical_grant
+        from iam_role_global
+        join roles_with_grants
+          on roles_with_grants.role_id = iam_role_global.public_id
+       where iam_role_global.grant_scope = 'descendants'
+    ),
+    global_roles_with_individual_grant_scopes as (
+      select iam_role_global.public_id         as role_id,
+             iam_role_global.scope_id          as role_scope_id,
+             'global'                          as role_parent_scope_id,
+             individual.scope_id               as grant_scope,
+             roles_with_grants.canonical_grant as canonical_grant
+        from iam_role_global
+        join roles_with_grants
+          on roles_with_grants.role_id = iam_role_global.public_id
+        join iam_role_global_individual_project_grant_scope individual
+          on individual.role_id = iam_role_global.public_id
+    ),
+    org_roles_with_children_grant_scopes as (
+      select iam_role_org.public_id            as role_id,
+             iam_role_org.scope_id             as role_scope_id,
+             'global'                          as role_parent_scope_id,
+             iam_role_org.grant_scope          as grant_scope,
+             roles_with_grants.canonical_grant as canonical_grant
+        from iam_role_org
+        join roles_with_grants
+          on roles_with_grants.role_id = iam_role_org.public_id
+       where iam_role_org.grant_scope = 'children'
+    ),
+    org_roles_with_individual_grant_scopes as (
+      select iam_role_org.public_id            as role_id,
+             iam_role_org.scope_id             as role_scope_id,
+             'global'                          as role_parent_scope_id,
+             individual.scope_id               as grant_scope,
+             roles_with_grants.canonical_grant as canonical_grant
+        from iam_role_org
+        join roles_with_grants
+          on roles_with_grants.role_id = iam_role_org.public_id
+        join iam_role_org_individual_grant_scope individual
+          on individual.role_id = iam_role_org.public_id
+    ),
+    project_roles_this_grant_scope as (
+      select iam_role_project.public_id        as role_id,
+             iam_role_project.scope_id         as role_scope_id,
+             iam_scope_project.parent_id       as role_parent_scope_id,
+             iam_role_project.scope_id         as grant_scope,
+             roles_with_grants.canonical_grant as canonical_grant
+        from iam_role_project
+        join roles_with_grants
+          on roles_with_grants.role_id = iam_role_project.public_id
+        join iam_scope_project
+          on iam_scope_project.scope_id = iam_role_project.scope_id
+       where iam_role_project.grant_this_role_scope
+    ),
+    all_roles as (
+      select role_id,
+             role_scope_id,
+             role_parent_scope_id,
+             grant_scope,
+             canonical_grant
+        from global_roles_with_descendant_grant_scopes
+       union
+      select role_id,
+             role_scope_id,
+             role_parent_scope_id,
+             grant_scope,
+             canonical_grant
+        from global_roles_with_individual_grant_scopes
+       union
+      select role_id,
+             role_scope_id,
+             role_parent_scope_id,
+             grant_scope,
+             canonical_grant
+        from org_roles_with_children_grant_scopes
+       union
+      select role_id,
+             role_scope_id,
+             role_parent_scope_id,
+             grant_scope,
+             canonical_grant
+        from org_roles_with_individual_grant_scopes
+       union
+      select role_id,
+             role_scope_id,
+             role_parent_scope_id,
+             grant_scope,
+             canonical_grant
+        from project_roles_this_grant_scope
+    )
+    select role_id,
+           role_scope_id,
+           role_parent_scope_id,
+           grant_scope,
+           canonical_grant as grant
+      from all_roles
+  group by role_id,
+           role_scope_id,
+           role_parent_scope_id,
+           grant_scope,
+           canonical_grant;
+    `
+
 	estimateCountRoles = `
 		select reltuples::bigint as estimate from pg_class where oid in ('iam_role'::regclass)
 	`

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -810,9 +810,9 @@ func (r *Repository) grantsForUserProjectResourcesRecursiveScopes(
 	)
 	switch {
 	case reqScopeId == globals.GlobalPrefix:
-		query = grantsForUserProjectResourcesGlobalScopeQuery
+		query = grantsForUserProjectResourcesGlobalScopeRecursiveQuery
 	case strings.HasPrefix(reqScopeId, globals.OrgPrefix):
-		query = grantsForUserProjectResourcesOrgScopeQuery
+		query = grantsForUserProjectResourcesOrgScopeRecursiveQuery
 		args = append(args, sql.Named("request_scope_id", reqScopeId))
 	case strings.HasPrefix(reqScopeId, globals.ProjectPrefix):
 		// Can't recursely list any further at project scope

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -2954,318 +2954,646 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	testcases := []struct {
+	type testcase struct {
 		name     string
 		input    testInput
 		output   []perms.GrantTuple
 		errorMsg string
-	}{
-		{
-			name: "return grants for target resource at proj1a request scope",
-			input: testInput{
-				userId:     user.PublicId,
-				reqScopeId: proj1a.PublicId,
-				resource:   resource.Target,
-			},
-			output: []perms.GrantTuple{
-				{
-					RoleId:            globalRoleDescendants.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      globals.GrantScopeDescendants,
-					Grant:             "ids=*;type=*;actions=read",
-				},
-				{
-					RoleId:            globalRoleThisAndProj1a.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      proj1a.PublicId,
-					Grant:             "ids=*;type=target;actions=set-credential-sources",
-				},
-			},
-		},
-		{
-			name: "return grants for target resource at proj1b request scope",
-			input: testInput{
-				userId:     user.PublicId,
-				reqScopeId: proj1b.PublicId,
-				resource:   resource.Target,
-			},
-			output: []perms.GrantTuple{
-				{
-					RoleId:            globalRoleDescendants.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      globals.GrantScopeDescendants,
-					Grant:             "ids=*;type=*;actions=read",
-				},
-				{
-					RoleId:            org1RoleProj1b.PublicId,
-					RoleScopeId:       org1.PublicId,
-					RoleParentScopeId: "global",
-					GrantScopeId:      proj1b.PublicId,
-					Grant:             "ids=*;type=target;actions=list-resolvable-aliases",
-				},
-				{
-					RoleId:            proj1bRoleThis.PublicId,
-					RoleScopeId:       proj1b.PublicId,
-					RoleParentScopeId: org1.PublicId,
-					GrantScopeId:      proj1b.PublicId,
-					Grant:             "ids=*;type=*;actions=*",
-				},
-			},
-		},
-		{
-			name: "return grants for target resource at proj2 request scope",
-			input: testInput{
-				userId:     user.PublicId,
-				reqScopeId: proj2.PublicId,
-				resource:   resource.Target,
-			},
-			output: []perms.GrantTuple{
-				{
-					RoleId:            globalRoleDescendants.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      globals.GrantScopeDescendants,
-					Grant:             "ids=*;type=*;actions=read",
-				},
-				{
-					RoleId:            globalRoleProj2.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      proj2.PublicId,
-					Grant:             "ids=*;type=target;actions=create,update",
-				},
-				{
-					RoleId:            proj2RoleThis.PublicId,
-					RoleScopeId:       proj2.PublicId,
-					RoleParentScopeId: org2.PublicId,
-					GrantScopeId:      proj2.PublicId,
-					Grant:             "ids=*;type=target;actions=add-host-sources,remove-host-sources",
-				},
-			},
-		},
-		{
-			name: "return grants for scope resource at proj1a request scope",
-			input: testInput{
-				userId:     user.PublicId,
-				reqScopeId: proj1a.PublicId,
-				resource:   resource.Scope,
-			},
-			output: []perms.GrantTuple{
-				{
-					RoleId:            globalRoleDescendants.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      globals.GrantScopeDescendants,
-					Grant:             "ids=*;type=*;actions=read",
-				},
-			},
-		},
-		{
-			name: "return grants for scope resource at proj1b request scope",
-			input: testInput{
-				userId:     user.PublicId,
-				reqScopeId: proj1b.PublicId,
-				resource:   resource.Scope,
-			},
-			output: []perms.GrantTuple{
-				{
-					RoleId:            globalRoleDescendants.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      globals.GrantScopeDescendants,
-					Grant:             "ids=*;type=*;actions=read",
-				},
-				{
-					RoleId:            org1RoleProj1b.PublicId,
-					RoleScopeId:       org1.PublicId,
-					RoleParentScopeId: "global",
-					GrantScopeId:      proj1b.PublicId,
-					Grant:             "ids=*;type=scope;actions=list,no-op",
-				},
-				{
-					RoleId:            proj1bRoleThis.PublicId,
-					RoleScopeId:       proj1b.PublicId,
-					RoleParentScopeId: org1.PublicId,
-					GrantScopeId:      proj1b.PublicId,
-					Grant:             "ids=*;type=*;actions=*",
-				},
-			},
-		},
-		{
-			name: "return grants for scope resource at proj2 request scope",
-			input: testInput{
-				userId:     user.PublicId,
-				reqScopeId: proj2.PublicId,
-				resource:   resource.Scope,
-			},
-			output: []perms.GrantTuple{
-				{
-					RoleId:            globalRoleDescendants.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      globals.GrantScopeDescendants,
-					Grant:             "ids=*;type=*;actions=read",
-				},
-				{
-					RoleId:            globalRoleProj2.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      proj2.PublicId,
-					Grant:             "ids=*;type=scope;actions=list,read",
-				},
-				{
-					RoleId:            org2RoleThisAndChildren.PublicId,
-					RoleScopeId:       org2.PublicId,
-					RoleParentScopeId: "global",
-					GrantScopeId:      globals.GrantScopeChildren,
-					Grant:             "ids=*;type=scope;actions=list-keys,read",
-				},
-				{
-					RoleId:            proj2RoleThis.PublicId,
-					RoleScopeId:       proj2.PublicId,
-					RoleParentScopeId: org2.PublicId,
-					GrantScopeId:      proj2.PublicId,
-					Grant:             "ids=*;type=scope;actions=attach-storage-policy,detach-storage-policy",
-				},
-			},
-		},
-		{
-			name: "return '*' and 'unknown' grants when no resource specified at proj1a request scope",
-			input: testInput{
-				userId:     user.PublicId,
-				reqScopeId: proj1a.PublicId,
-			},
-			output: []perms.GrantTuple{
-				{
-					RoleId:            globalRoleDescendants.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      globals.GrantScopeDescendants,
-					Grant:             "ids=*;type=*;actions=read",
-				},
-			},
-		},
-		{
-			name: "return '*' and 'unknown' grants when no resource specified at proj1b request scope",
-			input: testInput{
-				userId:     user.PublicId,
-				reqScopeId: proj1b.PublicId,
-			},
-			output: []perms.GrantTuple{
-				{
-					RoleId:            globalRoleDescendants.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      globals.GrantScopeDescendants,
-					Grant:             "ids=*;type=*;actions=read",
-				},
-				{
-					RoleId:            proj1bRoleThis.PublicId,
-					RoleScopeId:       proj1b.PublicId,
-					RoleParentScopeId: org1.PublicId,
-					GrantScopeId:      proj1b.PublicId,
-					Grant:             "ids=*;type=*;actions=*",
-				},
-			},
-		},
-		{
-			name: "return '*' and 'unknown' grants when no resource specified at proj2 request scope",
-			input: testInput{
-				userId:     user.PublicId,
-				reqScopeId: proj2.PublicId,
-			},
-			output: []perms.GrantTuple{
-				{
-					RoleId:            globalRoleDescendants.PublicId,
-					RoleScopeId:       "global",
-					RoleParentScopeId: "global",
-					GrantScopeId:      globals.GrantScopeDescendants,
-					Grant:             "ids=*;type=*;actions=read",
-				},
-			},
-		},
-		{
-			name: "u_anon should return no grants at proj1a request scope",
-			input: testInput{
-				userId:     globals.AnonymousUserId,
-				reqScopeId: proj1a.PublicId,
-			},
-			output: []perms.GrantTuple{},
-		},
-		{
-			name: "u_anon should return no grants at proj1b request scope",
-			input: testInput{
-				userId:     globals.AnonymousUserId,
-				reqScopeId: proj1b.PublicId,
-			},
-			output: []perms.GrantTuple{},
-		},
-		{
-			name: "u_anon should return no grants at proj2 request scope",
-			input: testInput{
-				userId:     globals.AnonymousUserId,
-				reqScopeId: proj2.PublicId,
-			},
-			output: []perms.GrantTuple{},
-		},
-		{
-			name: "u_auth should return no grants at proj1a request scope",
-			input: testInput{
-				userId:     globals.AnyAuthenticatedUserId,
-				reqScopeId: proj1a.PublicId,
-			},
-			output: []perms.GrantTuple{},
-		},
-		{
-			name: "u_auth should return no grants at proj1b request scope",
-			input: testInput{
-				userId:     globals.AnyAuthenticatedUserId,
-				reqScopeId: proj1b.PublicId,
-			},
-			output: []perms.GrantTuple{},
-		},
-		{
-			name: "u_auth should return no grants at proj2 request scope",
-			input: testInput{
-				userId:     globals.AnyAuthenticatedUserId,
-				reqScopeId: proj2.PublicId,
-			},
-			output: []perms.GrantTuple{},
-		},
-		{
-			name: "missing user id should return error",
-			input: testInput{
-				resource:   resource.Target,
-				reqScopeId: proj2.PublicId,
-			},
-			errorMsg: "missing user id",
-		},
-		{
-			name: "missing scope id should return error",
-			input: testInput{
-				userId:     user.PublicId,
-				reqScopeId: "",
-				resource:   resource.Target,
-			},
-			errorMsg: "missing request scope id",
-		},
 	}
 
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := repo.grantsForUserProjectResources(ctx, tc.input.userId, tc.input.reqScopeId, tc.input.resource)
-			if tc.errorMsg != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.errorMsg)
-				return
-			}
-			require.NoError(t, err)
-			assert.ElementsMatch(t, got, tc.output)
-		})
-	}
+	t.Run("Non-recursive request scopes", func(t *testing.T) {
+
+		testcases := append([]testcase{},
+			testcase{
+				name: "return grants for target resource at proj1a request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: proj1a.PublicId,
+					resource:   resource.Target,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+					{
+						RoleId:            globalRoleThisAndProj1a.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj1a.PublicId,
+						Grant:             "ids=*;type=target;actions=set-credential-sources",
+					},
+				},
+			},
+			testcase{
+				name: "return grants for target resource at proj1b request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: proj1b.PublicId,
+					resource:   resource.Target,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+					{
+						RoleId:            org1RoleProj1b.PublicId,
+						RoleScopeId:       org1.PublicId,
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=target;actions=list-resolvable-aliases",
+					},
+					{
+						RoleId:            proj1bRoleThis.PublicId,
+						RoleScopeId:       proj1b.PublicId,
+						RoleParentScopeId: org1.PublicId,
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=*;actions=*",
+					},
+				},
+			},
+			testcase{
+				name: "return grants for target resource at proj2 request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: proj2.PublicId,
+					resource:   resource.Target,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=target;actions=create,update",
+					},
+					{
+						RoleId:            proj2RoleThis.PublicId,
+						RoleScopeId:       proj2.PublicId,
+						RoleParentScopeId: org2.PublicId,
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=target;actions=add-host-sources,remove-host-sources",
+					},
+				},
+			},
+			testcase{
+				name: "return grants for scope resource at proj1a request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: proj1a.PublicId,
+					resource:   resource.Scope,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+				},
+			},
+			testcase{
+				name: "return grants for scope resource at proj1b request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: proj1b.PublicId,
+					resource:   resource.Scope,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+					{
+						RoleId:            org1RoleProj1b.PublicId,
+						RoleScopeId:       org1.PublicId,
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=scope;actions=list,no-op",
+					},
+					{
+						RoleId:            proj1bRoleThis.PublicId,
+						RoleScopeId:       proj1b.PublicId,
+						RoleParentScopeId: org1.PublicId,
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=*;actions=*",
+					},
+				},
+			},
+			testcase{
+				name: "return grants for scope resource at proj2 request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: proj2.PublicId,
+					resource:   resource.Scope,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=list,read",
+					},
+					{
+						RoleId:            org2RoleThisAndChildren.PublicId,
+						RoleScopeId:       org2.PublicId,
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeChildren,
+						Grant:             "ids=*;type=scope;actions=list-keys,read",
+					},
+					{
+						RoleId:            proj2RoleThis.PublicId,
+						RoleScopeId:       proj2.PublicId,
+						RoleParentScopeId: org2.PublicId,
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=attach-storage-policy,detach-storage-policy",
+					},
+				},
+			},
+			testcase{
+				name: "return '*' and 'unknown' grants when no resource specified at proj1a request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: proj1a.PublicId,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+				},
+			},
+			testcase{
+				name: "return '*' and 'unknown' grants when no resource specified at proj1b request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: proj1b.PublicId,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+					{
+						RoleId:            proj1bRoleThis.PublicId,
+						RoleScopeId:       proj1b.PublicId,
+						RoleParentScopeId: org1.PublicId,
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=*;actions=*",
+					},
+				},
+			},
+			testcase{
+				name: "return '*' and 'unknown' grants when no resource specified at proj2 request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: proj2.PublicId,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+				},
+			},
+			testcase{
+				name: "u_anon should return no grants at proj1a request scope",
+				input: testInput{
+					userId:     globals.AnonymousUserId,
+					reqScopeId: proj1a.PublicId,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "u_anon should return no grants at proj1b request scope",
+				input: testInput{
+					userId:     globals.AnonymousUserId,
+					reqScopeId: proj1b.PublicId,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "u_anon should return no grants at proj2 request scope",
+				input: testInput{
+					userId:     globals.AnonymousUserId,
+					reqScopeId: proj2.PublicId,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "u_auth should return no grants at proj1a request scope",
+				input: testInput{
+					userId:     globals.AnyAuthenticatedUserId,
+					reqScopeId: proj1a.PublicId,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "u_auth should return no grants at proj1b request scope",
+				input: testInput{
+					userId:     globals.AnyAuthenticatedUserId,
+					reqScopeId: proj1b.PublicId,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "u_auth should return no grants at proj2 request scope",
+				input: testInput{
+					userId:     globals.AnyAuthenticatedUserId,
+					reqScopeId: proj2.PublicId,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "missing user id should return error",
+				input: testInput{
+					resource:   resource.Target,
+					reqScopeId: proj2.PublicId,
+				},
+				errorMsg: "missing user id",
+			},
+			testcase{
+				name: "missing scope id should return error",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: "",
+					resource:   resource.Target,
+				},
+				errorMsg: "missing request scope id",
+			},
+		)
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := repo.grantsForUserProjectResources(ctx, tc.input.userId, tc.input.reqScopeId, tc.input.resource)
+				if tc.errorMsg != "" {
+					require.Error(t, err)
+					assert.Contains(t, err.Error(), tc.errorMsg)
+					return
+				}
+				require.NoError(t, err)
+				assert.ElementsMatch(t, got, tc.output)
+			})
+		}
+	})
+
+	t.Run("Recursive request scopes", func(t *testing.T) {
+		testcases := append([]testcase{},
+			testcase{
+				name: "return grants for target resource at global request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: globals.GlobalPrefix,
+					resource:   resource.Target,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+					{
+						RoleId:            globalRoleThisAndProj1a.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj1a.PublicId,
+						Grant:             "ids=*;type=target;actions=set-credential-sources",
+					},
+					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=target;actions=create,update",
+					},
+					{
+						RoleId:            org1RoleProj1b.PublicId,
+						RoleScopeId:       org1.PublicId,
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=target;actions=list-resolvable-aliases",
+					},
+					{
+						RoleId:            proj1bRoleThis.PublicId,
+						RoleScopeId:       proj1b.PublicId,
+						RoleParentScopeId: org1.PublicId,
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=*;actions=*",
+					},
+					{
+						RoleId:            proj2RoleThis.PublicId,
+						RoleScopeId:       proj2.PublicId,
+						RoleParentScopeId: org2.PublicId,
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=target;actions=add-host-sources,remove-host-sources",
+					},
+				},
+			},
+			testcase{
+				name: "return grants for target resource at org1 request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: org1.PublicId,
+					resource:   resource.Target,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            org1RoleProj1b.PublicId,
+						RoleScopeId:       org1.PublicId,
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=target;actions=list-resolvable-aliases",
+					},
+					{
+						RoleId:            proj1bRoleThis.PublicId,
+						RoleScopeId:       proj1b.PublicId,
+						RoleParentScopeId: org1.PublicId,
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=*;actions=*",
+					},
+				},
+			},
+			testcase{
+				name: "return grants for target resource at org2 request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: org2.PublicId,
+					resource:   resource.Target,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            proj2RoleThis.PublicId,
+						RoleScopeId:       proj2.PublicId,
+						RoleParentScopeId: org2.PublicId,
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=target;actions=add-host-sources,remove-host-sources",
+					},
+				},
+			},
+			testcase{
+				name: "return grants for scope resource at global request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: globals.GlobalPrefix,
+					resource:   resource.Scope,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=list,read",
+					},
+					{
+						RoleId:            org1RoleProj1b.PublicId,
+						RoleScopeId:       org1.PublicId,
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=scope;actions=list,no-op",
+					},
+					{
+						RoleId:            org2RoleThisAndChildren.PublicId,
+						RoleScopeId:       org2.PublicId,
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeChildren,
+						Grant:             "ids=*;type=scope;actions=list-keys,read",
+					},
+					{
+						RoleId:            proj1bRoleThis.PublicId,
+						RoleScopeId:       proj1b.PublicId,
+						RoleParentScopeId: org1.PublicId,
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=*;actions=*",
+					},
+					{
+						RoleId:            proj2RoleThis.PublicId,
+						RoleScopeId:       proj2.PublicId,
+						RoleParentScopeId: org2.PublicId,
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=attach-storage-policy,detach-storage-policy",
+					},
+				},
+			},
+			testcase{
+				name: "return grants for scope resource at org1 request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: org1.PublicId,
+					resource:   resource.Scope,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            org1RoleProj1b.PublicId,
+						RoleScopeId:       org1.PublicId,
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=scope;actions=list,no-op",
+					},
+					{
+						RoleId:            proj1bRoleThis.PublicId,
+						RoleScopeId:       proj1b.PublicId,
+						RoleParentScopeId: org1.PublicId,
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=*;actions=*",
+					},
+				},
+			},
+			testcase{
+				name: "return grants for scope resource at org2 request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: org2.PublicId,
+					resource:   resource.Scope,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            org2RoleThisAndChildren.PublicId,
+						RoleScopeId:       org2.PublicId,
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeChildren,
+						Grant:             "ids=*;type=scope;actions=list-keys,read",
+					},
+					{
+						RoleId:            proj2RoleThis.PublicId,
+						RoleScopeId:       proj2.PublicId,
+						RoleParentScopeId: org2.PublicId,
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=attach-storage-policy,detach-storage-policy",
+					},
+				},
+			},
+			testcase{
+				name: "return '*' and 'unknown' grants when no resource specified at global request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: globals.GlobalPrefix,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            globalRoleDescendants.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      globals.GrantScopeDescendants,
+						Grant:             "ids=*;type=*;actions=read",
+					},
+					{
+						RoleId:            proj1bRoleThis.PublicId,
+						RoleScopeId:       proj1b.PublicId,
+						RoleParentScopeId: org1.PublicId,
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=*;actions=*",
+					},
+				},
+			},
+			testcase{
+				name: "return '*' and 'unknown' grants when no resource specified at org1 request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: org1.PublicId,
+				},
+				output: []perms.GrantTuple{
+					{
+						RoleId:            proj1bRoleThis.PublicId,
+						RoleScopeId:       proj1b.PublicId,
+						RoleParentScopeId: org1.PublicId,
+						GrantScopeId:      proj1b.PublicId,
+						Grant:             "ids=*;type=*;actions=*",
+					},
+				},
+			},
+			testcase{
+				name: "return '*' and 'unknown' grants when no resource specified at org2 request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: org2.PublicId,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "u_anon should return no grants at global request scope",
+				input: testInput{
+					userId:     globals.AnonymousUserId,
+					reqScopeId: globals.GlobalPrefix,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "u_anon should return no grants at org1 request scope",
+				input: testInput{
+					userId:     globals.AnonymousUserId,
+					reqScopeId: org1.PublicId,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "u_anon should return no grants at org2 request scope",
+				input: testInput{
+					userId:     globals.AnonymousUserId,
+					reqScopeId: org2.PublicId,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "u_auth should return no grants at global request scope",
+				input: testInput{
+					userId:     globals.AnyAuthenticatedUserId,
+					reqScopeId: globals.GlobalPrefix,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "u_auth should return no grants at org1 request scope",
+				input: testInput{
+					userId:     globals.AnyAuthenticatedUserId,
+					reqScopeId: org1.PublicId,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "u_auth should return no grants at org2 request scope",
+				input: testInput{
+					userId:     globals.AnyAuthenticatedUserId,
+					reqScopeId: org2.PublicId,
+				},
+				output: []perms.GrantTuple{},
+			},
+			testcase{
+				name: "missing user id should return error",
+				input: testInput{
+					resource:   resource.Target,
+					reqScopeId: proj2.PublicId,
+				},
+				errorMsg: "missing user id",
+			},
+			testcase{
+				name: "missing scope id should return error",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: "",
+					resource:   resource.Target,
+				},
+				errorMsg: "missing request scope id",
+			},
+		)
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := repo.grantsForUserProjectResourcesRecursiveScopes(ctx, tc.input.userId, tc.input.reqScopeId, tc.input.resource)
+				if tc.errorMsg != "" {
+					require.Error(t, err)
+					assert.Contains(t, err.Error(), tc.errorMsg)
+					return
+				}
+				require.NoError(t, err)
+				assert.ElementsMatch(t, got, tc.output)
+			})
+		}
+	})
 }
 
 func TestGrantsForUserGlobalAndOrgResources(t *testing.T) {
@@ -3300,7 +3628,6 @@ func TestGrantsForUserGlobalAndOrgResources(t *testing.T) {
 	org2RoleThisAndChildren := TestRole(t, conn, org2Scope.PublicId, WithGrantScopeIds([]string{globals.GrantScopeThis, globals.GrantScopeChildren}))
 	roles = append(roles, org1RoleThis, org1RoleChildren, org2RoleThisAndChildren)
 
-	// TestRoleGrant(t, conn, org1RoleThis.PublicId, "ids=ampw_12345;type=auth-method;actions=read")
 	TestRoleGrant(t, conn, org1RoleThis.PublicId, "ids=ampw_12345;actions=read")
 	TestRoleGrant(t, conn, org1RoleChildren.PublicId, "ids=*;type=account;actions=change-password")
 	TestRoleGrant(t, conn, org2RoleThisAndChildren.PublicId, "ids=*;type=account;actions=delete")

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -2945,7 +2945,7 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 	roles = append(roles, proj1bRoleThis, proj2RoleThis)
 
 	TestRoleGrant(t, conn, proj1bRoleThis.PublicId, "ids=*;type=*;actions=*")
-	TestRoleGrant(t, conn, proj2RoleThis.PublicId, "ids=*;type=target;actions=add-host-sources,remove-host-sources")
+	TestRoleGrant(t, conn, proj2RoleThis.PublicId, "ids=tssh_12345;actions=add-host-sources,remove-host-sources")
 	TestRoleGrant(t, conn, proj2RoleThis.PublicId, "ids=*;type=scope;actions=attach-storage-policy,detach-storage-policy")
 
 	// Add users to created roles
@@ -3046,7 +3046,7 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 						RoleScopeId:       proj2.PublicId,
 						RoleParentScopeId: org2.PublicId,
 						GrantScopeId:      proj2.PublicId,
-						Grant:             "ids=*;type=target;actions=add-host-sources,remove-host-sources",
+						Grant:             "ids=tssh_12345;actions=add-host-sources,remove-host-sources",
 					},
 				},
 			},
@@ -3134,6 +3134,13 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 						GrantScopeId:      proj2.PublicId,
 						Grant:             "ids=*;type=scope;actions=attach-storage-policy,detach-storage-policy",
 					},
+					{
+						RoleId:            proj2RoleThis.PublicId,
+						RoleScopeId:       proj2.PublicId,
+						RoleParentScopeId: org2.PublicId,
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=tssh_12345;actions=add-host-sources,remove-host-sources",
+					},
 				},
 			},
 			testcase{
@@ -3188,6 +3195,13 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 						RoleParentScopeId: "global",
 						GrantScopeId:      globals.GrantScopeDescendants,
 						Grant:             "ids=*;type=*;actions=read",
+					},
+					{
+						RoleId:            proj2RoleThis.PublicId,
+						RoleScopeId:       proj2.PublicId,
+						RoleParentScopeId: org2.PublicId,
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=tssh_12345;actions=add-host-sources,remove-host-sources",
 					},
 				},
 			},
@@ -3322,7 +3336,7 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 						RoleScopeId:       proj2.PublicId,
 						RoleParentScopeId: org2.PublicId,
 						GrantScopeId:      proj2.PublicId,
-						Grant:             "ids=*;type=target;actions=add-host-sources,remove-host-sources",
+						Grant:             "ids=tssh_12345;actions=add-host-sources,remove-host-sources",
 					},
 				},
 			},
@@ -3363,7 +3377,7 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 						RoleScopeId:       proj2.PublicId,
 						RoleParentScopeId: org2.PublicId,
 						GrantScopeId:      proj2.PublicId,
-						Grant:             "ids=*;type=target;actions=add-host-sources,remove-host-sources",
+						Grant:             "ids=tssh_12345;actions=add-host-sources,remove-host-sources",
 					},
 				},
 			},
@@ -3417,6 +3431,13 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 						GrantScopeId:      proj2.PublicId,
 						Grant:             "ids=*;type=scope;actions=attach-storage-policy,detach-storage-policy",
 					},
+					{
+						RoleId:            proj2RoleThis.PublicId,
+						RoleScopeId:       proj2.PublicId,
+						RoleParentScopeId: org2.PublicId,
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=tssh_12345;actions=add-host-sources,remove-host-sources",
+					},
 				},
 			},
 			testcase{
@@ -3465,60 +3486,39 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 						GrantScopeId:      proj2.PublicId,
 						Grant:             "ids=*;type=scope;actions=attach-storage-policy,detach-storage-policy",
 					},
+					{
+						RoleId:            proj2RoleThis.PublicId,
+						RoleScopeId:       proj2.PublicId,
+						RoleParentScopeId: org2.PublicId,
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=tssh_12345;actions=add-host-sources,remove-host-sources",
+					},
 				},
 			},
 			testcase{
-				name: "return '*' and 'unknown' grants when no resource specified at global request scope",
+				name: "unknown resource type should return error",
 				input: testInput{
 					userId:     user.PublicId,
 					reqScopeId: globals.GlobalPrefix,
+					resource:   resource.Unknown,
 				},
-				output: []perms.GrantTuple{
-					{
-						RoleId:            globalRoleDescendants.PublicId,
-						RoleScopeId:       "global",
-						RoleParentScopeId: "global",
-						GrantScopeId:      globals.GrantScopeDescendants,
-						Grant:             "ids=*;type=*;actions=read",
-					},
-					{
-						RoleId:            proj1bRoleThis.PublicId,
-						RoleScopeId:       proj1b.PublicId,
-						RoleParentScopeId: org1.PublicId,
-						GrantScopeId:      proj1b.PublicId,
-						Grant:             "ids=*;type=*;actions=*",
-					},
-				},
+				errorMsg: "a specific resource type must be specified",
 			},
 			testcase{
-				name: "return '*' and 'unknown' grants when no resource specified at org1 request scope",
+				name: "'*' resource type should return error",
 				input: testInput{
 					userId:     user.PublicId,
-					reqScopeId: org1.PublicId,
+					reqScopeId: globals.GlobalPrefix,
+					resource:   resource.All,
 				},
-				output: []perms.GrantTuple{
-					{
-						RoleId:            proj1bRoleThis.PublicId,
-						RoleScopeId:       proj1b.PublicId,
-						RoleParentScopeId: org1.PublicId,
-						GrantScopeId:      proj1b.PublicId,
-						Grant:             "ids=*;type=*;actions=*",
-					},
-				},
-			},
-			testcase{
-				name: "return '*' and 'unknown' grants when no resource specified at org2 request scope",
-				input: testInput{
-					userId:     user.PublicId,
-					reqScopeId: org2.PublicId,
-				},
-				output: []perms.GrantTuple{},
+				errorMsg: "a specific resource type must be specified",
 			},
 			testcase{
 				name: "u_anon should return no grants at global request scope",
 				input: testInput{
 					userId:     globals.AnonymousUserId,
 					reqScopeId: globals.GlobalPrefix,
+					resource:   resource.Target,
 				},
 				output: []perms.GrantTuple{},
 			},
@@ -3527,6 +3527,7 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 				input: testInput{
 					userId:     globals.AnonymousUserId,
 					reqScopeId: org1.PublicId,
+					resource:   resource.Target,
 				},
 				output: []perms.GrantTuple{},
 			},
@@ -3535,6 +3536,7 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 				input: testInput{
 					userId:     globals.AnonymousUserId,
 					reqScopeId: org2.PublicId,
+					resource:   resource.Target,
 				},
 				output: []perms.GrantTuple{},
 			},
@@ -3543,6 +3545,7 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 				input: testInput{
 					userId:     globals.AnyAuthenticatedUserId,
 					reqScopeId: globals.GlobalPrefix,
+					resource:   resource.Target,
 				},
 				output: []perms.GrantTuple{},
 			},
@@ -3551,6 +3554,7 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 				input: testInput{
 					userId:     globals.AnyAuthenticatedUserId,
 					reqScopeId: org1.PublicId,
+					resource:   resource.Target,
 				},
 				output: []perms.GrantTuple{},
 			},
@@ -3559,6 +3563,7 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 				input: testInput{
 					userId:     globals.AnyAuthenticatedUserId,
 					reqScopeId: org2.PublicId,
+					resource:   resource.Target,
 				},
 				output: []perms.GrantTuple{},
 			},
@@ -3578,6 +3583,24 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 					resource:   resource.Target,
 				},
 				errorMsg: "missing request scope id",
+			},
+			testcase{
+				name: "return error when trying to recursively list grants at an unknown request scope",
+				input: testInput{
+					userId:     user.PublicId,
+					reqScopeId: scope.Unknown.String(),
+					resource:   resource.Target,
+				},
+				errorMsg: "request scope must be global scope, an org scope, or a project scope",
+			},
+			testcase{
+				name: "return no grants for a resource that has no permissions granted for it",
+				input: testInput{
+					userId:     globals.AnonymousUserId,
+					reqScopeId: globals.GlobalPrefix,
+					resource:   resource.Session,
+				},
+				output: []perms.GrantTuple{},
 			},
 		)
 


### PR DESCRIPTION
Add query to fetch grants for a user for resources that can be project scoped when the request scope is _not_ a project.

- When `request_scope='global'`, retrieve grant scopes on _all_ projects
- When `request_scope='o_XXXXX'`, retrieve grant scopes on all projects under the specified org