### PR TITLE
uses /etc/boundary.d/ as recommended installation directory

### DIFF
--- a/website/content/docs/architecture/high-availability.mdx
+++ b/website/content/docs/architecture/high-availability.mdx
@@ -51,6 +51,6 @@ For general configuration, we recommend the following:
 
 ### Controller configuration
 
-When running Boundary controller as a service we recommend storing the file at `/etc/boundary-controller.hcl`. A `boundary` user and group should exist to manage this configuration file and to further restrict who can read and modify it.
+When running Boundary controller as a service we recommend storing the file at `/etc/boundary.d/boundary-controller.hcl`. A `boundary` user and group should exist to manage this configuration file and to further restrict who can read and modify it.
 
 For detailed configuration options, see our [configuration docs](/boundary/docs/configuration).

--- a/website/content/docs/commands/database/init.mdx
+++ b/website/content/docs/commands/database/init.mdx
@@ -13,10 +13,10 @@ The `database init` command initializes Boundary's database.
 
 ## Examples
 
-The following example initializes a Boundary's database with the configuration specified in the `/etc/boundary/controller.hcl` file:
+The following example initializes a Boundary's database with the configuration specified in the `/etc/boundary.d/controller.hcl` file:
 
 ```shell-session
-$ boundary database init -config=/etc/boundary/controller.hcl
+$ boundary database init -config=/etc/boundary.d/controller.hcl
 ```
 
 The `controller.hcl` file contains the database URL.

--- a/website/content/docs/commands/database/migrate.mdx
+++ b/website/content/docs/commands/database/migrate.mdx
@@ -16,7 +16,7 @@ The `database migrate` command migrates the Boundary database within an enclosin
 The following example migrates Boundary's database to the database URL specified in the controller configuration file:
 
 ```shell-session
-$ boundary database migrate -config=/etc/boundary/controller.hcl
+$ boundary database migrate -config=/etc/boundary.d/controller.hcl
 ```
 
 ## Usage

--- a/website/content/docs/commands/server.mdx
+++ b/website/content/docs/commands/server.mdx
@@ -51,7 +51,7 @@ $ boundary server -config="/home/ubuntu/boundary/downstream-worker.hcl"
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary server -config=/etc/boundary/controller.hcl
+$ boundary server -config=/etc/boundary.d/controller.hcl
 ```
 
 </CodeBlockConfig>

--- a/website/content/docs/deploy/self-managed/systemd.mdx
+++ b/website/content/docs/deploy/self-managed/systemd.mdx
@@ -13,7 +13,7 @@ This section covers how to install Boundary under the [systemd](https://systemd.
 
 `TYPE` below can be either `worker` or `controller` if you want to run them independently, e.g. for high availability. If you want to run combined nodes, modify as desired.
 
-1. `/etc/boundary-${TYPE}.hcl`: Configuration file for the boundary service.
+1. `/etc/boundary.d/boundary-${TYPE}.hcl`: Configuration file for the boundary service.
 
 2. `/usr/local/bin/boundary`: The Boundary binary, which can be built from the [source](https://github.com/hashicorp/boundary) or downloaded from our [release page](/boundary/downloads).
 


### PR DESCRIPTION
## Description

This PR updates these files to recommend installing boundary HCL config files in /etc/boundary.d/:

website/content/docs/architecture/high-availability.mdx
website/content/docs/commands/database/init.mdx
website/content/docs/commands/database/migrate.mdx
website/content/docs/commands/server.mdx
website/content/docs/deploy/self-managed/systemd.mdx

This PR supersedes 2104, which can be closed after this is merged.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
