### PR TITLE
docs: Fix a typo in Client Agent docs

### DIFF
--- a/website/content/docs/api-clients/client-agent.mdx
+++ b/website/content/docs/api-clients/client-agent.mdx
@@ -132,7 +132,7 @@ The configuration file contains the following fields:
 
    Example:
    ```hcl
-   interface_to_use=en1
+   interface_to_use="en1"
    ```
 
 - `log_file` - Specifies where to write the Boundary Client Agent log file to.


### PR DESCRIPTION
Per [ICU-17216](https://hashicorp.atlassian.net/browse/ICU-17216), in the Client Agent docs, the example command for `interface_to_use` is missing quotation marks around the value. This PR fixes that typo.

View the update in the preview deployment:

Client Agent > [interface to use](https://boundary-o0itdm2ds-hashicorp.vercel.app/boundary/docs/api-clients/client-agent#interface_to_use)

[ICU-17216]: https://hashicorp.atlassian.net/browse/ICU-17216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ