### PR TITLE
fix(alias): return user-friendly error when alias value is invalid

### DIFF
--- a/internal/alias/target/repository_alias.go
+++ b/internal/alias/target/repository_alias.go
@@ -83,6 +83,9 @@ func (r *Repository) CreateAlias(ctx context.Context, a *Alias, opt ...Option) (
 		if strings.Contains(err.Error(), `violates foreign key constraint "target_fkey"`) {
 			return nil, errors.Wrap(ctx, err, op, errors.WithCode(errors.NotFound), errors.WithMsg("target with specified destination id %q was not found", a.GetDestinationId()))
 		}
+		if strings.Contains(err.Error(), `wt_target_alias_value_shape`) {
+			return nil, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("alias value %q contains invalid characters", a.Value)))
+		}
 		return nil, errors.Wrap(ctx, err, op)
 	}
 	return newAlias, nil
@@ -180,6 +183,9 @@ func (r *Repository) UpdateAlias(ctx context.Context, a *Alias, version uint32, 
 		}
 		if strings.Contains(err.Error(), `violates foreign key constraint "target_fkey"`) {
 			return nil, db.NoRowsAffected, errors.Wrap(ctx, err, op, errors.WithCode(errors.NotFound), errors.WithMsg("target with specified destination id %q was not found", a.GetDestinationId()))
+		}
+		if strings.Contains(err.Error(), `wt_target_alias_value_shape`) {
+			return nil, db.NoRowsAffected, errors.Wrap(ctx, err, op, errors.WithMsg("alias value contains invalid characters"))
 		}
 		return nil, db.NoRowsAffected, errors.Wrap(ctx, err, op)
 	}

--- a/internal/alias/target/repository_alias_test.go
+++ b/internal/alias/target/repository_alias_test.go
@@ -76,6 +76,16 @@ func TestRepository_CreateAlias(t *testing.T) {
 			errContains: "public id not empty",
 		},
 		{
+			name: "invalid-alias-value",
+			in: &target.Alias{
+				Alias: &store.Alias{
+					ScopeId: "global",
+					Value:   "invalid_alias",
+				},
+			},
+			errContains: "contains invalid characters",
+		},
+		{
 			name: "valid-with-value",
 			in: &target.Alias{
 				Alias: &store.Alias{
@@ -747,6 +757,17 @@ func TestRepository_UpdateAlias(t *testing.T) {
 		assert.Truef(t, errors.Match(errors.T(errors.NotUnique), err), "want err code: %v got err: %v", errors.NotUnique, err)
 		assert.Nil(t, got2)
 		assert.Equal(t, db.NoRowsAffected, gotCount2, "row count")
+	})
+
+	t.Run("invalid-alias", func(t *testing.T) {
+		value := "invalid_alais"
+		c1 := target.TestAlias(t, db.New(conn), "test")
+		c1.Value = value
+		got1, gotCount1, err := repo.UpdateAlias(context.Background(), c1, 1, []string{"value"})
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "contains invalid characters")
+		assert.Nil(t, got1)
+		assert.Equal(t, db.NoRowsAffected, gotCount1, "row count")
 	})
 }
 


### PR DESCRIPTION
## Description
Return a user-friendly error when an invalid alias value is used. 
Fixes reported usability bug.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
