### PR TITLE
updates permsFile with new resource table path

### DIFF
--- a/internal/website/permstable/permstable.go
+++ b/internal/website/permstable/permstable.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/boundary/internal/types/resource"
 )
 
-const permsFile = "website/content/docs/configuration/identity-access-management/resource-table.mdx"
+const permsFile = "website/content/docs/rbac/resource-table.mdx"
 
 var (
 	iamScopes    = []string{"Global", "Org"}


### PR DESCRIPTION
## Description

This PR updates the permsFile path with the new location of the resource-table.mdx file:

`const permsFile = "website/content/docs/rbac/resource-table.mdx"`

This should fix the make gen delta tests.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
