### PR TITLE
chore(e2e): Update windows worker module to support other configs

### DIFF
--- a/enos/modules/aws_rdp_member_server_with_worker/main.tf
+++ b/enos/modules/aws_rdp_member_server_with_worker/main.tf
@@ -311,11 +311,12 @@ resource "local_file" "worker_config" {
     enos_local_exec.add_boundary_cli,
   ]
   content = templatefile("${path.module}/scripts/worker.hcl", {
-    controller_ip    = var.controller_ip
-    aws_kms_key      = data.aws_kms_key.kms_key.id
-    aws_region       = var.aws_region
-    worker_public_ip = aws_instance.worker.public_ip
-    test_dir         = local.test_dir
+    controller_ip           = var.controller_ip
+    aws_kms_key             = data.aws_kms_key.kms_key.id
+    aws_region              = var.aws_region
+    worker_public_ip        = aws_instance.worker.public_ip
+    test_dir                = local.test_dir
+    hcp_boundary_cluster_id = var.hcp_boundary_cluster_id
   })
   filename = "${path.root}/.terraform/tmp/worker.hcl"
 }

--- a/enos/modules/aws_rdp_member_server_with_worker/scripts/worker_hcp_bsr.hcl
+++ b/enos/modules/aws_rdp_member_server_with_worker/scripts/worker_hcp_bsr.hcl
@@ -13,15 +13,18 @@ listener "tcp" {
   purpose = "proxy"
 }
 
+hcp_boundary_cluster_id = "${hcp_boundary_cluster_id}"
+
 # worker block for configuring the specifics of the
 # worker service
 worker {
   public_addr = "${worker_public_ip}"
-  name = "win-worker-0"
-  initial_upstreams = ["[${controller_ip}]:9201"]
   tags {
     type = ["worker", "rdp", "windows"]
   }
+
+  auth_storage_path = "${test_dir}/worker"
+  recording_storage_path = "${test_dir}/recordings"
 }
 
 # Events (logging) configuration. This
@@ -53,10 +56,4 @@ events {
       }
     }
   }
-}
-
-kms "awskms" {
-  purpose    = "worker-auth"
-  region     = "${aws_region}"
-  kms_key_id = "${aws_kms_key}"
 }

--- a/enos/modules/aws_rdp_member_server_with_worker/variables.tf
+++ b/enos/modules/aws_rdp_member_server_with_worker/variables.tf
@@ -110,3 +110,20 @@ variable "domain_controller_sec_group_id_list" {
   type        = list(any)
   description = "ID's of AWS Network Security Groups created during creation of the domain controller."
 }
+
+# =================================================================
+# Boundary Worker Configuration
+# =================================================================
+variable "worker_config_file_path" {
+  description = "Path to config file to use (relative to module directory)"
+  type        = string
+  default     = "scripts/worker.hcl"
+}
+
+variable "hcp_boundary_cluster_id" {
+  description = "ID of the Boundary cluster in HCP"
+  type        = string
+  default     = ""
+  // If using HCP int, ensure that the cluster id starts with "int-"
+  // Example: "int-19283a-123123-..."
+}


### PR DESCRIPTION
## Description
This PR updates the module that creates a windows worker to support using other types of configs for the worker. This PR also includes a config that can be used for HCP testing. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
