### PR TITLE
docs: Back port #6044 to `release/0.19.x`

### DIFF
--- a/website/content/docs/monitor/index.mdx
+++ b/website/content/docs/monitor/index.mdx
@@ -50,7 +50,7 @@ Refer to the following topics for more information on the various ways to monito
 
 - [Monitor metrics](/boundary/docs/monitor/metrics)
 - [Monitor health](/boundary/docs/monitor/health)
-- [Monitor events](/boundary/docs/monitor/events)
+- [Filter events](/boundary/docs/monitor/events/filter-events)
    - [Common sink parameters](/boundary/docs/monitor/events/common)
    - [File sink](/boundary/docs/monitor/events/file)
-   - [Stderr sink](/boundary//docs/monitor/events/stderr)
+   - [Stderr sink](/boundary/docs/monitor/events/stderr)


### PR DESCRIPTION
The back ports failed for #6044. This PR manually cherry-picks the following updates to the `release/0.19.x` branch:

* docs: Fix broken link in Monitor Boundary

* docs: Fix a typo

## Description

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
