### PR TITLE
test(e2e): Check all addresses in GCP host catalog test

### DIFF
--- a/testing/internal/e2e/tests/gcp/dynamichostcatalog_host_set_test.go
+++ b/testing/internal/e2e/tests/gcp/dynamichostcatalog_host_set_test.go
@@ -150,22 +150,22 @@ func TestCliCreateGcpDynamicHostCatalogWithHostSet(t *testing.T) {
 		),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
-
-	parts := strings.Fields(string(output.Stdout))
-	hostIp := parts[len(parts)-1]
 	t.Log("Successfully connected to the target")
 
-	// Check if connected host exists in the host set
+	addresses := strings.Fields(string(output.Stdout))
+	addressFound := false
 	var targetIps []string
 	err = json.Unmarshal([]byte(c.GcpHostSetIps), &targetIps)
 	require.NoError(t, err)
-	hostIpInList := false
-	for _, v := range targetIps {
-		if v == hostIp {
-			hostIpInList = true
+	for _, address := range addresses {
+		for _, targetIp := range targetIps {
+			if address == targetIp {
+				addressFound = true
+				break
+			}
 		}
 	}
-	require.True(t, hostIpInList, fmt.Sprintf("Connected host (%s) is not in expected list (%s)", hostIp, targetIps))
+	require.True(t, addressFound, "Connected host (%s) is not in expected list (%s)", string(output.Stdout), c.GcpHostSetIps)
 }
 
 // TestApiCreateGcpDynamicHostCatalog uses the Go api to create a host catalog with the GCP plugin.


### PR DESCRIPTION
This PR updates an end-to-end test for GCP dynamic host catalogs. The test started failing due to the following reason
```
│     dynamichostcatalog_host_set_test.go:168: 
│         	Error Trace:	/src/boundary/testing/internal/e2e/tests/gcp/dynamichostcatalog_host_set_test.go:168
│         	Error:      	Should be true
│         	Test:       	TestCliCreateGcpDynamicHostCatalogWithHostSet
│         	Messages:   	Connected host (fe80::4001:aff:fe80:2) is not in expected list ([10.128.0.2 34.58.202.253])
```

It seems like GCP hosts are now returning ipv4 and ipv6 addresses when `hostname -i` is called
```
ubuntu@boundary-michael-li1695779881-0:~$ hostname -i
10.128.15.201 fe80::4001:aff:fe80:fc9
```

This PR makes a modification to check if any of the addresses from the output of `hostname -i` is in the list of expected ip addresses.

https://hashicorp.atlassian.net/browse/ICU-17211