### PR TITLE
docs: Backport #5989 to `stable-website`

### DIFF
--- a/website/content/docs/client-agent/conflicting-software.mdx
+++ b/website/content/docs/client-agent/conflicting-software.mdx
@@ -203,6 +203,29 @@ As a workaround, you can configure Parallels Desktop to use a different network 
 Select an alternative network configuration such as **Host-Only**, **Default Adapter**, or **Wi-Fi** instead of **Shared Network**.
 Refer to the Parallels Desktop documentation for more information.
 
+## Cisco AnyConnect VPN
+
+When the Cisco AnyConnect VPN is active at the same time as the Boundary Client Agent, DNS resolution may fail for Boundary aliases.
+
+The Boundary Client Agent by default uses the IPv4 range `100.x.x.x` for its local proxies. The Cisco AnyConnect VPN treats this range as a **secured range**, which forces DNS queries to resolve through the VPN instead of the Boundary Client Agent. As a result, Boundary aliases cannot be resolved.
+
+You can configure the Boundary Client Agent to use a different IPv4 prefix by setting the `v4_prefix` option in the client configuration file. This setting overrides the default `100.x.x.x` range and avoids the conflict with Cisco AnyConnect VPN.
+
+For example:
+```hcl
+v4_prefix = "172.16.0.0/12"
+```
+<Note>
+
+You can set the `v4_prefix` to any valid RFC1918 private IPv4 range, as long as it does not overlap with ranges secured by the VPN. Common options include:
+
+-   `10.0.0.0/8`
+-   `172.16.0.0/12`
+
+Choose a range that best fits your environment.
+
+</Note>
+
 ## Uninstall the Client Agent on Mac
 
 If you used the Mac installer, you can run `/Library/Application Support/HashiCorp/Boundary Uninstaller.app` to uninstall Boundary.


### PR DESCRIPTION
The backport for #5989 failed. This PR cherry-picks the following updates to the `stable-website` branch:

* updating the doc with anyconnect vpn conflicting software

* addressed pr comments

* done some minor formatting

## Description

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
