### PR TITLE
bug: fix list target permissions resource ID overriding all resource grants

### DIFF
--- a/internal/daemon/controller/handlers/targets/tcp/grants_test.go
+++ b/internal/daemon/controller/handlers/targets/tcp/grants_test.go
@@ -165,7 +165,32 @@ func TestGrants_ReadActions(t *testing.T) {
 				wantErr:  handlers.ForbiddenError(),
 			},
 			{
-				name: "iss 5003 less permissive grants should not override more permissive ones",
+				name: "iss 5003 less permissive grants should not override more permissive grants with specific type",
+				input: &pbs.ListTargetsRequest{
+					ScopeId:   globals.GlobalPrefix,
+					Recursive: true,
+				},
+				userFunc: iam.TestUserGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, password.TestAuthMethodWithAccount, []iam.TestRoleGrantsRequest{
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{fmt.Sprintf("ids=%s;actions=authorize-session;output_fields=id,authorized_actions,scope_id,address", target1.GetPublicId())},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+					{
+						RoleScopeId: globals.GlobalPrefix,
+						Grants:      []string{"ids=*;type=target;actions=read,list;output_fields=id,authorized_actions,scope_id,address"},
+						GrantScopes: []string{globals.GrantScopeDescendants},
+					},
+				}),
+				wantErr: nil,
+				wantIdOutputFields: map[string][]string{
+					target1.GetPublicId(): {globals.IdField, globals.AuthorizedActionsField, globals.ScopeIdField, globals.AddressField},
+					target2.GetPublicId(): {globals.IdField, globals.AuthorizedActionsField, globals.ScopeIdField, globals.AddressField},
+					target3.GetPublicId(): {globals.IdField, globals.AuthorizedActionsField, globals.ScopeIdField, globals.AddressField},
+				},
+			},
+			{
+				name: "iss 5003 less permissive grants should not override more permissive grants",
 				input: &pbs.ListTargetsRequest{
 					ScopeId:   globals.GlobalPrefix,
 					Recursive: true,
@@ -179,11 +204,6 @@ func TestGrants_ReadActions(t *testing.T) {
 					{
 						RoleScopeId: globals.GlobalPrefix,
 						Grants:      []string{fmt.Sprintf("ids=%s;actions=authorize-session;output_fields=id,authorized_actions,scope_id,address", target1.GetPublicId())},
-						GrantScopes: []string{globals.GrantScopeDescendants},
-					},
-					{
-						RoleScopeId: globals.GlobalPrefix,
-						Grants:      []string{"ids=*;type=target;actions=read,list;output_fields=id,authorized_actions,scope_id,address"},
 						GrantScopes: []string{globals.GrantScopeDescendants},
 					},
 				}),

--- a/internal/session/repository.go
+++ b/internal/session/repository.go
@@ -100,7 +100,7 @@ func (r *Repository) listPermissionWhereClauses() ([]string, []any) {
 		clauses = append(clauses, fmt.Sprintf("project_id = @project_id_%d", inClauseCnt))
 		args = append(args, sql.Named(fmt.Sprintf("project_id_%d", inClauseCnt), p.GrantScopeId))
 
-		if len(p.ResourceIds) > 0 {
+		if len(p.ResourceIds) > 0 && !p.All {
 			clauses = append(clauses, fmt.Sprintf("public_id = any(@public_id_%d)", inClauseCnt))
 			args = append(args, sql.Named(fmt.Sprintf("public_id_%d", inClauseCnt), "{"+strings.Join(p.ResourceIds, ",")+"}"))
 		}

--- a/internal/target/repository.go
+++ b/internal/target/repository.go
@@ -390,7 +390,7 @@ func (r *Repository) listPermissionWhereClauses() ([]string, []any) {
 		clauses = append(clauses, fmt.Sprintf("project_id = @project_id_%d", inClauseCnt))
 		args = append(args, sql.Named(fmt.Sprintf("project_id_%d", inClauseCnt), p.GrantScopeId))
 
-		if len(p.ResourceIds) > 0 {
+		if len(p.ResourceIds) > 0 && !p.All {
 			clauses = append(clauses, fmt.Sprintf("public_id = any(@public_id_%d)", inClauseCnt))
 			args = append(args, sql.Named(fmt.Sprintf("public_id_%d", inClauseCnt), "{"+strings.Join(p.ResourceIds, ",")+"}"))
 		}


### PR DESCRIPTION
Fix issue #5003 

When a resource ID is specified for the same scope, list permissions handling prioritizes the specific resource ID rather than the `ids=*` which grants permissions to more resources causing the query to incorrectly filter out resources that the user should have permissions to take actions on.

- **fix list target not handling all resources permissions**
- **add test**
