### PR TITLE
docs: Add Client Agent commands to CLI docs (#5826)

### DIFF
--- a/website/content/docs/commands/client-agent/index.mdx
+++ b/website/content/docs/commands/client-agent/index.mdx
@@ -1,0 +1,59 @@
+---
+layout: docs
+page_title: client-agent - Command
+description: >-
+  The "client-agent" command lets you interact with the Boundary Client Agent.
+---
+
+# client-agent
+
+Command: `boundary client-agent`
+
+The `client-agent` command lets you interact with the Boundary Client Agent.
+You can check the Client Agent's status, pause it, resume it, or list the active transparent sessions the Client Agent is managing.
+
+## Examples
+
+The following command lets you check the status of the Client Agent to ensure it is running:
+
+```shell-session
+$ boundary client-agent status
+```
+
+The following command retrieves information about any sessions that the Client Agent is managing:
+
+```shell-session
+$ boundary client-agent sessions
+```
+
+You can temporarily disable the Client Agent by pausing it with the following command:
+
+```shell-session
+$ boundary client-agent pause
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+Usage: boundary client-agent <subcommand> [options] [args]
+
+  # ...
+
+Subcommands:
+    pause       Pauses the running boundary client agent
+    resume      Resumes the paused boundary client agent
+    sessions    List active transparent sessions managed by the client agent.
+    status      Get the status information of the running boundary client agent
+```
+
+</CodeBlockConfig>
+
+For more information, examples, and usage, click on the name
+of the subcommand in the sidebar or one of the links below:
+
+- [pause](/boundary/docs/commands/client-agent/pause)
+- [resume](/boundary/docs/commands/client-agent/resume)
+- [sessions](/boundary/docs/commands/client-agent/sessions)
+- [status](/boundary/docs/commands/client-agent/status)

--- a/website/content/docs/commands/client-agent/pause.mdx
+++ b/website/content/docs/commands/client-agent/pause.mdx
@@ -1,0 +1,38 @@
+---
+layout: docs
+page_title: client-agent pause - Command
+description: >-
+  The "client-agent pause" command pauses the Client Agent so that it does not intercept DNS requests.
+---
+
+# client-agent pause
+
+Command: `boundary client-agent pause`
+
+The `boundary client-agent pause` command lets you temporarily stop the Client Agent.
+When the Client Agent is paused, it does not intercept DNS requests and you cannot use transparent sessions.
+
+## Example
+
+The following command pauses the Client Agent:
+
+```shell-session
+$ boundary client-agent pause
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary client-agent pause [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `client-agent-port=<uint>` - Specifies the port on which the Client Agent listens.
+You can also specify the port using the **BOUNDARY_CLIENT_AGENT_LISTENING_PORT** environment variable.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/client-agent/resume.mdx
+++ b/website/content/docs/commands/client-agent/resume.mdx
@@ -1,0 +1,39 @@
+---
+layout: docs
+page_title: client-agent resume - Command
+description: >-
+  The "client-agent resume" command resumes running the Client Agent when it is paused.
+---
+
+# client-agent resume
+
+Command: `boundary client-agent resume`
+
+The `boundary client-agent resume` command lets you resume the Client Agent when it is paused.
+When the Client Agent is paused, it does not intercept DNS requests and you cannot use transparent sessions.
+You must resume the Client Agent to use transparent sessions again after you pause it.
+
+## Example
+
+The following command resumes the Client Agent:
+
+```shell-session
+$ boundary client-agent resume
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary client-agent resume [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `client-agent-port=<uint>` - Specifies the port on which the Client Agent listens.
+You can also specify the port using the **BOUNDARY_CLIENT_AGENT_LISTENING_PORT** environment variable.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/client-agent/sessions.mdx
+++ b/website/content/docs/commands/client-agent/sessions.mdx
@@ -1,0 +1,37 @@
+---
+layout: docs
+page_title: client-agent sessions - Command
+description: >-
+  The "client-agent sessions" command lists any active sessions that the Client Agent is managing. It also lists any associated brokered credentials.
+---
+
+# client-agent sessions
+
+Command: `boundary client-agent sessions`
+
+The `boundary client-agent sessions` command lists any sessions that the Client Agent is managing as well as any brokered credentials that are associated with those sessions.
+
+## Example
+
+The following command lists any sessions that the Client Agent is managing:
+
+```shell-session
+$ boundary client-agent sessions
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary client-agent sessions [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `client-agent-port=<uint>` - Specifies the port on which the Client Agent listens.
+You can also specify the port using the **BOUNDARY_CLIENT_AGENT_LISTENING_PORT** environment variable.
+
+@include 'cmd-option-note.mdx'

--- a/website/content/docs/commands/client-agent/status.mdx
+++ b/website/content/docs/commands/client-agent/status.mdx
@@ -1,0 +1,39 @@
+---
+layout: docs
+page_title: client-agent status - Command
+description: >-
+  The "client-agent status" command provides the status of the Client Agent so you can ensure that it is running.
+---
+
+# client-agent status
+
+Command: `boundary client-agent status`
+
+You can use the `boundary client-agent status` command to ensure that the Client Agent is running.
+The command provides the runtime status and information about whether the current user is authenticated.
+It may also include a list of errors, if the Client Agent has encountered any.
+
+## Example
+
+The following command provides the current status of the Client Agent:
+
+```shell-session
+$ boundary client-agent status
+```
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary client-agent status [options] [args]
+```
+
+</CodeBlockConfig>
+
+### Command options
+
+- `client-agent-port=<uint>` - Specifies the port on which the Client Agent listens.
+You can also specify the port using the **BOUNDARY_CLIENT_AGENT_LISTENING_PORT** environment variable.
+
+@include 'cmd-option-note.mdx'

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -880,19 +880,6 @@
         ]
       },
       {
-        "title": "billing",
-        "routes": [
-          {
-            "title": "Overview",
-            "path": "commands/billing"
-          },
-          {
-            "title": "monthly-active-users",
-            "path": "commands/billing/monthly-active-users"
-          }
-        ]
-      },
-      {
         "title": "authenticate",
         "routes": [
           {
@@ -910,6 +897,69 @@
           {
             "title": "password",
             "path": "commands/authenticate/password"
+          }
+        ]
+      },
+      {
+        "title": "billing",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "commands/billing"
+          },
+          {
+            "title": "monthly-active-users",
+            "path": "commands/billing/monthly-active-users"
+          }
+        ]
+      },
+      {
+        "title": "cache",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "commands/cache"
+          },
+          {
+            "title": "add-token",
+            "path": "commands/cache/add-token"
+          },
+          {
+            "title": "start",
+            "path": "commands/cache/start"
+          },
+          {
+            "title": "status",
+            "path": "commands/cache/status"
+          },
+          {
+            "title": "stop",
+            "path": "commands/cache/stop"
+          }
+        ]
+      },
+      {
+        "title": "client-agent",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "commands/client-agent"
+          },
+          {
+            "title": "pause",
+            "path": "commands/client-agent/pause"
+          },
+          {
+            "title": "resume",
+            "path": "commands/client-agent/resume"
+          },
+          {
+            "title": "sessions",
+            "path": "commands/client-agent/sessions"
+          },
+          {
+            "title": "status",
+            "path": "commands/client-agent/status"
           }
         ]
       },
@@ -1051,31 +1101,6 @@
           {
             "title": "update",
             "path": "commands/credentials/update"
-          }
-        ]
-      },
-      {
-        "title": "cache",
-        "routes": [
-          {
-            "title": "Overview",
-            "path": "commands/cache"
-          },
-          {
-            "title": "add-token",
-            "path": "commands/cache/add-token"
-          },
-          {
-            "title": "start",
-            "path": "commands/cache/start"
-          },
-          {
-            "title": "status",
-            "path": "commands/cache/status"
-          },
-          {
-            "title": "stop",
-            "path": "commands/cache/stop"
           }
         ]
       },


### PR DESCRIPTION
The backports for PR #5826 failed. This PR cherry-picks the following commits to the `stable-website` branch:

* docs: Add Client Agent commands to CLI docs

* docs: Fix typos

* docs: Update status description

* Update website/content/docs/commands/client-agent/index.mdx

Co-authored-by: Robin Beck <stellarsquall@users.noreply.github.com>

* docs: Capitalize Client Agent

* docs: Undo capitalization

* Apply batch suggestions from code review

Co-authored-by: Robin Beck <stellarsquall@users.noreply.github.com>

---------

Co-authored-by: Robin Beck <stellarsquall@users.noreply.github.com>