### PR TITLE
proto: change username of UP cred to be sensitive

### DIFF
--- a/internal/proto/controller/api/resources/sessionrecordings/v1/session_recording.proto
+++ b/internal/proto/controller/api/resources/sessionrecordings/v1/session_recording.proto
@@ -314,7 +314,7 @@ message Credential {
 // The attributes of a UsernamePassword Credential.
 message UsernamePasswordCredentialAttributes {
   // The username associated with the credential.
-  string username = 1; // @gotags: class:"public"
+  string username = 1; // @gotags: class:"sensitive"
 
   // The hmac value of the password.
   string password_hmac = 2; // @gotags: class:"public"

--- a/internal/proto/controller/servers/services/v1/credential.proto
+++ b/internal/proto/controller/servers/services/v1/credential.proto
@@ -21,7 +21,7 @@ message Credential {
 // UsernamePassword is a credential containing a username and a password.
 message UsernamePassword {
   // The username of the credential
-  string username = 10; // @gotags: `class:"public"`
+  string username = 10; // @gotags: `class:"sensitive"`
 
   // The password of the credential
   string password = 20; // @gotags: `class:"secret"`


### PR DESCRIPTION
## Description
The username of UsernamePassword creds should be set to sensitive instead of public.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
