### PR TITLE
docs: Fix version 0.19.x redirects (#6128)

### DIFF
--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -4,11 +4,11 @@ page_title: Documentation
 description: Boundary reference documentation
 ---
 
-# Boundary Reference Documentation
+# Boundary reference documentation
 
-Welcome to the Boundary reference documentation! The documentation is reference
+Welcome to the Boundary reference documentation. The documentation is reference
 material for Boundary's concepts and available features.
 
-- Get started using Boundary with our [step-by-step onboarding tutorial](/boundary/tutorials) at HashiCorp Learn.
-- Install Boundary by using a precompiled binary or building from source with the documentation [here](/boundary/docs/getting-started/)
-- Learn about Boundary's [core concepts](/boundary/docs/concepts/) for how identities, permissions, and resources are organized.
+- Get started using Boundary with our [step-by-step onboarding tutorials](/boundary/tutorials).
+- Deploy Boundary in a [self-managed environment](/boundary/docs/deploy/self-managed) or on the [HashiCorp Cloud Platform (HCP)](/boundary/docs/hcp/get-started/deploy-and-login).
+- Learn about [what Boundary is](/boundary/docs/what-is-boundary/) or refer to the [domain model](/boundary/docs/domain-model) to understand how identities, permissions, and resources are organized.

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -25,8 +25,19 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/boundary/docs/concepts/index',
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/overview/what-is-boundary',
+    destination: '/boundary/docs/:version/what-is-boundary',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/concepts',
     destination: '/boundary/docs/what-is-boundary',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts',
+    destination: '/boundary/docs/:version/what-is-boundary',
     permanent: true,
   },
   {
@@ -35,8 +46,18 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/roadmap',
+    destination: '/boundary/docs/:version/what-is-boundary',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/oss',
     destination: '/boundary/docs/what-is-boundary',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss',
+    destination: '/boundary/docs/:version/what-is-boundary',
     permanent: true,
   },
   {
@@ -50,6 +71,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/use-cases',
+    destination: '/boundary/docs/:version/overview/use-cases',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/:version(v0\\.(?:10)\\.x)/overview/use-cases',
     destination: '/boundary/docs/:version/use-cases',
     permanent: true,
@@ -57,6 +83,12 @@ module.exports = [
   {
     source: '/boundary/docs/overview/vs/other-software',
     destination: '/boundary/docs/overview/use-cases',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/overview/vs/other-software',
+    destination: '/boundary/docs/:version/overview/use-cases',
     permanent: true,
   },
   {
@@ -71,8 +103,19 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/overview/vs/zero-trust',
+    destination: '/boundary/docs/:version/overview/zero-trust',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/overview/vs/bastion-hosts',
     destination: '/boundary/docs/overview/bastion-hosts',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/overview/vs/bastion-hosts',
+    destination: '/boundary/docs/:version/overview/bastion-hosts',
     permanent: true,
   },
   {
@@ -93,6 +136,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/overview/vs/vpn',
+    destination: '/boundary/docs/:version/overview/vpn',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/overview/vs/pam',
     destination: '/boundary/docs/overview/pam',
     permanent: true,
@@ -101,6 +149,11 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:11|12|13|14|15|16|17|18)\\.x)/overview/pam',
     destination: '/boundary/docs/:version/overview/vs/pam',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/overview/vs/pam',
+    destination: '/boundary/docs/:version/overview/pam',
     permanent: true,
   },
   {
@@ -115,6 +168,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/overview/vs/sdp',
+    destination: '/boundary/docs/:version/overview/sdp',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/overview/vs/secrets-management',
     destination: '/boundary/docs/overview/secrets-management',
     permanent: true,
@@ -123,6 +181,12 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:11|12|13|14|15|16|17|18)\\.x)/overview/secrets-management',
     destination: '/boundary/docs/:version/overview/vs/secrets-management',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/overview/vs/secrets-management',
+    destination: '/boundary/docs/:version/overview/secrets-management',
     permanent: true,
   },
   {
@@ -137,8 +201,18 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/troubleshoot/faq',
+    destination: '/boundary/docs/:version/overview/faq',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/getting-started/installing',
     destination: '/boundary/docs/getting-started',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/installing',
+    destination: '/boundary/docs/:version/deploy/self-managed',
     permanent: true,
   },
   {
@@ -164,6 +238,17 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/getting-started/dev-mode/dev-mode',
+    destination: '/boundary/docs/:version/getting-started/dev-mode',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss/installing/dev-mode',
+    destination: '/boundary/docs/:version/getting-started/dev-mode',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/oss/installing/run-and-login',
     destination: '/boundary/docs/getting-started/dev-mode/run-and-login',
     permanent: true,
@@ -172,6 +257,20 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:9|10|11|12)\\.x)/getting-started/dev-mode/run-and-login',
     destination: '/boundary/docs/:version/oss/installing/run-and-login',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/getting-started/run-and-login',
+    destination:
+      '/boundary/docs/:version/getting-started/dev-mode/run-and-login',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss/installing/run-and-login',
+    destination:
+      '/boundary/docs/:version/getting-started/dev-mode/run-and-login',
     permanent: true,
   },
   {
@@ -187,6 +286,19 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss/installing/connect-to-dev-target',
+    destination:
+      '/boundary/docs/:version/getting-started/dev-mode/connect-to-dev-target',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/architecture/:slug*',
+    destination: '/boundary/docs/:version/architecture/:slug*',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/install-boundary/system-requirements',
     destination: '/boundary/docs/architecture/system-requirements',
     permanent: true,
@@ -195,6 +307,12 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:13|14)\\.x)/architecture/system-requirements',
     destination: '/boundary/docs/:version/install-boundary/system-requirements',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/system-requirements',
+    destination: '/boundary/docs/:version/architecture/system-requirements',
     permanent: true,
   },
   {
@@ -212,6 +330,16 @@ module.exports = [
   {
     source: '/boundary/docs/oss/installing/postgres',
     destination: '/boundary/docs/architecture/system-requirements',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss/installing/postgres',
+    destination: '/boundary/docs/:version/architecture/system-requirements',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/installing/postgres',
+    destination: '/boundary/docs/:version/architecture/system-requirements',
     permanent: true,
   },
   {
@@ -245,6 +373,20 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss/installing/reference-architectures',
+    destination:
+      '/boundary/docs/:version/architecture/recommended-architecture',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/installing/reference-architectures',
+    destination:
+      '/boundary/docs/:version/architecture/recommended-architecture',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/install-boundary/recommended-architecture',
     destination: '/boundary/docs/architecture/recommended-architecture',
     permanent: true,
@@ -254,6 +396,13 @@ module.exports = [
       '/boundary/docs/:version(v0\\.(?:13|14)\\.x)/architecture/recommended-architecture',
     destination:
       '/boundary/docs/:version/install-boundary/recommended-architecture',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/recommended-architecture',
+    destination:
+      '/boundary/docs/:version/architecture/recommended-architecture',
     permanent: true,
   },
   {
@@ -277,6 +426,12 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:13|14)\\.x)/architecture/fault-tolerance',
     destination: '/boundary/docs/:version/install-boundary/fault-tolerance',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/fault-tolerance',
+    destination: '/boundary/docs/:version/architecture/fault-tolerance',
     permanent: true,
   },
   {
@@ -309,6 +464,18 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss/installing/high-availability',
+    destination: '/boundary/docs/:version/architecture/high-availability',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/installing/high-availability',
+    destination: '/boundary/docs/:version/architecture/high-availability',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/install-boundary/high-availability',
     destination: '/boundary/docs/architecture/high-availability',
     permanent: true,
@@ -317,6 +484,12 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:13|14)\\.x)/architecture/high-availability',
     destination: '/boundary/docs/:version/install-boundary/high-availability',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/high-availability',
+    destination: '/boundary/docs/:version/architecture/high-availability',
     permanent: true,
   },
   {
@@ -331,6 +504,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary',
+    destination: '/boundary/docs/:version/deploy/self-managed',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/install-boundary/install',
     destination: '/boundary/docs/deploy/self-managed/install',
     permanent: true,
@@ -342,6 +520,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/install',
+    destination: '/boundary/docs/:version/deploy/self-managed/install',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/install-boundary/deploy',
     destination: '/boundary/docs/deploy/self-managed/install',
     permanent: true,
@@ -350,6 +533,11 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:18)\\.x)/deploy/self-managed/install',
     destination: '/boundary/docs/:version/install-boundary/deploy',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/deploy',
+    destination: '/boundary/docs/:version/deploy/self-managed/install',
     permanent: true,
   },
   {
@@ -370,6 +558,13 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/configure-controllers',
+    destination:
+      '/boundary/docs/:version/deploy/self-managed/configure-controllers',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/install-boundary/configure-workers',
     destination: '/boundary/docs/deploy/self-managed/deploy-workers',
     permanent: true,
@@ -378,6 +573,12 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:13|14|15|16|17|18)\\.x)/deploy/self-managed/deploy-workers',
     destination: '/boundary/docs/:version/install-boundary/configure-workers',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/configure-workers',
+    destination: '/boundary/docs/:version/deploy/self-managed/deploy-workers',
     permanent: true,
   },
   {
@@ -392,6 +593,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/initialize',
+    destination: '/boundary/docs/:version/deploy/self-managed/initialize',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/oss/installing/no-gen-resources',
     destination: '/boundary/docs/deploy/self-managed/initialize',
     permanent: true,
@@ -403,6 +610,18 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:9|10|11|12)\\.x)/oss/installing/no-gen-resources',
+    destination: '/boundary/docs/:version/deploy/self-managed/initialize',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss/installing/no-gen-resources',
+    destination: '/boundary/docs/:version/deploy/self-managed/initialize',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/install-boundary/no-gen-resources',
     destination: '/boundary/docs/deploy/self-managed/initialize',
     permanent: true,
@@ -411,6 +630,18 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:13|14)\\.x)/deploy/self-managed/initialize',
     destination: '/boundary/docs/:version/install-boundary/no-gen-resources',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/no-gen-resources',
+    destination: '/boundary/docs/:version/deploy/self-managed/initialize',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/installing/no-gen-resources',
+    destination: '/boundary/docs/:version/deploy/self-managed/initialize',
     permanent: true,
   },
   {
@@ -428,6 +659,12 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:18)\\.x)/deploy/self-managed/install-clients',
     destination: '/boundary/docs/:version/install-boundary/install-clients',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/install-clients',
+    destination: '/boundary/docs/:version/deploy/self-managed/install-clients',
     permanent: true,
   },
   {
@@ -451,13 +688,34 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss/installing/systemd',
+    destination: '/boundary/docs/:version/deploy/self-managed/systemd',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/installing/systemd',
+    destination: '/boundary/docs/:version/deploy/self-managed/systemd',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/oss/installing',
-    destination: '/boundary/docs/deploy',
+    destination: '/boundary/docs/deploy/self-managed',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss/installing',
+    destination: '/boundary/docs/:version/deploy/self-managed',
     permanent: true,
   },
   {
     source: '/boundary/docs/getting-started/connect-to-target',
     destination: '/boundary/docs/hcp/get-started/connect-to-target',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/getting-started/connect-to-target',
+    destination: '/boundary/docs/:version/hcp/get-started/connect-to-target',
     permanent: true,
   },
   {
@@ -479,6 +737,12 @@ module.exports = [
   },
   {
     source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/getting-started/deploy-and-login',
+    destination: '/boundary/docs/:version/hcp/get-started/deploy-and-login',
+    permanent: true,
+  },
+  {
+    source:
       '/boundary/docs/:version(v0\\.(?:9|10|11|12)\\.x)/hcp/get-started/deploy-and-login',
     destination: '/boundary/docs/:version/getting-started/deploy-and-login',
     permanent: true,
@@ -486,6 +750,12 @@ module.exports = [
   {
     source: '/boundary/docs/install-boundary/terraform-patterns',
     destination: '/boundary/docs/deploy/terraform-patterns',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/install-boundary/terraform-patterns/:slug*',
+    destination: '/boundary/docs/:version/deploy/terraform-patterns/:slug*',
     permanent: true,
   },
   {
@@ -617,8 +887,19 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/security/data-encryption',
+    destination: '/boundary/docs/:version/secure/encryption/data-encryption',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/concepts/security',
     destination: '/boundary/docs/secure/encryption/data-encryption',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/security',
+    destination: '/boundary/docs/:version/secure/encryption/data-encryption',
     permanent: true,
   },
   {
@@ -630,6 +911,12 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18)\\.x)/secure/encryption/connections-tls',
     destination: '/boundary/docs/:version/concepts/security/connections-tls',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/security/connections-tls',
+    destination: '/boundary/docs/:version/secure/encryption/connections-tls',
     permanent: true,
   },
   {
@@ -653,8 +940,19 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/operations',
+    destination: '/boundary/docs/:version/monitor',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/configuration/listener',
     destination: '/boundary/docs/monitor/listeners',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/listener/:slug*',
+    destination: '/boundary/docs/:version/monitor/listeners/:slug*',
     permanent: true,
   },
   {
@@ -696,8 +994,18 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss/operations/metrics',
+    destination: '/boundary/docs/:version/monitor/metrics',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/operations/metrics',
     destination: '/boundary/docs/monitor/metrics',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/operations/metrics',
+    destination: '/boundary/docs/:version/monitor/metrics',
     permanent: true,
   },
   {
@@ -718,6 +1026,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/operations/health',
+    destination: '/boundary/docs/:version/monitor/health',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/oss/operations/health',
     destination: '/boundary/docs/monitor/health',
     permanent: true,
@@ -728,8 +1041,24 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/oss/operations/health',
+    destination: '/boundary/docs/:version/monitor/health',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/configuration/events',
     destination: '/boundary/docs/monitor/events/events',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/events',
+    destination: '/boundary/docs/:version/monitor/events/events',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/events/overview',
+    destination: '/boundary/docs/:version/monitor/events/events',
     permanent: true,
   },
   {
@@ -745,6 +1074,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/monitor/events',
+    destination: '/boundary/docs/:version/monitor/events/events',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/concepts/filtering/events',
     destination: '/boundary/docs/monitor/events/filter-events',
     permanent: true,
@@ -756,8 +1090,20 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/filtering/events',
+    destination: '/boundary/docs/:version/monitor/events/filter-events',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/configuration/events/common',
     destination: '/boundary/docs/monitor/events/common',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/events/common',
+    destination: '/boundary/docs/:version/monitor/events/common',
     permanent: true,
   },
   {
@@ -778,6 +1124,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/events/file',
+    destination: '/boundary/docs/:version/monitor/events/file',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/configuration/events/stderr',
     destination: '/boundary/docs/monitor/events/stderr',
     permanent: true,
@@ -789,8 +1141,24 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/events/stderr',
+    destination: '/boundary/docs/:version/monitor/events/stderr',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/release-notes',
     destination: '/boundary/docs',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/release-notes',
+    destination: '/boundary/docs/:version',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/release-notes/v0_20_0',
+    destination: '/boundary/docs/:version',
     permanent: true,
   },
   {
@@ -802,6 +1170,11 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:1|2|3|4|5|6|7|8|10|11|12|13|14|15|16|17|18)\\.x)/workers',
     destination: '/boundary/docs/:version/configuration/worker',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/worker',
+    destination: '/boundary/docs/:version/workers',
     permanent: true,
   },
   {
@@ -822,13 +1195,31 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/worker/worker-configuration',
+    destination: '/boundary/docs/:version/workers/registration',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/configuration/worker/kms-worker',
     destination: '/boundary/docs/workers/registration',
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/worker/kms-worker',
+    destination: '/boundary/docs/:version/workers/registration',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/configuration/worker/pki-worker',
     destination: '/boundary/docs/workers/registration',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/worker/pki-worker',
+    destination: '/boundary/docs/:version/workers/registration',
     permanent: true,
   },
   {
@@ -844,6 +1235,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/connection-workflows/multi-hop',
+    destination: '/boundary/docs/:version/workers/multi-hop',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/concepts/filtering/worker-tags',
     destination: '/boundary/docs/workers/worker-tags',
     permanent: true,
@@ -852,6 +1249,12 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18)\\.x)/workers/worker-tags',
     destination: '/boundary/docs/:version/concepts/filtering/worker-tags',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/filtering/worker-tags',
+    destination: '/boundary/docs/:version/workers/worker-tags',
     permanent: true,
   },
   {
@@ -865,6 +1268,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/service-discovery',
+    destination: '/boundary/docs/:version/hosts',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/concepts/host-discovery',
     destination: '/boundary/docs/hosts',
     permanent: true,
@@ -872,6 +1281,12 @@ module.exports = [
   {
     source: '/boundary/docs/:version(v0\\.(?:13|14|15|16|17|18)\\.x)/hosts',
     destination: '/boundary/docs/:version/concepts/host-discovery',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/host-discovery/:slug*',
+    destination: '/boundary/docs/:version/hosts/:slug*',
     permanent: true,
   },
   {
@@ -911,6 +1326,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/target-aliases',
+    destination: '/boundary/docs/:version/targets/configuration',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/configuration/target-aliases/connect-target-alias',
     destination: '/boundary/docs/targets/connections/connect-target-alias',
     permanent: true,
@@ -923,6 +1344,13 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/target-aliases/connect-target-alias',
+    destination:
+      '/boundary/docs/:version/targets/connections/connect-target-alias',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/configuration/target-aliases/create-target-alias',
     destination: '/boundary/docs/targets/configuration/create-target-alias',
     permanent: true,
@@ -932,6 +1360,13 @@ module.exports = [
       '/boundary/docs/:version(v0\\.(?:18)\\.x)/targets/configuration/create-target-alias',
     destination:
       '/boundary/docs/:version/configuration/target-aliases/create-target-alias',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/target-aliases/create-target-alias',
+    destination:
+      '/boundary/docs/:version/targets/configuration/create-target-alias',
     permanent: true,
   },
   {
@@ -948,6 +1383,13 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/target-aliases/transparent-sessions',
+    destination:
+      '/boundary/docs/:version/targets/configuration/configure-transparent-sessions',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/concepts/connection-workflows',
     destination: '/boundary/docs/targets/connections',
     permanent: true,
@@ -956,6 +1398,12 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:14|15|16|17|18)\\.x)/targets/connections',
     destination: '/boundary/docs/:version/concepts/connection-workflows',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/connection-workflows',
+    destination: '/boundary/docs/:version/targets/connections',
     permanent: true,
   },
   {
@@ -971,6 +1419,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/connection-workflows/connect-helpers',
+    destination: '/boundary/docs/:version/targets/connections/connect-helpers',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/concepts/connection-workflows/exec-flag',
     destination: '/boundary/docs/targets/connections/exec-flag',
     permanent: true,
@@ -980,6 +1434,12 @@ module.exports = [
       '/boundary/docs/:version(v0\\.(?:14|15|16|17|18)\\.x)/targets/connections/exec-flag',
     destination:
       '/boundary/docs/:version/concepts/connection-workflows/exec-flag',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/connection-workflows/exec-flag',
+    destination: '/boundary/docs/:version/targets/connections/exec-flag',
     permanent: true,
   },
   {
@@ -1001,13 +1461,32 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/connection-workflows/workflow-ssh-proxycommand',
+    destination:
+      '/boundary/docs/:version/targets/connections/workflow-ssh-proxycommand',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/configuration/credential-management',
     destination: '/boundary/docs/credentials',
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/credential-management/:slug*',
+    destination: '/boundary/docs/:version/credentials/:slug*',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/:version(v0\\.(?:15|16|17|18)\\.x)/credentials',
     destination: '/boundary/docs/:version/configuration/credential-management',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/credentials/rdp-testing-and-compatibility-matrix',
+    destination: '/boundary/docs/:version/credentials',
     permanent: true,
   },
   {
@@ -1074,6 +1553,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/session-recording',
+    destination: '/boundary/docs/:version/session-recording',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/operations/session-recordings',
     destination: '/boundary/docs/session-recording',
     permanent: true,
@@ -1094,6 +1579,13 @@ module.exports = [
   },
   {
     source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/session-recording/configure-worker-storage',
+    destination:
+      '/boundary/docs/:version/session-recording/configuration/configure-worker-storage',
+    permanent: true,
+  },
+  {
+    source:
       '/boundary/docs/:version(v0\\.(?:13|14|15)\\.x)/session-recording/configuration/configure-worker-storage',
     destination:
       '/boundary/docs/:version/configuration/session-recording/create-storage-bucket',
@@ -1103,6 +1595,13 @@ module.exports = [
     source: '/boundary/docs/configuration/session-recording/storage-providers',
     destination:
       '/boundary/docs/session-recording/configuration/storage-providers',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/session-recording/storage-providers/:slug*',
+    destination:
+      '/boundary/docs/:version/session-recording/configuration/storage-providers/:slug*',
     permanent: true,
   },
   {
@@ -1163,6 +1662,13 @@ module.exports = [
   },
   {
     source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/session-recording/create-storage-bucket',
+    destination:
+      '/boundary/docs/:version/session-recording/configuration/create-storage-bucket',
+    permanent: true,
+  },
+  {
+    source:
       '/boundary/docs/configuration/session-recording/enable-session-recording',
     destination:
       '/boundary/docs/session-recording/configuration/enable-session-recording',
@@ -1173,6 +1679,13 @@ module.exports = [
       '/boundary/docs/:version(v0\\.(?:13|14|15|16|17|18)\\.x)/session-recording/configuration/enable-session-recording',
     destination:
       '/boundary/docs/:version/configuration/session-recording/enable-session-recording',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/session-recording/enable-session-recording',
+    destination:
+      '/boundary/docs/:version/session-recording/configuration/enable-session-recording',
     permanent: true,
   },
   {
@@ -1190,6 +1703,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19|20)\\.x)/operations/manage-recorded-sessions',
+    destination: '/boundary/docs/:version/session-recording',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/troubleshoot/troubleshoot-recorded-sessions',
     destination:
       '/boundary/docs/session-recording/configuration/troubleshoot-recorded-sessions',
@@ -1200,6 +1719,13 @@ module.exports = [
       '/boundary/docs/:version(v0\\.(?:13|14|15|16|17|18)\\.x)/session-recording/configuration/troubleshoot-recorded-sessions',
     destination:
       '/boundary/docs/:version/troubleshoot/troubleshoot-recorded-sessions',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/troubleshoot/troubleshoot-recorded-sessions',
+    destination:
+      '/boundary/docs/:version/session-recording/configuration/troubleshoot-recorded-sessions',
     permanent: true,
   },
   {
@@ -1218,6 +1744,13 @@ module.exports = [
   },
   {
     source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/session-recording/configure-storage-policy',
+    destination:
+      '/boundary/docs/:version/session-recording/compliance/configure-storage-policy',
+    permanent: true,
+  },
+  {
+    source:
       '/boundary/docs/configuration/session-recording/update-storage-policy',
     destination:
       '/boundary/docs/session-recording/compliance/update-storage-policy',
@@ -1228,6 +1761,13 @@ module.exports = [
       '/boundary/docs/:version(v0\\.(?:15|16|17|18)\\.x)/session-recording/compliance/update-storage-policy',
     destination:
       '/boundary/docs/:version/configuration/session-recording/update-storage-policy',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/session-recording/update-storage-policy',
+    destination:
+      '/boundary/docs/:version/session-recording/compliance/update-storage-policy',
     permanent: true,
   },
   {
@@ -1245,6 +1785,13 @@ module.exports = [
   },
   {
     source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/operations/session-recordings/validate-data-store',
+    destination:
+      '/boundary/docs/:version/session-recording/compliance/validate-data-store',
+    permanent: true,
+  },
+  {
+    source:
       '/boundary/docs/operations/session-recordings/validate-session-recordings',
     destination:
       '/boundary/docs/session-recording/compliance/validate-session-recordings',
@@ -1258,8 +1805,33 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/operations/session-recordings',
+    destination: '/boundary/docs/:version/session-recording',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/operations/session-recordings/manage-recorded-sessions',
+    destination: '/boundary/docs/:version/session-recording',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/operations/session-recordings/validate-session-recordings',
+    destination:
+      '/boundary/docs/:version/session-recording/compliance/validate-session-recordings',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/configuration/identity-access-management',
     destination: '/boundary/docs/rbac',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/configuration/identity-access-management/:slug*',
+    destination: '/boundary/docs/:version/rbac/:slug*',
     permanent: true,
   },
   {
@@ -1271,6 +1843,12 @@ module.exports = [
   {
     source: '/boundary/docs/concepts/security/permissions',
     destination: '/boundary/docs/rbac',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/security/permissions/:slug*',
+    destination: '/boundary/docs/:version/rbac/:slug*',
     permanent: true,
   },
   {
@@ -1343,6 +1921,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/common-workflows/manage-roles',
+    destination: '/boundary/docs/:version/rbac/manage-roles',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/concepts/security/permissions/resource-table',
     destination: '/boundary/docs/rbac/resource-table',
     permanent: true,
@@ -1378,6 +1962,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/common-workflows/manage-users-groups',
+    destination: '/boundary/docs/:version/rbac/users/manage-users-groups',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/concepts/filtering/oidc-managed-groups',
     destination: '/boundary/docs/rbac/users/managed-groups',
     permanent: true,
@@ -1387,6 +1977,12 @@ module.exports = [
       '/boundary/docs/:version(v0\\.(?:4|5|6|7|8|9|10|11|12|13|14|15)\\.x)/rbac/users/managed-groups',
     destination:
       '/boundary/docs/:version/concepts/filtering/oidc-managed-groups',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/filtering/oidc-managed-groups',
+    destination: '/boundary/docs/:version/rbac/users/managed-groups',
     permanent: true,
   },
   {
@@ -1401,8 +1997,19 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/filtering/managed-groups',
+    destination: '/boundary/docs/:version/rbac/users/managed-groups',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/integrations',
     destination: '/boundary/docs',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/integrations',
+    destination: '/boundary/docs/:version',
     permanent: true,
   },
   {
@@ -1413,6 +2020,11 @@ module.exports = [
   {
     source: '/boundary/docs/:version(v0\\.(?:15|16|17|18)\\.x)/vault',
     destination: '/boundary/docs/:version/integrations/vault',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/integrations/vault',
+    destination: '/boundary/docs/:version/vault',
     permanent: true,
   },
   {
@@ -1427,6 +2039,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/api-clients/go-sdk',
+    destination: '/boundary/docs/:version/go-sdk',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/api-clients/client-agent',
     destination: '/boundary/docs/client-agent',
     permanent: true,
@@ -1437,6 +2054,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/api-clients/client-agent',
+    destination: '/boundary/docs/:version/client-agent',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/api-clients/client-cache',
     destination: '/boundary/docs/client-cache',
     permanent: true,
@@ -1444,6 +2066,11 @@ module.exports = [
   {
     source: '/boundary/docs/:version(v0\\.(?:15|16|17|18)\\.x)/client-cache',
     destination: '/boundary/docs/:version/api-clients/client-cache',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/api-clients/client-cache',
+    destination: '/boundary/docs/:version/client-cache',
     permanent: true,
   },
   {
@@ -1458,6 +2085,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/api-clients/api',
+    destination: '/boundary/docs/:version/api',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/api-clients/api/pagination',
     destination: '/boundary/docs/api/pagination',
     permanent: true,
@@ -1465,6 +2097,12 @@ module.exports = [
   {
     source: '/boundary/docs/:version(v0\\.(?:15|16|17|18)\\.x)/api/pagination',
     destination: '/boundary/docs/:version/api-clients/api/pagination',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/api-clients/api/pagination',
+    destination: '/boundary/docs/:version/api/pagination',
     permanent: true,
   },
   {
@@ -1479,6 +2117,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/api-clients/api/rate-limiting',
+    destination: '/boundary/docs/:version/api/rate-limiting',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/api-clients/cli',
     destination: '/boundary/docs/commands/',
     permanent: true,
@@ -1490,6 +2134,27 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/api-clients/cli',
+    destination: '/boundary/docs/:version/commands',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/commands/connect/cassandra',
+    destination: '/boundary/docs/:version/commands',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/commands/connect/mysql',
+    destination: '/boundary/docs/:version/commands',
+    permanent: true,
+  },
+  {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/commands/daemon/:slug*',
+    destination: '/boundary/docs/:version/commands/cache/:slug*',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/concepts/domain-model',
     destination: '/boundary/docs/domain-model',
     permanent: true,
@@ -1498,6 +2163,12 @@ module.exports = [
     source:
       '/boundary/docs/:version(v0\\.(?:1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18)\\.x)/domain-model',
     destination: '/boundary/docs/:version/concepts/domain-model',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/domain-model/:slug*',
+    destination: '/boundary/docs/:version/domain-model/:slug*',
     permanent: true,
   },
   {
@@ -1737,8 +2408,19 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/filtering',
+    destination: '/boundary/docs/:version/filtering',
+    permanent: true,
+  },
+  {
     source: '/boundary/docs/concepts/filtering/resource-listing',
     destination: '/boundary/docs/filtering',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/concepts/filtering/resource-listing',
+    destination: '/boundary/docs/:version/filtering',
     permanent: true,
   },
   {
@@ -1749,6 +2431,12 @@ module.exports = [
   {
     source: '/boundary/docs/:version(v0\\.(?:12|13|14|15|16|17|18)\\.x)/errors',
     destination: '/boundary/docs/:version/troubleshoot/common-errors',
+    permanent: true,
+  },
+  {
+    source:
+      '/boundary/docs/:version(v0\\.(?:19)\\.x)/troubleshoot/common-errors',
+    destination: '/boundary/docs/:version/errors',
     permanent: true,
   },
   {


### PR DESCRIPTION
## Description

The automatic backport for #6128 failed. This PR cherry-picks the following commits to the `release/0.20.x` branch:

* docs: Fix version 0.19.x redirects

* docs: Adds architecture and Terraform redirects

* docs: Main install topics

* docs: Integrations and operations

* docs: Fixes remaining 0.19.x redirects

* docs: Updates reference doc page

* docs: Fixes


## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [X ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
