### PR TITLE
fix(target): Skip fetching proxy server cert

### DIFF
--- a/internal/target/repository.go
+++ b/internal/target/repository.go
@@ -53,7 +53,7 @@ type Repository struct {
 }
 
 // getTargetProxyServerCertificateFn can be overridden for testing or extension purposes.
-// By default, it returns nil, nil.
+// By default, it returns nil, nil because TCP targets do not currently use a proxy server certificate.
 var getTargetProxyServerCertificateFn = func(ctx context.Context, r *Repository, target targetView, databaseWrapper wrapping.Wrapper, opts options) (*ServerCertificate, error) {
 	return nil, nil
 }

--- a/internal/target/repository_proxy_server_certificate_test.go
+++ b/internal/target/repository_proxy_server_certificate_test.go
@@ -303,7 +303,7 @@ func TestFetchTargetAliasProxyServerCertificate(t *testing.T) {
 }
 
 // Test_LookupTargetForSessionAuthorization tests looking up a target for session both with and without an alias.
-// The target used in this test does not have a proxy server certificate because CE targets do not support proxy server certificates.
+// The target used in this test does not have a proxy server certificate because TCP targets do not currently support proxy server certificates.
 // Fetching the proxy server certificate is tested in other enterprise tests.
 func Test_LookupTargetForSessionAuthorization(t *testing.T) {
 	t.Parallel()

--- a/internal/target/repository_proxy_server_certificate_test.go
+++ b/internal/target/repository_proxy_server_certificate_test.go
@@ -302,7 +302,10 @@ func TestFetchTargetAliasProxyServerCertificate(t *testing.T) {
 	}
 }
 
-func Test_FetchCertsWithinLookupTargetForSessionAuthorization(t *testing.T) {
+// Test_LookupTargetForSessionAuthorization tests looking up a target for session both with and without an alias.
+// The target used in this test does not have a proxy server certificate because CE targets do not support proxy server certificates.
+// Fetching the proxy server certificate is tested in other enterprise tests.
+func Test_LookupTargetForSessionAuthorization(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	conn, _ := db.TestSetup(t, "postgres")
@@ -312,74 +315,50 @@ func Test_FetchCertsWithinLookupTargetForSessionAuthorization(t *testing.T) {
 	_, proj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
 	repo, err := target.NewRepository(context.Background(), rw, rw, testKms)
 	require.NoError(t, err)
-	databaseWrapper, err := testKms.GetWrapper(ctx, proj.PublicId, kms.KeyPurposeDatabase)
-	require.NoError(t, err)
 
 	tar := targettest.TestNewTestTarget(ctx, t, conn, proj.PublicId, "test-target")
-	tar2 := targettest.TestNewTestTarget(ctx, t, conn, proj.PublicId, "test-target2")
 
 	// Create an alias
 	aliasValue := "test-alias"
 	alias := talias.TestAlias(t, rw, aliasValue, talias.WithDestinationId(tar.GetPublicId()))
-	require.NoError(t, err)
 	require.NotNil(t, alias)
-
-	// Create our default localhost target cert
-	cer, err := target.NewTargetProxyCertificate(ctx, target.WithTargetId(tar.GetPublicId()))
-	require.NoError(t, err)
-	require.NotNil(t, cer)
-	id, err := db.NewPublicId(ctx, globals.ProxyServerCertificatePrefix)
-	require.NoError(t, err)
-	cer.PublicId = id
-	err = cer.Encrypt(ctx, databaseWrapper)
-	require.NoError(t, err)
-	err = rw.Create(ctx, cer)
-	require.NoError(t, err)
 
 	tests := []struct {
 		name     string
 		publicId string
 		opt      []target.Option
-		wantCert bool
+		wantErr  bool
 	}{
 		{
-			name:     "success-get-target-with-certificate",
-			publicId: tar.GetPublicId(),
-			wantCert: true,
-		},
-		{
-			name:     "success-get-target-with-alias-certificate",
-			publicId: tar.GetPublicId(),
-			opt: []target.Option{
-				target.WithAlias(alias),
-			},
-			wantCert: true,
-		},
-		{
 			name:     "success-get-target-no-cert",
-			publicId: tar2.GetPublicId(),
-			wantCert: false,
+			publicId: tar.GetPublicId(),
+			wantErr:  false,
 		},
 		{
 			name:     "success-get-target-no-cert-with-alias",
-			publicId: tar2.GetPublicId(),
+			publicId: tar.GetPublicId(),
 			opt: []target.Option{
 				target.WithAlias(alias),
 			},
-			wantCert: false,
+			wantErr: false,
+		},
+		{
+			name:     "fail-missing-target-id",
+			publicId: "",
+			wantErr:  true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := repo.LookupTargetForSessionAuthorization(ctx, tt.publicId, proj.PublicId, tt.opt...)
-			require.NoError(err)
-			assert.NotNil(got)
-			if tt.wantCert {
-				assert.NotNil(got.GetProxyServerCertificate())
-			} else {
-				assert.Nil(got.GetProxyServerCertificate())
+			if tt.wantErr {
+				require.Error(err)
+				return
 			}
+			require.NoError(err)
+			require.NotNil(got)
+			assert.Nil(got.GetProxyServerCertificate())
 		})
 	}
 }


### PR DESCRIPTION
## Description

Proxy server certificates are not necessary for or used with CE Targets. As a follow up to https://github.com/hashicorp/boundary/pull/6050 this PR will update LookupTargetForSessionAuthorization to use either a separate function to search for proxy server certificates. In CE this function is empty and returns `nil, nil`. 

The goal of this change is to improve performance by avoiding unnecessary trips to the database for targets that do not have proxy server certificates.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
