### PR TITLE
docs: Note that keyboard-interactive auth is not supported

### DIFF
--- a/website/content/docs/concepts/credential-management.mdx
+++ b/website/content/docs/concepts/credential-management.mdx
@@ -99,7 +99,9 @@ Credential injection is required for the SSH target type, allowing users to inje
 - Usernames and passwords
 - Usernames and public keys
 
-Additional credentials can be brokered to SSH targets after the session is establised using injected credentials.
+The SSH server must be configured to allow password authentication. Keyboard-interactive authentication is not supported for credential injection.
+
+You can broker additional credentials to SSH targets after the session is established using injected credentials.
 
 ### Security considerations
 

--- a/website/content/docs/concepts/credential-management.mdx
+++ b/website/content/docs/concepts/credential-management.mdx
@@ -99,7 +99,8 @@ Credential injection is required for the SSH target type, allowing users to inje
 - Usernames and passwords
 - Usernames and public keys
 
-The SSH server must be configured to allow password authentication. Keyboard-interactive authentication is not supported for credential injection.
+Keyboard-interactive authentication is not supported for credential injection.
+When you use Username password credentials, ensure that your SSH server is configured to allow password authentication.
 
 You can broker additional credentials to SSH targets after the session is established using injected credentials.
 

--- a/website/content/docs/configuration/credential-management/configure-credential-injection.mdx
+++ b/website/content/docs/configuration/credential-management/configure-credential-injection.mdx
@@ -24,7 +24,7 @@ Credential injection provides end users with a passwordless experience when they
 
 - You must have a static credential saved in your static credential store or Vault credential store. The credential must correspond to the target to which you want to authenticate.
 
-- For SSH credential injection, your SSH server must be configured to allow password authentication. Keyboard-interactive authentication is not supported.
+- Keyboard-interactive authentication is not supported. When you use Username password credentials, ensure that your SSH server is configured to allow password authentication.
 
 ## Configuration
 
@@ -82,3 +82,4 @@ Refer to the following topics for more information:
 - [Create static credential stores](/boundary/docs/configuration/credential-management/static-cred-boundary)
 - [Create Vault credential stores](/boundary/docs/configuration/credential-management/static-cred-vault)
 - [Target types](/boundary/docs/concepts/domain-model/targets#target-types)
+- [Credentials](/boundary/docs/concepts/domain-model/credentials)

--- a/website/content/docs/configuration/credential-management/configure-credential-injection.mdx
+++ b/website/content/docs/configuration/credential-management/configure-credential-injection.mdx
@@ -24,6 +24,8 @@ Credential injection provides end users with a passwordless experience when they
 
 - You must have a static credential saved in your static credential store or Vault credential store. The credential must correspond to the target to which you want to authenticate.
 
+- For SSH credential injection, your SSH server must be configured to allow password authentication. Keyboard-interactive authentication is not supported.
+
 ## Configuration
 
 Complete the following steps to configure targets with credential injection:


### PR DESCRIPTION
## Description

Last week we ran into a somewhat confusing situation with injected SSH credentials that could be helped with some additional documentation. Context here: https://hashicorp.slack.com/archives/C01AQDJF3SA/p1751574938390999?thread_ts=1751340829.616129&cid=C01AQDJF3SA.

I updated the main conceptual topic that explains credential management and the procedure that describes the configuration steps to add statements that the keyboard-interactive auth method is not supported for SSH credential injection.

View the updates in the preview deployment:

- Credential management > [Credential injection](https://boundary-5rlmvy3qd-hashicorp.vercel.app/boundary/docs/concepts/credential-management#credential-injection)
- Configuring credential injection > [Requirements](https://boundary-5rlmvy3qd-hashicorp.vercel.app/boundary/docs/configuration/credential-management/configure-credential-injection#requirements)



## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
