### PR TITLE
docs: Document HTTPS naming convention for aliases (#5787)

### DIFF
--- a/website/content/docs/concepts/aliases.mdx
+++ b/website/content/docs/concepts/aliases.mdx
@@ -55,6 +55,13 @@ For this reason, if you expect any Windows users to use an alias, it should cont
 
 Refer to the [transparent sessions](/boundary/docs/concepts/transparent-sessions) documentation for more information.
 
+### HTTPS websites
+
+If you create an alias for a website that uses HTTPS, the alias must match the website's hostname.
+You may receive connection errors if the alias does not match the website's hostname exactly.
+
+For example, if you want to create an alias to connect to https://www.hashicorp.com, you must name the alias `www.hashicorp.com`.
+
 ## Scopes
 
 You can only create aliases in the `global` scope. However, you can associate aliases with targets or hosts from any scope. Support for additional resource types may be added in the future.

--- a/website/content/docs/configuration/target-aliases/create-target-alias.mdx
+++ b/website/content/docs/configuration/target-aliases/create-target-alias.mdx
@@ -7,6 +7,10 @@ description: >-
 
 # Create target aliases
 
+An alias is a globally unique, DNS-like string that is associated with a destination resource. You can establish a session to a target by referencing its alias, instead of having to provide a target ID or target name and scope ID.
+
+For more information about aliases, including naming conventions and best practices, refer to [Aliases](/boundary/docs/concepts/aliases).
+
 You can create aliases and associate them with targets using the following methods:
 
 - [Create an alias for an existing target](#create-an-alias-for-an-existing-target)


### PR DESCRIPTION
The automatic backport to `stable-website` failed for PR #5787 . This PR manually cherry picks the following commits to that branch:

* docs: Document HTTPS naming convention for aliases

* docs: Punctuation fix