### PR TITLE
chore(e2e): Add recovery key to boundary config

### DIFF
--- a/enos/modules/aws_boundary/templates/controller.hcl
+++ b/enos/modules/aws_boundary/templates/controller.hcl
@@ -56,6 +56,12 @@ kms "awskms" {
   kms_key_id = "${kms_key_id}"
 }
 
+kms "awskms" {
+  purpose    = "recovery"
+  region     = "${region}"
+  kms_key_id = "${kms_key_id}"
+}
+
 events {
   audit_enabled        = true
   observations_enabled = true

--- a/enos/modules/aws_boundary/templates/controller_bsr.hcl
+++ b/enos/modules/aws_boundary/templates/controller_bsr.hcl
@@ -62,6 +62,12 @@ kms "awskms" {
   kms_key_id = "${kms_key_id}"
 }
 
+kms "awskms" {
+  purpose    = "recovery"
+  region     = "${region}"
+  kms_key_id = "${kms_key_id}"
+}
+
 events {
   audit_enabled        = true
   observations_enabled = true


### PR DESCRIPTION
## Description
This PR updates the e2e test infra to define a recovery key for the controller when creating it in AWS (see https://developer.hashicorp.com/boundary/docs/install-boundary/configure-controllers for more info). This was done for two reasons
- Aligns more closely with customer configurations
- Enables testing of authenticating using the recovery key. Recently, this was needed to test some fixes in the Boundary Terraform Provider where we needed to authenticate using the recovery key

```
# Example
provider "boundary" {
  addr                   = "http://boundary-alb-hihncznv-1698252270.us-east-1.elb.amazonaws.com:9200"
  recovery_kms_hcl = <<EOT
    kms "awskms" {
      purpose            = "recovery"
      ...
    }
  EOT
}
```



## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
