### PR TITLE
chore(e2e): Remove unused code in github action workflow

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -22,9 +22,6 @@ on:
         required: false
         type: string
 
-env:
-  PKG_NAME: boundary
-
 jobs:
   setup:
     outputs:
@@ -202,7 +199,7 @@ jobs:
         run: |
           wget https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_linux_amd64.zip -O /tmp/test-deps/vault.zip
       - name: Install Vault CLI
-        if: contains(matrix.filter, 'vault') || contains(matrix.filter, 'e2e_docker') || matrix.filter == 'e2e_database' || matrix.filter == 'e2e_ui_aws builder:crt'
+        if: contains(matrix.filter, 'vault') || contains(matrix.filter, 'e2e_docker') || matrix.filter == 'e2e_database'
         run: |
           unzip /tmp/test-deps/vault.zip -d /usr/local/bin
       - name: GH fix for localhost resolution
@@ -233,24 +230,6 @@ jobs:
         if: contains(matrix.filter, 'e2e_docker')
         run: |
           mv ${{ steps.download-docker.outputs.download-path }}/*.tar enos/support/boundary_docker_image.tar
-      - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        if: contains(matrix.filter, 'e2e_ui')
-        with:
-          node-version: '16.x'
-      - name: Checkout boundary-ui
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: contains(matrix.filter, 'e2e_ui')
-        with:
-          repository: hashicorp/boundary-ui
-          path: enos/support/src/boundary-ui
-      - name: Install boundary-ui dependencies
-        if: contains(matrix.filter, 'e2e_ui')
-        run: yarn --cwd enos/support/src/boundary-ui install
-      - name: Install playwright dependencies (i.e. browsers)
-        if: contains(matrix.filter, 'e2e_ui')
-        run: npx playwright install --with-deps
-        working-directory: enos/support/src/boundary-ui
       - name: Output Terraform version info
         run: |
           mkdir -p ./enos/terraform-plugin-cache
@@ -293,13 +272,6 @@ jobs:
         if: contains(matrix.filter, 'e2e_docker') && steps.run.outcome == 'failure'
         run: |
           docker logs database
-      - name: Upload e2e UI tests debug info
-        if: contains(matrix.filter, 'e2e_ui') && steps.run.outcome == 'failure'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: test-e2e-ui-debug
-          path: enos/support/src/boundary-ui/ui/admin/tests/e2e/artifacts/test-failures
-          retention-days: 5
       - name: Retry Enos scenario
         id: run_retry
         if: steps.run.outcome == 'failure'


### PR DESCRIPTION
This PR removes some unused code in the e2e test github action workflow. This was originally added when playing around with running Admin UI tests in this workflow, but that will potentially occur in a different workflow. Regardless, it's unused right now and will have an outdated usage of `yarn`, since we're moving to `pnpm`.