### PR TITLE
docs: Document known issue with transparent sessions

### DIFF
--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -36,6 +36,7 @@ Refer to the following table for known issues:
 | Windows installer does not support partial installations | The Windows installer fails to start the Client Agent if the Desktop client is not installed at the same time. |
 | Alias connection failures inside containers/VMs | Using transparent sessions rely on network access to the local network of the computer the Client Agent is running on. Network enclaves such as those created by Docker containers and VMs cannot reach this network. |
 | DNS lookup is broken on MacOS 15.1 and 15.2 | MacOS 15.1 and 15.2 may incorrectly block DNS lookups for the Client Agent. This issue is resolved in MacOS 15.3 and later. |
+| DNS resolution fails after switching network interfaces | If you switch network interfaces while the Client Agent is running, DNS resolution can fail and you may lose connectivity for some applications. This failure can occur when you switch from an ethernet connection to a wireless network, for example. |
 
 ## More information
 

--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -36,7 +36,7 @@ Refer to the following table for known issues:
 | Windows installer does not support partial installations | The Windows installer fails to start the Client Agent if the Desktop client is not installed at the same time. |
 | Alias connection failures inside containers/VMs | Using transparent sessions rely on network access to the local network of the computer the Client Agent is running on. Network enclaves such as those created by Docker containers and VMs cannot reach this network. |
 | DNS lookup is broken on MacOS 15.1 and 15.2 | MacOS 15.1 and 15.2 may incorrectly block DNS lookups for the Client Agent. This issue is resolved in MacOS 15.3 and later. |
-| DNS resolution fails after switching network interfaces | If you switch network interfaces while the Client Agent is running, DNS resolution can fail and you may lose connectivity for some applications. This failure can occur when you switch from an ethernet connection to a wireless network, for example. |
+| DNS resolution may fail after switching network interfaces | If you switch network interfaces while the Client Agent is running, DNS resolution can fail and you may lose connectivity for some applications. This failure can occur when you switch from an ethernet connection to a wireless network, for example. |
 
 ## More information
 


### PR DESCRIPTION
This PR adds a known issue to the transparent sessions documentation. The issue is being worked on in [ICU-15293](https://hashicorp.atlassian.net/browse/ICU-15293). There is no workaround at this time.

View the update in the preview deployment:

Transparent sessions > [Known issues](https://boundary-5t36xc6n3-hashicorp.vercel.app/boundary/docs/concepts/transparent-sessions#known-issues)

[ICU-15293]: https://hashicorp.atlassian.net/browse/ICU-15293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ