### PR TITLE
feat(mongo): Add MongoDB connection support for Boundary CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   This new helper command allows users to authorize sessions against MySQL
   targets and automatically invoke a MySQL client with the appropriate
   connection parameters and credentials.
+* cli: Added `boundary connect mongo` command for connecting to MongoDB targets.
+  This new helper command allows users to authorize sessions against MongoDB
+  targets and automatically invoke a MongoDB client with the appropriate
+  connection parameters and credentials.
 * Adds support to parse User-Agent headers and emit them in telemetry events
   ([PR](https://github.com/hashicorp/boundary/pull/5645)).
 * cli: Added `boundary connect cassandra` command for connecting to Cassandra targets.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -417,6 +417,12 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 				Func:    "mysql",
 			}
 		}),
+		"connect mongo": wrapper.Wrap(func() wrapper.WrappableCommand {
+			return &connect.Command{
+				Command: base.NewCommand(ui, opts...),
+				Func:    "mongo",
+			}
+		}),
 		"connect cassandra": wrapper.Wrap(func() wrapper.WrappableCommand {
 			return &connect.Command{
 				Command: base.NewCommand(ui, opts...),

--- a/internal/cmd/commands/connect/connect.go
+++ b/internal/cmd/commands/connect/connect.go
@@ -80,6 +80,9 @@ type Command struct {
 	// MySQL
 	mysqlFlags
 
+	// MongoDB
+	mongoFlags
+
 	// Cassandra
 	cassandraFlags
 
@@ -111,6 +114,8 @@ func (c *Command) Synopsis() string {
 		return postgresSynopsis
 	case "mysql":
 		return mysqlSynopsis
+	case "mongo":
+		return mongoSynopsis
 	case "cassandra":
 		return cassandraSynopsis
 	case "rdp":
@@ -235,6 +240,9 @@ func (c *Command) Flags() *base.FlagSets {
 	case "mysql":
 		mysqlOptions(c, set)
 
+	case "mongo":
+		mongoOptions(c, set)
+
 	case "cassandra":
 		cassandraOptions(c, set)
 
@@ -327,6 +335,8 @@ func (c *Command) Run(args []string) (retCode int) {
 			c.flagExec = c.postgresFlags.defaultExec()
 		case "mysql":
 			c.flagExec = c.mysqlFlags.defaultExec()
+		case "mongo":
+			c.flagExec = c.mongoFlags.defaultExec()
 		case "cassandra":
 			c.flagExec = c.cassandraFlags.defaultExec()
 		case "rdp":
@@ -682,6 +692,16 @@ func (c *Command) handleExec(clientProxy *apiproxy.ClientProxy, passthroughArgs 
 		args = append(args, mysqlArgs...)
 		envs = append(envs, mysqlEnvs...)
 		creds = mysqlCreds
+
+	case "mongo":
+		mongoArgs, mongoEnvs, mongoCreds, mongoErr := c.mongoFlags.buildArgs(c, port, host, addr, creds)
+		if mongoErr != nil {
+			argsErr = mongoErr
+			break
+		}
+		args = append(args, mongoArgs...)
+		envs = append(envs, mongoEnvs...)
+		creds = mongoCreds
 
 	case "cassandra":
 		cassandraArgs, cassandraEnvs, cassandraCreds, cassandraErr := c.cassandraFlags.buildArgs(c, port, host, addr, creds)

--- a/internal/cmd/commands/connect/mongo.go
+++ b/internal/cmd/commands/connect/mongo.go
@@ -1,0 +1,129 @@
+package connect
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/boundary/api/proxy"
+	"github.com/hashicorp/boundary/internal/cmd/base"
+	"github.com/posener/complete"
+)
+
+const (
+	mongoSynopsis = "Authorize a session against a target and invoke a MongoDB client to connect"
+)
+
+func mongoOptions(c *Command, set *base.FlagSets) {
+	f := set.NewFlagSet("MongoDB Options")
+
+	f.StringVar(&base.StringVar{
+		Name:       "style",
+		Target:     &c.flagMongoStyle,
+		EnvVar:     "BOUNDARY_CONNECT_MONGO_STYLE",
+		Completion: complete.PredictSet("mongo"),
+		Default:    "mongo",
+		Usage:      `Specifies how the CLI will attempt to invoke a MongoDB client. This will also set a suitable default for -exec if a value was not specified. Currently-understood values are "mongo".`,
+	})
+
+	f.StringVar(&base.StringVar{
+		Name:       "username",
+		Target:     &c.flagUsername,
+		EnvVar:     "BOUNDARY_CONNECT_USERNAME",
+		Completion: complete.PredictNothing,
+		Usage:      `Specifies the username to pass through to the client. May be overridden by credentials sourced from a credential store.`,
+	})
+
+	f.StringVar(&base.StringVar{
+		Name:       "dbname",
+		Target:     &c.flagDbname,
+		EnvVar:     "BOUNDARY_CONNECT_DBNAME",
+		Completion: complete.PredictNothing,
+		Usage:      `Specifies the database name to pass through to the client.`,
+	})
+}
+
+type mongoFlags struct {
+	flagMongoStyle string
+}
+
+func (m *mongoFlags) defaultExec() string {
+	return strings.ToLower(m.flagMongoStyle)
+}
+
+func (m *mongoFlags) buildArgs(c *Command, port, ip, _ string, creds proxy.Credentials) (args, envs []string, retCreds proxy.Credentials, retErr error) {
+	var username, password string
+
+	retCreds = creds
+	if len(retCreds.UsernamePassword) > 0 {
+		// Mark credential as consumed so it is not printed to user
+		retCreds.UsernamePassword[0].Consumed = true
+
+		// For now just grab the first username password credential brokered
+		username = retCreds.UsernamePassword[0].Username
+		password = retCreds.UsernamePassword[0].Password
+	}
+
+	switch m.flagMongoStyle {
+	case "mongo":
+		// Handle password first - create a temporary file for MongoDB connection string
+		if password != "" {
+			passfile, err := os.CreateTemp("", "*")
+			if err != nil {
+				return nil, nil, proxy.Credentials{}, fmt.Errorf("Error saving MongoDB password to tmp file: %w", err)
+			}
+			c.cleanupFuncs = append(c.cleanupFuncs, func() error {
+				if err := os.Remove(passfile.Name()); err != nil {
+					return fmt.Errorf("Error removing temporary password file; consider removing %s manually: %w", passfile.Name(), err)
+				}
+				return nil
+			})
+			_, err = passfile.Write([]byte(password))
+			if err != nil {
+				_ = passfile.Close()
+				return nil, nil, proxy.Credentials{}, fmt.Errorf("Error writing password file to %s: %w", passfile.Name(), err)
+			}
+			if err := passfile.Close(); err != nil {
+				return nil, nil, proxy.Credentials{}, fmt.Errorf("Error closing password file after writing to %s: %w", passfile.Name(), err)
+			}
+			// Set password file as environment variable for MongoDB client
+			envs = append(envs, "MONGODB_PASSWORD_FILE="+passfile.Name())
+
+			if c.flagDbname == "" {
+				c.UI.Warn("Credentials are being brokered but no -dbname parameter provided. mongo may misinterpret another parameter as the database name.")
+			}
+		}
+
+		// Build MongoDB connection string
+		connectionString := "mongodb://"
+		
+		// Add username and password to connection string
+		if username != "" {
+			connectionString += username
+			if password != "" {
+				connectionString += ":" + password
+			}
+			connectionString += "@"
+		} else if c.flagUsername != "" {
+			connectionString += c.flagUsername
+			if password != "" {
+				connectionString += ":" + password
+			}
+			connectionString += "@"
+		}
+
+		// Add host and port
+		connectionString += ip
+		if port != "" {
+			connectionString += ":" + port
+		}
+
+		// Add database name
+		if c.flagDbname != "" {
+			connectionString += "/" + c.flagDbname
+		}
+
+		args = append(args, connectionString)
+	}
+	return
+}

--- a/testing/internal/e2e/tests/base/target_tcp_connect_mongo_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_mongo_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package base_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/url"
+	"os/exec"
+	"testing"
+
+	"github.com/creack/pty"
+	"github.com/hashicorp/boundary/internal/target"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/hashicorp/boundary/testing/internal/e2e/infra"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCliTcpTargetConnectMongo uses the boundary cli to connect to a
+// target using `connect mongo`
+func TestCliTcpTargetConnectMongo(t *testing.T) {
+	e2e.MaybeSkipTest(t)
+	ctx := context.Background()
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	// e2e_cluster network is created by the e2e infra setup
+	network, err := pool.NetworksByName("e2e_cluster")
+	require.NoError(t, err, "Failed to get e2e_cluster network")
+
+	c := infra.StartMongo(t, pool, &network[0], "mongo", "7.0")
+	require.NotNil(t, c, "MongoDB container should not be nil")
+	t.Cleanup(func() {
+		if err := pool.Purge(c.Resource); err != nil {
+			t.Logf("Failed to purge MongoDB container: %v", err)
+		}
+	})
+
+	u, err := url.Parse(c.UriNetwork)
+	require.NoError(t, err, "Failed to parse MongoDB URL")
+
+	user, hostname, port, db := u.User.Username(), u.Hostname(), u.Port(), u.Path[1:]
+	pw, pwSet := u.User.Password()
+	t.Logf("MongoDB info: user=%s, db=%s, host=%s, port=%s, password-set:%t",
+		user, db, hostname, port, pwSet)
+
+	// Wait for MongoDB to be ready
+	err = pool.Retry(func() error {
+		return exec.CommandContext(ctx, "docker", "exec", hostname,
+			"mongosh", "--eval", "db.runCommand('ping')").Run()
+	})
+	require.NoError(t, err, "MongoDB container failed to start")
+
+	// Start Boundary database
+	boundaryDb := infra.StartBoundaryDatabase(t, pool, &network[0], "postgres", "15")
+	require.NotNil(t, boundaryDb, "Boundary database container should not be nil")
+	t.Cleanup(func() {
+		if err := pool.Purge(boundaryDb.Resource); err != nil {
+			t.Logf("Failed to purge Boundary database container: %v", err)
+		}
+	})
+
+	// Initialize Boundary database
+	_ = infra.GetDbInitInfoFromContainer(t, pool, boundaryDb)
+	
+	// Start Boundary server
+	boundaryContainer := infra.StartBoundary(t, pool, &network[0], "boundary", "latest", boundaryDb.UriNetwork)
+	require.NotNil(t, boundaryContainer, "Boundary container should not be nil")
+	t.Cleanup(func() {
+		if err := pool.Purge(boundaryContainer.Resource); err != nil {
+			t.Logf("Failed to purge Boundary container: %v", err)
+		}
+	})
+
+	boundary.AuthenticateAdminCli(t, ctx)
+
+	orgId, err := boundary.CreateOrgCli(t, ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", orgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
+
+	projectId, err := boundary.CreateProjectCli(t, ctx, orgId)
+	require.NoError(t, err)
+
+	targetId, err := boundary.CreateTargetCli(
+		t,
+		ctx,
+		projectId,
+		port,
+		target.WithAddress(hostname),
+	)
+	require.NoError(t, err)
+
+	storeId, err := boundary.CreateCredentialStoreStaticCli(t, ctx, projectId)
+	require.NoError(t, err)
+
+	credentialId, err := boundary.CreateStaticCredentialPasswordCli(
+		t,
+		ctx,
+		storeId,
+		user,
+		pw,
+	)
+	require.NoError(t, err)
+
+	err = boundary.AddBrokeredCredentialSourceToTargetCli(t, ctx, targetId, credentialId)
+	require.NoError(t, err)
+
+	cmd := exec.CommandContext(ctx,
+		"boundary",
+		"connect", "mongo",
+		"-target-id", targetId,
+		"-dbname", db,
+	)
+	f, err := pty.Start(cmd)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := f.Close()
+		require.NoError(t, err)
+	})
+
+	_, err = f.Write([]byte("show collections\n"))
+	require.NoError(t, err)
+	_, err = f.Write([]byte("db.getName()\n"))
+	require.NoError(t, err)
+	_, err = f.Write([]byte("exit\n"))
+	require.NoError(t, err)
+	_, err = f.Write([]byte{4})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, f)
+
+	output := buf.String()
+	t.Logf("MongoDB session output: %s", output)
+
+	require.Contains(t, output, db, "Session did not return expected database query result")
+	t.Log("Successfully connected to MongoDB target")
+}

--- a/website/content/docs/commands/connect/index.mdx
+++ b/website/content/docs/commands/connect/index.mdx
@@ -43,6 +43,7 @@ Subcommands:
     kube        Authorize a session against a target and invoke a Kubernetes client to connect
     cassandra   Authorize a session against a target and invoke a Cassandra client to connect
     mysql       Authorize a session against a target and invoke a MySQL client to connect
+    mongo       Authorize a session against a target and invoke a MongoDB client to connect
     postgres    Authorize a session against a target and invoke a Postgres client to connect
     rdp         Authorize a session against a target and invoke an RDP client to connect
     ssh         Authorize a session against a target and invoke an SSH client to connect
@@ -57,6 +58,7 @@ of the subcommand in the sidebar or one of the links below:
 - [kube](/boundary/docs/commands/connect/kube)
 - [cassandra](/boundary/docs/commands/connect/cassandra)
 - [mysql](/boundary/docs/commands/connect/mysql)
+- [mongo](/boundary/docs/commands/connect/mongo)
 - [postgres](/boundary/docs/commands/connect/postgres)
 - [rdp](/boundary/docs/commands/connect/rdp)
 - [ssh](/boundary/docs/commands/connect/ssh)

--- a/website/content/docs/commands/connect/mongo.mdx
+++ b/website/content/docs/commands/connect/mongo.mdx
@@ -1,0 +1,79 @@
+---
+layout: docs
+page_title: connect mongo - Command
+description: >-
+  The "connect mongo" command performs a target authorization or consumes an existing authorization token, and then launches a proxied MongoDB connection.
+---
+
+# connect mongo
+
+Command: `boundary connect mongo`
+
+The `connect mongo` command authorizes a session against a target and invokes a MongoDB client for the connection.
+The command fills in the local address and port.
+
+@include 'cmd-connect-env-vars.mdx'
+
+
+## Examples
+
+The following example shows how to connect to a target with the ID `ttcp_eTcMueUYv` using a MongoDB helper:
+
+```shell-session
+$ boundary connect mongo -target-id=ttcp_eTcZMueUYv \
+   -dbname=northwind \
+   -username=superuser \
+   -format=table
+```
+
+When prompted, you must enter the password for the user, "superuser":
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+Enter password:
+Current Mongosh Log ID:	64a1b2c3d4e5f6789012345
+Connecting to:		mongodb://127.0.0.1:12345/northwind?authSource=admin
+Using MongoDB:		7.0.0
+Using Mongosh:		2.0.0
+
+northwind> show collections
+orders
+products
+customers
+
+northwind> db.products.count()
+77
+
+northwind>
+```
+
+</CodeBlockConfig>
+
+## Usage
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ boundary connect mongo [options] [args]
+```
+
+</CodeBlockConfig>
+
+@include 'cmd-connect-command-options.mdx'
+
+### MongoDB options:
+
+- `-dbname` `(string: "")` - The database name you want to pass through to the client.
+You can also specify the database name using the **BOUNDARY_CONNECT_DBNAME** environment variable.
+
+- `-style`  `(string: "")` - How the CLI attempts to invoke a MongoDB client.
+This value also sets a suitable default for `-exec`, if you did not specify a value.
+The default and currently-understood value is `mongo`.
+You can also specify how the CLI attempts to invoke a MongoDB client using the **BOUNDARY_CONNECT_MONGO_STYLE** environment variable.
+
+- `-username`  `(string: "")` - The username you want to pass through to the client.
+This value may be overridden by credentials sourced from a credential store.
+You can also specify a username using the **BOUNDARY_CONNECT_USERNAME** environment variable.
+
+@include 'cmd-option-note.mdx' 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1234,6 +1234,10 @@
             "path": "commands/connect/mysql"
           },
           {
+            "title": "mongo",
+            "path": "commands/connect/mongo"
+          },
+          {
             "title": "postgres",
             "path": "commands/connect/postgres"
           },


### PR DESCRIPTION
This PR adds MongoDB connection support to the Boundary CLI. Users can now securely and easily connect to MongoDB targets using the boundary connect mongo command.   

## What's Added?
- `boundary connect mongo` command
- Credential and target support for MongoDB
- Required tests and documentation updates

## Testing
- [x] All tests passed successfully
- [x] MongoDB connection tests were performed
- [x] End-to-end testing with Docker containers

## Notes
This PR follows the same architecture and UX as the existing helper commands for PostgreSQL and MySQL.