### PR TITLE
chore(e2e): fixed enos scripts to allow for crt builder in windows scenario

### DIFF
--- a/enos/modules/build_crt/main.tf
+++ b/enos/modules/build_crt/main.tf
@@ -6,8 +6,24 @@ variable "path" {
   default = "/tmp"
 }
 
+variable "build_target" {
+  default = "build-ui build"
+}
+
+variable "binary_name" {
+  default = "boundary"
+}
+
+variable "artifact_name" {
+  default = "boundary"
+}
+
 variable "edition" {
   default = "oss"
+}
+
+variable "goos" {
+  default = "linux"
 }
 
 output "artifact_path" {


### PR DESCRIPTION
fixed enos scripts to allow for crt builder in windows scenario. Did this by adding default dummy values to crt builder module.

## Description

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
