### PR TITLE
chore(e2e): Ensure permissions on key file are correct for windows boxes

### DIFF
--- a/enos/modules/aws_rdp_member_server_with_worker/main.tf
+++ b/enos/modules/aws_rdp_member_server_with_worker/main.tf
@@ -157,10 +157,16 @@ resource "aws_instance" "worker" {
                   $AuthorizedKey = (Invoke-WebRequest -Uri 'http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key' -Headers $ImdsHeaders -UseBasicParsing).Content
                   $AuthorizedKeysPath = 'C:\ProgramData\ssh\administrators_authorized_keys'
                   New-Item -Path $AuthorizedKeysPath -ItemType File -Value $AuthorizedKey -Force
+                  # Set the correct permissions on the authorized_keys file
+                  icacls "C:\ProgramData\ssh\administrators_authorized_keys" /inheritance:r
+                  icacls "C:\ProgramData\ssh\administrators_authorized_keys" /grant "Administrators:F" /grant "SYSTEM:F"
+                  icacls "C:\ProgramData\ssh\administrators_authorized_keys" /remove "Users"
+                  icacls "C:\ProgramData\ssh\administrators_authorized_keys" /remove "Authenticated Users"
 
                   # Ensure the SSH agent pulls in the new key.
                   Set-Service -Name ssh-agent -StartupType "Automatic"
                   Restart-Service -Name ssh-agent
+                  Restart-Service -Name sshd
 
                   ## Open the firewall for SSH and boundary connections
                   New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22


### PR DESCRIPTION
## Description
Tony was running into issues SSH'ing onto a Windows box (specifically on Windows Server 2022). After some investigation, I discovered that there may have been some incorrect file permissions on the public key on the Server.
```
> icalcs C:\ProgramData\ssh\administrators_authorized_keys

NT AUTHORITY\SYSTEM:(F)
BUILTIN\Administrators:(F)
NT AUTHORITY\Authenticated Users:(RX)
```

The public key needs to only have permissions for `System` and `Administrators`: github.com/PowerShell/Win32-OpenSSH/wiki/Security-protection-of-various-files-in-Win32-OpenSSH#administrators_authorized_keys.

This PR updates the startup script to remove the `Authenticated Users` group on the file and restarts the sshd service to take the change. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

https://hashicorp.atlassian.net/browse/ICU-17700
