### PR TITLE
fix(e2e): Use worker config from variable

### DIFF
--- a/enos/modules/aws_rdp_member_server_with_worker/main.tf
+++ b/enos/modules/aws_rdp_member_server_with_worker/main.tf
@@ -310,7 +310,7 @@ resource "local_file" "worker_config" {
   depends_on = [
     enos_local_exec.add_boundary_cli,
   ]
-  content = templatefile("${path.module}/scripts/worker.hcl", {
+  content = templatefile("${path.module}/${var.worker_config_file_path}", {
     controller_ip           = var.controller_ip
     aws_kms_key             = data.aws_kms_key.kms_key.id
     aws_region              = var.aws_region


### PR DESCRIPTION
## Description
This PR makes a fix to the `aws_rdp_member_server_with_worker` module to make sure it uses the worker config specified in the variable. Currently, if a scenario requests to use a different config, it will ignore that and just use `worker.hcl`.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
