### PR TITLE
chore(e2e): Add option for specifying windows format

### DIFF
--- a/enos/scripts/test_e2e_env.sh
+++ b/enos/scripts/test_e2e_env.sh
@@ -7,7 +7,33 @@ DIR=$(pwd)
 SCRIPTS_DIR=$( cd -- "$( dirname -- "$0" )" &> /dev/null && pwd )
 STATEDIR=$(ls -td $SCRIPTS_DIR/../.enos/*/ | head -1) # get latest directory
 
+# Default to linux format
+FORMAT="linux"
+
+# Parse flag
+while getopts "f:" opt; do
+  case ${opt} in
+    f)
+      if [[ "$OPTARG" == "linux" || "$OPTARG" == "windows" ]]; then
+        FORMAT="$OPTARG"
+      else
+        echo "Invalid format. Use 'linux' or 'windows'."
+        exit 1
+      fi
+      ;;
+    *)
+      echo "Usage: $0 [-f linux|windows]"
+      exit 1
+      ;;
+  esac
+done
+
 cd $STATEDIR
-terraform show -json terraform.tfstate | jq -r '.values.root_module.child_modules[].resources[] | select(.address=="module.run_e2e_test.enos_local_exec.run_e2e_test") | .values.environment | to_entries[] | select(.value != "") | "export \(.key)=\(.value|@sh)"'
+
+if [[ "$FORMAT" == "windows" ]]; then
+  terraform show -json terraform.tfstate | jq -r '.values.root_module.child_modules[].resources[] | select(.address=="module.run_e2e_test.enos_local_exec.run_e2e_test") | .values.environment | to_entries[] | select(.value != "") | "$env:\(.key)=\(.value|@sh);"'
+else
+  terraform show -json terraform.tfstate | jq -r '.values.root_module.child_modules[].resources[] | select(.address=="module.run_e2e_test.enos_local_exec.run_e2e_test") | .values.environment | to_entries[] | select(.value != "") | "export \(.key)=\(.value|@sh);"'
+fi
 
 cd $DIR


### PR DESCRIPTION
## Description
This PR updates an e2e test helper script that helps extract environment variables after using enos/terraform to create test infrastructure. An additional option was added to output environment variables in a Windows format so that it can be used in Powershell. 
```
❯ . /Users/mycow/Developer/boundary/enos/scripts/test_e2e_env.sh -f windows
$env:BOUNDARY_ADDR='http://boundary:9200';
$env:E2E_AWS_HOST_SET_IPS='[""]';
$env:E2E_LDAP_ADDR='ldap://ldap';
$env:E2E_LDAP_ADMIN_DN='cn=admin,dc=example,dc=org';
$env:E2E_LDAP_ADMIN_PASSWORD='admin';
$env:E2E_LDAP_DOMAIN_DN='dc=example,dc=org';
$env:E2E_LDAP_GROUP_NAME='scientists';
$env:E2E_LDAP_USER_NAME='einstein';
```

Usages:
```
. /Users/mycow/Developer/boundary/enos/scripts/test_e2e_env.sh               # returns linux format
. /Users/mycow/Developer/boundary/enos/scripts/test_e2e_env.sh -f windows
. /Users/mycow/Developer/boundary/enos/scripts/test_e2e_env.sh -f linux
```


## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
