### PR TITLE
Postgres 15 -> 16 Migration Update

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/85/02_alias_domain.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/85/02_alias_domain.up.sql
@@ -3,6 +3,9 @@
 
 begin;
 
+  -- Constraints wt_alias_too_short, wt_alias_no_suround_spaces, and wt_target_alias_too_long
+  -- have been updated in migration 96/01
+
   -- wt_alias defines a type for alias values
   create domain wt_alias as citext
     constraint wt_alias_too_short

--- a/internal/db/schema/migrations/oss/postgres/96/01_update_wt_alias_constraints.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/96/01_update_wt_alias_constraints.up.sql
@@ -1,0 +1,21 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+
+-- Modify the wt_alias domain to include explicit casts in its constraints
+alter domain wt_alias drop constraint if exists wt_alias_too_short;
+alter domain wt_alias drop constraint if exists wt_alias_no_suround_spaces;
+
+alter domain wt_alias add constraint wt_alias_too_short
+  check (length(trim(both from value::text)) > 0);
+alter domain wt_alias add constraint wt_alias_no_suround_spaces
+  check (trim(both from value::text) = value::text);
+
+-- Modify the wt_target_alias domain to include explicit casts in its constraints
+alter domain wt_target_alias drop constraint if exists wt_target_alias_too_long;
+
+alter domain wt_target_alias add constraint wt_target_alias_too_long
+  check (length(trim(both from value::text)) < 254);
+
+commit;


### PR DESCRIPTION
# Changes
This migration updates the `wt_alias` and `wt_target_alias` domains to include explicit `::text` casting in their constraints. Postgres 16 enforces stricter domain checks, requiring explicit casts to ensure compatibility. 

These changes address Postgres upgrade issues by aligning the constraints with the stricter evaluation rules.

# Previous Upgrade Behavior 
When attempting to upgrade from Postgres 15 -> 16 on Aurora RDS with Boundary `0.19.2` the following error: 
```
...
pg_restore: creating DOMAIN "public.wh_dim_key"
pg_restore: creating COMMENT "public.DOMAIN "wh_dim_key""
pg_restore: creating DOMAIN "public.wh_dim_text"
pg_restore: creating COMMENT "public.DOMAIN "wh_dim_text""
pg_restore: creating DOMAIN "public.wh_inet_port"
pg_restore: creating COMMENT "public.DOMAIN "wh_inet_port""
pg_restore: creating DOMAIN "public.wh_public_id"
pg_restore: creating COMMENT "public.DOMAIN "wh_public_id""
pg_restore: creating DOMAIN "public.wh_timestamp"
pg_restore: creating COMMENT "public.DOMAIN "wh_timestamp""
pg_restore: creating DOMAIN "public.wh_user_id"
pg_restore: creating COMMENT "public.DOMAIN "wh_user_id""
pg_restore: creating DOMAIN "public.wt_alias"
pg_restore: while PROCESSING TOC:
pg_restore: from TOC entry 2712; 1247 23905 DOMAIN wt_alias ryanderr
pg_restore: error: could not execute query: ERROR:  function pg_catalog.btrim(public.citext) does not exist
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
Command was: 
-- For binary upgrade, must preserve pg_type oid
SELECT pg_catalog.binary_upgrade_set_next_pg_type_oid('23905'::pg_catalog.oid);


-- For binary upgrade, must preserve pg_type array oid
SELECT pg_catalog.binary_upgrade_set_next_array_pg_type_oid('23904'::pg_catalog.oid);

CREATE DOMAIN "public"."wt_alias" AS "public"."citext"
	CONSTRAINT "wt_alias_no_suround_spaces" CHECK ((TRIM(BOTH FROM VALUE) = (VALUE)::"text"))
	CONSTRAINT "wt_alias_too_short" CHECK (("length"(TRIM(BOTH FROM VALUE)) > 0));

```