### PR TITLE
chore(e2e): Fix availability zone check

### DIFF
--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -34,8 +34,9 @@ scenario "e2e_aws_base_with_vault" {
 
     variables {
       instance_type = [
+        var.controller_instance_type,
         var.worker_instance_type,
-        var.controller_instance_type
+        var.target_instance_type
       ]
     }
   }

--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -34,8 +34,9 @@ scenario "e2e_aws_base" {
 
     variables {
       instance_type = [
+        var.controller_instance_type,
         var.worker_instance_type,
-        var.controller_instance_type
+        var.target_instance_type
       ]
     }
   }

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -39,8 +39,9 @@ scenario "e2e_aws" {
 
     variables {
       instance_type = [
+        var.controller_instance_type,
         var.worker_instance_type,
-        var.controller_instance_type
+        var.target_instance_type
       ]
     }
   }

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -36,8 +36,7 @@ scenario "e2e_database" {
 
     variables {
       instance_type = [
-        var.worker_instance_type,
-        var.controller_instance_type
+        var.target_instance_type
       ]
     }
   }

--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -35,8 +35,9 @@ scenario "e2e_ui_aws" {
 
     variables {
       instance_type = [
+        var.controller_instance_type,
         var.worker_instance_type,
-        var.controller_instance_type
+        var.target_instance_type
       ]
     }
   }

--- a/enos/modules/aws_az_finder/main.tf
+++ b/enos/modules/aws_az_finder/main.tf
@@ -16,14 +16,20 @@ variable "instance_type" {
 }
 
 data "aws_ec2_instance_type_offerings" "infra" {
+  for_each = toset(var.instance_type)
   filter {
     name   = "instance-type"
-    values = var.instance_type
+    values = [each.key]
   }
 
   location_type = "availability-zone"
 }
 
+locals {
+  az_sets    = [for d in data.aws_ec2_instance_type_offerings.infra : toset(d.locations)]
+  common_azs = length(local.az_sets) > 0 ? setintersection(local.az_sets...) : []
+}
+
 output "availability_zones" {
-  value = data.aws_ec2_instance_type_offerings.infra.locations
+  value = local.common_azs
 }


### PR DESCRIPTION
## Description
This PR tries to mitigate the following error which occasionally pops up when creating e2e test infra
> Error: creating EC2 Instance: operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: 0242e007-2f30-40f9-81e8-c84e4d856bb7, api error Unsupported: Your requested instance type (t3a.small) is not supported in your requested Availability Zone (us-east-1e). Please retry your request by not specifying an Availability Zone or choosing us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1f.

Two changes are made
- Update scenarios to pass in a full list of all instance types being used 
- Update the availability zone module to only return zones that support ALL instance types passed in (previously, it would return a full list of zones that support any of the instance types passed in)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
