### PR TITLE
Allow rollbacks of migrations if hooks fail

### DIFF
--- a/internal/db/schema/internal/postgres/postgres.go
+++ b/internal/db/schema/internal/postgres/postgres.go
@@ -202,6 +202,24 @@ func (p *Postgres) CommitRun(ctx context.Context) error {
 	return nil
 }
 
+// RollbackRun rolls back a transaction.
+func (p *Postgres) RollbackRun(ctx context.Context) error {
+	const op = "postgres.(Postgres).RollbackRun"
+	defer func() {
+		p.tx = nil
+	}()
+	if p.tx == nil {
+		return errors.New(ctx, errors.MigrationIntegrity, op, "no pending transaction")
+	}
+	if err := p.tx.Rollback(); err != nil {
+		if errors.Is(err, sql.ErrTxDone) {
+			return nil
+		}
+		return errors.Wrap(ctx, err, op)
+	}
+	return nil
+}
+
 // Run will apply a migration. The io.Reader should provide the SQL
 // statements to execute, and the int is the version for that set of
 // statements. This should always be wrapped by StartRun and CommitRun.


### PR DESCRIPTION
## Description
If, during a migration, a hook fails to work correctly, the migration will currently not be rolled back which can cause Boundary to end up in a state where we do not support the current db version. This fix will rollback any transactions if a hook errors while running.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
