### PR TITLE
docs: Release notes for 0.19.3

### DIFF
--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -441,7 +441,7 @@ description: >-
 
   <tr>
     <td style={{verticalAlign: 'middle'}}>
-      Commmands to skip auto-creation of roles
+      Commands to skip auto-creation of roles
     </td>
     <td style={{verticalAlign: 'middle'}}>
       When you create a new scope, Boundary grants the current user administrative access to the newly created scope and also creates a role that grants the anonymous user access to log in. You can use the <code>-skip-admin-role-creation</code> and <code>-skip-default-role-creation</code> flags to prevent this default behavior.

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -408,7 +408,7 @@ description: >-
     <td style={{verticalAlign: 'middle'}}>
     You may have redundant grant scopes if you applied a grant to a scope and the scope also inherited the grant from the <code>this</code>, <code>children</code>, or <code>descendants</code> options. Redundant grant scopes could cause performance issues. As of Boundary version 0.19.3, redundant grant scopes are no longer permitted.
     <br /><br />
-    When you run the <code>boundary database migrate</code> command to upgrade a cluster to Boundary version 0.19.3, the migration will fail with a message, if the database contains any redundant grant scopes. The migration tool provides the following command to automatically repair the grant scopes:
+    When you run the <code>boundary database migrate</code> command to upgrade a cluster to Boundary version 0.19.3, the migration will fail with a message if the database contains any redundant grant scopes. The migration tool provides the following command to automatically repair the grant scopes:
     <br /><br />
     <code>boundary database migrate -repair=oss:96001</code>
     <br /><br />
@@ -444,7 +444,7 @@ description: >-
       Commmands to skip auto-creation of roles
     </td>
     <td style={{verticalAlign: 'middle'}}>
-      When you create a new scope, Boundary grants the current user administrative access to the newly created scope and also creates a role that grants the anonymous user access to log in by default. You can use the <code>-skip-admin-role-creation</code> and <code>-skip-default-role-creation</code> flags to prevent this default behavior.
+      When you create a new scope, Boundary grants the current user administrative access to the newly created scope and also creates a role that grants the anonymous user access to log. You can use the <code>-skip-admin-role-creation</code> and <code>-skip-default-role-creation</code> flags to prevent this default behavior.
       <br /><br />
       The <code>-skip-admin-role-creation</code> and <code>-skip-default-role-creation</code> flags are being deprecated in Boundary version 0.19.3. They will be removed from the product in two versions, and will be replaced with a new option to create the default roles.
       <br /><br />

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -28,6 +28,8 @@ description: >-
     </td>
     <td style={{verticalAlign: 'middle'}}>
     In a future version Boundary will no longer automatically create roles when new scopes are created. This was implemented prior to multi-scope grants to ensure administrators and users had default permissions in new scopes. Since Boundary 0.15, initial roles created for new clusters provide these permissions by default to all scopes using multi-scope grants.
+    <br /><br />
+    Learn more:&nbsp; <a href="#feature-deprecations">Feature deprecations</a>
     </td>
   </tr>
 
@@ -76,6 +78,19 @@ description: >-
     On May 27, 2025 new versions of the Boundary Client Agent and installer were released with a new numbering scheme that more closely follows Boundary's release numbers. Those versions were released as 0.19.5 to match the major Boundary version 0.19.x. Going forward, the Client Agent and installer will use the same major number as the current Boundary release. Any patches or updates will be reflected in the minor number.
     <br /><br />
     Learn more about control plane and client compatibility:&nbsp; <a href="/boundary/docs/enterprise/supported-versions">Boundary Enterprise supported versions policy </a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    Redundant grant scopes are no longer permitted
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Previously, you could configure redundant grant scopes if you applied a grant to a scope and the scope also inherited the grant from the <code>this</code>, <code>children</code>, or <code>descendants</code> option. As of Boundary version 0.19.3, redundant grant scopes are no longer permitted.
+    <br /><br />
+    When you upgrade a cluster to Boundary version 0.19.3, the migration will fail with a message if the database contains any redundant grant scopes. The migration tool provides a command that automatically removes any redundant grant scopes so that you can proceed with the upgrade.
+    <br /><br />
+    Learn more about removing redundant grant scopes and upgrading to version 0.19.3:&nbsp; <a href="#redundant-grants">Known issues and breaking changes </a>
     </td>
   </tr>
 
@@ -357,7 +372,7 @@ description: >-
     <ul>
     <li><a href="/boundary/docs/api-clients/client-agent#grants">Boundary Client Agent grants</a> requirements</li>
     <li><a href="/boundary/docs/commands/roles/create"><code>roles create</code></a> command documentation</li>
-    <li><a href="/boundary/docs/comands/roles/add-grant-scopes"><code>roles add-grant-scopes</code></a> command documentation</li>
+    <li><a href="/boundary/docs/commands/roles/add-grant-scopes"><code>roles add-grant-scopes</code></a> command documentation</li>
     <li><a href="/boundary/docs/commands/roles/add-grants"><code>roles add-grants</code></a> command documentation</li>
     </ul>
     </td>
@@ -378,6 +393,67 @@ description: >-
     Learn more: <a href="/boundary/docs/concepts/transparent-sessions">Transparent sessions</a>
     <br /><br />
     <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+   <tr id="redundant-grants">
+    <td style={{verticalAlign: 'middle'}}>
+    0.15.0 - 0.19.2
+    <br /><br />
+    (Fixed in Boundary version 0.19.3)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Redundant grant scopes cause performance issues
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Previously, you could configure redundant grant scopes if you applied a grant to a scope and the scope also inherited the grant from the <code>this</code>, <code>children</code>, or <code>descendants</code> option. Redundant grant scopes could cause performance issues. As of Boundary version 0.19.3, redundant grant scopes are no longer permitted.
+    <br /><br />
+    When you run the <code>boundary database migrate</code> command to upgrade a cluster to Boundary version 0.19.3, the migration will fail with a message, if the database contains any redundant grant scopes. The migration tool provides the following command to automatically repair the grant scopes:
+    <br /><br />
+    <code>boundary database migrate -repair=oss:96001</code>
+    <br /><br />
+    Run the command to remove any redundant grant scopes from roles and any individually granted scopes that are redundant to any <code>descendants</code> or <code>children</code> grants. When the migration is complete, Boundary produces a message that details the changes.
+    <br /><br />
+    Learn more:
+      <ul>
+      <li><a href="/boundary/docs/concepts/domain-model/scopes">Scopes</a></li>
+      <li><a href="/boundary/docs/commands/roles/add-grant-scopes"><code>roles add-grant-scopes</code></a> command documentation</li>
+      <li><a href="/boundary/docs/commands/roles/remove-grant-scopes"><code>roles remove-grant-scopes</code></a> command documentation</li>
+      <li><a href="/boundary/docs/commands/roles/set-grant-scopes"><code>roles set-grant-scopes</code></a> command documentation</li>
+      </ul>
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+## Feature deprecations
+
+<table>
+  <thead>
+    <tr>
+      <th style={{verticalAlign: 'middle'}}>Deprecated</th>
+      <th style={{verticalAlign: 'middle'}}>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+      Commmands to skip auto-creation of roles
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+      When you create a new scope, Boundary grants the current user administrative access to the newly created scope and also creates a role that grants the anonymous user access to log in by default. You can use the <code>-skip-admin-role-creation</code> and <code>-skip-default-role-creation</code> flags to prevent this default behavior.
+      <br /><br />
+      The <code>-skip-admin-role-creation</code> and <code>-skip-default-role-creation</code> flags are being deprecated in Boundary version 0.19.3. They will be removed from the product in two versions, and will be replaced with a new option to create the default roles.
+      <br /><br />
+      Learn more:
+      <ul>
+      <li><a href="/boundary/docs/commands/roles/add-grant-scopes"><code>roles add-grant-scopes</code></a> command documentation</li>
+      <li><a href="/boundary/docs/commands/roles/remove-grant-scopes"><code>roles remove-grant-scopes</code></a> command documentation</li>
+      <li><a href="/boundary/docs/commands/roles/set-grant-scopes"><code>roles set-grant-scopes</code></a> command documentation</li>
+      </ul>
     </td>
   </tr>
 

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -444,7 +444,7 @@ description: >-
       Commmands to skip auto-creation of roles
     </td>
     <td style={{verticalAlign: 'middle'}}>
-      When you create a new scope, Boundary grants the current user administrative access to the newly created scope and also creates a role that grants the anonymous user access to log. You can use the <code>-skip-admin-role-creation</code> and <code>-skip-default-role-creation</code> flags to prevent this default behavior.
+      When you create a new scope, Boundary grants the current user administrative access to the newly created scope and also creates a role that grants the anonymous user access to log in. You can use the <code>-skip-admin-role-creation</code> and <code>-skip-default-role-creation</code> flags to prevent this default behavior.
       <br /><br />
       The <code>-skip-admin-role-creation</code> and <code>-skip-default-role-creation</code> flags are being deprecated in Boundary version 0.19.3. They will be removed from the product in two versions, and will be replaced with a new option to create the default roles.
       <br /><br />

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -28,8 +28,6 @@ description: >-
     </td>
     <td style={{verticalAlign: 'middle'}}>
     In a future version Boundary will no longer automatically create roles when new scopes are created. This was implemented prior to multi-scope grants to ensure administrators and users had default permissions in new scopes. Since Boundary 0.15, initial roles created for new clusters provide these permissions by default to all scopes using multi-scope grants.
-    <br /><br />
-    Learn more:&nbsp; <a href="#feature-deprecations">Feature deprecations</a>
     </td>
   </tr>
 
@@ -422,36 +420,6 @@ description: >-
       <li><a href="/boundary/docs/commands/roles/set-grant-scopes"><code>roles set-grant-scopes</code></a> command documentation</li>
       </ul>
     <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
-    </td>
-  </tr>
-
-  </tbody>
-</table>
-
-## Feature deprecations
-
-<table>
-  <thead>
-    <tr>
-      <th style={{verticalAlign: 'middle'}}>Deprecated</th>
-      <th style={{verticalAlign: 'middle'}}>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-
-  <tr>
-    <td style={{verticalAlign: 'middle'}}>
-      Commands to skip auto-creation of roles
-    </td>
-    <td style={{verticalAlign: 'middle'}}>
-      When you create a new scope, Boundary grants the current user administrative access to the newly created scope and also creates a role that grants the anonymous user access to log in. You can use the <code>-skip-admin-role-creation</code> and <code>-skip-default-role-creation</code> flags to prevent this default behavior.
-      <br /><br />
-      The <code>-skip-admin-role-creation</code> and <code>-skip-default-role-creation</code> flags are being deprecated in Boundary version 0.19.3. They will be removed from the product in two versions, and will be replaced with a new option to create the default roles.
-      <br /><br />
-      Learn more:
-      <ul>
-      <li><a href="/boundary/docs/commands/scopes/create"><code>scopes create</code></a> command documentation</li>
-      </ul>
     </td>
   </tr>
 

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -406,7 +406,7 @@ description: >-
     Redundant grant scopes cause performance issues
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    You could configure redundant grant scopes if you applied a grant to a scope and the scope also inherited the grant from the <code>this</code>, <code>children</code>, or <code>descendants</code> options. Redundant grant scopes could cause performance issues. As of Boundary version 0.19.3, redundant grant scopes are no longer permitted.
+    You may have redundant grant scopes if you applied a grant to a scope and the scope also inherited the grant from the <code>this</code>, <code>children</code>, or <code>descendants</code> options. Redundant grant scopes could cause performance issues. As of Boundary version 0.19.3, redundant grant scopes are no longer permitted.
     <br /><br />
     When you run the <code>boundary database migrate</code> command to upgrade a cluster to Boundary version 0.19.3, the migration will fail with a message, if the database contains any redundant grant scopes. The migration tool provides the following command to automatically repair the grant scopes:
     <br /><br />

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -450,9 +450,7 @@ description: >-
       <br /><br />
       Learn more:
       <ul>
-      <li><a href="/boundary/docs/commands/roles/add-grant-scopes"><code>roles add-grant-scopes</code></a> command documentation</li>
-      <li><a href="/boundary/docs/commands/roles/remove-grant-scopes"><code>roles remove-grant-scopes</code></a> command documentation</li>
-      <li><a href="/boundary/docs/commands/roles/set-grant-scopes"><code>roles set-grant-scopes</code></a> command documentation</li>
+      <li><a href="/boundary/docs/commands/scopes/create"><code>scopes create</code></a> command documentation</li>
       </ul>
     </td>
   </tr>

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -410,7 +410,7 @@ description: >-
     <br /><br />
     When you run the <code>boundary database migrate</code> command to upgrade a cluster to Boundary version 0.19.3, the migration will fail with a message if the database contains any redundant grant scopes. The migration tool provides the following command to automatically repair the grant scopes:
     <br /><br />
-    <code>boundary database migrate -repair=oss:96001</code>
+    <code>boundary database migrate -repair=oss:97001</code>
     <br /><br />
     Run the command to remove any redundant grant scopes from roles. Any individually granted scopes that are already covered by <code>descendants</code> or <code>children</code> grants are considered invalid and removed. When the migration is complete, the migration tool produces a message that details any changes.
     <br /><br />

--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -86,7 +86,7 @@ description: >-
     Redundant grant scopes are no longer permitted
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Previously, you could configure redundant grant scopes if you applied a grant to a scope and the scope also inherited the grant from the <code>this</code>, <code>children</code>, or <code>descendants</code> option. As of Boundary version 0.19.3, redundant grant scopes are no longer permitted.
+    You may have redundant grant scopes if you applied a grant to a scope and the scope also inherited the grant from the <code>this</code>, <code>children</code>, or <code>descendants</code> options. As of Boundary version 0.19.3, redundant grant scopes are no longer permitted.
     <br /><br />
     When you upgrade a cluster to Boundary version 0.19.3, the migration will fail with a message if the database contains any redundant grant scopes. The migration tool provides a command that automatically removes any redundant grant scopes so that you can proceed with the upgrade.
     <br /><br />
@@ -396,7 +396,7 @@ description: >-
     </td>
   </tr>
 
-   <tr id="redundant-grants">
+  <tr id="redundant-grants">
     <td style={{verticalAlign: 'middle'}}>
     0.15.0 - 0.19.2
     <br /><br />
@@ -406,13 +406,13 @@ description: >-
     Redundant grant scopes cause performance issues
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    Previously, you could configure redundant grant scopes if you applied a grant to a scope and the scope also inherited the grant from the <code>this</code>, <code>children</code>, or <code>descendants</code> option. Redundant grant scopes could cause performance issues. As of Boundary version 0.19.3, redundant grant scopes are no longer permitted.
+    You could configure redundant grant scopes if you applied a grant to a scope and the scope also inherited the grant from the <code>this</code>, <code>children</code>, or <code>descendants</code> options. Redundant grant scopes could cause performance issues. As of Boundary version 0.19.3, redundant grant scopes are no longer permitted.
     <br /><br />
     When you run the <code>boundary database migrate</code> command to upgrade a cluster to Boundary version 0.19.3, the migration will fail with a message, if the database contains any redundant grant scopes. The migration tool provides the following command to automatically repair the grant scopes:
     <br /><br />
     <code>boundary database migrate -repair=oss:96001</code>
     <br /><br />
-    Run the command to remove any redundant grant scopes from roles and any individually granted scopes that are redundant to any <code>descendants</code> or <code>children</code> grants. When the migration is complete, Boundary produces a message that details the changes.
+    Run the command to remove any redundant grant scopes from roles. Any individually granted scopes that are already covered by <code>descendants</code> or <code>children</code> grants are considered invalid and removed. When the migration is complete, the migration tool produces a message that details any changes.
     <br /><br />
     Learn more:
       <ul>


### PR DESCRIPTION
This PR updates the 0.19.x release notes for the upcoming 0.19.3 release. It contains the following updates, click the links to see them in the preview deployment:

- Added an item to the [Important changes](https://boundary-kel28fwk3-hashicorp.vercel.app/boundary/docs/release-notes/v0_19_0#important-changes) table to explain that redundant grant scopes are no longer permitted.
- Added an item to the [Known issues](https://boundary-kel28fwk3-hashicorp.vercel.app/boundary/docs/release-notes/v0_19_0#known-issues-and-breaking-changes) section to explain the command to remove redundant grant scopes and the reason for the change