### PR TITLE
docs: Update Boundary licensing information

### DIFF
--- a/website/content/docs/enterprise/licensing.mdx
+++ b/website/content/docs/enterprise/licensing.mdx
@@ -62,7 +62,7 @@ Refer to the sample configurations below:
 When the Boundary license expires, the controller performs a graceful shutdown.
 Ongoing sessions continue to run, but you cannot create any new sessions.
 
-Prior to the expiration date, Boundary logs five system event warnings to the event stream at the following intervals:
+Prior to the license expiration, Boundary logs five system event warnings to the event stream at the following intervals:
 
 | Warning | Interval                           |
 |---------| ---------------------------------- |


### PR DESCRIPTION
## Description

Per [SPE-1197](https://hashicorp.atlassian.net/browse/SPE-1197), a customer had some questions about what happens when the Boundary Enterprise license expires. These included:

- What happens when the license expires? Is there a grace period?
- Are there any notifications prior to expiration?
- How do you update a license key and is there downtime?
- What is the recommended upgrade path?

These scenarios were documented in the Vault docs, and the customer expected to find the information in the Boundary docs too.

This PR updates the Boundary Enterprise licensing documentation with more information about what happens in the scenarios listed above.

[View the preview deployment](https://boundary-9vkx7hhhh-hashicorp.vercel.app/boundary/docs/enterprise/licensing)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[SPE-1197]: https://hashicorp.atlassian.net/browse/SPE-1197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ