### PR TITLE
chore(e2e): Add rds:DescribeDBEngineVersions permission to service user

### DIFF
--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -220,6 +220,7 @@ data "aws_iam_policy_document" "enos_policy_document" {
       "rds:CreateDBSubnetGroup",
       "rds:DeleteDBInstance",
       "rds:DeleteDBSubnetGroup",
+      "rds:DescribeDBEngineVersions",
       "rds:DescribeDBInstances",
       "rds:DescribeDBSubnetGroups",
       "rds:ListTagsForResource",


### PR DESCRIPTION
## Description
This PR updates the terraform for the CI AWS service user to include the `rds:DescribeDBEngineVersions` permission. This was needed to make some changes for how we select the database version used in AWS tests. That will occur in a subsequent PR.

This terraform has already been applied to the service user and was tested in this run: https://github.com/hashicorp/boundary/actions/runs/18013041897/job/51256355972

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

https://hashicorp.atlassian.net/browse/ICU-9702