### PR TITLE
chore(e2e): Add workflow dispatch option to aws-nuke job

### DIFF
--- a/.github/workflows/test-ci-cleanup-oss.yml
+++ b/.github/workflows/test-ci-cleanup-oss.yml
@@ -1,5 +1,6 @@
 name: test-ci-cleanup-oss
 on:
+  workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '05 02 * * *'


### PR DESCRIPTION
## Description
This PR adds the ability to manually kick off this job (cleaning up AWS resources used by CI) in order to test some other changes. When @psekar was rotating some keys due to some security findings, I noticed we had both `secrets.AWS_ACCESS_KEY_ID` and `secrets.AWS_ACCESS_KEY_ID_CI` pairs. I'm not entirely sure why we need both, and I'd like to test if we can remove the use of `secrets.AWS_ACCESS_KEY_ID` (this job is the only place that uses it... and it uses both)

```
aws-nuke:
    if: ${{ github.event.repository.name == 'boundary' }}
    runs-on: ${{ fromJSON(vars.RUNNER) }}
    container:
      image: rebuy/aws-nuke
      options:
        --user root
        -t
      env:
        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }} <------------
        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }} <------------
        TIME_LIMIT: "48h"
    timeout-minutes: 60
    steps:
      - name: Configure AWS credentials
        id: aws-configure
        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
        with:
          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }} <------------
          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }} <------------
          aws-region: us-east-1
          role-to-assume: ${{ secrets.AWS_ROLE_ARN_CI }}
          role-skip-session-tagging: true
          role-duration-seconds: 3600
          mask-aws-account-id: false
      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
      - name: Configure
        run: |
          cp enos/ci/aws-nuke.yml .
          sed -i "s/ACCOUNT_NUM/${{ steps.aws-configure.outputs.aws-account-id }}/g" aws-nuke.yml
          sed -i "s/TIME_LIMIT/${TIME_LIMIT}/g" aws-nuke.yml
      # We don't care if cleanup succeeds or fails, because dependencies be dependenceies,
      # we'll fail on actually actionable things in the quota steep afterwards.
      - name: Clean up abandoned resources
        # Filter STDERR because it's super noisy about things we don't have access to
        run: |
          aws-nuke -c aws-nuke.yml -q --no-dry-run --force 2>/tmp/aws-nuke-error.log || true
```

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
