### PR TITLE
Suppressing non-impactful vulnerability warning from CVE

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -14,7 +14,7 @@ container {
 				# busybox@1.37.0-r12 https://nvd.nist.gov/vuln/detail/CVE-2025-46394
 				#
 				# Boundary does not shell out to the busybox tar program.
-				"CVE-2025-46394", 
+				"CVE-2025-46394",
 
 				# busybox@1.37.0-r12 https://nvd.nist.gov/vuln/detail/CVE-2024-58251
 				#
@@ -30,6 +30,12 @@ container {
 				#
 				# Boundary does not utilize ping in iputils.
 				"CVE-2025-47268"
+
+
+				# iputils@20240905-r0 https://nvd.nist.gov/vuln/detail/CVE-2025-48964
+				#
+				# Boundary does not utilize ping in iputils.
+				"CVE-2025-48964"
 			]
 		}
 	}


### PR DESCRIPTION
## Description
There was a reported vulnerability CVE-2025-48964 from Alpine Linux's Security Issue Tracker in iputils@20240905-r0, however Boundary does not utilise ping in iputils so the CVE is not impactful.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
