### PR TITLE
config: remove unused telemetry stanza

### DIFF
--- a/enos/modules/docker_worker/worker-config-bsr-downstream.hcl
+++ b/enos/modules/docker_worker/worker-config-bsr-downstream.hcl
@@ -3,11 +3,6 @@
 
 disable_mlock = true
 
-telemetry {
-  prometheus_retention_time = "24h"
-  disable_hostname          = true
-}
-
 listener "tcp" {
   address     = "0.0.0.0:${port}"
   purpose     = "proxy"

--- a/enos/modules/docker_worker/worker-config-bsr.hcl
+++ b/enos/modules/docker_worker/worker-config-bsr.hcl
@@ -3,11 +3,6 @@
 
 disable_mlock = true
 
-telemetry {
-  prometheus_retention_time = "24h"
-  disable_hostname          = true
-}
-
 listener "tcp" {
   address     = "0.0.0.0:${port}"
   purpose     = "proxy"

--- a/enos/modules/docker_worker/worker-config-controller-led.hcl
+++ b/enos/modules/docker_worker/worker-config-controller-led.hcl
@@ -3,11 +3,6 @@
 
 disable_mlock = true
 
-telemetry {
-  prometheus_retention_time = "24h"
-  disable_hostname          = true
-}
-
 listener "tcp" {
   address     = "0.0.0.0:${port}"
   purpose     = "proxy"

--- a/enos/modules/docker_worker/worker-config-downstream.hcl
+++ b/enos/modules/docker_worker/worker-config-downstream.hcl
@@ -3,11 +3,6 @@
 
 disable_mlock = true
 
-telemetry {
-  prometheus_retention_time = "24h"
-  disable_hostname          = true
-}
-
 listener "tcp" {
   address     = "0.0.0.0:${port}"
   purpose     = "proxy"

--- a/enos/modules/docker_worker/worker-config-worker-led.hcl
+++ b/enos/modules/docker_worker/worker-config-worker-led.hcl
@@ -3,11 +3,6 @@
 
 disable_mlock = true
 
-telemetry {
-  prometheus_retention_time = "24h"
-  disable_hostname          = true
-}
-
 listener "tcp" {
   address     = "0.0.0.0:${port}"
   purpose     = "proxy"

--- a/enos/modules/docker_worker/worker-config.hcl
+++ b/enos/modules/docker_worker/worker-config.hcl
@@ -3,11 +3,6 @@
 
 disable_mlock = true
 
-telemetry {
-  prometheus_retention_time = "24h"
-  disable_hostname          = true
-}
-
 listener "tcp" {
   address     = "0.0.0.0:${port}"
   purpose     = "proxy"

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -46,11 +46,6 @@ const (
 
 	devConfig = `
 disable_mlock = true
-
-telemetry {
-	prometheus_retention_time = "24h"
-	disable_hostname = true
-}
 `
 
 	devControllerExtraConfig = `
@@ -1353,10 +1348,6 @@ func parseEventing(eventObj *ast.ObjectItem) (*event.EventerConfig, error) {
 // Sanitized returns a copy of the config with all values that are considered
 // sensitive stripped. It also strips all `*Raw` values that are mainly
 // used for parsing.
-//
-// Specifically, the fields that this method strips are:
-// - KMS.Config
-// - Telemetry.CirconusAPIToken
 func (c *Config) Sanitized() map[string]any {
 	// Create shared config if it doesn't exist (e.g. in tests) so that map
 	// keys are actually populated


### PR DESCRIPTION
I think this was somehow accidentally included from Vault back in the day and never removed. As far as I can tell these options have absolutely no effect on anything in Boundary and will probably only cause confusion.