### PR TITLE
Revert "fix(target): Skip fetching proxy server cert"

### DIFF
--- a/internal/target/repository.go
+++ b/internal/target/repository.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/boundary/internal/types/scope"
 	"github.com/hashicorp/boundary/internal/util"
 	"github.com/hashicorp/go-dbw"
-	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 )
 
 // RepositoryFactory enables `target.Repository` object instantiation,
@@ -50,12 +49,6 @@ type Repository struct {
 	// These are passed in on the repository constructor using `WithPermissions`, meaning the
 	// `Repository` object is contextualized to whatever the request context is.
 	permissions []perms.Permission
-}
-
-// getTargetProxyServerCertificateFn can be overridden for testing or extension purposes.
-// By default, it returns nil, nil because TCP targets do not currently use a proxy server certificate.
-var getTargetProxyServerCertificateFn = func(ctx context.Context, r *Repository, target targetView, databaseWrapper wrapping.Wrapper, opts options) (*ServerCertificate, error) {
-	return nil, nil
 }
 
 // NewRepository creates a new target Repository.
@@ -147,9 +140,16 @@ func (r *Repository) LookupTargetForSessionAuthorization(ctx context.Context, pu
 				address = targetAddress.GetAddress()
 			}
 
-			cert, err = getTargetProxyServerCertificateFn(ctx, r, target, databaseWrapper, opts)
-			if err != nil && !errors.IsNotFoundError(err) {
-				return errors.Wrap(ctx, err, op)
+			if opts.WithAlias != nil {
+				cert, err = fetchTargetAliasProxyServerCertificate(ctx, read, w, target.PublicId, target.ProjectId, opts.WithAlias, databaseWrapper, target.GetSessionMaxSeconds())
+				if err != nil && !errors.IsNotFoundError(err) {
+					return errors.Wrap(ctx, err, op)
+				}
+			} else {
+				cert, err = fetchTargetProxyServerCertificate(ctx, read, w, target.PublicId, target.ProjectId, databaseWrapper, target.GetSessionMaxSeconds())
+				if err != nil && !errors.IsNotFoundError(err) {
+					return errors.Wrap(ctx, err, op)
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
Reverts hashicorp/boundary#6055

After discussion with Irena, Johan, and Tim we've decided that this optimization is not necessary at this point. The operation to check for the certificate is normally fast, and without evidence of a performance impacting slow down we can allow it to continue. 