### PR TITLE
Remove Duplicate Error Check

### DIFF
--- a/internal/server/rewrapping.go
+++ b/internal/server/rewrapping.go
@@ -142,9 +142,6 @@ func workerAuthServerLedActivationTokenRewrapFn(ctx context.Context, dataKeyVers
 	if err != nil {
 		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to fetch kms wrapper for rewrapping"))
 	}
-	if err != nil {
-		return errors.Wrap(ctx, err, op, errors.WithMsg("failed to retrieve updated key version id"))
-	}
 	for _, token := range tokens {
 		if err := token.decrypt(ctx, wrapper); err != nil {
 			return errors.Wrap(ctx, err, op, errors.WithMsg("failed to decrypt activation token"))


### PR DESCRIPTION
# Overview
Remove duplicate `err != nil` check in the `server` package for `workerAuthServerLedActivationTokenRewrapFn` rewrapping. This check is currently unreachable due to the previous `if err != nil` check and is not tested against. 