### PR TITLE
docs: Add `key_id` field to KMS docs

### DIFF
--- a/website/content/docs/configuration/kms/aead.mdx
+++ b/website/content/docs/configuration/kms/aead.mdx
@@ -29,3 +29,5 @@ kms "aead" {
 - `key` - The base64-encoded 256-bit encryption key.
 
 - `key_id` - The unique name of this key.
+It is used to identify the key when you perform a root key migration.
+You can use the `key_id` field with all KMS stanzas.

--- a/website/content/docs/configuration/kms/alicloudkms.mdx
+++ b/website/content/docs/configuration/kms/alicloudkms.mdx
@@ -24,6 +24,7 @@ kms "alicloudkms" {
   access_key = "0wNEpMMlzy7szvai"
   secret_key = "PupkTg8jdmau1cXxYacgE736PJj4cA"
   kms_key_id = "08c33a6f-4e0a-4a1b-a3fa-7ddfa1d4fb73"
+  key_id     = "global_worker-auth"
 }
 ```
 
@@ -53,6 +54,10 @@ These parameters apply to the `kms` stanza in the Boundary configuration file:
 - `kms_key_id` `(string: <required>)`: The AliCloud KMS key ID to use for encryption
   and decryption. May also be specified by the `ALICLOUDKMS_WRAPPER_KEY_ID`
   environment variable.
+
+- `key_id` - The unique name of this key.
+It is used to identify the key when you perform a root key migration.
+You can use the `key_id` field with all KMS stanzas.
 
 ## Authentication
 

--- a/website/content/docs/configuration/kms/awskms.mdx
+++ b/website/content/docs/configuration/kms/awskms.mdx
@@ -22,6 +22,7 @@ kms "awskms" {
   secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   kms_key_id = "19ec80b0-dfdd-4d97-8164-c6examplekey"
   endpoint   = "https://vpce-0e1bb1852241f8cc6-pzi0do8n.kms.us-east-1.vpce.amazonaws.com"
+  key_id     = "global_worker-auth"
 }
 ```
 
@@ -77,6 +78,10 @@ These parameters apply to the `kms` stanza in the Boundary configuration file:
   variable. This is useful, for example, when connecting to KMS over a [VPC
   Endpoint](https://docs.aws.amazon.com/kms/latest/developerguide/kms-vpc-endpoint.html).
   If not set, Boundary will use the default API endpoint for your region.
+
+- `key_id` - The unique name of this key.
+It is used to identify the key when you perform a root key migration.
+You can use the `key_id` field with all KMS stanzas.
 
 ## Authentication
 

--- a/website/content/docs/configuration/kms/azurekeyvault.mdx
+++ b/website/content/docs/configuration/kms/azurekeyvault.mdx
@@ -25,6 +25,7 @@ kms "azurekeyvault" {
   client_secret  = "DUJDS3..."
   vault_name     = "hc-vault"
   key_name       = "vault_key"
+  key_id         = "global_worker-auth"
 }
 ```
 
@@ -52,6 +53,10 @@ These parameters apply to the `kms` stanza in the Vault configuration file:
 
 - `key_name` `(string: <required>)`: The Key Vault key to use for encryption and decryption. May also be specified by the
   `AZUREKEYVAULT_WRAPPER_KEY_NAME` environment variable.
+
+- `key_id` - The unique name of this key.
+It is used to identify the key when you perform a root key migration.
+You can use the `key_id` field with all KMS stanzas.
 
 ## Authentication
 

--- a/website/content/docs/configuration/kms/gcpckms.mdx
+++ b/website/content/docs/configuration/kms/gcpckms.mdx
@@ -24,6 +24,7 @@ kms "gcpckms" {
   region      = "global"
   key_ring    = "boundary-keyring"
   crypto_key  = "boundary-key"
+  key_id      = "global_worker-auth"
 }
 ```
 
@@ -52,6 +53,10 @@ These parameters apply to the `kms` stanza in the Boundary configuration file:
 - `crypto_key` `(string: <required>)`: The GCP CKMS crypto key to use for
   encryption and decryption. May also be specified by the `GCPCKMS_WRAPPER_CRYPTO_KEY`
   environment variable.
+
+- `key_id` - The unique name of this key.
+It is used to identify the key when you perform a root key migration.
+You can use the `key_id` field with all KMS stanzas.
 
 ## Authentication &amp; permissions
 

--- a/website/content/docs/configuration/kms/transit.mdx
+++ b/website/content/docs/configuration/kms/transit.mdx
@@ -22,6 +22,7 @@ kms "transit" {
   address            = "https://vault:8200"
   token              = "s.Qf1s5zigZ4OX6akYjQXJC1jY"
   disable_renewal    = "false"
+  key_id             = "global_worker-auth"
 
   // Key configuration
   key_name           = "transit_key_name"
@@ -86,6 +87,10 @@ These parameters apply to the `kms` stanza in the Vault configuration file:
   Using this option is highly discouraged and decreases the security of data
   transmissions to and from the Vault server. This may also be specified using the
   `VAULT_SKIP_VERIFY` environment variable.
+
+- `key_id` - The unique name of this key.
+It is used to identify the key when you perform a root key migration.
+You can use the `key_id` field with all KMS stanzas.
 
 ## Authentication
 


### PR DESCRIPTION
## Description

From a Slack [conversation](https://hashicorp.slack.com/archives/C016ZKNM05T/p1760070691822429), many of the KMS configuration docs are missing descriptions for the `key_id` field which is required for root key migration. This PR adds the field definition for the field and adds it to the code examples on the following pages:

- [AEAD](https://boundary-70mkzaqq0-hashicorp.vercel.app/boundary/docs/configuration/kms/aead)
- [AliCloud](https://boundary-70mkzaqq0-hashicorp.vercel.app/boundary/docs/configuration/kms/alicloudkms)
- [AWS](https://boundary-70mkzaqq0-hashicorp.vercel.app/boundary/docs/configuration/kms/awskms)
- [Azure Key Vault](https://boundary-70mkzaqq0-hashicorp.vercel.app/boundary/docs/configuration/kms/azurekeyvault)
- [GCP Cloud](https://boundary-70mkzaqq0-hashicorp.vercel.app/boundary/docs/configuration/kms/gcpckms)
- [Vault transit](https://boundary-70mkzaqq0-hashicorp.vercel.app/boundary/docs/configuration/kms/transit)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [X] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
