### PR TITLE
Cherry pick commits from `llb-normalized-grants-tests-only` to `llb normalized grants`

### DIFF
--- a/internal/auth/db_test.go
+++ b/internal/auth/db_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package auth
+package auth_test
 
 import (
 	"context"

--- a/internal/auth/ldap/testing.go
+++ b/internal/auth/ldap/testing.go
@@ -24,8 +24,8 @@ import (
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/kms"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
-	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/auth/ldap/testing.go
+++ b/internal/auth/ldap/testing.go
@@ -12,6 +12,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"net"
 	"net/url"
@@ -19,8 +20,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/boundary/internal/auth"
 	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/kms"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/stretchr/testify/require"
 )
@@ -174,6 +178,21 @@ func TestAccount(t testing.TB, conn *db.DB, am *AuthMethod, loginName string, op
 
 	require.NoError(rw.Create(ctx, a))
 	return a
+}
+
+// TestAuthMethodWithAccountInManagedGroup creates an authMethod, and an account within that authmethod, an
+// LDAP managed group, and add the newly created account as a member of the LDAP managed group.
+func TestAuthMethodWithAccountInManagedGroup(t *testing.T, conn *db.DB, kmsCache *kms.Kms, scopeId string) (auth.AuthMethod, auth.Account, auth.ManagedGroup) {
+	t.Helper()
+	uuid, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	ctx := context.Background()
+	databaseWrapper, err := kmsCache.GetWrapper(context.Background(), scopeId, kms.KeyPurposeDatabase)
+	require.NoError(t, err)
+	am := TestAuthMethod(t, conn, databaseWrapper, scopeId, []string{fmt.Sprintf("ldap://%s", uuid)})
+	managedGroup := TestManagedGroup(t, conn, am, []string{uuid})
+	acct := TestAccount(t, conn, am, "testacct", WithMemberOfGroups(ctx, uuid))
+	return am, acct, managedGroup
 }
 
 // TestManagedGroup creates a test ldap managed group.

--- a/internal/auth/password/testing.go
+++ b/internal/auth/password/testing.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/auth"
 	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,6 +72,16 @@ func TestMultipleAccounts(t testing.TB, conn *db.DB, authMethodId string, count 
 		auts = append(auts, TestAccount(t, conn, authMethodId, fmt.Sprintf("name%d", i)))
 	}
 	return auts
+}
+
+// TestAuthMethodWithAccount creates an authMethod and an account within that authmethod
+// returing both the AM and the account
+func TestAuthMethodWithAccount(t *testing.T, conn *db.DB) (auth.AuthMethod, auth.Account) {
+	authMethod := TestAuthMethod(t, conn, globals.GlobalPrefix)
+	loginName, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	acct := TestAccount(t, conn, authMethod.GetPublicId(), loginName)
+	return authMethod, acct
 }
 
 // TestAccount creates a password account to the provided DB with the provided

--- a/internal/auth/testing.go
+++ b/internal/auth/testing.go
@@ -10,7 +10,13 @@ import (
 
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/db/timestamp"
+	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/stretchr/testify/require"
+)
+
+type (
+	TestAuthMethodWithAccountFunc           func(t *testing.T, conn *db.DB) (AuthMethod, Account)
+	TestAuthMethodWithAccountInManagedGroup func(t *testing.T, conn *db.DB, kmsCache *kms.Kms, scopeId string) (AuthMethod, Account, ManagedGroup)
 )
 
 // ManagedGroupMemberAccount represents an entry from

--- a/internal/authtoken/testing.go
+++ b/internal/authtoken/testing.go
@@ -51,7 +51,7 @@ func TestAuthToken(t testing.TB, conn *db.DB, kms *kms.Kms, scopeId string, opt 
 // TestRoleGrantsForToken contains information used by TestAuthTokenWithRoles to create
 // roles and their associated grants (with grant scopes)
 type TestRoleGrantsForToken struct {
-	RoleScopeID  string
+	RoleScopeId  string
 	GrantStrings []string
 	GrantScopes  []string
 }
@@ -75,7 +75,7 @@ func TestAuthTokenWithRoles(t testing.TB, conn *db.DB, kms *kms.Kms, scopeId str
 	acct := password.TestAccount(t, conn, authMethod.GetPublicId(), loginName)
 	user := iam.TestUser(t, iamRepo, scopeId, iam.WithAccountIds(acct.GetPublicId()))
 	for _, r := range roles {
-		role := iam.TestRoleWithGrants(t, conn, r.RoleScopeID, r.GrantScopes, r.GrantStrings)
+		role := iam.TestRoleWithGrants(t, conn, r.RoleScopeId, r.GrantScopes, r.GrantStrings)
 		_ = iam.TestUserRole(t, conn, role.PublicId, user.PublicId)
 	}
 	fullGrantToken, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())

--- a/internal/daemon/controller/handlers/accounts/grants_test.go
+++ b/internal/daemon/controller/handlers/accounts/grants_test.go
@@ -1030,3 +1030,144 @@ func TestGrants_UpdateAccount(t *testing.T) {
 		})
 	}
 }
+
+func TestGrants_AuthorizedActions(t *testing.T) {
+	t.Run("password", func(t *testing.T) {
+		ctx := context.TODO()
+		conn, _ := db.TestSetup(t, "postgres")
+		rw := db.New(conn)
+		wrap := db.TestWrapper(t)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		pwRepoFn := func() (*password.Repository, error) {
+			return password.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		// not using OIDC or LDAP in this test so no need to set them up
+		oidcRepoFn := func() (*oidc.Repository, error) {
+			return &oidc.Repository{}, nil
+		}
+		ldapRepoFn := func() (*ldap.Repository, error) {
+			return &ldap.Repository{}, nil
+		}
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+
+		globalAM := password.TestAuthMethod(t, conn, globals.GlobalPrefix)
+		user, account := iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+			{
+				RoleScopeId: globals.GlobalPrefix,
+				Grants:      []string{"ids=*;type=*;actions=*"},
+				GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+			},
+		})()
+		password.TestAccount(t, conn, globalAM.PublicId, "user1")
+		password.TestAccount(t, conn, globalAM.PublicId, "user2")
+		password.TestAccount(t, conn, globalAM.PublicId, "user3")
+		s, err := accounts.NewService(ctx, pwRepoFn, oidcRepoFn, ldapRepoFn, 1000)
+		require.NoError(t, err)
+
+		tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+		require.NoError(t, err)
+		fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+		got, err := s.ListAccounts(fullGrantAuthCtx, &pbs.ListAccountsRequest{
+			AuthMethodId: globalAM.PublicId,
+		})
+		require.NoError(t, err)
+		for _, item := range got.Items {
+			require.ElementsMatch(t, item.AuthorizedActions, []string{"read", "no-op", "delete", "set-password", "change-password", "update"})
+		}
+	})
+	t.Run("ldap", func(t *testing.T) {
+		ctx := context.TODO()
+		conn, _ := db.TestSetup(t, "postgres")
+		rw := db.New(conn)
+		wrap := db.TestWrapper(t)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		databaseWrapper, err := kmsCache.GetWrapper(context.Background(), globals.GlobalPrefix, kms.KeyPurposeDatabase)
+		require.NoError(t, err)
+		ldapAM := ldap.TestAuthMethod(t, conn, databaseWrapper, globals.GlobalPrefix, []string{"ldaps://ldap1"})
+		_ = ldap.TestAccount(t, conn, ldapAM, "testacct")
+		_ = ldap.TestAccount(t, conn, ldapAM, "testacct2")
+		_ = ldap.TestAccount(t, conn, ldapAM, "testacct3")
+		pwRepoFn := func() (*password.Repository, error) {
+			return &password.Repository{}, nil
+		}
+		oidcRepoFn := func() (*oidc.Repository, error) {
+			return &oidc.Repository{}, nil
+		}
+		ldapRepoFn := func() (*ldap.Repository, error) {
+			return ldap.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+		user, account := iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+			{
+				RoleScopeId: globals.GlobalPrefix,
+				Grants:      []string{"ids=*;type=*;actions=*"},
+				GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+			},
+		})()
+		s, err := accounts.NewService(ctx, pwRepoFn, oidcRepoFn, ldapRepoFn, 1000)
+		require.NoError(t, err)
+
+		tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+		require.NoError(t, err)
+		fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+		got, err := s.ListAccounts(fullGrantAuthCtx, &pbs.ListAccountsRequest{
+			AuthMethodId: ldapAM.PublicId,
+		})
+		require.NoError(t, err)
+		for _, item := range got.Items {
+			require.ElementsMatch(t, item.AuthorizedActions, []string{"read", "update", "delete", "no-op"})
+		}
+	})
+	t.Run("oidc", func(t *testing.T) {
+		ctx := context.TODO()
+		conn, _ := db.TestSetup(t, "postgres")
+		rw := db.New(conn)
+		wrap := db.TestWrapper(t)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		databaseWrapper, err := kmsCache.GetWrapper(context.Background(), globals.GlobalPrefix, kms.KeyPurposeDatabase)
+		require.NoError(t, err)
+		oidcAM := oidc.TestAuthMethod(t, conn, databaseWrapper, globals.GlobalPrefix, oidc.ActivePublicState,
+			"alice-rp", "fido",
+			oidc.WithSigningAlgs(oidc.RS256),
+			oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://www.alice2.com")[0]),
+			oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://www.alice.com/callback")[0]),
+		)
+		oidc.TestAccount(t, conn, oidcAM, "testacct")
+		oidc.TestAccount(t, conn, oidcAM, "testacct2")
+		oidc.TestAccount(t, conn, oidcAM, "testacct3")
+		pwRepoFn := func() (*password.Repository, error) {
+			return &password.Repository{}, nil
+		}
+		ldapRepoFn := func() (*ldap.Repository, error) { return &ldap.Repository{}, nil }
+		oidcRepoFn := func() (*oidc.Repository, error) {
+			return oidc.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+		user, account := iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+			{
+				RoleScopeId: globals.GlobalPrefix,
+				Grants:      []string{"ids=*;type=*;actions=*"},
+				GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+			},
+		})()
+		s, err := accounts.NewService(ctx, pwRepoFn, oidcRepoFn, ldapRepoFn, 1000)
+		require.NoError(t, err)
+
+		tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+		require.NoError(t, err)
+		fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+		got, err := s.ListAccounts(fullGrantAuthCtx, &pbs.ListAccountsRequest{
+			AuthMethodId: oidcAM.PublicId,
+		})
+		require.NoError(t, err)
+		for _, item := range got.Items {
+			require.ElementsMatch(t, item.AuthorizedActions, []string{"read", "update", "delete", "no-op"})
+		}
+	})
+}

--- a/internal/daemon/controller/handlers/accounts/grants_test.go
+++ b/internal/daemon/controller/handlers/accounts/grants_test.go
@@ -5,20 +5,27 @@ package accounts_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
+	authdomain "github.com/hashicorp/boundary/internal/auth"
 	"github.com/hashicorp/boundary/internal/auth/ldap"
 	"github.com/hashicorp/boundary/internal/auth/oidc"
 	"github.com/hashicorp/boundary/internal/auth/password"
 	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/accounts"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/accounts"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/protobuf/field_mask"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestListPassword_Grants(t *testing.T) {
@@ -88,6 +95,938 @@ func TestListPassword_Grants(t *testing.T) {
 				gotIDs = append(gotIDs, item.Id)
 			}
 			require.ElementsMatch(t, tc.wantAccountIDs, gotIDs)
+		})
+	}
+}
+
+func TestGrants_ListAccounts(t *testing.T) {
+	ctx := context.TODO()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	kms := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	pwRepoFn := func() (*password.Repository, error) {
+		return password.NewRepository(ctx, rw, rw, kms)
+	}
+	// not using OIDC or LDAP in this test so no need to set them up
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		return &oidc.Repository{}, nil
+	}
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		return &ldap.Repository{}, nil
+	}
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kms)
+	require.NoError(t, err)
+
+	globalPasswordAM := password.TestAuthMethod(t, conn, globals.GlobalPrefix)
+	globalPWAccounts := password.TestMultipleAccounts(t, conn, globalPasswordAM.GetPublicId(), 3)
+
+	org, _ := iam.TestScopes(t, iamRepo)
+	orgAM := password.TestAuthMethod(t, conn, org.GetPublicId())
+	orgPWAccounts := password.TestMultipleAccounts(t, conn, orgAM.GetPublicId(), 3)
+
+	s, err := accounts.NewService(ctx, pwRepoFn, oidcRepoFn, ldapRepoFn, 1000)
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name           string
+		userAcountFunc func(t *testing.T) func() (*iam.User, authdomain.Account)
+		input          *pbs.ListAccountsRequest
+		wantAccountIDs []string
+		wantErr        error
+	}{
+		{
+			name: "grant children at global can list org accounts",
+			input: &pbs.ListAccountsRequest{
+				AuthMethodId: orgAM.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			wantAccountIDs: []string{orgPWAccounts[0].PublicId, orgPWAccounts[1].PublicId, orgPWAccounts[2].PublicId},
+			wantErr:        nil,
+		},
+		{
+			name: "grant children at global cannot list global accounts",
+			input: &pbs.ListAccountsRequest{
+				AuthMethodId: globalPasswordAM.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=account;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			wantAccountIDs: nil,
+			wantErr:        handlers.ForbiddenError(),
+		},
+		{
+			name: "grant this at global can list global accounts",
+			input: &pbs.ListAccountsRequest{
+				AuthMethodId: globalPasswordAM.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=account;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			wantAccountIDs: []string{globalPWAccounts[0].PublicId, globalPWAccounts[1].PublicId, globalPWAccounts[2].PublicId},
+			wantErr:        nil,
+		},
+		{
+			name: "grant this at global cannot list org accounts",
+			input: &pbs.ListAccountsRequest{
+				AuthMethodId: orgAM.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			wantAccountIDs: nil,
+			wantErr:        handlers.ForbiddenError(),
+		},
+		{
+			name: "grant this at org can list org accounts",
+			input: &pbs.ListAccountsRequest{
+				AuthMethodId: orgAM.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=account;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			wantAccountIDs: []string{orgPWAccounts[0].PublicId, orgPWAccounts[1].PublicId, orgPWAccounts[2].PublicId},
+			wantErr:        nil,
+		},
+		{
+			name: "grant specific resource type can list account",
+			input: &pbs.ListAccountsRequest{
+				AuthMethodId: orgAM.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=account;actions=list,no-op"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			wantAccountIDs: []string{orgPWAccounts[0].PublicId, orgPWAccounts[1].PublicId, orgPWAccounts[2].PublicId},
+			wantErr:        nil,
+		},
+		{
+			name: "grant pinned grants can list account",
+			input: &pbs.ListAccountsRequest{
+				AuthMethodId: orgAM.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=*;actions=read,list,no-op", orgAM.PublicId)},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				})
+			},
+			wantAccountIDs: []string{orgPWAccounts[0].PublicId, orgPWAccounts[1].PublicId, orgPWAccounts[2].PublicId},
+			wantErr:        nil,
+		},
+		{
+			name: "grant pinned grants cannot list account that is not the pinned ID",
+			input: &pbs.ListAccountsRequest{
+				AuthMethodId: globalPasswordAM.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=*;actions=read,list,no-op", orgAM.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				})
+			},
+			wantAccountIDs: nil,
+			wantErr:        handlers.ForbiddenError(),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userAcountFunc(t)()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			got, err := s.ListAccounts(fullGrantAuthCtx, tc.input)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, got.Items, len(orgPWAccounts))
+			var gotIDs []string
+			for _, item := range got.Items {
+				gotIDs = append(gotIDs, item.Id)
+			}
+			require.ElementsMatch(t, tc.wantAccountIDs, gotIDs)
+		})
+	}
+}
+
+func TestGrants_GetAccounts(t *testing.T) {
+	ctx := context.TODO()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	kms := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	pwRepoFn := func() (*password.Repository, error) {
+		return password.NewRepository(ctx, rw, rw, kms)
+	}
+	// not using OIDC or LDAP in this test so no need to set them up
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		return &oidc.Repository{}, nil
+	}
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		return &ldap.Repository{}, nil
+	}
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kms)
+	require.NoError(t, err)
+
+	globalPasswordAM := password.TestAuthMethod(t, conn, globals.GlobalPrefix)
+	globalPWAccount := password.TestAccount(t, conn, globalPasswordAM.GetPublicId(), "global_name")
+
+	org, _ := iam.TestScopes(t, iamRepo)
+	orgAM := password.TestAuthMethod(t, conn, org.GetPublicId())
+	orgPWAccount := password.TestAccount(t, conn, orgAM.GetPublicId(), "org_name")
+
+	s, err := accounts.NewService(ctx, pwRepoFn, oidcRepoFn, ldapRepoFn, 1000)
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name           string
+		userAcountFunc func(t *testing.T) func() (*iam.User, authdomain.Account)
+		input          *pbs.GetAccountRequest
+		wantAccountID  string
+		wantErr        error
+	}{
+		{
+			name: "grant children at global can read account in org",
+			input: &pbs.GetAccountRequest{
+				Id: orgPWAccount.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=read"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			wantAccountID: orgPWAccount.PublicId,
+			wantErr:       nil,
+		},
+		{
+			name: "grant descendant at global cannot read global account",
+			input: &pbs.GetAccountRequest{
+				Id: globalPWAccount.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=read"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				})
+			},
+			wantAccountID: "",
+			wantErr:       handlers.ForbiddenError(),
+		},
+		{
+			name: "grant this at global can read global account",
+			input: &pbs.GetAccountRequest{
+				Id: globalPWAccount.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserManagedGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=account;actions=read"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			wantAccountID: globalPWAccount.PublicId,
+			wantErr:       nil,
+		},
+		{
+			name: "grant this at global cannot read org account",
+			input: &pbs.GetAccountRequest{
+				Id: orgPWAccount.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserManagedGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=read"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			wantAccountID: orgPWAccount.PublicId,
+			wantErr:       nil,
+		},
+		{
+			name: "grant this at org can read org account",
+			input: &pbs.GetAccountRequest{
+				Id: orgPWAccount.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=read"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			wantAccountID: orgPWAccount.PublicId,
+			wantErr:       nil,
+		},
+		{
+			name: "grant descendant with specific resource id can read org account",
+			input: &pbs.GetAccountRequest{
+				Id: orgPWAccount.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("id=%s;type=account;actions=read", orgAM.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				})
+			},
+			wantAccountID: orgPWAccount.PublicId,
+			wantErr:       nil,
+		},
+		{
+			name: "grant specific id but not grant this at global cannot read global account",
+			input: &pbs.GetAccountRequest{
+				Id: globalPWAccount.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("id=%s;type=account;actions=read", globalPasswordAM.PublicId)},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				})
+			},
+			wantAccountID: "",
+			wantErr:       handlers.ForbiddenError(),
+		},
+		{
+			name: "grant specific id but not grant this at global cannot read global account",
+			input: &pbs.GetAccountRequest{
+				Id: globalPWAccount.PublicId,
+			},
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=account;actions=list"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				})
+			},
+			wantAccountID: "",
+			wantErr:       handlers.ForbiddenError(),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userAcountFunc(t)()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			got, err := s.GetAccount(fullGrantAuthCtx, tc.input)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantAccountID, got.Item.Id)
+		})
+	}
+}
+
+func TestGrants_CreateAccount(t *testing.T) {
+	ctx := context.TODO()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	kms := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	pwRepoFn := func() (*password.Repository, error) {
+		return password.NewRepository(ctx, rw, rw, kms)
+	}
+	// not using OIDC or LDAP in this test so no need to set them up
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		return &oidc.Repository{}, nil
+	}
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		return &ldap.Repository{}, nil
+	}
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kms)
+	require.NoError(t, err)
+	org1 := iam.TestOrg(t, iamRepo)
+	org2 := iam.TestOrg(t, iamRepo)
+
+	globalAM := password.TestAuthMethod(t, conn, globals.GlobalPrefix)
+	org1AM := password.TestAuthMethod(t, conn, org1.GetPublicId())
+	org2AM := password.TestAuthMethod(t, conn, org2.GetPublicId())
+
+	s, err := accounts.NewService(ctx, pwRepoFn, oidcRepoFn, ldapRepoFn, 1000)
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name                     string
+		userAcountFunc           func(t *testing.T) func() (*iam.User, authdomain.Account)
+		authmethodIdExpectErrMap map[string]error
+	}{
+		{
+			name: "grant this and descendant at global can create accounts everywhere",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=account;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: nil,
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "grant this and children at global can create accounts everywhere",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserManagedGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: nil,
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "grant children at global can create accounts in org",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserManagedGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "grant descendant at global can create accounts in org",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserManagedGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "pinned grant org1AM can only create accounts in org1AM",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserManagedGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=account;actions=create", org1AM.PublicId)},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "grant auth-method type does not allow create account",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   handlers.ForbiddenError(),
+				org2AM.PublicId:   handlers.ForbiddenError(),
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userAcountFunc(t)()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for authMethodId, wantErr := range tc.authmethodIdExpectErrMap {
+				loginName, _ := uuid.GenerateUUID()
+				input := &pbs.CreateAccountRequest{
+					Item: &pb.Account{
+						AuthMethodId: authMethodId,
+						Type:         "password",
+						Attrs: &pb.Account_PasswordAccountAttributes{
+							PasswordAccountAttributes: &pb.PasswordAccountAttributes{
+								LoginName: loginName,
+								Password:  nil,
+							},
+						},
+					},
+				}
+				_, err := s.CreateAccount(fullGrantAuthCtx, input)
+				if wantErr != nil {
+					require.Error(t, err)
+					require.ErrorIs(t, err, wantErr)
+					continue
+				}
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGrants_DeleteAccount(t *testing.T) {
+	ctx := context.TODO()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	kms := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	pwRepoFn := func() (*password.Repository, error) {
+		return password.NewRepository(ctx, rw, rw, kms)
+	}
+	// not using OIDC or LDAP in this test so no need to set them up
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		return &oidc.Repository{}, nil
+	}
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		return &ldap.Repository{}, nil
+	}
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kms)
+	require.NoError(t, err)
+	org1 := iam.TestOrg(t, iamRepo)
+	org2 := iam.TestOrg(t, iamRepo)
+
+	globalAM := password.TestAuthMethod(t, conn, globals.GlobalPrefix)
+	org1AM := password.TestAuthMethod(t, conn, org1.GetPublicId())
+	org2AM := password.TestAuthMethod(t, conn, org2.GetPublicId())
+
+	allAuthMethodIds := []string{globalAM.PublicId, org1AM.PublicId, org2AM.PublicId}
+
+	s, err := accounts.NewService(ctx, pwRepoFn, oidcRepoFn, ldapRepoFn, 1000)
+	require.NoError(t, err)
+	testcases := []struct {
+		name                     string
+		userAcountFunc           func(t *testing.T) func() (*iam.User, authdomain.Account)
+		authmethodIdExpectErrMap map[string]error
+	}{
+		{
+			name: "grant this and descendant at global can delete accounts everywhere",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: nil,
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "grant this and children at global can delete accounts everywhere",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserManagedGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=account;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: nil,
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "grant children at global can delete accounts in org",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserManagedGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=account;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "grant descendant at global can delete accounts in org",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=account;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "grant this and descendant at global with specific type and action can delete accounts in org",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=account;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: nil,
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "pinned grant org1AM can only delete accounts in org1AM",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=account;actions=delete", org1AM.PublicId)},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "grant auth-method type does not allow delete create account",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   handlers.ForbiddenError(),
+				org2AM.PublicId:   handlers.ForbiddenError(),
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			authMethodAccountMap := map[string]*password.Account{}
+			for _, amid := range allAuthMethodIds {
+				loginName, _ := uuid.GenerateUUID()
+				acct := password.TestAccount(t, conn, amid, loginName)
+				authMethodAccountMap[amid] = acct
+			}
+			user, account := tc.userAcountFunc(t)()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for authMethodId, wantErr := range tc.authmethodIdExpectErrMap {
+				_, err := s.DeleteAccount(fullGrantAuthCtx, &pbs.DeleteAccountRequest{
+					Id: authMethodAccountMap[authMethodId].PublicId,
+				})
+				if wantErr != nil {
+					require.Error(t, err)
+					require.ErrorIs(t, err, wantErr)
+					continue
+				}
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGrants_UpdateAccount(t *testing.T) {
+	ctx := context.TODO()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	kms := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	pwRepoFn := func() (*password.Repository, error) {
+		return password.NewRepository(ctx, rw, rw, kms)
+	}
+	// not using OIDC or LDAP in this test so no need to set them up
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		return &oidc.Repository{}, nil
+	}
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		return &ldap.Repository{}, nil
+	}
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kms)
+	require.NoError(t, err)
+	org1 := iam.TestOrg(t, iamRepo)
+	org2 := iam.TestOrg(t, iamRepo)
+
+	globalAM := password.TestAuthMethod(t, conn, globals.GlobalPrefix)
+	org1AM := password.TestAuthMethod(t, conn, org1.GetPublicId())
+	org2AM := password.TestAuthMethod(t, conn, org2.GetPublicId())
+
+	allAuthMethodIds := []string{globalAM.PublicId, org1AM.PublicId, org2AM.PublicId}
+
+	s, err := accounts.NewService(ctx, pwRepoFn, oidcRepoFn, ldapRepoFn, 1000)
+	require.NoError(t, err)
+	testcases := []struct {
+		name                     string
+		userAcountFunc           func(t *testing.T) func() (*iam.User, authdomain.Account)
+		authmethodIdExpectErrMap map[string]error
+	}{
+		{
+			name: "grant this and descendant at global can update accounts everywhere",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=update"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: nil,
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "grant this and children at global can update accounts everywhere",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserManagedGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=update"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: nil,
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "grant children at global can update accounts in org",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserManagedGroupGrantsFunc(t, conn, kms, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=update"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "grant descendant at global can update accounts in org",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=account;actions=update"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "grant this and descendant at global with specific type and action can update accounts in org",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=account;actions=update"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: nil,
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   nil,
+			},
+		},
+		{
+			name: "pinned grant org1AM can only update accounts in org1AM",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=account;actions=update", org1AM.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   nil,
+				org2AM.PublicId:   handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "grant auth-method type does not allow update create account",
+			userAcountFunc: func(t *testing.T) func() (*iam.User, authdomain.Account) {
+				return iam.TestUserDirectGrantsFunc(t, conn, kms, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				})
+			},
+			authmethodIdExpectErrMap: map[string]error{
+				globalAM.PublicId: handlers.ForbiddenError(),
+				org1AM.PublicId:   handlers.ForbiddenError(),
+				org2AM.PublicId:   handlers.ForbiddenError(),
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			authMethodAccountMap := map[string]*password.Account{}
+			for _, amid := range allAuthMethodIds {
+				loginName, _ := uuid.GenerateUUID()
+				acct := password.TestAccount(t, conn, amid, loginName)
+				authMethodAccountMap[amid] = acct
+			}
+			user, account := tc.userAcountFunc(t)()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for authMethodId, wantErr := range tc.authmethodIdExpectErrMap {
+				newName, _ := uuid.GenerateUUID()
+				newDescription, _ := uuid.GenerateUUID()
+				_, err := s.UpdateAccount(fullGrantAuthCtx, &pbs.UpdateAccountRequest{
+					Id: authMethodAccountMap[authMethodId].PublicId,
+					Item: &pb.Account{
+						Name:        &wrapperspb.StringValue{Value: newName},
+						Description: &wrapperspb.StringValue{Value: newDescription},
+						Version:     1,
+					},
+					UpdateMask: &field_mask.FieldMask{
+						Paths: []string{globals.NameField, globals.DescriptionField},
+					},
+				})
+				if wantErr != nil {
+					require.Error(t, err)
+					require.ErrorIs(t, err, wantErr)
+					continue
+				}
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/internal/daemon/controller/handlers/accounts/grants_test.go
+++ b/internal/daemon/controller/handlers/accounts/grants_test.go
@@ -59,7 +59,7 @@ func TestListPassword_Grants(t *testing.T) {
 			},
 			roleRequest: []authtoken.TestRoleGrantsForToken{
 				{
-					RoleScopeID:  globals.GlobalPrefix,
+					RoleScopeId:  globals.GlobalPrefix,
 					GrantStrings: []string{"ids=*;type=*;actions=list,read"},
 					GrantScopes:  []string{globals.GrantScopeChildren},
 				},

--- a/internal/daemon/controller/handlers/aliases/grants_test.go
+++ b/internal/daemon/controller/handlers/aliases/grants_test.go
@@ -61,7 +61,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=alias;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},
@@ -77,7 +77,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=group;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},

--- a/internal/daemon/controller/handlers/aliases/grants_test.go
+++ b/internal/daemon/controller/handlers/aliases/grants_test.go
@@ -5,20 +5,30 @@ package aliases_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
 	"github.com/hashicorp/boundary/internal/alias/target"
+	"github.com/hashicorp/boundary/internal/auth"
+	"github.com/hashicorp/boundary/internal/auth/ldap"
+	"github.com/hashicorp/boundary/internal/auth/oidc"
+	"github.com/hashicorp/boundary/internal/auth/password"
 	"github.com/hashicorp/boundary/internal/authtoken"
-	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	cauth "github.com/hashicorp/boundary/internal/daemon/controller/auth"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/aliases"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/target/tcp"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/aliases"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // TestGrants_ReadActions tests read actions to assert that grants are being applied properly
@@ -35,6 +45,8 @@ func TestGrants_ReadActions(t *testing.T) {
 	wrap := db.TestWrapper(t)
 	kmsCache := kms.TestKms(t, conn, wrap)
 	iamRepo := iam.TestRepo(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
 	iamRepoFn := func() (*iam.Repository, error) {
 		return iamRepo, nil
 	}
@@ -47,49 +59,131 @@ func TestGrants_ReadActions(t *testing.T) {
 	globalAlias2 := target.TestAlias(t, rw, "test.alias.two", target.WithDescription("alias_2"), target.WithName("alias_two"))
 	t.Run("List", func(t *testing.T) {
 		testcases := []struct {
-			name          string
-			input         *pbs.ListAliasesRequest
-			rolesToCreate []authtoken.TestRoleGrantsForToken
-			wantErr       error
-			wantIDs       []string
+			name     string
+			input    *pbs.ListAliasesRequest
+			userFunc func() (*iam.User, auth.Account)
+			wantErr  error
+			wantIDs  []string
 		}{
 			{
-				name: "global role grant this returns all created aliases",
+				name: "global role grant this with wildcard returns all created aliases",
 				input: &pbs.ListAliasesRequest{
 					ScopeId:   globals.GlobalPrefix,
 					Recursive: true,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=alias;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
+				}),
 				wantErr: nil,
 				wantIDs: []string{globalAlias1.PublicId, globalAlias2.PublicId},
 			},
 			{
-				name: "global role grant this with a non-applicable type throws an error",
+				name: "global role grant this with type set to 'alias' returns all created aliases",
 				input: &pbs.ListAliasesRequest{
 					ScopeId:   globals.GlobalPrefix,
 					Recursive: true,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=group;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{globalAlias1.PublicId, globalAlias2.PublicId},
+			},
+			{
+				name: "global LDAP role grant with wildcard returns all created aliases",
+				input: &pbs.ListAliasesRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
 				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{globalAlias1.PublicId, globalAlias2.PublicId},
+			},
+			{
+				name: "global alias role grant with wildcard returns all created aliases",
+				input: &pbs.ListAliasesRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{globalAlias1.PublicId, globalAlias2.PublicId},
+			},
+			{
+				name: "global alias role grant with list action returns an empty list",
+				input: &pbs.ListAliasesRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=list"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{},
+			},
+			{
+				name: "global alias role grant with list action returns all created aliases",
+				input: &pbs.ListAliasesRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=no-op,list"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{globalAlias1.PublicId, globalAlias2.PublicId},
+			},
+			{
+				name: "global role grant with a non-applicable type returns a permission denied error",
+				input: &pbs.ListAliasesRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=group;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
 				wantErr: handlers.ApiErrorWithCode(codes.PermissionDenied),
 			},
 		}
 
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
-				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				user, accountID := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, accountID.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
 				got, finalErr := s.ListAliases(fullGrantAuthCtx, tc.input)
 				if tc.wantErr != nil {
 					require.ErrorIs(t, finalErr, tc.wantErr)
@@ -101,6 +195,1079 @@ func TestGrants_ReadActions(t *testing.T) {
 					gotIDs = append(gotIDs, g.GetId())
 				}
 				require.ElementsMatch(t, tc.wantIDs, gotIDs)
+			})
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		testcases := []struct {
+			name            string
+			userFunc        func() (*iam.User, auth.Account)
+			inputWantErrMap map[*pbs.GetAliasRequest]error
+		}{
+			{
+				name: "global role alias grant with this scope with all permissions returns all aliases",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetAliasRequest]error{
+					{Id: globalAlias1.PublicId}: nil,
+					{Id: globalAlias2.PublicId}: nil,
+				},
+			},
+			{
+				name: "global role alias grant this scope with specific alias type returns all aliases",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetAliasRequest]error{
+					{Id: globalAlias1.PublicId}: nil,
+					{Id: globalAlias2.PublicId}: nil,
+				},
+			},
+			{
+				name: "global role alias grant this scope with specific alias type and id returns all aliases",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=alias;actions=*", globalAlias1.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetAliasRequest]error{
+					{Id: globalAlias1.PublicId}: nil,
+				},
+			},
+			{
+				name: "global role alias grant this scope with specific alias type and read action returns all aliases",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=read"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetAliasRequest]error{
+					{Id: globalAlias1.PublicId}: nil,
+					{Id: globalAlias2.PublicId}: nil,
+				},
+			},
+			{
+				name: "global role alias grant this scope with non-applicable type returns a permission denied error",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=group;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetAliasRequest]error{
+					{Id: globalAlias1.PublicId}: handlers.ForbiddenError(),
+					{Id: globalAlias2.PublicId}: handlers.ForbiddenError(),
+				},
+			},
+			{
+				name: "global role alias grant this scope with descendants scope returns a permission denied error",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetAliasRequest]error{
+					{Id: globalAlias1.PublicId}: handlers.ForbiddenError(),
+					{Id: globalAlias2.PublicId}: handlers.ForbiddenError(),
+				},
+			},
+			{
+				name: "global role alias grant this scope with list action returns a permission denied error",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=list"},
+						GrantScopes: []string{globals.GlobalPrefix},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetAliasRequest]error{
+					{Id: globalAlias1.PublicId}: handlers.ForbiddenError(),
+					{Id: globalAlias2.PublicId}: handlers.ForbiddenError(),
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, accountID := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, accountID.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				for input, wantErr := range tc.inputWantErrMap {
+					_, err := s.GetAlias(fullGrantAuthCtx, input)
+					if wantErr != nil {
+						require.ErrorIs(t, err, wantErr)
+						continue
+					}
+					require.NoError(t, err)
+				}
+			})
+		}
+	})
+}
+
+// TestGrants_WriteActions tests write actions to assert that grants are being applied properly
+//
+//	[create, update, delete]
+//	 Role - which scope the role is created in
+//			- global level
+//		Scopes [resource]:
+//			- globalAlias1 [globalAlias]
+//			- globalAlias2 [globalAlias]
+func TestGrants_WriteActions(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		ctx := context.Background()
+		conn, _ := db.TestSetup(t, "postgres")
+		rw := db.New(conn)
+		wrap := db.TestWrapper(t)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+		iamRepoFn := func() (*iam.Repository, error) {
+			return iamRepo, nil
+		}
+		repoFn := func() (*target.Repository, error) {
+			return target.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		s, err := aliases.NewService(ctx, repoFn, iamRepoFn, 1000)
+		require.NoError(t, err)
+
+		testcases := []struct {
+			name              string
+			userFunc          func() (*iam.User, auth.Account)
+			canCreateInScopes map[*pbs.CreateAliasRequest]error
+		}{
+			{
+				name: "direct grant all can create all",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateAliasRequest]error{
+					{Item: &pb.Alias{ScopeId: globals.GlobalPrefix, Type: "target", Value: "valid.alias.one"}}: nil,
+				},
+			},
+			{
+				name: "direct grant with alias type can create",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateAliasRequest]error{
+					{Item: &pb.Alias{ScopeId: globals.GlobalPrefix, Type: "target", Value: "valid.alias.two"}}: nil,
+				},
+			},
+			{
+				name: "groups grant all can create all",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateAliasRequest]error{
+					{Item: &pb.Alias{ScopeId: globals.GlobalPrefix, Type: "target", Value: "valid.alias.three"}}: nil,
+				},
+			},
+			{
+				name: "ldap grant all can create all",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateAliasRequest]error{
+					{Item: &pb.Alias{ScopeId: globals.GlobalPrefix, Type: "target", Value: "valid.alias.four"}}: nil,
+				},
+			},
+			{
+				name: "oidc grant all can create all",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateAliasRequest]error{
+					{Item: &pb.Alias{ScopeId: globals.GlobalPrefix, Type: "target", Value: "valid.alias.five"}}: nil,
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, accountID := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, accountID.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				for req, wantErr := range tc.canCreateInScopes {
+					_, err := s.CreateAlias(fullGrantAuthCtx, req)
+					if wantErr != nil {
+						require.ErrorIs(t, err, wantErr)
+						continue
+					}
+					require.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		testcases := []struct {
+			name                        string
+			setupScopesResourcesAndUser func(t *testing.T, conn *db.DB, rw *db.Db, iamRepo *iam.Repository, kmsCache *kms.Kms) (*target.Alias, func() (*iam.User, auth.Account))
+			wantErr                     error
+		}{
+			{
+				name: "grant with wildcard can update alias",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, rw *db.Db, iamRepo *iam.Repository, kmsCache *kms.Kms) (*target.Alias, func() (*iam.User, auth.Account)) {
+					globalAlias := target.TestAlias(t, rw, "test.alias.one", target.WithDescription("alias_1"), target.WithName("alias_one"))
+					return globalAlias, iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: globals.GlobalPrefix,
+							Grants:      []string{"ids=*;type=*;actions=*"},
+							GrantScopes: []string{globals.GrantScopeThis},
+						},
+					})
+				},
+				wantErr: nil,
+			},
+			{
+				name: "grant with specific scope can update alias",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, rw *db.Db, iamRepo *iam.Repository, kmsCache *kms.Kms) (*target.Alias, func() (*iam.User, auth.Account)) {
+					globalAlias := target.TestAlias(t, rw, "test.alias.two", target.WithDescription("alias_2"), target.WithName("alias_two"))
+					return globalAlias, iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: globals.GlobalPrefix,
+							Grants:      []string{"ids=*;type=*;actions=*"},
+							GrantScopes: []string{globals.GlobalPrefix},
+						},
+					})
+				},
+				wantErr: nil,
+			},
+			{
+				name: "grant specific resource and scope success",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, rw *db.Db, iamRepo *iam.Repository, kmsCache *kms.Kms) (*target.Alias, func() (*iam.User, auth.Account)) {
+					globalAlias := target.TestAlias(t, rw, "test.alias.three", target.WithDescription("alias_3"), target.WithName("alias_three"))
+					return globalAlias, iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: globals.GlobalPrefix,
+							Grants:      []string{fmt.Sprintf("ids=%s;types=alias;actions=*", globalAlias.PublicId)},
+							GrantScopes: []string{globals.GlobalPrefix},
+						},
+					})
+				},
+				wantErr: nil,
+			},
+			{
+				name: "grants with children scope only fails update",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, rw *db.Db, iamRepo *iam.Repository, kmsCache *kms.Kms) (*target.Alias, func() (*iam.User, auth.Account)) {
+					globalAlias := target.TestAlias(t, rw, "test.alias.four", target.WithDescription("alias_4"), target.WithName("alias_four"))
+					return globalAlias, iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: globals.GlobalPrefix,
+							Grants:      []string{"ids=*;type=*;actions=*"},
+							GrantScopes: []string{globals.GrantScopeChildren},
+						},
+					})
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				ctx := context.Background()
+				conn, _ := db.TestSetup(t, "postgres")
+				rw := db.New(conn)
+				wrap := db.TestWrapper(t)
+				kmsCache := kms.TestKms(t, conn, wrap)
+				iamRepo := iam.TestRepo(t, conn, wrap)
+				atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+				require.NoError(t, err)
+				iamRepoFn := func() (*iam.Repository, error) {
+					return iamRepo, nil
+				}
+				repoFn := func() (*target.Repository, error) {
+					return target.NewRepository(ctx, rw, rw, kmsCache)
+				}
+
+				s, err := aliases.NewService(ctx, repoFn, iamRepoFn, 1000)
+				require.NoError(t, err)
+				original, userFunc := tc.setupScopesResourcesAndUser(t, conn, rw, iamRepo, kmsCache)
+				user, accountID := userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, accountID.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				got, err := s.UpdateAlias(fullGrantAuthCtx, &pbs.UpdateAliasRequest{
+					Id: original.PublicId,
+					Item: &pb.Alias{
+						Name:        &wrapperspb.StringValue{Value: "new-name"},
+						Description: &wrapperspb.StringValue{Value: "new-description"},
+						Version:     1,
+					},
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"name", "description"},
+					},
+				})
+				if tc.wantErr != nil {
+					require.Error(t, err)
+					require.ErrorIs(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, uint32(2), got.Item.Version)
+				require.True(t, got.Item.UpdatedTime.AsTime().After(original.UpdateTime.AsTime()))
+			})
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		ctx := context.Background()
+		conn, _ := db.TestSetup(t, "postgres")
+		rw := db.New(conn)
+		wrap := db.TestWrapper(t)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+		iamRepoFn := func() (*iam.Repository, error) {
+			return iamRepo, nil
+		}
+		repoFn := func() (*target.Repository, error) {
+			return target.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		s, err := aliases.NewService(ctx, repoFn, iamRepoFn, 1000)
+		require.NoError(t, err)
+		globalAlias1 := target.TestAlias(t, rw, "test.alias.one", target.WithDescription("alias_1"), target.WithName("alias_one"))
+		globalAlias2 := target.TestAlias(t, rw, "test.alias.two", target.WithDescription("alias_2"), target.WithName("alias_two"))
+		globalAlias3 := target.TestAlias(t, rw, "test.alias.three", target.WithDescription("alias_3"), target.WithName("alias_three"))
+
+		testcases := []struct {
+			name              string
+			userFunc          func() (*iam.User, auth.Account)
+			canDeleteInScopes map[*pbs.DeleteAliasRequest]error
+		}{
+			{
+				name: "grant all can delete all",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canDeleteInScopes: map[*pbs.DeleteAliasRequest]error{
+					{Id: globalAlias1.PublicId}: nil,
+				},
+			},
+			{
+				name: "grant alias type can delete aliases",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canDeleteInScopes: map[*pbs.DeleteAliasRequest]error{
+					{Id: globalAlias2.PublicId}: nil,
+				},
+			},
+			{
+				name: "grant non-applicable type cannot delete aliases",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=group;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canDeleteInScopes: map[*pbs.DeleteAliasRequest]error{
+					{Id: globalAlias3.PublicId}: handlers.ForbiddenError(),
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, accountID := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, accountID.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				for req, wantErr := range tc.canDeleteInScopes {
+					_, err := s.DeleteAlias(fullGrantAuthCtx, req)
+					if wantErr != nil {
+						require.ErrorIs(t, err, wantErr)
+						continue
+					}
+					require.NoError(t, err)
+				}
+			})
+		}
+	})
+}
+
+func TestOutputFields(t *testing.T) {
+	genUuid := func(t *testing.T) string {
+		id, err := uuid.GenerateUUID()
+		require.NoError(t, err)
+		return id
+	}
+	t.Run("ListAlias", func(t *testing.T) {
+		ctx := context.Background()
+		conn, _ := db.TestSetup(t, "postgres")
+		rw := db.New(conn)
+		wrap := db.TestWrapper(t)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+		iamRepoFn := func() (*iam.Repository, error) {
+			return iamRepo, nil
+		}
+		repoFn := func() (*target.Repository, error) {
+			return target.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		s, err := aliases.NewService(ctx, repoFn, iamRepoFn, 1000)
+		require.NoError(t, err)
+
+		_, p := iam.TestScopes(t, iamRepo)
+		tar := tcp.TestTarget(ctx, t, conn, p.GetPublicId(), "testTarget")
+
+		globalAlias1 := target.TestAlias(
+			t,
+			rw,
+			"test.alias.one",
+			target.WithDescription("alias_1"),
+			target.WithName("alias_one"),
+			target.WithDestinationId(tar.GetPublicId()),
+			target.WithHostId("hst_1234567890"),
+		)
+
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			// keys are the alias IDs | this also means 'id' is required in the outputfields for assertions to work properly
+			expectOutfields map[string][]string
+		}{
+			{
+				name: "grant with output_fields only returns: name, version, description",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=id,name,description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: map[string][]string{
+					globalAlias1.PublicId: {globals.IdField, globals.NameField, globals.DescriptionField},
+				},
+			},
+			{
+				name: "grant with output_fields only returns: scope_id, destination_id, type, value",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=id,scope_id,destination_id,type,value"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: map[string][]string{
+					globalAlias1.PublicId: {globals.IdField, globals.ScopeIdField, globals.DestinationIdField, globals.TypeField, globals.ValueField},
+				},
+			},
+			{
+				name: "grant with output_fields only returns: update_time, create_time",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=id,updated_time,created_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: map[string][]string{
+					globalAlias1.PublicId: {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				},
+			},
+			{
+				name: "multiple grants with different output_fields returns all fields",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=id,name,description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=id,scope_id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=id,scope_id,destination_id,type,value,host_id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: map[string][]string{
+					globalAlias1.PublicId: {
+						globals.IdField,
+						globals.NameField,
+						globals.DescriptionField,
+						globals.ScopeIdField,
+						globals.CreatedTimeField,
+						globals.UpdatedTimeField,
+						globals.DestinationIdField,
+						globals.TypeField,
+						globals.ValueField,
+						globals.HostIdField,
+					},
+				},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, accountID := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, accountID.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				out, err := s.ListAliases(fullGrantAuthCtx, &pbs.ListAliasesRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				})
+				require.NoError(t, err)
+				for _, item := range out.Items {
+					handlers.TestAssertOutputFields(t, item, tc.expectOutfields[item.Id])
+				}
+			})
+		}
+	})
+
+	t.Run("GetAlias", func(t *testing.T) {
+		ctx := context.Background()
+		conn, _ := db.TestSetup(t, "postgres")
+		rw := db.New(conn)
+		wrap := db.TestWrapper(t)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+		iamRepoFn := func() (*iam.Repository, error) {
+			return iamRepo, nil
+		}
+		repoFn := func() (*target.Repository, error) {
+			return target.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		s, err := aliases.NewService(ctx, repoFn, iamRepoFn, 1000)
+		require.NoError(t, err)
+
+		_, p := iam.TestScopes(t, iamRepo)
+		tar := tcp.TestTarget(ctx, t, conn, p.GetPublicId(), "testTarget")
+
+		globalAlias1 := target.TestAlias(
+			t,
+			rw,
+			"test.alias.one",
+			target.WithDescription("alias_1"),
+			target.WithName("alias_one"),
+			target.WithDestinationId(tar.GetPublicId()),
+			target.WithHostId("hst_1234567890"),
+		)
+
+		testcases := []struct {
+			name            string
+			userFunc        func() (*iam.User, auth.Account)
+			expectOutfields []string
+		}{
+			{
+				name: "grant with output_fields only returns: name and description",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=read;output_fields=name,description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.NameField, globals.DescriptionField},
+			},
+			{
+				name: "grant with output_fields only returns: scopeId and value",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=read;output_fields=scope_id,value"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.ScopeIdField, globals.ValueField},
+			},
+			{
+				name: "grant with output_fields only returns: updated_time and create_time",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=read;output_fields=updated_time,created_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.UpdatedTimeField, globals.CreatedTimeField},
+			},
+			{
+				name: "grant with output_fields only returns: id, destination_id, host_id, version",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=read;output_fields=id,destination_id,host_id,version"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.IdField, globals.DestinationIdField, globals.HostIdField, globals.VersionField},
+			},
+			{
+				name: "composite grants id, authorized_actions, member_ids",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=read;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=read;output_fields=destination_id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=read;output_fields=type"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=read;output_fields=value"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.IdField, globals.DestinationIdField, globals.TypeField, globals.ValueField},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, accountID := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, accountID.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				out, err := s.GetAlias(fullGrantAuthCtx, &pbs.GetAliasRequest{Id: globalAlias1.PublicId})
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, out.Item, tc.expectOutfields)
+			})
+		}
+	})
+
+	t.Run("CreateAlias", func(t *testing.T) {
+		ctx := context.Background()
+		conn, _ := db.TestSetup(t, "postgres")
+		rw := db.New(conn)
+		wrap := db.TestWrapper(t)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+		iamRepoFn := func() (*iam.Repository, error) {
+			return iamRepo, nil
+		}
+		repoFn := func() (*target.Repository, error) {
+			return target.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		s, err := aliases.NewService(ctx, repoFn, iamRepoFn, 1000)
+		require.NoError(t, err)
+
+		_, p := iam.TestScopes(t, iamRepo)
+		tar := tcp.TestTarget(ctx, t, conn, p.GetPublicId(), "testTarget")
+
+		testcases := []struct {
+			name            string
+			userFunc        func() (*iam.User, auth.Account)
+			input           *pbs.CreateAliasRequest
+			expectOutfields []string
+		}{
+			{
+				name: "grant with output_fields only returns: name and description",
+				input: &pbs.CreateAliasRequest{
+					Item: &pb.Alias{
+						Name:        &wrapperspb.StringValue{Value: genUuid(t)},
+						Description: &wrapperspb.StringValue{Value: genUuid(t)},
+						ScopeId:     globals.GlobalPrefix,
+						Type:        "target",
+						Value:       "valid.alias.one",
+					},
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=name,description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.NameField, globals.DescriptionField},
+			},
+			{
+				name: "grant with output_fields only returns: scope_id and value",
+				input: &pbs.CreateAliasRequest{
+					Item: &pb.Alias{
+						Name:        &wrapperspb.StringValue{Value: genUuid(t)},
+						Description: &wrapperspb.StringValue{Value: genUuid(t)},
+						ScopeId:     globals.GlobalPrefix,
+						Type:        "target",
+						Value:       "valid.alias.two",
+					},
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=scope_id,value"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.ScopeIdField, globals.ValueField},
+			},
+			{
+				name: "grant with output_fields only returns: update_time and create_time",
+				input: &pbs.CreateAliasRequest{
+					Item: &pb.Alias{
+						Name:        &wrapperspb.StringValue{Value: genUuid(t)},
+						Description: &wrapperspb.StringValue{Value: genUuid(t)},
+						ScopeId:     globals.GlobalPrefix,
+						Type:        "target",
+						Value:       "valid.alias.three",
+					},
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=updated_time,created_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.UpdatedTimeField, globals.CreatedTimeField},
+			},
+			{
+				name: "grant with output_fields only returns: id, destination_id, value, version",
+				input: &pbs.CreateAliasRequest{
+					Item: &pb.Alias{
+						Name:          &wrapperspb.StringValue{Value: genUuid(t)},
+						Description:   &wrapperspb.StringValue{Value: genUuid(t)},
+						ScopeId:       globals.GlobalPrefix,
+						Type:          "target",
+						Value:         "valid.alias.four",
+						DestinationId: &wrapperspb.StringValue{Value: tar.GetPublicId()},
+					},
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=id,destination_id,value,version"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.IdField, globals.DestinationIdField, globals.ValueField, globals.VersionField},
+			},
+			{
+				name: "composite grants all fields",
+				input: &pbs.CreateAliasRequest{
+					Item: &pb.Alias{
+						Name:          &wrapperspb.StringValue{Value: genUuid(t)},
+						Description:   &wrapperspb.StringValue{Value: genUuid(t)},
+						ScopeId:       globals.GlobalPrefix,
+						Type:          "target",
+						Value:         "valid.alias.five",
+						DestinationId: &wrapperspb.StringValue{Value: tar.GetPublicId()},
+					},
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=destination_id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=scope_id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=name"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=created_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=value"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=type"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=host_id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=*;output_fields=version"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeIdField,
+					globals.DestinationIdField,
+					globals.NameField,
+					globals.DescriptionField,
+					globals.CreatedTimeField,
+					globals.ValueField,
+					globals.TypeField,
+					globals.HostIdField,
+					globals.VersionField,
+				},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, accountID := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, accountID.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				out, err := s.CreateAlias(fullGrantAuthCtx, tc.input)
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, out.Item, tc.expectOutfields)
+			})
+		}
+	})
+
+	t.Run("UpdateAlias", func(t *testing.T) {
+		ctx := context.Background()
+		conn, _ := db.TestSetup(t, "postgres")
+		rw := db.New(conn)
+		wrap := db.TestWrapper(t)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+		iamRepoFn := func() (*iam.Repository, error) {
+			return iamRepo, nil
+		}
+		repoFn := func() (*target.Repository, error) {
+			return target.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		_, p := iam.TestScopes(t, iamRepo)
+		tar := tcp.TestTarget(ctx, t, conn, p.GetPublicId(), "testTarget")
+
+		// this can be used across test cases because we're only testing for output fields, not the update behaviors
+		inputFunc := func(t *testing.T) *pbs.UpdateAliasRequest {
+			alias1 := "test.alias." + genUuid(t)
+			globalAlias1 := target.TestAlias(
+				t,
+				rw,
+				alias1,
+				target.WithDescription("alias_1"),
+				target.WithName("alias_one"),
+				target.WithDestinationId(tar.GetPublicId()),
+				target.WithHostId("hst_1234567890"),
+			)
+			return &pbs.UpdateAliasRequest{
+				Id: globalAlias1.PublicId,
+				Item: &pb.Alias{
+					Name:        &wrapperspb.StringValue{Value: genUuid(t)},
+					Description: &wrapperspb.StringValue{Value: genUuid(t)},
+					Version:     globalAlias1.Version,
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"name", "description"},
+				},
+			}
+		}
+
+		s, err := aliases.NewService(ctx, repoFn, iamRepoFn, 1000)
+		require.NoError(t, err)
+		testcases := []struct {
+			name            string
+			userFunc        func() (*iam.User, auth.Account)
+			expectOutfields []string
+		}{
+			{
+				name: "grant with output_fields only returns: name and description",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=name,description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.NameField, globals.DescriptionField},
+			},
+			{
+				name: "grant with output_fields only returns: scope_id and value",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=scope_id,value"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.ScopeIdField, globals.ValueField},
+			},
+			{
+				name: "grant with output_fields only returns: update_time and create_time",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=updated_time,created_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.UpdatedTimeField, globals.CreatedTimeField},
+			},
+			{
+				name: "grant with output_fields only returns: id, destination_id, value, version",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=id,destination_id,value,version"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{globals.IdField, globals.DestinationIdField, globals.ValueField, globals.VersionField},
+			},
+			{
+				name: "composite grants all fields",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=scope_id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=name"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=created_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=version"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=destination_id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=type"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=value"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=alias;actions=update;output_fields=host_id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeIdField,
+					globals.DestinationIdField,
+					globals.NameField,
+					globals.DescriptionField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					globals.ValueField,
+					globals.TypeField,
+					globals.HostIdField,
+					globals.VersionField,
+				},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, accountID := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, accountID.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				out, err := s.UpdateAlias(fullGrantAuthCtx, inputFunc(t))
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, out.Item, tc.expectOutfields)
 			})
 		}
 	})

--- a/internal/daemon/controller/handlers/aliases/grants_test.go
+++ b/internal/daemon/controller/handlers/aliases/grants_test.go
@@ -321,6 +321,51 @@ func TestGrants_ReadActions(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("authorized action", func(t *testing.T) {
+		testcases := []struct {
+			name                  string
+			input                 *pbs.ListAliasesRequest
+			userFunc              func() (*iam.User, auth.Account)
+			wantErr               error
+			wantAuthorizedActions []string
+		}{
+			{
+				name: "global role grant this with wildcard returns all created aliases",
+				input: &pbs.ListAliasesRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr:               nil,
+				wantAuthorizedActions: []string{"read", "update", "delete", "no-op"},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, accountID := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, accountID.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				got, finalErr := s.ListAliases(fullGrantAuthCtx, tc.input)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, finalErr, tc.wantErr)
+					return
+				}
+				require.NoError(t, finalErr)
+				for _, item := range got.Items {
+					require.ElementsMatch(t, tc.wantAuthorizedActions, item.AuthorizedActions)
+				}
+			})
+		}
+	})
 }
 
 // TestGrants_WriteActions tests write actions to assert that grants are being applied properly

--- a/internal/daemon/controller/handlers/authmethods/grants_test.go
+++ b/internal/daemon/controller/handlers/authmethods/grants_test.go
@@ -592,8 +592,7 @@ func TestGrants_ReadActions(t *testing.T) {
 	})
 }
 
-// TestGrants_WriteActions tests write actions to assert that grants are being applied properly
-func TestGrants_WriteActions(t *testing.T) {
+func TestGrants_Create(t *testing.T) {
 	ctx := context.Background()
 	conn, _ := db.TestSetup(t, "postgres")
 	wrap := db.TestWrapper(t)
@@ -635,575 +634,739 @@ func TestGrants_WriteActions(t *testing.T) {
 	org1, p1 := iam.TestScopes(t, iamRepo)
 	org2, _ := iam.TestScopes(t, iamRepo)
 
-	t.Run("Create", func(t *testing.T) {
-		testcases := []struct {
-			name             string
-			userFunc         func() (*iam.User, auth.Account)
-			canCreateInScope map[string]expectedOutput
-		}{
-			{
-				name: "direct grant all can create all",
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
-					{
-						RoleScopeId: globals.GlobalPrefix,
-						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope_id,name,description,type,created_time,updated_time,version"},
-						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
-					},
-				}),
-				canCreateInScope: map[string]expectedOutput{
-					globals.GlobalPrefix: {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
-					org1.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
-					org2.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+	testcases := []struct {
+		name             string
+		userFunc         func() (*iam.User, auth.Account)
+		canCreateInScope map[string]expectedOutput
+	}{
+		{
+			name: "direct grant all can create all",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope_id,name,description,type,created_time,updated_time,version"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 				},
+			}),
+			canCreateInScope: map[string]expectedOutput{
+				globals.GlobalPrefix: {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+				org1.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+				org2.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
 			},
-			{
-				name: "global role grant children can only create org auth methods",
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
-					{
-						RoleScopeId: globals.GlobalPrefix,
-						Grants:      []string{"ids=*;type=auth-method;actions=create;output_fields=id,scope_id,created_time"},
-						GrantScopes: []string{globals.GrantScopeChildren},
-					},
-				}),
-				canCreateInScope: map[string]expectedOutput{
-					globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
-					org1.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.CreatedTimeField}},
-					org2.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.CreatedTimeField}},
+		},
+		{
+			name: "global role grant children can only create org auth methods",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=auth-method;actions=create;output_fields=id,scope_id,created_time"},
+					GrantScopes: []string{globals.GrantScopeChildren},
 				},
+			}),
+			canCreateInScope: map[string]expectedOutput{
+				globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
+				org1.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.CreatedTimeField}},
+				org2.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.CreatedTimeField}},
 			},
-			{
-				name: "org role can't create global auth methods nor auth methods in other orgs",
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
-					{
-						RoleScopeId: org2.PublicId,
-						Grants:      []string{"ids=*;type=auth-method;actions=create;output_fields=id,name,description"},
-						GrantScopes: []string{globals.GrantScopeThis},
-					},
-				}),
-				canCreateInScope: map[string]expectedOutput{
-					globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
-					org1.PublicId:        {wantErr: handlers.ForbiddenError()},
-					org2.PublicId:        {wantOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField}},
+		},
+		{
+			name: "org role can't create global auth methods nor auth methods in other orgs",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org2.PublicId,
+					Grants:      []string{"ids=*;type=auth-method;actions=create;output_fields=id,name,description"},
+					GrantScopes: []string{globals.GrantScopeThis},
 				},
+			}),
+			canCreateInScope: map[string]expectedOutput{
+				globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
+				org1.PublicId:        {wantErr: handlers.ForbiddenError()},
+				org2.PublicId:        {wantOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField}},
 			},
-			{
-				name: "incorrect grants returns 403 error",
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
-					{
-						RoleScopeId: globals.GlobalPrefix,
-						Grants:      []string{"ids=*;type=auth-method;actions=list,read,update;output_fields=id,scope_id"},
-						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
-					},
-					{
-						RoleScopeId: org1.PublicId,
-						Grants:      []string{"ids=*;type=auth-method;actions=list,read,update;output_fields=id,name"},
-						GrantScopes: []string{globals.GrantScopeThis},
-					},
-				}),
-				canCreateInScope: map[string]expectedOutput{
-					globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
-					org1.PublicId:        {wantErr: handlers.ForbiddenError()},
-					org2.PublicId:        {wantErr: handlers.ForbiddenError()},
+		},
+		{
+			name: "incorrect grants returns 403 error",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=auth-method;actions=list,read,update;output_fields=id,scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 				},
-			},
-			{
-				name:     "no grants returns 403 error",
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, nil),
-				canCreateInScope: map[string]expectedOutput{
-					globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
-					org1.PublicId:        {wantErr: handlers.ForbiddenError()},
-					org2.PublicId:        {wantErr: handlers.ForbiddenError()},
+				{
+					RoleScopeId: org1.PublicId,
+					Grants:      []string{"ids=*;type=auth-method;actions=list,read,update;output_fields=id,name"},
+					GrantScopes: []string{globals.GrantScopeThis},
 				},
+			}),
+			canCreateInScope: map[string]expectedOutput{
+				globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
+				org1.PublicId:        {wantErr: handlers.ForbiddenError()},
+				org2.PublicId:        {wantErr: handlers.ForbiddenError()},
 			},
-			{
-				name: "project role can't create auth methods in any scope (403)",
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
-					{
-						RoleScopeId: p1.PublicId,
-						Grants:      []string{"ids=*;type=*;actions=*"},
-						GrantScopes: []string{globals.GrantScopeThis},
-					},
-				}),
-				canCreateInScope: map[string]expectedOutput{
-					globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
-					org1.PublicId:        {wantErr: handlers.ForbiddenError()},
-					org2.PublicId:        {wantErr: handlers.ForbiddenError()},
+		},
+		{
+			name:     "no grants returns 403 error",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, nil),
+			canCreateInScope: map[string]expectedOutput{
+				globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
+				org1.PublicId:        {wantErr: handlers.ForbiddenError()},
+				org2.PublicId:        {wantErr: handlers.ForbiddenError()},
+			},
+		},
+		{
+			name: "project role can't create auth methods in any scope (403)",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: p1.PublicId,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis},
 				},
+			}),
+			canCreateInScope: map[string]expectedOutput{
+				globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
+				org1.PublicId:        {wantErr: handlers.ForbiddenError()},
+				org2.PublicId:        {wantErr: handlers.ForbiddenError()},
 			},
-		}
+		},
+	}
 
-		for _, tc := range testcases {
-			t.Run(tc.name, func(t *testing.T) {
-				user, account := tc.userFunc()
-				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
-				require.NoError(t, err)
-				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
 
-				for scopeId, expectedOutput := range tc.canCreateInScope {
-					// Build a distinct name for each Auth Method
-					name := fmt.Sprintf("[%s] ", tc.name)
-					switch scopeId {
-					case globals.GlobalPrefix:
-						name += "global"
-					case org1.PublicId:
-						name += "org 1"
-					case org2.PublicId:
-						name += "org 2"
-					default:
-						t.Fatalf("Unexpected scope ID: %s", scopeId)
-					}
-
-					resp, err := s.CreateAuthMethod(fullGrantAuthCtx, &pbs.CreateAuthMethodRequest{Item: &pb.AuthMethod{
-						Name:        wrapperspb.String(name),
-						Description: wrapperspb.String("test description"),
-						ScopeId:     scopeId,
-						Type:        "password",
-					}})
-					if expectedOutput.wantErr != nil {
-						require.ErrorIs(t, err, expectedOutput.wantErr)
-						continue
-					}
-					require.NoError(t, err)
-					handlers.TestAssertOutputFields(t, resp.Item, expectedOutput.wantOutfields)
+			for scopeId, expectedOutput := range tc.canCreateInScope {
+				// Build a distinct name for each Auth Method
+				name := fmt.Sprintf("[%s] ", tc.name)
+				switch scopeId {
+				case globals.GlobalPrefix:
+					name += "global"
+				case org1.PublicId:
+					name += "org 1"
+				case org2.PublicId:
+					name += "org 2"
+				default:
+					t.Fatalf("Unexpected scope ID: %s", scopeId)
 				}
-			})
-		}
-	})
 
-	t.Run("Update", func(t *testing.T) {
-		// Create global & org auth methods to test updates
-		globalAmId := password.TestAuthMethod(t, conn, globals.GlobalPrefix, password.WithName("global name"), password.WithDescription("global desc")).PublicId
-		org1AmId := password.TestAuthMethod(t, conn, org1.PublicId, password.WithName("org 1 name"), password.WithDescription("org 2 desc")).PublicId
-		org2AmId := password.TestAuthMethod(t, conn, org2.PublicId, password.WithName("org 2 name"), password.WithDescription("org 2 desc")).PublicId
+				resp, err := s.CreateAuthMethod(fullGrantAuthCtx, &pbs.CreateAuthMethodRequest{Item: &pb.AuthMethod{
+					Name:        wrapperspb.String(name),
+					Description: wrapperspb.String("test description"),
+					ScopeId:     scopeId,
+					Type:        "password",
+				}})
+				if expectedOutput.wantErr != nil {
+					require.ErrorIs(t, err, expectedOutput.wantErr)
+					continue
+				}
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, resp.Item, expectedOutput.wantOutfields)
+			}
+		})
+	}
+}
 
-		testcases := []struct {
-			name                string
-			rolesToCreate       []authtoken.TestRoleGrantsForToken
-			canUpdateAuthMethod map[string]expectedOutput
-		}{
-			{
-				name: "global role grant this and children can update global auth method",
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
-					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=auth-method;actions=update;output_fields=id,scope_id,name,description,type,version"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
-					},
-				},
-				canUpdateAuthMethod: map[string]expectedOutput{
+type directGrantUserAccountSetup func() (*iam.User, auth.Account)
+
+func TestGrants_Update(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		return oidc.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		return ldap.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	pwRepoFn := func() (*password.Repository, error) {
+		return password.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	atRepoFn := func() (*authtoken.Repository, error) {
+		return atRepo, nil
+	}
+	authMethodRepoFn := func() (*auth.AuthMethodRepository, error) {
+		return auth.NewAuthMethodRepository(ctx, rw, rw, kmsCache)
+	}
+
+	s, err := authmethods.NewService(ctx,
+		kmsCache,
+		pwRepoFn,
+		oidcRepoFn,
+		iamRepoFn,
+		atRepoFn,
+		ldapRepoFn,
+		authMethodRepoFn,
+		1000)
+	require.NoError(t, err)
+	org1, p1 := iam.TestScopes(t, iamRepo)
+	org2, _ := iam.TestScopes(t, iamRepo)
+
+	testcases := []struct {
+		name                string
+		setupFunc           func(t *testing.T) (directGrantUserAccountSetup, map[string]expectedOutput)
+		canUpdateAuthMethod func(t *testing.T) map[string]expectedOutput
+	}{
+		{
+			name: "global role grant this and children can update global auth method",
+			setupFunc: func(t *testing.T) (directGrantUserAccountSetup, map[string]expectedOutput) {
+				globalAmId := password.TestAuthMethod(t, conn, globals.GlobalPrefix).PublicId
+				org1AmId := password.TestAuthMethod(t, conn, org1.PublicId).PublicId
+				org2AmId := password.TestAuthMethod(t, conn, org2.PublicId).PublicId
+				wantOutput := map[string]expectedOutput{
 					globalAmId: {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.VersionField}},
 					org1AmId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.VersionField}},
 					org2AmId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.VersionField}},
-				},
+				}
+				userAccountFunc := iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=update;output_fields=id,scope_id,name,description,type,version"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				})
+				return userAccountFunc, wantOutput
 			},
-			{
-				name: "global role grant this & org role grant this can update their respective auth methods",
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
-					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=auth-method;actions=update;output_fields=id,name,description,version"},
-						GrantScopes:  []string{globals.GrantScopeThis},
-					},
-					{
-						RoleScopeId:  org1.PublicId,
-						GrantStrings: []string{"ids=*;type=auth-method;actions=update;output_fields=id,scope_id,type,version"},
-						GrantScopes:  []string{globals.GrantScopeThis},
-					},
-				},
-				canUpdateAuthMethod: map[string]expectedOutput{
+			canUpdateAuthMethod: func(t *testing.T) map[string]expectedOutput {
+				globalAmId := password.TestAuthMethod(t, conn, globals.GlobalPrefix).PublicId
+				org1AmId := password.TestAuthMethod(t, conn, org1.PublicId).PublicId
+				org2AmId := password.TestAuthMethod(t, conn, org2.PublicId).PublicId
+				return map[string]expectedOutput{
+					globalAmId: {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.VersionField}},
+					org1AmId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.VersionField}},
+					org2AmId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.VersionField}},
+				}
+			},
+		},
+		{
+			name: "global role grant this & org role grant this can update their respective auth methods",
+			setupFunc: func(t *testing.T) (directGrantUserAccountSetup, map[string]expectedOutput) {
+				globalAmId := password.TestAuthMethod(t, conn, globals.GlobalPrefix).PublicId
+				org1AmId := password.TestAuthMethod(t, conn, org1.PublicId).PublicId
+				org2AmId := password.TestAuthMethod(t, conn, org2.PublicId).PublicId
+				wantOutput := map[string]expectedOutput{
 					globalAmId: {wantOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField}},
 					org1AmId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.VersionField}},
 					org2AmId:   {wantErr: handlers.ForbiddenError()},
-				},
+				}
+				userAccountFunc := iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=update;output_fields=id,name,description,version"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=auth-method;actions=update;output_fields=id,scope_id,type,version"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+				return userAccountFunc, wantOutput
 			},
-			{
-				name: "org role can't update global auth methods",
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
-					RoleScopeId:  org1.PublicId,
-					GrantStrings: []string{"ids=*;type=auth-method;actions=update;output_fields=id,version,created_time,updated_time"},
-					GrantScopes:  []string{globals.GrantScopeThis},
-				}},
-				canUpdateAuthMethod: map[string]expectedOutput{
+		},
+		{
+			name: "org role can't update global auth methods",
+			setupFunc: func(t *testing.T) (directGrantUserAccountSetup, map[string]expectedOutput) {
+				globalAmId := password.TestAuthMethod(t, conn, globals.GlobalPrefix).PublicId
+				org1AmId := password.TestAuthMethod(t, conn, org1.PublicId).PublicId
+				org2AmId := password.TestAuthMethod(t, conn, org2.PublicId).PublicId
+				wantOutput := map[string]expectedOutput{
 					globalAmId: {wantErr: handlers.ForbiddenError()},
 					org1AmId:   {wantOutfields: []string{globals.IdField, globals.VersionField, globals.CreatedTimeField, globals.UpdatedTimeField}},
 					org2AmId:   {wantErr: handlers.ForbiddenError()},
-				},
-			},
-			{
-				name: "global role grant children of global auth method's id can only update children auth methods",
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
-					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=" + globalAmId + ";type=auth-method;actions=update;output_fields=id"},
-						GrantScopes:  []string{globals.GrantScopeChildren},
-					},
-				},
-				canUpdateAuthMethod: map[string]expectedOutput{
-					globalAmId: {wantErr: handlers.ForbiddenError()},
-					org1AmId:   {wantOutfields: []string{globals.IdField}},
-					org2AmId:   {wantOutfields: []string{globals.IdField}},
-				},
-			},
-			{
-				name: "incorrect grants returns 403 error",
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
-					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read,create"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
-					},
-					{
-						RoleScopeId:  org1.PublicId,
-						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read,create"},
-						GrantScopes:  []string{globals.GrantScopeThis},
-					},
-				},
-				canUpdateAuthMethod: map[string]expectedOutput{
-					globalAmId: {wantErr: handlers.ForbiddenError()},
-					org1AmId:   {wantErr: handlers.ForbiddenError()},
-					org2AmId:   {wantErr: handlers.ForbiddenError()},
-				},
-			},
-			{
-				name:          "no grants returns 403 error",
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{},
-				canUpdateAuthMethod: map[string]expectedOutput{
-					globalAmId: {wantErr: handlers.ForbiddenError()},
-					org1AmId:   {wantErr: handlers.ForbiddenError()},
-					org2AmId:   {wantErr: handlers.ForbiddenError()},
-				},
-			},
-			{
-				name: "project role can't update auth methods in any scope (403)",
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
-					{
-						RoleScopeId:  p1.GetPublicId(),
-						GrantStrings: []string{"ids=*;type=*;actions=*"},
-						GrantScopes:  []string{globals.GrantScopeThis},
-					},
-				},
-				canUpdateAuthMethod: map[string]expectedOutput{
-					globalAmId: {wantErr: handlers.ForbiddenError()},
-					org1AmId:   {wantErr: handlers.ForbiddenError()},
-					org2AmId:   {wantErr: handlers.ForbiddenError()},
-				},
-			},
-		}
-
-		for i, tc := range testcases {
-			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
-				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
-
-				for amId, expectedOutput := range tc.canUpdateAuthMethod {
-					resp, err := s.UpdateAuthMethod(fullGrantAuthCtx, &pbs.UpdateAuthMethodRequest{
-						Id: amId,
-						UpdateMask: &field_mask.FieldMask{
-							Paths: []string{"name", "description"},
-						},
-						Item: &pb.AuthMethod{
-							Name:        &wrapperspb.StringValue{Value: fmt.Sprintf("updated name (%d)", i)},
-							Description: &wrapperspb.StringValue{Value: fmt.Sprintf("updated description (%d)", i)},
-							Version:     uint32(i + 1), // increment version to simulate an update
-						},
-					})
-					if expectedOutput.wantErr != nil {
-						require.ErrorIs(t, err, expectedOutput.wantErr)
-						return
-					}
-					require.NoError(t, err)
-					handlers.TestAssertOutputFields(t, resp.Item, expectedOutput.wantOutfields)
 				}
-			})
-		}
-	})
-
-	t.Run("Delete", func(t *testing.T) {
-		allScopeIDs := []string{globals.GlobalPrefix, org1.PublicId, org2.PublicId}
-		testcases := []struct {
-			name                    string
-			am                      *password.AuthMethod
-			userFunc                func() (*iam.User, auth.Account)
-			deleteAllowedAtScopeIDs []string
-		}{
-			{
-				name: "grant all can delete all",
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
-					{
-						RoleScopeId: globals.GlobalPrefix,
-						Grants:      []string{"ids=*;type=*;actions=*"},
-						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
-					},
-				}),
-				deleteAllowedAtScopeIDs: allScopeIDs,
-			},
-			{
-				name: "grant children can only delete in orgs",
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
-					{
-						RoleScopeId: globals.GlobalPrefix,
-						Grants:      []string{"ids=*;type=*;actions=*"},
-						GrantScopes: []string{globals.GrantScopeChildren},
-					},
-				}),
-				deleteAllowedAtScopeIDs: []string{org1.PublicId, org2.PublicId},
-			},
-			{
-				name: "org role can't delete global auth methods",
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				userAccountFunc := iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
 						RoleScopeId: org1.PublicId,
-						Grants:      []string{"ids=*;type=auth-method;actions=delete"},
+						Grants:      []string{"ids=*;type=auth-method;actions=update;output_fields=id,version,created_time,updated_time"},
 						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				}),
-				deleteAllowedAtScopeIDs: []string{org1.PublicId},
+				})
+				return userAccountFunc, wantOutput
 			},
-			{
-				name: "incorrect grants returns 403 error",
-				am:   password.TestAuthMethod(t, conn, org1.PublicId),
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+		},
+		{
+			name: "global role grant children of global auth method's id can only update children auth methods",
+			setupFunc: func(t *testing.T) (directGrantUserAccountSetup, map[string]expectedOutput) {
+				globalAmId := password.TestAuthMethod(t, conn, globals.GlobalPrefix).PublicId
+				org1AmId := password.TestAuthMethod(t, conn, org1.PublicId).PublicId
+				org2AmId := password.TestAuthMethod(t, conn, org2.PublicId).PublicId
+				wantOutput := map[string]expectedOutput{
+					globalAmId: {wantErr: handlers.ForbiddenError()},
+					org1AmId:   {wantOutfields: []string{globals.IdField}},
+					org2AmId:   {wantErr: handlers.ForbiddenError()},
+				}
+				userAccountFunc := iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
 						RoleScopeId: globals.GlobalPrefix,
-						Grants:      []string{"ids=*;type=auth-method;actions=list,read,create,update"},
+						Grants: []string{
+							fmt.Sprintf("ids=%s;type=auth-method;actions=update;output_fields=id", org1AmId),
+						},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+				return userAccountFunc, wantOutput
+			},
+		},
+		{
+			name: "incorrect grants returns 403 error",
+			setupFunc: func(t *testing.T) (directGrantUserAccountSetup, map[string]expectedOutput) {
+				globalAmId := password.TestAuthMethod(t, conn, globals.GlobalPrefix).PublicId
+				org1AmId := password.TestAuthMethod(t, conn, org1.PublicId).PublicId
+				org2AmId := password.TestAuthMethod(t, conn, org2.PublicId).PublicId
+				wantOutput := map[string]expectedOutput{
+					globalAmId: {wantErr: handlers.ForbiddenError()},
+					org1AmId:   {wantErr: handlers.ForbiddenError()},
+					org2AmId:   {wantErr: handlers.ForbiddenError()},
+				}
+				userAccountFunc := iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=list,read,create"},
 						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
-				}),
-			},
-			{
-				name:     "no grants returns 403 error",
-				am:       password.TestAuthMethod(t, conn, globals.GlobalPrefix),
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, nil),
-			},
-			{
-				name: "project role can't delete auth methods at any scope (403)",
-				am:   password.TestAuthMethod(t, conn, globals.GlobalPrefix),
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId: p1.PublicId,
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=auth-method;actions=list,read,create"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+				return userAccountFunc, wantOutput
+			},
+		},
+		{
+			name: "no grants returns 403 error",
+			setupFunc: func(t *testing.T) (directGrantUserAccountSetup, map[string]expectedOutput) {
+				globalAmId := password.TestAuthMethod(t, conn, globals.GlobalPrefix).PublicId
+				org1AmId := password.TestAuthMethod(t, conn, org1.PublicId).PublicId
+				org2AmId := password.TestAuthMethod(t, conn, org2.PublicId).PublicId
+				wantOutput := map[string]expectedOutput{
+					globalAmId: {wantErr: handlers.ForbiddenError()},
+					org1AmId:   {wantErr: handlers.ForbiddenError()},
+					org2AmId:   {wantErr: handlers.ForbiddenError()},
+				}
+				userAccountFunc := iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{})
+				return userAccountFunc, wantOutput
+			},
+		},
+		{
+			name: "project role can't update auth methods in any scope (403)",
+			setupFunc: func(t *testing.T) (directGrantUserAccountSetup, map[string]expectedOutput) {
+				globalAmId := password.TestAuthMethod(t, conn, globals.GlobalPrefix).PublicId
+				org1AmId := password.TestAuthMethod(t, conn, org1.PublicId).PublicId
+				org2AmId := password.TestAuthMethod(t, conn, org2.PublicId).PublicId
+				wantOutput := map[string]expectedOutput{
+					globalAmId: {wantErr: handlers.ForbiddenError()},
+					org1AmId:   {wantErr: handlers.ForbiddenError()},
+					org2AmId:   {wantErr: handlers.ForbiddenError()},
+				}
+				userAccountFunc := iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: p1.GetPublicId(),
 						Grants:      []string{"ids=*;type=*;actions=*"},
 						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				}),
+				})
+				return userAccountFunc, wantOutput
 			},
-		}
+		},
+	}
 
-		for _, tc := range testcases {
-			t.Run(tc.name, func(t *testing.T) {
-				// setup a map to track which scope correlates to an auth method
-				scopeIdAuthMethodMap := map[string]*password.AuthMethod{}
-				for _, scopeId := range allScopeIDs {
-					am := password.TestAuthMethod(t, conn, scopeId)
-					scopeIdAuthMethodMap[scopeId] = am
-				}
-				user, account := tc.userFunc()
-				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
-				require.NoError(t, err)
-				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
-				for scope, am := range scopeIdAuthMethodMap {
-					_, err = s.DeleteAuthMethod(fullGrantAuthCtx, &pbs.DeleteAuthMethodRequest{Id: am.PublicId})
-					if !slices.Contains(tc.deleteAllowedAtScopeIDs, scope) {
-						require.ErrorIs(t, err, handlers.ForbiddenError())
-						continue
-					}
-					require.NoErrorf(t, err, "failed to delete auth method in scope %s", scope)
-				}
-			})
-		}
-	})
-
-	t.Run("Authenticate", func(t *testing.T) {
-		pwRepo, err := pwRepoFn()
-		require.NoError(t, err)
-
-		// We need a sys eventer in order to authenticate
-		eventConfig := event.TestEventerConfig(t, "TestGrants_WriteActions", event.TestWithObservationSink(t))
-		testLock := &sync.Mutex{}
-		testLogger := hclog.New(&hclog.LoggerOptions{
-			Mutex: testLock,
-			Name:  "test",
-		})
-
-		require.NoError(t, event.InitSysEventer(testLogger, testLock, "TestGrants_WriteActions", event.WithEventerConfig(&eventConfig.EventerConfig)))
-		sinkFileName := eventConfig.ObservationEvents.Name()
-		t.Cleanup(func() {
-			require.NoError(t, os.Remove(sinkFileName))
-			event.TestResetSystEventer(t)
-		})
-
-		testcases := []struct {
-			name          string
-			scopeId       string
-			input         *pbs.AuthenticateRequest
-			userFunc      func() (*iam.User, auth.Account)
-			rolesToCreate []authtoken.TestRoleGrantsForToken
-			wantErr       error
-		}{
-			{
-				name:    "global role grant this and children can authenticate against a global auth method",
-				scopeId: globals.GlobalPrefix,
-				input: &pbs.AuthenticateRequest{
-					TokenType: "token",
-					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
-						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
-							LoginName: testLoginName,
-							Password:  testPassword,
-						},
+	for i, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			userAccountFunc, canUpdateAuthMethos := tc.setupFunc(t)
+			user, account := userAccountFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for amId, expectedOutput := range canUpdateAuthMethos {
+				resp, err := s.UpdateAuthMethod(fullGrantAuthCtx, &pbs.UpdateAuthMethodRequest{
+					Id: amId,
+					UpdateMask: &field_mask.FieldMask{
+						Paths: []string{"name", "description"},
 					},
-				},
-				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
-					{
-						RoleScopeId: globals.GlobalPrefix,
-						Grants:      []string{"ids=*;type=auth-method;actions=authenticate"},
-						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					Item: &pb.AuthMethod{
+						Name:        &wrapperspb.StringValue{Value: fmt.Sprintf("updated name (%d)", i)},
+						Description: &wrapperspb.StringValue{Value: fmt.Sprintf("updated description (%d)", i)},
+						Version:     uint32(1), // increment version to simulate an update
 					},
-				}),
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
-					RoleScopeId:  globals.GlobalPrefix,
-					GrantStrings: []string{"ids=*;type=auth-method;actions=authenticate"},
-					GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
-				}},
-			},
-			{
-				name:    "org role can't authenticate against a global auth method",
-				scopeId: globals.GlobalPrefix,
-				input: &pbs.AuthenticateRequest{
-					TokenType: "token",
-					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
-						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
-							LoginName: testLoginName,
-							Password:  testPassword,
-						},
-					},
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
-					RoleScopeId:  org1.PublicId,
-					GrantStrings: []string{"ids=*;type=auth-method;actions=authenticate"},
-					GrantScopes:  []string{globals.GrantScopeThis},
-				}},
-				wantErr: handlers.ForbiddenError(),
-			},
-			{
-				name:    "no grants returns 403 error for a global auth method",
-				scopeId: globals.GlobalPrefix,
-				input: &pbs.AuthenticateRequest{
-					TokenType: "token",
-					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
-						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
-							LoginName: testLoginName,
-							Password:  testPassword,
-						},
-					},
-				},
-				wantErr: handlers.ForbiddenError(),
-			},
-			{
-				name:    "org auth methods, by default, grant anyone permission to authenticate (and list) auth methods",
-				scopeId: org1.PublicId,
-				input: &pbs.AuthenticateRequest{
-					TokenType: "token",
-					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
-						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
-							LoginName: testLoginName,
-							Password:  testPassword,
-						},
-					},
-				},
-			},
-			{
-				name:    "project role can authenticate against org auth methods because by default, org auth methods grant anyone permission to authenticate (and list) auth methods",
-				scopeId: org1.PublicId,
-				input: &pbs.AuthenticateRequest{
-					TokenType: "token",
-					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
-						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
-							LoginName: testLoginName,
-							Password:  testPassword,
-						},
-					},
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
-					RoleScopeId:  p1.PublicId,
-					GrantStrings: []string{"ids=*;type=auth-method;actions=authenticate"},
-					GrantScopes:  []string{globals.GrantScopeThis},
-				}},
-			},
-			{
-				name:    "granting authenticate again at the org scope allows authentication",
-				scopeId: org1.PublicId,
-				input: &pbs.AuthenticateRequest{
-					TokenType: "token",
-					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
-						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
-							LoginName: testLoginName,
-							Password:  testPassword,
-						},
-					},
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
-					RoleScopeId:  org1.PublicId,
-					GrantStrings: []string{"ids=*;type=auth-method;actions=authenticate"},
-					GrantScopes:  []string{globals.GrantScopeThis},
-				}},
-			},
-			{
-				name:    "project role can't authenticate against global auth methods",
-				scopeId: globals.GlobalPrefix,
-				input: &pbs.AuthenticateRequest{
-					TokenType: "token",
-					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
-						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
-							LoginName: testLoginName,
-							Password:  testPassword,
-						},
-					},
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
-					RoleScopeId:  p1.PublicId,
-					GrantStrings: []string{"ids=*;type=auth-method;actions=authenticate"},
-					GrantScopes:  []string{globals.GrantScopeThis},
-				}},
-				wantErr: handlers.ForbiddenError(),
-			},
-		}
-
-		for _, tc := range testcases {
-			t.Run(tc.name, func(t *testing.T) {
-				// Create auth method
-				if tc.scopeId == globals.GlobalPrefix {
-					tc.input.AuthMethodId = password.TestAuthMethod(t, conn, globals.GlobalPrefix).PublicId
-				} else {
-					tc.input.AuthMethodId = password.TestAuthMethod(t, conn, org1.PublicId).PublicId
-				}
-
-				// Create account for the auth method
-				account, err := password.NewAccount(ctx, tc.input.AuthMethodId, password.WithLoginName(testLoginName))
-				require.NoError(t, err)
-				account, err = pwRepo.CreateAccount(context.Background(), tc.scopeId, account, password.WithPassword(testPassword))
-				require.NoError(t, err)
-				require.NotNil(t, account)
-
-				// Create user linked to the account
-				user := iam.TestUser(t, iamRepo, tc.scopeId, iam.WithAccountIds(account.PublicId))
-
-				// Create the desired role/grants for the user
-				for _, roleToCreate := range tc.rolesToCreate {
-					role := iam.TestRoleWithGrants(t, conn, roleToCreate.RoleScopeId, roleToCreate.GrantScopes, roleToCreate.GrantStrings)
-					iam.TestUserRole(t, conn, role.PublicId, user.PublicId)
-				}
-
-				// Create auth token for the user
-				tok, err := atRepo.CreateAuthToken(ctx, user, account.PublicId)
-				require.NoError(t, err)
-				ctx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
-
-				_, err = s.Authenticate(ctx, tc.input)
-				if tc.wantErr != nil {
-					require.ErrorIs(t, err, tc.wantErr)
+				})
+				if expectedOutput.wantErr != nil {
+					require.ErrorIs(t, err, expectedOutput.wantErr)
 					return
 				}
 				require.NoError(t, err)
-			})
-		}
+				handlers.TestAssertOutputFields(t, resp.Item, expectedOutput.wantOutfields)
+			}
+		})
+	}
+}
+
+func TestGrants_Delete(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		return oidc.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		return ldap.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	pwRepoFn := func() (*password.Repository, error) {
+		return password.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	atRepoFn := func() (*authtoken.Repository, error) {
+		return atRepo, nil
+	}
+	authMethodRepoFn := func() (*auth.AuthMethodRepository, error) {
+		return auth.NewAuthMethodRepository(ctx, rw, rw, kmsCache)
+	}
+
+	s, err := authmethods.NewService(ctx,
+		kmsCache,
+		pwRepoFn,
+		oidcRepoFn,
+		iamRepoFn,
+		atRepoFn,
+		ldapRepoFn,
+		authMethodRepoFn,
+		1000)
+	require.NoError(t, err)
+	org1, p1 := iam.TestScopes(t, iamRepo)
+	org2, _ := iam.TestScopes(t, iamRepo)
+
+	allScopeIDs := []string{globals.GlobalPrefix, org1.PublicId, org2.PublicId}
+	testcases := []struct {
+		name                    string
+		am                      *password.AuthMethod
+		userFunc                func() (*iam.User, auth.Account)
+		deleteAllowedAtScopeIDs []string
+	}{
+		{
+			name: "grant all can delete all",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			deleteAllowedAtScopeIDs: allScopeIDs,
+		},
+		{
+			name: "grant children can only delete in orgs",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			deleteAllowedAtScopeIDs: []string{org1.PublicId, org2.PublicId},
+		},
+		{
+			name: "org role can't delete global auth methods",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org1.PublicId,
+					Grants:      []string{"ids=*;type=auth-method;actions=delete"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			deleteAllowedAtScopeIDs: []string{org1.PublicId},
+		},
+		{
+			name: "incorrect grants returns 403 error",
+			am:   password.TestAuthMethod(t, conn, org1.PublicId),
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=auth-method;actions=list,read,create,update"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+		},
+		{
+			name:     "no grants returns 403 error",
+			am:       password.TestAuthMethod(t, conn, globals.GlobalPrefix),
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, nil),
+		},
+		{
+			name: "project role can't delete auth methods at any scope (403)",
+			am:   password.TestAuthMethod(t, conn, globals.GlobalPrefix),
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: p1.PublicId,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// setup a map to track which scope correlates to an auth method
+			scopeIdAuthMethodMap := map[string]*password.AuthMethod{}
+			for _, scopeId := range allScopeIDs {
+				am := password.TestAuthMethod(t, conn, scopeId)
+				scopeIdAuthMethodMap[scopeId] = am
+			}
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for scope, am := range scopeIdAuthMethodMap {
+				_, err = s.DeleteAuthMethod(fullGrantAuthCtx, &pbs.DeleteAuthMethodRequest{Id: am.PublicId})
+				if !slices.Contains(tc.deleteAllowedAtScopeIDs, scope) {
+					require.ErrorIs(t, err, handlers.ForbiddenError())
+					continue
+				}
+				require.NoErrorf(t, err, "failed to delete auth method in scope %s", scope)
+			}
+		})
+	}
+}
+
+func TestGrants_Authentication(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	pwRepo, err := password.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		return oidc.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		return ldap.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	pwRepoFn := func() (*password.Repository, error) {
+		return pwRepo, nil
+	}
+	atRepoFn := func() (*authtoken.Repository, error) {
+		return atRepo, nil
+	}
+	authMethodRepoFn := func() (*auth.AuthMethodRepository, error) {
+		return auth.NewAuthMethodRepository(ctx, rw, rw, kmsCache)
+	}
+
+	s, err := authmethods.NewService(ctx,
+		kmsCache,
+		pwRepoFn,
+		oidcRepoFn,
+		iamRepoFn,
+		atRepoFn,
+		ldapRepoFn,
+		authMethodRepoFn,
+		1000)
+	require.NoError(t, err)
+	org1, p1 := iam.TestScopes(t, iamRepo)
+
+	// We need a sys eventer in order to authenticate
+	eventConfig := event.TestEventerConfig(t, "TestGrants_Authentication", event.TestWithObservationSink(t))
+	testLock := &sync.Mutex{}
+	testLogger := hclog.New(&hclog.LoggerOptions{
+		Mutex: testLock,
+		Name:  "test",
 	})
+
+	require.NoError(t, event.InitSysEventer(testLogger, testLock, "TestGrants_Authentication", event.WithEventerConfig(&eventConfig.EventerConfig)))
+	sinkFileName := eventConfig.ObservationEvents.Name()
+	t.Cleanup(func() {
+		require.NoError(t, os.Remove(sinkFileName))
+		event.TestResetSystEventer(t)
+	})
+
+	testcases := []struct {
+		name     string
+		scopeId  string
+		input    *pbs.AuthenticateRequest
+		userFunc func() (*iam.User, auth.Account)
+		wantErr  error
+	}{
+		{
+			name:    "global role grant this and children can authenticate against a global auth method",
+			scopeId: globals.GlobalPrefix,
+			input: &pbs.AuthenticateRequest{
+				Type: "token",
+				Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+					PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+						LoginName: testLoginName,
+						Password:  testPassword,
+					},
+				},
+			},
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=auth-method;actions=authenticate"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+		},
+		{
+			name:    "org role can't authenticate against a global auth method",
+			scopeId: globals.GlobalPrefix,
+			input: &pbs.AuthenticateRequest{
+				Type: "token",
+				Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+					PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+						LoginName: testLoginName,
+						Password:  testPassword,
+					},
+				},
+			},
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org1.PublicId,
+					Grants:      []string{"ids=*;type=auth-method;actions=authenticate"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			wantErr: handlers.ForbiddenError(),
+		},
+		{
+			name:    "no grants returns 403 error for a global auth method",
+			scopeId: globals.GlobalPrefix,
+			input: &pbs.AuthenticateRequest{
+				Type: "token",
+				Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+					PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+						LoginName: testLoginName,
+						Password:  testPassword,
+					},
+				},
+			},
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{}),
+			wantErr:  handlers.ForbiddenError(),
+		},
+		{
+			name:     "org auth methods, by default, grant anyone permission to authenticate (and list) auth methods",
+			scopeId:  org1.PublicId,
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{}),
+			input: &pbs.AuthenticateRequest{
+				Type: "token",
+				Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+					PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+						LoginName: testLoginName,
+						Password:  testPassword,
+					},
+				},
+			},
+		},
+		{
+			name:    "project role can authenticate against org auth methods because by default, org auth methods grant anyone permission to authenticate (and list) auth methods",
+			scopeId: org1.PublicId,
+			input: &pbs.AuthenticateRequest{
+				Type: "token",
+				Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+					PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+						LoginName: testLoginName,
+						Password:  testPassword,
+					},
+				},
+			},
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: p1.PublicId,
+					Grants:      []string{"ids=*;type=auth-method;actions=authenticate"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+		},
+		{
+			name:    "granting authenticate again at the org scope allows authentication",
+			scopeId: org1.PublicId,
+			input: &pbs.AuthenticateRequest{
+				Type: "token",
+				Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+					PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+						LoginName: testLoginName,
+						Password:  testPassword,
+					},
+				},
+			},
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org1.PublicId,
+					Grants:      []string{"ids=*;type=auth-method;actions=authenticate"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+		},
+		{
+			name:    "project role can't authenticate against global auth methods",
+			scopeId: globals.GlobalPrefix,
+			input: &pbs.AuthenticateRequest{
+				Type: "token",
+				Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+					PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+						LoginName: testLoginName,
+						Password:  testPassword,
+					},
+				},
+			},
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: p1.PublicId,
+					Grants:      []string{"ids=*;type=auth-method;actions=authenticate"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			wantErr: handlers.ForbiddenError(),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// set up an identity that we'll use to call authenticate request on. We'll use this credentials
+			// and auth method to make authenticate request on
+			tc.input.AuthMethodId = password.TestAuthMethod(t, conn, tc.scopeId).PublicId
+			newAcct, err := password.NewAccount(ctx, tc.input.AuthMethodId, password.WithLoginName(testLoginName))
+			require.NoError(t, err)
+			acctToLogin, err := pwRepo.CreateAccount(context.Background(), tc.scopeId, newAcct, password.WithPassword(testPassword))
+			require.NoError(t, err)
+			_ = iam.TestUser(t, iamRepo, tc.scopeId, iam.WithAccountIds(acctToLogin.PublicId))
+
+			// set up an identity that we'll use to call authenticate request
+			// Authentication API will rely on this user's grants to authorize the request
+			user, acctLoggingIn := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, acctLoggingIn.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			_, err = s.Authenticate(fullGrantAuthCtx, tc.input)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }

--- a/internal/daemon/controller/handlers/authmethods/grants_test.go
+++ b/internal/daemon/controller/handlers/authmethods/grants_test.go
@@ -5,7 +5,10 @@ package authmethods_test
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"slices"
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
@@ -16,23 +19,37 @@ import (
 	"github.com/hashicorp/boundary/internal/authtoken"
 	controllerauth "github.com/hashicorp/boundary/internal/daemon/controller/auth"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
+	"github.com/hashicorp/boundary/internal/event"
+	"github.com/hashicorp/go-hclog"
+	"google.golang.org/genproto/protobuf/field_mask"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/authmethods"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/authmethods"
 	"github.com/stretchr/testify/require"
 )
+
+// expectedOutput consolidates common output fields for the test cases
+type expectedOutput struct {
+	wantErr       error
+	wantOutfields []string
+}
 
 // TestGrants_ReadActions tests read actions to assert that grants are being applied properly
 func TestGrants_ReadActions(t *testing.T) {
 	ctx := context.Background()
 	conn, _ := db.TestSetup(t, "postgres")
 	wrap := db.TestWrapper(t)
-	iamRepo := iam.TestRepo(t, conn, wrap)
 	rw := db.New(conn)
 	kmsCache := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
 	iamRepoFn := func() (*iam.Repository, error) {
 		return iamRepo, nil
 	}
@@ -46,7 +63,7 @@ func TestGrants_ReadActions(t *testing.T) {
 		return password.NewRepository(ctx, rw, rw, kmsCache)
 	}
 	atRepoFn := func() (*authtoken.Repository, error) {
-		return authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		return atRepo, nil
 	}
 	authMethodRepoFn := func() (*auth.AuthMethodRepository, error) {
 		return auth.NewAuthMethodRepository(ctx, rw, rw, kmsCache)
@@ -62,21 +79,29 @@ func TestGrants_ReadActions(t *testing.T) {
 		authMethodRepoFn,
 		1000)
 	require.NoError(t, err)
-	org1, _ := iam.TestScopes(t, iamRepo)
+	org1, p1 := iam.TestScopes(t, iamRepo)
 	org2, _ := iam.TestScopes(t, iamRepo)
+
+	// Need to create a wrapper for each scope (global, org1, org2) to test grants against OIDC/LDAP at that scope
 	databaseWrapper, err := kmsCache.GetWrapper(context.Background(), globals.GlobalPrefix, kms.KeyPurposeDatabase)
 	require.NoError(t, err)
-	oidcGlobal := oidc.TestAuthMethod(t, conn, databaseWrapper, globals.GlobalPrefix, oidc.InactiveState, "client-id", "secret")
-	oidcOrg1 := oidc.TestAuthMethod(t, conn, databaseWrapper, org1.GetPublicId(), oidc.InactiveState, "client-id", "secret")
-	oidcOrg2 := oidc.TestAuthMethod(t, conn, databaseWrapper, org2.GetPublicId(), oidc.InactiveState, "client-id", "secret")
+	databaseWrapperOrg1, err := kmsCache.GetWrapper(context.Background(), org1.GetPublicId(), kms.KeyPurposeDatabase)
+	require.NoError(t, err)
+	databaseWrapperOrg2, err := kmsCache.GetWrapper(context.Background(), org2.GetPublicId(), kms.KeyPurposeDatabase)
+	require.NoError(t, err)
 
-	ldapGlobal := ldap.TestAuthMethod(t, conn, wrap, globals.GlobalPrefix, []string{"ldaps://alice.com"})
-	ldapOrg1 := ldap.TestAuthMethod(t, conn, wrap, org1.GetPublicId(), []string{"ldaps://alice.com"})
-	ldapOrg2 := ldap.TestAuthMethod(t, conn, wrap, org2.GetPublicId(), []string{"ldaps://alice.com"})
+	// Create OIDC/LDAP/Password auth methods for each scope
+	oidcGlobal := oidc.TestAuthMethod(t, conn, databaseWrapper, globals.GlobalPrefix, oidc.InactiveState, "client-id", "secret", oidc.WithName("oidc-global"), oidc.WithDescription("test oidc desc"))
+	oidcOrg1 := oidc.TestAuthMethod(t, conn, databaseWrapperOrg1, org1.GetPublicId(), oidc.InactiveState, "client-id", "secret", oidc.WithName("oidc-org-1"), oidc.WithDescription("test oidc desc"))
+	oidcOrg2 := oidc.TestAuthMethod(t, conn, databaseWrapperOrg2, org2.GetPublicId(), oidc.InactiveState, "client-id", "secret", oidc.WithName("oidc-org-2"), oidc.WithDescription("test oidc desc"))
 
-	pwGlobal := password.TestAuthMethod(t, conn, globals.GlobalPrefix)
-	pwOrg1 := password.TestAuthMethod(t, conn, org1.GetPublicId())
-	pwOrg2 := password.TestAuthMethod(t, conn, org2.GetPublicId())
+	ldapGlobal := ldap.TestAuthMethod(t, conn, databaseWrapper, globals.GlobalPrefix, []string{"ldaps://alice.com"}, ldap.WithName(ctx, "ldap-global"), ldap.WithDescription(ctx, "test ldap desc"))
+	ldapOrg1 := ldap.TestAuthMethod(t, conn, databaseWrapperOrg1, org1.GetPublicId(), []string{"ldaps://alice.com"}, ldap.WithName(ctx, "ldap-org-1"), ldap.WithDescription(ctx, "test ldap desc"))
+	ldapOrg2 := ldap.TestAuthMethod(t, conn, databaseWrapperOrg2, org2.GetPublicId(), []string{"ldaps://alice.com"}, ldap.WithName(ctx, "ldap-org-2"), ldap.WithDescription(ctx, "test ldap desc"))
+
+	pwGlobal := password.TestAuthMethod(t, conn, globals.GlobalPrefix, password.WithName("pw-global"), password.WithDescription("test pw desc"))
+	pwOrg1 := password.TestAuthMethod(t, conn, org1.GetPublicId(), password.WithName("pw-org-1"), password.WithDescription("test pw desc"))
+	pwOrg2 := password.TestAuthMethod(t, conn, org2.GetPublicId(), password.WithName("pw-org-2"), password.WithDescription("test pw desc"))
 
 	// ignoreList consists of auth method IDs to omit from the result set
 	// this is to handle auth methods that are created during the auth token
@@ -85,27 +110,47 @@ func TestGrants_ReadActions(t *testing.T) {
 
 	t.Run("List", func(t *testing.T) {
 		testcases := []struct {
-			name                     string
-			input                    *pbs.ListAuthMethodsRequest
-			includeGlobalAuthMethods bool
-			rolesToCreate            []authtoken.TestRoleGrantsForToken
-			wantErr                  error
-			wantIDs                  []string
+			name            string
+			input           *pbs.ListAuthMethodsRequest
+			userFunc        func() (*iam.User, auth.Account)
+			wantErr         error
+			wantIDs         []string
+			expectOutfields map[string][]string
 		}{
 			{
-				name: "global role grant this and children returns all auth methods",
+				name:  "global role grant this only returns global auth methods",
+				input: &pbs.ListAuthMethodsRequest{ScopeId: globals.GlobalPrefix},
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope_id,name,description,type,created_time,updated_time,version,type"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantIDs: []string{
+					oidcGlobal.PublicId,
+					ldapGlobal.PublicId,
+					pwGlobal.PublicId,
+				},
+				expectOutfields: map[string][]string{
+					oidcGlobal.PublicId: {globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField},
+					ldapGlobal.PublicId: {globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField},
+					pwGlobal.PublicId:   {globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField},
+				},
+			},
+			{
+				name: "global role grant this recursively returns all auth methods",
 				input: &pbs.ListAuthMethodsRequest{
 					ScopeId:   globals.GlobalPrefix,
 					Recursive: true,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=list,no-op;output_fields=id,scope,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
-				wantErr: nil,
+				}),
 				wantIDs: []string{
 					oidcGlobal.PublicId,
 					oidcOrg1.PublicId,
@@ -117,15 +162,85 @@ func TestGrants_ReadActions(t *testing.T) {
 					pwOrg1.PublicId,
 					pwOrg2.PublicId,
 				},
+				expectOutfields: map[string][]string{
+					oidcGlobal.PublicId: {globals.IdField, globals.ScopeField, globals.AuthorizedActionsField},
+					ldapGlobal.PublicId: {globals.IdField, globals.ScopeField, globals.AuthorizedActionsField},
+					pwGlobal.PublicId:   {globals.IdField, globals.ScopeField, globals.AuthorizedActionsField},
+				},
 			},
 			{
-				name: "no grants return children org",
+				name: "global role grant this and children returns global auth methods",
+				input: &pbs.ListAuthMethodsRequest{
+					ScopeId: globals.GlobalPrefix,
+				},
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=list,no-op;output_fields=id,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantIDs: []string{
+					oidcGlobal.PublicId,
+					ldapGlobal.PublicId,
+					pwGlobal.PublicId,
+				},
+				expectOutfields: map[string][]string{
+					oidcGlobal.PublicId: {globals.IdField, globals.AuthorizedActionsField},
+					ldapGlobal.PublicId: {globals.IdField, globals.AuthorizedActionsField},
+					pwGlobal.PublicId:   {globals.IdField, globals.AuthorizedActionsField},
+				},
+			},
+			{
+				name: "global role grant this and children recursive returns all auth methods",
 				input: &pbs.ListAuthMethodsRequest{
 					ScopeId:   globals.GlobalPrefix,
 					Recursive: true,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{},
-				wantErr:       nil,
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=list,no-op;output_fields=id,name"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantIDs: []string{
+					oidcGlobal.PublicId,
+					oidcOrg1.PublicId,
+					oidcOrg2.PublicId,
+					ldapGlobal.PublicId,
+					ldapOrg1.PublicId,
+					ldapOrg2.PublicId,
+					pwGlobal.PublicId,
+					pwOrg1.PublicId,
+					pwOrg2.PublicId,
+				},
+				expectOutfields: map[string][]string{
+					oidcGlobal.PublicId: {globals.IdField, globals.NameField},
+					oidcOrg1.PublicId:   {globals.IdField, globals.NameField},
+					oidcOrg2.PublicId:   {globals.IdField, globals.NameField},
+					ldapGlobal.PublicId: {globals.IdField, globals.NameField},
+					ldapOrg1.PublicId:   {globals.IdField, globals.NameField},
+					ldapOrg2.PublicId:   {globals.IdField, globals.NameField},
+					pwGlobal.PublicId:   {globals.IdField, globals.NameField},
+					pwOrg1.PublicId:     {globals.IdField, globals.NameField},
+					pwOrg2.PublicId:     {globals.IdField, globals.NameField},
+				},
+			},
+			{
+				name: "no grants recursive return children org",
+				input: &pbs.ListAuthMethodsRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{},
+						GrantScopes: []string{},
+					},
+				}),
+				wantErr: nil,
 				// auth methods in `global` are filtered out because the user does not have grants to read
 				// them in the global scope. Auth methods in org 1 and org 2 show up - my guess is because
 				// the u_anon grants allow auth methods to be read on any org.
@@ -140,49 +255,81 @@ func TestGrants_ReadActions(t *testing.T) {
 					pwOrg1.PublicId,
 					pwOrg2.PublicId,
 				},
+				expectOutfields: map[string][]string{},
 			},
 			{
 				name: "org role grant this and children returns auth methods in org1",
 				input: &pbs.ListAuthMethodsRequest{
-					ScopeId:   org1.PublicId,
-					Recursive: true,
+					ScopeId: org1.PublicId,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  org1.PublicId,
-						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=auth-method;actions=list,no-op;output_fields=id,scope_id,name,description,type,created_time,updated_time,version,type"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
+				}),
+				wantIDs: []string{
+					oidcOrg1.PublicId,
+					ldapOrg1.PublicId,
+					pwOrg1.PublicId,
 				},
-				wantErr: nil,
-				wantIDs: []string{oidcOrg1.PublicId, ldapOrg1.PublicId, pwOrg1.PublicId},
+				expectOutfields: map[string][]string{
+					oidcOrg1.PublicId: {globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField},
+					ldapOrg1.PublicId: {globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField},
+					pwOrg1.PublicId:   {globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField},
+				},
+			},
+			{
+				name: "project role can't list auth methods (403)",
+				input: &pbs.ListAuthMethodsRequest{
+					ScopeId: globals.GlobalPrefix,
+				},
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: p1.PublicId,
+						Grants:      []string{"ids=*;type=auth-method;actions=list,no-op;output_fields=id,scope_id,name"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
 			},
 		}
 
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
+				// Call function to create direct/indirect relationship
+				user, account := tc.userFunc()
+
+				// Create auth token for the user
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+
+				// Create auth context from the auth token
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
 				// auth method created during token generation will not be taken into considerations during this test
 				// adding to the ignoreList so it can be ignored later
 				ignoreList = append(ignoreList, tok.GetAuthMethodId())
-				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
 				got, finalErr := s.ListAuthMethods(fullGrantAuthCtx, tc.input)
 				if tc.wantErr != nil {
 					require.ErrorIs(t, finalErr, tc.wantErr)
 					return
 				}
-				// authtoken.TestAuthTokenWithRoles creates an auth method at `global` scope so
-				// include AuthMethodID of the user used to generate AuthToken in the "wantIDs" set
-				// when listing auth methods at global scope
 				require.NoError(t, finalErr)
 				var gotIDs []string
 				for _, g := range got.Items {
-					// do not include IDs in the ignore list in the
-					// result sets
+					// do not include IDs in the ignore list in the result sets
 					if slices.Contains(ignoreList, g.Id) {
 						continue
 					}
 					gotIDs = append(gotIDs, g.GetId())
+
+					// check if the output fields are as expected
+					if tc.expectOutfields[g.Id] != nil {
+						handlers.TestAssertOutputFields(t, g, tc.expectOutfields[g.Id])
+					}
 				}
 				require.ElementsMatch(t, tc.wantIDs, gotIDs)
 			})
@@ -192,74 +339,818 @@ func TestGrants_ReadActions(t *testing.T) {
 	t.Run("Get", func(t *testing.T) {
 		testcases := []struct {
 			name             string
-			input            *pbs.ListAuthMethodsRequest
-			amIDExpectErrMap map[string]error
-			rolesToCreate    []authtoken.TestRoleGrantsForToken
+			userFunc         func() (*iam.User, auth.Account)
+			canGetAuthMethod map[string]expectedOutput
 		}{
 			{
-				name: "global role grant this and children returns all auth methods",
-				amIDExpectErrMap: map[string]error{
-					pwGlobal.GetPublicId(): nil,
-					pwOrg1.GetPublicId():   nil,
-					pwOrg2.GetPublicId():   nil,
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				name: "global role grant this can only get global auth methods",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope_id,name,description,type,created_time,updated_time,version,type"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
+				}),
+				canGetAuthMethod: map[string]expectedOutput{
+					pwGlobal.PublicId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField}},
+					pwOrg1.PublicId:     {wantErr: handlers.ForbiddenError()},
+					pwOrg2.PublicId:     {wantErr: handlers.ForbiddenError()},
+					oidcGlobal.PublicId: {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField}},
+					oidcOrg1.PublicId:   {wantErr: handlers.ForbiddenError()},
+					oidcOrg2.PublicId:   {wantErr: handlers.ForbiddenError()},
+					ldapGlobal.PublicId: {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField}},
+					ldapOrg1.PublicId:   {wantErr: handlers.ForbiddenError()},
+					ldapOrg2.PublicId:   {wantErr: handlers.ForbiddenError()},
 				},
 			},
 			{
-				name: "org role grant this and children returns auth methods in org1",
-				input: &pbs.ListAuthMethodsRequest{
-					ScopeId:   org1.PublicId,
-					Recursive: true,
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				name: "global role grant children can only get org auth methods",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeChildren},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,name,description"},
+						GrantScopes: []string{globals.GrantScopeChildren},
 					},
-				},
-				amIDExpectErrMap: map[string]error{
-					pwGlobal.GetPublicId(): handlers.ForbiddenError(),
-					pwOrg1.GetPublicId():   nil,
-					pwOrg2.GetPublicId():   nil,
+				}),
+				canGetAuthMethod: map[string]expectedOutput{
+					pwGlobal.PublicId:   {wantErr: handlers.ForbiddenError()},
+					pwOrg1.PublicId:     {wantOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField}},
+					pwOrg2.PublicId:     {wantOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField}},
+					oidcGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					oidcOrg1.PublicId:   {wantOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField}},
+					oidcOrg2.PublicId:   {wantOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField}},
+					ldapGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					ldapOrg1.PublicId:   {wantOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField}},
+					ldapOrg2.PublicId:   {wantOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField}},
 				},
 			},
 			{
-				name: "no grants return all auth methods",
-				input: &pbs.ListAuthMethodsRequest{
-					ScopeId:   globals.GlobalPrefix,
-					Recursive: true,
-					PageSize:  500,
+				name: "global role grant descendants can only get org auth methods",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,created_time,updated_time,version"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				canGetAuthMethod: map[string]expectedOutput{
+					pwGlobal.PublicId:   {wantErr: handlers.ForbiddenError()},
+					pwOrg1.PublicId:     {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					pwOrg2.PublicId:     {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					oidcGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					oidcOrg1.PublicId:   {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					oidcOrg2.PublicId:   {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					ldapGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					ldapOrg1.PublicId:   {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					ldapOrg2.PublicId:   {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{},
-				amIDExpectErrMap: map[string]error{
-					pwGlobal.GetPublicId(): handlers.ForbiddenError(),
-					pwOrg1.GetPublicId():   handlers.ForbiddenError(),
-					pwOrg2.GetPublicId():   handlers.ForbiddenError(),
+			},
+			{
+				name: "global role grant this and children with all permissions returns all auth methods",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,created_time,updated_time,version"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				canGetAuthMethod: map[string]expectedOutput{
+					pwGlobal.PublicId:   {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					pwOrg1.PublicId:     {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					pwOrg2.PublicId:     {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					oidcGlobal.PublicId: {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					oidcOrg1.PublicId:   {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					oidcOrg2.PublicId:   {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					ldapGlobal.PublicId: {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					ldapOrg1.PublicId:   {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					ldapOrg2.PublicId:   {wantOutfields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+				},
+			},
+			{
+				name: "org1 role grant this scope with all permissions",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope_id,type"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetAuthMethod: map[string]expectedOutput{
+					pwGlobal.PublicId:   {wantErr: handlers.ForbiddenError()},
+					pwOrg1.PublicId:     {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField}},
+					pwOrg2.PublicId:     {wantErr: handlers.ForbiddenError()},
+					oidcGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					oidcOrg1.PublicId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField}},
+					oidcOrg2.PublicId:   {wantErr: handlers.ForbiddenError()},
+					ldapGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					ldapOrg1.PublicId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField}},
+					ldapOrg2.PublicId:   {wantErr: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name:     "no grants returns no auth methods",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, nil),
+				canGetAuthMethod: map[string]expectedOutput{
+					pwGlobal.PublicId:   {wantErr: handlers.ForbiddenError()},
+					pwOrg1.PublicId:     {wantErr: handlers.ForbiddenError()},
+					pwOrg2.PublicId:     {wantErr: handlers.ForbiddenError()},
+					oidcGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					oidcOrg1.PublicId:   {wantErr: handlers.ForbiddenError()},
+					oidcOrg2.PublicId:   {wantErr: handlers.ForbiddenError()},
+					ldapGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					ldapOrg1.PublicId:   {wantErr: handlers.ForbiddenError()},
+					ldapOrg2.PublicId:   {wantErr: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "project role can't get auth methods (403)",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: p1.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,name,description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetAuthMethod: map[string]expectedOutput{
+					pwGlobal.PublicId:   {wantErr: handlers.ForbiddenError()},
+					pwOrg1.PublicId:     {wantErr: handlers.ForbiddenError()},
+					pwOrg2.PublicId:     {wantErr: handlers.ForbiddenError()},
+					oidcGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					oidcOrg1.PublicId:   {wantErr: handlers.ForbiddenError()},
+					oidcOrg2.PublicId:   {wantErr: handlers.ForbiddenError()},
+					ldapGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					ldapOrg1.PublicId:   {wantErr: handlers.ForbiddenError()},
+					ldapOrg2.PublicId:   {wantErr: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "global and org roles with id-only grants return only the granted resources",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + pwGlobal.PublicId + ";actions=read;output_fields=id,name,description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + oidcOrg2.PublicId + ";actions=read;output_fields=id,name,description"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=" + ldapOrg1.PublicId + ";actions=read;output_fields=id,name,description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetAuthMethod: map[string]expectedOutput{
+					pwGlobal.PublicId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField}},
+					pwOrg1.PublicId:     {wantErr: handlers.ForbiddenError()},
+					pwOrg2.PublicId:     {wantErr: handlers.ForbiddenError()},
+					oidcGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					oidcOrg1.PublicId:   {wantErr: handlers.ForbiddenError()},
+					oidcOrg2.PublicId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField}},
+					ldapGlobal.PublicId: {wantErr: handlers.ForbiddenError()},
+					ldapOrg1.PublicId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField}},
+					ldapOrg2.PublicId:   {wantErr: handlers.ForbiddenError()},
 				},
 			},
 		}
 
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
 				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
-				for amId, wantErr := range tc.amIDExpectErrMap {
-					_, err := s.GetAuthMethod(fullGrantAuthCtx, &pbs.GetAuthMethodRequest{
-						Id: amId,
-					})
-					if wantErr != nil {
-						require.ErrorIs(t, err, wantErr)
+				for id, expectedOutput := range tc.canGetAuthMethod {
+					input := &pbs.GetAuthMethodRequest{Id: id}
+					_, err := s.GetAuthMethod(fullGrantAuthCtx, input)
+					if expectedOutput.wantErr != nil {
+						require.ErrorIs(t, err, expectedOutput.wantErr)
 						continue
+					}
+					// check if the output fields are as expected
+					if tc.canGetAuthMethod[id].wantOutfields != nil {
+						handlers.TestAssertOutputFields(t, input, tc.canGetAuthMethod[id].wantOutfields)
 					}
 					require.NoError(t, err)
 				}
+			})
+		}
+	})
+}
+
+// TestGrants_WriteActions tests write actions to assert that grants are being applied properly
+func TestGrants_WriteActions(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		return oidc.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		return ldap.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	pwRepoFn := func() (*password.Repository, error) {
+		return password.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	atRepoFn := func() (*authtoken.Repository, error) {
+		return atRepo, nil
+	}
+	authMethodRepoFn := func() (*auth.AuthMethodRepository, error) {
+		return auth.NewAuthMethodRepository(ctx, rw, rw, kmsCache)
+	}
+
+	s, err := authmethods.NewService(ctx,
+		kmsCache,
+		pwRepoFn,
+		oidcRepoFn,
+		iamRepoFn,
+		atRepoFn,
+		ldapRepoFn,
+		authMethodRepoFn,
+		1000)
+	require.NoError(t, err)
+	org1, p1 := iam.TestScopes(t, iamRepo)
+	org2, _ := iam.TestScopes(t, iamRepo)
+
+	t.Run("Create", func(t *testing.T) {
+		testcases := []struct {
+			name             string
+			userFunc         func() (*iam.User, auth.Account)
+			canCreateInScope map[string]expectedOutput
+		}{
+			{
+				name: "direct grant all can create all",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope_id,name,description,type,created_time,updated_time,version"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				canCreateInScope: map[string]expectedOutput{
+					globals.GlobalPrefix: {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					org1.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+					org2.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+				},
+			},
+			{
+				name: "global role grant children can only create org auth methods",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=create;output_fields=id,scope_id,created_time"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				canCreateInScope: map[string]expectedOutput{
+					globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
+					org1.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.CreatedTimeField}},
+					org2.PublicId:        {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.CreatedTimeField}},
+				},
+			},
+			{
+				name: "org role can't create global auth methods nor auth methods in other orgs",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org2.PublicId,
+						Grants:      []string{"ids=*;type=auth-method;actions=create;output_fields=id,name,description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScope: map[string]expectedOutput{
+					globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
+					org1.PublicId:        {wantErr: handlers.ForbiddenError()},
+					org2.PublicId:        {wantOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField}},
+				},
+			},
+			{
+				name: "incorrect grants returns 403 error",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=list,read,update;output_fields=id,scope_id"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=auth-method;actions=list,read,update;output_fields=id,name"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScope: map[string]expectedOutput{
+					globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
+					org1.PublicId:        {wantErr: handlers.ForbiddenError()},
+					org2.PublicId:        {wantErr: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name:     "no grants returns 403 error",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, nil),
+				canCreateInScope: map[string]expectedOutput{
+					globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
+					org1.PublicId:        {wantErr: handlers.ForbiddenError()},
+					org2.PublicId:        {wantErr: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "project role can't create auth methods in any scope (403)",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: p1.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScope: map[string]expectedOutput{
+					globals.GlobalPrefix: {wantErr: handlers.ForbiddenError()},
+					org1.PublicId:        {wantErr: handlers.ForbiddenError()},
+					org2.PublicId:        {wantErr: handlers.ForbiddenError()},
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				for scopeId, expectedOutput := range tc.canCreateInScope {
+					// Build a distinct name for each Auth Method
+					name := fmt.Sprintf("[%s] ", tc.name)
+					switch scopeId {
+					case globals.GlobalPrefix:
+						name += "global"
+					case org1.PublicId:
+						name += "org 1"
+					case org2.PublicId:
+						name += "org 2"
+					default:
+						t.Fatalf("Unexpected scope ID: %s", scopeId)
+					}
+
+					resp, err := s.CreateAuthMethod(fullGrantAuthCtx, &pbs.CreateAuthMethodRequest{Item: &pb.AuthMethod{
+						Name:        wrapperspb.String(name),
+						Description: wrapperspb.String("test description"),
+						ScopeId:     scopeId,
+						Type:        "password",
+					}})
+					if expectedOutput.wantErr != nil {
+						require.ErrorIs(t, err, expectedOutput.wantErr)
+						continue
+					}
+					require.NoError(t, err)
+					handlers.TestAssertOutputFields(t, resp.Item, expectedOutput.wantOutfields)
+				}
+			})
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		// Create global & org auth methods to test updates
+		globalAmId := password.TestAuthMethod(t, conn, globals.GlobalPrefix, password.WithName("global name"), password.WithDescription("global desc")).PublicId
+		org1AmId := password.TestAuthMethod(t, conn, org1.PublicId, password.WithName("org 1 name"), password.WithDescription("org 2 desc")).PublicId
+		org2AmId := password.TestAuthMethod(t, conn, org2.PublicId, password.WithName("org 2 name"), password.WithDescription("org 2 desc")).PublicId
+
+		testcases := []struct {
+			name                string
+			rolesToCreate       []authtoken.TestRoleGrantsForToken
+			canUpdateAuthMethod map[string]expectedOutput
+		}{
+			{
+				name: "global role grant this and children can update global auth method",
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeId:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=auth-method;actions=update;output_fields=id,scope_id,name,description,type,version"},
+						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				},
+				canUpdateAuthMethod: map[string]expectedOutput{
+					globalAmId: {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.VersionField}},
+					org1AmId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.VersionField}},
+					org2AmId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.TypeField, globals.VersionField}},
+				},
+			},
+			{
+				name: "global role grant this & org role grant this can update their respective auth methods",
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeId:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=auth-method;actions=update;output_fields=id,name,description,version"},
+						GrantScopes:  []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId:  org1.PublicId,
+						GrantStrings: []string{"ids=*;type=auth-method;actions=update;output_fields=id,scope_id,type,version"},
+						GrantScopes:  []string{globals.GrantScopeThis},
+					},
+				},
+				canUpdateAuthMethod: map[string]expectedOutput{
+					globalAmId: {wantOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField}},
+					org1AmId:   {wantOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.VersionField}},
+					org2AmId:   {wantErr: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "org role can't update global auth methods",
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
+					RoleScopeId:  org1.PublicId,
+					GrantStrings: []string{"ids=*;type=auth-method;actions=update;output_fields=id,version,created_time,updated_time"},
+					GrantScopes:  []string{globals.GrantScopeThis},
+				}},
+				canUpdateAuthMethod: map[string]expectedOutput{
+					globalAmId: {wantErr: handlers.ForbiddenError()},
+					org1AmId:   {wantOutfields: []string{globals.IdField, globals.VersionField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					org2AmId:   {wantErr: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "global role grant children of global auth method's id can only update children auth methods",
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeId:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=" + globalAmId + ";type=auth-method;actions=update;output_fields=id"},
+						GrantScopes:  []string{globals.GrantScopeChildren},
+					},
+				},
+				canUpdateAuthMethod: map[string]expectedOutput{
+					globalAmId: {wantErr: handlers.ForbiddenError()},
+					org1AmId:   {wantOutfields: []string{globals.IdField}},
+					org2AmId:   {wantOutfields: []string{globals.IdField}},
+				},
+			},
+			{
+				name: "incorrect grants returns 403 error",
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeId:  globals.GlobalPrefix,
+						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read,create"},
+						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+					{
+						RoleScopeId:  org1.PublicId,
+						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read,create"},
+						GrantScopes:  []string{globals.GrantScopeThis},
+					},
+				},
+				canUpdateAuthMethod: map[string]expectedOutput{
+					globalAmId: {wantErr: handlers.ForbiddenError()},
+					org1AmId:   {wantErr: handlers.ForbiddenError()},
+					org2AmId:   {wantErr: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name:          "no grants returns 403 error",
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{},
+				canUpdateAuthMethod: map[string]expectedOutput{
+					globalAmId: {wantErr: handlers.ForbiddenError()},
+					org1AmId:   {wantErr: handlers.ForbiddenError()},
+					org2AmId:   {wantErr: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "project role can't update auth methods in any scope (403)",
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+					{
+						RoleScopeId:  p1.GetPublicId(),
+						GrantStrings: []string{"ids=*;type=*;actions=*"},
+						GrantScopes:  []string{globals.GrantScopeThis},
+					},
+				},
+				canUpdateAuthMethod: map[string]expectedOutput{
+					globalAmId: {wantErr: handlers.ForbiddenError()},
+					org1AmId:   {wantErr: handlers.ForbiddenError()},
+					org2AmId:   {wantErr: handlers.ForbiddenError()},
+				},
+			},
+		}
+
+		for i, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				for amId, expectedOutput := range tc.canUpdateAuthMethod {
+					resp, err := s.UpdateAuthMethod(fullGrantAuthCtx, &pbs.UpdateAuthMethodRequest{
+						Id: amId,
+						UpdateMask: &field_mask.FieldMask{
+							Paths: []string{"name", "description"},
+						},
+						Item: &pb.AuthMethod{
+							Name:        &wrapperspb.StringValue{Value: fmt.Sprintf("updated name (%d)", i)},
+							Description: &wrapperspb.StringValue{Value: fmt.Sprintf("updated description (%d)", i)},
+							Version:     uint32(i + 1), // increment version to simulate an update
+						},
+					})
+					if expectedOutput.wantErr != nil {
+						require.ErrorIs(t, err, expectedOutput.wantErr)
+						return
+					}
+					require.NoError(t, err)
+					handlers.TestAssertOutputFields(t, resp.Item, expectedOutput.wantOutfields)
+				}
+			})
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		allScopeIDs := []string{globals.GlobalPrefix, org1.PublicId, org2.PublicId}
+		testcases := []struct {
+			name                    string
+			am                      *password.AuthMethod
+			userFunc                func() (*iam.User, auth.Account)
+			deleteAllowedAtScopeIDs []string
+		}{
+			{
+				name: "grant all can delete all",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				deleteAllowedAtScopeIDs: allScopeIDs,
+			},
+			{
+				name: "grant children can only delete in orgs",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				deleteAllowedAtScopeIDs: []string{org1.PublicId, org2.PublicId},
+			},
+			{
+				name: "org role can't delete global auth methods",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=auth-method;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				deleteAllowedAtScopeIDs: []string{org1.PublicId},
+			},
+			{
+				name: "incorrect grants returns 403 error",
+				am:   password.TestAuthMethod(t, conn, org1.PublicId),
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=list,read,create,update"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+			},
+			{
+				name:     "no grants returns 403 error",
+				am:       password.TestAuthMethod(t, conn, globals.GlobalPrefix),
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, nil),
+			},
+			{
+				name: "project role can't delete auth methods at any scope (403)",
+				am:   password.TestAuthMethod(t, conn, globals.GlobalPrefix),
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: p1.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				// setup a map to track which scope correlates to an auth method
+				scopeIdAuthMethodMap := map[string]*password.AuthMethod{}
+				for _, scopeId := range allScopeIDs {
+					am := password.TestAuthMethod(t, conn, scopeId)
+					scopeIdAuthMethodMap[scopeId] = am
+				}
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				for scope, am := range scopeIdAuthMethodMap {
+					_, err = s.DeleteAuthMethod(fullGrantAuthCtx, &pbs.DeleteAuthMethodRequest{Id: am.PublicId})
+					if !slices.Contains(tc.deleteAllowedAtScopeIDs, scope) {
+						require.ErrorIs(t, err, handlers.ForbiddenError())
+						continue
+					}
+					require.NoErrorf(t, err, "failed to delete auth method in scope %s", scope)
+				}
+			})
+		}
+	})
+
+	t.Run("Authenticate", func(t *testing.T) {
+		pwRepo, err := pwRepoFn()
+		require.NoError(t, err)
+
+		// We need a sys eventer in order to authenticate
+		eventConfig := event.TestEventerConfig(t, "TestGrants_WriteActions", event.TestWithObservationSink(t))
+		testLock := &sync.Mutex{}
+		testLogger := hclog.New(&hclog.LoggerOptions{
+			Mutex: testLock,
+			Name:  "test",
+		})
+
+		require.NoError(t, event.InitSysEventer(testLogger, testLock, "TestGrants_WriteActions", event.WithEventerConfig(&eventConfig.EventerConfig)))
+		sinkFileName := eventConfig.ObservationEvents.Name()
+		t.Cleanup(func() {
+			require.NoError(t, os.Remove(sinkFileName))
+			event.TestResetSystEventer(t)
+		})
+
+		testcases := []struct {
+			name          string
+			scopeId       string
+			input         *pbs.AuthenticateRequest
+			userFunc      func() (*iam.User, auth.Account)
+			rolesToCreate []authtoken.TestRoleGrantsForToken
+			wantErr       error
+		}{
+			{
+				name:    "global role grant this and children can authenticate against a global auth method",
+				scopeId: globals.GlobalPrefix,
+				input: &pbs.AuthenticateRequest{
+					TokenType: "token",
+					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+							LoginName: testLoginName,
+							Password:  testPassword,
+						},
+					},
+				},
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-method;actions=authenticate"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
+					RoleScopeId:  globals.GlobalPrefix,
+					GrantStrings: []string{"ids=*;type=auth-method;actions=authenticate"},
+					GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				}},
+			},
+			{
+				name:    "org role can't authenticate against a global auth method",
+				scopeId: globals.GlobalPrefix,
+				input: &pbs.AuthenticateRequest{
+					TokenType: "token",
+					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+							LoginName: testLoginName,
+							Password:  testPassword,
+						},
+					},
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
+					RoleScopeId:  org1.PublicId,
+					GrantStrings: []string{"ids=*;type=auth-method;actions=authenticate"},
+					GrantScopes:  []string{globals.GrantScopeThis},
+				}},
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name:    "no grants returns 403 error for a global auth method",
+				scopeId: globals.GlobalPrefix,
+				input: &pbs.AuthenticateRequest{
+					TokenType: "token",
+					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+							LoginName: testLoginName,
+							Password:  testPassword,
+						},
+					},
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name:    "org auth methods, by default, grant anyone permission to authenticate (and list) auth methods",
+				scopeId: org1.PublicId,
+				input: &pbs.AuthenticateRequest{
+					TokenType: "token",
+					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+							LoginName: testLoginName,
+							Password:  testPassword,
+						},
+					},
+				},
+			},
+			{
+				name:    "project role can authenticate against org auth methods because by default, org auth methods grant anyone permission to authenticate (and list) auth methods",
+				scopeId: org1.PublicId,
+				input: &pbs.AuthenticateRequest{
+					TokenType: "token",
+					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+							LoginName: testLoginName,
+							Password:  testPassword,
+						},
+					},
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
+					RoleScopeId:  p1.PublicId,
+					GrantStrings: []string{"ids=*;type=auth-method;actions=authenticate"},
+					GrantScopes:  []string{globals.GrantScopeThis},
+				}},
+			},
+			{
+				name:    "granting authenticate again at the org scope allows authentication",
+				scopeId: org1.PublicId,
+				input: &pbs.AuthenticateRequest{
+					TokenType: "token",
+					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+							LoginName: testLoginName,
+							Password:  testPassword,
+						},
+					},
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
+					RoleScopeId:  org1.PublicId,
+					GrantStrings: []string{"ids=*;type=auth-method;actions=authenticate"},
+					GrantScopes:  []string{globals.GrantScopeThis},
+				}},
+			},
+			{
+				name:    "project role can't authenticate against global auth methods",
+				scopeId: globals.GlobalPrefix,
+				input: &pbs.AuthenticateRequest{
+					TokenType: "token",
+					Attrs: &pbs.AuthenticateRequest_PasswordLoginAttributes{
+						PasswordLoginAttributes: &pbs.PasswordLoginAttributes{
+							LoginName: testLoginName,
+							Password:  testPassword,
+						},
+					},
+				},
+				rolesToCreate: []authtoken.TestRoleGrantsForToken{{
+					RoleScopeId:  p1.PublicId,
+					GrantStrings: []string{"ids=*;type=auth-method;actions=authenticate"},
+					GrantScopes:  []string{globals.GrantScopeThis},
+				}},
+				wantErr: handlers.ForbiddenError(),
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Create auth method
+				if tc.scopeId == globals.GlobalPrefix {
+					tc.input.AuthMethodId = password.TestAuthMethod(t, conn, globals.GlobalPrefix).PublicId
+				} else {
+					tc.input.AuthMethodId = password.TestAuthMethod(t, conn, org1.PublicId).PublicId
+				}
+
+				// Create account for the auth method
+				account, err := password.NewAccount(ctx, tc.input.AuthMethodId, password.WithLoginName(testLoginName))
+				require.NoError(t, err)
+				account, err = pwRepo.CreateAccount(context.Background(), tc.scopeId, account, password.WithPassword(testPassword))
+				require.NoError(t, err)
+				require.NotNil(t, account)
+
+				// Create user linked to the account
+				user := iam.TestUser(t, iamRepo, tc.scopeId, iam.WithAccountIds(account.PublicId))
+
+				// Create the desired role/grants for the user
+				for _, roleToCreate := range tc.rolesToCreate {
+					role := iam.TestRoleWithGrants(t, conn, roleToCreate.RoleScopeId, roleToCreate.GrantScopes, roleToCreate.GrantStrings)
+					iam.TestUserRole(t, conn, role.PublicId, user.PublicId)
+				}
+
+				// Create auth token for the user
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.PublicId)
+				require.NoError(t, err)
+				ctx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				_, err = s.Authenticate(ctx, tc.input)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
 			})
 		}
 	})

--- a/internal/daemon/controller/handlers/authmethods/grants_test.go
+++ b/internal/daemon/controller/handlers/authmethods/grants_test.go
@@ -100,7 +100,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -149,7 +149,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org1.PublicId,
+						RoleScopeId:  org1.PublicId,
 						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -205,7 +205,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -219,7 +219,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=auth-method;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeChildren},
 					},

--- a/internal/daemon/controller/handlers/authtokens/grants_test.go
+++ b/internal/daemon/controller/handlers/authtokens/grants_test.go
@@ -79,7 +79,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=auth-token;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -95,7 +95,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org1.PublicId,
+						RoleScopeId:  org1.PublicId,
 						GrantStrings: []string{"ids=*;type=auth-token;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},

--- a/internal/daemon/controller/handlers/authtokens/grants_test.go
+++ b/internal/daemon/controller/handlers/authtokens/grants_test.go
@@ -9,13 +9,17 @@ import (
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
+	a "github.com/hashicorp/boundary/internal/auth"
+	"github.com/hashicorp/boundary/internal/auth/password"
 	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	at "github.com/hashicorp/boundary/internal/daemon/controller/handlers/authtokens"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,49 +69,258 @@ func TestGrants_ReadActions(t *testing.T) {
 
 	t.Run("List", func(t *testing.T) {
 		testcases := []struct {
-			name          string
-			input         *pbs.ListAuthTokensRequest
-			rolesToCreate []authtoken.TestRoleGrantsForToken
-			wantErr       error
-			wantIDs       []string
+			name            string
+			input           *pbs.ListAuthTokensRequest
+			userFunc        func() (*iam.User, a.Account)
+			wantErr         error
+			wantIDs         []string
+			expectOutfields []string
 		}{
 			{
-				name: "global role grant this and children returns global and org groups",
+				name: "global role grant this returns global token",
 				input: &pbs.ListAuthTokensRequest{
 					ScopeId:   globals.GlobalPrefix,
 					Recursive: true,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=auth-token;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope_id,scope,user_id"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
+				}),
 				wantErr: nil,
-				wantIDs: []string{globalAT.PublicId, org1AT.PublicId, org2AT.PublicId},
+				wantIDs: []string{globalAT.PublicId},
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeIdField,
+					globals.ScopeField,
+					globals.UserIdField,
+				},
 			},
 			{
-				name: "org role grant this and children returns org groups",
+				name: "global role grant this and children returns global and org tokens",
+				input: &pbs.ListAuthTokensRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-token;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{globalAT.PublicId, org1AT.PublicId, org2AT.PublicId},
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeIdField,
+					globals.ScopeField,
+					globals.UserIdField,
+					globals.AuthMethodIdField,
+					globals.AccountIdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					globals.ApproximateLastUsedTimeField,
+					globals.ExpirationTimeField,
+					globals.AuthorizedActionsField,
+				},
+			},
+			{
+				name: "global role grant this and descendants returns global and org tokens",
+				input: &pbs.ListAuthTokensRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-token;actions=list,read;output_fields=id,approximate_last_used_time,expiration_time,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{globalAT.PublicId, org1AT.PublicId, org2AT.PublicId},
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ApproximateLastUsedTimeField,
+					globals.ExpirationTimeField,
+					globals.AuthorizedActionsField,
+				},
+			},
+			{
+				name: "global role grant descendants with recursive returns global and org tokens",
+				input: &pbs.ListAuthTokensRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-token;actions=list,read;output_fields=id,approximate_last_used_time,expiration_time,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{org1AT.PublicId, org2AT.PublicId},
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ApproximateLastUsedTimeField,
+					globals.ExpirationTimeField,
+					globals.AuthorizedActionsField,
+				},
+			},
+			{
+				name: "global role grant descendants without recursive returns error",
+				input: &pbs.ListAuthTokensRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: false,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-token;actions=list,read;output_fields=id,approximate_last_used_time,expiration_time,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+				wantIDs: nil,
+			},
+			{
+				name: "org role grant this returns org tokens",
 				input: &pbs.ListAuthTokensRequest{
 					ScopeId:   org1.PublicId,
 					Recursive: true,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  org1.PublicId,
-						GrantStrings: []string{"ids=*;type=auth-token;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=auth-token;actions=list,read;output_fields=id,auth_method_id,account_id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
+				}),
 				wantErr: nil,
 				wantIDs: []string{org1AT.PublicId},
+				expectOutfields: []string{
+					globals.IdField,
+					globals.AuthMethodIdField,
+					globals.AccountIdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+				},
+			},
+			{
+				name: "org role grant this and children returns org tokens",
+				input: &pbs.ListAuthTokensRequest{
+					ScopeId:   org1.PublicId,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{org1AT.PublicId},
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeIdField,
+					globals.ScopeField,
+					globals.UserIdField,
+					globals.AuthMethodIdField,
+					globals.AccountIdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					globals.ApproximateLastUsedTimeField,
+					globals.ExpirationTimeField,
+					globals.AuthorizedActionsField,
+				},
+			},
+			{
+				name: "global role grant this and children returns org tokens",
+				input: &pbs.ListAuthTokensRequest{
+					ScopeId:   org1.PublicId,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{org1AT.PublicId},
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeIdField,
+					globals.ScopeField,
+					globals.UserIdField,
+					globals.AuthMethodIdField,
+					globals.AccountIdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					globals.ApproximateLastUsedTimeField,
+					globals.ExpirationTimeField,
+					globals.AuthorizedActionsField,
+				},
+			},
+			{
+				name: "org role grant this pinned id returns org tokens",
+				input: &pbs.ListAuthTokensRequest{
+					ScopeId:   org1.PublicId,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=auth-token;actions=*", org1AT.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{org1AT.PublicId},
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeIdField,
+					globals.ScopeField,
+					globals.UserIdField,
+					globals.AuthMethodIdField,
+					globals.AccountIdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					globals.ApproximateLastUsedTimeField,
+					globals.ExpirationTimeField,
+					globals.AuthorizedActionsField,
+				},
+			},
+			{
+				name: "org role grant this does not list other org tokens",
+				input: &pbs.ListAuthTokensRequest{
+					ScopeId:   org2.PublicId,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr:         nil,
+				wantIDs:         nil,
+				expectOutfields: nil,
 			},
 		}
 
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
+				user, acct := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())
+				require.NoError(t, err)
 				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
 				got, finalErr := s.ListAuthTokens(fullGrantAuthCtx, tc.input)
 				if tc.wantErr != nil {
@@ -124,6 +337,304 @@ func TestGrants_ReadActions(t *testing.T) {
 				for _, id := range tc.wantIDs {
 					require.Contains(t, gotIDs, id)
 				}
+				for _, item := range got.Items {
+					handlers.TestAssertOutputFields(t, item, tc.expectOutfields)
+				}
+			})
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		testcases := []struct {
+			name            string
+			input           *pbs.GetAuthTokenRequest
+			userFunc        func() (*iam.User, a.Account)
+			wantErr         error
+			wantId          string
+			expectOutfields []string
+		}{
+			{
+				name: "global role grant this returns global token",
+				input: &pbs.GetAuthTokenRequest{
+					Id: globalAT.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=read;output_fields=id,scope_id,scope,user_id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeIdField,
+					globals.ScopeField,
+					globals.UserIdField,
+				},
+				wantId: globalAT.PublicId,
+			},
+			{
+				name: "org role grant this returns org token",
+				input: &pbs.GetAuthTokenRequest{
+					Id: org1AT.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=auth-token;actions=read;output_fields=id,auth_method_id,account_id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				expectOutfields: []string{
+					globals.IdField,
+					globals.AuthMethodIdField,
+					globals.AccountIdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+				},
+				wantId: org1AT.PublicId,
+			},
+			{
+				name: "org role grant this cannot read global token",
+				input: &pbs.GetAuthTokenRequest{
+					Id: globalAT.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr:         handlers.ForbiddenError(),
+				expectOutfields: nil,
+			},
+			{
+				name: "global role grant this and children can read org token",
+				input: &pbs.GetAuthTokenRequest{
+					Id: org1AT.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope_id,scope,user_id"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: nil,
+				expectOutfields: []string{
+					globals.IdField,
+					globals.AuthMethodIdField,
+					globals.ScopeIdField,
+					globals.ScopeField,
+					globals.UserIdField,
+					globals.AccountIdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					globals.ApproximateLastUsedTimeField,
+					globals.ExpirationTimeField,
+					globals.AuthorizedActionsField,
+				},
+				wantId: org1AT.PublicId,
+			},
+			{
+				name: "org role grant this pinned id returns org token",
+				input: &pbs.GetAuthTokenRequest{
+					Id: org1AT.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=auth-token;actions=read;output_fields=id,scope_id,scope,user_id", org1AT.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeIdField,
+					globals.ScopeField,
+					globals.UserIdField,
+				},
+				wantId: org1AT.PublicId,
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, acct := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				got, finalErr := s.GetAuthToken(fullGrantAuthCtx, tc.input)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, finalErr, tc.wantErr)
+					return
+				}
+				require.NoError(t, finalErr)
+				assert.Equal(t, tc.wantId, got.GetItem().Id)
+				handlers.TestAssertOutputFields(t, got.GetItem(), tc.expectOutfields)
+			})
+		}
+	})
+}
+
+func TestGrants_CreateActions(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	kmsCache := kms.TestKms(t, conn, wrap)
+
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	atRepoFn := func() (*authtoken.Repository, error) { return atRepo, nil }
+
+	s, err := at.NewService(ctx, atRepoFn, iamRepoFn, 1000)
+	require.NoError(t, err)
+
+	org1, _ := iam.TestScopes(t, iamRepo)
+	org2, _ := iam.TestScopes(t, iamRepo)
+	org3, _ := iam.TestScopes(t, iamRepo)
+	pinnedId := authtoken.TestAuthToken(t, conn, kmsCache, org2.GetPublicId())
+	selfToken := authtoken.TestAuthToken(t, conn, kmsCache, org3.GetPublicId())
+
+	t.Run("Delete", func(t *testing.T) {
+		testcases := []struct {
+			name          string
+			createTokenFn func() *authtoken.AuthToken
+			userFunc      func() (*iam.User, a.Account)
+			ctxAuthToken  func(ctx context.Context, user *iam.User, acctId string) (*authtoken.AuthToken, error)
+			wantErr       error
+		}{
+			{
+				name: "global role grant this deletes global token",
+				createTokenFn: func() *authtoken.AuthToken {
+					return authtoken.TestAuthToken(t, conn, kmsCache, globals.GlobalPrefix)
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				ctxAuthToken: func(ctx context.Context, user *iam.User, acctId string) (*authtoken.AuthToken, error) {
+					return atRepo.CreateAuthToken(ctx, user, acctId)
+				},
+				wantErr: nil,
+			},
+			{
+				name: "global role grant this and children can delete org tokens",
+				createTokenFn: func() *authtoken.AuthToken {
+					return authtoken.TestAuthToken(t, conn, kmsCache, org1.GetPublicId())
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=auth-token;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				ctxAuthToken: func(ctx context.Context, user *iam.User, acctId string) (*authtoken.AuthToken, error) {
+					return atRepo.CreateAuthToken(ctx, user, acctId)
+				},
+				wantErr: nil,
+			},
+			{
+				name: "global role grant this and descendants can delete org tokens",
+				createTokenFn: func() *authtoken.AuthToken {
+					return authtoken.TestAuthToken(t, conn, kmsCache, org2.GetPublicId())
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				ctxAuthToken: func(ctx context.Context, user *iam.User, acctId string) (*authtoken.AuthToken, error) {
+					return atRepo.CreateAuthToken(ctx, user, acctId)
+				},
+				wantErr: nil,
+			},
+			{
+				name: "global role grant this can delete pinned org token",
+				createTokenFn: func() *authtoken.AuthToken {
+					return pinnedId
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=auth-token;actions=*", pinnedId.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				ctxAuthToken: func(ctx context.Context, user *iam.User, acctId string) (*authtoken.AuthToken, error) {
+					return atRepo.CreateAuthToken(ctx, user, acctId)
+				},
+				wantErr: nil,
+			},
+			{
+				name: "org role grant this can delete self",
+				createTokenFn: func() *authtoken.AuthToken {
+					return selfToken
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=delete:self"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				ctxAuthToken: func(ctx context.Context, user *iam.User, acctId string) (*authtoken.AuthToken, error) {
+					return selfToken, nil
+				},
+				wantErr: nil,
+			},
+			{
+				name: "org role grant this can't delete global",
+				createTokenFn: func() *authtoken.AuthToken {
+					return authtoken.TestAuthToken(t, conn, kmsCache, globals.GlobalPrefix)
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{org2.PublicId},
+					},
+				}),
+				ctxAuthToken: func(ctx context.Context, user *iam.User, acctId string) (*authtoken.AuthToken, error) {
+					return atRepo.CreateAuthToken(ctx, user, acctId)
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, acct := tc.userFunc()
+				inputToken := tc.createTokenFn()
+				input := &pbs.DeleteAuthTokenRequest{
+					Id: inputToken.PublicId,
+				}
+				authToken, err := tc.ctxAuthToken(ctx, user, acct.GetPublicId())
+				require.NoError(t, err)
+				// authToken, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())
+				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, authToken, iamRepo)
+				_, finalErr := s.DeleteAuthToken(fullGrantAuthCtx, input)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, finalErr, tc.wantErr)
+					return
+				}
+				require.NoError(t, finalErr)
 			})
 		}
 	})

--- a/internal/daemon/controller/handlers/billing/grants_test.go
+++ b/internal/daemon/controller/handlers/billing/grants_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package billing_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/auth"
+	"github.com/hashicorp/boundary/internal/auth/ldap"
+	"github.com/hashicorp/boundary/internal/auth/password"
+	"github.com/hashicorp/boundary/internal/authtoken"
+	"github.com/hashicorp/boundary/internal/billing"
+	cauth "github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
+	billingservice "github.com/hashicorp/boundary/internal/daemon/controller/handlers/billing"
+	"github.com/hashicorp/boundary/internal/db"
+	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGrants_MonthlyActiveUsers tests read actions to assert that grants are being applied properly
+//
+//	 Role - which scope the role is created in
+//			- global level
+func TestGrants_MonthlyActiveUsers(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	org, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrap))
+
+	repoFn := func() (*billing.Repository, error) {
+		return billing.TestRepo(t, conn), nil
+	}
+	billing.TestGenerateActiveUsers(t, conn)
+
+	today := time.Now().UTC()
+	monthStart := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, time.UTC)
+	threeMonthsAgo := time.Date(monthStart.AddDate(0, -3, 0).Year(), monthStart.AddDate(0, -3, 0).Month(), 1, 0, 0, 0, 0, time.UTC).Format("2006-01")
+	oneMonthAgo := time.Date(monthStart.AddDate(0, -1, 0).Year(), monthStart.AddDate(0, -1, 0).Month(), 1, 0, 0, 0, 0, time.UTC).Format("2006-01")
+
+	s, err := billingservice.NewService(ctx, repoFn)
+	require.NoError(t, err)
+
+	t.Run("MonthlyActiveUsers", func(t *testing.T) {
+		testcases := []struct {
+			name                  string
+			input                 *pbs.MonthlyActiveUsersRequest
+			userFunc              func() (*iam.User, auth.Account)
+			wantErr               error
+			expectedItemsReturned int
+		}{
+			{
+				name: "global role with wildcard returns monthly active users",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				input: &pbs.MonthlyActiveUsersRequest{
+					StartTime: threeMonthsAgo,
+					EndTime:   oneMonthAgo,
+				},
+				expectedItemsReturned: 2,
+			},
+			{
+				name: "global role + direct association with type billing returns monthly active users",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=billing;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				input: &pbs.MonthlyActiveUsersRequest{
+					StartTime: threeMonthsAgo,
+					EndTime:   oneMonthAgo,
+				},
+				expectedItemsReturned: 2,
+			},
+			{
+				name: "global role + direct association with multiple roles returns monthly active users",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=group;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=billing;actions=no-op"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=billing;actions=monthly-active-users"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				input: &pbs.MonthlyActiveUsersRequest{
+					StartTime: threeMonthsAgo,
+					EndTime:   oneMonthAgo,
+				},
+				expectedItemsReturned: 2,
+			},
+			{
+				name: "global role + group association with type billing returns monthly active users",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=billing;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				input: &pbs.MonthlyActiveUsersRequest{
+					StartTime: threeMonthsAgo,
+					EndTime:   oneMonthAgo,
+				},
+				expectedItemsReturned: 2,
+			},
+			{
+				name: "global role + managed group association with type billing returns monthly active users",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=billing;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				input: &pbs.MonthlyActiveUsersRequest{
+					StartTime: threeMonthsAgo,
+					EndTime:   oneMonthAgo,
+				},
+				expectedItemsReturned: 2,
+			},
+			{
+				name: "global role with type billing and actions monthly-active-users returns monthly active users",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=billing;actions=monthly-active-users"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				input: &pbs.MonthlyActiveUsersRequest{
+					StartTime: threeMonthsAgo,
+					EndTime:   oneMonthAgo,
+				},
+				expectedItemsReturned: 2,
+			},
+			{
+				name: "global role with non-applicable type returns an error",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=group;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				input: &pbs.MonthlyActiveUsersRequest{
+					StartTime: threeMonthsAgo,
+					EndTime:   oneMonthAgo,
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "global role with billing type and non-applicable actions returns an error",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=billing;actions=no-op"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				input: &pbs.MonthlyActiveUsersRequest{
+					StartTime: threeMonthsAgo,
+					EndTime:   oneMonthAgo,
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "global role grant this with a non-applicable type returns a permission error",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=group;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				input: &pbs.MonthlyActiveUsersRequest{
+					StartTime: threeMonthsAgo,
+					EndTime:   oneMonthAgo,
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "global role grant descendant returns no monthly active users",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=billing;actions=*"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				input: &pbs.MonthlyActiveUsersRequest{
+					StartTime: threeMonthsAgo,
+					EndTime:   oneMonthAgo,
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "global role grant descendant returns no monthly active users",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=billing;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				input: &pbs.MonthlyActiveUsersRequest{
+					StartTime: threeMonthsAgo,
+					EndTime:   oneMonthAgo,
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, accountID := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, accountID.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				got, finalErr := s.MonthlyActiveUsers(fullGrantAuthCtx, tc.input)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, finalErr, tc.wantErr)
+					return
+				}
+				require.NoError(t, finalErr)
+				require.Len(t, got.Items, tc.expectedItemsReturned)
+			})
+		}
+	})
+}

--- a/internal/daemon/controller/handlers/credentiallibraries/grants_test.go
+++ b/internal/daemon/controller/handlers/credentiallibraries/grants_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/auth"
+	"github.com/hashicorp/boundary/internal/auth/oidc"
 	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/credential/vault"
-	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	controllerauth "github.com/hashicorp/boundary/internal/daemon/controller/auth"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/credentiallibraries"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
@@ -31,6 +33,8 @@ func TestGrants_ReadActions(t *testing.T) {
 	}
 	kmsCache := kms.TestKms(t, conn, wrap)
 	sche := scheduler.TestScheduler(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
 
 	vaultRepoFn := func() (*vault.Repository, error) {
 		return vault.NewRepository(ctx, rw, rw, kmsCache, sche)
@@ -45,24 +49,24 @@ func TestGrants_ReadActions(t *testing.T) {
 
 	t.Run("List", func(t *testing.T) {
 		testcases := []struct {
-			name          string
-			input         *pbs.ListCredentialLibrariesRequest
-			rolesToCreate []authtoken.TestRoleGrantsForToken
-			wantErr       error
-			wantIDs       []string
+			name     string
+			input    *pbs.ListCredentialLibrariesRequest
+			userFunc func() (*iam.User, auth.Account)
+			wantErr  error
+			wantIDs  []string
 		}{
 			{
 				name: "global role grant descendant returns all credentials library",
 				input: &pbs.ListCredentialLibrariesRequest{
 					CredentialStoreId: proj1CredStore[0].GetPublicId(),
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=credential-library;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=credential-library;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
-				},
+				}),
 				wantErr: nil,
 				wantIDs: []string{proj1Libs[0].GetPublicId(), proj1Libs[1].GetPublicId(), proj1Libs[2].GetPublicId()},
 			},
@@ -71,13 +75,13 @@ func TestGrants_ReadActions(t *testing.T) {
 				input: &pbs.ListCredentialLibrariesRequest{
 					CredentialStoreId: proj1CredStore[0].GetPublicId(),
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  org.GetPublicId(),
-						GrantStrings: []string{"ids=*;type=credential-library;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+						RoleScopeId: org.GetPublicId(),
+						Grants:      []string{"ids=*;type=credential-library;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
-				},
+				}),
 				wantErr: nil,
 				wantIDs: []string{proj1Libs[0].GetPublicId(), proj1Libs[1].GetPublicId(), proj1Libs[2].GetPublicId()},
 			},
@@ -85,8 +89,10 @@ func TestGrants_ReadActions(t *testing.T) {
 
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
-				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
 				got, finalErr := s.ListCredentialLibraries(fullGrantAuthCtx, tc.input)
 				if tc.wantErr != nil {
 					require.ErrorIs(t, finalErr, tc.wantErr)

--- a/internal/daemon/controller/handlers/credentiallibraries/grants_test.go
+++ b/internal/daemon/controller/handlers/credentiallibraries/grants_test.go
@@ -58,7 +58,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=credential-library;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
@@ -73,7 +73,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org.GetPublicId(),
+						RoleScopeId:  org.GetPublicId(),
 						GrantStrings: []string{"ids=*;type=credential-library;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},

--- a/internal/daemon/controller/handlers/credentials/grants_test.go
+++ b/internal/daemon/controller/handlers/credentials/grants_test.go
@@ -6,19 +6,42 @@ package credentials_test
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"testing"
 
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/auth"
+	"github.com/hashicorp/boundary/internal/auth/password"
 	"github.com/hashicorp/boundary/internal/authtoken"
+	"github.com/hashicorp/boundary/internal/credential"
 	"github.com/hashicorp/boundary/internal/credential/static"
-	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	controllerauth "github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/credentials"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/credentials"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
+
+const (
+	// UsernamePasswordAttributesField is the field name for the UsernamePassword subtype of the `Credential.Attrs` attributes field
+	//
+	// When the "attributes" field is specified as an output_field and can be one of many sub-types, the expected output field must be the corresponding sub-type and not `globals.AttributesField`
+	UsernamePasswordAttributesField = "username_password_attributes"
+)
+
+// expectedOutput consolidates common output fields for the test cases
+type expectedOutput struct {
+	err          error
+	outputFields []string
+}
 
 // TestGrants_ReadActions tests read actions to assert that grants are being applied properly
 //
@@ -39,9 +62,8 @@ func TestGrants_ReadActions(t *testing.T) {
 	conn, _ := db.TestSetup(t, "postgres")
 	wrap := db.TestWrapper(t)
 	rw := db.New(conn)
-	iamRepo := iam.TestRepo(t, conn, wrap)
 	kmsCache := kms.TestKms(t, conn, wrap)
-
+	iamRepo := iam.TestRepo(t, conn, wrap)
 	iamRepoFn := func() (*iam.Repository, error) {
 		return iamRepo, nil
 	}
@@ -51,88 +73,803 @@ func TestGrants_ReadActions(t *testing.T) {
 	s, err := credentials.NewService(ctx, iamRepoFn, staticRepoFn, 1000)
 	require.NoError(t, err)
 
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
 	org, proj := iam.TestScopes(t, iamRepo)
 
 	credStore := static.TestCredentialStore(t, conn, wrap, proj.GetPublicId())
-	var wantCreds []string
-	for i := 0; i < 10; i++ {
+	var credIds []string
+	for i := range 5 {
 		user := fmt.Sprintf("user-%d", i)
 		pass := fmt.Sprintf("pass-%d", i)
-		c := static.TestUsernamePasswordCredential(t, conn, wrap, user, pass, credStore.GetPublicId(), proj.GetPublicId())
-		require.NoError(t, err)
-		wantCreds = append(wantCreds, c.GetPublicId())
+		c := static.TestUsernamePasswordCredential(t, conn, wrap, user, pass, credStore.GetPublicId(), proj.GetPublicId(), static.WithName(fmt.Sprintf("cred-%d", i)), static.WithDescription(fmt.Sprintf("desc-%d", i)))
+		credIds = append(credIds, c.GetPublicId())
 	}
 
 	t.Run("List", func(t *testing.T) {
 		testcases := []struct {
 			name          string
-			input         *pbs.ListCredentialsRequest
-			rolesToCreate []authtoken.TestRoleGrantsForToken
+			userFunc      func() (*iam.User, auth.Account)
 			wantErr       error
-			wantIDs       []string
+			wantOutfields map[string][]string
 		}{
 			{
-				name: "global role grant this returns all created credentials",
-				input: &pbs.ListCredentialsRequest{
-					CredentialStoreId: credStore.GetPublicId(),
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				name: "global role grant this returns 403 because credentials live on projects",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=credential;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
-				wantErr: nil,
-				wantIDs: wantCreds,
+				}),
+				wantErr: handlers.ForbiddenError(),
 			},
 			{
-				name: "org role grant this returns all created credentials",
-				input: &pbs.ListCredentialsRequest{
-					CredentialStoreId: credStore.GetPublicId(),
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				name: "org role grant this returns 403 because credentials live on projects",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  org.PublicId,
-						GrantStrings: []string{"ids=*;type=credential;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+						RoleScopeId: org.GetPublicId(),
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
-				wantErr: nil,
-				wantIDs: wantCreds,
+				}),
+				wantErr: handlers.ForbiddenError(),
 			},
 			{
-				name: "project role grant this returns all created credentials",
-				input: &pbs.ListCredentialsRequest{
-					CredentialStoreId: credStore.GetPublicId(),
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				name: "project role grant this returns all credentials on the project",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  proj.PublicId,
-						GrantStrings: []string{"ids=*;type=credential;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis},
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
+				}),
+				wantOutfields: map[string][]string{
+					credIds[0]: {globals.IdField},
+					credIds[1]: {globals.IdField},
+					credIds[2]: {globals.IdField},
+					credIds[3]: {globals.IdField},
+					credIds[4]: {globals.IdField},
 				},
-				wantErr: nil,
-				wantIDs: wantCreds,
+			},
+			{
+				name: "global role grant this & children returns 403 because credentials live on projects",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "org role grant children returns all credentials on child projects",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,credential_store_id,scope,name,description,created_time,updated_time,version,type,authorized_actions,attributes"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					credIds[0]: {globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField},
+					credIds[1]: {globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField},
+					credIds[2]: {globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField},
+					credIds[3]: {globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField},
+					credIds[4]: {globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField},
+				},
+			},
+			{
+				name: "global role grant this & descendants returns all credentials on descendant projects",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					credIds[0]: {globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					credIds[1]: {globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					credIds[2]: {globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					credIds[3]: {globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					credIds[4]: {globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				},
+			},
+			{
+				name: "project role grant this returns all credentials on the project",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,credential_store_id,scope,name,description,created_time,updated_time,version,type,authorized_actions,attributes"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					credIds[0]: {globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField},
+					credIds[1]: {globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField},
+					credIds[2]: {globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField},
+					credIds[3]: {globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField},
+					credIds[4]: {globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField},
+				},
+			},
+			{
+				name: "global role grant with credential-store id, list action, credential type, and descendant scope returns all credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + credStore.PublicId + ";type=credential;actions=list,no-op;output_fields=id,name,description,credential_store_id"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					credIds[0]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.CredentialStoreIdField},
+					credIds[1]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.CredentialStoreIdField},
+					credIds[2]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.CredentialStoreIdField},
+					credIds[3]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.CredentialStoreIdField},
+					credIds[4]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.CredentialStoreIdField},
+				},
+			},
+			{
+				name: "org role grant with credential-store id, list action, credential type, and children scope returns all credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + credStore.PublicId + ";type=credential;actions=list,no-op;output_fields=id,name,description,version,credential_store_id"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					credIds[0]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField, globals.CredentialStoreIdField},
+					credIds[1]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField, globals.CredentialStoreIdField},
+					credIds[2]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField, globals.CredentialStoreIdField},
+					credIds[3]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField, globals.CredentialStoreIdField},
+					credIds[4]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField, globals.CredentialStoreIdField},
+				},
+			},
+			{
+				name: "project role grant with credential-store id, list action, credential type, and this scope returns all credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + credStore.PublicId + ";type=credential;actions=list,no-op;output_fields=id,name,description,version,credential_store_id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					credIds[0]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField, globals.CredentialStoreIdField},
+					credIds[1]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField, globals.CredentialStoreIdField},
+					credIds[2]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField, globals.CredentialStoreIdField},
+					credIds[3]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField, globals.CredentialStoreIdField},
+					credIds[4]: {globals.IdField, globals.NameField, globals.DescriptionField, globals.VersionField, globals.CredentialStoreIdField},
+				},
+			},
+			{
+				name: "incorrect grants can't list credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=credential;actions=read,create,update,delete"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name:     "no grants returns 403",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, nil),
+				wantErr:  handlers.ForbiddenError(),
 			},
 		}
 
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
-				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
-				got, finalErr := s.ListCredentials(fullGrantAuthCtx, tc.input)
+				// Call function to create direct/indirect relationship
+				user, account := tc.userFunc()
+
+				// Create auth token for the user
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+
+				// Create auth context from the auth token
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				got, finalErr := s.ListCredentials(fullGrantAuthCtx, &pbs.ListCredentialsRequest{CredentialStoreId: credStore.GetPublicId()})
 				if tc.wantErr != nil {
 					require.ErrorIs(t, finalErr, tc.wantErr)
 					return
 				}
 				require.NoError(t, finalErr)
-				var gotIDs []string
+				var gotIds []string
 				for _, g := range got.Items {
-					gotIDs = append(gotIDs, g.GetId())
+					gotIds = append(gotIds, g.GetId())
+
+					// check if the output fields are as expected
+					if tc.wantOutfields[g.Id] != nil {
+						handlers.TestAssertOutputFields(t, g, tc.wantOutfields[g.Id])
+					}
 				}
-				require.ElementsMatch(t, tc.wantIDs, gotIDs)
+
+				wantIds := slices.Collect(maps.Keys(tc.wantOutfields))
+				require.ElementsMatch(t, wantIds, gotIds)
+			})
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		testcases := []struct {
+			name             string
+			userFunc         func() (*iam.User, auth.Account)
+			canGetCredential map[string]expectedOutput
+		}{
+			{
+				name: "global role grant this returns 403",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetCredential: map[string]expectedOutput{
+					credIds[0]: {err: handlers.ForbiddenError()},
+					credIds[1]: {err: handlers.ForbiddenError()},
+					credIds[2]: {err: handlers.ForbiddenError()},
+					credIds[3]: {err: handlers.ForbiddenError()},
+					credIds[4]: {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "org role grant this returns 403",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetCredential: map[string]expectedOutput{
+					credIds[0]: {err: handlers.ForbiddenError()},
+					credIds[1]: {err: handlers.ForbiddenError()},
+					credIds[2]: {err: handlers.ForbiddenError()},
+					credIds[3]: {err: handlers.ForbiddenError()},
+					credIds[4]: {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "project role grant this returns all credentials on the project",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetCredential: map[string]expectedOutput{
+					credIds[0]: {outputFields: []string{globals.IdField}},
+					credIds[1]: {outputFields: []string{globals.IdField}},
+					credIds[2]: {outputFields: []string{globals.IdField}},
+					credIds[3]: {outputFields: []string{globals.IdField}},
+					credIds[4]: {outputFields: []string{globals.IdField}},
+				},
+			},
+			{
+				name: "global role grant this & children returns 403 because credentials live on projects",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				canGetCredential: map[string]expectedOutput{
+					credIds[0]: {err: handlers.ForbiddenError()},
+					credIds[1]: {err: handlers.ForbiddenError()},
+					credIds[2]: {err: handlers.ForbiddenError()},
+					credIds[3]: {err: handlers.ForbiddenError()},
+					credIds[4]: {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "org role grant children returns all credentials on child projects",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				canGetCredential: map[string]expectedOutput{
+					credIds[0]: {outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					credIds[1]: {outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					credIds[2]: {outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					credIds[3]: {outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					credIds[4]: {outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+				},
+			},
+			{
+				name: "global role grant this & descendants returns all credentials on descendant projects",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				canGetCredential: map[string]expectedOutput{
+					credIds[0]: {outputFields: []string{globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					credIds[1]: {outputFields: []string{globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					credIds[2]: {outputFields: []string{globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					credIds[3]: {outputFields: []string{globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					credIds[4]: {outputFields: []string{globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+				},
+			},
+			{
+				name: "project role grant this returns all credentials on the project",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,credential_store_id,scope,name,description,created_time,updated_time,version,type,authorized_actions,attributes"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetCredential: map[string]expectedOutput{
+					credIds[0]: {outputFields: []string{globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField}},
+					credIds[1]: {outputFields: []string{globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField}},
+					credIds[2]: {outputFields: []string{globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField}},
+					credIds[3]: {outputFields: []string{globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField}},
+					credIds[4]: {outputFields: []string{globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField}},
+				},
+			},
+			{
+				name: "incorrect grants returns no credential",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=credential;actions=list,create,update,delete;output_fields=id,name,description,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetCredential: map[string]expectedOutput{
+					credIds[0]: {err: handlers.ForbiddenError()},
+					credIds[1]: {err: handlers.ForbiddenError()},
+					credIds[2]: {err: handlers.ForbiddenError()},
+					credIds[3]: {err: handlers.ForbiddenError()},
+					credIds[4]: {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name:     "no grants returns no credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, nil),
+				canGetCredential: map[string]expectedOutput{
+					credIds[0]: {err: handlers.ForbiddenError()},
+					credIds[1]: {err: handlers.ForbiddenError()},
+					credIds[2]: {err: handlers.ForbiddenError()},
+					credIds[3]: {err: handlers.ForbiddenError()},
+					credIds[4]: {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "project role grant with credential id, get action, and this scope returns the id'd credential",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + credIds[0] + ";actions=read;output_fields=id,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetCredential: map[string]expectedOutput{
+					credIds[0]: {outputFields: []string{globals.IdField, globals.AuthorizedActionsField}},
+					credIds[1]: {err: handlers.ForbiddenError()},
+					credIds[2]: {err: handlers.ForbiddenError()},
+					credIds[3]: {err: handlers.ForbiddenError()},
+					credIds[4]: {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "org role grant with credential id, get action, and this & children scope returns the id'd credential",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + credIds[4] + ";actions=read;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				canGetCredential: map[string]expectedOutput{
+					credIds[0]: {err: handlers.ForbiddenError()},
+					credIds[1]: {err: handlers.ForbiddenError()},
+					credIds[2]: {err: handlers.ForbiddenError()},
+					credIds[3]: {err: handlers.ForbiddenError()},
+					credIds[4]: {outputFields: []string{globals.IdField}},
+				},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				for id, expected := range tc.canGetCredential {
+					input := &pbs.GetCredentialRequest{Id: id}
+					got, err := s.GetCredential(fullGrantAuthCtx, input)
+					if expected.err != nil {
+						require.ErrorIs(t, err, expected.err)
+						continue
+					}
+					// check if the output fields are as expected
+					if tc.canGetCredential[id].outputFields != nil {
+						handlers.TestAssertOutputFields(t, got.Item, tc.canGetCredential[id].outputFields)
+					}
+					require.NoError(t, err)
+				}
+			})
+		}
+	})
+}
+
+func TestGrants_WriteActions(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	kmsCache := kms.TestKms(t, conn, wrap)
+
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	staticRepoFn := func() (*static.Repository, error) {
+		return static.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	s, err := credentials.NewService(ctx, iamRepoFn, staticRepoFn, 1000)
+	require.NoError(t, err)
+
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	org, proj := iam.TestScopes(t, iamRepo)
+
+	t.Run("Create", func(t *testing.T) {
+		credStore := static.TestCredentialStore(t, conn, wrap, proj.GetPublicId())
+
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			expected expectedOutput
+		}{
+			{
+				name: "global role grant this can't create credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "org role grant this can't create credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "project role grant this can create credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField}},
+			},
+			{
+				name: "global role grant this & descendants can create credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=credential;actions=create,read,update;output_fields=id,credential_store_id,scope,name,description,created_time,updated_time,version,type,authorized_actions,attributes"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField}},
+			},
+			{
+				name: "org role grant this & children can create credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=credential;actions=create;output_fields=id,scope,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "global role grant pinned to credential-store id, credential type, and descendant scope can create credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + credStore.PublicId + ";type=credential;actions=create;output_fields=id,credential_store_id,name,scope,description,created_time,updated_time,version"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.CredentialStoreIdField, globals.NameField, globals.ScopeField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+			},
+			{
+				name: "global role grant pinned to credential-store id, credential type, and children scope cannot create credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + credStore.PublicId + ";type=credential;actions=create;output_fields=id,credential_store_id,name,scope,description,created_time,updated_time,version"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "org role grant pinned to credential-store id, credential type, and children scope can create credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + credStore.PublicId + ";type=credential;actions=create;output_fields=id,credential_store_id,name,scope,description,created_time,updated_time,version"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.CredentialStoreIdField, globals.NameField, globals.ScopeField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+			},
+			{
+				name: "project role grant pinned to credential-store id, credential type, and this scope can create credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + credStore.PublicId + ";type=credential;actions=create;output_fields=id,credential_store_id,name,scope,description,created_time,updated_time,version"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.CredentialStoreIdField, globals.NameField, globals.ScopeField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField}},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				got, err := s.CreateCredential(fullGrantAuthCtx, &pbs.CreateCredentialRequest{Item: &pb.Credential{
+					CredentialStoreId: credStore.GetPublicId(),
+					Name:              &wrappers.StringValue{Value: "test credential - " + tc.name},
+					Description:       &wrappers.StringValue{Value: "test desc"},
+					Type:              credential.UsernamePasswordSubtype.String(),
+					Attrs: &pb.Credential_UsernamePasswordAttributes{
+						UsernamePasswordAttributes: &pb.UsernamePasswordAttributes{
+							Username: wrapperspb.String("static-username"),
+							Password: wrapperspb.String("static-password"),
+						},
+					},
+				}})
+				if tc.expected.err != nil {
+					require.ErrorIs(t, err, tc.expected.err)
+					return
+				}
+				// check if the output fields are as expected
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, got.Item, tc.expected.outputFields)
+			})
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			expected expectedOutput
+		}{
+			{
+				name: "global role grant this can't update credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "org role grant this can't update credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "project role grant this can update credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField}},
+			},
+			{
+				name: "global role grant this & descendants can update credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=credential;actions=update;output_fields=id,credential_store_id,scope,name,description,created_time,updated_time,version,type,authorized_actions,attributes"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.CredentialStoreIdField, globals.ScopeField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField, UsernamePasswordAttributesField}},
+			},
+			{
+				name: "org role grant this & children can update credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=credential;actions=update;output_fields=id,scope,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "incorrect grants can't update credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=credential;actions=list,create,delete;output_fields=id,name,description,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name:     "no grants can't update credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, nil),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				credStore := static.TestCredentialStore(t, conn, wrap, proj.GetPublicId())
+				cred := static.TestUsernamePasswordCredential(t, conn, wrap, "user", "pass", credStore.GetPublicId(), proj.GetPublicId(), static.WithName("cred"), static.WithDescription("desc"))
+
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				got, err := s.UpdateCredential(fullGrantAuthCtx, &pbs.UpdateCredentialRequest{
+					Id: cred.PublicId,
+					Item: &pb.Credential{
+						Name:        &wrappers.StringValue{Value: "updated credential name (" + tc.name + ")"},
+						Description: &wrappers.StringValue{Value: "test desc"},
+						Version:     1,
+					},
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "description"}},
+				})
+				if tc.expected.err != nil {
+					require.ErrorIs(t, err, tc.expected.err)
+					return
+				}
+				// check if the output fields are as expected
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, got.Item, tc.expected.outputFields)
+			})
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			wantErr  error
+		}{
+			{
+				name: "global role grant this can't delete credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "org role grant this can't delete credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "project role grant this can delete credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+			},
+			{
+				name: "global role grant this & descendants can delete credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=credential;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+			},
+			{
+				name: "org role grant this & children can delete credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=credential;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+			},
+			{
+				name: "incorrect grants can't delete credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=credential;actions=list,create,update"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name:     "no grants can't delete credentials",
+				userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, nil),
+				wantErr:  handlers.ForbiddenError(),
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				credStore := static.TestCredentialStore(t, conn, wrap, proj.GetPublicId())
+				cred := static.TestUsernamePasswordCredential(t, conn, wrap, "user", "pass", credStore.GetPublicId(), proj.GetPublicId(), static.WithName("cred"), static.WithDescription("desc"))
+
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				_, err = s.DeleteCredential(fullGrantAuthCtx, &pbs.DeleteCredentialRequest{Id: cred.PublicId})
+				if tc.wantErr != nil {
+					require.ErrorIs(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
 			})
 		}
 	})

--- a/internal/daemon/controller/handlers/credentials/grants_test.go
+++ b/internal/daemon/controller/handlers/credentials/grants_test.go
@@ -78,7 +78,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=credential;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
@@ -93,7 +93,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org.PublicId,
+						RoleScopeId:  org.PublicId,
 						GrantStrings: []string{"ids=*;type=credential;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -108,7 +108,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  proj.PublicId,
+						RoleScopeId:  proj.PublicId,
 						GrantStrings: []string{"ids=*;type=credential;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},

--- a/internal/daemon/controller/handlers/credentialstores/grants_test.go
+++ b/internal/daemon/controller/handlers/credentialstores/grants_test.go
@@ -87,7 +87,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=credential-store;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
@@ -103,7 +103,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org.PublicId,
+						RoleScopeId:  org.PublicId,
 						GrantStrings: []string{"ids=*;type=credential-store;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -118,7 +118,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  proj.PublicId,
+						RoleScopeId:  proj.PublicId,
 						GrantStrings: []string{"ids=*;type=credential-store;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},

--- a/internal/daemon/controller/handlers/credentialstores/grants_test.go
+++ b/internal/daemon/controller/handlers/credentialstores/grants_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/scheduler"
+	"github.com/hashicorp/boundary/internal/types/resource"
 	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/credentialstores"
 	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
@@ -87,11 +88,13 @@ func TestGrants_ListCredentialStores(t *testing.T) {
 	}
 
 	testcases := []struct {
-		name     string
-		input    *pbs.ListCredentialStoresRequest
-		userFunc func() (*iam.User, authdomain.Account)
-		wantErr  error
-		wantIDs  []string
+		name                                 string
+		input                                *pbs.ListCredentialStoresRequest
+		userFunc                             func() (*iam.User, authdomain.Account)
+		wantErr                              error
+		wantIDs                              []string
+		wantIdAuthorizedActionsMap           map[string][]string
+		wantIdAuthorizedCollectionActionsMap map[string][]string
 	}{
 		{
 			name: "global role grant this returns all created credential stores",
@@ -312,6 +315,39 @@ func TestGrants_ListCredentialStores(t *testing.T) {
 			require.ElementsMatch(t, tc.wantIDs, gotIDs)
 		})
 	}
+
+	t.Run("authorized actions", func(t *testing.T) {
+		user, account := iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+			{
+				RoleScopeId: globals.GlobalPrefix,
+				Grants:      []string{"ids=*;type=*;actions=*"},
+				GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+			},
+		})()
+		tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+		require.NoError(t, err)
+		fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+		got, err := s.ListCredentialStores(fullGrantAuthCtx, &pbs.ListCredentialStoresRequest{
+			ScopeId:   globals.GlobalPrefix,
+			Recursive: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, got.Items, len(slices.Concat(proj1Stores, proj2Stores, proj3Stores)))
+		for _, item := range got.Items {
+			switch item.Type {
+			case "vault":
+				require.ElementsMatch(t, item.AuthorizedActions, []string{"no-op", "read", "update", "delete"})
+				require.Len(t, item.AuthorizedCollectionActions, 1)
+				require.ElementsMatch(t, item.AuthorizedCollectionActions[resource.CredentialLibrary.PluralString()].AsSlice(), []string{"list", "create"})
+			case "static":
+				require.ElementsMatch(t, item.AuthorizedActions, []string{"no-op", "read", "update", "delete"})
+				require.Len(t, item.AuthorizedCollectionActions, 1)
+				require.ElementsMatch(t, item.AuthorizedCollectionActions[resource.Credential.PluralString()].AsSlice(), []string{"list", "create"})
+			default:
+				t.Fatalf("unknown item type: %s", item.Type)
+			}
+		}
+	})
 }
 
 func TestGrants_GetCredentialStores(t *testing.T) {

--- a/internal/daemon/controller/handlers/credentialstores/grants_test.go
+++ b/internal/daemon/controller/handlers/credentialstores/grants_test.go
@@ -5,51 +5,1291 @@ package credentialstores_test
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
+	authdomain "github.com/hashicorp/boundary/internal/auth"
+	"github.com/hashicorp/boundary/internal/auth/password"
 	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/credential"
 	"github.com/hashicorp/boundary/internal/credential/static"
 	"github.com/hashicorp/boundary/internal/credential/vault"
 	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/credentialstores"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/scheduler"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/credentialstores"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-// TestGrants_ReadActions tests read actions to assert that grants are being applied properly
-//
-//	 Role - which scope the role is created in
-//			- global level
-//			- org level
-//			- proj level
-//		Grant - what IAM grant scope is set for the permission
-//			- global: descendant
-//			- org: children
-//			- project: this
-//		Scopes [resource]:
-//			- global
-//				- org1
-//					- proj1
-func TestGrants_ReadActions(t *testing.T) {
+// TestGrants_ListCredentialStores tests read actions to assert that grants are being applied properly
+// non-recursive list is not allowed at global/org so non-recursive lists at global/org will not be covered
+func TestGrants_ListCredentialStores(t *testing.T) {
 	ctx := context.Background()
 	conn, _ := db.TestSetup(t, "postgres")
 	wrap := db.TestWrapper(t)
 	rw := db.New(conn)
 	iamRepo := iam.TestRepo(t, conn, wrap)
 	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
 
-	sche := scheduler.TestScheduler(t, conn, wrap)
 	iamRepoFn := func() (*iam.Repository, error) {
 		return iamRepo, nil
 	}
 	vaultRepoFn := func() (*vault.Repository, error) {
-		return vault.NewRepository(ctx, rw, rw, kmsCache, sche)
+		return vault.NewRepository(ctx, rw, rw, kmsCache, scheduler.TestScheduler(t, conn, wrap))
+	}
+	staticRepoFn := func() (*static.Repository, error) {
+		return static.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	credStoreRepoFn := func() (*credential.StoreRepository, error) {
+		return credential.NewStoreRepository(context.Background(), rw, rw)
+	}
+	s, err := credentialstores.NewService(ctx, iamRepoFn, vaultRepoFn, staticRepoFn, credStoreRepoFn, 1000)
+	require.NoError(t, err)
+
+	org1, proj1 := iam.TestScopes(t, iamRepo)
+	org2, proj2 := iam.TestScopes(t, iamRepo)
+	proj3 := iam.TestProject(t, iamRepo, org2.GetPublicId())
+
+	var proj1Stores []string
+	for _, s := range vault.TestCredentialStores(t, conn, wrap, proj1.GetPublicId(), 1) {
+		proj1Stores = append(proj1Stores, s.GetPublicId())
+	}
+	for _, s := range static.TestCredentialStores(t, conn, wrap, proj1.GetPublicId(), 1) {
+		proj1Stores = append(proj1Stores, s.GetPublicId())
+	}
+
+	var proj2Stores []string
+	for _, s := range vault.TestCredentialStores(t, conn, wrap, proj2.GetPublicId(), 2) {
+		proj2Stores = append(proj2Stores, s.GetPublicId())
+	}
+	for _, s := range static.TestCredentialStores(t, conn, wrap, proj2.GetPublicId(), 2) {
+		proj2Stores = append(proj2Stores, s.GetPublicId())
+	}
+
+	var proj3Stores []string
+	for _, s := range vault.TestCredentialStores(t, conn, wrap, proj3.GetPublicId(), 2) {
+		proj3Stores = append(proj3Stores, s.GetPublicId())
+	}
+	for _, s := range static.TestCredentialStores(t, conn, wrap, proj3.GetPublicId(), 2) {
+		proj3Stores = append(proj3Stores, s.GetPublicId())
+	}
+
+	testcases := []struct {
+		name     string
+		input    *pbs.ListCredentialStoresRequest
+		userFunc func() (*iam.User, authdomain.Account)
+		wantErr  error
+		wantIDs  []string
+	}{
+		{
+			name: "global role grant this returns all created credential stores",
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=list,read"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: slices.Concat(proj1Stores, proj2Stores, proj3Stores),
+		},
+		{
+			name: "global role grant recursive list without access returns empty list",
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=list,read"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: []string{},
+		},
+		{
+			name: "org role grant this and children recursive-list returns all created credential stores",
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   org1.GetPublicId(),
+				Recursive: true,
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=list,read"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: proj1Stores,
+		},
+		{
+			name: "org role children grants list org return all credential stores in child projects",
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org2.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=list,read"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: slices.Concat(proj2Stores, proj3Stores),
+		},
+		{
+			name: "org role grant this list a different org returns error",
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   org1.GetPublicId(),
+				Recursive: true,
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org2.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=list,read"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			wantErr: handlers.ForbiddenError(),
+			wantIDs: nil,
+		},
+		{
+			name: "project role grant this returns all created credential stores",
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId: proj1.GetPublicId(),
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=list,read"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: proj1Stores,
+		},
+		{
+			name: "project role grant this without list actions return error",
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId: proj1.GetPublicId(),
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=read"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			wantErr: handlers.ForbiddenError(),
+			wantIDs: proj1Stores,
+		},
+		{
+			name: "project role grant this without list actions return error",
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId: proj1.GetPublicId(),
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=read"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			wantErr: handlers.ForbiddenError(),
+			wantIDs: proj1Stores,
+		},
+		{
+			name: "grants specific project ID recursive list from global returns only granted project",
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=list,no-op"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: proj1Stores,
+		},
+		{
+			name: "multiple grants specific project ID recursive list from global returns only granted project",
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=list"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=list,no-op"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: proj2.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=list,no-op"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: slices.Concat(proj1Stores, proj2Stores),
+		},
+		{
+			name: "multiple grants specific credentials-library no-op returns only granted credentials-library",
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=list"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants: []string{
+						fmt.Sprintf("ids=%s;type=credential-store;actions=no-op", proj1Stores[0]),
+					},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: org2.PublicId,
+					Grants: []string{
+						fmt.Sprintf("ids=%s;type=credential-store;actions=no-op", proj2Stores[0]),
+						fmt.Sprintf("ids=%s;type=credential-store;actions=no-op", proj3Stores[0]),
+					},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: []string{proj1Stores[0], proj2Stores[0], proj3Stores[0]},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			got, err := s.ListCredentialStores(fullGrantAuthCtx, tc.input)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			var gotIDs []string
+			for _, g := range got.Items {
+				gotIDs = append(gotIDs, g.GetId())
+			}
+			require.ElementsMatch(t, tc.wantIDs, gotIDs)
+		})
+	}
+}
+
+func TestGrants_GetCredentialStores(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	vaultRepoFn := func() (*vault.Repository, error) {
+		return vault.NewRepository(ctx, rw, rw, kmsCache, scheduler.TestScheduler(t, conn, wrap))
+	}
+	staticRepoFn := func() (*static.Repository, error) {
+		return static.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	credStoreRepoFn := func() (*credential.StoreRepository, error) {
+		return credential.NewStoreRepository(context.Background(), rw, rw)
+	}
+	s, err := credentialstores.NewService(ctx, iamRepoFn, vaultRepoFn, staticRepoFn, credStoreRepoFn, 1000)
+	require.NoError(t, err)
+
+	_, proj1 := iam.TestScopes(t, iamRepo)
+	org2, proj2 := iam.TestScopes(t, iamRepo)
+	proj3 := iam.TestProject(t, iamRepo, org2.GetPublicId())
+
+	proj1VaultStore := vault.TestCredentialStores(t, conn, wrap, proj1.GetPublicId(), 1)[0]
+	proj2StaticStore := static.TestCredentialStores(t, conn, wrap, proj2.GetPublicId(), 1)[0]
+	proj3VaultStore := vault.TestCredentialStores(t, conn, wrap, proj3.GetPublicId(), 1)[0]
+
+	testcases := []struct {
+		name          string
+		userFunc      func() (*iam.User, authdomain.Account)
+		inputErrorMap map[*pbs.GetCredentialStoreRequest]error
+	}{
+		{
+			name: "global role grant descendant can read all created credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=read"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			inputErrorMap: map[*pbs.GetCredentialStoreRequest]error{
+				{Id: proj1VaultStore.GetPublicId()}:  nil,
+				{Id: proj2StaticStore.GetPublicId()}: nil,
+				{Id: proj3VaultStore.GetPublicId()}:  nil,
+			},
+		},
+		{
+			name: "global role grant this and children cannot get any credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=read"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			inputErrorMap: map[*pbs.GetCredentialStoreRequest]error{
+				{Id: proj1VaultStore.GetPublicId()}:  handlers.ForbiddenError(),
+				{Id: proj2StaticStore.GetPublicId()}: handlers.ForbiddenError(),
+				{Id: proj3VaultStore.GetPublicId()}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "org role grant children can read all credential stores under granted org",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org2.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=read"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			inputErrorMap: map[*pbs.GetCredentialStoreRequest]error{
+				{Id: proj1VaultStore.GetPublicId()}:  handlers.ForbiddenError(),
+				{Id: proj2StaticStore.GetPublicId()}: nil,
+				{Id: proj3VaultStore.GetPublicId()}:  nil,
+			},
+		},
+		{
+			name: "project role can only read credential stores in this project",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=read"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.GetCredentialStoreRequest]error{
+				{Id: proj1VaultStore.GetPublicId()}:  nil,
+				{Id: proj2StaticStore.GetPublicId()}: handlers.ForbiddenError(),
+				{Id: proj3VaultStore.GetPublicId()}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "composite grants individually grant each project roles can read all credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=read"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: proj2.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=read"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: proj3.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=read"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.GetCredentialStoreRequest]error{
+				{Id: proj1VaultStore.GetPublicId()}:  nil,
+				{Id: proj2StaticStore.GetPublicId()}: nil,
+				{Id: proj3VaultStore.GetPublicId()}:  nil,
+			},
+		},
+		{
+			name: "global grants individual resources can only read resources that are granted access",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{fmt.Sprintf("ids=%s,%s;type=credential-store;actions=read", proj1VaultStore.GetPublicId(), proj3VaultStore.GetPublicId())},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			inputErrorMap: map[*pbs.GetCredentialStoreRequest]error{
+				{Id: proj1VaultStore.GetPublicId()}:  nil,
+				{Id: proj2StaticStore.GetPublicId()}: handlers.ForbiddenError(),
+				{Id: proj3VaultStore.GetPublicId()}:  nil,
+			},
+		},
+		{
+			name: "global grants not granting read permission cannot read credentials store",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=list,create,delete"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+				{
+					RoleScopeId: proj2.GetPublicId(),
+					Grants:      []string{"ids=*;type=credential-store;actions=read"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.GetCredentialStoreRequest]error{
+				{Id: proj1VaultStore.GetPublicId()}:  handlers.ForbiddenError(),
+				{Id: proj2StaticStore.GetPublicId()}: nil,
+				{Id: proj3VaultStore.GetPublicId()}:  handlers.ForbiddenError(),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for input, wantErr := range tc.inputErrorMap {
+				_, err = s.GetCredentialStore(fullGrantAuthCtx, input)
+				if wantErr != nil {
+					require.ErrorIs(t, err, wantErr)
+					continue
+				}
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGrants_CreateCredentialStores(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	vaultRepoFn := func() (*vault.Repository, error) {
+		return vault.NewRepository(ctx, rw, rw, kmsCache, scheduler.TestScheduler(t, conn, wrap))
+	}
+	staticRepoFn := func() (*static.Repository, error) {
+		return static.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	credStoreRepoFn := func() (*credential.StoreRepository, error) {
+		return credential.NewStoreRepository(context.Background(), rw, rw)
+	}
+	s, err := credentialstores.NewService(ctx, iamRepoFn, vaultRepoFn, staticRepoFn, credStoreRepoFn, 1000)
+	require.NoError(t, err)
+
+	_, proj1 := iam.TestScopes(t, iamRepo)
+	org2, proj2 := iam.TestScopes(t, iamRepo)
+	proj3 := iam.TestProject(t, iamRepo, org2.GetPublicId())
+	v := vault.NewTestVaultServer(t, vault.WithTestVaultTLS(vault.TestClientTLS))
+
+	staticCredStoreInput := func(scopeID string) *pbs.CreateCredentialStoreRequest {
+		return &pbs.CreateCredentialStoreRequest{
+			Item: &pb.CredentialStore{
+				ScopeId: scopeID,
+				Type:    static.Subtype.String(),
+			},
+		}
+	}
+	vaultCredStoreInput := func(scopeID string) *pbs.CreateCredentialStoreRequest {
+		_, token := v.CreateToken(t)
+		return &pbs.CreateCredentialStoreRequest{
+			Item: &pb.CredentialStore{
+				ScopeId: scopeID,
+				Type:    vault.Subtype.String(),
+				Attrs: &pb.CredentialStore_VaultCredentialStoreAttributes{
+					VaultCredentialStoreAttributes: &pb.VaultCredentialStoreAttributes{
+						Address:           wrapperspb.String(v.Addr),
+						Token:             wrapperspb.String(token),
+						CaCert:            wrapperspb.String(string(v.CaCert)),
+						ClientCertificate: wrapperspb.String(string(v.ClientCert) + string(v.ClientKey)),
+					},
+				},
+			},
+		}
+	}
+
+	testcases := []struct {
+		name          string
+		userFunc      func() (*iam.User, authdomain.Account)
+		inputErrorMap map[*pbs.CreateCredentialStoreRequest]error
+	}{
+		{
+			name: "global role grant descendant can list all created credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=create"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			inputErrorMap: map[*pbs.CreateCredentialStoreRequest]error{
+				staticCredStoreInput(proj1.PublicId): nil,
+				staticCredStoreInput(proj2.PublicId): nil,
+				staticCredStoreInput(proj3.PublicId): nil,
+			},
+		},
+		{
+			name: "global role grant this and children cannot create credential store in any project",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=create"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			inputErrorMap: map[*pbs.CreateCredentialStoreRequest]error{
+				staticCredStoreInput(proj1.PublicId): handlers.ForbiddenError(),
+				staticCredStoreInput(proj2.PublicId): handlers.ForbiddenError(),
+				staticCredStoreInput(proj3.PublicId): handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "org role grant children can create credential stores under granted org",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org2.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=create"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			inputErrorMap: map[*pbs.CreateCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): handlers.ForbiddenError(),
+				vaultCredStoreInput(proj2.PublicId): nil,
+				vaultCredStoreInput(proj3.PublicId): nil,
+			},
+		},
+		{
+			name: "project role can only read credential stores in this project",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=create"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.CreateCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): nil,
+				vaultCredStoreInput(proj2.PublicId): handlers.ForbiddenError(),
+				vaultCredStoreInput(proj3.PublicId): handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "composite grants individually grant each project roles can create in granted project",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=create"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: proj2.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=create"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: proj3.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=create"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.CreateCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): nil,
+				vaultCredStoreInput(proj2.PublicId): nil,
+				vaultCredStoreInput(proj3.PublicId): nil,
+			},
+		},
+		{
+			name: "global grants not granting create permission cannot create credentials store",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=delete"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+				{
+					RoleScopeId: proj2.GetPublicId(),
+					Grants:      []string{"ids=*;type=credential-store;actions=create"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.CreateCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): handlers.ForbiddenError(),
+				vaultCredStoreInput(proj2.PublicId): nil,
+				vaultCredStoreInput(proj3.PublicId): handlers.ForbiddenError(),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for input, wantErr := range tc.inputErrorMap {
+				_, err = s.CreateCredentialStore(fullGrantAuthCtx, input)
+				if wantErr != nil {
+					require.ErrorIs(t, err, wantErr)
+					continue
+				}
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGrants_DeleteCredentialStores(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	vaultRepoFn := func() (*vault.Repository, error) {
+		return vault.NewRepository(ctx, rw, rw, kmsCache, scheduler.TestScheduler(t, conn, wrap))
+	}
+	staticRepoFn := func() (*static.Repository, error) {
+		return static.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	credStoreRepoFn := func() (*credential.StoreRepository, error) {
+		return credential.NewStoreRepository(context.Background(), rw, rw)
+	}
+	s, err := credentialstores.NewService(ctx, iamRepoFn, vaultRepoFn, staticRepoFn, credStoreRepoFn, 1000)
+	require.NoError(t, err)
+
+	_, proj1 := iam.TestScopes(t, iamRepo)
+	org2, proj2 := iam.TestScopes(t, iamRepo)
+	proj3 := iam.TestProject(t, iamRepo, org2.GetPublicId())
+
+	staticCredStoreInput := func(scopeID string) *pbs.DeleteCredentialStoreRequest {
+		store := static.TestCredentialStores(t, conn, wrap, scopeID, 1)[0]
+		return &pbs.DeleteCredentialStoreRequest{
+			Id: store.PublicId,
+		}
+	}
+	vaultCredStoreInput := func(scopeID string) *pbs.DeleteCredentialStoreRequest {
+		id, _ := uuid.GenerateUUID()
+		store := vault.TestCredentialStore(t, conn, wrap, scopeID, fmt.Sprintf("http://vault%s", id), id, fmt.Sprintf("accessor-%s", id))
+		return &pbs.DeleteCredentialStoreRequest{
+			Id: store.PublicId,
+		}
+	}
+
+	testcases := []struct {
+		name          string
+		userFunc      func() (*iam.User, authdomain.Account)
+		inputErrorMap map[*pbs.DeleteCredentialStoreRequest]error
+	}{
+		{
+			name: "global role grant descendant can delete credential stores everywhere",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=delete"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			inputErrorMap: map[*pbs.DeleteCredentialStoreRequest]error{
+				staticCredStoreInput(proj1.PublicId): nil,
+				staticCredStoreInput(proj2.PublicId): nil,
+				staticCredStoreInput(proj3.PublicId): nil,
+			},
+		},
+		{
+			name: "global role grant this and children cannot delete credential store in any project",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=delete"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			inputErrorMap: map[*pbs.DeleteCredentialStoreRequest]error{
+				staticCredStoreInput(proj1.PublicId): handlers.ForbiddenError(),
+				staticCredStoreInput(proj2.PublicId): handlers.ForbiddenError(),
+				staticCredStoreInput(proj3.PublicId): handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "org role grant children can delete credential stores under granted org",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org2.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=delete"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			inputErrorMap: map[*pbs.DeleteCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): handlers.ForbiddenError(),
+				vaultCredStoreInput(proj2.PublicId): nil,
+				vaultCredStoreInput(proj3.PublicId): nil,
+			},
+		},
+		{
+			name: "project role can only delete credential stores in this project",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=delete"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.DeleteCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): nil,
+				vaultCredStoreInput(proj2.PublicId): handlers.ForbiddenError(),
+				vaultCredStoreInput(proj3.PublicId): handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "composite grants individually grant each project roles can delete in granted project",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=delete"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: proj2.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=delete"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: proj3.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=delete"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.DeleteCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): nil,
+				vaultCredStoreInput(proj2.PublicId): nil,
+				vaultCredStoreInput(proj3.PublicId): nil,
+			},
+		},
+		{
+			name: "global grants not granting create permission cannot delete credentials store",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=list"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+				{
+					RoleScopeId: proj2.GetPublicId(),
+					Grants:      []string{"ids=*;type=credential-store;actions=delete"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.DeleteCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): handlers.ForbiddenError(),
+				vaultCredStoreInput(proj2.PublicId): nil,
+				vaultCredStoreInput(proj3.PublicId): handlers.ForbiddenError(),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for input, wantErr := range tc.inputErrorMap {
+				_, err = s.DeleteCredentialStore(fullGrantAuthCtx, input)
+				if wantErr != nil {
+					require.ErrorIs(t, err, wantErr)
+					continue
+				}
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGrants_UpdateCredentialStores(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	vaultRepoFn := func() (*vault.Repository, error) {
+		return vault.NewRepository(ctx, rw, rw, kmsCache, scheduler.TestScheduler(t, conn, wrap))
+	}
+	staticRepoFn := func() (*static.Repository, error) {
+		return static.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	credStoreRepoFn := func() (*credential.StoreRepository, error) {
+		return credential.NewStoreRepository(context.Background(), rw, rw)
+	}
+	s, err := credentialstores.NewService(ctx, iamRepoFn, vaultRepoFn, staticRepoFn, credStoreRepoFn, 1000)
+	require.NoError(t, err)
+
+	_, proj1 := iam.TestScopes(t, iamRepo)
+	org2, proj2 := iam.TestScopes(t, iamRepo)
+	proj3 := iam.TestProject(t, iamRepo, org2.GetPublicId())
+
+	staticCredStoreInput := func(scopeID string) *pbs.UpdateCredentialStoreRequest {
+		old, _ := uuid.GenerateUUID()
+		newId, _ := uuid.GenerateUUID()
+		store := static.TestCredentialStore(t, conn, wrap, scopeID, static.WithName(old), static.WithDescription(old))
+		return &pbs.UpdateCredentialStoreRequest{
+			Id: store.PublicId,
+			Item: &pb.CredentialStore{
+				Name:        &wrapperspb.StringValue{Value: newId},
+				Description: &wrapperspb.StringValue{Value: newId},
+				Version:     store.Version,
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"name", "description"},
+			},
+		}
+	}
+	vaultCredStoreInput := func(scopeID string) *pbs.UpdateCredentialStoreRequest {
+		id, _ := uuid.GenerateUUID()
+		newId, _ := uuid.GenerateUUID()
+		store := vault.TestCredentialStore(t, conn, wrap, scopeID, fmt.Sprintf("http://vault%s", id), id, fmt.Sprintf("accessor-%s", id))
+		return &pbs.UpdateCredentialStoreRequest{
+			Id: store.PublicId,
+			Item: &pb.CredentialStore{
+				Name:        &wrapperspb.StringValue{Value: newId},
+				Description: &wrapperspb.StringValue{Value: newId},
+				Version:     store.Version,
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"name", "description"},
+			},
+		}
+	}
+
+	testcases := []struct {
+		name          string
+		userFunc      func() (*iam.User, authdomain.Account)
+		inputErrorMap map[*pbs.UpdateCredentialStoreRequest]error
+	}{
+		{
+			name: "global role grant descendant can update credential stores everywhere",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=update"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			inputErrorMap: map[*pbs.UpdateCredentialStoreRequest]error{
+				staticCredStoreInput(proj1.PublicId): nil,
+				staticCredStoreInput(proj2.PublicId): nil,
+				staticCredStoreInput(proj3.PublicId): nil,
+			},
+		},
+		{
+			name: "global role grant this and children cannot update credential store in any project",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=update"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			inputErrorMap: map[*pbs.UpdateCredentialStoreRequest]error{
+				staticCredStoreInput(proj1.PublicId): handlers.ForbiddenError(),
+				staticCredStoreInput(proj2.PublicId): handlers.ForbiddenError(),
+				staticCredStoreInput(proj3.PublicId): handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "org role grant children can update credential stores under granted org",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org2.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=update"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			inputErrorMap: map[*pbs.UpdateCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): handlers.ForbiddenError(),
+				vaultCredStoreInput(proj2.PublicId): nil,
+				vaultCredStoreInput(proj3.PublicId): nil,
+			},
+		},
+		{
+			name: "project role can only update credential stores in this project",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=update"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.UpdateCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): nil,
+				vaultCredStoreInput(proj2.PublicId): handlers.ForbiddenError(),
+				vaultCredStoreInput(proj3.PublicId): handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "composite grants individually grant each project roles can update in granted project",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=update"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: proj2.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=update"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: proj3.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=update"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.UpdateCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): nil,
+				vaultCredStoreInput(proj2.PublicId): nil,
+				vaultCredStoreInput(proj3.PublicId): nil,
+			},
+		},
+		{
+			name: "global grants not granting create permission cannot update credentials store",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=create"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+				{
+					RoleScopeId: proj2.GetPublicId(),
+					Grants:      []string{"ids=*;type=credential-store;actions=update"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputErrorMap: map[*pbs.UpdateCredentialStoreRequest]error{
+				vaultCredStoreInput(proj1.PublicId): handlers.ForbiddenError(),
+				vaultCredStoreInput(proj2.PublicId): nil,
+				vaultCredStoreInput(proj3.PublicId): handlers.ForbiddenError(),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for input, wantErr := range tc.inputErrorMap {
+				_, err = s.UpdateCredentialStore(fullGrantAuthCtx, input)
+				if wantErr != nil {
+					require.ErrorIs(t, err, wantErr)
+					continue
+				}
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOutputFields_ListCredentialStores(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	vaultRepoFn := func() (*vault.Repository, error) {
+		return vault.NewRepository(ctx, rw, rw, kmsCache, scheduler.TestScheduler(t, conn, wrap))
+	}
+	staticRepoFn := func() (*static.Repository, error) {
+		return static.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	credStoreRepoFn := func() (*credential.StoreRepository, error) {
+		return credential.NewStoreRepository(context.Background(), rw, rw)
+	}
+	s, err := credentialstores.NewService(ctx, iamRepoFn, vaultRepoFn, staticRepoFn, credStoreRepoFn, 1000)
+	require.NoError(t, err)
+
+	org, staticProj := iam.TestScopes(t, iamRepo)
+	staticCredStore := static.TestCredentialStore(t, conn, wrap, staticProj.GetPublicId(), static.WithName("static"), static.WithDescription("static"))
+	vaultProj := iam.TestProject(t, iamRepo, org.GetPublicId())
+	randomId, _ := uuid.GenerateUUID()
+	vaultCredStore := vault.TestCredentialStore(t,
+		conn,
+		wrap,
+		vaultProj.PublicId,
+		fmt.Sprintf("http://vault%s", randomId),
+		randomId,
+		fmt.Sprintf("accessor-%s", randomId),
+		vault.WithName("vault"), vault.WithDescription("desc"), vault.WithCACert([]byte{1, 2, 3}), vault.WithWorkerFilter(`"worker" in "/tags/name`))
+
+	testcases := []struct {
+		name                string
+		userFunc            func() (*iam.User, authdomain.Account)
+		input               *pbs.ListCredentialStoresRequest
+		idToOutputFieldsMap map[string][]string // ID is always required in the output_fields
+	}{
+		{
+			name: "global role grants descendant applies output_fields correctly when recursively listing credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope,scope_id,name,description,authorized_actions,authorized_collection_actions"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			idToOutputFieldsMap: map[string][]string{
+				staticCredStore.PublicId: {
+					globals.IdField,
+					globals.ScopeField,
+					globals.ScopeIdField,
+					globals.NameField,
+					globals.DescriptionField,
+					globals.AuthorizedActionsField,
+					globals.AuthorizedCollectionActionsField,
+				},
+				vaultCredStore.PublicId: {
+					globals.IdField,
+					globals.ScopeField,
+					globals.ScopeIdField,
+					globals.NameField,
+					globals.DescriptionField,
+					globals.AuthorizedActionsField,
+					globals.AuthorizedCollectionActionsField,
+				},
+			},
+		},
+		{
+			name: "org role grants children applies output_fields correctly when recursively listing credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org.GetPublicId(),
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,created_time,updated_time,version,authorized_actions,authorized_collection_actions"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   org.GetPublicId(),
+				Recursive: true,
+			},
+			idToOutputFieldsMap: map[string][]string{
+				staticCredStore.PublicId: {
+					globals.IdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					globals.VersionField,
+					globals.AuthorizedActionsField,
+					globals.AuthorizedCollectionActionsField,
+				},
+				vaultCredStore.PublicId: {
+					globals.IdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					globals.VersionField,
+					globals.AuthorizedActionsField,
+					globals.AuthorizedCollectionActionsField,
+				},
+			},
+		},
+		{
+			name: "project role grants this applies output_fields correctly when listing credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: staticProj.GetPublicId(),
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,created_time,updated_time,version,authorized_actions,authorized_collection_actions"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId: staticProj.GetPublicId(),
+			},
+			idToOutputFieldsMap: map[string][]string{
+				staticCredStore.PublicId: {
+					globals.IdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					globals.VersionField,
+					globals.AuthorizedActionsField,
+					globals.AuthorizedCollectionActionsField,
+				},
+			},
+		},
+		{
+			name: "multiple role grants this applies output_fields correctly when listing credential stores across multiple scopes",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=credential-store;actions=list"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: staticProj.GetPublicId(),
+					Grants: []string{
+						"ids=*;type=*;actions=*;output_fields=id,created_time,updated_time,version,authorized_actions,authorized_collection_actions",
+					},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: vaultProj.GetPublicId(),
+					Grants: []string{
+						"ids=*;type=*;actions=*;output_fields=id,name,description,scope,scope_id,authorized_actions,authorized_collection_actions",
+					},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			idToOutputFieldsMap: map[string][]string{
+				staticCredStore.PublicId: {
+					globals.IdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					globals.VersionField,
+					globals.AuthorizedActionsField,
+					globals.AuthorizedCollectionActionsField,
+				},
+				vaultCredStore.PublicId: {
+					globals.IdField,
+					globals.NameField,
+					globals.DescriptionField,
+					globals.ScopeField,
+					globals.ScopeIdField,
+					globals.AuthorizedActionsField,
+					globals.AuthorizedCollectionActionsField,
+				},
+			},
+		},
+		{
+			name: "global role grants descendant applies attributes output_fields correctly for each given type",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants: []string{
+						"ids=*;type=*;actions=*;output_fields=id,type,attributes,authorized_actions,authorized_collection_actions",
+					},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			input: &pbs.ListCredentialStoresRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			idToOutputFieldsMap: map[string][]string{
+				staticCredStore.PublicId: {
+					globals.IdField,
+					globals.TypeField,
+					globals.AuthorizedActionsField,
+					globals.AuthorizedCollectionActionsField,
+				},
+				vaultCredStore.PublicId: {
+					globals.IdField,
+					globals.TypeField,
+					"vault_credential_store_attributes",
+					globals.AuthorizedActionsField,
+					globals.AuthorizedCollectionActionsField,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			got, err := s.ListCredentialStores(fullGrantAuthCtx, tc.input)
+			require.NoError(t, err)
+			require.Equalf(t, len(got.Items), len(tc.idToOutputFieldsMap), "returned items do not match the number of expected items")
+			for _, item := range got.Items {
+				fmt.Println(item.String())
+				wantFields, ok := tc.idToOutputFieldsMap[item.Id]
+				require.Truef(t, ok, "returned item %s does not exist in expect map", item.GetId())
+				handlers.TestAssertOutputFields(t, item, wantFields)
+			}
+		})
+	}
+}
+
+func TestOutputFields_GetCredentialStore(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	vaultRepoFn := func() (*vault.Repository, error) {
+		return vault.NewRepository(ctx, rw, rw, kmsCache, scheduler.TestScheduler(t, conn, wrap))
 	}
 	staticRepoFn := func() (*static.Repository, error) {
 		return static.NewRepository(ctx, rw, rw, kmsCache)
@@ -61,89 +1301,471 @@ func TestGrants_ReadActions(t *testing.T) {
 	require.NoError(t, err)
 
 	org, proj := iam.TestScopes(t, iamRepo)
+	staticCredStore := static.TestCredentialStore(t, conn, wrap, proj.GetPublicId(), static.WithName("static"), static.WithDescription("static"))
+	vaultProj := iam.TestProject(t, iamRepo, org.GetPublicId())
+	randomId, _ := uuid.GenerateUUID()
+	vaultCredStore := vault.TestCredentialStore(t,
+		conn,
+		wrap,
+		vaultProj.PublicId,
+		fmt.Sprintf("http://vault%s", randomId),
+		randomId,
+		fmt.Sprintf("accessor-%s", randomId),
+		vault.WithName("vault"), vault.WithDescription("desc"))
 
-	var wantStores []string
-	for _, s := range vault.TestCredentialStores(t, conn, wrap, proj.GetPublicId(), 5) {
-		wantStores = append(wantStores, s.GetPublicId())
+	testcases := []struct {
+		name           string
+		userFunc       func() (*iam.User, authdomain.Account)
+		input          *pbs.GetCredentialStoreRequest
+		expectedFields []string
+	}{
+		{
+			name: "global role grants descendant applies output_fields correctly when reading credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope,scope_id,name,description,authorized_actions,authorized_collection_actions"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			input: &pbs.GetCredentialStoreRequest{
+				Id: staticCredStore.PublicId,
+			},
+			expectedFields: []string{
+				globals.IdField,
+				globals.ScopeField,
+				globals.ScopeIdField,
+				globals.NameField,
+				globals.DescriptionField,
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
+			},
+		},
+		{
+			name: "org role grants descendant applies output_fields correctly when reading credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org.PublicId,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,version,attributes,authorized_actions,authorized_collection_actions"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			input: &pbs.GetCredentialStoreRequest{
+				Id: vaultCredStore.PublicId,
+			},
+			expectedFields: []string{
+				globals.IdField,
+				globals.VersionField,
+				"vault_credential_store_attributes",
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
+			},
+		},
+		{
+			name: "id specific grants descendant applies output_fields correctly",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants: []string{
+						fmt.Sprintf("id=%s;type=credential-store;actions=*;output_fields=id,created_time,updated_time,authorized_actions", vaultCredStore.PublicId),
+					},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			input: &pbs.GetCredentialStoreRequest{
+				Id: vaultCredStore.PublicId,
+			},
+			expectedFields: []string{
+				globals.IdField,
+				globals.CreatedTimeField,
+				globals.UpdatedTimeField,
+				globals.AuthorizedActionsField,
+			},
+		},
+		{
+			name: "id specific with composite grants pinned that allows collection actions applies output_fields correctly for credential library child resource",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants: []string{
+						fmt.Sprintf("id=%s;type=credential-store;actions=read;output_fields=id,authorized_actions,authorized_collection_actions", vaultCredStore.PublicId),
+						fmt.Sprintf("id=%s;type=credential-library;actions=create,list", vaultCredStore.PublicId), // without this grants, authorized_collection_actions won't be filled
+					},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			input: &pbs.GetCredentialStoreRequest{
+				Id: vaultCredStore.PublicId,
+			},
+			expectedFields: []string{
+				globals.IdField,
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
+			},
+		},
+		{
+			name: "id specific grants descendant applies output_fields correctly",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: vaultProj.PublicId,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=*"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			input: &pbs.GetCredentialStoreRequest{
+				Id: vaultCredStore.PublicId,
+			},
+			expectedFields: []string{
+				globals.IdField,
+				globals.ScopeIdField,
+				globals.ScopeField,
+				globals.VersionField,
+				globals.CreatedTimeField,
+				globals.UpdatedTimeField,
+				globals.TypeField,
+				globals.NameField,
+				globals.DescriptionField,
+				"vault_credential_store_attributes",
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
+			},
+		},
 	}
 
-	for _, s := range static.TestCredentialStores(t, conn, wrap, proj.GetPublicId(), 5) {
-		wantStores = append(wantStores, s.GetPublicId())
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			got, err := s.GetCredentialStore(fullGrantAuthCtx, tc.input)
+			require.NoError(t, err)
+			handlers.TestAssertOutputFields(t, got.Item, tc.expectedFields)
+		})
+	}
+}
+
+// TestOutputFields_CreateCredentialStore only covers type=vault credentials store
+// since the output_fields for Vault credential store is a superset of
+// the static credential store
+func TestOutputFields_CreateCredentialStore(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	vaultRepoFn := func() (*vault.Repository, error) {
+		return vault.NewRepository(ctx, rw, rw, kmsCache, scheduler.TestScheduler(t, conn, wrap))
+	}
+	staticRepoFn := func() (*static.Repository, error) {
+		return static.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	credStoreRepoFn := func() (*credential.StoreRepository, error) {
+		return credential.NewStoreRepository(context.Background(), rw, rw)
+	}
+	s, err := credentialstores.NewService(ctx, iamRepoFn, vaultRepoFn, staticRepoFn, credStoreRepoFn, 1000)
+	require.NoError(t, err)
+	v := vault.NewTestVaultServer(t, vault.WithTestVaultTLS(vault.TestClientTLS))
+
+	org, proj := iam.TestScopes(t, iamRepo)
+
+	vaultCredStoreInput := func() *pbs.CreateCredentialStoreRequest {
+		_, token := v.CreateToken(t)
+		id, _ := uuid.GenerateUUID()
+		return &pbs.CreateCredentialStoreRequest{
+			Item: &pb.CredentialStore{
+				ScopeId:     proj.PublicId,
+				Type:        vault.Subtype.String(),
+				Name:        wrapperspb.String(id),
+				Description: wrapperspb.String(id),
+				Attrs: &pb.CredentialStore_VaultCredentialStoreAttributes{
+					VaultCredentialStoreAttributes: &pb.VaultCredentialStoreAttributes{
+						Address:           wrapperspb.String(v.Addr),
+						Token:             wrapperspb.String(token),
+						CaCert:            wrapperspb.String(string(v.CaCert)),
+						ClientCertificate: wrapperspb.String(string(v.ClientCert) + string(v.ClientKey)),
+					},
+				},
+			},
+		}
 	}
 
-	t.Run("List", func(t *testing.T) {
-		testcases := []struct {
-			name          string
-			input         *pbs.ListCredentialStoresRequest
-			rolesToCreate []authtoken.TestRoleGrantsForToken
-			wantErr       error
-			wantIDs       []string
-		}{
-			{
-				name: "global role grant this returns all created credential stores",
-				input: &pbs.ListCredentialStoresRequest{
-					ScopeId:   globals.GlobalPrefix,
-					Recursive: true,
+	testcases := []struct {
+		name           string
+		userFunc       func() (*iam.User, authdomain.Account)
+		expectedFields []string
+	}{
+		{
+			name: "global role grants descendant applies output_fields correctly when reading credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope,scope_id,name,description,authorized_actions,authorized_collection_actions"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
-					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=credential-store;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
-					},
-				},
-				wantErr: nil,
-				wantIDs: wantStores,
+			}),
+			expectedFields: []string{
+				globals.IdField,
+				globals.ScopeField,
+				globals.ScopeIdField,
+				globals.NameField,
+				globals.DescriptionField,
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
 			},
-			{
-				name: "org role grant this returns all created credential stores",
-				input: &pbs.ListCredentialStoresRequest{
-					ScopeId:   org.GetPublicId(),
-					Recursive: true,
+		},
+		{
+			name: "org role grants descendant applies output_fields correctly when reading credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org.PublicId,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,version,attributes,authorized_actions,authorized_collection_actions"},
+					GrantScopes: []string{globals.GrantScopeChildren},
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
-					{
-						RoleScopeId:  org.PublicId,
-						GrantStrings: []string{"ids=*;type=credential-store;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
-					},
-				},
-				wantErr: nil,
-				wantIDs: wantStores,
+			}),
+			expectedFields: []string{
+				globals.IdField,
+				globals.VersionField,
+				"vault_credential_store_attributes",
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
 			},
-			{
-				name: "project role grant this returns all created credential stores",
-				input: &pbs.ListCredentialStoresRequest{
-					ScopeId: proj.GetPublicId(),
+		},
+		{
+			name: "org role grants descendant applies output_fields correctly when reading credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org.PublicId,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,version,attributes,authorized_actions,authorized_collection_actions"},
+					GrantScopes: []string{globals.GrantScopeChildren},
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
-					{
-						RoleScopeId:  proj.PublicId,
-						GrantStrings: []string{"ids=*;type=credential-store;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis},
-					},
-				},
-				wantErr: nil,
-				wantIDs: wantStores,
+			}),
+			expectedFields: []string{
+				globals.IdField,
+				globals.VersionField,
+				"vault_credential_store_attributes",
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
 			},
-		}
+		},
+		{
+			name: "not granting credential-library access does not return authorized_collection_actions",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org.PublicId,
+					Grants:      []string{"ids=*;type=credential-store;actions=*;output_fields=id,version,attributes,authorized_actions,authorized_collection_actions"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			expectedFields: []string{
+				globals.IdField,
+				globals.VersionField,
+				"vault_credential_store_attributes",
+				globals.AuthorizedActionsField,
+			},
+		},
+		{
+			name: "composite specific grants with credential-library access return authorized_collection_actions",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org.PublicId,
+					Grants: []string{
+						"ids=*;type=credential-store;actions=create,read;output_fields=id,version,attributes,authorized_actions,authorized_collection_actions",
+						"ids=*;type=credential-library;actions=create,list",
+					},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			expectedFields: []string{
+				globals.IdField,
+				globals.VersionField,
+				"vault_credential_store_attributes",
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
+			},
+		},
+		{
+			name: "id specific grants descendant applies output_fields correctly",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj.PublicId,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=*"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectedFields: []string{
+				globals.IdField,
+				globals.ScopeIdField,
+				globals.ScopeField,
+				globals.VersionField,
+				globals.CreatedTimeField,
+				globals.UpdatedTimeField,
+				globals.TypeField,
+				globals.NameField,
+				globals.DescriptionField,
+				"vault_credential_store_attributes",
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
+			},
+		},
+	}
 
-		for _, tc := range testcases {
-			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
-				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
-				got, finalErr := s.ListCredentialStores(fullGrantAuthCtx, tc.input)
-				if tc.wantErr != nil {
-					require.ErrorIs(t, finalErr, tc.wantErr)
-					return
-				}
-				require.NoError(t, finalErr)
-				var gotIDs []string
-				for _, g := range got.Items {
-					gotIDs = append(gotIDs, g.GetId())
-				}
-				require.ElementsMatch(t, tc.wantIDs, gotIDs)
-			})
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			got, err := s.CreateCredentialStore(fullGrantAuthCtx, vaultCredStoreInput())
+			require.NoError(t, err)
+			handlers.TestAssertOutputFields(t, got.Item, tc.expectedFields)
+		})
+	}
+}
+
+func TestOutputFields_UpdateCredentialStore(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	iamRepoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	vaultRepoFn := func() (*vault.Repository, error) {
+		return vault.NewRepository(ctx, rw, rw, kmsCache, scheduler.TestScheduler(t, conn, wrap))
+	}
+	staticRepoFn := func() (*static.Repository, error) {
+		return static.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	credStoreRepoFn := func() (*credential.StoreRepository, error) {
+		return credential.NewStoreRepository(context.Background(), rw, rw)
+	}
+	s, err := credentialstores.NewService(ctx, iamRepoFn, vaultRepoFn, staticRepoFn, credStoreRepoFn, 1000)
+	require.NoError(t, err)
+
+	org, proj := iam.TestScopes(t, iamRepo)
+	vaultCredStoreInput := func() *pbs.UpdateCredentialStoreRequest {
+		id, _ := uuid.GenerateUUID()
+		newId, _ := uuid.GenerateUUID()
+		store := vault.TestCredentialStore(t, conn, wrap, proj.PublicId, fmt.Sprintf("http://vault%s", id), id, fmt.Sprintf("accessor-%s", id))
+		return &pbs.UpdateCredentialStoreRequest{
+			Id: store.PublicId,
+			Item: &pb.CredentialStore{
+				Name:        &wrapperspb.StringValue{Value: newId},
+				Description: &wrapperspb.StringValue{Value: newId},
+				Version:     store.Version,
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"name", "description"},
+			},
 		}
-	})
+	}
+
+	testcases := []struct {
+		name           string
+		userFunc       func() (*iam.User, authdomain.Account)
+		expectedFields []string
+	}{
+		{
+			name: "global role grants descendant applies output_fields correctly when reading credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope,scope_id,name,description,attributes"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			expectedFields: []string{
+				globals.IdField,
+				globals.ScopeField,
+				globals.ScopeIdField,
+				globals.NameField,
+				"vault_credential_store_attributes",
+				globals.DescriptionField,
+			},
+		},
+		{
+			name: "org role grants descendant applies output_fields correctly when reading credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org.PublicId,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=version,type,created_time,updated_time,authorized_actions,authorized_collection_actions"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			expectedFields: []string{
+				globals.VersionField,
+				globals.CreatedTimeField,
+				globals.UpdatedTimeField,
+				globals.TypeField,
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
+			},
+		},
+		{
+			name: "org role grants descendant applies output_fields correctly when reading credential stores",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org.PublicId,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,version,attributes,authorized_actions,authorized_collection_actions"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			expectedFields: []string{
+				globals.IdField,
+				globals.VersionField,
+				"vault_credential_store_attributes",
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
+			},
+		},
+		{
+			name: "id specific grants descendant applies output_fields correctly",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj.PublicId,
+					Grants:      []string{"ids=*;type=*;actions=*;output_fields=*"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectedFields: []string{
+				globals.IdField,
+				globals.ScopeIdField,
+				globals.ScopeField,
+				globals.VersionField,
+				globals.CreatedTimeField,
+				globals.UpdatedTimeField,
+				globals.TypeField,
+				globals.NameField,
+				globals.DescriptionField,
+				"vault_credential_store_attributes",
+				globals.AuthorizedActionsField,
+				globals.AuthorizedCollectionActionsField,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			got, err := s.UpdateCredentialStore(fullGrantAuthCtx, vaultCredStoreInput())
+			require.NoError(t, err)
+			handlers.TestAssertOutputFields(t, got.Item, tc.expectedFields)
+		})
+	}
 }

--- a/internal/daemon/controller/handlers/groups/grants_test.go
+++ b/internal/daemon/controller/handlers/groups/grants_test.go
@@ -5,115 +5,2178 @@ package groups_test
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/auth"
+	"github.com/hashicorp/boundary/internal/auth/ldap"
+	"github.com/hashicorp/boundary/internal/auth/oidc"
+	"github.com/hashicorp/boundary/internal/auth/password"
 	"github.com/hashicorp/boundary/internal/authtoken"
-	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	cauth "github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/groups"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/groups"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-// TestGrants_ReadActions tests read actions to assert that grants are being applied properly
-//
-//	 Role - which scope the role is created in
-//			- global level
-//			- org level
-//			- project level
-//		Grant - what IAM grant scope is set for the permission
-//			- global: descendant
-//			- org: children
-//			- project
-//		Scopes [resource]:
-//			- global [globalGroup]
-//				- org1 [org1Group]
-//					- proj1 [proj1Group]
-//				- org2 [org2Group]
-//					- proj2 [proj2Group]
-//					- proj3 [proj3Group]
-func TestGrants_ReadActions(t *testing.T) {
+func TestGrants_ListGroups(t *testing.T) {
 	ctx := context.Background()
 	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
 	wrap := db.TestWrapper(t)
 	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
 	repoFn := func() (*iam.Repository, error) {
 		return iamRepo, nil
 	}
-	kmsCache := kms.TestKms(t, conn, wrap)
 	s, err := groups.NewService(ctx, repoFn, 1000)
 	require.NoError(t, err)
-	org1, _ := iam.TestScopes(t, iamRepo)
+	org1, proj1 := iam.TestScopes(t, iamRepo)
 	org2, proj2 := iam.TestScopes(t, iamRepo)
-	proj3 := iam.TestProject(t, iamRepo, org2.PublicId)
+	proj3 := iam.TestProject(t, iamRepo, org2.GetPublicId())
+
 	globalGroup := iam.TestGroup(t, conn, globals.GlobalPrefix, iam.WithDescription("global"), iam.WithName("global"))
 	org1Group := iam.TestGroup(t, conn, org1.GetPublicId(), iam.WithDescription("org1"), iam.WithName("org1"))
 	org2Group := iam.TestGroup(t, conn, org2.GetPublicId(), iam.WithDescription("org2"), iam.WithName("org2"))
-
+	proj1Group := iam.TestGroup(t, conn, proj1.GetPublicId(), iam.WithDescription("proj1"), iam.WithName("proj1"))
 	proj2Group := iam.TestGroup(t, conn, proj2.GetPublicId(), iam.WithDescription("proj2"), iam.WithName("proj2"))
 	proj3Group := iam.TestGroup(t, conn, proj3.GetPublicId(), iam.WithDescription("proj3"), iam.WithName("proj3"))
-
-	t.Run("List", func(t *testing.T) {
-		testcases := []struct {
-			name          string
-			input         *pbs.ListGroupsRequest
-			rolesToCreate []authtoken.TestRoleGrantsForToken
-			wantErr       error
-			wantIDs       []string
-		}{
-			{
-				name: "global role grant this and children returns global and org groups",
-				input: &pbs.ListGroupsRequest{
-					ScopeId:   globals.GlobalPrefix,
-					Recursive: true,
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
-					{
-						RoleScopeID:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=group;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
-					},
-				},
-				wantErr: nil,
-				wantIDs: []string{globalGroup.PublicId, org1Group.PublicId, org2Group.PublicId},
+	testcases := []struct {
+		name     string
+		input    *pbs.ListGroupsRequest
+		userFunc func() (*iam.User, auth.Account)
+		wantErr  error
+		wantIDs  []string
+	}{
+		{
+			name:    "global role grant this only returns in global groups",
+			wantErr: nil,
+			input: &pbs.ListGroupsRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
 			},
-			{
-				name: "org role grant this and children returns org and project groups",
-				input: &pbs.ListGroupsRequest{
-					ScopeId:   org2.PublicId,
-					Recursive: true,
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis},
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
-					{
-						RoleScopeID:  org2.PublicId,
-						GrantStrings: []string{"ids=*;type=group;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
-					},
-				},
-				wantErr: nil,
-				wantIDs: []string{org2Group.PublicId, proj2Group.PublicId, proj3Group.PublicId},
+			}),
+			wantIDs: []string{globalGroup.PublicId},
+		},
+		{
+			name: "global role grant this and children returns global and org groups",
+			input: &pbs.ListGroupsRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
 			},
-		}
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=list,read"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: []string{globalGroup.PublicId, org1Group.PublicId, org2Group.PublicId},
+		},
+		{
+			name: "global role grant via managed groups this and children returns org and proj groups",
+			input: &pbs.ListGroupsRequest{
+				ScopeId:   org1.PublicId,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org1.PublicId,
+					Grants:      []string{"ids=*;type=group;actions=list,read"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: []string{org1Group.PublicId, proj1Group.PublicId},
+		},
+		{
+			name: "global role grant this and descendant returns all groups",
+			input: &pbs.ListGroupsRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: []string{globalGroup.PublicId, org1Group.PublicId, org2Group.PublicId, proj1Group.PublicId, proj2Group.PublicId, proj3Group.PublicId},
+		},
+		{
+			name: "org role grant children IDs only org children",
+			input: &pbs.ListGroupsRequest{
+				ScopeId:   org2.PublicId,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: []string{org2Group.PublicId, proj2Group.PublicId, proj3Group.PublicId},
+		},
+		{
+			name: "LDAP org role grant children IDs only org children",
+			input: &pbs.ListGroupsRequest{
+				ScopeId:   org2.PublicId,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org2.PublicId,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: []string{org2Group.PublicId},
+		},
+		{
+			name: "no list permission returns error",
+			input: &pbs.ListGroupsRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants: []string{
+						fmt.Sprintf("ids=%s;types=group;actions=read", proj1Group.PublicId),
+					},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			wantErr: handlers.ForbiddenError(),
+			wantIDs: nil,
+		},
+		{
+			name: "global role scope specific grants only returns granted scopes",
+			input: &pbs.ListGroupsRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=read,list"},
+					GrantScopes: []string{proj1.PublicId, proj2.PublicId, proj3.PublicId},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=read,list"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			wantErr: nil,
+			wantIDs: []string{globalGroup.PublicId, proj1Group.PublicId, proj2Group.PublicId, proj3Group.PublicId},
+		},
+		{
+			name: "global role not granted group resources returns error",
+			input: &pbs.ListGroupsRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			},
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=target;actions=read,list"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			wantErr: handlers.ForbiddenError(),
+			wantIDs: nil,
+		},
+	}
 
-		for _, tc := range testcases {
-			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
-				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
-				got, finalErr := s.ListGroups(fullGrantAuthCtx, tc.input)
-				if tc.wantErr != nil {
-					require.ErrorIs(t, finalErr, tc.wantErr)
-					return
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			got, finalErr := s.ListGroups(fullGrantAuthCtx, tc.input)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, finalErr, tc.wantErr)
+				return
+			}
+			require.NoError(t, finalErr)
+			var gotIDs []string
+			for _, g := range got.Items {
+				gotIDs = append(gotIDs, g.GetId())
+			}
+			require.ElementsMatch(t, tc.wantIDs, gotIDs)
+		})
+	}
+}
+
+func TestGrants_GetGroup(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+	org1, proj1 := iam.TestScopes(t, iamRepo)
+	org2, proj2 := iam.TestScopes(t, iamRepo)
+
+	globalGroup := iam.TestGroup(t, conn, globals.GlobalPrefix, iam.WithDescription("global"), iam.WithName("global"))
+	org1Group := iam.TestGroup(t, conn, org1.GetPublicId(), iam.WithDescription("org1"), iam.WithName("org1"))
+	org2Group := iam.TestGroup(t, conn, org2.GetPublicId(), iam.WithDescription("org2"), iam.WithName("org2"))
+	proj1Group := iam.TestGroup(t, conn, proj1.GetPublicId(), iam.WithDescription("proj1"), iam.WithName("proj1"))
+	proj2Group := iam.TestGroup(t, conn, proj2.GetPublicId(), iam.WithDescription("proj2"), iam.WithName("proj2"))
+
+	testcases := []struct {
+		name            string
+		userFunc        func() (*iam.User, auth.Account)
+		inputWantErrMap map[*pbs.GetGroupRequest]error
+	}{
+		{
+			name: "global role group grant this scope with all permissions",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: nil,
+				{Id: org1Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj1Group.PublicId}:  handlers.ForbiddenError(),
+				{Id: org2Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj2Group.PublicId}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "global role group grant this scope with all permissions",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: nil,
+				{Id: org1Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj1Group.PublicId}:  handlers.ForbiddenError(),
+				{Id: org2Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj2Group.PublicId}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "global role grant children scopes with all permissions",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: handlers.ForbiddenError(),
+				{Id: org1Group.PublicId}:   nil,
+				{Id: proj1Group.PublicId}:  handlers.ForbiddenError(),
+				{Id: org2Group.PublicId}:   nil,
+				{Id: proj2Group.PublicId}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "global role grant descendant scopes with all permissions",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeDescendants},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: handlers.ForbiddenError(),
+				{Id: org1Group.PublicId}:   nil,
+				{Id: proj1Group.PublicId}:  nil,
+				{Id: org2Group.PublicId}:   nil,
+				{Id: proj2Group.PublicId}:  nil,
+			},
+		},
+		{
+			name: "global role grant this and children scopes with all permissions",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: nil,
+				{Id: org1Group.PublicId}:   nil,
+				{Id: proj1Group.PublicId}:  handlers.ForbiddenError(),
+				{Id: org2Group.PublicId}:   nil,
+				{Id: proj2Group.PublicId}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "global role grant this and descendant scopes with all permissions",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: nil,
+				{Id: org1Group.PublicId}:   nil,
+				{Id: proj1Group.PublicId}:  nil,
+				{Id: org2Group.PublicId}:   nil,
+				{Id: proj2Group.PublicId}:  nil,
+			},
+		},
+		{
+			name: "org1 role grant this scope with all permissions",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org1.GetPublicId(),
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: handlers.ForbiddenError(),
+				{Id: org1Group.PublicId}:   nil,
+				{Id: proj1Group.PublicId}:  handlers.ForbiddenError(),
+				{Id: org2Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj2Group.PublicId}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "org1 role grant children scope with all permissions",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org1.GetPublicId(),
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: handlers.ForbiddenError(),
+				{Id: org1Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj1Group.PublicId}:  nil,
+				{Id: org2Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj2Group.PublicId}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "org1 role grant this and children scopes with all permissions",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: org1.GetPublicId(),
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: handlers.ForbiddenError(),
+				{Id: org1Group.PublicId}:   nil,
+				{Id: proj1Group.PublicId}:  nil,
+				{Id: org2Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj2Group.PublicId}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "proj1 role grant this scope with all permissions",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: proj1.GetPublicId(),
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: handlers.ForbiddenError(),
+				{Id: org1Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj1Group.PublicId}:  nil,
+				{Id: org2Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj2Group.PublicId}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "global role grant this and descendant scope with read permissions on specific group",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{fmt.Sprintf("ids=%s;types=group ;actions=read", org1Group.PublicId)},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: handlers.ForbiddenError(),
+				{Id: org1Group.PublicId}:   nil,
+				{Id: proj1Group.PublicId}:  handlers.ForbiddenError(),
+				{Id: org2Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj2Group.PublicId}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "global role grant this and specific scopes with read permissions on specific group",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants: []string{
+						fmt.Sprintf("ids=%s;types=group;actions=read", org1Group.PublicId),
+						fmt.Sprintf("ids=%s;types=group;actions=read", proj1Group.PublicId),
+					},
+					GrantScopes: []string{org1.PublicId, proj1.PublicId},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: handlers.ForbiddenError(),
+				{Id: org1Group.PublicId}:   nil,
+				{Id: proj1Group.PublicId}:  nil,
+				{Id: org2Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj2Group.PublicId}:  handlers.ForbiddenError(),
+			},
+		},
+		{
+			name: "union multiple role grant specific resources permissions",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants: []string{
+						fmt.Sprintf("ids=%s;types=group;actions=read", globalGroup.PublicId),
+					},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: org1.GetPublicId(),
+					Grants: []string{
+						fmt.Sprintf("ids=%s;types=group;actions=read", org1Group.PublicId),
+						fmt.Sprintf("ids=%s;types=group;actions=read", proj1Group.PublicId),
+					},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+				},
+			}),
+			inputWantErrMap: map[*pbs.GetGroupRequest]error{
+				{Id: globalGroup.PublicId}: nil,
+				{Id: org1Group.PublicId}:   nil,
+				{Id: proj1Group.PublicId}:  nil,
+				{Id: org2Group.PublicId}:   handlers.ForbiddenError(),
+				{Id: proj2Group.PublicId}:  handlers.ForbiddenError(),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for input, wantErr := range tc.inputWantErrMap {
+				_, err := s.GetGroup(fullGrantAuthCtx, input)
+				// not found means expect error
+				if wantErr != nil {
+					require.ErrorIs(t, err, wantErr)
+					continue
 				}
-				require.NoError(t, finalErr)
-				var gotIDs []string
-				for _, g := range got.Items {
-					gotIDs = append(gotIDs, g.GetId())
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGrants_CreateGroup(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+
+	org1, proj1 := iam.TestScopes(t, iamRepo)
+	org2, proj2 := iam.TestScopes(t, iamRepo)
+	proj3 := iam.TestProject(t, iamRepo, org2.GetPublicId())
+
+	testcases := []struct {
+		name              string
+		userFunc          func() (*iam.User, auth.Account)
+		canCreateInScopes map[*pbs.CreateGroupRequest]error
+	}{
+		{
+			name: "direct grant all can create all",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			canCreateInScopes: map[*pbs.CreateGroupRequest]error{
+				{Item: &pb.Group{ScopeId: globals.GlobalPrefix}}: nil,
+				{Item: &pb.Group{ScopeId: org1.PublicId}}:        nil,
+				{Item: &pb.Group{ScopeId: org2.PublicId}}:        nil,
+				{Item: &pb.Group{ScopeId: proj1.PublicId}}:       nil,
+				{Item: &pb.Group{ScopeId: proj2.PublicId}}:       nil,
+				{Item: &pb.Group{ScopeId: proj3.PublicId}}:       nil,
+			},
+		},
+		{
+			name: "groups grant all can create all",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			canCreateInScopes: map[*pbs.CreateGroupRequest]error{
+				{Item: &pb.Group{ScopeId: globals.GlobalPrefix}}: nil,
+				{Item: &pb.Group{ScopeId: org1.PublicId}}:        nil,
+				{Item: &pb.Group{ScopeId: org2.PublicId}}:        nil,
+				{Item: &pb.Group{ScopeId: proj1.PublicId}}:       nil,
+				{Item: &pb.Group{ScopeId: proj2.PublicId}}:       nil,
+				{Item: &pb.Group{ScopeId: proj3.PublicId}}:       nil,
+			},
+		},
+		{
+			name: "ldap grant all can create all",
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			canCreateInScopes: map[*pbs.CreateGroupRequest]error{
+				{Item: &pb.Group{ScopeId: globals.GlobalPrefix}}: nil,
+				{Item: &pb.Group{ScopeId: org1.PublicId}}:        nil,
+				{Item: &pb.Group{ScopeId: org2.PublicId}}:        nil,
+				{Item: &pb.Group{ScopeId: proj1.PublicId}}:       nil,
+				{Item: &pb.Group{ScopeId: proj2.PublicId}}:       nil,
+				{Item: &pb.Group{ScopeId: proj3.PublicId}}:       nil,
+			},
+		},
+		{
+			name: "oidc grant all can create all",
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			canCreateInScopes: map[*pbs.CreateGroupRequest]error{
+				{Item: &pb.Group{ScopeId: globals.GlobalPrefix}}: nil,
+				{Item: &pb.Group{ScopeId: org1.PublicId}}:        nil,
+				{Item: &pb.Group{ScopeId: org2.PublicId}}:        nil,
+				{Item: &pb.Group{ScopeId: proj1.PublicId}}:       nil,
+				{Item: &pb.Group{ScopeId: proj2.PublicId}}:       nil,
+				{Item: &pb.Group{ScopeId: proj3.PublicId}}:       nil,
+			},
+		},
+		{
+			name: "grant children can only create in orgs",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			canCreateInScopes: map[*pbs.CreateGroupRequest]error{
+				{Item: &pb.Group{ScopeId: globals.GlobalPrefix}}: handlers.ForbiddenError(),
+				{Item: &pb.Group{ScopeId: org1.PublicId}}:        nil,
+				{Item: &pb.Group{ScopeId: org2.PublicId}}:        nil,
+				{Item: &pb.Group{ScopeId: proj1.PublicId}}:       handlers.ForbiddenError(),
+				{Item: &pb.Group{ScopeId: proj2.PublicId}}:       handlers.ForbiddenError(),
+				{Item: &pb.Group{ScopeId: proj3.PublicId}}:       handlers.ForbiddenError(),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+			for req, wantErr := range tc.canCreateInScopes {
+				_, err := s.CreateGroup(fullGrantAuthCtx, req)
+				if wantErr != nil {
+					require.ErrorIs(t, err, wantErr)
+					continue
 				}
-				require.ElementsMatch(t, tc.wantIDs, gotIDs)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGrants_DeleteGroup(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+
+	org1, proj1 := iam.TestScopes(t, iamRepo)
+	org2, proj2 := iam.TestScopes(t, iamRepo)
+	proj3 := iam.TestProject(t, iamRepo, org2.GetPublicId())
+
+	allScopeIds := []string{globals.GlobalPrefix, org1.PublicId, org2.PublicId, proj1.PublicId, proj2.PublicId, proj3.PublicId}
+	testcases := []struct {
+		name                    string
+		userFunc                func() (*iam.User, auth.Account)
+		deleteAllowedAtScopeIds []string
+	}{
+		{
+			name: "grant all can delete all",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			deleteAllowedAtScopeIds: allScopeIds,
+		},
+		{
+			name: "grant children can only delete in orgs",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=*;actions=*"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+			}),
+			deleteAllowedAtScopeIds: []string{org1.PublicId, org2.PublicId},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// setup a map to track which scope correlates to a group
+			scopeIdGroupMap := map[string]*iam.Group{}
+			for _, scp := range allScopeIds {
+				g := iam.TestGroup(t, conn, scp)
+				scopeIdGroupMap[scp] = g
+			}
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for scope, group := range scopeIdGroupMap {
+				_, err = s.DeleteGroup(fullGrantAuthCtx, &pbs.DeleteGroupRequest{Id: group.PublicId})
+				if !slices.Contains(tc.deleteAllowedAtScopeIds, scope) {
+					require.ErrorIs(t, err, handlers.ForbiddenError())
+					continue
+				}
+				require.NoErrorf(t, err, "failed to delete group in scope %s", scope)
+			}
+		})
+	}
+}
+
+func TestGrants_UpdateGroup(t *testing.T) {
+	testcases := []struct {
+		name                        string
+		setupScopesResourcesAndUser func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*iam.Group, func() (*iam.User, auth.Account))
+		wantErr                     error
+	}{
+		{
+			name: "global_scope_group_good_grant_success",
+			setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*iam.Group, func() (*iam.User, auth.Account)) {
+				g := iam.TestGroup(t, conn, globals.GlobalPrefix)
+				return g, iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			wantErr: nil,
+		},
+		{
+			name: "grant specific scope success",
+			setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*iam.Group, func() (*iam.User, auth.Account)) {
+				_, proj := iam.TestScopes(t, iamRepo)
+				g := iam.TestGroup(t, conn, proj.PublicId)
+				return g, iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{proj.PublicId},
+					},
+				})
+			},
+			wantErr: nil,
+		},
+		{
+			name: "grant specific resource and scope success",
+			setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*iam.Group, func() (*iam.User, auth.Account)) {
+				_, proj := iam.TestScopes(t, iamRepo)
+				g := iam.TestGroup(t, conn, proj.PublicId)
+				return g, iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;types=group;actions=*", g.PublicId)},
+						GrantScopes: []string{proj.PublicId},
+					},
+				})
+			},
+			wantErr: nil,
+		},
+		{
+			name: "no grant fails update",
+			setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*iam.Group, func() (*iam.User, auth.Account)) {
+				g := iam.TestGroup(t, conn, globals.GlobalPrefix)
+				return g, iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})
+			},
+			wantErr: handlers.ForbiddenError(),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			conn, _ := db.TestSetup(t, "postgres")
+			rw := db.New(conn)
+			wrap := db.TestWrapper(t)
+			iamRepo := iam.TestRepo(t, conn, wrap)
+			kmsCache := kms.TestKms(t, conn, wrap)
+			atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+			require.NoError(t, err)
+			repoFn := func() (*iam.Repository, error) {
+				return iamRepo, nil
+			}
+			s, err := groups.NewService(ctx, repoFn, 1000)
+			require.NoError(t, err)
+			original, userFunc := tc.setupScopesResourcesAndUser(t, conn, iamRepo, kmsCache)
+			user, account := userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			got, err := s.UpdateGroup(fullGrantAuthCtx, &pbs.UpdateGroupRequest{
+				Id: original.PublicId,
+				Item: &pb.Group{
+					Name:        &wrapperspb.StringValue{Value: "new-name"},
+					Description: &wrapperspb.StringValue{Value: "new-description"},
+					Version:     1,
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"name", "description"},
+				},
 			})
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, uint32(2), got.Item.Version)
+			require.True(t, got.Item.UpdatedTime.AsTime().After(original.UpdateTime.AsTime()))
+		})
+	}
+}
+
+func TestGrants_GroupMembership(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+
+	org1, _ := iam.TestScopes(t, iamRepo)
+	org2, proj2 := iam.TestScopes(t, iamRepo)
+	proj3 := iam.TestProject(t, iamRepo, org2.GetPublicId())
+
+	globalUsers := []*iam.User{iam.TestUser(t, iamRepo, globals.GlobalPrefix), iam.TestUser(t, iamRepo, globals.GlobalPrefix)}
+	org1Users := []*iam.User{iam.TestUser(t, iamRepo, org1.PublicId), iam.TestUser(t, iamRepo, org1.PublicId)}
+	org2Users := []*iam.User{iam.TestUser(t, iamRepo, org2.PublicId), iam.TestUser(t, iamRepo, org2.PublicId)}
+
+	type groupGetter interface {
+		GetItem() *pb.Group
+	}
+
+	type testActionResult struct {
+		action  func(context.Context, *iam.Group) (groupGetter, error)
+		wantErr error
+	}
+
+	testcases := []struct {
+		name              string
+		userFunc          func() *iam.User
+		setupGroupAndRole func(t *testing.T) (*iam.Group, func() (*iam.User, auth.Account))
+		// collection of actions to be executed in the tests in order, *iam.Group returned from each action which
+		// gets passed to the next action as parameter to preserve information such as `version` increments
+		actions []testActionResult
+	}{
+		{
+			name: "all actions valid grant success",
+
+			setupGroupAndRole: func(t *testing.T) (*iam.Group, func() (*iam.User, auth.Account)) {
+				group := iam.TestGroup(t, conn, globals.GlobalPrefix)
+				return group, iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			actions: []testActionResult{
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.AddGroupMembers(authCtx, &pbs.AddGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(org1Users),
+						})
+						return out, err
+					},
+					wantErr: nil,
+				},
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.SetGroupMembers(authCtx, &pbs.SetGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(globalUsers),
+						})
+						return out, err
+					},
+					wantErr: nil,
+				},
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.RemoveGroupMembers(authCtx, &pbs.RemoveGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(globalUsers),
+						})
+						return out, err
+					},
+					wantErr: nil,
+				},
+			},
+		},
+		{
+			name: "only add and set allowed fail to remove",
+			setupGroupAndRole: func(t *testing.T) (*iam.Group, func() (*iam.User, auth.Account)) {
+				group := iam.TestGroup(t, conn, org1.PublicId)
+				return group, iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=add-members"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: org1.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=set-members"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			actions: []testActionResult{
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.AddGroupMembers(authCtx, &pbs.AddGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(org1Users),
+						})
+						return out, err
+					},
+					wantErr: nil,
+				},
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.SetGroupMembers(authCtx, &pbs.SetGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(org1Users),
+						})
+						return out, err
+					},
+					wantErr: nil,
+				},
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.RemoveGroupMembers(authCtx, &pbs.RemoveGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(org1Users),
+						})
+						return out, err
+					},
+					wantErr: handlers.ForbiddenError(),
+				},
+			},
+		},
+		{
+			name: "add_member_valid_specific_grant_success",
+			setupGroupAndRole: func(t *testing.T) (*iam.Group, func() (*iam.User, auth.Account)) {
+				group := iam.TestGroup(t, conn, org2.PublicId)
+				return group, iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org2.PublicId,
+						Grants:      []string{fmt.Sprintf("ids=%s;types=group;actions=add-members", group.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			actions: []testActionResult{
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.AddGroupMembers(authCtx, &pbs.AddGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(org2Users),
+						})
+						return out, err
+					},
+					wantErr: nil,
+				},
+			},
+		},
+		{
+			name: "remove_member_valid_specific_grant_success",
+			setupGroupAndRole: func(t *testing.T) (*iam.Group, func() (*iam.User, auth.Account)) {
+				group := iam.TestGroup(t, conn, proj2.PublicId)
+				iam.TestGroupMember(t, conn, group.PublicId, org2Users[0].PublicId)
+				iam.TestGroupMember(t, conn, group.PublicId, org2Users[1].PublicId)
+				return group, iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;types=group;actions=remove-members", group.PublicId)},
+						GrantScopes: []string{proj2.PublicId},
+					},
+				})
+			},
+			actions: []testActionResult{
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.RemoveGroupMembers(authCtx, &pbs.RemoveGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(org2Users),
+						})
+						return out, err
+					},
+					wantErr: nil,
+				},
+			},
+		},
+		{
+			name: "cross_scope_add_member_valid_specific_grant_success",
+			setupGroupAndRole: func(t *testing.T) (*iam.Group, func() (*iam.User, auth.Account)) {
+				group := iam.TestGroup(t, conn, proj3.PublicId)
+				return group, iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;types=group;actions=add-members", group.PublicId)},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				})
+			},
+			actions: []testActionResult{
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						users := userIDs(org1Users)
+						users = append(users, userIDs(org2Users)...)
+						out, err := s.AddGroupMembers(authCtx, &pbs.AddGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: users,
+						})
+						return out, err
+					},
+					wantErr: nil,
+				},
+			},
+		},
+		{
+			name: "add_member_with_valid_grant_string_invalid_scope_forbidden_error",
+			setupGroupAndRole: func(t *testing.T) (*iam.Group, func() (*iam.User, auth.Account)) {
+				group := iam.TestGroup(t, conn, org2.PublicId)
+				return group, iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})
+			},
+			actions: []testActionResult{
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.AddGroupMembers(authCtx, &pbs.AddGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(org2Users),
+						})
+						return out, err
+					},
+					wantErr: handlers.ForbiddenError(),
+				},
+			},
+		},
+		{
+			name: "multiple_grants_success",
+			setupGroupAndRole: func(t *testing.T) (*iam.Group, func() (*iam.User, auth.Account)) {
+				group := iam.TestGroup(t, conn, proj2.PublicId)
+				return group, iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj2.PublicId,
+						Grants:      []string{fmt.Sprintf("ids=%s;types=group;actions=add-members", group.PublicId)},
+						GrantScopes: []string{proj2.PublicId},
+					},
+					{
+						RoleScopeId: proj2.PublicId,
+						Grants:      []string{fmt.Sprintf("ids=%s;types=group;actions=set-members", group.PublicId)},
+						GrantScopes: []string{proj2.PublicId},
+					},
+					{
+						RoleScopeId: proj2.PublicId,
+						Grants:      []string{fmt.Sprintf("ids=%s;types=group;actions=remove-members", group.PublicId)},
+						GrantScopes: []string{proj2.PublicId},
+					},
+				})
+			},
+			actions: []testActionResult{
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.AddGroupMembers(authCtx, &pbs.AddGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(org2Users),
+						})
+						return out, err
+					},
+					wantErr: nil,
+				},
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.SetGroupMembers(authCtx, &pbs.SetGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(org2Users),
+						})
+						return out, err
+					},
+					wantErr: nil,
+				},
+				{
+					action: func(authCtx context.Context, g *iam.Group) (groupGetter, error) {
+						out, err := s.RemoveGroupMembers(authCtx, &pbs.RemoveGroupMembersRequest{
+							Id:        g.PublicId,
+							Version:   g.Version,
+							MemberIds: userIDs(org2Users),
+						})
+						return out, err
+					},
+					wantErr: nil,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			group, userFn := tc.setupGroupAndRole(t)
+			user, account := userFn()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			for _, act := range tc.actions {
+				out, err := act.action(fullGrantAuthCtx, group)
+				if act.wantErr != nil {
+					require.Error(t, err)
+					require.ErrorIs(t, err, act.wantErr)
+					continue
+				}
+				require.NoError(t, err)
+				// set version for future updates
+				group.Version = out.GetItem().Version
+			}
+		})
+	}
+}
+
+func TestOutputFields_ListGroups(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+
+	globalGroup := iam.TestGroup(t, conn, globals.GlobalPrefix, iam.WithDescription("global"), iam.WithName("global"))
+
+	org, proj := iam.TestScopes(t, iamRepo)
+	orgGroup := iam.TestGroup(t, conn, org.PublicId, iam.WithDescription("org"), iam.WithName("org"))
+	projGroup := iam.TestGroup(t, conn, proj.PublicId, iam.WithDescription("proj"), iam.WithName("proj"))
+
+	globalUser := iam.TestUser(t, iamRepo, globals.GlobalPrefix)
+	orgUser := iam.TestUser(t, iamRepo, globals.GlobalPrefix)
+	projectUser := iam.TestUser(t, iamRepo, globals.GlobalPrefix)
+
+	_ = iam.TestGroupMember(t, conn, globalGroup.PublicId, globalUser.PublicId)
+	_ = iam.TestGroupMember(t, conn, orgGroup.PublicId, orgUser.PublicId)
+	_ = iam.TestGroupMember(t, conn, projGroup.PublicId, projectUser.PublicId)
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+	testcases := []struct {
+		name     string
+		userFunc func() (*iam.User, auth.Account)
+		// keys are the group IDs | this also means 'id' is required in the outputfields for assertions to work properly
+		expectOutfields map[string][]string
+	}{
+		{
+			name: "grants name, version, description",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id,name,description"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			expectOutfields: map[string][]string{
+				globalGroup.PublicId: {globals.IdField, globals.NameField, globals.DescriptionField},
+				orgGroup.PublicId:    {globals.IdField, globals.NameField, globals.DescriptionField},
+				projGroup.PublicId:   {globals.IdField, globals.NameField, globals.DescriptionField},
+			},
+		},
+		{
+			name: "grants scope, scopeId, authorized_actions",
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id,scope,scope_id,authorized_actions"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			expectOutfields: map[string][]string{
+				globalGroup.PublicId: {globals.IdField, globals.ScopeField, globals.ScopeIdField, globals.AuthorizedActionsField},
+				orgGroup.PublicId:    {globals.IdField, globals.ScopeField, globals.ScopeIdField, globals.AuthorizedActionsField},
+				projGroup.PublicId:   {globals.IdField, globals.ScopeField, globals.ScopeIdField, globals.AuthorizedActionsField},
+			},
+		},
+		{
+			name: "grants update_time, create_time",
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id,updated_time,created_time,members,member_ids"},
+					GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+				},
+			}),
+			expectOutfields: map[string][]string{
+				globalGroup.PublicId: {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				orgGroup.PublicId:    {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				projGroup.PublicId:   {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+			},
+		},
+		{
+			name: "different output_fields for different scope",
+			userFunc: iam.TestUserDirectGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id,name,description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id,scope,scope_id,created_time,updated_time"},
+					GrantScopes: []string{globals.GrantScopeChildren},
+				},
+				{
+					RoleScopeId: proj.PublicId,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id,authorized_actions"},
+					GrantScopes: []string{proj.PublicId},
+				},
+			}),
+			expectOutfields: map[string][]string{
+				globalGroup.PublicId: {globals.IdField, globals.NameField, globals.DescriptionField},
+				orgGroup.PublicId:    {globals.IdField, globals.ScopeField, globals.ScopeIdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				projGroup.PublicId:   {globals.IdField, globals.AuthorizedActionsField},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			out, err := s.ListGroups(fullGrantAuthCtx, &pbs.ListGroupsRequest{
+				ScopeId:   globals.GlobalPrefix,
+				Recursive: true,
+			})
+			require.NoError(t, err)
+			for _, item := range out.Items {
+				handlers.TestAssertOutputFields(t, item, tc.expectOutfields[item.Id])
+			}
+		})
+	}
+}
+
+func TestOutputFields_GetGroup(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	globalGroupWithMember := iam.TestGroup(t, conn, globals.GlobalPrefix, iam.WithDescription("global"), iam.WithName("global"))
+	u := iam.TestUser(t, iamRepo, globals.GlobalPrefix)
+	_ = iam.TestGroupMember(t, conn, globalGroupWithMember.PublicId, u.PublicId)
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name            string
+		userFunc        func() (*iam.User, auth.Account)
+		expectOutfields []string
+	}{
+		{
+			name: "grants name and description",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=read;output_fields=name,description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.NameField, globals.DescriptionField},
+		},
+		{
+			name: "grants scope and scopeId",
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=read;output_fields=scope,scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.ScopeField, globals.ScopeIdField},
+		},
+		{
+			name: "grants update_time and create_time",
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=read;output_fields=updated_time,created_time"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.UpdatedTimeField, globals.CreatedTimeField},
+		},
+		{
+			name: "grants id, authorized_actions, version",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=read;output_fields=id,authorized_actions,version"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.IdField, globals.AuthorizedActionsField, globals.VersionField},
+		},
+		{
+			name: "grants members, member_id",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=read;output_fields=members,member_ids"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.MembersField, globals.MemberIdsField},
+		},
+		{
+			name: "composite grants id, authorized_actions, member_ids",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=read;output_fields=id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=read;output_fields=member_ids"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=read;output_fields=authorized_actions"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.IdField, globals.MemberIdsField, globals.AuthorizedActionsField},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			out, err := s.GetGroup(fullGrantAuthCtx, &pbs.GetGroupRequest{Id: globalGroupWithMember.PublicId})
+			require.NoError(t, err)
+			handlers.TestAssertOutputFields(t, out.Item, tc.expectOutfields)
+		})
+	}
+}
+
+func TestOutputFields_CreateGroup(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	genUuid := func() string {
+		u, _ := uuid.GenerateUUID()
+		return u
+	}
+
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+	testcases := []struct {
+		name            string
+		userFunc        func() (*iam.User, auth.Account)
+		input           *pbs.CreateGroupRequest
+		expectOutfields []string
+	}{
+		{
+			name: "grants name and description",
+			input: &pbs.CreateGroupRequest{
+				Item: &pb.Group{
+					Name:        &wrapperspb.StringValue{Value: genUuid()},
+					Description: &wrapperspb.StringValue{Value: genUuid()},
+					ScopeId:     globals.GlobalPrefix,
+				},
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=name,description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.NameField, globals.DescriptionField},
+		},
+		{
+			name: "grants scope and scopeId",
+			input: &pbs.CreateGroupRequest{
+				Item: &pb.Group{
+					Name:        &wrapperspb.StringValue{Value: genUuid()},
+					Description: &wrapperspb.StringValue{Value: genUuid()},
+					ScopeId:     globals.GlobalPrefix,
+				},
+			},
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope,scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.ScopeField, globals.ScopeIdField},
+		},
+		{
+			name: "grants update_time and create_time",
+			input: &pbs.CreateGroupRequest{
+				Item: &pb.Group{
+					Name:        &wrapperspb.StringValue{Value: genUuid()},
+					Description: &wrapperspb.StringValue{Value: genUuid()},
+					ScopeId:     globals.GlobalPrefix,
+				},
+			},
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=updated_time,created_time"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.UpdatedTimeField, globals.CreatedTimeField},
+		},
+		{
+			name: "grants id, authorized_actions, version",
+			input: &pbs.CreateGroupRequest{
+				Item: &pb.Group{
+					Name:        &wrapperspb.StringValue{Value: genUuid()},
+					Description: &wrapperspb.StringValue{Value: genUuid()},
+					ScopeId:     globals.GlobalPrefix,
+				},
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id,authorized_actions,version"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.IdField, globals.AuthorizedActionsField, globals.VersionField},
+		},
+		{
+			name: "composite grants all fields",
+			input: &pbs.CreateGroupRequest{
+				Item: &pb.Group{
+					Name:        &wrapperspb.StringValue{Value: genUuid()},
+					Description: &wrapperspb.StringValue{Value: genUuid()},
+					ScopeId:     globals.GlobalPrefix,
+				},
+			},
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=name"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=created_time"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=authorized_actions"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=version"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{
+				globals.IdField,
+				globals.ScopeField,
+				globals.ScopeIdField,
+				globals.NameField,
+				globals.DescriptionField,
+				globals.CreatedTimeField,
+				globals.AuthorizedActionsField,
+				globals.VersionField,
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			out, err := s.CreateGroup(fullGrantAuthCtx, tc.input)
+			require.NoError(t, err)
+			handlers.TestAssertOutputFields(t, out.Item, tc.expectOutfields)
+		})
+	}
+}
+
+func TestOutputFields_UpdateGroup(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+
+	// this can be used across test cases because we're only testing for output fields, not the update behaviors
+	inputFunc := func(t *testing.T) *pbs.UpdateGroupRequest {
+		name, _ := uuid.GenerateUUID()
+		desc, _ := uuid.GenerateUUID()
+		globalGroupWithMember := iam.TestGroup(t, conn, globals.GlobalPrefix, iam.WithDescription("global"), iam.WithName("global"))
+		u := iam.TestUser(t, iamRepo, globals.GlobalPrefix)
+		_ = iam.TestGroupMember(t, conn, globalGroupWithMember.PublicId, u.PublicId)
+		return &pbs.UpdateGroupRequest{
+			Id: globalGroupWithMember.PublicId,
+			Item: &pb.Group{
+				Name:        &wrapperspb.StringValue{Value: name},
+				Description: &wrapperspb.StringValue{Value: desc},
+				Version:     globalGroupWithMember.Version,
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"name", "description"},
+			},
 		}
-	})
+	}
+
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+	testcases := []struct {
+		name            string
+		userFunc        func() (*iam.User, auth.Account)
+		expectOutfields []string
+	}{
+		{
+			name: "grants name and description",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=name,description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.NameField, globals.DescriptionField},
+		},
+		{
+			name: "grants scope and scopeId",
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope,scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.ScopeField, globals.ScopeIdField},
+		},
+		{
+			name: "grants update_time and create_time",
+
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=updated_time,created_time"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.UpdatedTimeField, globals.CreatedTimeField},
+		},
+		{
+			name: "grants id, authorized_actions, version",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id,authorized_actions,version"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.IdField, globals.AuthorizedActionsField, globals.VersionField},
+		},
+		{
+			name: "composite grants all fields",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=name"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=created_time"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=authorized_actions"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=version"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{
+				globals.IdField,
+				globals.ScopeField,
+				globals.ScopeIdField,
+				globals.NameField,
+				globals.DescriptionField,
+				globals.CreatedTimeField,
+				globals.AuthorizedActionsField,
+				globals.VersionField,
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			out, err := s.UpdateGroup(fullGrantAuthCtx, inputFunc(t))
+			require.NoError(t, err)
+			handlers.TestAssertOutputFields(t, out.Item, tc.expectOutfields)
+		})
+	}
+}
+
+func TestOutputFields_AddGroupMembers(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+
+	// this can be used across test cases because we're only testing for output fields, not the update behaviors
+	inputFunc := func(t *testing.T) *pbs.AddGroupMembersRequest {
+		name, _ := uuid.GenerateUUID()
+		desc, _ := uuid.GenerateUUID()
+		globalGroupWithMember := iam.TestGroup(t, conn, globals.GlobalPrefix, iam.WithDescription(desc), iam.WithName(name))
+		u := iam.TestUser(t, iamRepo, globals.GlobalPrefix)
+		return &pbs.AddGroupMembersRequest{
+			Id:        globalGroupWithMember.PublicId,
+			Version:   globalGroupWithMember.Version,
+			MemberIds: []string{u.PublicId},
+		}
+	}
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+	testcases := []struct {
+		name            string
+		userFunc        func() (*iam.User, auth.Account)
+		expectOutfields []string
+	}{
+		{
+			name: "grants name and description",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=name,description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.NameField, globals.DescriptionField},
+		},
+		{
+			name: "grants scope and scopeId",
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope,scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.ScopeField, globals.ScopeIdField},
+		},
+		{
+			name: "grants update_time and create_time",
+
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=updated_time,created_time"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.UpdatedTimeField, globals.CreatedTimeField},
+		},
+		{
+			name: "grants id, authorized_actions, version",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id,authorized_actions,version"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.IdField, globals.AuthorizedActionsField, globals.VersionField},
+		},
+		{
+			name: "composite grants all fields",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=name"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=created_time"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=authorized_actions"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=version"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{
+				globals.IdField,
+				globals.ScopeField,
+				globals.ScopeIdField,
+				globals.NameField,
+				globals.DescriptionField,
+				globals.CreatedTimeField,
+				globals.AuthorizedActionsField,
+				globals.VersionField,
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			out, err := s.AddGroupMembers(fullGrantAuthCtx, inputFunc(t))
+			require.NoError(t, err)
+			handlers.TestAssertOutputFields(t, out.Item, tc.expectOutfields)
+		})
+	}
+}
+
+func TestOutputFields_SetGroupMembers(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+
+	// this can be used across test cases because we're only testing for output fields, not the update behaviors
+	inputFunc := func(t *testing.T) *pbs.SetGroupMembersRequest {
+		name, _ := uuid.GenerateUUID()
+		desc, _ := uuid.GenerateUUID()
+		globalGroupWithMember := iam.TestGroup(t, conn, globals.GlobalPrefix, iam.WithDescription(desc), iam.WithName(name))
+		u := iam.TestUser(t, iamRepo, globals.GlobalPrefix)
+		return &pbs.SetGroupMembersRequest{
+			Id:        globalGroupWithMember.PublicId,
+			Version:   globalGroupWithMember.Version,
+			MemberIds: []string{u.PublicId},
+		}
+	}
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+	testcases := []struct {
+		name            string
+		userFunc        func() (*iam.User, auth.Account)
+		expectOutfields []string
+	}{
+		{
+			name: "grants name and description",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=name,description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.NameField, globals.DescriptionField},
+		},
+		{
+			name: "grants scope and scopeId",
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope,scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.ScopeField, globals.ScopeIdField},
+		},
+		{
+			name: "grants update_time and create_time",
+
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=updated_time,created_time"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.UpdatedTimeField, globals.CreatedTimeField},
+		},
+		{
+			name: "grants id, authorized_actions, version",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id,authorized_actions,version"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.IdField, globals.AuthorizedActionsField, globals.VersionField},
+		},
+		{
+			name: "composite grants all fields",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=name"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=created_time"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=authorized_actions"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=version"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{
+				globals.IdField,
+				globals.ScopeField,
+				globals.ScopeIdField,
+				globals.NameField,
+				globals.DescriptionField,
+				globals.CreatedTimeField,
+				globals.AuthorizedActionsField,
+				globals.VersionField,
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			out, err := s.SetGroupMembers(fullGrantAuthCtx, inputFunc(t))
+			require.NoError(t, err)
+			handlers.TestAssertOutputFields(t, out.Item, tc.expectOutfields)
+		})
+	}
+}
+
+func TestOutputFields_RemoveGroupMembers(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+
+	// this can be used across test cases because we're only testing for output fields, not the update behaviors
+	inputFunc := func(t *testing.T) *pbs.RemoveGroupMembersRequest {
+		name, _ := uuid.GenerateUUID()
+		desc, _ := uuid.GenerateUUID()
+		globalGroupWithMember := iam.TestGroup(t, conn, globals.GlobalPrefix, iam.WithDescription(desc), iam.WithName(name))
+		// create 2 users and remove one so the tests can differentiate between the group without members vs. having no access to read members
+		u1 := iam.TestUser(t, iamRepo, globals.GlobalPrefix)
+		u2 := iam.TestUser(t, iamRepo, globals.GlobalPrefix)
+		_ = iam.TestGroupMember(t, conn, globalGroupWithMember.PublicId, u1.PublicId)
+		_ = iam.TestGroupMember(t, conn, globalGroupWithMember.PublicId, u2.PublicId)
+		return &pbs.RemoveGroupMembersRequest{
+			Id:        globalGroupWithMember.PublicId,
+			Version:   globalGroupWithMember.Version,
+			MemberIds: []string{u2.PublicId},
+		}
+	}
+	s, err := groups.NewService(ctx, repoFn, 1000)
+	require.NoError(t, err)
+	testcases := []struct {
+		name            string
+		userFunc        func() (*iam.User, auth.Account)
+		expectOutfields []string
+	}{
+		{
+			name: "grants name and description",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=name,description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.NameField, globals.DescriptionField},
+		},
+		{
+			name: "grants scope and scopeId",
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope,scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.ScopeField, globals.ScopeIdField},
+		},
+		{
+			name: "grants update_time and create_time",
+
+			userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=updated_time,created_time"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.UpdatedTimeField, globals.CreatedTimeField},
+		},
+		{
+			name: "grants id, authorized_actions, version",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id,authorized_actions,version"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{globals.IdField, globals.AuthorizedActionsField, globals.VersionField},
+		},
+		{
+			name: "composite grants all fields",
+			userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=scope_id"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=name"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=description"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=created_time"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=authorized_actions"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+				{
+					RoleScopeId: globals.GlobalPrefix,
+					Grants:      []string{"ids=*;type=group;actions=*;output_fields=version"},
+					GrantScopes: []string{globals.GrantScopeThis},
+				},
+			}),
+			expectOutfields: []string{
+				globals.IdField,
+				globals.ScopeField,
+				globals.ScopeIdField,
+				globals.NameField,
+				globals.DescriptionField,
+				globals.CreatedTimeField,
+				globals.AuthorizedActionsField,
+				globals.VersionField,
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account := tc.userFunc()
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			out, err := s.RemoveGroupMembers(fullGrantAuthCtx, inputFunc(t))
+			require.NoError(t, err)
+			handlers.TestAssertOutputFields(t, out.Item, tc.expectOutfields)
+		})
+	}
+}
+
+func userIDs(users []*iam.User) []string {
+	result := make([]string, len(users))
+	for i, u := range users {
+		result[i] = u.PublicId
+	}
+	return result
 }

--- a/internal/daemon/controller/handlers/host_catalogs/grants_test.go
+++ b/internal/daemon/controller/handlers/host_catalogs/grants_test.go
@@ -88,7 +88,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=host-catalog;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
@@ -104,7 +104,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org.PublicId,
+						RoleScopeId:  org.PublicId,
 						GrantStrings: []string{"ids=*;type=host-catalog;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -120,7 +120,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  proj.PublicId,
+						RoleScopeId:  proj.PublicId,
 						GrantStrings: []string{"ids=*;type=host-catalog;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},

--- a/internal/daemon/controller/handlers/host_catalogs/grants_test.go
+++ b/internal/daemon/controller/handlers/host_catalogs/grants_test.go
@@ -5,11 +5,15 @@ package host_catalogs_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/auth"
+	"github.com/hashicorp/boundary/internal/auth/ldap"
 	"github.com/hashicorp/boundary/internal/authtoken"
-	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	cauth "github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/host_catalogs"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
@@ -19,9 +23,14 @@ import (
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/plugin"
+	"github.com/hashicorp/boundary/internal/plugin/loopback"
 	"github.com/hashicorp/boundary/internal/scheduler"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/hostcatalogs"
 	plgpb "github.com/hashicorp/boundary/sdk/pbs/plugin"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // TestGrants_ReadActions tests read actions to assert that grants are being applied properly
@@ -46,6 +55,8 @@ func TestGrants_ReadActions(t *testing.T) {
 	iamRepo := iam.TestRepo(t, conn, wrap)
 	kmsCache := kms.TestKms(t, conn, wrap)
 	sche := scheduler.TestScheduler(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
 	staticRepoFn := func() (*static.Repository, error) {
 		return static.NewRepository(ctx, rw, rw, kmsCache)
 	}
@@ -61,79 +72,231 @@ func TestGrants_ReadActions(t *testing.T) {
 	catalogServiceFn := func() (*host.CatalogRepository, error) {
 		return host.NewCatalogRepository(ctx, rw, rw)
 	}
+	plg := plugin.TestPlugin(t, conn, "test")
+	plgm := map[string]plgpb.HostPluginServiceClient{
+		plg.GetPublicId(): loopback.NewWrappingPluginHostClient(&plgpb.UnimplementedHostPluginServiceServer{}),
+	}
 	s, err := host_catalogs.NewService(ctx, staticRepoFn, pluginHostRepoFn, pluginRepoFn, iamRepoFn, catalogServiceFn, 1000)
 	require.NoError(t, err)
 
 	org, proj := iam.TestScopes(t, iamRepo)
 
-	hcs := static.TestCatalogs(t, conn, proj.GetPublicId(), 5)
-	var wantHcs []string
-	for _, h := range hcs {
-		wantHcs = append(wantHcs, h.GetPublicId())
+	var allHcs []string
+	for range 5 {
+		hc := hostplugin.TestCatalog(
+			t,
+			conn,
+			proj.GetPublicId(),
+			plg.GetPublicId(),
+			hostplugin.WithAttributes(&structpb.Struct{Fields: map[string]*structpb.Value{"foo": structpb.NewStringValue("bar")}}),
+			hostplugin.WithWorkerFilter(`"test" in "/tags/type"`),
+			hostplugin.WithSecrets(&structpb.Struct{Fields: map[string]*structpb.Value{"foo": structpb.NewStringValue("bar")}}),
+			hostplugin.WithSecretsHmac([]byte("foobar")),
+		)
+		allHcs = append(allHcs, hc.GetPublicId())
+
+		_ = hostplugin.TestSet(t, conn, kmsCache, sche, hc, plgm)
 	}
 
 	t.Run("List", func(t *testing.T) {
 		testcases := []struct {
-			name          string
-			input         *pbs.ListHostCatalogsRequest
-			rolesToCreate []authtoken.TestRoleGrantsForToken
-			wantErr       error
-			wantIDs       []string
+			name            string
+			input           *pbs.ListHostCatalogsRequest
+			userFunc        func() (user *iam.User, account auth.Account)
+			wantErr         error
+			wantIDs         []string
+			expectOutfields []string
 		}{
 			{
-				name: "global role grant this returns all created host catalogs",
+				name: "direct association - global role with host-catalog type, list, read actions, grant scope: this and descendants returns all created host catalogs",
 				input: &pbs.ListHostCatalogsRequest{
 					ScopeId:   proj.GetPublicId(),
 					Recursive: true,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=host-catalog;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-catalog;actions=list,read;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
-				},
-				wantErr: nil,
-				wantIDs: wantHcs,
+				}),
+				wantErr:         nil,
+				wantIDs:         allHcs,
+				expectOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
 			},
 			{
-				name: "org role grant this returns all created host catalogs",
+				name: "group association - global role with host-catalog type, list, read actions, grant scope: this and descendants returns all created host catalogs",
 				input: &pbs.ListHostCatalogsRequest{
 					ScopeId:   proj.GetPublicId(),
 					Recursive: true,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  org.PublicId,
-						GrantStrings: []string{"ids=*;type=host-catalog;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-catalog;actions=list,read;output_fields=id,scope_id,type"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
-				},
-				wantErr: nil,
-				wantIDs: wantHcs,
+				}),
+				wantIDs:         allHcs,
+				expectOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField},
 			},
 			{
-				name: "project role grant this returns all created host catalogs",
+				name: "managed group association - global role with host-catalog type, list, read actions, grant scope: this and descendants returns all created host catalogs",
 				input: &pbs.ListHostCatalogsRequest{
 					ScopeId:   proj.GetPublicId(),
 					Recursive: true,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  proj.PublicId,
-						GrantStrings: []string{"ids=*;type=host-catalog;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-catalog;actions=list,read;output_fields=id,attributes"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
+				}),
+				wantIDs:         allHcs,
+				expectOutfields: []string{globals.IdField, globals.AttributesField},
+			},
+			{
+				name: "org role with host-catalog type, list, read actions, grant scope: this and children returns all created host catalogs",
+				input: &pbs.ListHostCatalogsRequest{
+					ScopeId:   org.GetPublicId(),
+					Recursive: true,
 				},
-				wantErr: nil,
-				wantIDs: wantHcs,
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-catalog;actions=list,read;output_fields=id,authorized_actions,secrets_hmac,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantIDs:         allHcs,
+				expectOutfields: []string{globals.IdField, globals.AuthorizedActionsField, globals.SecretsHmacField, globals.CreatedTimeField, globals.UpdatedTimeField},
+			},
+			{
+				name: "org role with host-catalog type, list, read actions, grant scope children returns all created host catalogs",
+				input: &pbs.ListHostCatalogsRequest{
+					ScopeId:   proj.GetPublicId(),
+					Recursive: true,
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-catalog;actions=list,read;output_fields=id,type"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				wantIDs:         allHcs,
+				expectOutfields: []string{globals.IdField, globals.TypeField},
+			},
+			{
+				name: "project role with host-catalog type, list, read actions, grant scope: this returns all created host catalogs",
+				input: &pbs.ListHostCatalogsRequest{
+					ScopeId:   proj.GetPublicId(),
+					Recursive: true,
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-catalog;actions=list,read;output_fields=id,type"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantIDs:         allHcs,
+				expectOutfields: []string{globals.IdField, globals.TypeField},
+			},
+			{
+				name: "project role with host-catalog type, list action, grant scope: does not return any host catalogs",
+				input: &pbs.ListHostCatalogsRequest{
+					ScopeId:   proj.GetPublicId(),
+					Recursive: true,
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-catalog;actions=list"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantIDs: nil,
+			},
+			{
+				name: "project role with host-catalog type, list and no-op actions, grant scope: this returns all created host catalogs",
+				input: &pbs.ListHostCatalogsRequest{
+					ScopeId:   proj.GetPublicId(),
+					Recursive: true,
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-catalog;actions=no-op,list;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantIDs:         allHcs,
+				expectOutfields: []string{globals.IdField},
+			},
+			{
+				name: "project role with non-applicable type, list and no-op actions, grant scope: this returns forbidden error",
+				input: &pbs.ListHostCatalogsRequest{
+					ScopeId:   proj.GetPublicId(),
+					Recursive: true,
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host;actions=no-op,list"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "global role with host-catalog type, list and no-op actions, grant scope: children returns forbidden error",
+				input: &pbs.ListHostCatalogsRequest{
+					ScopeId:   proj.GetPublicId(),
+					Recursive: true,
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-catalog;actions=no-op,list"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				wantIDs: nil,
+			},
+			{
+				name: "org role with host-catalog type, list and no-op actions, grant scope: this returns forbidden error",
+				input: &pbs.ListHostCatalogsRequest{
+					ScopeId:   proj.GetPublicId(),
+					Recursive: true,
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-catalog;actions=no-op,list"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantIDs: nil,
+			},
+			{
+				name: "role with no grant",
+				input: &pbs.ListHostCatalogsRequest{
+					ScopeId:   proj.GetPublicId(),
+					Recursive: true,
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, nil),
+				wantErr:  handlers.ForbiddenError(),
 			},
 		}
 
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
-				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
 				got, finalErr := s.ListHostCatalogs(fullGrantAuthCtx, tc.input)
 				if tc.wantErr != nil {
 					require.ErrorIs(t, finalErr, tc.wantErr)
@@ -145,6 +308,746 @@ func TestGrants_ReadActions(t *testing.T) {
 					gotIDs = append(gotIDs, g.GetId())
 				}
 				require.ElementsMatch(t, tc.wantIDs, gotIDs)
+				for _, item := range got.Items {
+					handlers.TestAssertOutputFields(t, item, tc.expectOutfields)
+				}
+			})
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		testcases := []struct {
+			name            string
+			userFunc        func() (user *iam.User, account auth.Account)
+			inputWantErrMap map[*pbs.GetHostCatalogRequest]error
+			wantErr         error
+			expectOutfields []string
+		}{
+			{
+				name: "direct association - project role with id, host-catalog type, read action, grant scope: this returns host catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + allHcs[2] + ";type=host-catalog;actions=read;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetHostCatalogRequest]error{
+					{Id: allHcs[0]}: handlers.ForbiddenError(),
+					{Id: allHcs[1]}: handlers.ForbiddenError(),
+					{Id: allHcs[2]}: nil,
+					{Id: allHcs[3]}: handlers.ForbiddenError(),
+					{Id: allHcs[4]}: handlers.ForbiddenError(),
+				},
+				expectOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+			},
+			{
+				name: "group association - global role with id, host-catalog type, read action, grant scope: this and descendants returns host catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + allHcs[0] + ";type=host-catalog;actions=read;output_fields=id,scope_id,type"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetHostCatalogRequest]error{
+					{Id: allHcs[0]}: nil,
+					{Id: allHcs[1]}: handlers.ForbiddenError(),
+					{Id: allHcs[2]}: handlers.ForbiddenError(),
+					{Id: allHcs[3]}: handlers.ForbiddenError(),
+					{Id: allHcs[4]}: handlers.ForbiddenError(),
+				},
+				expectOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField},
+			},
+			{
+				name: "direct association - global role with host-catalog type, read action, grant scope: descendants returns host catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-catalog;actions=read;output_fields=id,type"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetHostCatalogRequest]error{
+					{Id: allHcs[0]}: nil,
+					{Id: allHcs[1]}: nil,
+					{Id: allHcs[2]}: nil,
+					{Id: allHcs[3]}: nil,
+					{Id: allHcs[4]}: nil,
+				},
+				expectOutfields: []string{globals.IdField, globals.TypeField},
+			},
+			{
+				name: "org role with host-catalog type, read action, grant scope: children returns host catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-catalog;actions=read;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetHostCatalogRequest]error{
+					{Id: allHcs[0]}: nil,
+					{Id: allHcs[1]}: nil,
+					{Id: allHcs[2]}: nil,
+					{Id: allHcs[3]}: nil,
+					{Id: allHcs[4]}: nil,
+				},
+				expectOutfields: []string{globals.IdField},
+			},
+			{
+				name: "project role with host-catalog type, read action, grant scope: this returns host catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-catalog;actions=read;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetHostCatalogRequest]error{
+					{Id: allHcs[0]}: nil,
+					{Id: allHcs[1]}: nil,
+					{Id: allHcs[2]}: nil,
+					{Id: allHcs[3]}: nil,
+					{Id: allHcs[4]}: nil,
+				},
+				expectOutfields: []string{globals.IdField},
+			},
+			{
+				name: "project role with host-catalog type, update action, grant scope: this returns forbidden error",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-catalog;actions=update"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetHostCatalogRequest]error{
+					{Id: allHcs[0]}: handlers.ForbiddenError(),
+					{Id: allHcs[1]}: handlers.ForbiddenError(),
+					{Id: allHcs[2]}: handlers.ForbiddenError(),
+					{Id: allHcs[3]}: handlers.ForbiddenError(),
+					{Id: allHcs[4]}: handlers.ForbiddenError(),
+				},
+			},
+			{
+				name: "union multiple grants returns a subset of all host catalogs",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + allHcs[0] + ";type=host-catalog;actions=read;output_fields=id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + allHcs[0] + ";type=host-catalog;actions=read;output_fields=scope_id,type"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + allHcs[2] + ";type=host-catalog;actions=read;output_fields=id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + allHcs[2] + ";type=host-catalog;actions=read;output_fields=scope_id,type"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + allHcs[3] + ";type=host-catalog;actions=read;output_fields=id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + allHcs[3] + ";type=host-catalog;actions=read;output_fields=scope_id,type"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				inputWantErrMap: map[*pbs.GetHostCatalogRequest]error{
+					{Id: allHcs[0]}: nil,
+					{Id: allHcs[1]}: handlers.ForbiddenError(),
+					{Id: allHcs[2]}: nil,
+					{Id: allHcs[3]}: nil,
+					{Id: allHcs[4]}: handlers.ForbiddenError(),
+				},
+				expectOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+			},
+			{
+				name:     "no grants can't read host catalogs",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, nil),
+				inputWantErrMap: map[*pbs.GetHostCatalogRequest]error{
+					{Id: allHcs[0]}: handlers.ForbiddenError(),
+					{Id: allHcs[1]}: handlers.ForbiddenError(),
+					{Id: allHcs[2]}: handlers.ForbiddenError(),
+					{Id: allHcs[3]}: handlers.ForbiddenError(),
+					{Id: allHcs[4]}: handlers.ForbiddenError(),
+				},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				for input, wantErr := range tc.inputWantErrMap {
+					got, err := s.GetHostCatalog(fullGrantAuthCtx, input)
+					if wantErr != nil {
+						require.ErrorIs(t, err, wantErr)
+						continue
+					}
+					require.NoError(t, err)
+					handlers.TestAssertOutputFields(t, got.Item, tc.expectOutfields)
+				}
+			})
+		}
+	})
+}
+
+func TestGrants_WriteActions(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		ctx := context.Background()
+		conn, _ := db.TestSetup(t, "postgres")
+		wrap := db.TestWrapper(t)
+		rw := db.New(conn)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		sche := scheduler.TestScheduler(t, conn, wrap)
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+		staticRepoFn := func() (*static.Repository, error) {
+			return static.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		pluginHostRepoFn := func() (*hostplugin.Repository, error) {
+			return hostplugin.NewRepository(ctx, rw, rw, kmsCache, sche, map[string]plgpb.HostPluginServiceClient{})
+		}
+		pluginRepoFn := func() (*plugin.Repository, error) {
+			return plugin.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		iamRepoFn := func() (*iam.Repository, error) {
+			return iam.TestRepo(t, conn, wrap), nil
+		}
+		catalogServiceFn := func() (*host.CatalogRepository, error) {
+			return host.NewCatalogRepository(ctx, rw, rw)
+		}
+		s, err := host_catalogs.NewService(ctx, staticRepoFn, pluginHostRepoFn, pluginRepoFn, iamRepoFn, catalogServiceFn, 1000)
+		require.NoError(t, err)
+
+		org, proj := iam.TestScopes(t, iamRepo)
+		proj2 := iam.TestProject(t, iamRepo, org.GetPublicId())
+
+		testcases := []struct {
+			name              string
+			userFunc          func() (userId *iam.User, account auth.Account)
+			canCreateInScopes map[*pbs.CreateHostCatalogRequest]error
+			expectOutfields   []string
+		}{
+			{
+				name: "direct grant with wildcard can create host catalog in project",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"id=*;type=*;actions=*;output_fields=id,name"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateHostCatalogRequest]error{
+					{Item: &pb.HostCatalog{ScopeId: proj.PublicId, Type: "static", Name: &wrapperspb.StringValue{Value: "hc-direct-test-1"}}}:  nil,
+					{Item: &pb.HostCatalog{ScopeId: proj2.PublicId, Type: "static", Name: &wrapperspb.StringValue{Value: "hc-direct-test-2"}}}: handlers.ForbiddenError(),
+				},
+				expectOutfields: []string{globals.IdField, globals.NameField},
+			},
+			{
+				name: "groups grant with wildcard can create host catalog in project",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj2.PublicId,
+						Grants:      []string{"id=*;type=*;actions=*;output_fields=id,name"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateHostCatalogRequest]error{
+					{Item: &pb.HostCatalog{ScopeId: proj.PublicId, Type: "static", Name: &wrapperspb.StringValue{Value: "hc-group-test-1"}}}:  handlers.ForbiddenError(),
+					{Item: &pb.HostCatalog{ScopeId: proj2.PublicId, Type: "static", Name: &wrapperspb.StringValue{Value: "hc-group-test-2"}}}: nil,
+				},
+				expectOutfields: []string{globals.IdField, globals.NameField},
+			},
+			{
+				name: "ldap grant with wildcard can create host catalog in project",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"id=*;type=*;actions=*;output_fields=id,name"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateHostCatalogRequest]error{
+					{Item: &pb.HostCatalog{ScopeId: proj.PublicId, Type: "static", Name: &wrapperspb.StringValue{Value: "hc-ldap-test-1"}}}:  nil,
+					{Item: &pb.HostCatalog{ScopeId: proj2.PublicId, Type: "static", Name: &wrapperspb.StringValue{Value: "hc-ldap-test-2"}}}: handlers.ForbiddenError(),
+				},
+				expectOutfields: []string{globals.IdField, globals.NameField},
+			},
+			{
+				name: "global role - descendant grant with host-catalog type can create host catalog in project",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=host-catalog;actions=*;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateHostCatalogRequest]error{
+					{Item: &pb.HostCatalog{ScopeId: proj.PublicId, Type: "static"}}:  nil,
+					{Item: &pb.HostCatalog{ScopeId: proj2.PublicId, Type: "static"}}: nil,
+				},
+				expectOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+			},
+			{
+				name: "global role - individual project id grant with host-catalog type can create host catalog in the specified project only",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=host-catalog;actions=*;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{proj2.PublicId},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateHostCatalogRequest]error{
+					{Item: &pb.HostCatalog{ScopeId: proj.PublicId, Type: "static"}}:  handlers.ForbiddenError(),
+					{Item: &pb.HostCatalog{ScopeId: proj2.PublicId, Type: "static"}}: nil,
+				},
+				expectOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+			},
+			{
+				name: "org role - children grant with host-catalog type can create host catalog in all its child projects",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"id=*;type=host-catalog;actions=*;output_fields=id,scope_id,type"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateHostCatalogRequest]error{
+					{Item: &pb.HostCatalog{ScopeId: proj.PublicId, Type: "static"}}:  nil,
+					{Item: &pb.HostCatalog{ScopeId: proj2.PublicId, Type: "static"}}: nil,
+				},
+				expectOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField},
+			},
+			{
+				name: "org role - individual project id grant with host-catalog type can create host catalog in the specified project only",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"id=*;type=host-catalog;actions=*;output_fields=id,scope_id,type"},
+						GrantScopes: []string{proj2.PublicId},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateHostCatalogRequest]error{
+					{Item: &pb.HostCatalog{ScopeId: proj.PublicId, Type: "static"}}:  handlers.ForbiddenError(),
+					{Item: &pb.HostCatalog{ScopeId: proj2.PublicId, Type: "static"}}: nil,
+				},
+				expectOutfields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField},
+			},
+			{
+				name: "direct grant with host-catalog type, create action, grant scope: this can create host catalog in project",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"id=*;type=host-catalog;actions=create;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateHostCatalogRequest]error{
+					{Item: &pb.HostCatalog{ScopeId: proj.PublicId, Type: "static"}}:  nil,
+					{Item: &pb.HostCatalog{ScopeId: proj2.PublicId, Type: "static"}}: handlers.ForbiddenError(),
+				},
+				expectOutfields: []string{globals.IdField},
+			},
+			{
+				name: "direct grant with host-catalog type, update action, grant scope: this can create host catalog in project",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"id=*;type=host-catalog;actions=update"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateHostCatalogRequest]error{
+					{Item: &pb.HostCatalog{ScopeId: proj.PublicId, Type: "static"}}:  handlers.ForbiddenError(),
+					{Item: &pb.HostCatalog{ScopeId: proj2.PublicId, Type: "static"}}: handlers.ForbiddenError(),
+				},
+			},
+			{
+				name: "grant children can only create in orgs",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"id=*;type=host-catalog;actions=*"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				canCreateInScopes: map[*pbs.CreateHostCatalogRequest]error{
+					{Item: &pb.HostCatalog{ScopeId: proj.PublicId, Type: "static"}}:  handlers.ForbiddenError(),
+					{Item: &pb.HostCatalog{ScopeId: proj2.PublicId, Type: "static"}}: handlers.ForbiddenError(),
+				},
+			},
+			{
+				name:     "no grants can't create in any scope",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, nil),
+				canCreateInScopes: map[*pbs.CreateHostCatalogRequest]error{
+					{Item: &pb.HostCatalog{ScopeId: proj.PublicId, Type: "static"}}:  handlers.ForbiddenError(),
+					{Item: &pb.HostCatalog{ScopeId: proj2.PublicId, Type: "static"}}: handlers.ForbiddenError(),
+				},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				for req, wantErr := range tc.canCreateInScopes {
+					got, err := s.CreateHostCatalog(fullGrantAuthCtx, req)
+					if wantErr != nil {
+						require.ErrorIs(t, err, wantErr)
+						continue
+					}
+					require.NoError(t, err)
+					handlers.TestAssertOutputFields(t, got.Item, tc.expectOutfields)
+				}
+			})
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		ctx := context.Background()
+		conn, _ := db.TestSetup(t, "postgres")
+		wrap := db.TestWrapper(t)
+		rw := db.New(conn)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		sche := scheduler.TestScheduler(t, conn, wrap)
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+		staticRepoFn := func() (*static.Repository, error) {
+			return static.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		pluginHostRepoFn := func() (*hostplugin.Repository, error) {
+			return hostplugin.NewRepository(ctx, rw, rw, kmsCache, sche, map[string]plgpb.HostPluginServiceClient{})
+		}
+		pluginRepoFn := func() (*plugin.Repository, error) {
+			return plugin.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		iamRepoFn := func() (*iam.Repository, error) {
+			return iam.TestRepo(t, conn, wrap), nil
+		}
+		catalogServiceFn := func() (*host.CatalogRepository, error) {
+			return host.NewCatalogRepository(ctx, rw, rw)
+		}
+		s, err := host_catalogs.NewService(ctx, staticRepoFn, pluginHostRepoFn, pluginRepoFn, iamRepoFn, catalogServiceFn, 1000)
+		require.NoError(t, err)
+
+		org, proj := iam.TestScopes(t, iamRepo)
+
+		testcases := []struct {
+			name                        string
+			setupScopesResourcesAndUser func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (userId *iam.User, account auth.Account))
+			wantErr                     error
+			expectOutfields             []string
+		}{
+			{
+				name: "direct grant with wildcard can update host catalog in project",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (userId *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: proj.PublicId,
+							Grants:      []string{"id=*;type=*;actions=*;output_fields=id,name,updated_time,version"},
+							GrantScopes: []string{globals.GrantScopeThis},
+						},
+					})
+				},
+				wantErr:         nil,
+				expectOutfields: []string{globals.IdField, globals.NameField, globals.UpdatedTimeField, globals.VersionField},
+			},
+			{
+				name: "global role - direct grant with grant_scope project can update host catalog in project",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (userId *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: globals.GlobalPrefix,
+							Grants:      []string{"ids=*;type=host-catalog;actions=*;output_fields=id,name,description,updated_time,version"},
+							GrantScopes: []string{proj.PublicId},
+						},
+					})
+				},
+				wantErr:         nil,
+				expectOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField, globals.UpdatedTimeField, globals.VersionField},
+			},
+			{
+				name: "grant with specific resource and scope can update host catalog in project",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (userId *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: org.PublicId,
+							Grants:      []string{fmt.Sprintf("ids=%s;types=host-catalog;actions=*;output_fields=id,scope_id,type,name,description,created_time,updated_time,version", hc.PublicId)},
+							GrantScopes: []string{proj.PublicId},
+						},
+					})
+				},
+				wantErr: nil,
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeIdField,
+					globals.TypeField,
+					globals.NameField,
+					globals.VersionField,
+					globals.DescriptionField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+				},
+			},
+			{
+				name: "non applicable grant returns forbidden error",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (userId *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: globals.GlobalPrefix,
+							Grants:      []string{"id=*;type=*;actions=*"},
+							GrantScopes: []string{globals.GrantScopeChildren},
+						},
+					})
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "no grants returns forbidden error",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (userId *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, nil)
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				original, userFunc := tc.setupScopesResourcesAndUser(t, conn, iamRepo, kmsCache)
+				user, account := userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				got, err := s.UpdateHostCatalog(fullGrantAuthCtx, &pbs.UpdateHostCatalogRequest{
+					Id: original.PublicId,
+					Item: &pb.HostCatalog{
+						Name:        &wrapperspb.StringValue{Value: "new-name-" + original.PublicId},
+						Description: &wrapperspb.StringValue{Value: "new-description"},
+						Version:     1,
+					},
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"name", "description"},
+					},
+				})
+				if tc.wantErr != nil {
+					require.Error(t, err)
+					require.ErrorIs(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, uint32(2), got.Item.Version)
+				require.True(t, got.Item.UpdatedTime.AsTime().After(original.UpdateTime.AsTime()))
+				handlers.TestAssertOutputFields(t, got.Item, tc.expectOutfields)
+			})
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		ctx := context.Background()
+		conn, _ := db.TestSetup(t, "postgres")
+		wrap := db.TestWrapper(t)
+		rw := db.New(conn)
+		iamRepo := iam.TestRepo(t, conn, wrap)
+		kmsCache := kms.TestKms(t, conn, wrap)
+		sche := scheduler.TestScheduler(t, conn, wrap)
+		atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+		require.NoError(t, err)
+		staticRepoFn := func() (*static.Repository, error) {
+			return static.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		pluginHostRepoFn := func() (*hostplugin.Repository, error) {
+			return hostplugin.NewRepository(ctx, rw, rw, kmsCache, sche, map[string]plgpb.HostPluginServiceClient{})
+		}
+		pluginRepoFn := func() (*plugin.Repository, error) {
+			return plugin.NewRepository(ctx, rw, rw, kmsCache)
+		}
+		iamRepoFn := func() (*iam.Repository, error) {
+			return iam.TestRepo(t, conn, wrap), nil
+		}
+		catalogServiceFn := func() (*host.CatalogRepository, error) {
+			return host.NewCatalogRepository(ctx, rw, rw)
+		}
+		s, err := host_catalogs.NewService(ctx, staticRepoFn, pluginHostRepoFn, pluginRepoFn, iamRepoFn, catalogServiceFn, 1000)
+		require.NoError(t, err)
+
+		org, proj := iam.TestScopes(t, iamRepo)
+
+		testcases := []struct {
+			name                        string
+			setupScopesResourcesAndUser func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (user *iam.User, account auth.Account))
+			wantErr                     error
+		}{
+			{
+				name: "direct grant with wildcard can delete host catalog in project",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (user *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: proj.PublicId,
+							Grants:      []string{"id=*;type=*;actions=*"},
+							GrantScopes: []string{globals.GrantScopeThis},
+						},
+					})
+				},
+				wantErr: nil,
+			},
+			{
+				name: "direct grant with type: host-catalog can delete host catalog in project",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (user *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: proj.PublicId,
+							Grants:      []string{"id=*;type=host-catalog;actions=*"},
+							GrantScopes: []string{globals.GrantScopeThis},
+						},
+					})
+				},
+				wantErr: nil,
+			},
+			{
+				name: "direct grant with type: host-catalog, update action can delete host catalog in project",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (user *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: proj.PublicId,
+							Grants:      []string{"id=*;type=host-catalog;actions=delete"},
+							GrantScopes: []string{globals.GrantScopeThis},
+						},
+					})
+				},
+				wantErr: nil,
+			},
+			{
+				name: "direct grant with global scope, descendants grants scope, host-catalog type, delete action can delete host catalog in project",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (user *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: globals.GlobalPrefix,
+							Grants:      []string{"id=*;type=host-catalog;actions=delete"},
+							GrantScopes: []string{globals.GrantScopeDescendants},
+						},
+					})
+				},
+				wantErr: nil,
+			},
+			{
+				name: "direct grant with org scope, children grants scope, host-catalog type, delete action can delete host catalog in project",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (user *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: org.PublicId,
+							Grants:      []string{"id=*;type=host-catalog;actions=delete"},
+							GrantScopes: []string{globals.GrantScopeChildren},
+						},
+					})
+				},
+				wantErr: nil,
+			},
+			{
+				name: "direct grant with non-applicable grant scope returns forbidden error",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (user *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: proj.PublicId,
+							Grants:      []string{"id=*;type=host-catalog;actions=update"},
+							GrantScopes: []string{globals.GrantScopeThis},
+						},
+					})
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "direct grant with non-applicable type returns forbidden error",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (user *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: proj.PublicId,
+							Grants:      []string{"id=*;type=group;actions=*"},
+							GrantScopes: []string{globals.GrantScopeThis},
+						},
+					})
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "direct grant with global scope and children grant scope returns forbidden error",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (user *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: globals.GlobalPrefix,
+							Grants:      []string{"id=*;type=*;actions=*"},
+							GrantScopes: []string{globals.GrantScopeChildren},
+						},
+					})
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "direct grant with org scope and this grant scope returns forbidden error",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (user *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+						{
+							RoleScopeId: org.PublicId,
+							Grants:      []string{"id=*;type=host-catalog;actions=*"},
+							GrantScopes: []string{globals.GrantScopeThis},
+						},
+					})
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "no grants returns forbidden error",
+				setupScopesResourcesAndUser: func(t *testing.T, conn *db.DB, iamRepo *iam.Repository, kmsCache *kms.Kms) (*static.HostCatalog, func() (user *iam.User, account auth.Account)) {
+					hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+					return hc, iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, nil)
+				},
+				wantErr: handlers.ForbiddenError(),
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				original, userFunc := tc.setupScopesResourcesAndUser(t, conn, iamRepo, kmsCache)
+				user, account := userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := cauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				_, err = s.DeleteHostCatalog(fullGrantAuthCtx, &pbs.DeleteHostCatalogRequest{Id: original.PublicId})
+				if tc.wantErr != nil {
+					require.Error(t, err)
+					require.ErrorIs(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
 			})
 		}
 	})

--- a/internal/daemon/controller/handlers/host_sets/grants_test.go
+++ b/internal/daemon/controller/handlers/host_sets/grants_test.go
@@ -79,7 +79,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=host-set;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
@@ -94,7 +94,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org.PublicId,
+						RoleScopeId:  org.PublicId,
 						GrantStrings: []string{"ids=*;type=host-set;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -109,7 +109,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  proj.PublicId,
+						RoleScopeId:  proj.PublicId,
 						GrantStrings: []string{"ids=*;type=host-set;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},

--- a/internal/daemon/controller/handlers/host_sets/grants_test.go
+++ b/internal/daemon/controller/handlers/host_sets/grants_test.go
@@ -5,11 +5,18 @@ package host_sets_test
 
 import (
 	"context"
+	"fmt"
+	"maps"
+	"slices"
 	"testing"
 
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/hashicorp/boundary/globals"
+	"github.com/hashicorp/boundary/internal/auth"
+	"github.com/hashicorp/boundary/internal/auth/oidc"
 	"github.com/hashicorp/boundary/internal/authtoken"
-	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	controllerauth "github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/host_sets"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
@@ -18,9 +25,17 @@ import (
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/scheduler"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/hostsets"
 	plgpb "github.com/hashicorp/boundary/sdk/pbs/plugin"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
+
+// expectedOutput consolidates common output fields for the test cases
+type expectedOutput struct {
+	err          error
+	outputFields []string
+}
 
 // TestGrants_ReadActions tests read actions to assert that grants are being applied properly
 //
@@ -41,11 +56,492 @@ func TestGrants_ReadActions(t *testing.T) {
 	conn, _ := db.TestSetup(t, "postgres")
 	wrap := db.TestWrapper(t)
 	rw := db.New(conn)
-	iamRepo := iam.TestRepo(t, conn, wrap)
 	kmsCache := kms.TestKms(t, conn, wrap)
-	sche := scheduler.TestScheduler(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	scheduler := scheduler.TestScheduler(t, conn, wrap)
 	pluginRepoFn := func() (*hostplugin.Repository, error) {
-		return hostplugin.NewRepository(ctx, rw, rw, kmsCache, sche, map[string]plgpb.HostPluginServiceClient{})
+		return hostplugin.NewRepository(ctx, rw, rw, kmsCache, scheduler, map[string]plgpb.HostPluginServiceClient{})
+	}
+	repoFn := func() (*static.Repository, error) {
+		return static.NewRepository(ctx, rw, rw, kmsCache)
+	}
+	s, err := host_sets.NewService(ctx, repoFn, pluginRepoFn, 1000)
+	require.NoError(t, err)
+
+	org, proj := iam.TestScopes(t, iamRepo)
+	proj2 := iam.TestProject(t, iamRepo, org.GetPublicId(), iam.WithName("project #2"))
+
+	// Create five test Host Sets under a test Host Catalog
+	hc := static.TestCatalogs(t, conn, proj.GetPublicId(), 1)[0]
+	hsets := make([]*static.HostSet, 5)
+	for i := range cap(hsets) {
+		hsets[i] = static.TestSet(t, conn, hc.PublicId,
+			static.WithName(fmt.Sprintf("test name %d", i)),
+			static.WithDescription(fmt.Sprintf("test description %d", i)),
+		)
+	}
+
+	// do it again for the second project
+	hc2 := static.TestCatalogs(t, conn, proj2.GetPublicId(), 1)[0]
+	hsets2 := make([]*static.HostSet, 3)
+	for i := range cap(hsets2) {
+		hsets2[i] = static.TestSet(t, conn, hc2.PublicId,
+			static.WithName(fmt.Sprintf("test name %d", i)),
+			static.WithDescription(fmt.Sprintf("test description %d", i)),
+		)
+	}
+
+	t.Run("List", func(t *testing.T) {
+		testcases := []struct {
+			name          string
+			input         *pbs.ListHostSetsRequest
+			userFunc      func() (*iam.User, auth.Account)
+			wantErr       error
+			wantOutfields map[string][]string
+		}{
+			{
+				name: "global role grant this returns 403 because host-sets live on projects",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "org role grant this returns 403 because host-sets live on projects",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.GetPublicId(),
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "project role grant this returns all host-sets on the project",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField},
+					hsets[1].GetPublicId(): {globals.IdField},
+					hsets[2].GetPublicId(): {globals.IdField},
+					hsets[3].GetPublicId(): {globals.IdField},
+					hsets[4].GetPublicId(): {globals.IdField},
+				},
+			},
+			{
+				name: "global role grant this & children returns 403 because host-sets live on projects",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "org role grant children returns all host-sets on child projects",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[1].GetPublicId(): {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[2].GetPublicId(): {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[3].GetPublicId(): {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[4].GetPublicId(): {globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				},
+			},
+			{
+				name: "global role grant this & descendants returns all host-sets on descendant projects",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[1].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[2].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[3].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[4].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				},
+			},
+			{
+				name: "project role grant this returns all host-sets on the project",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField},
+					hsets[1].GetPublicId(): {globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField},
+					hsets[2].GetPublicId(): {globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField},
+					hsets[3].GetPublicId(): {globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField},
+					hsets[4].GetPublicId(): {globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField},
+				},
+			},
+			// The next two cases share identical setup, but test ListHostSets in different projects/host-catalogs:
+			{
+				name: "org role grant with pinned host-catalog id, list action, host-set type, and children scope can list all host sets in the pinned host-catalog",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=list,no-op;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[1].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[2].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[3].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[4].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				},
+			},
+			{
+				name: "org role grant with pinned host-catalog id, list action, host-set type, and children scope can not list host sets in a different host-catalog",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc2.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=list,no-op;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "project role grant with host-catalog id, list action, host-set type, and this scope returns all host sets",
+				input: &pbs.ListHostSetsRequest{
+					HostCatalogId: hc.GetPublicId(),
+				},
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=list,no-op;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantOutfields: map[string][]string{
+					hsets[0].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[1].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[2].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[3].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+					hsets[4].GetPublicId(): {globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Call function to create direct/indirect relationship
+				user, account := tc.userFunc()
+
+				// Create auth token for the user
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+
+				// Create auth context from the auth token
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				got, finalErr := s.ListHostSets(fullGrantAuthCtx, tc.input)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, finalErr, tc.wantErr)
+					return
+				}
+				require.NoError(t, finalErr)
+				var gotIds []string
+				for _, g := range got.Items {
+					gotIds = append(gotIds, g.GetId())
+
+					// check if the output fields are as expected
+					if tc.wantOutfields[g.Id] != nil {
+						handlers.TestAssertOutputFields(t, g, tc.wantOutfields[g.Id])
+					}
+				}
+				wantIds := slices.Collect(maps.Keys(tc.wantOutfields))
+				require.ElementsMatch(t, wantIds, gotIds)
+			})
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		testcases := []struct {
+			name          string
+			userFunc      func() (*iam.User, auth.Account)
+			canGetHostSet map[string]expectedOutput
+		}{
+			{
+				name: "global role grant this returns 403",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetHostSet: map[string]expectedOutput{
+					hsets[0].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[1].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[2].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[3].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[4].GetPublicId(): {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "org role grant this returns 403",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetHostSet: map[string]expectedOutput{
+					hsets[0].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[1].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[2].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[3].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[4].GetPublicId(): {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "project role grant this returns all host-sets on the project",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetHostSet: map[string]expectedOutput{
+					hsets[0].GetPublicId(): {outputFields: []string{globals.IdField}},
+					hsets[1].GetPublicId(): {outputFields: []string{globals.IdField}},
+					hsets[2].GetPublicId(): {outputFields: []string{globals.IdField}},
+					hsets[3].GetPublicId(): {outputFields: []string{globals.IdField}},
+					hsets[4].GetPublicId(): {outputFields: []string{globals.IdField}},
+				},
+			},
+			{
+				name: "global role grant this & children returns 403 because host-sets live on projects",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				canGetHostSet: map[string]expectedOutput{
+					hsets[0].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[1].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[2].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[3].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[4].GetPublicId(): {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "org role grant children returns all host-sets on child projects",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				canGetHostSet: map[string]expectedOutput{
+					hsets[0].GetPublicId(): {outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					hsets[1].GetPublicId(): {outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					hsets[2].GetPublicId(): {outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					hsets[3].GetPublicId(): {outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					hsets[4].GetPublicId(): {outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+				},
+			},
+			{
+				name: "global role grant this & descendants returns all host-sets on descendant projects",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				canGetHostSet: map[string]expectedOutput{
+					hsets[0].GetPublicId(): {outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					hsets[1].GetPublicId(): {outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					hsets[2].GetPublicId(): {outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					hsets[3].GetPublicId(): {outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+					hsets[4].GetPublicId(): {outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+				},
+			},
+			{
+				name: "project role grant this returns all host-sets on the project",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetHostSet: map[string]expectedOutput{
+					hsets[0].GetPublicId(): {outputFields: []string{globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+					hsets[1].GetPublicId(): {outputFields: []string{globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+					hsets[2].GetPublicId(): {outputFields: []string{globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+					hsets[3].GetPublicId(): {outputFields: []string{globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+					hsets[4].GetPublicId(): {outputFields: []string{globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+				},
+			},
+			{
+				name: "incorrect grants returns no host set",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=list,create,update,delete;output_fields=id,name,description,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetHostSet: map[string]expectedOutput{
+					hsets[0].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[1].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[2].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[3].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[4].GetPublicId(): {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name:     "no grants returns no host sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, nil),
+				canGetHostSet: map[string]expectedOutput{
+					hsets[0].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[1].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[2].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[3].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[4].GetPublicId(): {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "project role grant with host-set id, get action, host-set type, and this scope returns the id'd host set",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hsets[0].PublicId + ";actions=read;output_fields=id,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				canGetHostSet: map[string]expectedOutput{
+					hsets[0].GetPublicId(): {outputFields: []string{globals.IdField, globals.AuthorizedActionsField}},
+					hsets[1].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[2].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[3].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[4].GetPublicId(): {err: handlers.ForbiddenError()},
+				},
+			},
+			{
+				name: "org role grant with host-set id, get action, host-set type, and this & children scope returns the id'd host set",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + hsets[4].PublicId + ";actions=read;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				canGetHostSet: map[string]expectedOutput{
+					hsets[0].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[1].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[2].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[3].GetPublicId(): {err: handlers.ForbiddenError()},
+					hsets[4].GetPublicId(): {outputFields: []string{globals.IdField}},
+				},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				for id, expected := range tc.canGetHostSet {
+					input := &pbs.GetHostSetRequest{Id: id}
+					_, err := s.GetHostSet(fullGrantAuthCtx, input)
+					if expected.err != nil {
+						require.ErrorIs(t, err, expected.err)
+						continue
+					}
+					// check if the output fields are as expected
+					if tc.canGetHostSet[id].outputFields != nil {
+						handlers.TestAssertOutputFields(t, input, tc.canGetHostSet[id].outputFields)
+					}
+					require.NoError(t, err)
+				}
+			})
+		}
+	})
+}
+
+func TestGrants_WriteActions(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	scheduler := scheduler.TestScheduler(t, conn, wrap)
+	pluginRepoFn := func() (*hostplugin.Repository, error) {
+		return hostplugin.NewRepository(ctx, rw, rw, kmsCache, scheduler, map[string]plgpb.HostPluginServiceClient{})
 	}
 	repoFn := func() (*static.Repository, error) {
 		return static.NewRepository(ctx, rw, rw, kmsCache)
@@ -58,82 +554,797 @@ func TestGrants_ReadActions(t *testing.T) {
 	hcs := static.TestCatalogs(t, conn, proj.GetPublicId(), 1)
 	hc := hcs[0]
 
-	hsets := static.TestSets(t, conn, hc.GetPublicId(), 5)
-	var wantHostSets []string
-	for _, h := range hsets {
-		wantHostSets = append(wantHostSets, h.GetPublicId())
-	}
-
-	t.Run("List", func(t *testing.T) {
+	t.Run("Create", func(t *testing.T) {
 		testcases := []struct {
-			name          string
-			input         *pbs.ListHostSetsRequest
-			rolesToCreate []authtoken.TestRoleGrantsForToken
-			wantErr       error
-			wantIDs       []string
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			expected expectedOutput
 		}{
 			{
-				name: "global role grant this returns all created host-set",
-				input: &pbs.ListHostSetsRequest{
-					HostCatalogId: hc.GetPublicId(),
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				name: "global role grant this can't create host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=host-set;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
-				wantErr: nil,
-				wantIDs: wantHostSets,
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
 			},
 			{
-				name: "org role grant this returns all created host-set",
-				input: &pbs.ListHostSetsRequest{
-					HostCatalogId: hc.GetPublicId(),
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				name: "org role grant this can't create host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  org.PublicId,
-						GrantStrings: []string{"ids=*;type=host-set;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
-				wantErr: nil,
-				wantIDs: wantHostSets,
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
 			},
 			{
-				name: "project role grant this returns all created host-set",
-				input: &pbs.ListHostSetsRequest{
-					HostCatalogId: hc.GetPublicId(),
-				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				name: "project role grant this can create host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  proj.PublicId,
-						GrantStrings: []string{"ids=*;type=host-set;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis},
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
-				wantErr: nil,
-				wantIDs: wantHostSets,
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField}},
+			},
+			{
+				name: "global role grant this & descendants can create host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-set;actions=create,read,update;output_fields=id,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+			},
+			{
+				name: "org role grant this & children can create host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=create;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
 			},
 		}
-
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
-				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
-				got, finalErr := s.ListHostSets(fullGrantAuthCtx, tc.input)
-				if tc.wantErr != nil {
-					require.ErrorIs(t, finalErr, tc.wantErr)
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				got, err := s.CreateHostSet(fullGrantAuthCtx, &pbs.CreateHostSetRequest{Item: &pb.HostSet{
+					HostCatalogId: hc.GetPublicId(),
+					Name:          &wrappers.StringValue{Value: "test host set - " + tc.name},
+					Description:   &wrappers.StringValue{Value: "test desc"},
+				}})
+				if tc.expected.err != nil {
+					require.ErrorIs(t, err, tc.expected.err)
 					return
 				}
-				require.NoError(t, finalErr)
-				var gotIDs []string
-				for _, g := range got.Items {
-					gotIDs = append(gotIDs, g.GetId())
+				// check if the output fields are as expected
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, got.Item, tc.expected.outputFields)
+			})
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			expected expectedOutput
+		}{
+			{
+				name: "global role grant this can't update host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "org role grant this can't update host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "project role grant this can update host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField}},
+			},
+			{
+				name: "global role grant this & descendants can update host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-set;actions=update;output_fields=id,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+			},
+			{
+				name: "org role grant this & children can update host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=update;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "incorrect grants can't update host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=list,create,delete;output_fields=id,name,description,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name:     "no grants can't update host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, nil),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+				hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
+
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				got, err := s.UpdateHostSet(fullGrantAuthCtx, &pbs.UpdateHostSetRequest{
+					Id: hset.PublicId,
+					Item: &pb.HostSet{
+						Name:        &wrappers.StringValue{Value: "updated host set name (" + tc.name + ")"},
+						Description: &wrappers.StringValue{Value: "test desc"},
+						Version:     1,
+					},
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "description"}},
+				})
+				if tc.expected.err != nil {
+					require.ErrorIs(t, err, tc.expected.err)
+					return
 				}
-				require.ElementsMatch(t, tc.wantIDs, gotIDs)
+				// check if the output fields are as expected
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, got.Item, tc.expected.outputFields)
+			})
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			wantErr  error
+		}{
+			{
+				name: "global role grant this can't delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "org role grant this can't delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name: "project role grant this can delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+			},
+			{
+				name: "global role grant this & descendants can delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-set;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+			},
+			{
+				name: "org role grant this & children can delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+			},
+			{
+				name: "incorrect grants can't delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=list,create,update"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+			{
+				name:     "no grants can't delete host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, nil),
+				wantErr:  handlers.ForbiddenError(),
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				hc := static.TestCatalogs(t, conn, proj.PublicId, 1)[0]
+				hset := static.TestSets(t, conn, hc.GetPublicId(), 1)[0]
+
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				_, err = s.DeleteHostSet(fullGrantAuthCtx, &pbs.DeleteHostSetRequest{Id: hset.PublicId})
+				if tc.wantErr != nil {
+					require.ErrorIs(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("Add Host Set Hosts", func(t *testing.T) {
+		hc := static.TestCatalog(t, conn, proj.PublicId, static.WithName("test add host set hosts catalog"), static.WithDescription("test desc"))
+		hcClone := static.TestCatalog(t, conn, proj.PublicId, static.WithName("clone add host set hosts catalog"), static.WithDescription("clone desc"))
+
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			expected expectedOutput
+		}{
+			{
+				name: "global role grant this can't add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "org role grant this can't add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "project role grant this can add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=add-hosts;output_fields=id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "global role grant this & descendants can add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-set;actions=add-hosts;output_fields=id,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+			},
+			{
+				name: "org role grant this & children can add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=add-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "incorrect grants can't add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=list,create,update,delete;output_fields=id,name,description,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name:     "no grants can't add hosts to host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, nil),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "global role grant with host-catalog id, add-hosts action, host-set type, and this/children scope allows adding hosts to host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=add-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "org role grant with host-catalog id, add-hosts action, host-set type, and this/children scope allows adding hosts to host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=add-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "project role grant with host-catalog id, add-hosts action, host-set type, and this/children scope allows adding hosts to host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=add-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "project role grant with an unassociated host-catalog id and add-hosts action does not allow adding hosts to host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hcClone.PublicId + ";type=host-set;actions=add-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				hset := static.TestSet(t, conn, hc.PublicId,
+					static.WithName("test name - "+tc.name),
+					static.WithDescription("test description"),
+				)
+				hosts := static.TestHosts(t, conn, hc.GetPublicId(), 2)
+
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				got, err := s.AddHostSetHosts(fullGrantAuthCtx, &pbs.AddHostSetHostsRequest{
+					Id: hset.PublicId,
+					HostIds: []string{
+						hosts[0].PublicId,
+						hosts[1].PublicId,
+					},
+					Version: 1,
+				})
+				if tc.expected.err != nil {
+					require.ErrorIs(t, err, tc.expected.err)
+					return
+				}
+				// check if the output fields are as expected
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, got.Item, tc.expected.outputFields)
+			})
+		}
+	})
+
+	t.Run("Remove Host Set Hosts", func(t *testing.T) {
+		hc := static.TestCatalog(t, conn, proj.PublicId, static.WithName("test remove host set hosts catalog"), static.WithDescription("test desc"))
+		hcClone := static.TestCatalog(t, conn, proj.PublicId, static.WithName("clone remove host set hosts catalog"), static.WithDescription("clone desc"))
+
+		// We need to create a host set with hosts in order to remove hosts.
+		// As a result, each testcase is granted the `add-hosts` action for our test host-catalog.
+		grantAddHostSetHosts := iam.TestRoleGrantsRequest{
+			RoleScopeId: proj.PublicId,
+			Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=add-hosts;output_fields=id"},
+			GrantScopes: []string{globals.GrantScopeThis},
+		}
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			expected expectedOutput
+		}{
+			{
+				name: "global role grant this can't remove hosts from host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					grantAddHostSetHosts,
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "org role grant this can't remove hosts from host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					grantAddHostSetHosts,
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "project role grant this can remove hosts from host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					grantAddHostSetHosts,
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=remove-hosts;output_fields=id,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "global role grant this & descendants can remove hosts from host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					grantAddHostSetHosts,
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-set;actions=remove-hosts;output_fields=id,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+			},
+			{
+				name: "org role grant this & children can remove hosts from host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					grantAddHostSetHosts,
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=remove-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "incorrect grants can't remove hosts from host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					grantAddHostSetHosts,
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=list,create,update;output_fields=id,name,description,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name:     "no grants can't remove hosts from host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{grantAddHostSetHosts}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "global role grant with host-catalog id, remove-hosts action, host-set type, and this/children scope allows removing hosts from host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					grantAddHostSetHosts,
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=remove-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "org role grant with host-catalog id, remove-hosts action, host-set type, and this/children scope allows removing hosts from host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					grantAddHostSetHosts,
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=remove-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "project role grant with host-catalog id, remove-hosts action, host-set type, and this/children scope allows removing hosts from host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					grantAddHostSetHosts,
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=remove-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "project role grant with an unassociated host-catalog id and remove-hosts action does not allow removing hosts from host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					grantAddHostSetHosts,
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hcClone.PublicId + ";type=host-set;actions=remove-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				hset := static.TestSet(t, conn, hc.PublicId,
+					static.WithName("test name - "+tc.name),
+					static.WithDescription("test description"),
+				)
+				hosts := static.TestHosts(t, conn, hc.GetPublicId(), 2)
+
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				// add hosts to the host set
+				_, err = s.AddHostSetHosts(fullGrantAuthCtx, &pbs.AddHostSetHostsRequest{
+					Id: hset.PublicId,
+					HostIds: []string{
+						hosts[0].PublicId,
+						hosts[1].PublicId,
+					},
+					// Version: version,
+					Version: 1,
+				})
+				require.NoError(t, err)
+
+				// remove hosts from the host set
+				got, err := s.RemoveHostSetHosts(fullGrantAuthCtx, &pbs.RemoveHostSetHostsRequest{
+					Id: hset.PublicId,
+					HostIds: []string{
+						hosts[0].PublicId,
+						hosts[1].PublicId,
+					},
+					Version: 2,
+				})
+				if tc.expected.err != nil {
+					require.ErrorIs(t, err, tc.expected.err)
+					return
+				}
+				// check if the output fields are as expected
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, got.Item, tc.expected.outputFields)
+			})
+		}
+	})
+
+	t.Run("Set Host Set Hosts", func(t *testing.T) {
+		hc := static.TestCatalog(t, conn, proj.PublicId, static.WithName("test set host set hosts catalog"), static.WithDescription("test desc"))
+		hcClone := static.TestCatalog(t, conn, proj.PublicId, static.WithName("clone set host set hosts catalog"), static.WithDescription("clone desc"))
+
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, auth.Account)
+			expected expectedOutput
+		}{
+			{
+				name: "global role grant this can't set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "org role grant this can't set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "project role grant this can set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=set-hosts;output_fields=id,host_ids,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "global role grant this & descendants can set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=host-set;actions=set-hosts;output_fields=id,host_ids,host_catalog_id,scope_id,name,description,created_time,updated_time,version,type,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.HostCatalogIdField, globals.ScopeIdField, globals.NameField, globals.DescriptionField, globals.CreatedTimeField, globals.UpdatedTimeField, globals.VersionField, globals.TypeField, globals.AuthorizedActionsField}},
+			},
+			{
+				name: "org role grant this & children can set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=set-hosts;output_fields=id,host_ids,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "incorrect grants can't set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=*;type=host-set;actions=list,create,update;output_fields=id,name,description,host_ids,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name:     "no grants can't set hosts on host-sets",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, nil),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+			{
+				name: "global role grant with host-catalog id, set-hosts action, host-set type, and this/children scope allows setting hosts on host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=set-hosts;output_fields=id,host_ids,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "org role grant with host-catalog id, set-hosts action, host-set type, and this/children scope allows setting hosts on host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=set-hosts;output_fields=id,host_ids,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "project role grant with host-catalog id, set-hosts action, host-set type, and this/children scope allows setting hosts on host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hc.PublicId + ";type=host-set;actions=set-hosts;output_fields=id,host_ids,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{outputFields: []string{globals.IdField, globals.HostIdsField, globals.ScopeIdField, globals.TypeField, globals.CreatedTimeField, globals.UpdatedTimeField}},
+			},
+			{
+				name: "project role grant with an unassociated host-catalog id and set-hosts action does not allow setting hosts on host-sets under the specified host-catalog",
+				userFunc: iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, oidc.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: proj.PublicId,
+						Grants:      []string{"ids=" + hcClone.PublicId + ";type=host-set;actions=set-hosts;output_fields=id,scope_id,type,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				expected: expectedOutput{err: handlers.ForbiddenError()},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				hset := static.TestSet(t, conn, hc.PublicId,
+					static.WithName("test name - "+tc.name),
+					static.WithDescription("test description"),
+				)
+				hosts := static.TestHosts(t, conn, hc.GetPublicId(), 3)
+
+				user, account := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				got, err := s.SetHostSetHosts(fullGrantAuthCtx, &pbs.SetHostSetHostsRequest{
+					Id: hset.PublicId,
+					HostIds: []string{
+						hosts[0].PublicId,
+						hosts[1].PublicId,
+						hosts[2].PublicId,
+					},
+					Version: 1,
+				})
+				if tc.expected.err != nil {
+					require.ErrorIs(t, err, tc.expected.err)
+					return
+				}
+				require.NoError(t, err)
+
+				wantIds := []string{hosts[0].PublicId, hosts[1].PublicId, hosts[2].PublicId}
+				require.ElementsMatch(t, wantIds, got.Item.HostIds)
+
+				// check if the output fields are as expected
+				require.NoError(t, err)
+				handlers.TestAssertOutputFields(t, got.Item, tc.expected.outputFields)
 			})
 		}
 	})

--- a/internal/daemon/controller/handlers/hosts/grants_test.go
+++ b/internal/daemon/controller/handlers/hosts/grants_test.go
@@ -81,7 +81,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=host;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
@@ -96,7 +96,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org.PublicId,
+						RoleScopeId:  org.PublicId,
 						GrantStrings: []string{"ids=*;type=host;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -111,7 +111,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  proj.PublicId,
+						RoleScopeId:  proj.PublicId,
 						GrantStrings: []string{"ids=*;type=host;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},

--- a/internal/daemon/controller/handlers/managed_groups/grants_test.go
+++ b/internal/daemon/controller/handlers/managed_groups/grants_test.go
@@ -5,22 +5,43 @@ package managed_groups_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
+	a "github.com/hashicorp/boundary/internal/auth"
 	"github.com/hashicorp/boundary/internal/auth/ldap"
 	"github.com/hashicorp/boundary/internal/auth/oidc"
+	"github.com/hashicorp/boundary/internal/auth/password"
 	"github.com/hashicorp/boundary/internal/authtoken"
 	"github.com/hashicorp/boundary/internal/daemon/controller/auth"
+	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers/managed_groups"
 	"github.com/hashicorp/boundary/internal/db"
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	pb "github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/managedgroups"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/protobuf/field_mask"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // TestGrants_ReadActions tests read actions to assert that grants are being applied properly
+//
+//	Role - which scope the role is created in
+//		 - global level
+//		 - org level
+//		 - proj level
+//	Grant - what IAM grant scope is set for the permission
+//		  - global: descendant
+//		  - org: children
+//		  - project: this
+//	Scopes [resource]:
+//		  - global
+//			- org1
+//			  - proj1
 func TestGrants_ReadActions(t *testing.T) {
 	ctx := context.Background()
 	conn, _ := db.TestSetup(t, "postgres")
@@ -36,6 +57,8 @@ func TestGrants_ReadActions(t *testing.T) {
 		// Use a small limit to test that membership lookup is explicitly unlimited
 		return ldap.NewRepository(ctx, rw, rw, kmsCache, ldap.WithLimit(ctx, 1))
 	}
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
 
 	s, err := managed_groups.NewService(ctx, oidcRepoFn, ldapRepoFn, 1000)
 	require.NoError(t, err)
@@ -44,6 +67,9 @@ func TestGrants_ReadActions(t *testing.T) {
 
 	globalDBWrapper, err := kmsCache.GetWrapper(ctx, globals.GlobalPrefix, kms.KeyPurposeDatabase)
 	require.NoError(t, err)
+	orgDBWrapper, err := kmsCache.GetWrapper(ctx, org.PublicId, kms.KeyPurposeDatabase)
+	require.NoError(t, err)
+
 	globalOidcAm := oidc.TestAuthMethod(
 		t, conn, globalDBWrapper, globals.GlobalPrefix, oidc.ActivePrivateState,
 		"alice-rp", "fido",
@@ -51,63 +77,347 @@ func TestGrants_ReadActions(t *testing.T) {
 		oidc.WithSigningAlgs(oidc.RS256),
 		oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://www.alice.com/callback")[0]),
 	)
+	globalOidcAm2 := oidc.TestAuthMethod(
+		t, conn, globalDBWrapper, globals.GlobalPrefix, oidc.ActivePrivateState,
+		"alice-rp-global2", "fido",
+		oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://www.alice.com")[0]),
+		oidc.WithSigningAlgs(oidc.RS256),
+		oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://www.alice.com/callback")[0]),
+	)
+	orgOidcAm := oidc.TestAuthMethod(
+		t, conn, orgDBWrapper, org.PublicId, oidc.ActivePrivateState,
+		"alice_rp_2", "alices-dogs-name",
+		oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://alice-org.com")[0]),
+		oidc.WithSigningAlgs(oidc.RS256),
+		oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://api.com")[0]),
+	)
+
 	_ = oidc.TestAccount(t, conn, globalOidcAm, "test-subject-1", oidc.WithName("global-1"), oidc.WithDescription("global-1"))
 	_ = oidc.TestAccount(t, conn, globalOidcAm, "test-subject-2", oidc.WithName("global-2"), oidc.WithDescription("global-2"))
-	globalMg1 := oidc.TestManagedGroup(t, conn, globalOidcAm, oidc.TestFakeManagedGroupFilter)
-	globalMg2 := oidc.TestManagedGroup(t, conn, globalOidcAm, oidc.TestFakeManagedGroupFilter)
+	_ = oidc.TestAccount(t, conn, globalOidcAm2, "test-subject-3", oidc.WithName("global-3"), oidc.WithDescription("global-3"))
+	_ = oidc.TestAccount(t, conn, orgOidcAm, "org-subject-1", oidc.WithName("org-1"), oidc.WithDescription("org-1"))
+	globalMg1 := oidc.TestManagedGroup(t, conn, globalOidcAm, oidc.TestFakeManagedGroupFilter, oidc.WithName("global-1"), oidc.WithDescription("global-1"))
+	globalMg2 := oidc.TestManagedGroup(t, conn, globalOidcAm, oidc.TestFakeManagedGroupFilter, oidc.WithName("global-2"), oidc.WithDescription("global-2"))
+	globalMg3 := oidc.TestManagedGroup(t, conn, globalOidcAm2, oidc.TestFakeManagedGroupFilter, oidc.WithName("global-3"), oidc.WithDescription("global-3"))
+	orgOidcMg := oidc.TestManagedGroup(t, conn, orgOidcAm, oidc.TestFakeManagedGroupFilter, oidc.WithName("org-1"), oidc.WithDescription("org-1"))
 
-	orgDBWrapper, err := kmsCache.GetWrapper(ctx, org.PublicId, kms.KeyPurposeDatabase)
-	require.NoError(t, err)
-	orgLdapAm := ldap.TestAuthMethod(t, conn, orgDBWrapper, org.PublicId, []string{"ldaps://ldap1"}, ldap.WithName(ctx, "global"), ldap.WithDescription(ctx, "global"))
+	globalLdapAm := ldap.TestAuthMethod(t, conn, globalDBWrapper, globals.GlobalPrefix, []string{"ldaps://ldap1"}, ldap.WithName(ctx, "global"), ldap.WithDescription(ctx, "global"))
+	orgLdapAm := ldap.TestAuthMethod(t, conn, orgDBWrapper, org.PublicId, []string{"ldaps://ldap2"}, ldap.WithName(ctx, "org"), ldap.WithDescription(ctx, "org"))
+	orgLdapAm2 := ldap.TestAuthMethod(t, conn, orgDBWrapper, org.PublicId, []string{"ldaps://ldap3"}, ldap.WithName(ctx, "org2"), ldap.WithDescription(ctx, "org2"))
+
 	_ = ldap.TestAccount(t, conn, orgLdapAm, "test-login-name-1", ldap.WithMemberOfGroups(ctx, "admin"), ldap.WithName(ctx, "org-1"), ldap.WithDescription(ctx, "org-1"))
-	_ = ldap.TestAccount(t, conn, orgLdapAm, "test-login-name-2", ldap.WithMemberOfGroups(ctx, "admin"), ldap.WithName(ctx, "org-2"), ldap.WithDescription(ctx, "org-2"))
-	orgMg := ldap.TestManagedGroup(t, conn, orgLdapAm, []string{"admin", "users"})
+	_ = ldap.TestAccount(t, conn, orgLdapAm2, "test-login-name-2", ldap.WithMemberOfGroups(ctx, "admin"), ldap.WithName(ctx, "org-2"), ldap.WithDescription(ctx, "org-2"))
+	_ = ldap.TestManagedGroup(t, conn, orgLdapAm2, []string{"admin", "users"})
+	orgLdapMg := ldap.TestManagedGroup(t, conn, orgLdapAm, []string{"admin", "users"}, ldap.WithName(ctx, "ldap-name"), ldap.WithDescription(ctx, "ldap-desc"))
+	globalLdapMg := ldap.TestManagedGroup(t, conn, globalLdapAm, []string{"admin", "users"}, ldap.WithName(ctx, "globaldap-name"), ldap.WithDescription(ctx, "globaldap-desc"))
 
 	t.Run("List", func(t *testing.T) {
 		testcases := []struct {
-			name          string
-			input         *pbs.ListManagedGroupsRequest
-			rolesToCreate []authtoken.TestRoleGrantsForToken
-			wantErr       error
-			wantIDs       []string
+			name            string
+			input           *pbs.ListManagedGroupsRequest
+			userFunc        func() (*iam.User, a.Account)
+			wantErr         error
+			wantIDs         []string
+			expectOutfields []string
 		}{
+			// oidc
 			{
-				name: "global role grant this returns all created oidc managed groups",
+				name: "global role grant this returns all global oidc managed groups",
 				input: &pbs.ListManagedGroupsRequest{
 					AuthMethodId: globalOidcAm.PublicId,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  globals.GlobalPrefix,
-						GrantStrings: []string{"ids=*;type=managed-group;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read;output_fields=id,name,description"},
+						GrantScopes: []string{globals.GrantScopeThis},
 					},
-				},
-				wantErr: nil,
-				wantIDs: []string{globalMg1.PublicId, globalMg2.PublicId},
+				}),
+				wantErr:         nil,
+				wantIDs:         []string{globalMg1.PublicId, globalMg2.PublicId},
+				expectOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField},
 			},
 			{
-				name: "org role grant this returns all created ldap managed groups",
+				name: "global role grant this and children only returns global oidc managed groups",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: globalOidcAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read;output_fields=id,scope,created_time,updated_time"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr:         nil,
+				wantIDs:         []string{globalMg1.PublicId, globalMg2.PublicId},
+				expectOutfields: []string{globals.IdField, globals.ScopeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+			},
+			{
+				name: "global role grant this and descendents only returns global oidc managed groups",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: globalOidcAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read;output_fields=id,version,type,auth_method_id"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr:         nil,
+				wantIDs:         []string{globalMg1.PublicId, globalMg2.PublicId},
+				expectOutfields: []string{globals.IdField, globals.VersionField, globals.TypeField, globals.AuthMethodIdField},
+			},
+			{
+				name: "global role grant this everything only returns global oidc managed groups",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: globalOidcAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*;output_fields=id,attrs,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr:         nil,
+				wantIDs:         []string{globalMg1.PublicId, globalMg2.PublicId},
+				expectOutfields: []string{globals.IdField, "attrs", globals.AuthorizedActionsField},
+			},
+			{
+				name: "global role grant this pinned id returns specific global oidc managed group",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: globalOidcAm2.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=managed-group;actions=*", globalOidcAm2.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{globalMg3.PublicId},
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeField,
+					globals.NameField,
+					globals.DescriptionField,
+					globals.VersionField,
+					globals.TypeField,
+					globals.AuthMethodIdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					"attrs",
+					globals.AuthorizedActionsField,
+					"oidc_managed_group_attributes",
+				},
+			},
+			{
+				name: "org role grant this only returns org oidc managed groups",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: orgOidcAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{orgOidcMg.PublicId},
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeField,
+					globals.NameField,
+					globals.DescriptionField,
+					globals.VersionField,
+					globals.TypeField,
+					globals.AuthMethodIdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					"attrs",
+					globals.AuthorizedActionsField,
+					"oidc_managed_group_attributes",
+				},
+			},
+			{
+				name: "no list permission returns error",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: orgOidcAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=managed-group;actions=read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr:         handlers.ForbiddenError(),
+				wantIDs:         nil,
+				expectOutfields: nil,
+			},
+			{
+				name: "global role not granted group resources returns error",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: orgOidcAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=target;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr:         handlers.ForbiddenError(),
+				wantIDs:         nil,
+				expectOutfields: nil,
+			},
+			// ldap
+			{
+				name: "global role grant this returns global created ldap managed group",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: globalLdapAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read;output_fields=id,name,description"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{
+					globalLdapMg.PublicId,
+				},
+				expectOutfields: []string{globals.IdField, globals.NameField, globals.DescriptionField},
+			},
+			{
+				name: "global role grant this pinned id returns global created ldap managed group",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: globalLdapAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=managed-group;actions=list,read;output_fields=id,scope,created_time,updated_time", globalLdapAm.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{
+					globalLdapMg.PublicId,
+				},
+				expectOutfields: []string{globals.IdField, globals.ScopeField, globals.CreatedTimeField, globals.UpdatedTimeField},
+			},
+			{
+				name: "global role grant this and children returns global created ldap managed group",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: globalLdapAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read;output_fields=id,version,type,auth_method_id"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{
+					globalLdapMg.PublicId,
+				},
+				expectOutfields: []string{globals.IdField, globals.VersionField, globals.TypeField, globals.AuthMethodIdField},
+			},
+			{
+				name: "global role grant this and descendants returns global created ldap managed group",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: globalLdapAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read;output_fields=id,attrs,authorized_actions"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr: nil,
+				wantIDs: []string{
+					globalLdapMg.PublicId,
+				},
+				expectOutfields: []string{globals.IdField, "attrs", globals.AuthorizedActionsField},
+			},
+			{
+				name: "org role grant this returns all org ldap managed groups",
 				input: &pbs.ListManagedGroupsRequest{
 					AuthMethodId: orgLdapAm.PublicId,
 				},
-				rolesToCreate: []authtoken.TestRoleGrantsForToken{
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
 					{
-						RoleScopeId:  org.PublicId,
-						GrantStrings: []string{"ids=*;type=managed-group;actions=list,read"},
-						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
-				},
+				}),
 				wantErr: nil,
 				wantIDs: []string{
-					orgMg.PublicId,
+					orgLdapMg.PublicId,
 				},
+				expectOutfields: []string{
+					globals.IdField,
+					globals.ScopeField,
+					globals.NameField,
+					globals.DescriptionField,
+					globals.VersionField,
+					globals.TypeField,
+					globals.AuthMethodIdField,
+					globals.CreatedTimeField,
+					globals.UpdatedTimeField,
+					"attrs",
+					globals.AuthorizedActionsField,
+					"ldap_managed_group_attributes",
+				},
+			},
+			{
+				name: "no list permission returns error",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: orgOidcAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=managed-group;actions=read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr:         handlers.ForbiddenError(),
+				wantIDs:         nil,
+				expectOutfields: nil,
+			},
+			{
+				name: "global role not granted group resources returns error",
+				input: &pbs.ListManagedGroupsRequest{
+					AuthMethodId: orgLdapAm.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=target;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr:         handlers.ForbiddenError(),
+				wantIDs:         nil,
+				expectOutfields: nil,
 			},
 		}
 
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-				tok := authtoken.TestAuthTokenWithRoles(t, conn, kmsCache, globals.GlobalPrefix, tc.rolesToCreate)
+				user, acct := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())
+				require.NoError(t, err)
 				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
 				got, finalErr := s.ListManagedGroups(fullGrantAuthCtx, tc.input)
 				if tc.wantErr != nil {
@@ -120,6 +430,908 @@ func TestGrants_ReadActions(t *testing.T) {
 					gotIDs = append(gotIDs, g.GetId())
 				}
 				require.ElementsMatch(t, tc.wantIDs, gotIDs)
+				for _, item := range got.Items {
+					handlers.TestAssertOutputFields(t, item, tc.expectOutfields)
+				}
+			})
+		}
+	})
+	t.Run("Get", func(t *testing.T) {
+		testcases := []struct {
+			name     string
+			input    *pbs.GetManagedGroupRequest
+			userFunc func() (*iam.User, a.Account)
+			wantErr  error
+			wantID   string
+		}{
+			// oidc
+			{
+				name: "global role grant this returns specific global oidc managed group",
+				input: &pbs.GetManagedGroupRequest{
+					Id: globalMg1.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantID:  globalMg1.PublicId,
+			},
+			{
+				name: "global role grant pinned id returns specific global oidc managed group",
+				input: &pbs.GetManagedGroupRequest{
+					Id: globalMg2.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=managed-group;actions=read", globalOidcAm.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantID:  globalMg2.PublicId,
+			},
+			{
+				name: "global role grant wrong pinned id returns error",
+				input: &pbs.GetManagedGroupRequest{
+					Id: globalMg2.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=managed-group;actions=list,read", globalOidcAm2.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+				wantID:  "",
+			},
+			{
+				name: "org role grant this only returns error",
+				input: &pbs.GetManagedGroupRequest{
+					Id: orgOidcMg.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+				wantID:  "",
+			},
+			{
+				name: "org role grant this and children returns org",
+				input: &pbs.GetManagedGroupRequest{
+					Id: orgOidcMg.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: nil,
+				wantID:  orgOidcMg.PublicId,
+			},
+			{
+				name: "org role grant this and descendants returns org",
+				input: &pbs.GetManagedGroupRequest{
+					Id: orgOidcMg.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr: nil,
+				wantID:  orgOidcMg.PublicId,
+			},
+			// ldap
+			{
+				name: "global role grant this returns specific global ldap managed group",
+				input: &pbs.GetManagedGroupRequest{
+					Id: globalLdapMg.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantID:  globalLdapMg.PublicId,
+			},
+			{
+				name: "global role grant pinned id returns specific global ldap managed group",
+				input: &pbs.GetManagedGroupRequest{
+					Id: globalLdapMg.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=managed-group;actions=read", globalLdapAm.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				wantID:  globalLdapMg.PublicId,
+			},
+			{
+				name: "global role grant wrong pinned id returns error",
+				input: &pbs.GetManagedGroupRequest{
+					Id: globalLdapMg.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=managed-group;actions=list,read", globalOidcAm2.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+				wantID:  "",
+			},
+			{
+				name: "org role grant this only returns error",
+				input: &pbs.GetManagedGroupRequest{
+					Id: orgLdapMg.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+				wantID:  "",
+			},
+			{
+				name: "org role grant this and children returns org",
+				input: &pbs.GetManagedGroupRequest{
+					Id: orgLdapMg.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: nil,
+				wantID:  orgLdapMg.PublicId,
+			},
+			{
+				name: "org role grant this and descendants returns org",
+				input: &pbs.GetManagedGroupRequest{
+					Id: orgLdapMg.PublicId,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=list,read"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr: nil,
+				wantID:  orgLdapMg.PublicId,
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, acct := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				got, finalErr := s.GetManagedGroup(fullGrantAuthCtx, tc.input)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, finalErr, tc.wantErr)
+					return
+				}
+				require.NoError(t, finalErr)
+				require.Equal(t, tc.wantID, got.Item.Id)
+			})
+		}
+	})
+}
+
+func TestGrants_WriteActions(t *testing.T) {
+	ctx := context.Background()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrap := db.TestWrapper(t)
+	rw := db.New(conn)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	oidcRepoFn := func() (*oidc.Repository, error) {
+		// Use a small limit to test that membership lookup is explicitly unlimited
+		return oidc.NewRepository(ctx, rw, rw, kmsCache, oidc.WithLimit(1))
+	}
+	ldapRepoFn := func() (*ldap.Repository, error) {
+		// Use a small limit to test that membership lookup is explicitly unlimited
+		return ldap.NewRepository(ctx, rw, rw, kmsCache, ldap.WithLimit(ctx, 1))
+	}
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+
+	s, err := managed_groups.NewService(ctx, oidcRepoFn, ldapRepoFn, 1000)
+	require.NoError(t, err)
+
+	org, _ := iam.TestScopes(t, iamRepo)
+
+	globalDBWrapper, err := kmsCache.GetWrapper(ctx, globals.GlobalPrefix, kms.KeyPurposeDatabase)
+	require.NoError(t, err)
+	orgDBWrapper, err := kmsCache.GetWrapper(ctx, org.PublicId, kms.KeyPurposeDatabase)
+	require.NoError(t, err)
+
+	globalOidcAm := oidc.TestAuthMethod(
+		t, conn, globalDBWrapper, globals.GlobalPrefix, oidc.ActivePrivateState,
+		"alice-rp", "fido",
+		oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://www.alice.com")[0]),
+		oidc.WithSigningAlgs(oidc.RS256),
+		oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://www.alice.com/callback")[0]),
+	)
+	orgOidcAm1 := oidc.TestAuthMethod(
+		t, conn, orgDBWrapper, org.PublicId, oidc.ActivePrivateState,
+		"alice_rp_2", "alices-dogs-name",
+		oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://alice-org.com")[0]),
+		oidc.WithSigningAlgs(oidc.RS256),
+		oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://api.com")[0]),
+	)
+	orgOidcAm2 := oidc.TestAuthMethod(
+		t, conn, orgDBWrapper, org.PublicId, oidc.ActivePrivateState,
+		"alice_rp_3", "alices-dogs-name",
+		oidc.WithIssuer(oidc.TestConvertToUrls(t, "https://alice-oraoeug.com")[0]),
+		oidc.WithSigningAlgs(oidc.RS256),
+		oidc.WithApiUrl(oidc.TestConvertToUrls(t, "https://apiaoeu.com")[0]),
+	)
+	globalLdapAm := ldap.TestAuthMethod(t, conn, globalDBWrapper, globals.GlobalPrefix, []string{"ldaps://ldap1"}, ldap.WithName(ctx, "global"), ldap.WithDescription(ctx, "global"))
+	orgLdapAm1 := ldap.TestAuthMethod(t, conn, orgDBWrapper, org.PublicId, []string{"ldaps://ldap2"}, ldap.WithName(ctx, "org"), ldap.WithDescription(ctx, "org"))
+	orgLdapAm2 := ldap.TestAuthMethod(t, conn, orgDBWrapper, org.PublicId, []string{"ldaps://ldap3"}, ldap.WithName(ctx, "org2"), ldap.WithDescription(ctx, "org2"))
+
+	t.Run("create oidc", func(t *testing.T) {
+		testcases := []struct {
+			name                     string
+			userFunc                 func() (*iam.User, a.Account)
+			authmethodIdExpectErrMap map[string]error
+		}{
+			// oidc
+			{
+				name: "oidc global role grant this and children can create managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalOidcAm.PublicId: nil,
+					orgOidcAm1.PublicId:   nil,
+					orgOidcAm2.PublicId:   nil,
+				},
+			},
+			{
+				name: "oidc global role grant this and descendants can create managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalOidcAm.PublicId: nil,
+					orgOidcAm1.PublicId:   nil,
+					orgOidcAm2.PublicId:   nil,
+				},
+			},
+			{
+				name: "oidc global role grant this only global can create managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalOidcAm.PublicId: nil,
+					orgOidcAm1.PublicId:   handlers.ForbiddenError(),
+					orgOidcAm2.PublicId:   handlers.ForbiddenError(),
+				},
+			},
+			{
+				name: "oidc children at global can create accounts in org",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalOidcAm.PublicId: handlers.ForbiddenError(),
+					orgOidcAm1.PublicId:   nil,
+					orgOidcAm2.PublicId:   nil,
+				},
+			},
+			{
+				name: "oidc descendant at global can create accounts in org",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalOidcAm.PublicId: handlers.ForbiddenError(),
+					orgOidcAm1.PublicId:   nil,
+					orgOidcAm2.PublicId:   nil,
+				},
+			},
+			{
+				name: "oidc pinned org1 grant can only create accounts in org1",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=managed-group;actions=create", orgOidcAm1.PublicId)},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalOidcAm.PublicId: handlers.ForbiddenError(),
+					orgOidcAm1.PublicId:   nil,
+					orgOidcAm2.PublicId:   handlers.ForbiddenError(),
+				},
+			},
+			{
+				name: "oidc target type does not allow create managed group",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=target;actions=*"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalOidcAm.PublicId: handlers.ForbiddenError(),
+					orgOidcAm1.PublicId:   handlers.ForbiddenError(),
+					orgOidcAm2.PublicId:   handlers.ForbiddenError(),
+				},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, acct := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				for am, wantErr := range tc.authmethodIdExpectErrMap {
+					name, err := uuid.GenerateUUID()
+					require.NoError(t, err)
+					item := &pbs.CreateManagedGroupRequest{
+						Item: &pb.ManagedGroup{
+							AuthMethodId: am,
+							Name:         &wrapperspb.StringValue{Value: name},
+							Description:  &wrapperspb.StringValue{Value: "desc"},
+							Type:         oidc.Subtype.String(),
+							Attrs: &pb.ManagedGroup_OidcManagedGroupAttributes{
+								OidcManagedGroupAttributes: &pb.OidcManagedGroupAttributes{
+									Filter: oidc.TestFakeManagedGroupFilter,
+								},
+							},
+						},
+					}
+					got, err := s.CreateManagedGroup(fullGrantAuthCtx, item)
+					if wantErr != nil {
+						require.ErrorIs(t, err, wantErr)
+						return
+					}
+					require.NoError(t, err)
+					require.NotNil(t, got)
+				}
+			})
+		}
+	})
+	t.Run("create ldap", func(t *testing.T) {
+		testcases := []struct {
+			name                     string
+			userFunc                 func() (*iam.User, a.Account)
+			authmethodIdExpectErrMap map[string]error
+		}{
+			{
+				name: "ldap global role grant this and children can create managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalLdapAm.PublicId: nil,
+					orgLdapAm1.PublicId:   nil,
+					orgLdapAm2.PublicId:   nil,
+				},
+			},
+			{
+				name: "ldap global role grant this and descendants can create managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalLdapAm.PublicId: nil,
+					orgLdapAm1.PublicId:   nil,
+					orgLdapAm2.PublicId:   nil,
+				},
+			},
+			{
+				name: "ldap global role grant this only global can create managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalLdapAm.PublicId: nil,
+					orgLdapAm1.PublicId:   handlers.ForbiddenError(),
+					orgLdapAm2.PublicId:   handlers.ForbiddenError(),
+				},
+			},
+			{
+				name: "ldap children at global can create accounts in org",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalLdapAm.PublicId: handlers.ForbiddenError(),
+					orgLdapAm1.PublicId:   nil,
+					orgLdapAm2.PublicId:   nil,
+				},
+			},
+			{
+				name: "ldap descendant at global can create accounts in org",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalLdapAm.PublicId: handlers.ForbiddenError(),
+					orgLdapAm1.PublicId:   nil,
+					orgLdapAm2.PublicId:   nil,
+				},
+			},
+			{
+				name: "ldap pinned org1 grant can only create accounts in org1",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=managed-group;actions=create", orgLdapAm1.PublicId)},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalLdapAm.PublicId: handlers.ForbiddenError(),
+					orgLdapAm1.PublicId:   nil,
+					orgLdapAm2.PublicId:   handlers.ForbiddenError(),
+				},
+			},
+			{
+				name: "ldap target type does not allow create managed group",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=target;actions=*"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				authmethodIdExpectErrMap: map[string]error{
+					globalLdapAm.PublicId: handlers.ForbiddenError(),
+					orgLdapAm1.PublicId:   handlers.ForbiddenError(),
+					orgLdapAm2.PublicId:   handlers.ForbiddenError(),
+				},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, acct := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				for am, wantErr := range tc.authmethodIdExpectErrMap {
+					name, err := uuid.GenerateUUID()
+					require.NoError(t, err)
+					item := &pbs.CreateManagedGroupRequest{
+						Item: &pb.ManagedGroup{
+							AuthMethodId: am,
+							Name:         &wrapperspb.StringValue{Value: name},
+							Description:  &wrapperspb.StringValue{Value: "desc"},
+							Type:         ldap.Subtype.String(),
+							Attrs: &pb.ManagedGroup_LdapManagedGroupAttributes{
+								LdapManagedGroupAttributes: &pb.LdapManagedGroupAttributes{
+									GroupNames: []string{"admin", "users"},
+								},
+							},
+						},
+					}
+					got, err := s.CreateManagedGroup(fullGrantAuthCtx, item)
+					if wantErr != nil {
+						require.ErrorIs(t, err, wantErr)
+						return
+					}
+					require.NoError(t, err)
+					require.NotNil(t, got)
+				}
+			})
+		}
+	})
+	t.Run("update oidc", func(t *testing.T) {
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, a.Account)
+			wantErr  error
+		}{
+			{
+				name: "oidc global role grant this can update managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+			},
+			{
+				name: "oidc global role grant this and children can update managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: nil,
+			},
+			{
+				name: "oidc global role grant this and descendants can update managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=update"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr: nil,
+			},
+			{
+				name: "oidc global role pinned id grant this can update managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=managed-group;actions=*", globalOidcAm.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+			},
+			{
+				name: "oidc global role grant this cannot update managed groups in org scope",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{org.PublicId},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				mg := oidc.TestManagedGroup(t, conn, globalOidcAm, oidc.TestFakeManagedGroupFilter, oidc.WithName("default"), oidc.WithDescription("default"))
+				user, acct := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				name, err := uuid.GenerateUUID()
+				require.NoError(t, err)
+				item := &pbs.UpdateManagedGroupRequest{
+					UpdateMask: &field_mask.FieldMask{
+						Paths: []string{globals.NameField, globals.DescriptionField},
+					},
+					Id: mg.GetPublicId(),
+					Item: &pb.ManagedGroup{
+						Version:     1,
+						Name:        &wrapperspb.StringValue{Value: name},
+						Description: &wrapperspb.StringValue{Value: "desc"},
+						Type:        oidc.Subtype.String(),
+					},
+				}
+				got, err := s.UpdateManagedGroup(fullGrantAuthCtx, item)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				require.NotNil(t, got)
+			})
+		}
+	})
+	t.Run("update ldap", func(t *testing.T) {
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, a.Account)
+			wantErr  error
+		}{
+			{
+				name: "ldap global role grant this can update managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+			},
+			{
+				name: "ldap global role grant this and chlidren can update managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: nil,
+			},
+			{
+				name: "ldap global role grant this and descendants can update managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr: nil,
+			},
+			{
+				name: "ldap global role pinned id grant this specific can update managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;type=managed-group;actions=*", globalLdapAm.PublicId)},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+			},
+			{
+				name: "ldap global role grant this specific can update managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=update"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+			},
+			{
+				name: "ldap global role grant this cannot update managed groups in org scope",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{org.PublicId},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				mg := ldap.TestManagedGroup(t, conn, globalLdapAm, []string{"admin", "users"}, ldap.WithName(ctx, "default"), ldap.WithDescription(ctx, "default"))
+				user, acct := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+				name, err := uuid.GenerateUUID()
+				require.NoError(t, err)
+				item := &pbs.UpdateManagedGroupRequest{
+					UpdateMask: &field_mask.FieldMask{
+						Paths: []string{globals.NameField, globals.DescriptionField},
+					},
+					Id: mg.GetPublicId(),
+					Item: &pb.ManagedGroup{
+						Version:     1,
+						Name:        &wrapperspb.StringValue{Value: name},
+						Description: &wrapperspb.StringValue{Value: "desc"},
+						Type:        ldap.Subtype.String(),
+					},
+				}
+				got, err := s.UpdateManagedGroup(fullGrantAuthCtx, item)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				require.NotNil(t, got)
+			})
+		}
+	})
+	t.Run("delete", func(t *testing.T) {
+		testcases := []struct {
+			name     string
+			userFunc func() (*iam.User, a.Account)
+			wantErr  error
+			mg       a.ManagedGroup
+		}{
+			{
+				name: "oidc global role grant this can delete managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				mg:      oidc.TestManagedGroup(t, conn, globalOidcAm, oidc.TestFakeManagedGroupFilter),
+			},
+			{
+				name: "oidc global role grant this and children can delete managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: nil,
+				mg:      oidc.TestManagedGroup(t, conn, globalOidcAm, oidc.TestFakeManagedGroupFilter),
+			},
+			{
+				name: "oidc global role grant this and descendants can delete managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr: nil,
+				mg:      oidc.TestManagedGroup(t, conn, globalOidcAm, oidc.TestFakeManagedGroupFilter),
+			},
+			{
+				name: "oidc org role grant this can delete managed groups in org scope",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: org.PublicId,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{org.PublicId},
+					},
+				}),
+				wantErr: nil,
+				mg:      oidc.TestManagedGroup(t, conn, orgOidcAm1, oidc.TestFakeManagedGroupFilter),
+			},
+			{
+				name: "oidc global role grant this cannot delete managed groups in org scope",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{org.PublicId},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+				mg:      oidc.TestManagedGroup(t, conn, globalOidcAm, oidc.TestFakeManagedGroupFilter),
+			},
+			{
+				name: "ldap global role grant this can delete managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				}),
+				wantErr: nil,
+				mg:      ldap.TestManagedGroup(t, conn, globalLdapAm, []string{"admin", "users"}),
+			},
+			{
+				name: "ldap global role grant this and children can delete managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=*"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
+					},
+				}),
+				wantErr: nil,
+				mg:      ldap.TestManagedGroup(t, conn, globalLdapAm, []string{"admin", "users"}),
+			},
+			{
+				name: "ldap global role grant this and descendants can delete managed groups everywhere",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=managed-group;actions=delete"},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr: nil,
+				mg:      ldap.TestManagedGroup(t, conn, globalLdapAm, []string{"admin", "users"}),
+			},
+			{
+				name: "ldap global role grant this cannot delete wrong type",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=target;actions=delete"},
+						GrantScopes: []string{org.PublicId},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+				mg:      ldap.TestManagedGroup(t, conn, globalLdapAm, []string{"admin", "users"}),
+			},
+			{
+				name: "ldap global role grant this cannot delete managed groups in org scope",
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=*;actions=*"},
+						GrantScopes: []string{org.PublicId},
+					},
+				}),
+				wantErr: handlers.ForbiddenError(),
+				mg:      ldap.TestManagedGroup(t, conn, globalLdapAm, []string{"admin", "users"}),
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				user, acct := tc.userFunc()
+				tok, err := atRepo.CreateAuthToken(ctx, user, acct.GetPublicId())
+				require.NoError(t, err)
+				fullGrantAuthCtx := auth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+
+				req := &pbs.DeleteManagedGroupRequest{
+					Id: tc.mg.GetPublicId(),
+				}
+				_, err = s.DeleteManagedGroup(fullGrantAuthCtx, req)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
 			})
 		}
 	})

--- a/internal/daemon/controller/handlers/managed_groups/grants_test.go
+++ b/internal/daemon/controller/handlers/managed_groups/grants_test.go
@@ -78,7 +78,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=managed-group;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
@@ -93,7 +93,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org.PublicId,
+						RoleScopeId:  org.PublicId,
 						GrantStrings: []string{"ids=*;type=managed-group;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},

--- a/internal/daemon/controller/handlers/roles/grants_test.go
+++ b/internal/daemon/controller/handlers/roles/grants_test.go
@@ -110,7 +110,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=role;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -130,7 +130,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org2.PublicId,
+						RoleScopeId:  org2.PublicId,
 						GrantStrings: []string{"ids=*;type=role;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},

--- a/internal/daemon/controller/handlers/scopes/grants_test.go
+++ b/internal/daemon/controller/handlers/scopes/grants_test.go
@@ -60,7 +60,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=scope;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -79,7 +79,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org1.PublicId,
+						RoleScopeId:  org1.PublicId,
 						GrantStrings: []string{"ids=*;type=scope;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},

--- a/internal/daemon/controller/handlers/targets/tcp/grants_test.go
+++ b/internal/daemon/controller/handlers/targets/tcp/grants_test.go
@@ -60,7 +60,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org1.GetPublicId(),
+						RoleScopeId:  org1.GetPublicId(),
 						GrantStrings: []string{"ids=*;type=target;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -76,7 +76,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  proj2.GetPublicId(),
+						RoleScopeId:  proj2.GetPublicId(),
 						GrantStrings: []string{"ids=*;type=target;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},

--- a/internal/daemon/controller/handlers/testing.go
+++ b/internal/daemon/controller/handlers/testing.go
@@ -1,0 +1,29 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestAssertOutputFields asserts that the output fields of a group match the expected fields
+// fields that is nil or empty in the result will throw an error if they are listed in expectedFields
+// e.g. members when group does not contain any members
+func TestAssertOutputFields(t *testing.T, p proto.Message, expectFields []string) {
+	msg := p.ProtoReflect()
+	descriptor := msg.Descriptor()
+	for i := 0; i < descriptor.Fields().Len(); i++ {
+		fd := descriptor.Fields().Get(i)
+		fieldName := string(fd.Name())
+		if !slices.Contains(expectFields, fieldName) {
+			require.Falsef(t, msg.Has(fd), "expect field '%s' to be empty but got %+v", fd.Name(), msg.Get(fd).Interface())
+			continue
+		}
+		require.Truef(t, msg.Has(fd), "expect field '%s' NOT be empty but got %+v", fd.Name(), msg.Get(fd).Interface())
+	}
+}

--- a/internal/daemon/controller/handlers/users/grants_test.go
+++ b/internal/daemon/controller/handlers/users/grants_test.go
@@ -78,7 +78,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -104,7 +104,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				includeTestUsers: false,
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org2.PublicId,
+						RoleScopeId:  org2.PublicId,
 						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
@@ -124,7 +124,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				includeTestUsers: false,
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeChildren},
 					},
@@ -144,7 +144,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				includeTestUsers: false,
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeChildren},
 					},
@@ -165,7 +165,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				includeTestUsers: false,
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org1.PublicId,
+						RoleScopeId:  org1.PublicId,
 						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},
@@ -184,12 +184,12 @@ func TestGrants_ReadActions(t *testing.T) {
 				includeTestUsers: false,
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org1.PublicId,
+						RoleScopeId:  org1.PublicId,
 						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},
 					{
-						RoleScopeID:  org2.PublicId,
+						RoleScopeId:  org2.PublicId,
 						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},
@@ -210,7 +210,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				includeTestUsers: false,
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},
@@ -227,7 +227,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				includeTestUsers: true,
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},
@@ -248,7 +248,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeChildren},
 					},
@@ -264,7 +264,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  org2.PublicId,
+						RoleScopeId:  org2.PublicId,
 						GrantStrings: []string{"ids=*;type=user;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeChildren},
 					},

--- a/internal/daemon/controller/handlers/workers/grants_test.go
+++ b/internal/daemon/controller/handlers/workers/grants_test.go
@@ -81,7 +81,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=worker;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},
@@ -97,7 +97,7 @@ func TestGrants_ReadActions(t *testing.T) {
 				},
 				rolesToCreate: []authtoken.TestRoleGrantsForToken{
 					{
-						RoleScopeID:  globals.GlobalPrefix,
+						RoleScopeId:  globals.GlobalPrefix,
 						GrantStrings: []string{"ids=*;type=group;actions=list,read"},
 						GrantScopes:  []string{globals.GrantScopeThis},
 					},

--- a/internal/host/static/testing.go
+++ b/internal/host/static/testing.go
@@ -12,6 +12,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestCatalog creates a static host catalog to the provided DB
+// with the provided project id.  If any errors are encountered during the creation of
+// the host catalog, the test will fail.
+// Name and description are the only valid options. All other options are
+// ignored.
+func TestCatalog(t testing.TB, conn *db.DB, projectId string, opt ...Option) *HostCatalog {
+	t.Helper()
+	ctx := context.Background()
+	assert := assert.New(t)
+
+	cat, err := NewHostCatalog(ctx, projectId, opt...)
+	assert.NoError(err)
+	assert.NotNil(cat)
+	id, err := newHostCatalogId(ctx)
+	assert.NoError(err)
+	assert.NotEmpty(id)
+	cat.PublicId = id
+
+	w := db.New(conn)
+	err2 := w.Create(ctx, cat)
+	assert.NoError(err2)
+
+	return cat
+}
+
 // TestCatalogs creates count number of static host catalogs to the provided DB
 // with the provided project id.  If any errors are encountered during the creation of
 // the host catalog, the test will fail.
@@ -86,6 +111,31 @@ func TestHosts(t testing.TB, conn *db.DB, catalogId string, count int) []*Host {
 		hosts = append(hosts, host)
 	}
 	return hosts
+}
+
+// TestSet creates a static host set in the provided DB
+// with the provided catalog id. The catalog must have been created
+// previously. Name and description are the only valid options. All other options are
+// ignored. The test will fail if any errors are encountered.
+func TestSet(t testing.TB, conn *db.DB, catalogId string, opt ...Option) *HostSet {
+	t.Helper()
+	ctx := context.Background()
+	assert := assert.New(t)
+
+	set, err := NewHostSet(ctx, catalogId, opt...)
+	assert.NoError(err)
+	assert.NotNil(set)
+
+	id, err := newHostSetId(ctx)
+	assert.NoError(err)
+	assert.NotEmpty(id)
+	set.PublicId = id
+
+	w := db.New(conn)
+	err2 := w.Create(ctx, set)
+	assert.NoError(err2)
+
+	return set
 }
 
 // TestSets creates count number of static host sets in the provided DB

--- a/internal/iam/testing.go
+++ b/internal/iam/testing.go
@@ -728,16 +728,7 @@ func TestUserGroupGrantsFunc(
 		rw := db.New(conn)
 		repo, err := NewRepository(ctx, rw, rw, kmsCache)
 		require.NoError(t, err)
-		role, err := NewRole(ctx, scopeId)
-		require.NoError(t, err)
-		id, err := newRoleId(ctx)
-		require.NoError(t, err)
-		role.PublicId = id
-		require.NoError(t, rw.Create(ctx, role))
-		require.NotEmpty(t, role.PublicId)
-		require.NoError(t, err)
 		group := TestGroup(t, conn, scopeId)
-		require.NoError(t, err)
 		user := TestUser(t, repo, scopeId, WithAccountIds(account.GetPublicId()))
 		for _, trg := range testRoleGrants {
 			role := TestRoleWithGrants(t, conn, trg.RoleScopeId, trg.GrantScopes, trg.Grants)

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -609,7 +609,7 @@ func Parse(ctx context.Context, tuple GrantTuple, opt ...Option) (Grant, error) 
 				default:
 					// Specified resource type, verify it's a child
 					if grant.typ.Parent() != idType {
-						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains type %s that is not a child type of the type (%s) of the specified id", grant.CanonicalString(), grant.typ.String(), idType.String()))
+						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains type %s that is not a child type of the type (%s) of the specified id", grant.CanonicalString(), grant.typ.String(), grant.typ.Parent()))
 					}
 				}
 			default: // no specified id


### PR DESCRIPTION
Cherrypick the commits from `llb-normalized-grants-tests-only` to `llb-normalized-grants`. 

Note: commits 81a665725328339fbc7151b40f47fa7fee005b17 and 71df2341c3319ba4ba671d1cc12bc90a7976c42c were already cherrypicked to `llb-normalized-grants`

