### PR TITLE
chore(e2e): Fix bucket lifecycle warning

### DIFF
--- a/enos/modules/aws_bucket/main.tf
+++ b/enos/modules/aws_bucket/main.tf
@@ -25,6 +25,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "example" {
       days = 7
     }
     status = "Enabled"
+    filter {}
   }
 }
 


### PR DESCRIPTION
## Description
The aws provider was returning the following warning on the [aws_s3_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) resource, which will become an error in future versions of the provider.
```
│ Warning: Invalid Attribute Combination
│ 
│   with module.storage_bucket.aws_s3_bucket_lifecycle_configuration.example,
│   on ../../modules/aws_bucket/main.tf line 19, in resource "aws_s3_bucket_lifecycle_configuration" "example":
│   19: resource "aws_s3_bucket_lifecycle_configuration" "example" {
│ 
│ No attribute specified when one (and only one) of [rule[0].filter,rule[0].prefix] is required
│ 
│ This will be an error in a future version of the provider
│ 
│ (and one more similar warning elsewhere)
```

This PR adds a field to state that this policy applies to all objects, mitigating this warning.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
