### PR TITLE
target(addr): add validation for ipv4, ipv6, and dns addr

### DIFF
--- a/internal/target/address_ext_test.go
+++ b/internal/target/address_ext_test.go
@@ -40,7 +40,112 @@ func TestAddress_New(t *testing.T) {
 			wantErr: errors.InvalidParameter,
 		},
 		{
-			name: "valid",
+			name: "invalid-address-1",
+			args: args{
+				address:  "-invalid.address",
+				targetId: "targ_0000000",
+			},
+			wantErr: errors.InvalidParameter,
+		},
+		{
+			name: "invalid-address-2",
+			args: args{
+				address:  "invalid.1234",
+				targetId: "targ_0000000",
+			},
+			wantErr: errors.InvalidParameter,
+		},
+		{
+			name: "invalid-address-3",
+			args: args{
+				address:  "invalid_address",
+				targetId: "targ_0000000",
+			},
+			wantErr: errors.InvalidParameter,
+		},
+		{
+			name: "invalid-address-4",
+			args: args{
+				address:  "i",
+				targetId: "targ_0000000",
+			},
+			wantErr: errors.InvalidParameter,
+		},
+		{
+			name: "invalid-address-5",
+			args: args{
+				address:  "toolonglabeltoolonglabeltoolonglabeltoolonglabeltoolonglabeltoolonglabeltoolong.co",
+				targetId: "targ_0000000",
+			},
+			wantErr: errors.InvalidParameter,
+		},
+		{
+			name: "valid-dns-1",
+			args: args{
+				targetId: "targ_0000000",
+				address:  "valid.",
+			},
+			want: &target.Address{
+				TargetAddress: &store.TargetAddress{
+					TargetId: "targ_0000000",
+					Address:  "valid.",
+				},
+			},
+		},
+		{
+			name: "valid-dns-2",
+			args: args{
+				targetId: "targ_0000000",
+				address:  "valid.address",
+			},
+			want: &target.Address{
+				TargetAddress: &store.TargetAddress{
+					TargetId: "targ_0000000",
+					Address:  "valid.address",
+				},
+			},
+		},
+		{
+			name: "valid-dns-3",
+			args: args{
+				targetId: "targ_0000000",
+				address:  "valid-address",
+			},
+			want: &target.Address{
+				TargetAddress: &store.TargetAddress{
+					TargetId: "targ_0000000",
+					Address:  "valid-address",
+				},
+			},
+		},
+		{
+			name: "valid-dns-4",
+			args: args{
+				targetId: "targ_0000000",
+				address:  "123-valid",
+			},
+			want: &target.Address{
+				TargetAddress: &store.TargetAddress{
+					TargetId: "targ_0000000",
+					Address:  "123-valid",
+				},
+			},
+		},
+		{
+			name: "valid-dns-5",
+			args: args{
+				targetId: "targ_0000000",
+				address:  "xn--d1acufc.xn--p1ai",
+			},
+			want: &target.Address{
+				TargetAddress: &store.TargetAddress{
+					TargetId: "targ_0000000",
+					Address:  "xn--d1acufc.xn--p1ai",
+				},
+			},
+		},
+		{
+			name: "valid-ipv4",
 			args: args{
 				targetId: "targ_0000000",
 				address:  "0.0.0.0",
@@ -49,6 +154,45 @@ func TestAddress_New(t *testing.T) {
 				TargetAddress: &store.TargetAddress{
 					TargetId: "targ_0000000",
 					Address:  "0.0.0.0",
+				},
+			},
+		},
+		{
+			name: "valid-ipv4-port",
+			args: args{
+				targetId: "targ_0000000",
+				address:  "0.0.0.0:35",
+			},
+			want: &target.Address{
+				TargetAddress: &store.TargetAddress{
+					TargetId: "targ_0000000",
+					Address:  "0.0.0.0:35",
+				},
+			},
+		},
+		{
+			name: "valid-ipv6",
+			args: args{
+				targetId: "targ_0000000",
+				address:  "0::0",
+			},
+			want: &target.Address{
+				TargetAddress: &store.TargetAddress{
+					TargetId: "targ_0000000",
+					Address:  "0::0",
+				},
+			},
+		},
+		{
+			name: "valid-ipv6-port",
+			args: args{
+				targetId: "targ_0000000",
+				address:  "0::0:45",
+			},
+			want: &target.Address{
+				TargetAddress: &store.TargetAddress{
+					TargetId: "targ_0000000",
+					Address:  "0::0:45",
 				},
 			},
 		},

--- a/internal/target/address_ext_test.go
+++ b/internal/target/address_ext_test.go
@@ -66,14 +66,6 @@ func TestAddress_New(t *testing.T) {
 		{
 			name: "invalid-address-4",
 			args: args{
-				address:  "i",
-				targetId: "targ_0000000",
-			},
-			wantErr: errors.InvalidParameter,
-		},
-		{
-			name: "invalid-address-5",
-			args: args{
 				address:  "toolonglabeltoolonglabeltoolonglabeltoolonglabeltoolonglabeltoolonglabeltoolong.co",
 				targetId: "targ_0000000",
 			},


### PR DESCRIPTION
## Description
Target address validation was only checking length and allowed DNS names with invalid symbols, leading to a bug.
This PR adds validation to ensure the address is a valid IP or DNS name

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
