### PR TITLE
chore(sqltest): update deprecated NZ timezone and update test matrix

### DIFF
--- a/.github/workflows/test-sql.yml
+++ b/.github/workflows/test-sql.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     strategy:
       matrix:
-        postgres-version: [ latest, 12-alpine, 13-alpine, 14-alpine, 15-alpine ]
+        postgres-version: [ latest, 13-alpine, 14-alpine, 15-alpine, 16-alpine, 17-alpine ]
     name: SQL Tests ${{ matrix.postgres-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/internal/db/sqltest/tests/hcp/billing/monthly_active_users_all_timezone.sql
+++ b/internal/db/sqltest/tests/hcp/billing/monthly_active_users_all_timezone.sql
@@ -21,7 +21,7 @@ begin;
                   'Truncate tables in preparation for testing');
 
   -- generate auth tokens for users simulating the server being configured to use a different time zone.
-  set time zone 'NZ';
+  set time zone 'Pacific/Auckland';
   with
   month_range (date_key, time_key, month) as (
     select wh_date_key(s), wh_time_key(s), s
@@ -98,19 +98,19 @@ begin;
          else results_eq(
            'select * from hcp_billing_monthly_active_users_all',
            $$
-           values (date_trunc('month', now(),                       'nz'), date_trunc('hour',  now(),                       'nz'), 0::bigint),
-                  (date_trunc('month', now() - interval  '1 month', 'nz'), date_trunc('month', now(),                       'nz'), 6::bigint),
-                  (date_trunc('month', now() - interval  '2 month', 'nz'), date_trunc('month', now() - interval  '1 month', 'nz'), 6::bigint),
-                  (date_trunc('month', now() - interval  '3 month', 'nz'), date_trunc('month', now() - interval  '2 month', 'nz'), 6::bigint),
-                  (date_trunc('month', now() - interval  '4 month', 'nz'), date_trunc('month', now() - interval  '3 month', 'nz'), 6::bigint),
-                  (date_trunc('month', now() - interval  '5 month', 'nz'), date_trunc('month', now() - interval  '4 month', 'nz'), 6::bigint),
-                  (date_trunc('month', now() - interval  '6 month', 'nz'), date_trunc('month', now() - interval  '5 month', 'nz'), 6::bigint),
-                  (date_trunc('month', now() - interval  '7 month', 'nz'), date_trunc('month', now() - interval  '6 month', 'nz'), 6::bigint),
-                  (date_trunc('month', now() - interval  '8 month', 'nz'), date_trunc('month', now() - interval  '7 month', 'nz'), 6::bigint),
-                  (date_trunc('month', now() - interval  '9 month', 'nz'), date_trunc('month', now() - interval  '8 month', 'nz'), 6::bigint),
-                  (date_trunc('month', now() - interval '10 month', 'nz'), date_trunc('month', now() - interval  '9 month', 'nz'), 6::bigint),
-                  (date_trunc('month', now() - interval '11 month', 'nz'), date_trunc('month', now() - interval '10 month', 'nz'), 6::bigint),
-                  (date_trunc('month', now() - interval '12 month', 'nz'), date_trunc('month', now() - interval '11 month', 'nz'), 6::bigint)
+           values (date_trunc('month', now(),                       'Pacific/Auckland'), date_trunc('hour',  now(),                       'Pacific/Auckland'), 0::bigint),
+                  (date_trunc('month', now() - interval  '1 month', 'Pacific/Auckland'), date_trunc('month', now(),                       'Pacific/Auckland'), 6::bigint),
+                  (date_trunc('month', now() - interval  '2 month', 'Pacific/Auckland'), date_trunc('month', now() - interval  '1 month', 'Pacific/Auckland'), 6::bigint),
+                  (date_trunc('month', now() - interval  '3 month', 'Pacific/Auckland'), date_trunc('month', now() - interval  '2 month', 'Pacific/Auckland'), 6::bigint),
+                  (date_trunc('month', now() - interval  '4 month', 'Pacific/Auckland'), date_trunc('month', now() - interval  '3 month', 'Pacific/Auckland'), 6::bigint),
+                  (date_trunc('month', now() - interval  '5 month', 'Pacific/Auckland'), date_trunc('month', now() - interval  '4 month', 'Pacific/Auckland'), 6::bigint),
+                  (date_trunc('month', now() - interval  '6 month', 'Pacific/Auckland'), date_trunc('month', now() - interval  '5 month', 'Pacific/Auckland'), 6::bigint),
+                  (date_trunc('month', now() - interval  '7 month', 'Pacific/Auckland'), date_trunc('month', now() - interval  '6 month', 'Pacific/Auckland'), 6::bigint),
+                  (date_trunc('month', now() - interval  '8 month', 'Pacific/Auckland'), date_trunc('month', now() - interval  '7 month', 'Pacific/Auckland'), 6::bigint),
+                  (date_trunc('month', now() - interval  '9 month', 'Pacific/Auckland'), date_trunc('month', now() - interval  '8 month', 'Pacific/Auckland'), 6::bigint),
+                  (date_trunc('month', now() - interval '10 month', 'Pacific/Auckland'), date_trunc('month', now() - interval  '9 month', 'Pacific/Auckland'), 6::bigint),
+                  (date_trunc('month', now() - interval '11 month', 'Pacific/Auckland'), date_trunc('month', now() - interval '10 month', 'Pacific/Auckland'), 6::bigint),
+                  (date_trunc('month', now() - interval '12 month', 'Pacific/Auckland'), date_trunc('month', now() - interval '11 month', 'Pacific/Auckland'), 6::bigint)
             $$)
          end;
 

--- a/internal/db/sqltest/tests/hcp/billing/monthly_timezone.sql
+++ b/internal/db/sqltest/tests/hcp/billing/monthly_timezone.sql
@@ -23,7 +23,7 @@ begin;
                     'hcp_billing_monthly_sessions_last_2_months should return 2 rows each with 0 sessions pending');
 
 
-  set time zone 'NZ';
+  set time zone 'Pacific/Auckland';
 
   with time_series (time) as (
     select date_trunc('month', now(), 'utc') - interval '1 minute'


### PR DESCRIPTION
## Description
Sql tests were failing with the following message:
`psql:/test/hcp/billing/monthly_active_users_all_timezone.sql:24: ERROR:  invalid value for parameter "TimeZone": "NZ"`

[It appears that the latest Postgres release has changed how timezones are treated:](https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-TIMEZONES)
```
You cannot set the configuration parameters [TimeZone](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-TIMEZONE) 
or [log_timezone](https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-LOG-TIMEZONE) 
to a time zone abbreviation, but you can use abbreviations in date/time input values and with the 
AT TIME ZONE operator.
```

The sql test matrix has also been updated to remove tests against 12 and add testing against 16 and 17.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
