### PR TITLE
docs: Backport - Release notes for 0.19.3 (#5852)

### DIFF
--- a/website/content/docs/release-notes/v0_19_0.mdx
+++ b/website/content/docs/release-notes/v0_19_0.mdx
@@ -79,6 +79,19 @@ description: >-
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    Redundant grant scopes are no longer permitted
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    You may have redundant grant scopes if you applied a grant to a scope and the scope also inherited the grant from the <code>this</code>, <code>children</code>, or <code>descendants</code> options. As of Boundary version 0.19.3, redundant grant scopes are no longer permitted.
+    <br /><br />
+    When you upgrade a cluster to Boundary version 0.19.3, the migration will fail with a message if the database contains any redundant grant scopes. The migration tool provides a command that automatically removes any redundant grant scopes so that you can proceed with the upgrade.
+    <br /><br />
+    Learn more about removing redundant grant scopes and upgrading to version 0.19.3:&nbsp; <a href="#redundant-grants">Known issues and breaking changes </a>
+    </td>
+  </tr>
+
   </tbody>
 </table>
 
@@ -357,7 +370,7 @@ description: >-
     <ul>
     <li><a href="/boundary/docs/api-clients/client-agent#grants">Boundary Client Agent grants</a> requirements</li>
     <li><a href="/boundary/docs/commands/roles/create"><code>roles create</code></a> command documentation</li>
-    <li><a href="/boundary/docs/comands/roles/add-grant-scopes"><code>roles add-grant-scopes</code></a> command documentation</li>
+    <li><a href="/boundary/docs/commands/roles/add-grant-scopes"><code>roles add-grant-scopes</code></a> command documentation</li>
     <li><a href="/boundary/docs/commands/roles/add-grants"><code>roles add-grants</code></a> command documentation</li>
     </ul>
     </td>
@@ -377,6 +390,35 @@ description: >-
     <br /><br />
     Learn more: <a href="/boundary/docs/concepts/transparent-sessions">Transparent sessions</a>
     <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  <tr id="redundant-grants">
+    <td style={{verticalAlign: 'middle'}}>
+    0.15.0 - 0.19.2
+    <br /><br />
+    (Fixed in Boundary version 0.19.3)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    Redundant grant scopes cause performance issues
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    You may have redundant grant scopes if you applied a grant to a scope and the scope also inherited the grant from the <code>this</code>, <code>children</code>, or <code>descendants</code> options. Redundant grant scopes could cause performance issues. As of Boundary version 0.19.3, redundant grant scopes are no longer permitted.
+    <br /><br />
+    When you run the <code>boundary database migrate</code> command to upgrade a cluster to Boundary version 0.19.3, the migration will fail with a message if the database contains any redundant grant scopes. The migration tool provides the following command to automatically repair the grant scopes:
+    <br /><br />
+    <code>boundary database migrate -repair=oss:97001</code>
+    <br /><br />
+    Run the command to remove any redundant grant scopes from roles. Any individually granted scopes that are already covered by <code>descendants</code> or <code>children</code> grants are considered invalid and removed. When the migration is complete, the migration tool produces a message that details any changes.
+    <br /><br />
+    Learn more:
+      <ul>
+      <li><a href="/boundary/docs/concepts/domain-model/scopes">Scopes</a></li>
+      <li><a href="/boundary/docs/commands/roles/add-grant-scopes"><code>roles add-grant-scopes</code></a> command documentation</li>
+      <li><a href="/boundary/docs/commands/roles/remove-grant-scopes"><code>roles remove-grant-scopes</code></a> command documentation</li>
+      <li><a href="/boundary/docs/commands/roles/set-grant-scopes"><code>roles set-grant-scopes</code></a> command documentation</li>
+      </ul>
     <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
     </td>
   </tr>


### PR DESCRIPTION
The automated backport failed for #5852. This PR manually back ports these commits to the `stable-website` branch:

* docs: Release notes

* docs: Edits

* docs: Edits

* docs: Typo

* docs: Typo

* docs: Fix link to deprecated commands

* Update website/content/docs/release-notes/v0_19_0.mdx

Co-authored-by: Michael Milton <mikemountain@users.noreply.github.com>

* docs: Fix typo

* docs: Remove deprecated features

---------

Co-authored-by: Michael Milton <mikemountain@users.noreply.github.com>

## Description

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
