### PR TITLE
docs: Update Huntress interoperability

### DIFF
--- a/website/content/docs/interoperability-matrix/index.mdx
+++ b/website/content/docs/interoperability-matrix/index.mdx
@@ -70,10 +70,10 @@ Any patches or updates will be reflected in the minor number.
     <b>Windows version</b>: 0.14.14
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4, 0.19.6
+    0.1.4
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    0.1.4, 0.19.6
+    0.1.4
     </td>
     <td style={{verticalAlign: 'middle'}}>
     <b>MacOS</b>: 14.6, 15.3


### PR DESCRIPTION
## Description

The Client Agent interoperability matrix incorrectly states that Huntress is supported on version 0.19.6 of the Boundary installer and Client Agent. This PR removes that version.

[View the update in the preview deployment](https://boundary-1q8ugbsvj-hashicorp.vercel.app/boundary/docs/interoperability-matrix)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
