### PR TITLE
Manual backport of chore(errors): Add early disconnection error into release/0.20.x

### DIFF
--- a/internal/errors/code.go
+++ b/internal/errors/code.go
@@ -69,6 +69,9 @@ const (
 	InvalidListToken         Code = 136 // InvalidListToken represents an error where the provided list token is invalid
 	Paused                   Code = 137 // Paused represents an error when an operation cannot be completed because the thing being operated on is paused
 
+	// Note: Currently unused in OSS
+	WindowsRDPClientEarlyDisconnection Code = 138 // WindowsRDPClientEarlyDisconnection represents an error when a Windows RDP client disconnects early, a known behavior with Windows Remote Desktop clients
+
 	AuthAttemptExpired Code = 198 // AuthAttemptExpired represents an expired authentication attempt
 	AuthMethodInactive Code = 199 // AuthMethodInactive represents an error that means the auth method is not active.
 

--- a/internal/errors/code_test.go
+++ b/internal/errors/code_test.go
@@ -456,6 +456,11 @@ func TestCode_Both_String_Info(t *testing.T) {
 			want: Paused,
 		},
 		{
+			name: "WindowsRDPClientEarlyDisconnection",
+			c:    WindowsRDPClientEarlyDisconnection,
+			want: WindowsRDPClientEarlyDisconnection,
+		},
+		{
 			name: "ImmutableColumn",
 			c:    ImmutableColumn,
 			want: ImmutableColumn,

--- a/internal/errors/info.go
+++ b/internal/errors/info.go
@@ -347,6 +347,10 @@ var errorCodeInfo = map[Code]Info{
 		Message: "paused",
 		Kind:    State,
 	},
+	WindowsRDPClientEarlyDisconnection: {
+		Message: "rdp client disconnected early",
+		Kind:    State,
+	},
 	ExternalPlugin: {
 		Message: "plugin error",
 		Kind:    External,


### PR DESCRIPTION
## Description

There seems to be a problem with the backport assistant runner. It is including multiple commits instead of just one here: https://github.com/hashicorp/boundary/pull/6134 

This is a manual backport of #6126 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
