### PR TITLE
chore(e2e): Enable audio services in windows instances

### DIFF
--- a/enos/modules/aws_rdp_member_server/main.tf
+++ b/enos/modules/aws_rdp_member_server/main.tf
@@ -125,6 +125,10 @@ do {
 # add computer to domain
 Add-Computer -DomainName "${var.active_directory_domain}" -Credential $credential
 
+# Enable audio
+Set-Service -Name "Audiosrv" -StartupType Automatic
+Start-Service -Name "Audiosrv"
+
 Restart-Computer -Force
                 </powershell>
               EOF

--- a/enos/modules/aws_windows_client/main.tf
+++ b/enos/modules/aws_windows_client/main.tf
@@ -181,7 +181,7 @@ resource "aws_instance" "client" {
 
                   ## Open the firewall for SSH connections
                   New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
-                
+
                   # Create a non-admin user to be used for RDP connection. This
                   # is needed since the scheduled task that runs pyautogui
                   # doesn't work in an Administrator context.
@@ -197,6 +197,10 @@ resource "aws_instance" "client" {
                   Set-ItemProperty -Path $regPath -Name "DefaultUsername" -Value $Username -Type String
                   Set-ItemProperty -Path $regPath -Name "DefaultPassword" -Value "${local.test_password}" -Type String
                   Set-ItemProperty -Path $regPath -Name "DefaultDomainName" -Value "$env:COMPUTERNAME" -Type String
+
+                  # Enable audio
+                  Set-Service -Name "Audiosrv" -StartupType Automatic
+                  Start-Service -Name "Audiosrv"
                 </powershell>
               EOF
 


### PR DESCRIPTION
## Description
This PR updates terraform modules for windows instances to automatically enable audio services. This makes it easier to test audio over RDP connections

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
