### PR TITLE
docs: Document that grant strings allow multiple ids

### DIFF
--- a/website/content/docs/configuration/identity-access-management/permission-grant-formats.mdx
+++ b/website/content/docs/configuration/identity-access-management/permission-grant-formats.mdx
@@ -18,7 +18,7 @@ A grant string has a form similar to:
 
 There are two types of selectors:
 
-- An `id` field that indicates a specific resource or a wildcard to match all.
+- An `ids` field that indicates a specific resource or a wildcard to match all.
 You can enter multiple comma-separated ID values in a grant string.
 - A `type` field that indicates a specific resource type or a wildcard to match
   all; this might also be used to grant permissions on collections of resources.


### PR DESCRIPTION
## Description

In a Slack conversation, Jeff Mitchell pointed out the Permission grant formats help topic does not explain that you can include multiple comma-separated ID values in grant strings. This PR adds a statement to document that and an additional example.

[View the update in the preview deployment](https://boundary-go6gie3p8-hashicorp.vercel.app/boundary/docs/configuration/identity-access-management/permission-grant-formats)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [X] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
