### PR TITLE
docs: Update transparent session known issue

### DIFF
--- a/website/content/docs/concepts/transparent-sessions.mdx
+++ b/website/content/docs/concepts/transparent-sessions.mdx
@@ -28,7 +28,7 @@ Refer to the following table for known issues:
 | Issue | Description |
 | ----- | ----------- |
 | Connection is reset when trying to reconnect | If you use an SSH transparent session and then cancel the connection, you may have trouble reconnecting until Boundary cleans up the session. |
-| SSH connection fails with man-in-the-middle warning | On Ubuntu systems, the initial transparent session may be successful, but any subsequent connections prompt a warning that you may be experiencing a man-in-the-middle attack. |
+| SSH connection fails with man-in-the-middle warning | On Linux systems, the initial transparent session may be successful, but any subsequent connections prompt a warning that you may be experiencing a man-in-the-middle attack. <br /><br /> For more information, refer to [WARNING! Remote host indentification has changed! It is possible that someone is doing something nasty!](/boundary/docs/api-clients/client-agent#warning-remote-host-indentification-has-changed-it-is-possible-that-someone-is-doing-something-nasty) in the **Common error messages** section.|
 | Boundary Client Agent authentication does not persist across restarts | When you reboot, you are required to re-authenticate to the Client Agent before you can use transparent sessions. |
 | Windows installer prompts for restart | When you install Boundary, the Windows installer occasionally prompts you to restart your computer, however it is not necessary. |
 | Boundary Client Agent resumes on reboot | If the Client Agent is paused and the machine is rebooted, the Client Agent will be resumed after the reboot. |


### PR DESCRIPTION
One of the transparent sessions known issues incorrectly says that it affects Ubuntu systems, when it actually affects all Linux systems. We also have a recommended workaround for this issue documented in the **Common errors** section, and it could be helpful for users if we link out to it. This PR updates the known issue with those 2 fixes.

[View the update in the preview deployment](https://boundary-ouoduiovi-hashicorp.vercel.app/boundary/docs/concepts/transparent-sessions#known-issues)