### PR TITLE
Docs: fixes controller policy example

### DIFF
--- a/website/content/docs/domain-model/credential-stores.mdx
+++ b/website/content/docs/domain-model/credential-stores.mdx
@@ -122,8 +122,7 @@ removed from the credential store.
 
 #### Vault Boundary controller policy
 
-The token Boundary receives must have the capabilities listed below. An explanation
-for the use of each capability is given.
+The token Boundary receives must have the capabilities in the policy below. An explanation for each capability is documented above the written policy.
 
 ```hcl
 # Allow Boundary to read and verify the properties of the token. This is
@@ -165,14 +164,41 @@ path "sys/capabilities-self" {
 }
 ```
 
-The above [`boundary-controller` policy](https://boundaryproject.io/data/vault/boundary-controller-policy.hcl) is
-available for download. Below is an example of writing this policy to Vault:
+Follow the steps below to write this policy to Vault.
+
+Create the policy:
 
 ```shell-session
-# Download the policy
-$ curl https://boundaryproject.io/data/vault/boundary-controller-policy.hcl -O -s -L
+$ cat > boundary-controller-policy.hcl <<EOF
+path "auth/token/lookup-self" {
+  capabilities = ["read"]
+}
 
-# Write the policy to Vault
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+
+path "auth/token/revoke-self" {
+  capabilities = ["update"]
+}
+
+path "sys/leases/renew" {
+  capabilities = ["update"]
+}
+
+path "sys/leases/revoke" {
+  capabilities = ["update"]
+}
+
+path "sys/capabilities-self" {
+  capabilities = ["update"]
+}
+EOF
+```
+
+Write the policy to Vault:
+
+```shell-session
 $ vault policy write boundary-controller boundary-controller-policy.hcl
 ```
 


### PR DESCRIPTION
## Description

This PR fixes a broken example on the `domain-model/credential-stores` page.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
