### PR TITLE
test(grants): Use 'continue' when iterating over expected outputs

### DIFF
--- a/internal/daemon/controller/handlers/authmethods/grants_test.go
+++ b/internal/daemon/controller/handlers/authmethods/grants_test.go
@@ -1003,7 +1003,7 @@ func TestGrants_Update(t *testing.T) {
 				})
 				if expectedOutput.wantErr != nil {
 					require.ErrorIs(t, err, expectedOutput.wantErr)
-					return
+					continue
 				}
 				require.NoError(t, err)
 				handlers.TestAssertOutputFields(t, resp.Item, expectedOutput.wantOutfields)

--- a/internal/daemon/controller/handlers/managed_groups/grants_test.go
+++ b/internal/daemon/controller/handlers/managed_groups/grants_test.go
@@ -837,7 +837,7 @@ func TestGrants_WriteActions(t *testing.T) {
 					got, err := s.CreateManagedGroup(fullGrantAuthCtx, item)
 					if wantErr != nil {
 						require.ErrorIs(t, err, wantErr)
-						return
+						continue
 					}
 					require.NoError(t, err)
 					require.NotNil(t, got)
@@ -982,7 +982,7 @@ func TestGrants_WriteActions(t *testing.T) {
 					got, err := s.CreateManagedGroup(fullGrantAuthCtx, item)
 					if wantErr != nil {
 						require.ErrorIs(t, err, wantErr)
-						return
+						continue
 					}
 					require.NoError(t, err)
 					require.NotNil(t, got)


### PR DESCRIPTION
## Description

There are a couple of spots in grants tests where, if there's an expected error when iterating over the expected output, we `return` instead of continuing to iterate over the remaining expected outputs. This causes testcases to end prematurely instead of processing the entire testcase.

For example:

```go

expected := map[string]error {
    globalAuthMethod.PublicId: handlers.ForbiddenError(),
    org1AuthMethod.PublicId:   nil,
    org2AuthMethod.PublicId:   nil,
}

for id, wantError := range expected {
    result, err := GetAuthMethod(id)
    if wantError != nil {
        require.ErrorIs(t, wantError, err)
        return // <-- if globalAuthMethod is processed first, the other authmethods are skipped.
    }
}
```

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
