### PR TITLE
chore(e2e): Update firewall rules for instances in the windows domain

### DIFF
--- a/enos/modules/aws_rdp_member_server/main.tf
+++ b/enos/modules/aws_rdp_member_server/main.tf
@@ -70,13 +70,14 @@ resource "aws_instance" "member_server" {
                   # Force an immediate time synchronization
                   w32tm /resync /force
 
+                  # Set up SSH so we can remotely manage the instance
+                  # Note: Windows Server 2016 does not support OpenSSH
                   %{if var.server_version != "2016"~}
                   # set variables for retry loops
                   $timeout = 300
                   $interval = 30
 
-                  # Set up SSH so we can remotely manage the instance
-                  ## Install OpenSSH Server and Client
+                  # Install OpenSSH Server and Client
                   # Loop to make sure that SSH installs correctly
                   $elapsed = 0
                   do {
@@ -122,24 +123,35 @@ resource "aws_instance" "member_server" {
                     }
                   } while ($true)
 
-                  ## Set PowerShell as the default SSH shell
+                  # Set PowerShell as the default SSH shell
                   New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value (Get-Command powershell.exe).Path -PropertyType String -Force
 
-                  ## Configure SSH server to use private key authentication so that scripts don't have to use passwords
-                  ## Save the private key from instance metadata
+                  # Configure SSH server to use private key authentication so that scripts don't have to use passwords
+                  # Save the private key from instance metadata
                   $ImdsToken = (Invoke-WebRequest -Uri 'http://169.254.169.254/latest/api/token' -Method 'PUT' -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = 2160} -UseBasicParsing).Content
                   $ImdsHeaders = @{'X-aws-ec2-metadata-token' = $ImdsToken}
                   $AuthorizedKey = (Invoke-WebRequest -Uri 'http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key' -Headers $ImdsHeaders -UseBasicParsing).Content
                   $AuthorizedKeysPath = 'C:\ProgramData\ssh\administrators_authorized_keys'
                   New-Item -Path $AuthorizedKeysPath -ItemType File -Value $AuthorizedKey -Force
 
-                  ## Ensure the SSH agent pulls in the new key.
+                  # Ensure the SSH agent pulls in the new key.
                   Set-Service -Name ssh-agent -StartupType "Automatic"
                   Restart-Service -Name ssh-agent
 
-                  ## Open the firewall for SSH connections
+                  # Open the firewall for SSH connections
                   New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
                   %{endif~}
+
+                  # Open firewall ports for RDP functionality
+                  New-NetFirewallRule -Name kerberostcp -DisplayName 'Kerberos TCP' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 88
+                  New-NetFirewallRule -Name kerberosudp -DisplayName 'Kerberos UDP' -Enabled True -Direction Inbound -Protocol UDP -Action Allow -LocalPort 88
+                  New-NetFirewallRule -Name rpctcp -DisplayName 'RPC TCP ' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 135
+                  New-NetFirewallRule -Name rpcudp -DisplayName 'RPC UDP' -Enabled True -Direction Inbound -Protocol UDP -Action Allow -LocalPort 135
+                  New-NetFirewallRule -Name ldaptcp -DisplayName 'LDAP TCP ' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 389
+                  New-NetFirewallRule -Name ldapudp -DisplayName 'LDAP UDP' -Enabled True -Direction Inbound -Protocol UDP -Action Allow -LocalPort 389
+                  New-NetFirewallRule -Name smbtcp -DisplayName 'SMB TCP ' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 445
+                  New-NetFirewallRule -Name rdptcp -DisplayName 'RDP TCP ' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 3389
+                  New-NetFirewallRule -Name rdpudp -DisplayName 'RDP UDP' -Enabled True -Direction Inbound -Protocol UDP -Action Allow -LocalPort 3389
 
                   # Adds member server to the domain
                   [int]$intix = Get-NetAdapter | % { Process { If ( $_.Status -eq "up" ) { $_.ifIndex } }}

--- a/enos/modules/aws_rdp_member_server_with_worker/main.tf
+++ b/enos/modules/aws_rdp_member_server_with_worker/main.tf
@@ -101,7 +101,7 @@ resource "aws_instance" "worker" {
                   $interval = 30
 
                   # Set up SSH so we can remotely manage the instance
-                  ## Install OpenSSH Server and Client
+                  # Install OpenSSH Server and Client
                   # Loop to make sure that SSH installs correctly
                   $elapsed = 0
                   do {
@@ -162,10 +162,23 @@ resource "aws_instance" "worker" {
                   Set-Service -Name ssh-agent -StartupType "Automatic"
                   Restart-Service -Name ssh-agent
 
-                  ## Open the firewall for SSH and boundary connections
+                  # Open the firewall for SSH
                   New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+
+                  # Open firewall for boundary connections
                   New-NetFirewallRule -Name boundary_in -DisplayName 'Boundary inbound' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 9202
                   New-NetFirewallRule -Name boundary_out -DisplayName 'Boundary outbound' -Enabled True -Direction Outbound -Protocol TCP -Action Allow -LocalPort 9202
+
+                  # Open firewall ports for RDP functionality
+                  New-NetFirewallRule -Name kerberostcp -DisplayName 'Kerberos TCP' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 88
+                  New-NetFirewallRule -Name kerberosudp -DisplayName 'Kerberos UDP' -Enabled True -Direction Inbound -Protocol UDP -Action Allow -LocalPort 88
+                  New-NetFirewallRule -Name rpctcp -DisplayName 'RPC TCP' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 135
+                  New-NetFirewallRule -Name rpcudp -DisplayName 'RPC UDP' -Enabled True -Direction Inbound -Protocol UDP -Action Allow -LocalPort 135
+                  New-NetFirewallRule -Name ldaptcp -DisplayName 'LDAP TCP' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 389
+                  New-NetFirewallRule -Name ldapudp -DisplayName 'LDAP UDP' -Enabled True -Direction Inbound -Protocol UDP -Action Allow -LocalPort 389
+                  New-NetFirewallRule -Name smbtcp -DisplayName 'SMB TCP' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 445
+                  New-NetFirewallRule -Name rdptcp -DisplayName 'RDP TCP' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 3389
+                  New-NetFirewallRule -Name rdpudp -DisplayName 'RDP UDP' -Enabled True -Direction Inbound -Protocol UDP -Action Allow -LocalPort 3389
 
                   # Add computer to the domain
                   [int]$intix = Get-NetAdapter | % { Process { If ( $_.Status -eq "up" ) { $_.ifIndex } }}


### PR DESCRIPTION
## Description
This change ensures that for all of the ec2 instances in the Windows domain, the Windows firewall is opened for any RDP-related ports. While there doesn't seem to be any issues related to this at this time, it will rule out the firewall rules being a problem in the future.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
