### PR TITLE
docs: Fix asciicast link

### DIFF
--- a/website/content/docs/session-recording/index.mdx
+++ b/website/content/docs/session-recording/index.mdx
@@ -81,7 +81,9 @@ Be careful when you use Secure File Copy (SCP) to transfer large files during a 
 ## asciicast
 
 When you view recorded sessions using the CLI or Admin UI, Boundary can convert the recording into other formats for playback.
-Currently Boundary supports converting the recording of an individual SSH channel into an [asciicast](https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md) format to play back an interactive SSH session.
+Currently Boundary supports converting the recording of an individual SSH channel into an asciicast format to play back an interactive SSH session.
+
+Refer to the [asciinema documentation](https://docs.asciinema.org/) for more information about the [asciicast](https://docs.asciinema.org/manual/asciicast/v3/) format.
 
 ### Limitations
 


### PR DESCRIPTION
## Description

The link to asciicast in the session recording docs goes to an old document in the GitHub repo. It is producing a 404. This PR updates the link to point to the asciicast documentation.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
