### PR TITLE
docs: add Alias, Storage Policy to domain model overview (#5941)

### DIFF
--- a/website/content/docs/concepts/domain-model/aliases.mdx
+++ b/website/content/docs/concepts/domain-model/aliases.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Aliases
 
-An alias is a globally unique, DNS-like string that is associated wtih a destination resource.
+An alias is a globally unique, DNS-like string that is associated with a destination resource.
 Examples of valid aliases are `webserver` and `webserver.boundary`.
 You can establish a session to a target by referencing its alias, instead of having to provide a target ID or target name and scope ID.
 For example, if you have an alias `boundary.dev`, you can use it to connect to a target with the following command: `boundary connect ssh boundary.dev`.

--- a/website/content/docs/concepts/domain-model/index.mdx
+++ b/website/content/docs/concepts/domain-model/index.mdx
@@ -83,6 +83,11 @@ significant number of resources exist.
   issued from a configured [authentication method][]
   which can be used to establish the identity of a [user][].
 
+- **[Alias][]** :
+  A resource
+  that represents a globally unique, DNS-like string that is
+  associated with a destination resource, such as a [target][].
+
 - **[Credential][]** :
   A data structure containing one or more secrets
   that binds an identity to a set of permissions or capabilities
@@ -152,6 +157,11 @@ significant number of resources exist.
    A storage bucket is used to store [session recordings][].
    The storage bucket represents a bucket in an external object store.
 
+- **[Storage policy][]** :
+   A storage policy defines the rules for storing
+   [session recordings][] in a [storage bucket][].
+   The storage policy may specify the retention period for the recordings.
+
 - **[Target][]** :
   A resource
   that represents a networked service
@@ -178,6 +188,7 @@ Refer to the [Scopes] section to help you understand the structure of resources 
 [iam]: https://en.wikipedia.org/wiki/Identity_management
 [account]: /boundary/docs/concepts/domain-model/accounts
 [accounts]: /boundary/docs/concepts/domain-model/accounts
+[alias]: /boundary/docs/concepts/domain-model/aliases
 [authentication method]: /boundary/docs/concepts/domain-model/auth-methods
 [authentication methods]: /boundary/docs/concepts/domain-model/auth-methods
 [credential library]: /boundary/docs/concepts/domain-model/credential-libraries
@@ -204,6 +215,7 @@ Refer to the [Scopes] section to help you understand the structure of resources 
 [session recordings]: /boundary/docs/concepts/domain-model/session-recordings
 [sessions]: /boundary/docs/concepts/domain-model/sessions
 [storage bucket]: /boundary/docs/concepts/domain-model/storage-buckets
+[storage policy]: /boundary/docs/concepts/domain-model/storage-policy
 [target]: /boundary/docs/concepts/domain-model/targets
 [targets]: /boundary/docs/concepts/domain-model/targets
 [user]: /boundary/docs/concepts/domain-model/users


### PR DESCRIPTION
The back port PR #5945 contained a number of commits that were not included in the original PR (#5941 ). I closed that PR in favor of this one. This PR manually cherry-picks the commit from #5941.

* docs: add Alias to domain model overview

Also fix a typo in the Aliases page.

* docs: add storage policy to domain model overview

## Description

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
