### PR TITLE
update the disable client agent command for macos

### DIFF
--- a/website/content/docs/client-agent/manage.mdx
+++ b/website/content/docs/client-agent/manage.mdx
@@ -54,13 +54,13 @@ If you want to disable the Boundary Client Agent, you can stop it with the follo
 <Tab heading="MacOS" group="macos">
 
 ```shell-session
-$ sudo launchctl unload -w /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
+$ sudo launchctl bootout system /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
 ```
 
 Unloading the Boundary Client Agent removes its launch daemon configuration. To restart the Client Agent, use:
 
 ```shell-session
-$ sudo launchctl load -w /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
+$ sudo launchctl bootstrap system /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
 ```
 
 </Tab>


### PR DESCRIPTION
## Description

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
  
The current documented method of disabling the Boundary client conflicts with the Boundary Installer’s client-agent installation process.
If a user stops the Boundary client agent using the legacy command:
`sudo launchctl unload -w /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
`
then attempting to reinstall (upgrade), using boundary-installer, will result in the following error:
`The Installer encountered an error that caused the installation to fail. Contact the software manufacturer for assistance.
`
This happens because the Boundary Installer uses the modern launchctl alternatives `(bootstrap / bootout)` instead of the legacy load / unload. Our [preinstall](https://github.com/hashicorp/boundary-installer/blob/main/pkg/macos/boundary-client-agent/Scripts/preinstall#L16:L19) script do not currently account for cases where users follow the legacy instructions.
Modern launchctl (recommended, used by Boundary Installer)
```
sudo launchctl bootstrap system  /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
sudo launchctl bootout system  /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
```
Legacy launchctl (documented, but conflicts with Boundary Installer)
```
sudo launchctl load -w /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
sudo launchctl unload  -w /Library/LaunchDaemons/com.hashicorp.boundary.boundary-client-agent.plist
```