### PR TITLE
Closes any session created by `boundary connect` after command exit

### DIFF
--- a/api/proxy/proxy.go
+++ b/api/proxy/proxy.go
@@ -350,12 +350,20 @@ func (p *ClientProxy) Start(opt ...Option) (retErr error) {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), opts.withSessionTeardownTimeout)
+	return p.CloseSession(opts.withSessionTeardownTimeout)
+}
+
+// CloseSession attempts to close the currently proxied session by sending a
+// request to do so to the worker proxying the connection
+func (p *ClientProxy) CloseSession(sessionTeardownTimeout time.Duration) error {
+	if sessionTeardownTimeout == 0 {
+		sessionTeardownTimeout = sessionCancelTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sessionTeardownTimeout)
 	defer cancel()
 	if err := p.sendSessionTeardown(ctx); err != nil {
 		return fmt.Errorf("error sending session teardown request to worker: %w", err)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
This pr fixes an issue where failing to create the client proxy within `boundary connect ...` would leave pending sessions within boundary

## Description
1. parses the listener address earlier to creating sessions without an easy way to close them
2. automatically closes any session created by `boundary connect` using the client proxy or creating a new session client after the command has exited (successfully or unsuccessfully)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
