### PR TITLE
chore(docs): fix session recording policy formatting

### DIFF
--- a/website/content/docs/session-recording/compliance/configure-storage-policy.mdx
+++ b/website/content/docs/session-recording/compliance/configure-storage-policy.mdx
@@ -68,8 +68,8 @@ Complete the following steps to create a storage policy in Boundary for session 
    - **Description**: `SOC 2 compliant storage policy for session recordings`
    - **Retention Policy**: `SOC 2 (7 years)`
    - **Deletion Policy**: `Custom`
-   Delete after: `2657` days
-   Toggle the switch beside **Allow orgs to override**.
+   - Delete after: `2657` days
+   - Toggle the switch beside **Allow orgs to override**.
 
 1. Click **Save**.
 

--- a/website/content/docs/session-recording/compliance/update-storage-policy.mdx
+++ b/website/content/docs/session-recording/compliance/update-storage-policy.mdx
@@ -69,8 +69,8 @@ The following is an example of updating the `soc2-policy` policy.
    - **Description**: `SOC 2 compliant storage policy for session recordings, V2`
    - **Retention Policy**: `SOC 2 (7 years)`
    - **Deletion Policy**: `Custom`
-   **Delete after**: `2757` days
-   Toggle the switch beside **Allow orgs to override** to the off position.
+   - **Delete after**: `2757` days
+   - Toggle the switch beside **Allow orgs to override** to the off position.
 
 1. Click **Save**.
 


### PR DESCRIPTION
## Description
Fixes some formatting in instructions on creating storage policies where the last two instructions were stuck on the prior line.
See https://developer.hashicorp.com/boundary/docs/session-recording/compliance/update-storage-policy#update-a-storage-policy 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
