### PR TITLE
test: add grants test for user resource and fix ACL bug

### DIFF
--- a/internal/daemon/controller/handlers/users/grants_test.go
+++ b/internal/daemon/controller/handlers/users/grants_test.go
@@ -367,7 +367,7 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 					{
 						RoleScopeId: globals.GlobalPrefix,
 						Grants: []string{
-							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value",
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,version,description,value",
 							"ids=*;type=target;actions=*",
 						},
 						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
@@ -378,9 +378,9 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 				}
 			},
 			expectIdOutputFieldsMap: map[string][]string{
-				alias1.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
-				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
-				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+				alias1.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
+				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
+				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
 			},
 		},
 		{
@@ -390,7 +390,7 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 					{
 						RoleScopeId: globals.GlobalPrefix,
 						Grants: []string{
-							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value",
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,value",
 						},
 						GrantScopes: []string{globals.GrantScopeThis},
 					},
@@ -407,7 +407,7 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 				}
 			},
 			expectIdOutputFieldsMap: map[string][]string{
-				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
 			},
 		},
 		{
@@ -419,7 +419,7 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 					{
 						RoleScopeId: globals.GlobalPrefix,
 						Grants: []string{
-							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value",
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,value",
 						},
 						GrantScopes: []string{globals.GrantScopeThis},
 					},
@@ -447,7 +447,7 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 					{
 						RoleScopeId: globals.GlobalPrefix,
 						Grants: []string{
-							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value",
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,value",
 						},
 						GrantScopes: []string{globals.GrantScopeThis},
 					},
@@ -475,7 +475,7 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 					{
 						RoleScopeId: globals.GlobalPrefix,
 						Grants: []string{
-							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value",
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,value",
 						},
 						GrantScopes: []string{globals.GrantScopeThis},
 					},
@@ -485,9 +485,9 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 				}
 			},
 			expectIdOutputFieldsMap: map[string][]string{
-				alias1.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
-				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
-				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+				alias1.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
+				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
+				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
 			},
 		},
 		{
@@ -521,7 +521,7 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 					{
 						RoleScopeId: globals.GlobalPrefix,
 						Grants: []string{
-							fmt.Sprintf("ids=%s;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value", testUser.PublicId),
+							fmt.Sprintf("ids=%s;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,value", testUser.PublicId),
 						},
 						GrantScopes: []string{globals.GrantScopeThis},
 					},
@@ -531,9 +531,9 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 				}
 			},
 			expectIdOutputFieldsMap: map[string][]string{
-				alias1.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
-				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
-				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+				alias1.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
+				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
+				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
 			},
 		},
 		{
@@ -561,7 +561,7 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 					{
 						RoleScopeId: globals.GlobalPrefix,
 						Grants: []string{
-							fmt.Sprintf("ids=%s;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value", testUser.PublicId),
+							fmt.Sprintf("ids=%s;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,value", testUser.PublicId),
 						},
 						GrantScopes: []string{globals.GrantScopeThis},
 					},
@@ -571,8 +571,8 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 				}
 			},
 			expectIdOutputFieldsMap: map[string][]string{
-				alias1.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
-				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+				alias1.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
+				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
 			},
 		},
 		{
@@ -599,7 +599,7 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 					{
 						RoleScopeId: globals.GlobalPrefix,
 						Grants: []string{
-							fmt.Sprintf("ids=%s;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value", testUser.PublicId),
+							fmt.Sprintf("ids=%s;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,value", testUser.PublicId),
 						},
 						GrantScopes: []string{globals.GrantScopeThis},
 					},
@@ -609,8 +609,8 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 				}
 			},
 			expectIdOutputFieldsMap: map[string][]string{
-				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
-				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
+				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.ValueField},
 			},
 		},
 		{
@@ -620,7 +620,7 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 					{
 						RoleScopeId: globals.GlobalPrefix,
 						Grants: []string{
-							"ids=*;type=user;actions=list;output_fields=id,created_time,name,value",
+							"ids=*;type=user;actions=list;output_fields=id,created_time,value",
 						},
 						GrantScopes: []string{globals.GrantScopeThis},
 					},

--- a/internal/daemon/controller/handlers/users/grants_test.go
+++ b/internal/daemon/controller/handlers/users/grants_test.go
@@ -5,6 +5,7 @@ package users_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/boundary/globals"
@@ -19,24 +20,11 @@ import (
 	pbs "github.com/hashicorp/boundary/internal/gen/controller/api/services"
 	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/target"
+	"github.com/hashicorp/boundary/internal/target/tcp"
 	"github.com/stretchr/testify/require"
 )
 
-// TestGrants_ReadActions tests read actions to assert that grants are being applied properly
-//
-//	 Role - which scope the role is created in
-//			- global level
-//			- org level
-//		Grant - what IAM grant scope is set for the permission
-//			- global: descendant
-//			- org: children
-//		Scopes [resource]:
-//			- global [globalUser]
-//				- org1 [org1User]
-//					- org1User1
-//				- org2 [org2User]
-//					- org2User1
-//					- org2User2
 func TestGrants_ReadActions(t *testing.T) {
 	ctx := context.Background()
 	conn, _ := db.TestSetup(t, "postgres")
@@ -315,4 +303,245 @@ func TestGrants_ReadActions(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestGrants_ListResolvableAliases(t *testing.T) {
+	ctx := t.Context()
+	conn, _ := db.TestSetup(t, "postgres")
+	rw := db.New(conn)
+	wrap := db.TestWrapper(t)
+	iamRepo := iam.TestRepo(t, conn, wrap)
+	kmsCache := kms.TestKms(t, conn, wrap)
+	atRepo, err := authtoken.NewRepository(ctx, rw, rw, kmsCache)
+	require.NoError(t, err)
+	repoFn := func() (*iam.Repository, error) {
+		return iamRepo, nil
+	}
+	sqlDb, err := conn.SqlDB(ctx)
+	require.NoError(t, err)
+	// delete all default roles because they come with list-resolvable-aliases permissions
+	_, err = sqlDb.ExecContext(ctx, `delete from iam_role`)
+	require.NoError(t, err)
+	aliasRepoFn := func() (*talias.Repository, error) {
+		return talias.NewRepository(t.Context(), rw, rw, kmsCache)
+	}
+	s, err := users.NewService(ctx, repoFn, aliasRepoFn, 1000)
+	require.NoError(t, err)
+	org1, proj1 := iam.TestScopes(t, iamRepo, iam.WithSkipAdminRoleCreation(true), iam.WithSkipDefaultRoleCreation(true))
+	proj2 := iam.TestProject(t, iamRepo, org1.GetPublicId(), iam.WithSkipAdminRoleCreation(true), iam.WithSkipDefaultRoleCreation(true))
+	org2, proj3 := iam.TestScopes(t, iamRepo, iam.WithSkipAdminRoleCreation(true), iam.WithSkipDefaultRoleCreation(true))
+
+	target1 := tcp.TestTarget(ctx, t, conn, proj1.GetPublicId(), "test address-1", target.WithAddress("8.8.8.8"))
+	target2 := tcp.TestTarget(ctx, t, conn, proj2.GetPublicId(), "test address-2", target.WithAddress("8.8.8.8"))
+	target3 := tcp.TestTarget(ctx, t, conn, proj3.GetPublicId(), "test address-2", target.WithAddress("8.8.8.8"))
+
+	alias1 := talias.TestAlias(t, rw, "target1",
+		talias.WithName("target1"),
+		talias.WithDescription("target1"),
+		talias.WithDestinationId(target1.GetPublicId()),
+		talias.WithHostId(target1.GetPublicId()))
+	alias2 := talias.TestAlias(t, rw, "target2",
+		talias.WithName("target2"),
+		talias.WithDescription("target2"),
+		talias.WithDestinationId(target2.GetPublicId()),
+		talias.WithHostId(target2.GetPublicId()))
+	alias3 := talias.TestAlias(t, rw, "target3",
+		talias.WithName("target3"),
+		talias.WithDescription("target3"),
+		talias.WithDestinationId(target3.GetPublicId()),
+		talias.WithHostId(target3.GetPublicId()))
+
+	testcases := []struct {
+		name string
+		// setting returns user/account of a listing user which may be different than user in ListResolvableAliasesRequest
+		setupInput              func(t *testing.T) (*iam.User, auth.Account, *pbs.ListResolvableAliasesRequest)
+		expectIdOutputFieldsMap map[string][]string
+		wantErr                 error
+	}{
+		{
+			name: "global role this and descendants grants return all aliases list same user",
+			setupInput: func(t *testing.T) (*iam.User, auth.Account, *pbs.ListResolvableAliasesRequest) {
+				listingUser, listingAccount := iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants: []string{
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value",
+							"ids=*;type=target;actions=*",
+						},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				})()
+				return listingUser, listingAccount, &pbs.ListResolvableAliasesRequest{
+					Id: listingUser.PublicId,
+				}
+			},
+			expectIdOutputFieldsMap: map[string][]string{
+				alias1.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+			},
+		},
+		{
+			name: "global role this and org2 role children grants return all aliases list same user",
+			setupInput: func(t *testing.T) (*iam.User, auth.Account, *pbs.ListResolvableAliasesRequest) {
+				listingUser, listingAccount := iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants: []string{
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value",
+						},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: org2.PublicId,
+						Grants: []string{
+							"ids=*;type=target;actions=*",
+						},
+						GrantScopes: []string{globals.GrantScopeChildren},
+					},
+				})()
+				return listingUser, listingAccount, &pbs.ListResolvableAliasesRequest{
+					Id: listingUser.PublicId,
+				}
+			},
+			expectIdOutputFieldsMap: map[string][]string{
+				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+			},
+		},
+		{
+			name: "list other user without permissions returns nothing",
+			setupInput: func(t *testing.T) (*iam.User, auth.Account, *pbs.ListResolvableAliasesRequest) {
+				testUser, _ := iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{})()
+
+				listingUser, listingAccount := iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants: []string{
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value",
+						},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})()
+				return listingUser, listingAccount, &pbs.ListResolvableAliasesRequest{
+					Id: testUser.PublicId,
+				}
+			},
+			expectIdOutputFieldsMap: map[string][]string{},
+		},
+		{
+			name: "list other user with list-resolvable-aliases permissions but no targets permissions returns nothing",
+			setupInput: func(t *testing.T) (*iam.User, auth.Account, *pbs.ListResolvableAliasesRequest) {
+				testUser, _ := iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants: []string{
+							"ids=*;type=user;actions=*",
+						},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				})()
+
+				listingUser, listingAccount := iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants: []string{
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value",
+						},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})()
+				return listingUser, listingAccount, &pbs.ListResolvableAliasesRequest{
+					Id: testUser.PublicId,
+				}
+			},
+			expectIdOutputFieldsMap: map[string][]string{},
+		},
+		{
+			name: "list other user with no list-resolvable-aliases permissions but all targets permissions returns nothing",
+			setupInput: func(t *testing.T) (*iam.User, auth.Account, *pbs.ListResolvableAliasesRequest) {
+				testUser, _ := iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants: []string{
+							"ids=*;type=target;actions=*",
+						},
+						GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+					},
+				})()
+
+				listingUser, listingAccount := iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants: []string{
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value",
+						},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})()
+				return listingUser, listingAccount, &pbs.ListResolvableAliasesRequest{
+					Id: testUser.PublicId,
+				}
+			},
+			expectIdOutputFieldsMap: map[string][]string{},
+		},
+		{
+			name: "list other user with list-resolvable-aliases permissions and some targets permissions returns allowed targets",
+			setupInput: func(t *testing.T) (*iam.User, auth.Account, *pbs.ListResolvableAliasesRequest) {
+				testUser, _ := iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants: []string{
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=created_time",
+						},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants: []string{
+							fmt.Sprintf("ids=%s,%s;type=target;actions=authorize-session", target2.GetPublicId(), target3.GetPublicId()),
+						},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				})()
+
+				listingUser, listingAccount := iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants: []string{
+							"ids=*;type=user;actions=list-resolvable-aliases;output_fields=id,created_time,name,value",
+						},
+						GrantScopes: []string{globals.GrantScopeThis},
+					},
+				})()
+				return listingUser, listingAccount, &pbs.ListResolvableAliasesRequest{
+					Id: testUser.PublicId,
+				}
+			},
+			expectIdOutputFieldsMap: map[string][]string{
+				alias2.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+				alias3.PublicId: {globals.IdField, globals.CreatedTimeField, globals.NameField, globals.ValueField},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, account, input := tc.setupInput(t)
+			tok, err := atRepo.CreateAuthToken(ctx, user, account.GetPublicId())
+			require.NoError(t, err)
+			fullGrantAuthCtx := controllerauth.TestAuthContextFromToken(t, conn, wrap, tok, iamRepo)
+			got, err := s.ListResolvableAliases(fullGrantAuthCtx, input)
+			require.NoError(t, err)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, tc.wantErr, tc.wantErr)
+				return
+			}
+			require.Len(t, got.Items, len(tc.expectIdOutputFieldsMap))
+			for _, item := range got.Items {
+				expectFields, ok := tc.expectIdOutputFieldsMap[item.GetId()]
+				require.True(t, ok)
+				handlers.TestAssertOutputFields(t, item, expectFields)
+			}
+		})
+	}
+
 }

--- a/internal/daemon/controller/handlers/users/grants_test.go
+++ b/internal/daemon/controller/handlers/users/grants_test.go
@@ -678,5 +678,4 @@ func TestGrants_ListResolvableAliases(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/internal/daemon/controller/handlers/users/user_service.go
+++ b/internal/daemon/controller/handlers/users/user_service.go
@@ -915,7 +915,12 @@ func toResolvableAliasProto(a *talias.Alias, opt ...handlers.Option) (*aliaspb.A
 	if outputFields.Has(globals.TypeField) {
 		pbItem.Type = "target"
 	}
-
+	if outputFields.Has(globals.NameField) {
+		pbItem.Name = wrapperspb.String(a.GetName())
+	}
+	if outputFields.Has(globals.DescriptionField) {
+		pbItem.Description = wrapperspb.String(a.GetDescription())
+	}
 	return pbItem, nil
 }
 

--- a/internal/daemon/controller/handlers/users/user_service.go
+++ b/internal/daemon/controller/handlers/users/user_service.go
@@ -886,6 +886,8 @@ func toProto(ctx context.Context, in *iam.User, accts []string, opt ...handlers.
 	return &out, nil
 }
 
+// toResolvableAliasProto converts *talias.Alias to *aliaspb.Alias only including fields specified in output_fields.
+// These fields are not included in the result set: Name, Description, Version
 func toResolvableAliasProto(a *talias.Alias, opt ...handlers.Option) (*aliaspb.Alias, error) {
 	opts := handlers.GetOpts(opt...)
 	if opts.WithOutputFields == nil {
@@ -914,12 +916,6 @@ func toResolvableAliasProto(a *talias.Alias, opt ...handlers.Option) (*aliaspb.A
 	}
 	if outputFields.Has(globals.TypeField) {
 		pbItem.Type = "target"
-	}
-	if outputFields.Has(globals.NameField) {
-		pbItem.Name = wrapperspb.String(a.GetName())
-	}
-	if outputFields.Has(globals.DescriptionField) {
-		pbItem.Description = wrapperspb.String(a.GetDescription())
 	}
 	return pbItem, nil
 }

--- a/internal/perms/acl.go
+++ b/internal/perms/acl.go
@@ -427,8 +427,13 @@ func (a ACL) ListResolvableAliasesPermissions(requestedType resource.Type, actio
 			p.RoleParentScopeId = scope.Global.String()
 		}
 		if a.buildPermission(&scopes.ScopeInfo{ParentScopeId: scopeId}, requestedType, actions, false, &p) {
+			if p.All {
+				// only cache to childrenScopes when all IDs are granted because if the role with 'children' grant specifies
+				// resource IDs, the IDs may not overlap with the children scope roles which means we cannot skip
+				// parsing permissions on the children roles
+				childrenScopes[scopeId] = struct{}{}
+			}
 			perms = append(perms, p)
-			childrenScopes[scopeId] = struct{}{}
 		}
 	}
 

--- a/internal/perms/acl_test.go
+++ b/internal/perms/acl_test.go
@@ -1250,12 +1250,157 @@ func TestACL_ListResolvableAliasesPermissions(t *testing.T) {
 					OnlySelf:          false,
 				},
 				{
+					RoleScopeId:       "p_1a",
+					RoleParentScopeId: "o_1",
+					GrantScopeId:      "p_1a",
+					Resource:          resource.Target,
+					Action:            action.ListResolvableAliases,
+					ResourceIds:       []string{"ttcp_1234567890"},
+					All:               false,
+					OnlySelf:          false,
+				},
+				{
+					RoleScopeId:       "p_1b",
+					RoleParentScopeId: "o_1",
+					GrantScopeId:      "p_1b",
+					Resource:          resource.Target,
+					Action:            action.ListResolvableAliases,
+					ResourceIds:       []string{"ttcp_1234567890"},
+					All:               false,
+					OnlySelf:          false,
+				},
+				{
 					RoleScopeId:       "p_2",
 					RoleParentScopeId: "o_2",
 					GrantScopeId:      "p_2",
 					Resource:          resource.Target,
 					Action:            action.ListResolvableAliases,
 					ResourceIds:       []string{"ttcp_1234567890"},
+					All:               false,
+					OnlySelf:          false,
+				},
+			},
+		},
+		{
+			name:         "org_with_this_with_child_scope_direct_grants_parent_has_resource_all",
+			resourceType: resource.Target,
+			actionSet:    action.NewActionSet(action.Read, action.Cancel),
+			aclGrants: []scopeGrant{
+				{
+					roleScope:         "o_1",
+					roleParentScopeId: scope.Global.String(),
+					grantScope:        globals.GrantScopeChildren,
+					grants: []string{
+						"ids=*;type=target;actions=read",
+					},
+				},
+				{
+					roleScope:         "o_1",
+					roleParentScopeId: scope.Global.String(),
+					grantScope:        "o_1",
+					grants: []string{
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+				{
+					roleScope:         "p_1a",
+					roleParentScopeId: "o_1",
+					grantScope:        "p_1a",
+					grants: []string{
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+				{
+					roleScope:         "p_1b",
+					roleParentScopeId: "o_1",
+					grantScope:        "p_1b",
+					grants: []string{
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+				{
+					roleScope:         "p_2",
+					roleParentScopeId: "o_2",
+					grantScope:        "p_2",
+					grants: []string{
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+			},
+			expPermissions: []Permission{
+				{
+					RoleScopeId:       "o_1",
+					RoleParentScopeId: scope.Global.String(),
+					GrantScopeId:      globals.GrantScopeChildren,
+					Resource:          resource.Target,
+					Action:            action.ListResolvableAliases,
+					All:               true,
+					OnlySelf:          false,
+				},
+				{
+					RoleScopeId:       "o_1",
+					RoleParentScopeId: scope.Global.String(),
+					GrantScopeId:      "o_1",
+					Resource:          resource.Target,
+					Action:            action.ListResolvableAliases,
+					ResourceIds:       []string{"ttcp_1234567890"},
+					All:               false,
+					OnlySelf:          false,
+				},
+				{
+					RoleScopeId:       "p_2",
+					RoleParentScopeId: "o_2",
+					GrantScopeId:      "p_2",
+					Resource:          resource.Target,
+					Action:            action.ListResolvableAliases,
+					ResourceIds:       []string{"ttcp_1234567890"},
+					All:               false,
+					OnlySelf:          false,
+				},
+			},
+		},
+		{
+			name:         "org_with_child_scope_and_proj_granting_different_id",
+			resourceType: resource.Target,
+			actionSet:    action.NewActionSet(action.Read, action.Cancel),
+			aclGrants: []scopeGrant{
+				{
+					roleScope:         "o_1",
+					roleParentScopeId: scope.Global.String(),
+					grantScope:        globals.GrantScopeChildren,
+					grants: []string{
+						"ids=ttcp_1234567890;actions=read",
+					},
+				},
+				{
+					// project role that's a child of o_1
+					// granting a different resource than o_1 role
+					roleScope:         "p_1",
+					roleParentScopeId: "o_1",
+					grantScope:        "p_1",
+					grants: []string{
+						"ids=ttcp_abcdefghij;actions=read",
+					},
+				},
+			},
+			expPermissions: []Permission{
+				{
+					RoleScopeId:       "o_1",
+					RoleParentScopeId: scope.Global.String(),
+					GrantScopeId:      globals.GrantScopeChildren,
+					Resource:          resource.Target,
+					Action:            action.ListResolvableAliases,
+					ResourceIds:       []string{"ttcp_1234567890"},
+					All:               false,
+					OnlySelf:          false,
+				},
+				{
+					RoleScopeId:       "p_1",
+					RoleParentScopeId: "o_1",
+					GrantScopeId:      "p_1",
+					Resource:          resource.Target,
+					Action:            action.ListResolvableAliases,
+					ResourceIds:       []string{"ttcp_abcdefghij"},
 					All:               false,
 					OnlySelf:          false,
 				},


### PR DESCRIPTION
add grants tests for list-resolvable aliases

Fix bug in ACL where when a role in a scope is granted `children` grant scope with specific resource IDs, if there is a role in a child scope specifying different resource IDs in its grants, the child scope role permissions are ignored