### PR TITLE
fix(bug): database migration does not rollback schema version on hook failure

### DIFF
--- a/internal/db/schema/internal/postgres/postgres.go
+++ b/internal/db/schema/internal/postgres/postgres.go
@@ -202,7 +202,7 @@ func (p *Postgres) CommitRun(ctx context.Context) error {
 	return nil
 }
 
-// RollbackRun rolls back a transaction.
+// RollbackRun rolls back a transaction. If no transaction is active, it will return nil.
 func (p *Postgres) RollbackRun(ctx context.Context) error {
 	const op = "postgres.(Postgres).RollbackRun"
 	defer func() {

--- a/internal/db/schema/internal/postgres/postgres_test.go
+++ b/internal/db/schema/internal/postgres/postgres_test.go
@@ -46,6 +46,38 @@ create table foo (
 	assert.Equal(t, v, 1001)
 }
 
+func TestRun_Rollback(t *testing.T) {
+	ctx := context.Background()
+	p, _, _ := setup(ctx, t)
+
+	statements := bytes.NewReader([]byte(`
+create table foo (
+  id bigint primary key,
+  bar text
+);
+`))
+
+	err := p.StartRun(ctx)
+	require.NoError(t, err)
+
+	err = p.EnsureVersionTable(ctx)
+	require.NoError(t, err)
+
+	err = p.EnsureMigrationLogTable(ctx)
+	require.NoError(t, err)
+
+	err = p.Run(ctx, statements, 1001, "oss")
+	require.NoError(t, err)
+
+	err = p.RollbackRun(ctx)
+	require.NoError(t, err)
+
+	v, i, err := p.CurrentState(ctx, "oss")
+	require.NoError(t, err)
+	assert.False(t, i)
+	assert.Equal(t, -1, v)
+}
+
 func TestRun_NoTxn(t *testing.T) {
 	ctx := context.Background()
 	p, _, _ := setup(ctx, t)

--- a/internal/db/schema/manager.go
+++ b/internal/db/schema/manager.go
@@ -254,6 +254,7 @@ func (b *Manager) runMigrations(ctx context.Context, p *provider.Provider) ([]Re
 	}
 
 	defer func() {
+		// rolling back a commited run is a no-op, so we can safely call this every time
 		if err := b.driver.RollbackRun(ctx); err != nil {
 			retErr = stderrors.Join(retErr, err)
 		}

--- a/internal/db/schema/manager.go
+++ b/internal/db/schema/manager.go
@@ -254,11 +254,10 @@ func (b *Manager) runMigrations(ctx context.Context, p *provider.Provider) ([]Re
 	}
 
 	defer func() {
-		// rolling back a commited run is a no-op, so we can safely call this every time
+		// rolling back a committed run is a no-op, so we can safely call this every time
 		if err := b.driver.RollbackRun(ctx); err != nil {
 			retErr = stderrors.Join(retErr, err)
 		}
-		return
 	}()
 
 	if ensureErr := b.driver.EnsureVersionTable(ctx); ensureErr != nil {

--- a/internal/db/schema/manager_test.go
+++ b/internal/db/schema/manager_test.go
@@ -360,8 +360,8 @@ func TestApplyMigrationWithHooks(t *testing.T) {
 				Editions: []schema.EditionState{
 					{
 						Name:                  "hooks",
-						BinarySchemaVersion:   1001,
-						DatabaseSchemaVersion: 1001,
+						BinarySchemaVersion:   2001,
+						DatabaseSchemaVersion: 2001,
 						DatabaseSchemaState:   schema.Equal,
 					},
 				},
@@ -379,7 +379,7 @@ func TestApplyMigrationWithHooks(t *testing.T) {
 						0,
 						edition.WithPreHooks(
 							map[int]*migration.Hook{
-								1001: {
+								2001: {
 									CheckFunc: func(ctx context.Context, tx *sql.Tx) (migration.Problems, error) {
 										return migration.Problems{"failed"}, nil
 									},
@@ -393,7 +393,7 @@ func TestApplyMigrationWithHooks(t *testing.T) {
 			},
 			nil,
 			schema.MigrationCheckError{
-				Version:           1001,
+				Version:           2001,
 				Edition:           "hooks",
 				Problems:          migration.Problems{"failed"},
 				RepairDescription: "repair all the things",
@@ -403,8 +403,8 @@ func TestApplyMigrationWithHooks(t *testing.T) {
 				Editions: []schema.EditionState{
 					{
 						Name:                  "hooks",
-						BinarySchemaVersion:   1001,
-						DatabaseSchemaVersion: 1,
+						BinarySchemaVersion:   2001,
+						DatabaseSchemaVersion: 0,
 						DatabaseSchemaState:   schema.Behind,
 					},
 				},
@@ -447,8 +447,8 @@ func TestApplyMigrationWithHooks(t *testing.T) {
 				Editions: []schema.EditionState{
 					{
 						Name:                  "hooks",
-						BinarySchemaVersion:   1001,
-						DatabaseSchemaVersion: 1001,
+						BinarySchemaVersion:   2001,
+						DatabaseSchemaVersion: 2001,
 						DatabaseSchemaState:   schema.Equal,
 					},
 				},
@@ -494,7 +494,7 @@ func TestApplyMigrationWithHooks(t *testing.T) {
 				Editions: []schema.EditionState{
 					{
 						Name:                  "hooks",
-						BinarySchemaVersion:   1001,
+						BinarySchemaVersion:   2001,
 						DatabaseSchemaVersion: 1,
 						DatabaseSchemaState:   schema.Behind,
 					},

--- a/internal/db/schema/manager_test.go
+++ b/internal/db/schema/manager_test.go
@@ -404,7 +404,7 @@ func TestApplyMigrationWithHooks(t *testing.T) {
 					{
 						Name:                  "hooks",
 						BinarySchemaVersion:   2001,
-						DatabaseSchemaVersion: 0,
+						DatabaseSchemaVersion: 1,
 						DatabaseSchemaState:   schema.Behind,
 					},
 				},

--- a/internal/db/schema/testdata/hooks/updated/2/01_another_update.up.sql
+++ b/internal/db/schema/testdata/hooks/updated/2/01_another_update.up.sql
@@ -1,0 +1,8 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+    create table test_five (
+      id tt_public_id primary key
+    );
+commit;


### PR DESCRIPTION
## Description
- continuation of https://github.com/hashicorp/boundary/pull/5904
- address review comment from #5904 
- add test to `schema` package

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
