### PR TITLE
docs: Add interoperability matrix (#5478)

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -577,6 +577,8 @@ Restarting your computer may resolve the conflict.
 ## Conflicting software
 
 Some software is known to cause conflicts with the Boundary Client Agent.
+Refer to the [transparent sessions interoperability matrix](/boundary/docs/configuration/target-aliases/interoperability-matrix) for a list of the third-party products that have been tested for use with the Boundary Client Agent.
+
 The following sections are an incomplete list of potential conflicts and any available workarounds for issues.
 
 ### Cloudflare WARP client

--- a/website/content/docs/configuration/target-aliases/interoperability-matrix.mdx
+++ b/website/content/docs/configuration/target-aliases/interoperability-matrix.mdx
@@ -1,0 +1,177 @@
+---
+layout: docs
+page_title: Transparent sessions interoperability matrix
+description: >-
+    Refer to a matrix to determine which partner products and applications are supported by the Boundary components required for transparent sessions.
+---
+
+# Transparent sessions interoperability matrix
+
+@include 'alerts/enterprise-only.mdx'
+
+Transparent sessions require you to use the Boundary installer to install the Boundary Client Agent.
+To support a variety of use cases, HashiCorp verifies implementation and integrations with partner products and applications.
+
+HashiCorp engineering has tested and confirmed that you can use the following third-party products with the specific versions of the Boundary installer, Boundary Client Agent, and any operating systems listed in the table.
+Transparent sessions may operate with other versions of the products listed below or with other products, but they have not been tested.
+We will update the list of products as we test them.
+
+<Note>
+
+On May 27, 2025 new versions of the Boundary Client Agent and installer were released with a numbering scheme that more closely follows Boundary's release numbers.
+Those versions were released as 0.19.5 to match the major Boundary version 0.19.x.
+Going forward, the Client Agent and installer will use the same major number as the current Boundary release.
+Any patches or updates will be reflected in the minor number.
+
+</Note>
+
+<table>
+  <thead>
+    <tr>
+      <th style={{verticalAlign: 'middle', width: '25%'}}>Product</th>
+      <th style={{verticalAlign: 'middle'}}>Boundary installer versions</th>
+      <th style={{veritcalAlign: 'middle'}}>Boundary Client Agent versions</th>
+      <th style={{verticalAlign: 'middle', width: '25%'}}>OS versions tested</th>
+      <th style={{veritcalAlign: 'middle'}}>Conflicts and workarounds</th>
+    </tr>
+  </thead>
+  <tbody>
+
+<tr>
+    <td style={{verticalAlign: 'middle'}}>
+    CloudFlare WARP
+    <br /><br />
+    <b>MacOS version</b>: 2025.2.600.0
+    <br />
+    <b>Windows version</b>: 2025.2.600.0
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.1.4, 0.19.5
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.1.4, 0.19.5
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    <b>MacOS</b>: 14.6, 15.3
+    <br />
+    <b>Windows</b>: 10 Pro, 11 Pro
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Refer to <a href="/boundary/docs/api-clients/client-agent#cloudflare-warp-client">Conflicting software</a>
+    </td>
+</tr>
+
+<tr>
+    <td style={{verticalAlign: 'middle'}}>
+    Huntress
+    <br /><br />
+    <b>MacOS version</b>: 0.14.10
+    <br />
+    <b>Windows version</b>: 0.14.14
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.1.4
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.1.4
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    <b>MacOS</b>: 14.6, 15.3
+    <br />
+    <b>Windows</b>: 10 Pro, 11 Pro
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Refer to <a href="/boundary/docs/api-clients/client-agent#huntress-edr-client-windows">Conflicting software</a>
+    </td>
+</tr>
+
+<tr>
+    <td style={{verticalAlign: 'middle'}}>
+    Microsoft Defender for Endpoint
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.1.4, 0.19.5
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.1.4, 0.19.5
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    <b>MacOS</b>: 14, 15
+    <br />
+    <b>Windows</b>: 10, 11 Pro
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    &nbsp;
+    </td>
+</tr>
+
+<tr>
+    <td style={{verticalAlign: 'middle'}}>
+    Palo Alto GlobalProtect
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.5
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.5
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    <b>MacOS</b>: 14, 15
+    <br />
+    <b>Windows</b>: 10, 11
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    &nbsp;
+    </td>
+</tr>
+
+<tr>
+    <td style={{verticalAlign: 'middle'}}>
+    SentinelOne Singularity
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.1.4, 0.19.5
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.1.4, 0.19.5
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    <b>MacOS</b>: 14, 15.2
+    <br />
+    <b>Windows</b>: 10, 11
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    &nbsp;
+    </td>
+</tr>
+
+<tr>
+    <td style={{verticalAlign: 'middle'}}>
+    Zscaler ZPA
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.1.4, 0.19.5
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    0.1.4, 0.19.5
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    <b>MacOS</b>: 15
+    <br />
+    <b>Windows</b>: 11
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    &nbsp;
+    </td>
+</tr>
+
+  </tbody>
+</table>
+
+## More information
+
+For more information, refer to the following topics:
+
+- [Transparent sessions](/boundary/docs/concepts/transparent-sessions)
+- [Configure transparent sessions](/boundary/docs/configuration/target-aliases/transparent-sessions)
+- [Boundary Client Agent](/boundary/docs/api-clients/client-agent)

--- a/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
+++ b/website/content/docs/configuration/target-aliases/transparent-sessions.mdx
@@ -51,6 +51,8 @@ Make sure to select the options **Boundary Client Agent**, **CLI**, and **Deskto
    $ boundary client-agent status
    ```
 
+Refer to the [transparent sessions interoperability matrix](/boundary/docs/configuration/target-aliases/interoperability-matrix) for a list of the third-party products that have been tested for use with the Boundary installer and Client Agent.
+
 ## Configure targets
 
 The following section details how to configure targets and use transparent sessions.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -614,6 +614,15 @@
               "color": "neutral"
             },
             "path": "configuration/target-aliases/transparent-sessions"
+          },
+          {
+            "title": "Transparent sessions interoperability matrix",
+            "badge": {
+              "text": "HCP/ENT",
+              "type": "outlined",
+              "color": "neutral"
+            },
+            "path": "configuration/target-aliases/interoperability-matrix"
           }
         ]
       },


### PR DESCRIPTION
The backport for #5478 failed. This PR manually cherry-picks the following commits to the `stable-website` branch:

* docs: Add interoperability matrix

* docs: Remove one table version

* docs: New format

* docs: Update table format

* docs: Revisions and beta label

* docs: Add link, WARP caveat

* docs: Adjust table spacing

* docs: Update table and errors with new info

* docs: Remove version column

* docs: Adjust width for longer columns

* docs: Remove errors in favor of #5674

* docs: Remove beta labels

* docs: Update with newest test results