### PR TITLE
chore(e2e): Add controller and worker ips to output of scenario

### DIFF
--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -215,7 +215,11 @@ scenario "e2e_ui_aws" {
     }
   }
 
-  output "test_results" {
-    value = step.run_e2e_test.test_results
+  output "controller_ips" {
+    value = step.create_boundary_cluster.controller_ips
+  }
+
+  output "worker_ips" {
+    value = step.create_boundary_cluster.worker_ips
   }
 }


### PR DESCRIPTION
## Description
This PR updates the `e2e_ui_aws` scenario to output the IP addresses of the controller and worker when running `enos scenario output`. This is helpful with investigating issues. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
