### PR TITLE
fix(bug): runMigrations not using named returned properly

### DIFF
--- a/internal/db/schema/internal/postgres/postgres.go
+++ b/internal/db/schema/internal/postgres/postgres.go
@@ -209,7 +209,7 @@ func (p *Postgres) RollbackRun(ctx context.Context) error {
 		p.tx = nil
 	}()
 	if p.tx == nil {
-		return errors.New(ctx, errors.MigrationIntegrity, op, "no pending transaction")
+		return nil
 	}
 	if err := p.tx.Rollback(); err != nil {
 		if errors.Is(err, sql.ErrTxDone) {

--- a/internal/db/schema/manager.go
+++ b/internal/db/schema/manager.go
@@ -243,11 +243,8 @@ func (b *Manager) ApplyMigrations(ctx context.Context) ([]RepairLog, error) {
 // runMigrations passes migration queries to a database driver and manages
 // the version and dirty bit. Cancellation or deadline/timeout is managed
 // through the passed in context.
-func (b *Manager) runMigrations(ctx context.Context, p *provider.Provider) ([]RepairLog, error) {
+func (b *Manager) runMigrations(ctx context.Context, p *provider.Provider) (logEntries []RepairLog, retErr error) {
 	const op = "schema.(Manager).runMigrations"
-
-	var logEntries []RepairLog
-	var retErr error
 
 	if startErr := b.driver.StartRun(ctx); startErr != nil {
 		return nil, errors.Wrap(ctx, startErr, op)
@@ -312,5 +309,5 @@ func (b *Manager) runMigrations(ctx context.Context, p *provider.Provider) ([]Re
 		return nil, errors.Wrap(ctx, err, op)
 	}
 
-	return logEntries, retErr
+	return logEntries, nil
 }


### PR DESCRIPTION
- **return nil when no transaction is opened**
- **use named return for retErr**

## Description

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
