### PR TITLE
 fix(bug): authorized_collection_actions not returning from host-catalog

### DIFF
--- a/internal/daemon/controller/handlers/host_catalogs/grants_test.go
+++ b/internal/daemon/controller/handlers/host_catalogs/grants_test.go
@@ -516,7 +516,17 @@ func TestGrants_ReadActions(t *testing.T) {
 		user, account := iam.TestUserManagedGroupGrantsFunc(t, conn, kmsCache, globals.GlobalPrefix, ldap.TestAuthMethodWithAccountInManagedGroup, []iam.TestRoleGrantsRequest{
 			{
 				RoleScopeId: globals.GlobalPrefix,
-				Grants:      []string{"ids=*;type=*;actions=*"},
+				Grants:      []string{"ids=*;type=host-catalog;actions=*"},
+				GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+			},
+			{
+				RoleScopeId: globals.GlobalPrefix,
+				Grants:      []string{"ids=*;type=host;actions=*"},
+				GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
+			},
+			{
+				RoleScopeId: globals.GlobalPrefix,
+				Grants:      []string{"ids=*;type=host-set;actions=*"},
 				GrantScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 			},
 		})()

--- a/internal/daemon/controller/handlers/host_catalogs/host_catalog_service.go
+++ b/internal/daemon/controller/handlers/host_catalogs/host_catalog_service.go
@@ -701,7 +701,7 @@ func (s Service) authResult(ctx context.Context, id string, a action.Type, isRec
 	res := auth.VerifyResults{}
 
 	var parentId string
-	opts := []auth.Option{auth.WithAction(a), auth.WithRecursive(isRecursive)}
+	opts := []auth.Option{auth.WithAction(a), auth.WithRecursive(isRecursive), auth.WithFetchAdditionalResourceGrants(additionalResourceGrants...)}
 	switch a {
 	case action.List, action.Create:
 		parentId = id


### PR DESCRIPTION
## Description

When using 2 different roles to grant permissions to `host-catalog` and its child resources `host` and `host-sets`, collection_authorized_actions do not get populated