### PR TITLE
Refactor GrantsForUser subqueries to use aggregate functions

### DIFF
--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -391,33 +391,39 @@ const (
         from iam_role_global_individual_project_grant_scope
     ),
     global_roles_this_grant_scope as (
-      select iam_role_global.public_id         as role_id,
-             iam_role_global.scope_id          as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             iam_role_global.scope_id          as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+      select iam_role_global.public_id             as role_id,
+             iam_role_global.scope_id              as role_scope_id,
+             'global'                              as role_parent_scope_id,
+             iam_role_global.grant_scope           as grant_scope,
+             iam_role_global.grant_this_role_scope as grant_this_role_scope,
+             null                                  as individual_grant_scope,
+             roles_with_grants.canonical_grant     as canonical_grant
         from iam_role_global
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_global.public_id
        where iam_role_global.grant_this_role_scope
     ),
     global_roles_with_special_grant_scopes as (
-      select iam_role_global.public_id         as role_id,
-             iam_role_global.scope_id          as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             iam_role_global.grant_scope       as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+      select iam_role_global.public_id             as role_id,
+             iam_role_global.scope_id              as role_scope_id,
+             'global'                              as role_parent_scope_id,
+             iam_role_global.grant_scope           as grant_scope,
+             iam_role_global.grant_this_role_scope as grant_this_role_scope,
+             null                                  as individual_grant_scope,
+             roles_with_grants.canonical_grant     as canonical_grant
         from iam_role_global
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_global.public_id
        where iam_role_global.grant_scope = any('{ children, descendants }')
     ),
     global_roles_with_individual_grant_scopes as (
-      select iam_role_global.public_id         as role_id,
-             iam_role_global.scope_id          as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             individual.scope_id               as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+      select iam_role_global.public_id             as role_id,
+             iam_role_global.scope_id              as role_scope_id,
+             'global'                              as role_parent_scope_id,
+             iam_role_global.grant_scope           as grant_scope,
+             iam_role_global.grant_this_role_scope as grant_this_role_scope,
+             individual.scope_id                   as individual_grant_scope,
+             roles_with_grants.canonical_grant     as canonical_grant
         from iam_role_global
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_global.public_id
@@ -425,33 +431,39 @@ const (
           on individual.role_id = iam_role_global.public_id
     ),
     org_roles_this_grant_scope as (
-      select iam_role_org.public_id            as role_id,
-             iam_role_org.scope_id             as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             iam_role_org.scope_id             as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+      select iam_role_org.public_id             as role_id,
+             iam_role_org.scope_id              as role_scope_id,
+             'global'                           as role_parent_scope_id,
+             iam_role_org.grant_scope           as grant_scope,
+             iam_role_org.grant_this_role_scope as grant_this_role_scope,
+             null                               as individual_grant_scope,
+             roles_with_grants.canonical_grant  as canonical_grant
         from iam_role_org
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_org.public_id
        where iam_role_org.grant_this_role_scope
     ),
     org_roles_with_children_grant_scopes as (
-      select iam_role_org.public_id            as role_id,
-             iam_role_org.scope_id             as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             iam_role_org.grant_scope          as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+      select iam_role_org.public_id             as role_id,
+             iam_role_org.scope_id              as role_scope_id,
+             'global'                           as role_parent_scope_id,
+             iam_role_org.grant_scope           as grant_scope,
+             iam_role_org.grant_this_role_scope as grant_this_role_scope,
+             null                               as individual_grant_scope,
+             roles_with_grants.canonical_grant  as canonical_grant
         from iam_role_org
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_org.public_id
        where iam_role_org.grant_scope = 'children'
     ),
     org_roles_with_individual_grant_scopes as (
-      select iam_role_org.public_id            as role_id,
-             iam_role_org.scope_id             as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             individual.scope_id               as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+      select iam_role_org.public_id             as role_id,
+             iam_role_org.scope_id              as role_scope_id,
+             'global'                           as role_parent_scope_id,
+             iam_role_org.grant_scope           as grant_scope,
+             iam_role_org.grant_this_role_scope as grant_this_role_scope,
+             individual.scope_id                as individual_grant_scope,
+             roles_with_grants.canonical_grant  as canonical_grant
         from iam_role_org
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_org.public_id
@@ -459,11 +471,13 @@ const (
           on individual.role_id = iam_role_org.public_id
     ),
     project_roles_this_grant_scope as (
-      select iam_role_project.public_id        as role_id,
-             iam_role_project.scope_id         as role_scope_id,
-             iam_scope_project.parent_id       as role_parent_scope_id,
-             iam_role_project.scope_id         as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+      select iam_role_project.public_id             as role_id,
+             iam_role_project.scope_id              as role_scope_id,
+             iam_scope_project.parent_id            as role_parent_scope_id,
+             'individual'                           as grant_scope,
+             iam_role_project.grant_this_role_scope as grant_this_role_scope,
+             null                                   as individual_grant_scope,
+             roles_with_grants.canonical_grant      as canonical_grant
         from iam_role_project
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_project.public_id
@@ -476,6 +490,8 @@ const (
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
         from global_roles_this_grant_scope
        union
@@ -483,6 +499,8 @@ const (
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
         from global_roles_with_special_grant_scopes
        union
@@ -490,6 +508,8 @@ const (
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
         from global_roles_with_individual_grant_scopes
        union
@@ -497,6 +517,8 @@ const (
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
         from org_roles_this_grant_scope
        union
@@ -504,6 +526,8 @@ const (
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
         from org_roles_with_children_grant_scopes
        union
@@ -511,6 +535,8 @@ const (
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
         from org_roles_with_individual_grant_scopes
        union
@@ -518,6 +544,8 @@ const (
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
         from project_roles_this_grant_scope
     )
@@ -525,13 +553,15 @@ const (
            role_scope_id,
            role_parent_scope_id,
            grant_scope,
-           canonical_grant as grant
+           grant_this_role_scope,
+           array_agg(distinct(individual_grant_scope)) filter (where individual_grant_scope is not null) as individual_grant_scopes,
+           array_agg(distinct(canonical_grant))                                                          as canonical_grants
       from all_roles
   group by role_id,
            role_scope_id,
            role_parent_scope_id,
            grant_scope,
-           canonical_grant;
+           grant_this_role_scope;
     `
 
 	estimateCountRoles = `

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -284,63 +284,51 @@ const (
 
 	// grantsForUserProjectResourcesQuery gets a user's grants for resources only applicable to project scopes.
 	grantsForUserProjectResourcesQuery = resourceRoleGrantsForUsers + `,
-    global_roles_with_descendant_grant_scopes as (
-      select iam_role_global.public_id         as role_id,
-             iam_role_global.scope_id          as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             iam_role_global.grant_scope       as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+    global_roles_with_individual_or_descendant_grant_scopes as (
+      select iam_role_global.public_id             as role_id,
+             iam_role_global.scope_id              as role_scope_id,
+             'global'                              as role_parent_scope_id,
+             iam_role_global.grant_scope           as grant_scope,
+             iam_role_global.grant_this_role_scope as grant_this_role_scope,
+             coalesce(individual.scope_id, '')     as individual_grant_scope,
+             roles_with_grants.canonical_grant     as canonical_grant
         from iam_role_global
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_global.public_id
-       where iam_role_global.grant_scope = 'descendants'
-    ),
-    global_roles_with_individual_grant_scopes as (
-      select iam_role_global.public_id         as role_id,
-             iam_role_global.scope_id          as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             individual.scope_id               as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
-        from iam_role_global
-        join roles_with_grants
-          on roles_with_grants.role_id = iam_role_global.public_id
-        join iam_role_global_individual_project_grant_scope individual
+   left join iam_role_global_individual_project_grant_scope individual
           on individual.role_id = iam_role_global.public_id
-       where individual.scope_id = @request_scope_id
+       where iam_role_global.grant_scope = 'descendants'
+          or individual.scope_id = @request_scope_id
     ),
-    org_roles_with_children_grant_scopes as (
-      select iam_role_org.public_id            as role_id,
-             iam_role_org.scope_id             as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             iam_role_org.grant_scope          as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+    org_roles_with_individual_or_children_grant_scopes as (
+      select iam_role_org.public_id             as role_id,
+             iam_role_org.scope_id              as role_scope_id,
+             'global'                           as role_parent_scope_id,
+             iam_role_org.grant_scope           as grant_scope,
+             iam_role_org.grant_this_role_scope as grant_this_role_scope,
+             coalesce(individual.scope_id, '')  as individual_grant_scope,
+             roles_with_grants.canonical_grant  as canonical_grant
         from iam_role_org
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_org.public_id
         join iam_scope_project
           on iam_scope_project.parent_id = iam_role_org.scope_id
-         and iam_scope_project.scope_id = @request_scope_id
-       where iam_role_org.grant_scope = 'children'
-    ),
-    org_roles_with_individual_grant_scopes as (
-      select iam_role_org.public_id            as role_id,
-             iam_role_org.scope_id             as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             individual.scope_id               as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
-        from iam_role_org
-        join roles_with_grants
-          on roles_with_grants.role_id = iam_role_org.public_id
-        join iam_role_org_individual_grant_scope individual
+   left join iam_role_org_individual_grant_scope individual
           on individual.role_id = iam_role_org.public_id
        where individual.scope_id = @request_scope_id
+          or (
+             iam_role_org.grant_scope = 'children' and
+             iam_scope_project.scope_id = @request_scope_id
+          )
     ),
     project_roles_this_grant_scope as (
-      select iam_role_project.public_id        as role_id,
-             iam_role_project.scope_id         as role_scope_id,
-             iam_scope_project.parent_id       as role_parent_scope_id,
-             iam_role_project.scope_id         as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+      select iam_role_project.public_id             as role_id,
+             iam_role_project.scope_id              as role_scope_id,
+             iam_scope_project.parent_id            as role_parent_scope_id,
+             iam_role_project.scope_id              as grant_scope,
+             iam_role_project.grant_this_role_scope as grant_this_role_scope,
+             ''                                     as individual_grant_scope,
+             roles_with_grants.canonical_grant      as canonical_grant
         from iam_role_project
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_project.public_id
@@ -354,34 +342,26 @@ const (
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
-        from global_roles_with_descendant_grant_scopes
+        from global_roles_with_individual_or_descendant_grant_scopes
        union
       select role_id,
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
-        from global_roles_with_individual_grant_scopes
+        from org_roles_with_individual_or_children_grant_scopes
        union
       select role_id,
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
-             canonical_grant
-        from org_roles_with_children_grant_scopes
-       union
-      select role_id,
-             role_scope_id,
-             role_parent_scope_id,
-             grant_scope,
-             canonical_grant
-        from org_roles_with_individual_grant_scopes
-       union
-      select role_id,
-             role_scope_id,
-             role_parent_scope_id,
-             grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
         from project_roles_this_grant_scope
     )
@@ -389,13 +369,15 @@ const (
            role_scope_id,
            role_parent_scope_id,
            grant_scope,
-           canonical_grant as grant
+           grant_this_role_scope,
+           array_agg(distinct(individual_grant_scope)) as individual_grant_scopes,
+           array_agg(distinct(canonical_grant))        as canonical_grants
       from all_roles
   group by role_id,
            role_scope_id,
            role_parent_scope_id,
            grant_scope,
-           canonical_grant;
+           grant_this_role_scope;
     `
 
 	// grantsForUserRecursiveQuery gets a user's grants for resources

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -206,8 +206,8 @@ const (
            role_parent_scope_id,
            grant_scope,
            grant_this_role_scope,
-           null                                 as individual_grant_scopes,
-           array_agg(distinct(canonical_grant)) as canonical_grants
+           array_agg(distinct(individual_grant_scope)) filter (where individual_grant_scope is not null) as individual_grant_scopes,
+           array_agg(distinct(canonical_grant))        as canonical_grants
       from global_roles_this_grant_scope
   group by role_id,
            role_scope_id,
@@ -224,7 +224,7 @@ const (
              'global'                              as role_parent_scope_id,
              iam_role_global.grant_scope           as grant_scope,
              iam_role_global.grant_this_role_scope as grant_this_role_scope,
-             coalesce(individual.scope_id, '')     as individual_grant_scope,
+             individual.scope_id                   as individual_grant_scope,
              roles_with_grants.canonical_grant     as canonical_grant
         from iam_role_global
         join roles_with_grants
@@ -238,9 +238,9 @@ const (
       select iam_role_org.public_id             as role_id,
              iam_role_org.scope_id              as role_scope_id,
              'global'                           as role_parent_scope_id,
-             ''                                 as grant_scope,
+             'individual'                       as grant_scope,
              iam_role_org.grant_this_role_scope as grant_this_role_scope,
-             ''                                 as individual_grant_scope,
+             null                               as individual_grant_scope,
              roles_with_grants.canonical_grant  as canonical_grant
         from iam_role_org
         join roles_with_grants
@@ -272,7 +272,7 @@ const (
            role_parent_scope_id,
            grant_scope,
            grant_this_role_scope,
-           array_agg(distinct(individual_grant_scope)) as individual_grant_scopes,
+           array_agg(distinct(individual_grant_scope)) filter (where individual_grant_scope is not null) as individual_grant_scopes,
            array_agg(distinct(canonical_grant))        as canonical_grants
       from global_and_org_roles
   group by role_id,
@@ -290,7 +290,7 @@ const (
              'global'                              as role_parent_scope_id,
              iam_role_global.grant_scope           as grant_scope,
              iam_role_global.grant_this_role_scope as grant_this_role_scope,
-             coalesce(individual.scope_id, '')     as individual_grant_scope,
+             individual.scope_id                   as individual_grant_scope,
              roles_with_grants.canonical_grant     as canonical_grant
         from iam_role_global
         join roles_with_grants
@@ -306,7 +306,7 @@ const (
              'global'                           as role_parent_scope_id,
              iam_role_org.grant_scope           as grant_scope,
              iam_role_org.grant_this_role_scope as grant_this_role_scope,
-             coalesce(individual.scope_id, '')  as individual_grant_scope,
+             individual.scope_id                as individual_grant_scope,
              roles_with_grants.canonical_grant  as canonical_grant
         from iam_role_org
         join roles_with_grants
@@ -325,9 +325,9 @@ const (
       select iam_role_project.public_id             as role_id,
              iam_role_project.scope_id              as role_scope_id,
              iam_scope_project.parent_id            as role_parent_scope_id,
-             iam_role_project.scope_id              as grant_scope,
+             'individual'                           as grant_scope,
              iam_role_project.grant_this_role_scope as grant_this_role_scope,
-             ''                                     as individual_grant_scope,
+             null                                   as individual_grant_scope,
              roles_with_grants.canonical_grant      as canonical_grant
         from iam_role_project
         join roles_with_grants
@@ -370,8 +370,8 @@ const (
            role_parent_scope_id,
            grant_scope,
            grant_this_role_scope,
-           array_agg(distinct(individual_grant_scope)) as individual_grant_scopes,
-           array_agg(distinct(canonical_grant))        as canonical_grants
+           array_agg(distinct(individual_grant_scope)) filter (where individual_grant_scope is not null) as individual_grant_scopes,
+           array_agg(distinct(canonical_grant))                                                          as canonical_grants
       from all_roles
   group by role_id,
            role_scope_id,

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -218,36 +218,30 @@ const (
 
 	// grantsForUserOrgResourcesQuery gets a user's grants for resources only applicable to org scopes.
 	grantsForUserOrgResourcesQuery = resourceRoleGrantsForUsers + `,
-    global_roles_with_special_grant_scopes as (
-      select iam_role_global.public_id         as role_id,
-             iam_role_global.scope_id          as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             iam_role_global.grant_scope       as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+    global_roles_with_individual_or_special_grant_scopes as (
+      select iam_role_global.public_id             as role_id,
+             iam_role_global.scope_id              as role_scope_id,
+             'global'                              as role_parent_scope_id,
+             iam_role_global.grant_scope           as grant_scope,
+             iam_role_global.grant_this_role_scope as grant_this_role_scope,
+             coalesce(individual.scope_id, '')     as individual_grant_scope,
+             roles_with_grants.canonical_grant     as canonical_grant
         from iam_role_global
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_global.public_id
-       where iam_role_global.grant_scope = any('{ children, descendants }')
-    ),
-    global_roles_with_individual_grant_scopes as (
-      select iam_role_global.public_id         as role_id,
-             iam_role_global.scope_id          as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             individual.scope_id               as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
-        from iam_role_global
-        join roles_with_grants
-          on roles_with_grants.role_id = iam_role_global.public_id
-        join iam_role_global_individual_org_grant_scope individual
+   left join iam_role_global_individual_org_grant_scope individual
           on individual.role_id = iam_role_global.public_id
-       where individual.scope_id = @request_scope_id
+       where iam_role_global.grant_scope = any('{ children, descendants }')
+          or individual.scope_id = @request_scope_id
     ),
     org_roles_this_grant_scope as (
-      select iam_role_org.public_id            as role_id,
-             iam_role_org.scope_id             as role_scope_id,
-             'global'                          as role_parent_scope_id,
-             iam_role_org.scope_id             as grant_scope,
-             roles_with_grants.canonical_grant as canonical_grant
+      select iam_role_org.public_id             as role_id,
+             iam_role_org.scope_id              as role_scope_id,
+             'global'                           as role_parent_scope_id,
+             ''                                 as grant_scope,
+             iam_role_org.grant_this_role_scope as grant_this_role_scope,
+             ''                                 as individual_grant_scope,
+             roles_with_grants.canonical_grant  as canonical_grant
         from iam_role_org
         join roles_with_grants
           on roles_with_grants.role_id = iam_role_org.public_id
@@ -259,20 +253,17 @@ const (
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
-        from global_roles_with_special_grant_scopes
+        from global_roles_with_individual_or_special_grant_scopes
        union
       select role_id,
              role_scope_id,
              role_parent_scope_id,
              grant_scope,
-             canonical_grant
-        from global_roles_with_individual_grant_scopes
-       union
-      select role_id,
-             role_scope_id,
-             role_parent_scope_id,
-             grant_scope,
+             grant_this_role_scope,
+             individual_grant_scope,
              canonical_grant
         from org_roles_this_grant_scope
     )
@@ -280,13 +271,15 @@ const (
            role_scope_id,
            role_parent_scope_id,
            grant_scope,
-           canonical_grant as grant
+           grant_this_role_scope,
+           array_agg(distinct(individual_grant_scope)) as individual_grant_scopes,
+           array_agg(distinct(canonical_grant))        as canonical_grants
       from global_and_org_roles
   group by role_id,
            role_scope_id,
            role_parent_scope_id,
            grant_scope,
-           canonical_grant;
+           grant_this_role_scope;
     `
 
 	// grantsForUserProjectResourcesQuery gets a user's grants for resources only applicable to project scopes.

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -192,9 +192,9 @@ const (
       select iam_role_global.public_id             as role_id,
              iam_role_global.scope_id              as role_scope_id,
              'global'                              as role_parent_scope_id,
-             'global'                              as grant_scope,
+             'individual'                          as grant_scope,
              iam_role_global.grant_this_role_scope as grant_this_role_scope,
-             ''                                    as individual_grant_scope, -- individual_grant_scopes are not applicable to global roles
+             null                                  as individual_grant_scope, -- individual_grant_scopes are not applicable to global roles
              roles_with_grants.canonical_grant     as canonical_grant
         from iam_role_global
         join roles_with_grants
@@ -206,8 +206,8 @@ const (
            role_parent_scope_id,
            grant_scope,
            grant_this_role_scope,
-           array_agg(distinct(individual_grant_scope)) as individual_grant_scopes,
-           array_agg(distinct(canonical_grant))        as canonical_grants
+           null                                 as individual_grant_scopes,
+           array_agg(distinct(canonical_grant)) as canonical_grants
       from global_roles_this_grant_scope
   group by role_id,
            role_scope_id,

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -623,10 +623,6 @@ func (r *Repository) grantsForUserGlobalResources(
 					GrantScopeId:      grant.roleScopeId,
 					Grant:             canonicalGrant,
 				}
-
-				if gt.GrantScopeId == globals.GrantScopeThis || gt.GrantScopeId == "" {
-					gt.GrantScopeId = grant.roleScopeId
-				}
 				ret = append(ret, gt)
 			}
 		}
@@ -735,10 +731,6 @@ func (r *Repository) grantsForUserOrgResources(
 					GrantScopeId:      grant.roleScopeId,
 					Grant:             canonicalGrant,
 				}
-
-				if gt.GrantScopeId == globals.GrantScopeThis || gt.GrantScopeId == "" {
-					gt.GrantScopeId = grant.roleScopeId
-				}
 				ret = append(ret, gt)
 			}
 		}
@@ -845,10 +837,6 @@ func (r *Repository) grantsForUserProjectResources(
 					RoleParentScopeId: grant.roleParentScopeId,
 					GrantScopeId:      grant.roleScopeId,
 					Grant:             canonicalGrant,
-				}
-
-				if gt.GrantScopeId == globals.GrantScopeThis || gt.GrantScopeId == "" {
-					gt.GrantScopeId = grant.roleScopeId
 				}
 				ret = append(ret, gt)
 			}

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -574,20 +574,22 @@ func (r *Repository) grantsForUserGlobalResources(
 		sql.Named("resources", pq.Array(resources)),
 	)
 
-	var grants []perms.GrantTuple
+	var grants []grantsForUserResults
 	rows, err := r.reader.Query(ctx, grantsForUserGlobalResourcesQuery, args)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var g perms.GrantTuple
+		var g grantsForUserResults
 		if err := rows.Scan(
-			&g.RoleId,
-			&g.RoleScopeId,
-			&g.RoleParentScopeId,
-			&g.GrantScopeId,
-			&g.Grant,
+			&g.roleId,
+			&g.roleScopeId,
+			&g.roleParentScopeId,
+			&g.grantScope,
+			&g.grantThisRoleScope,
+			pq.Array(&g.individualGrantScopes),
+			pq.Array(&g.canonicalGrants),
 		); err != nil {
 			return nil, errors.Wrap(ctx, err, op)
 		}
@@ -596,7 +598,46 @@ func (r *Repository) grantsForUserGlobalResources(
 	if err := rows.Err(); err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
-	return grants, nil
+	ret := make(perms.GrantTuples, 0, len(grants)*3)
+	for _, grant := range grants {
+		// If the role has individual grant scopes, iterate over them and create a grant tuple for each
+		if grant.grantScope == globals.GrantScopeIndividual && len(grant.individualGrantScopes) > 0 {
+			for _, grantScope := range grant.individualGrantScopes {
+				for _, canonicalGrant := range grant.canonicalGrants {
+					gt := perms.GrantTuple{
+						RoleId:            grant.roleId,
+						RoleScopeId:       grant.roleScopeId,
+						RoleParentScopeId: grant.roleParentScopeId,
+						GrantScopeId:      grantScope,
+						Grant:             canonicalGrant,
+					}
+
+					if gt.GrantScopeId == globals.GrantScopeThis || gt.GrantScopeId == "" {
+						gt.GrantScopeId = grant.roleScopeId
+					}
+					ret = append(ret, gt)
+				}
+			}
+		}
+		// If the role does not have any individual grant scopes, create a grant tuple for each canonical grant
+		if grant.grantScope != globals.GrantScopeIndividual || len(grant.individualGrantScopes) == 0 {
+			for _, canonicalGrant := range grant.canonicalGrants {
+				gt := perms.GrantTuple{
+					RoleId:            grant.roleId,
+					RoleScopeId:       grant.roleScopeId,
+					RoleParentScopeId: grant.roleParentScopeId,
+					GrantScopeId:      grant.grantScope,
+					Grant:             canonicalGrant,
+				}
+
+				if gt.GrantScopeId == globals.GrantScopeThis || gt.GrantScopeId == "" {
+					gt.GrantScopeId = grant.roleScopeId
+				}
+				ret = append(ret, gt)
+			}
+		}
+	}
+	return ret, nil
 }
 
 // grantsForUserOrgResources returns user grants for resources that can be org scoped.

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -712,27 +712,8 @@ func (r *Repository) grantsForUserOrgResources(
 	}
 	ret := make(perms.GrantTuples, 0, len(grants)*3)
 	for _, grant := range grants {
-		// If the role has individual grant scopes, iterate over them and create a grant tuple for each
-		if grant.grantScope == globals.GrantScopeIndividual && len(grant.individualGrantScopes) > 0 {
-			for _, grantScope := range grant.individualGrantScopes {
-				for _, canonicalGrant := range grant.canonicalGrants {
-					gt := perms.GrantTuple{
-						RoleId:            grant.roleId,
-						RoleScopeId:       grant.roleScopeId,
-						RoleParentScopeId: grant.roleParentScopeId,
-						GrantScopeId:      grantScope,
-						Grant:             canonicalGrant,
-					}
 
-					if gt.GrantScopeId == globals.GrantScopeThis || gt.GrantScopeId == "" {
-						gt.GrantScopeId = grant.roleScopeId
-					}
-					ret = append(ret, gt)
-				}
-			}
-		}
-		// If the role does not have any individual grant scopes, create a grant tuple for each canonical grant
-		if grant.grantScope != globals.GrantScopeIndividual || len(grant.individualGrantScopes) == 0 {
+		if grant.grantScope != globals.GrantScopeIndividual {
 			for _, canonicalGrant := range grant.canonicalGrants {
 				gt := perms.GrantTuple{
 					RoleId:            grant.roleId,
@@ -741,9 +722,36 @@ func (r *Repository) grantsForUserOrgResources(
 					GrantScopeId:      grant.grantScope,
 					Grant:             canonicalGrant,
 				}
+				ret = append(ret, gt)
+			}
+		}
+
+		if grant.grantThisRoleScope && reqScopeId == grant.roleScopeId {
+			for _, canonicalGrant := range grant.canonicalGrants {
+				gt := perms.GrantTuple{
+					RoleId:            grant.roleId,
+					RoleScopeId:       grant.roleScopeId,
+					RoleParentScopeId: grant.roleParentScopeId,
+					GrantScopeId:      grant.roleScopeId,
+					Grant:             canonicalGrant,
+				}
 
 				if gt.GrantScopeId == globals.GrantScopeThis || gt.GrantScopeId == "" {
 					gt.GrantScopeId = grant.roleScopeId
+				}
+				ret = append(ret, gt)
+			}
+		}
+
+		// loop over grants creating tuple with grant_scope = s.ScopeId
+		for _, individualGrantScope := range grant.individualGrantScopes {
+			for _, canonicalGrant := range grant.canonicalGrants {
+				gt := perms.GrantTuple{
+					RoleId:            grant.roleId,
+					RoleScopeId:       grant.roleScopeId,
+					RoleParentScopeId: grant.roleParentScopeId,
+					GrantScopeId:      individualGrantScope,
+					Grant:             canonicalGrant,
 				}
 				ret = append(ret, gt)
 			}
@@ -815,27 +823,8 @@ func (r *Repository) grantsForUserProjectResources(
 	}
 	ret := make(perms.GrantTuples, 0, len(grants)*3)
 	for _, grant := range grants {
-		// If the role has individual grant scopes, iterate over them and create a grant tuple for each
-		if grant.grantScope == globals.GrantScopeIndividual && len(grant.individualGrantScopes) > 0 {
-			for _, grantScope := range grant.individualGrantScopes {
-				for _, canonicalGrant := range grant.canonicalGrants {
-					gt := perms.GrantTuple{
-						RoleId:            grant.roleId,
-						RoleScopeId:       grant.roleScopeId,
-						RoleParentScopeId: grant.roleParentScopeId,
-						GrantScopeId:      grantScope,
-						Grant:             canonicalGrant,
-					}
 
-					if gt.GrantScopeId == globals.GrantScopeThis || gt.GrantScopeId == "" {
-						gt.GrantScopeId = grant.roleScopeId
-					}
-					ret = append(ret, gt)
-				}
-			}
-		}
-		// If the role does not have any individual grant scopes, create a grant tuple for each canonical grant
-		if grant.grantScope != globals.GrantScopeIndividual || len(grant.individualGrantScopes) == 0 {
+		if grant.grantScope != globals.GrantScopeIndividual {
 			for _, canonicalGrant := range grant.canonicalGrants {
 				gt := perms.GrantTuple{
 					RoleId:            grant.roleId,
@@ -844,9 +833,36 @@ func (r *Repository) grantsForUserProjectResources(
 					GrantScopeId:      grant.grantScope,
 					Grant:             canonicalGrant,
 				}
+				ret = append(ret, gt)
+			}
+		}
+
+		if grant.grantThisRoleScope && reqScopeId == grant.roleScopeId {
+			for _, canonicalGrant := range grant.canonicalGrants {
+				gt := perms.GrantTuple{
+					RoleId:            grant.roleId,
+					RoleScopeId:       grant.roleScopeId,
+					RoleParentScopeId: grant.roleParentScopeId,
+					GrantScopeId:      grant.roleScopeId,
+					Grant:             canonicalGrant,
+				}
 
 				if gt.GrantScopeId == globals.GrantScopeThis || gt.GrantScopeId == "" {
 					gt.GrantScopeId = grant.roleScopeId
+				}
+				ret = append(ret, gt)
+			}
+		}
+
+		// loop over grants creating tuple with grant_scope = s.ScopeId
+		for _, individualGrantScope := range grant.individualGrantScopes {
+			for _, canonicalGrant := range grant.canonicalGrants {
+				gt := perms.GrantTuple{
+					RoleId:            grant.roleId,
+					RoleScopeId:       grant.roleScopeId,
+					RoleParentScopeId: grant.roleParentScopeId,
+					GrantScopeId:      individualGrantScope,
+					Grant:             canonicalGrant,
 				}
 				ret = append(ret, gt)
 			}

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -678,20 +678,22 @@ func (r *Repository) grantsForUserOrgResources(
 		sql.Named("request_scope_id", reqScopeId),
 	)
 
-	var grants []perms.GrantTuple
+	var grants []grantsForUserResults
 	rows, err := r.reader.Query(ctx, grantsForUserOrgResourcesQuery, args)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var g perms.GrantTuple
+		var g grantsForUserResults
 		if err := rows.Scan(
-			&g.RoleId,
-			&g.RoleScopeId,
-			&g.RoleParentScopeId,
-			&g.GrantScopeId,
-			&g.Grant,
+			&g.roleId,
+			&g.roleScopeId,
+			&g.roleParentScopeId,
+			&g.grantScope,
+			&g.grantThisRoleScope,
+			pq.Array(&g.individualGrantScopes),
+			pq.Array(&g.canonicalGrants),
 		); err != nil {
 			return nil, errors.Wrap(ctx, err, op)
 		}
@@ -700,7 +702,46 @@ func (r *Repository) grantsForUserOrgResources(
 	if err := rows.Err(); err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
-	return grants, nil
+	ret := make(perms.GrantTuples, 0, len(grants)*3)
+	for _, grant := range grants {
+		// If the role has individual grant scopes, iterate over them and create a grant tuple for each
+		if grant.grantScope == globals.GrantScopeIndividual && len(grant.individualGrantScopes) > 0 {
+			for _, grantScope := range grant.individualGrantScopes {
+				for _, canonicalGrant := range grant.canonicalGrants {
+					gt := perms.GrantTuple{
+						RoleId:            grant.roleId,
+						RoleScopeId:       grant.roleScopeId,
+						RoleParentScopeId: grant.roleParentScopeId,
+						GrantScopeId:      grantScope,
+						Grant:             canonicalGrant,
+					}
+
+					if gt.GrantScopeId == globals.GrantScopeThis || gt.GrantScopeId == "" {
+						gt.GrantScopeId = grant.roleScopeId
+					}
+					ret = append(ret, gt)
+				}
+			}
+		}
+		// If the role does not have any individual grant scopes, create a grant tuple for each canonical grant
+		if grant.grantScope != globals.GrantScopeIndividual || len(grant.individualGrantScopes) == 0 {
+			for _, canonicalGrant := range grant.canonicalGrants {
+				gt := perms.GrantTuple{
+					RoleId:            grant.roleId,
+					RoleScopeId:       grant.roleScopeId,
+					RoleParentScopeId: grant.roleParentScopeId,
+					GrantScopeId:      grant.grantScope,
+					Grant:             canonicalGrant,
+				}
+
+				if gt.GrantScopeId == globals.GrantScopeThis || gt.GrantScopeId == "" {
+					gt.GrantScopeId = grant.roleScopeId
+				}
+				ret = append(ret, gt)
+			}
+		}
+	}
+	return ret, nil
 }
 
 // grantsForUserProjectResources returns user grants for resources that can only be project scoped.

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -605,6 +605,8 @@ func TestGrantsForUserGlobalResources(t *testing.T) {
 	TestRoleGrant(t, conn, roleOrg1.PublicId, "ids=*;type=alias;actions=create,update,read,list")
 	TestRoleGrant(t, conn, roleOrg1.PublicId, "ids=*;type=alias;actions=delete")
 	TestRoleGrant(t, conn, roleThisAndOrg2.PublicId, "ids=*;type=alias;actions=delete")
+	TestRoleGrant(t, conn, roleThisAndOrg2.PublicId, "ids=*;type=alias;actions=read")
+	TestRoleGrant(t, conn, roleThisAndOrg2.PublicId, "ids=*;type=alias;actions=update")
 	TestRoleGrant(t, conn, roleDescendants.PublicId, "ids=*;type=*;actions=update")
 	TestRoleGrant(t, conn, roleThisAndChildren.PublicId, "ids=*;type=account;actions=create,update")
 	TestRoleGrant(t, conn, roleThisAndChildren.PublicId, "ids=*;type=group;actions=read;output_fields=id")
@@ -641,6 +643,20 @@ func TestGrantsForUserGlobalResources(t *testing.T) {
 					RoleParentScopeId: "global",
 					GrantScopeId:      "global",
 					Grant:             "ids=*;type=alias;actions=delete",
+				},
+				{
+					RoleId:            roleThisAndOrg2.PublicId,
+					RoleScopeId:       "global",
+					RoleParentScopeId: "global",
+					GrantScopeId:      "global",
+					Grant:             "ids=*;type=alias;actions=read",
+				},
+				{
+					RoleId:            roleThisAndOrg2.PublicId,
+					RoleScopeId:       "global",
+					RoleParentScopeId: "global",
+					GrantScopeId:      "global",
+					Grant:             "ids=*;type=alias;actions=update",
 				},
 			},
 		},

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -2014,7 +2014,7 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 	})
 }
 
-func TestGrantsForUserGlobalOrgProjectResourcesWithRecursive(t *testing.T) {
+func TestGrantsForUserRecursive(t *testing.T) {
 	ctx := context.Background()
 	conn, _ := db.TestSetup(t, "postgres")
 	wrap := db.TestWrapper(t)

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -750,14 +750,14 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 	user := TestUser(t, repo, "global")
 
 	// Create scopes
-	org1Scope := TestOrg(t, repo, WithSkipDefaultRoleCreation(true))
-	org2Scope := TestOrg(t, repo, WithSkipDefaultRoleCreation(true))
+	org1 := TestOrg(t, repo, WithSkipDefaultRoleCreation(true))
+	org2 := TestOrg(t, repo, WithSkipDefaultRoleCreation(true))
 
 	// Create & grant roles
 	roles := make([]*Role, 0)
 
-	globalRoleOrg1 := TestRole(t, conn, globals.GlobalPrefix, WithGrantScopeIds([]string{org1Scope.PublicId}))
-	globalRoleThisAndOrg2 := TestRole(t, conn, globals.GlobalPrefix, WithGrantScopeIds([]string{globals.GrantScopeThis, org2Scope.PublicId}))
+	globalRoleOrg1 := TestRole(t, conn, globals.GlobalPrefix, WithGrantScopeIds([]string{org1.PublicId}))
+	globalRoleThisAndOrg2 := TestRole(t, conn, globals.GlobalPrefix, WithGrantScopeIds([]string{globals.GrantScopeThis, org2.PublicId}))
 	globalRoleDescendants := TestRole(t, conn, globals.GlobalPrefix, WithGrantScopeIds([]string{globals.GrantScopeDescendants}))
 	globalRoleThisAndChildren := TestRole(t, conn, globals.GlobalPrefix, WithGrantScopeIds([]string{globals.GrantScopeThis, globals.GrantScopeChildren}))
 	roles = append(roles, globalRoleOrg1, globalRoleThisAndOrg2, globalRoleDescendants, globalRoleThisAndChildren)
@@ -769,16 +769,16 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 	TestRoleGrant(t, conn, globalRoleThisAndChildren.PublicId, "ids=*;type=user;actions=set-accounts")
 	TestRoleGrant(t, conn, globalRoleThisAndChildren.PublicId, "ids=*;type=policy;actions=read;output_fields=id")
 
-	org1RoleThis := TestRole(t, conn, org1Scope.PublicId, WithGrantScopeIds([]string{globals.GrantScopeThis}))
-	org1RoleChildren := TestRole(t, conn, org1Scope.PublicId, WithGrantScopeIds([]string{globals.GrantScopeChildren}))
-	org2RoleIndividual := TestRole(t, conn, org2Scope.PublicId)
-	org2RoleThisAndChildren := TestRole(t, conn, org2Scope.PublicId, WithGrantScopeIds([]string{globals.GrantScopeThis, globals.GrantScopeChildren}))
-	roles = append(roles, org1RoleThis, org1RoleChildren, org2RoleIndividual, org2RoleThisAndChildren)
+	org1RoleThis := TestRole(t, conn, org1.PublicId, WithGrantScopeIds([]string{globals.GrantScopeThis}))
+	org1RoleChildren := TestRole(t, conn, org1.PublicId, WithGrantScopeIds([]string{globals.GrantScopeChildren}))
+	org2RoleThis := TestRole(t, conn, org2.PublicId)
+	org2RoleThisAndChildren := TestRole(t, conn, org2.PublicId, WithGrantScopeIds([]string{globals.GrantScopeThis, globals.GrantScopeChildren}))
+	roles = append(roles, org1RoleThis, org1RoleChildren, org2RoleThis, org2RoleThisAndChildren)
 
 	TestRoleGrant(t, conn, org1RoleThis.PublicId, "ids=*;type=*;actions=*")
 	TestRoleGrant(t, conn, org1RoleChildren.PublicId, "ids=*;type=user;actions=add-accounts")
-	TestRoleGrant(t, conn, org2RoleIndividual.PublicId, "ids=*;type=user;actions=list-resolvable-aliases")
-	TestRoleGrant(t, conn, org2RoleIndividual.PublicId, "ids=*;type=policy;actions=list,no-op")
+	TestRoleGrant(t, conn, org2RoleThis.PublicId, "ids=*;type=user;actions=list-resolvable-aliases")
+	TestRoleGrant(t, conn, org2RoleThis.PublicId, "ids=*;type=policy;actions=list,no-op")
 	TestRoleGrant(t, conn, org2RoleThisAndChildren.PublicId, "ids=*;type=policy;actions=*")
 
 	// Add users to created roles
@@ -797,7 +797,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 			name: "return grants for user resource at org1 request scope",
 			input: testInput{
 				userId:     user.PublicId,
-				reqScopeId: org1Scope.PublicId,
+				reqScopeId: org1.PublicId,
 				resource:   []resource.Type{resource.User},
 			},
 			output: []perms.GrantTuple{
@@ -805,7 +805,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 					RoleId:            globalRoleOrg1.PublicId,
 					RoleScopeId:       "global",
 					RoleParentScopeId: "global",
-					GrantScopeId:      org1Scope.PublicId,
+					GrantScopeId:      org1.PublicId,
 					Grant:             "ids=*;type=user;actions=create,update",
 				},
 				{
@@ -824,9 +824,9 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 				},
 				{
 					RoleId:            org1RoleThis.PublicId,
-					RoleScopeId:       org1Scope.PublicId,
+					RoleScopeId:       org1.PublicId,
 					RoleParentScopeId: "global",
-					GrantScopeId:      org1Scope.PublicId,
+					GrantScopeId:      org1.PublicId,
 					Grant:             "ids=*;type=*;actions=*",
 				},
 			},
@@ -835,7 +835,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 			name: "return grants for user resource at org2 request scope",
 			input: testInput{
 				userId:     user.PublicId,
-				reqScopeId: org2Scope.PublicId,
+				reqScopeId: org2.PublicId,
 				resource:   []resource.Type{resource.User},
 			},
 			output: []perms.GrantTuple{
@@ -843,7 +843,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 					RoleId:            globalRoleThisAndOrg2.PublicId,
 					RoleScopeId:       "global",
 					RoleParentScopeId: "global",
-					GrantScopeId:      org2Scope.PublicId,
+					GrantScopeId:      org2.PublicId,
 					Grant:             "ids=*;type=user;actions=*",
 				},
 				{
@@ -861,10 +861,10 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 					Grant:             "ids=*;type=user;actions=set-accounts",
 				},
 				{
-					RoleId:            org2RoleIndividual.PublicId,
-					RoleScopeId:       org2Scope.PublicId,
+					RoleId:            org2RoleThis.PublicId,
+					RoleScopeId:       org2.PublicId,
 					RoleParentScopeId: "global",
-					GrantScopeId:      org2Scope.PublicId,
+					GrantScopeId:      org2.PublicId,
 					Grant:             "ids=*;type=user;actions=list-resolvable-aliases",
 				},
 			},
@@ -873,7 +873,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 			name: "return grants for policy resource at org1 request scope",
 			input: testInput{
 				userId:     user.PublicId,
-				reqScopeId: org1Scope.PublicId,
+				reqScopeId: org1.PublicId,
 				resource:   []resource.Type{resource.Policy},
 			},
 			output: []perms.GrantTuple{
@@ -881,7 +881,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 					RoleId:            globalRoleOrg1.PublicId,
 					RoleScopeId:       "global",
 					RoleParentScopeId: "global",
-					GrantScopeId:      org1Scope.PublicId,
+					GrantScopeId:      org1.PublicId,
 					Grant:             "ids=*;type=policy;actions=list,read",
 				},
 				{
@@ -900,9 +900,9 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 				},
 				{
 					RoleId:            org1RoleThis.PublicId,
-					RoleScopeId:       org1Scope.PublicId,
+					RoleScopeId:       org1.PublicId,
 					RoleParentScopeId: "global",
-					GrantScopeId:      org1Scope.PublicId,
+					GrantScopeId:      org1.PublicId,
 					Grant:             "ids=*;type=*;actions=*",
 				},
 			},
@@ -911,7 +911,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 			name: "return grants for policy resource at org2 request scope",
 			input: testInput{
 				userId:     user.PublicId,
-				reqScopeId: org2Scope.PublicId,
+				reqScopeId: org2.PublicId,
 				resource:   []resource.Type{resource.Policy},
 			},
 			output: []perms.GrantTuple{
@@ -930,17 +930,17 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 					Grant:             "ids=*;type=policy;actions=read;output_fields=id",
 				},
 				{
-					RoleId:            org2RoleIndividual.PublicId,
-					RoleScopeId:       org2Scope.PublicId,
+					RoleId:            org2RoleThis.PublicId,
+					RoleScopeId:       org2.PublicId,
 					RoleParentScopeId: "global",
-					GrantScopeId:      org2Scope.PublicId,
+					GrantScopeId:      org2.PublicId,
 					Grant:             "ids=*;type=policy;actions=list,no-op",
 				},
 				{
 					RoleId:            org2RoleThisAndChildren.PublicId,
-					RoleScopeId:       org2Scope.PublicId,
+					RoleScopeId:       org2.PublicId,
 					RoleParentScopeId: "global",
-					GrantScopeId:      org2Scope.PublicId,
+					GrantScopeId:      org2.PublicId,
 					Grant:             "ids=*;type=policy;actions=*",
 				},
 			},
@@ -949,7 +949,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 			name: "return '*' and 'unknown' grants when no resource specified at org1 request scope",
 			input: testInput{
 				userId:     user.PublicId,
-				reqScopeId: org1Scope.PublicId,
+				reqScopeId: org1.PublicId,
 			},
 			output: []perms.GrantTuple{
 				{
@@ -961,9 +961,9 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 				},
 				{
 					RoleId:            org1RoleThis.PublicId,
-					RoleScopeId:       org1Scope.PublicId,
+					RoleScopeId:       org1.PublicId,
 					RoleParentScopeId: "global",
-					GrantScopeId:      org1Scope.PublicId,
+					GrantScopeId:      org1.PublicId,
 					Grant:             "ids=*;type=*;actions=*",
 				},
 			},
@@ -972,7 +972,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 			name: "return '*' and 'unknown' grants when no resource specified at org2 request scope",
 			input: testInput{
 				userId:     user.PublicId,
-				reqScopeId: org2Scope.PublicId,
+				reqScopeId: org2.PublicId,
 			},
 			output: []perms.GrantTuple{
 				{
@@ -988,7 +988,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 			name: "u_anon should return no grants at org1 request scope",
 			input: testInput{
 				userId:     globals.AnonymousUserId,
-				reqScopeId: org1Scope.PublicId,
+				reqScopeId: org1.PublicId,
 			},
 			output: []perms.GrantTuple{},
 		},
@@ -996,7 +996,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 			name: "u_anon should return no grants at org2 request scope",
 			input: testInput{
 				userId:     globals.AnonymousUserId,
-				reqScopeId: org2Scope.PublicId,
+				reqScopeId: org2.PublicId,
 			},
 			output: []perms.GrantTuple{},
 		},
@@ -1004,7 +1004,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 			name: "u_auth should return no grants at org1 request scope",
 			input: testInput{
 				userId:     globals.AnyAuthenticatedUserId,
-				reqScopeId: org1Scope.PublicId,
+				reqScopeId: org1.PublicId,
 			},
 			output: []perms.GrantTuple{},
 		},
@@ -1012,7 +1012,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 			name: "u_auth should return no grants at org2 request scope",
 			input: testInput{
 				userId:     globals.AnyAuthenticatedUserId,
-				reqScopeId: org2Scope.PublicId,
+				reqScopeId: org2.PublicId,
 			},
 			output: []perms.GrantTuple{},
 		},
@@ -1020,7 +1020,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 			name: "missing user id should return error",
 			input: testInput{
 				resource:   []resource.Type{resource.User},
-				reqScopeId: org1Scope.PublicId,
+				reqScopeId: org1.PublicId,
 			},
 			errorMsg: "missing user id",
 		},

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -779,6 +779,7 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 	roles = append(roles, globalRoleOrg1, globalRoleThisAndOrg2, globalRoleDescendants, globalRoleThisAndChildren)
 
 	TestRoleGrant(t, conn, globalRoleOrg1.PublicId, "ids=*;type=user;actions=create,update")
+	TestRoleGrant(t, conn, globalRoleOrg1.PublicId, "ids=*;type=user;actions=delete,read")
 	TestRoleGrant(t, conn, globalRoleOrg1.PublicId, "ids=*;type=policy;actions=list,read")
 	TestRoleGrant(t, conn, globalRoleThisAndOrg2.PublicId, "ids=*;type=user;actions=*")
 	TestRoleGrant(t, conn, globalRoleDescendants.PublicId, "ids=*;type=*;actions=update")
@@ -823,6 +824,13 @@ func TestGrantsForUserOrgResources(t *testing.T) {
 					RoleParentScopeId: "global",
 					GrantScopeId:      org1.PublicId,
 					Grant:             "ids=*;type=user;actions=create,update",
+				},
+				{
+					RoleId:            globalRoleOrg1.PublicId,
+					RoleScopeId:       "global",
+					RoleParentScopeId: "global",
+					GrantScopeId:      org1.PublicId,
+					Grant:             "ids=*;type=user;actions=delete,read",
 				},
 				{
 					RoleId:            globalRoleDescendants.PublicId,

--- a/internal/iam/repository_role_grant_test.go
+++ b/internal/iam/repository_role_grant_test.go
@@ -1099,6 +1099,8 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 	TestRoleGrant(t, conn, globalRoleDescendants.PublicId, "ids=*;type=*;actions=read")
 	TestRoleGrant(t, conn, globalRoleThisAndProj1a.PublicId, "ids=*;type=target;actions=set-credential-sources")
 	TestRoleGrant(t, conn, globalRoleProj2.PublicId, "ids=*;type=scope;actions=list,read")
+	TestRoleGrant(t, conn, globalRoleProj2.PublicId, "ids=*;type=scope;actions=destroy-key-version")
+	TestRoleGrant(t, conn, globalRoleProj2.PublicId, "ids=*;type=scope;actions=rotate-keys")
 	TestRoleGrant(t, conn, globalRoleProj2.PublicId, "ids=*;type=target;actions=create,update")
 
 	org1RoleProj1b := TestRole(t, conn, org1.PublicId, WithGrantScopeIds([]string{proj1b.PublicId}))
@@ -1287,6 +1289,20 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 						RoleParentScopeId: "global",
 						GrantScopeId:      proj2.PublicId,
 						Grant:             "ids=*;type=scope;actions=list,read",
+					},
+					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=destroy-key-version",
+					},
+					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=rotate-keys",
 					},
 					{
 						RoleId:            org2RoleThisAndChildren.PublicId,
@@ -1656,6 +1672,20 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 						Grant:             "ids=*;type=scope;actions=list,read",
 					},
 					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=destroy-key-version",
+					},
+					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=rotate-keys",
+					},
+					{
 						RoleId:            org1RoleProj1b.PublicId,
 						RoleScopeId:       org1.PublicId,
 						RoleParentScopeId: "global",
@@ -1751,6 +1781,20 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 						Grant:             "ids=*;type=scope;actions=list,read",
 					},
 					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=destroy-key-version",
+					},
+					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=rotate-keys",
+					},
+					{
 						RoleId:            org2RoleThisAndChildren.PublicId,
 						RoleScopeId:       org2.PublicId,
 						RoleParentScopeId: "global",
@@ -1808,6 +1852,20 @@ func TestGrantsForUserProjectResources(t *testing.T) {
 						RoleParentScopeId: "global",
 						GrantScopeId:      proj2.PublicId,
 						Grant:             "ids=*;type=scope;actions=list,read",
+					},
+					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=destroy-key-version",
+					},
+					{
+						RoleId:            globalRoleProj2.PublicId,
+						RoleScopeId:       "global",
+						RoleParentScopeId: "global",
+						GrantScopeId:      proj2.PublicId,
+						Grant:             "ids=*;type=scope;actions=rotate-keys",
 					},
 					{
 						RoleId:            proj2RoleThis.PublicId,


### PR DESCRIPTION
This change intends to reduce the amount of rows retrieved by only querying each table once per CTE and using aggregate functions (`array_agg`). This should reduce the amount of rows returned from the DB in cases when there are many grants on a role:

Before:

```sql
-- returns one row per grant

    select role_id,
           role_scope_id,
           role_parent_scope_id,
           grant_scope,
           canonical_grant as grant
      from global_and_org_roles
  group by role_id,
           role_scope_id,
           role_parent_scope_id,
           grant_scope,
           canonical_grant;
```

After:

```sql
-- returns one row per role, with an array of distinct grants for each

    select role_id,
           role_scope_id,
           role_parent_scope_id,
           grant_scope,
           grant_this_role_scope,
           array_agg(distinct(individual_grant_scope)) as individual_grant_scopes,
           array_agg(distinct(canonical_grant))        as canonical_grants
      from global_and_org_roles
  group by role_id,
           role_scope_id,
           role_parent_scope_id,
           grant_scope,
           grant_this_role_scope;
```