### PR TITLE
chore(e2e): Allow AWS to select default db version

### DIFF
--- a/enos/modules/aws_boundary/rds.tf
+++ b/enos/modules/aws_boundary/rds.tf
@@ -6,14 +6,18 @@ resource "aws_db_subnet_group" "boundary" {
   subnet_ids = data.aws_subnets.infra.ids
 }
 
+data "aws_rds_engine_version" "default" {
+  engine = var.db_engine
+}
+
 resource "aws_db_instance" "boundary" {
   count               = var.db_create == true ? 1 : 0
   identifier          = "boundary-db-${random_string.cluster_id.result}"
   allocated_storage   = var.db_storage
   storage_type        = var.db_storage_type
   iops                = var.db_storage_iops
-  engine              = var.db_engine
-  engine_version      = var.db_engine == "aurora-postgres" ? null : var.db_version
+  engine              = data.aws_rds_engine_version.default.engine
+  engine_version      = data.aws_rds_engine_version.default.version
   instance_class      = var.db_class
   monitoring_interval = var.db_monitoring_interval
   monitoring_role_arn = var.db_monitoring_role_arn

--- a/enos/modules/aws_boundary/variables.tf
+++ b/enos/modules/aws_boundary/variables.tf
@@ -136,12 +136,6 @@ variable "db_class" {
   default     = "db.t4g.small"
 }
 
-variable "db_version" {
-  description = "AWS RDS DBS engine version (for postgres/mysql)"
-  type        = string
-  default     = "15.7"
-}
-
 variable "db_engine" {
   description = "AWS RDS DB engine type"
   type        = string


### PR DESCRIPTION
## Description
This PR updates the end-to-end tests that use AWS to dynamically select the version of RDS/postgres we're using. Previously, we were hard-coding it to a certain version and would periodically have to update it when that version becomes deprecated. Instead, we now have AWS select the default version for the engine we're using (postgres), which should be close to, if not, the latest. 

This also aligns with product's request to test with the latest version of postgres. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

https://hashicorp.atlassian.net/browse/ICU-9702
