### PR TITLE
Makefile: check for existence of dist in build-ui-ifne

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ clean-ui:
 
 .PHONY: build-ui-ifne
 build-ui-ifne:
-ifeq (,$(wildcard internal/ui/.tmp/boundary-ui))
+ifeq (,$(wildcard internal/ui/.tmp/boundary-ui/ui/admin/dist))
 	@echo "==> No UI assets found, building..."
 	@$(MAKE) build-ui
 else


### PR DESCRIPTION
The build-ui-ifne target is responsible for deciding whether the UI assets already exist on disk, or need to be built by cloning the UI repo and running its build scripts.

The old configuration would check whether the UI
repo folder existed, and assume that as long as this folder exists, it can be used to embed the UI assets. However, if the clone or ui build fails at any point, the Makefile target isn't able to retry the script.

Correct the path that is checked for to be the path that is actually included in the assets.go file. This way, the Makefile script will retry building the UI until a dist folder is created.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
