### PR TITLE
test(e2e): Add test for connect redis

### DIFF
--- a/testing/internal/e2e/tests/base/target_tcp_connect_redis_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_redis_test.go
@@ -4,122 +4,138 @@
 package base_test
 
 import (
+	"context"
+	"io"
+	"net/url"
+	"os/exec"
+	"strings"
 	"testing"
+
+	"github.com/hashicorp/boundary/internal/target"
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/testing/internal/e2e/boundary"
+	"github.com/hashicorp/boundary/testing/internal/e2e/infra"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCliTcpTargetConnectRedis uses the boundary cli to connect to a target using `connect redis`
 func TestCliTcpTargetConnectRedis(t *testing.T) {
-	t.Skip("Skipped (TODO: ICU-17634). Test fails due to issues between redis-cli and pty.")
-	return //nolint
+	e2e.MaybeSkipTest(t)
 
-	// e2e.MaybeSkipTest(t)
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
 
-	// pool, err := dockertest.NewPool("")
-	// require.NoError(t, err)
+	ctx := context.Background()
 
-	// ctx := context.Background()
+	network, err := pool.NetworksByName("e2e_cluster")
+	require.NoError(t, err, "Failed to get e2e_cluster network")
 
-	// network, err := pool.NetworksByName("e2e_cluster")
-	// require.NoError(t, err, "Failed to get e2e_cluster network")
+	c := infra.StartRedis(t, pool, &network[0], "redis", "latest")
+	require.NotNil(t, c, "Redis container should not be nil")
+	t.Cleanup(func() {
+		if err := pool.Purge(c.Resource); err != nil {
+			t.Logf("Failed to purge Redis container: %v", err)
+		}
+	})
 
-	// c := infra.StartRedis(t, pool, &network[0], "redis", "latest")
-	// require.NotNil(t, c, "Redis container should not be nil")
-	// t.Cleanup(func() {
-	// 	if err := pool.Purge(c.Resource); err != nil {
-	// 		t.Logf("Failed to purge Redis container: %v", err)
-	// 	}
-	// })
+	u, err := url.Parse(c.UriNetwork)
+	t.Log(u)
+	require.NoError(t, err, "Failed to parse Redis URL")
 
-	// u, err := url.Parse(c.UriNetwork)
-	// t.Log(u)
-	// require.NoError(t, err, "Failed to parse Redis URL")
+	user, hostname, port := u.User.Username(), u.Hostname(), u.Port()
+	pw, pwSet := u.User.Password()
 
-	// user, hostname, port := u.User.Username(), u.Hostname(), u.Port()
-	// pw, pwSet := u.User.Password()
+	t.Logf("Redis info: user=%s, host=%s, port=%s, password-set:%t",
+		user, hostname, port, pwSet)
 
-	// t.Logf("Redis info: user=%s, host=%s, port=%s, password-set:%t",
-	// 	user, hostname, port, pwSet)
+	// Wait for Redis to be ready
+	err = pool.Retry(func() error {
+		out, e := exec.CommandContext(ctx, "docker", "exec", hostname,
+			"redis-cli", "-h", hostname, "-p", port, "PING").CombinedOutput()
+		t.Logf("Redis PING output: %s", out)
+		return e
+	})
+	require.NoError(t, err, "Redis container failed to start")
 
-	// // Wait for Redis to be ready
-	// err = pool.Retry(func() error {
-	// 	out, e := exec.CommandContext(ctx, "docker", "exec", hostname,
-	// 		"redis-cli", "-h", hostname, "-p", port, "PING").CombinedOutput()
-	// 	t.Logf("Redis PING output: %s", out)
-	// 	return e
-	// })
-	// require.NoError(t, err, "Redis container failed to start")
+	boundary.AuthenticateAdminCli(t, ctx)
 
-	// boundary.AuthenticateAdminCli(t, ctx)
+	orgId, err := boundary.CreateOrgCli(t, ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		boundary.AuthenticateAdminCli(t, ctx)
+		output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", orgId))
+		require.NoError(t, output.Err, string(output.Stderr))
+	})
 
-	// orgId, err := boundary.CreateOrgCli(t, ctx)
-	// require.NoError(t, err)
-	// t.Cleanup(func() {
-	// 	ctx := context.Background()
-	// 	boundary.AuthenticateAdminCli(t, ctx)
-	// 	output := e2e.RunCommand(ctx, "boundary", e2e.WithArgs("scopes", "delete", "-id", orgId))
-	// 	require.NoError(t, output.Err, string(output.Stderr))
-	// })
+	projectId, err := boundary.CreateProjectCli(t, ctx, orgId)
+	require.NoError(t, err)
 
-	// projectId, err := boundary.CreateProjectCli(t, ctx, orgId)
-	// require.NoError(t, err)
+	targetId, err := boundary.CreateTargetCli(
+		t,
+		ctx,
+		projectId,
+		port,
+		target.WithAddress(hostname),
+	)
+	require.NoError(t, err)
 
-	// targetId, err := boundary.CreateTargetCli(
-	// 	t,
-	// 	ctx,
-	// 	projectId,
-	// 	port,
-	// 	target.WithAddress(hostname),
-	// )
-	// require.NoError(t, err)
+	storeId, err := boundary.CreateCredentialStoreStaticCli(t, ctx, projectId)
+	require.NoError(t, err)
 
-	// storeId, err := boundary.CreateCredentialStoreStaticCli(t, ctx, projectId)
-	// require.NoError(t, err)
+	credentialId, err := boundary.CreateStaticCredentialPasswordCli(
+		t,
+		ctx,
+		storeId,
+		user,
+		pw,
+	)
+	require.NoError(t, err)
 
-	// credentialId, err := boundary.CreateStaticCredentialPasswordCli(
-	// 	t,
-	// 	ctx,
-	// 	storeId,
-	// 	user,
-	// 	pw,
-	// )
-	// require.NoError(t, err)
+	err = boundary.AddBrokeredCredentialSourceToTargetCli(t, ctx, targetId, credentialId)
+	require.NoError(t, err)
 
-	// err = boundary.AddBrokeredCredentialSourceToTargetCli(t, ctx, targetId, credentialId)
-	// require.NoError(t, err)
+	t.Logf("Attempting to connect to Redis target %s", targetId)
 
-	// t.Logf("Attempting to connect to Redis target %s", targetId)
+	cmd := exec.CommandContext(ctx,
+		"boundary",
+		"connect", "redis",
+		"-target-id", targetId,
+	)
 
-	// cmd := exec.CommandContext(ctx,
-	// 	"boundary",
-	// 	"connect", "redis",
-	// 	"-target-id", targetId,
-	// )
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
 
-	// f, err := pty.Start(cmd)
-	// require.NoError(t, err)
-	// t.Cleanup(func() {
-	// 	err := f.Close()
-	// 	require.NoError(t, err)
-	// })
+	output, err := sendRedisCommand(stdin, stdout, "SET e2etestkey e2etestvalue\r\n")
+	require.NoError(t, err)
+	require.Equal(t, "OK", output)
 
-	// _, err = f.Write([]byte("SET e2etestkey e2etestvalue\r\n"))
-	// require.NoError(t, err)
-	// _, err = f.Write([]byte("GET e2etestkey\r\n"))
-	// require.NoError(t, err)
-	// _, err = f.Write([]byte("QUIT\r\n"))
-	// require.NoError(t, err)
-	// _, err = f.Write([]byte{4})
-	// require.NoError(t, err)
+	output, err = sendRedisCommand(stdin, stdout, "GET e2etestkey\r\n")
+	require.NoError(t, err)
+	require.Equal(t, "e2etestvalue", output)
 
-	//// io.Copy will hang because not all bytes seem to be written to pty (QUIT is not recognized).
+	output, err = sendRedisCommand(stdin, stdout, "QUIT\r\n")
+	require.Equal(t, io.EOF, err)
+	require.Empty(t, output)
 
-	// var buf bytes.Buffer
-	// _, _ = io.Copy(&buf, f)
-	// output := buf.String()
-	// t.Logf("Redis session output: %s", output)
+	// Confirm that boundary connect has closed
+	err = cmd.Wait()
+	require.NoError(t, err)
+}
 
-	// require.Contains(t, output, "OK")
-	// require.Contains(t, output, "\"e2etestvalue\"")
-
-	// t.Log("Successfully connected to Redis target")
+func sendRedisCommand(stdin io.WriteCloser, stdout io.ReadCloser, cmdStr string) (string, error) {
+	_, err := stdin.Write([]byte(cmdStr))
+	if err != nil {
+		return "", err
+	}
+	buf := make([]byte, 1024)
+	n, err := stdout.Read(buf)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(buf[:n])), nil
 }


### PR DESCRIPTION
## Description
This PR is a follow-up to https://github.com/hashicorp/boundary/pull/6001.

This PR adds an e2e test for `boundary connect redis`. Previously, there were issues figuring out how to send redis commands in the test using `pty`. An alternative was discovered to use `StdinPipe/StdoutPipe`. 

```
❯ go test -v -count=1 github.com/hashicorp/boundary/testing/internal/e2e/tests/base -run TestCliTcpTargetConnectRedis -timeout=1m
=== RUN   TestCliTcpTargetConnectRedis
    docker.go:433: Starting Redis database...
    docker.go:468: Configuring Redis authentication and user permissions...
    target_tcp_connect_redis_test.go:43: redis://e2eboundary:e2eboundary@e2eredis:6379
    target_tcp_connect_redis_test.go:49: Redis info: user=e2eboundary, host=e2eredis, port=6379, password-set:true
    target_tcp_connect_redis_test.go:56: Redis PING output: PONG
    scope.go:85: Created Org Id: o_2xjC9pzOgY
    scope.go:127: Created Project Id: p_7T9AhJ31DS
    target.go:181: Created Target: ttcp_OqTGTl7iaT
    credential.go:131: Created Credential Store: csst_iZmP4jknt4
    credential.go:237: Created Username/Password Credentials: credup_GpGztmJz74
    target_tcp_connect_redis_test.go:99: Attempting to connect to Redis target ttcp_OqTGTl7iaT
--- PASS: TestCliTcpTargetConnectRedis (4.92s)
```

https://hashicorp.atlassian.net/browse/ICU-17634

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
