### PR TITLE
small change in docker enos build

### DIFF
--- a/enos/modules/build_boundary_docker_local/build.sh
+++ b/enos/modules/build_boundary_docker_local/build.sh
@@ -10,6 +10,9 @@ pushd "${root_dir}" > /dev/null
 
 # make docker image
 export DEV_DOCKER_GOARCH=$(uname -m)
+if [[ $DEV_DOCKER_GOARCH == "x86_64" ]]; then
+   export DEV_DOCKER_GOARCH="amd64"
+fi
 export IMAGE_TAG_DEV="${IMAGE_NAME}"
 make build-ui docker-build-dev
 


### PR DESCRIPTION
## Description
Github runner returns x86_64 for GOARCH which is functionally the same as amd64 but it not recognized by go. This change allows the docker build to run on a github runner. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
