### PR TITLE
UpdateControllerStatus:Update Hotfix

### DIFF
--- a/internal/server/repository_controller.go
+++ b/internal/server/repository_controller.go
@@ -95,12 +95,18 @@ func (r *Repository) UpdateControllerStatus(ctx context.Context, controller *Con
 		db.ExpBackoff{},
 		func(reader db.Reader, w db.Writer) error {
 			var err error
-			rowsUpdated, err = w.Exec(ctx, updateController,
-				[]any{
-					sql.Named("controller_address", controller.Address),
-					sql.Named("controller_description", controller.Description),
-					sql.Named("controller_private_id", controller.PrivateId),
-				})
+			params := []any{
+				sql.Named("controller_private_id", controller.PrivateId),
+				sql.Named("controller_address", controller.Address),
+			}
+
+			if controller.Description != "" {
+				params = append(params, sql.Named("controller_description", controller.Description))
+			} else {
+				params = append(params, sql.Named("controller_description", nil))
+			}
+
+			rowsUpdated, err = w.Exec(ctx, updateController, params)
 			switch {
 			case err != nil:
 				return errors.Wrap(ctx, err, op+":Update")

--- a/internal/server/repository_controller_test.go
+++ b/internal/server/repository_controller_test.go
@@ -184,6 +184,28 @@ func TestRepository_UpdateControllerStatus(t *testing.T) {
 				require.Equal(t, 1, c)
 			},
 		},
+		"valid-ipv4-controller-remove-description": {
+			originalController: NewController("test", WithAddress("127.0.0.1"), WithDescription("short name description")),
+			updatedController:  NewController("test", WithAddress("127.0.0.2")),
+			wantCount:          1,
+			cleanUpFunc: func(t *testing.T, rw *db.Db, privateId string) {
+				t.Helper()
+				c, err := rw.Exec(ctx, removeControllerSql, []any{privateId})
+				require.NoError(t, err)
+				require.Equal(t, 1, c)
+			},
+		},
+		"valid-ipv4-controller-no-description": {
+			originalController: NewController("test", WithAddress("127.0.0.1")),
+			updatedController:  NewController("test", WithAddress("127.0.0.2")),
+			wantCount:          1,
+			cleanUpFunc: func(t *testing.T, rw *db.Db, privateId string) {
+				t.Helper()
+				c, err := rw.Exec(ctx, removeControllerSql, []any{privateId})
+				require.NoError(t, err)
+				require.Equal(t, 1, c)
+			},
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
## Description
- Update `UpdateControllerStatus` to handle empty string descriptions. When reading from the `server_controller` repo, `NULL` descriptions are cast to empty strings. To prevent violating the `wt_description_too_short` constraint in the `wt_description` domain, ensure that empty string descriptions are converted to `nil` before being passed to the appropriate prepared query [updateController](https://github.com/hashicorp/boundary/blob/d4b34b1f50f5ee1dd3a8477123cf6a18284b7f38/internal/server/query.go#L227).
- Add two additional unit tests to account for this scenario. 