### PR TITLE
SMRE-700: Allow including IBM license docs in docker image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 !bin/**
 !dist/**
 !.release/docker/**
+!.release/ibm-pao/**


### PR DESCRIPTION
## Description

This change allows docker image builds to include IBM's license documents.  These are required for enterprise builds, but the `.dockerignore` file is managed through this CE repository.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [X] I have documented a clear reason for, and description of, the change I am making.
- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [X] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
