### PR TITLE
revert node version for GHA

### DIFF
--- a/.github/workflows/test-cli-ui_oss.yml
+++ b/.github/workflows/test-cli-ui_oss.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Node for Bats install
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version: 16
       - name: Install Bats via NPM
         # Use npm so this workflow is portable on multiple runner distros
         run: npm install --location=global bats


### PR DESCRIPTION
## Description

This PR reverts the node version for one of the github actions that should not have been updates as part of the node updates

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
