### PR TITLE
chore(e2e): Increase test timeout to 30m

### DIFF
--- a/enos/modules/test_e2e_docker/main.tf
+++ b/enos/modules/test_e2e_docker/main.tf
@@ -221,7 +221,7 @@ variable "ldap_group_name" {
 }
 variable "test_timeout" {
   type    = string
-  default = "25m"
+  default = "30m"
 }
 variable "gcp_private_key_id" {
   description = "ID of the private key used to authenticate with GCP"


### PR DESCRIPTION
## Description
This PR updates the `go test` timeout in e2e tests to `30m`.

In the long-term, we will need to reorganize the e2e tests to improve overall run time. For now, we need to just make sure the tests aren't failing because of hitting the timeout. I believe we've been hitting this more after the introduction of some e2e tests for `boundary connect cassandra` and `boundary connect sql`.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
