### PR TITLE
docs: Update release notes for transparent sessions (#5784)

### DIFF
--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -32,7 +32,6 @@ Refer to the following table for known issues that may affect the public beta:
 | Connection is reset when trying to reconnect | If you use an SSH transparent session and then cancel the connection, you may have trouble reconnecting until Boundary cleans up the session. |
 | SSH connection fails with man-in-the-middle warning | On Ubuntu systems, the initial transparent session may be successful, but any subsequent connections prompt a warning that you may be experiencing a man-in-the-middle attack. |
 | Boundary Client Agent authentication does not persist across restarts | When you reboot, you are required to re-authenticate to the Client Agent before you can use transparent sessions. |
-| Windows shortcuts are mandatory | The Windows installer always installs Desktop and Start menu shortcuts. This is a known issue. Shortcuts will be optional in a future version of the installer. |
 | Windows installer prompts for restart | When you install Boundary, the Windows installer occasionally prompts you to restart your computer, however it is not necessary. |
 | Boundary Client Agent resumes on reboot | If the Client Agent is paused and the machine is rebooted, the Client Agent will be resumed after the reboot. |
 | Single-word aliases do not work on Windows | If you create an alias consisting of a single word without a dot (`.`), the alias will not work on Windows. |

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -66,6 +66,19 @@ description: >-
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    Boundary client version number realignment
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Previously, the Boundary Client Agent and installer used a numbering scheme that was inconsistent with Boundary's release numbers. This inconsistency could make it difficult to understand version support and compatibility.
+    <br /><br />
+    On May 27, 2025 new versions of the Boundary Client Agent and installer were released with a new numbering scheme that more closely follows Boundary's release numbers. Those versions were released as 0.19.5 to match the major Boundary version 0.19.x. Going forward, the Client Agent and installer will use the same major number as the current Boundary release. Any patches or updates will be reflected in the minor number.
+    <br /><br />
+    Learn more about control plane and client compatibility:&nbsp; <a href="/boundary/docs/enterprise/supported-versions">Boundary Enterprise supported versions policy </a>
+    </td>
+  </tr>
+
   </tbody>
 </table>
 
@@ -136,6 +149,24 @@ description: >-
     The Azure plugin now supports Azure Virtual Machine Scale Sets in both Flexible and Uniform orchestration modes for dynamic host catalogs. It automatically discovers any individual virtual machine instances that are part of the scale sets and adds them as hosts.
     <br /><br />
     Learn more:&nbsp;<a href="/boundary/docs/concepts/host-discovery/azure">Azure dynamic host catalogs</a>.
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      Transparent sessions
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      GA in version 0.19.2
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    The transparent sessions feature is now generally available to HCP Boundary and Boundary Enterprise users.
+    <br /><br />
+    Transparent sessions allows users to eliminate steps in their current workflows using Boundary’s Client Agent, a component that operates in the background to intercept network traffic and automatically route this traffic through a session if the user is authenticated and authorized.
+    <br /><br />
+    Platform teams and access management teams that administer Boundary can now build much faster, simpler secure remote access workflows that feel more intuitive and invisible to their developer customers.
+    <br /><br />
+    Learn more:&nbsp;<a href="/boundary/docs/concepts/transparent-sessions">Transparent sessions</a> and <a href="/boundary/docs/api-clients/client-agent">Client Agent</a>.
     </td>
   </tr>
 
@@ -329,6 +360,24 @@ description: >-
     <li><a href="/boundary/docs/comands/roles/add-grant-scopes"><code>roles add-grant-scopes</code></a> command documentation</li>
     <li><a href="/boundary/docs/commands/roles/add-grants"><code>roles add-grants</code></a> command documentation</li>
     </ul>
+    </td>
+  </tr>
+
+  <tr id="hcp-grants">
+    <td style={{verticalAlign: 'middle'}}>
+    0.18.0 - 0.19.0
+    <br /><br />
+    (Fixed in Boundary installer version 0.19.5)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Windows shortcuts are mandatory
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Previously, the Boundary installer for Windows always required you to install Desktop and Start menu shortcuts. This issue has been resolved, and you can now choose whether to install the shortcuts.
+    <br /><br />
+    Learn more: <a href="/boundary/docs/concepts/transparent-sessions">Transparent sessions</a>
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
     </td>
   </tr>
 


### PR DESCRIPTION
The `release/0.19.x` back port for #5784 failed. This PR recreates it manually.

* docs: Update release notes for transparent sessions

* Update website/content/docs/release-notes/v0_19_0.mdx

Co-authored-by: Johan Brandhorst-Satzkorn <johan.brandhorst@gmail.com>

* docs: Remove known issue and add fix

---------

Co-authored-by: Johan Brandhorst-Satzkorn <johan.brandhorst@gmail.com>