### PR TITLE
fix(target): Quiet proxy server not found logs

### DIFF
--- a/internal/target/repository_proxy_server_certificate.go
+++ b/internal/target/repository_proxy_server_certificate.go
@@ -102,7 +102,7 @@ func fetchTargetProxyServerCertificate(ctx context.Context, r db.Reader, w db.Wr
 
 	// If a cert is not found, this target type does not support proxy server certificates/ it was not generated during target creation.
 	if targetCert.Certificate == nil {
-		return nil, errors.New(ctx, errors.RecordNotFound, op, "target proxy server certificate not found")
+		return nil, errors.New(ctx, errors.RecordNotFound, op, "target proxy server certificate not found", errors.WithoutEvent())
 	}
 
 	return maybeRegenerateCert(ctx, targetCert, w, wrapper, sessionMaxSeconds)
@@ -135,7 +135,7 @@ func fetchTargetAliasProxyServerCertificate(ctx context.Context, r db.Reader, w 
 	}
 
 	if targetCert.Certificate == nil {
-		return nil, errors.New(ctx, errors.RecordNotFound, op, "target proxy server certificate not found")
+		return nil, errors.New(ctx, errors.RecordNotFound, op, "target proxy server certificate not found", errors.WithoutEvent())
 	}
 
 	aliasCert := allocTargetAliasProxyCertificate()


### PR DESCRIPTION
## Description

Proxy server certificates are only necessary for one kind of target. We are currently logging errors for every type of target when the certificate is not found. We can silence these logs as they are not necessary for debugging purposes for most target types. 

Issue: https://hashicorp.atlassian.net/browse/ICU-17650

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
