### PR TITLE
chore(e2e): Remove unused secrets in aws cleanup job

### DIFF
--- a/.github/workflows/test-ci-cleanup-oss.yml
+++ b/.github/workflows/test-ci-cleanup-oss.yml
@@ -38,8 +38,6 @@ jobs:
         --user root
         -t
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         TIME_LIMIT: "48h"
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Description
This PR updates the aws account cleanup job to remove some unused environment variables. This was the only place that used `secrets.AWS_ACCESS_KEY_ID`, but it's actually using `secrets.AWS_ACCESS_KEY_ID_CI` in one of the steps of this job.

Here is a test run using this branch: https://github.com/hashicorp/boundary/actions/runs/17552531526/job/49848228361

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
