### PR TITLE
Resolve GrantsForUser queries via resolveQuery()

### DIFF
--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/boundary/globals"
@@ -433,14 +432,6 @@ func (r *Repository) ListRoleGrants(ctx context.Context, roleId string, opt ...O
 	return roleGrants, nil
 }
 
-type MultiGrantTuple struct {
-	RoleId            string
-	RoleScopeId       string
-	RoleParentScopeId string
-	GrantScopeIds     string
-	Grants            string
-}
-
 type grantsForUserResults struct {
 	// roleId is the public ID of the role.
 	roleId string
@@ -597,15 +588,6 @@ func (r *Repository) GrantsForUser(ctx context.Context, userId string, res []res
 		}
 	}
 	return ret, nil
-}
-
-func (m *MultiGrantTuple) TestStableSort() {
-	grantScopeIds := strings.Split(m.GrantScopeIds, "^")
-	sort.Strings(grantScopeIds)
-	m.GrantScopeIds = strings.Join(grantScopeIds, "^")
-	gts := strings.Split(m.Grants, "^")
-	sort.Strings(gts)
-	m.Grants = strings.Join(gts, "^")
 }
 
 func (r *Repository) resolveQuery(

--- a/internal/iam/repository_role_grant.go
+++ b/internal/iam/repository_role_grant.go
@@ -472,6 +472,9 @@ func (r *Repository) GrantsForUser(ctx context.Context, userId string, res []res
 	if userId == "" {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing user id")
 	}
+	if res == nil {
+		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing resource type")
+	}
 	if slices.Contains(res, resource.Unknown) {
 		return nil, errors.New(ctx, errors.InvalidParameter, op, "resource type cannot be unknown")
 	}

--- a/internal/iam/repository_role_grant_ext_test.go
+++ b/internal/iam/repository_role_grant_ext_test.go
@@ -326,7 +326,7 @@ func TestGrantsForUser(t *testing.T) {
 				}, perms.GrantTuples{}
 			},
 			wantErr:    true,
-			wantErrMsg: "iam.(Repository).GrantsForUser: request scope id must be global for [worker] resources: parameter violation: error #100",
+			wantErrMsg: "iam.(Repository).GrantsForUser: unable to resolve query: iam.(Repository).resolveQuery: request scope id must be global for [worker] resources: parameter violation: error #100",
 		},
 		{
 			name: "global only resource (billing) project scope request",
@@ -340,7 +340,7 @@ func TestGrantsForUser(t *testing.T) {
 				}, perms.GrantTuples{}
 			},
 			wantErr:    true,
-			wantErrMsg: "iam.(Repository).GrantsForUser: request scope id must be global for [billing] resources: parameter violation: error #100",
+			wantErrMsg: "iam.(Repository).GrantsForUser: unable to resolve query: iam.(Repository).resolveQuery: request scope id must be global for [billing] resources: parameter violation: error #100",
 		},
 		{
 			name: "global org and project resource (role) global scope request recursive",
@@ -1938,7 +1938,7 @@ func TestGrantsForUser(t *testing.T) {
 				}, perms.GrantTuples{}
 			},
 			wantErr:    true,
-			wantErrMsg: "iam.(Repository).GrantsForUser: request scope id must be project for [target] resources: parameter violation: error #100",
+			wantErrMsg: "iam.(Repository).GrantsForUser: unable to resolve query: iam.(Repository).resolveQuery: request scope id must be project for [target] resources: parameter violation: error #100",
 		},
 		{
 			name: "project only resource (target) org scope request non recursive",
@@ -1952,7 +1952,7 @@ func TestGrantsForUser(t *testing.T) {
 				}, perms.GrantTuples{}
 			},
 			wantErr:    true,
-			wantErrMsg: "iam.(Repository).GrantsForUser: request scope id must be project for [target] resources: parameter violation: error #100",
+			wantErrMsg: "iam.(Repository).GrantsForUser: unable to resolve query: iam.(Repository).resolveQuery: request scope id must be project for [target] resources: parameter violation: error #100",
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
For each grantsForUser repo function, the logic to map from DB object -> `perms.GrantTuple` was very similar.

- This PR reduces code by removing those functions & moves the mapping logic into `GrantsForUser`
- Created a new function, `resolveQuery()`, to determine which query to use based on the request scope & the resources' applicable scopes