### PR TITLE
feat(credential/static): Add CRUDL support for static password credentials

### DIFF
--- a/internal/credential/public_ids.go
+++ b/internal/credential/public_ids.go
@@ -51,11 +51,11 @@ func NewUsernamePasswordDomainCredentialId(ctx context.Context) (string, error) 
 	return id, nil
 }
 
-// PasswordCredentialId generates a new public ID for a password credential.
-func PasswordCredentialId(ctx context.Context) (string, error) {
+// NewPasswordCredentialId generates a new public ID for a password credential.
+func NewPasswordCredentialId(ctx context.Context) (string, error) {
 	id, err := db.NewPublicId(ctx, globals.PasswordCredentialPrefix)
 	if err != nil {
-		return "", errors.Wrap(ctx, err, "credential.PasswordCredentialId")
+		return "", errors.Wrap(ctx, err, "credential.NewPasswordCredentialId")
 	}
 	return id, nil
 }

--- a/internal/credential/static/credential.go
+++ b/internal/credential/static/credential.go
@@ -92,6 +92,24 @@ func (c *listCredentialResult) toCredential(ctx context.Context) (credential.Sta
 			cred.PasswordHmac = []byte(c.Hmac1)
 		}
 		return cred, nil
+	case "p":
+		cred := &PasswordCredential{
+			PasswordCredential: &store.PasswordCredential{
+				PublicId:    c.PublicId,
+				StoreId:     c.StoreId,
+				Name:        c.Name,
+				Description: c.Description,
+				CreateTime:  c.CreateTime,
+				UpdateTime:  c.UpdateTime,
+				Version:     uint32(c.Version),
+				KeyId:       c.KeyId,
+			},
+		}
+		// Assign byte slices only if the string isn't empty
+		if c.Hmac1 != "" {
+			cred.PasswordHmac = []byte(c.Hmac1)
+		}
+		return cred, nil
 	case "ssh":
 		cred := &SshPrivateKeyCredential{
 			SshPrivateKeyCredential: &store.SshPrivateKeyCredential{

--- a/internal/credential/static/password_credential.go
+++ b/internal/credential/static/password_credential.go
@@ -1,0 +1,141 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package static
+
+import (
+	"context"
+
+	"github.com/hashicorp/boundary/internal/credential"
+	"github.com/hashicorp/boundary/internal/credential/static/store"
+	"github.com/hashicorp/boundary/internal/db/timestamp"
+	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/libs/crypto"
+	"github.com/hashicorp/boundary/internal/oplog"
+	"github.com/hashicorp/boundary/internal/types/resource"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/hashicorp/go-kms-wrapping/v2/extras/structwrapping"
+	"google.golang.org/protobuf/proto"
+)
+
+var _ credential.Static = (*PasswordCredential)(nil)
+
+// PasswordCredential contains the credential with a password.
+// It is owned by a credential store.
+type PasswordCredential struct {
+	*store.PasswordCredential
+	tableName string `gorm:"-"`
+}
+
+// NewPasswordCredential creates a new in memory static Credential containing a
+// password that is assigned to storeId. Name and description are the only
+// valid options. All other options are ignored.
+func NewPasswordCredential(
+	storeId string,
+	password credential.Password,
+	opt ...Option,
+) (*PasswordCredential, error) {
+	opts := getOpts(opt...)
+	l := &PasswordCredential{
+		PasswordCredential: &store.PasswordCredential{
+			StoreId:     storeId,
+			Name:        opts.withName,
+			Description: opts.withDescription,
+			Password:    []byte(password),
+		},
+	}
+	return l, nil
+}
+
+func allocPasswordCredential() *PasswordCredential {
+	return &PasswordCredential{
+		PasswordCredential: &store.PasswordCredential{},
+	}
+}
+
+func (c *PasswordCredential) clone() *PasswordCredential {
+	cp := proto.Clone(c.PasswordCredential)
+	return &PasswordCredential{
+		PasswordCredential: cp.(*store.PasswordCredential),
+	}
+}
+
+// TableName returns the table name.
+func (c *PasswordCredential) TableName() string {
+	if c.tableName != "" {
+		return c.tableName
+	}
+	return "credential_static_password_credential"
+}
+
+// SetTableName sets the table name.
+func (c *PasswordCredential) SetTableName(n string) {
+	c.tableName = n
+}
+
+// GetResourceType returns the resource type of the Credential
+func (c *PasswordCredential) GetResourceType() resource.Type {
+	return resource.Credential
+}
+
+func (c *PasswordCredential) oplog(op oplog.OpType) oplog.Metadata {
+	metadata := oplog.Metadata{
+		"resource-public-id": []string{c.PublicId},
+		"resource-type":      []string{"credential-static-password"},
+		"op-type":            []string{op.String()},
+	}
+	if c.StoreId != "" {
+		metadata["store-id"] = []string{c.StoreId}
+	}
+	return metadata
+}
+
+func (c *PasswordCredential) encrypt(ctx context.Context, cipher wrapping.Wrapper) error {
+	const op = "static.(PasswordCredential).encrypt"
+	if len(c.Password) == 0 {
+		return errors.New(ctx, errors.InvalidParameter, op, "no password defined")
+	}
+	if err := structwrapping.WrapStruct(ctx, cipher, c.PasswordCredential, nil); err != nil {
+		return errors.Wrap(ctx, err, op, errors.WithCode(errors.Encrypt))
+	}
+	keyId, err := cipher.KeyId(ctx)
+	if err != nil {
+		return errors.Wrap(ctx, err, op, errors.WithCode(errors.Encrypt), errors.WithMsg("error reading cipher key id"))
+	}
+	c.KeyId = keyId
+	if err := c.hmacPassword(ctx, cipher); err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	return nil
+}
+
+func (c *PasswordCredential) decrypt(ctx context.Context, cipher wrapping.Wrapper) error {
+	const op = "static.(PasswordCredential).decrypt"
+	if err := structwrapping.UnwrapStruct(ctx, cipher, c.PasswordCredential, nil); err != nil {
+		return errors.Wrap(ctx, err, op, errors.WithCode(errors.Decrypt))
+	}
+	return nil
+}
+
+func (c *PasswordCredential) hmacPassword(ctx context.Context, cipher wrapping.Wrapper) error {
+	const op = "static.(PasswordCredential).hmacPassword"
+	if cipher == nil {
+		return errors.New(ctx, errors.InvalidParameter, op, "missing cipher")
+	}
+	hm, err := crypto.HmacSha256(ctx, c.Password, cipher, []byte(c.StoreId), nil, crypto.WithEd25519())
+	if err != nil {
+		return errors.Wrap(ctx, err, op)
+	}
+	c.PasswordHmac = []byte(hm)
+	return nil
+}
+
+type deletedPasswordCredential struct {
+	PublicId   string `gorm:"primary_key"`
+	DeleteTime *timestamp.Timestamp
+}
+
+// TableName returns the tablename to override the default gorm table name
+func (s *deletedPasswordCredential) TableName() string {
+	return "credential_static_password_credential_deleted"
+}

--- a/internal/credential/static/password_credential_test.go
+++ b/internal/credential/static/password_credential_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package static
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/boundary/internal/credential"
+	"github.com/hashicorp/boundary/internal/credential/static/store"
+	"github.com/hashicorp/boundary/internal/db"
+	"github.com/hashicorp/boundary/internal/iam"
+	"github.com/hashicorp/boundary/internal/kms"
+	"github.com/hashicorp/boundary/internal/libs/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestPasswordCredential_New(t *testing.T) {
+	t.Parallel()
+	conn, _ := db.TestSetup(t, "postgres")
+	wrapper := db.TestWrapper(t)
+	kkms := kms.TestKms(t, conn, wrapper)
+	rw := db.New(conn)
+
+	_, prj := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))
+	cs := TestCredentialStore(t, conn, wrapper, prj.PublicId)
+
+	type args struct {
+		password credential.Password
+		storeId  string
+		options  []Option
+	}
+
+	tests := []struct {
+		name           string
+		args           args
+		want           *PasswordCredential
+		wantCreateErr  bool
+		wantEncryptErr bool
+	}{
+		{
+			name: "missing-password",
+			args: args{
+				storeId: cs.PublicId,
+			},
+			want:           allocPasswordCredential(),
+			wantEncryptErr: true,
+		},
+		{
+			name: "missing-store-id",
+			args: args{
+				password: "test-pass",
+			},
+			want:          allocPasswordCredential(),
+			wantCreateErr: true,
+		},
+		{
+			name: "valid-no-options",
+			args: args{
+				password: "test-pass",
+				storeId:  cs.PublicId,
+			},
+			want: &PasswordCredential{
+				PasswordCredential: &store.PasswordCredential{
+					Password: []byte("test-pass"),
+					StoreId:  cs.PublicId,
+				},
+			},
+		},
+		{
+			name: "valid-with-name",
+			args: args{
+				password: "test-pass",
+				storeId:  cs.PublicId,
+				options:  []Option{WithName("my-credential")},
+			},
+			want: &PasswordCredential{
+				PasswordCredential: &store.PasswordCredential{
+					Password: []byte("test-pass"),
+					StoreId:  cs.PublicId,
+					Name:     "my-credential",
+				},
+			},
+		},
+		{
+			name: "valid-with-description",
+			args: args{
+				password: "test-pass",
+				storeId:  cs.PublicId,
+				options:  []Option{WithDescription("my-credential-description")},
+			},
+			want: &PasswordCredential{
+				PasswordCredential: &store.PasswordCredential{
+					Password:    []byte("test-pass"),
+					StoreId:     cs.PublicId,
+					Description: "my-credential-description",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			ctx := context.Background()
+
+			got, err := NewPasswordCredential(tt.args.storeId, tt.args.password, tt.args.options...)
+
+			require.NoError(err)
+			require.NotNil(got)
+			assert.Emptyf(got.PublicId, "PublicId set")
+			id, err := credential.NewPasswordCredentialId(ctx)
+			require.NoError(err)
+
+			tt.want.PublicId = id
+			got.PublicId = id
+
+			databaseWrapper, err := kkms.GetWrapper(context.Background(), prj.PublicId, kms.KeyPurposeDatabase)
+			require.NoError(err)
+
+			err = got.encrypt(ctx, databaseWrapper)
+			if tt.wantEncryptErr {
+				require.Error(err)
+				return
+			}
+			assert.NoError(err)
+
+			err = rw.Create(context.Background(), got)
+			if tt.wantCreateErr {
+				require.Error(err)
+				return
+			}
+			assert.NoError(err)
+
+			got2 := allocPasswordCredential()
+			got2.PublicId = id
+			assert.Equal(id, got2.GetPublicId())
+			require.NoError(rw.LookupById(ctx, got2))
+
+			err = got2.decrypt(ctx, databaseWrapper)
+			require.NoError(err)
+
+			// Timestamps and version are automatically set
+			tt.want.CreateTime = got2.CreateTime
+			tt.want.UpdateTime = got2.UpdateTime
+			tt.want.Version = got2.Version
+
+			// KeyId is allocated via kms no need to validate in this test
+			tt.want.KeyId = got2.KeyId
+			got2.CtPassword = nil
+
+			// encrypt also calculates the hmac, validate it is correct
+			hm, err := crypto.HmacSha256(ctx, got.Password, databaseWrapper, []byte(got.StoreId), nil, crypto.WithEd25519())
+			require.NoError(err)
+			tt.want.PasswordHmac = []byte(hm)
+
+			assert.Empty(cmp.Diff(tt.want, got2.clone(), protocmp.Transform()))
+		})
+	}
+}

--- a/internal/credential/static/query.go
+++ b/internal/credential/static/query.go
@@ -26,6 +26,16 @@ select distinct upd.public_id,
             and upd.key_id = ?;
 `
 
+	credStaticPasswordRewrapQuery = `
+select distinct pass.public_id,
+                pass.password_encrypted,
+                pass.key_id
+           from credential_static_password_credential pass
+     inner join credential_static_store store
+             on store.public_id = pass.store_id
+          where store.project_id = ?
+            and pass.key_id = ?;
+`
 	credStaticSshPrivKeyRewrapQuery = `
 select distinct ssh.public_id,
                 ssh.private_key_encrypted,
@@ -56,6 +66,7 @@ select sum(reltuples::bigint) as estimate
   'credential_static_json_credential'::regclass,
   'credential_static_username_password_credential'::regclass,
   'credential_static_username_password_domain_credential'::regclass,
+  'credential_static_password_credential'::regclass,
   'credential_static_ssh_private_key_credential'::regclass
  )
 `
@@ -81,6 +92,11 @@ upw_creds as (
 upd_creds as (
   select * 
     from credential_static_username_password_domain_credential
+  where public_id in (select public_id from credentials)
+),
+p_creds as (
+  select * 
+    from credential_static_password_credential
   where public_id in (select public_id from credentials)
 ),
 ssh_creds as (
@@ -145,6 +161,22 @@ final as (
          create_time,
          update_time,
          version,
+         null as username,     -- Add this to make the union uniform
+         null as domain,       -- Add this to make the union uniform
+         key_id,
+         password_hmac as hmac1,
+         null::bytea as hmac2, -- Add this to make the union uniform
+         'p' as type
+    from p_creds
+   union
+  select public_id,
+         store_id,
+         project_id,
+         name,
+         description,
+         create_time,
+         update_time,
+         version,
          username,
          null as domain,       -- Add this to make the union uniform
          key_id,
@@ -180,6 +212,11 @@ upw_creds as (
 upd_creds as (
   select *
     from credential_static_username_password_domain_credential
+   where public_id in (select public_id from credentials)
+),
+p_creds as (
+  select *
+    from credential_static_password_credential
    where public_id in (select public_id from credentials)
 ),
 ssh_creds as (
@@ -235,6 +272,22 @@ final as (
          null::bytea as hmac2, -- Add this to make the union uniform
          'upd' as type
     from upd_creds
+   union
+  select public_id,
+         store_id,
+         project_id,
+         name,
+         description,
+         create_time,
+         update_time,
+         version,
+         null as username,     -- Add this to make the union uniform
+         null as domain,       -- Add this to make the union uniform
+         key_id,
+         password_hmac as hmac1,
+         null::bytea as hmac2, -- Add this to make the union uniform
+         'p' as type
+    from p_creds
    union
   select public_id,
          store_id,
@@ -281,6 +334,11 @@ upd_creds as (
     from credential_static_username_password_domain_credential
    where public_id in (select public_id from credentials)
 ),
+p_creds as (
+  select * 
+    from credential_static_password_credential
+  where public_id in (select public_id from credentials)
+),
 ssh_creds as (
   select *
     from credential_static_ssh_private_key_credential
@@ -334,6 +392,22 @@ final as (
          null::bytea as hmac2, -- Add this to make the union uniform
          'upd' as type
     from upd_creds
+   union
+  select public_id,
+         store_id,
+         project_id,
+         name,
+         description,
+         create_time,
+         update_time,
+         version,
+         null as username,     -- Add this to make the union uniform
+         null as domain,       -- Add this to make the union uniform
+         key_id,
+         password_hmac as hmac1,
+         null::bytea as hmac2, -- Add this to make the union uniform
+         'p' as type
+    from p_creds
    union
   select public_id,
          store_id,
@@ -381,6 +455,11 @@ upd_creds as (
     from credential_static_username_password_domain_credential
    where public_id in (select public_id from credentials)
 ),
+p_creds as (
+  select * 
+    from credential_static_password_credential
+  where public_id in (select public_id from credentials)
+),
 ssh_creds as (
   select *
     from credential_static_ssh_private_key_credential
@@ -434,6 +513,22 @@ final as (
          null::bytea as hmac2, -- Add this to make the union uniform
          'upd' as type
     from upd_creds
+   union
+  select public_id,
+         store_id,
+         project_id,
+         name,
+         description,
+         create_time,
+         update_time,
+         version,
+         null as username,     -- Add this to make the union uniform
+         null as domain,       -- Add this to make the union uniform
+         key_id,
+         password_hmac as hmac1,
+         null::bytea as hmac2, -- Add this to make the union uniform
+         'p' as type
+    from p_creds
    union
   select public_id,
          store_id,

--- a/internal/credential/static/repository_credentials.go
+++ b/internal/credential/static/repository_credentials.go
@@ -30,6 +30,11 @@ func (r *Repository) Retrieve(ctx context.Context, projectId string, ids []strin
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
+	var pCreds []*PasswordCredential
+	err = r.reader.SearchWhere(ctx, &pCreds, "public_id in (?)", []any{ids})
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op)
+	}
 	var spkCreds []*SshPrivateKeyCredential
 	err = r.reader.SearchWhere(ctx, &spkCreds, "public_id in (?)", []any{ids})
 	if err != nil {
@@ -41,9 +46,9 @@ func (r *Repository) Retrieve(ctx context.Context, projectId string, ids []strin
 		return nil, errors.Wrap(ctx, err, op)
 	}
 
-	if len(upCreds)+len(updCreds)+len(spkCreds)+len(jsonCreds) != len(ids) {
+	if len(upCreds)+len(updCreds)+len(pCreds)+len(spkCreds)+len(jsonCreds) != len(ids) {
 		return nil, errors.New(ctx, errors.NotSpecificIntegrity, op,
-			fmt.Sprintf("mismatch between creds and number of ids requested, expected %d got %d", len(ids), len(upCreds)+len(spkCreds)+len(jsonCreds)))
+			fmt.Sprintf("mismatch between creds and number of ids requested, expected %d got %d", len(ids), len(upCreds)+len(updCreds)+len(pCreds)+len(spkCreds)+len(jsonCreds)))
 	}
 
 	out := make([]credential.Static, 0, len(ids))
@@ -61,6 +66,19 @@ func (r *Repository) Retrieve(ctx context.Context, projectId string, ids []strin
 	}
 
 	for _, c := range updCreds {
+		// decrypt credential
+		databaseWrapper, err := r.kms.GetWrapper(ctx, projectId, kms.KeyPurposeDatabase)
+		if err != nil {
+			return nil, errors.Wrap(ctx, err, op, errors.WithMsg("unable to get database wrapper"))
+		}
+		if err := c.decrypt(ctx, databaseWrapper); err != nil {
+			return nil, errors.Wrap(ctx, err, op)
+		}
+
+		out = append(out, c)
+	}
+
+	for _, c := range pCreds {
 		// decrypt credential
 		databaseWrapper, err := r.kms.GetWrapper(ctx, projectId, kms.KeyPurposeDatabase)
 		if err != nil {

--- a/internal/credential/static/repository_credentials_test.go
+++ b/internal/credential/static/repository_credentials_test.go
@@ -39,6 +39,8 @@ func TestRepository_Retrieve(t *testing.T) {
 	upCred2 := TestUsernamePasswordCredential(t, conn, wrapper, "different user", "better password", staticStore.GetPublicId(), prj.GetPublicId())
 	updCred1 := TestUsernamePasswordDomainCredential(t, conn, wrapper, "user", "pass", "domain.com", staticStore.GetPublicId(), prj.GetPublicId())
 	updCred2 := TestUsernamePasswordDomainCredential(t, conn, wrapper, "different user", "better password", "new-domain.com", staticStore.GetPublicId(), prj.GetPublicId())
+	pCred1 := TestPasswordCredential(t, conn, wrapper, "better password", staticStore.GetPublicId(), prj.GetPublicId())
+	pCred2 := TestPasswordCredential(t, conn, wrapper, "another password", staticStore.GetPublicId(), prj.GetPublicId())
 	spkCred1 := TestSshPrivateKeyCredential(t, conn, wrapper, "final user", string(testdata.PEMBytes["ed25519"]), staticStore.GetPublicId(), prj.GetPublicId())
 	spkCred2 := TestSshPrivateKeyCredential(t, conn, wrapper, "last user", string(testdata.PEMBytes["rsa-openssh-format"]), staticStore.GetPublicId(), prj.GetPublicId())
 	spkCredWithPass := TestSshPrivateKeyCredential(t, conn, wrapper, "another last user",
@@ -126,6 +128,26 @@ func TestRepository_Retrieve(t *testing.T) {
 			},
 		},
 		{
+			name: "valid-one-p-cred",
+			args: args{
+				projectId: prj.GetPublicId(),
+				credIds:   []string{pCred1.GetPublicId()},
+			},
+			wantCreds: []credential.Static{
+				pCred1,
+			},
+		},
+		{
+			name: "valid-multiple-p-creds",
+			args: args{
+				projectId: prj.GetPublicId(),
+				credIds:   []string{pCred1.GetPublicId(), pCred2.GetPublicId()},
+			},
+			wantCreds: []credential.Static{
+				pCred1, pCred2,
+			},
+		},
+		{
 			name: "valid-ssh-pk-cred",
 			args: args{
 				projectId: prj.GetPublicId(),
@@ -169,10 +191,10 @@ func TestRepository_Retrieve(t *testing.T) {
 			name: "valid-mixed-creds",
 			args: args{
 				projectId: prj.GetPublicId(),
-				credIds:   []string{upCred1.GetPublicId(), spkCred1.GetPublicId(), spkCredWithPass.GetPublicId(), spkCred2.GetPublicId(), upCred2.GetPublicId(), jsonCred1.GetPublicId(), jsonCred2.GetPublicId(), updCred1.GetPublicId(), updCred2.GetPublicId()},
+				credIds:   []string{upCred1.GetPublicId(), spkCred1.GetPublicId(), spkCredWithPass.GetPublicId(), spkCred2.GetPublicId(), upCred2.GetPublicId(), jsonCred1.GetPublicId(), jsonCred2.GetPublicId(), updCred1.GetPublicId(), updCred2.GetPublicId(), pCred1.GetPublicId(), pCred2.GetPublicId()},
 			},
 			wantCreds: []credential.Static{
-				upCred1, spkCred1, spkCredWithPass, spkCred2, upCred2, jsonCred1, jsonCred2, updCred1, updCred2,
+				upCred1, spkCred1, spkCredWithPass, spkCred2, upCred2, jsonCred1, jsonCred2, updCred1, updCred2, pCred1, pCred2,
 			},
 		},
 	}
@@ -193,6 +215,7 @@ func TestRepository_Retrieve(t *testing.T) {
 					cmpopts.IgnoreUnexported(
 						UsernamePasswordCredential{}, store.UsernamePasswordCredential{},
 						UsernamePasswordDomainCredential{}, store.UsernamePasswordDomainCredential{},
+						PasswordCredential{}, store.PasswordCredential{},
 						SshPrivateKeyCredential{}, store.SshPrivateKeyCredential{},
 						JsonCredential{}, store.JsonCredential{}),
 					cmpopts.IgnoreTypes(&timestamp.Timestamp{}),

--- a/internal/credential/static/store/static.pb.go
+++ b/internal/credential/static/store/static.pb.go
@@ -136,6 +136,157 @@ func (x *CredentialStore) GetVersion() uint32 {
 	return 0
 }
 
+type PasswordCredential struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// public_id is a surrogate key suitable for use in a public API.
+	// @inject_tag: `gorm:"primary_key"`
+	PublicId string `protobuf:"bytes,1,opt,name=public_id,json=publicId,proto3" json:"public_id,omitempty" gorm:"primary_key"`
+	// create_time is set by the database.
+	// @inject_tag: `gorm:"default:current_timestamp"`
+	CreateTime *timestamp.Timestamp `protobuf:"bytes,2,opt,name=create_time,json=createTime,proto3" json:"create_time,omitempty" gorm:"default:current_timestamp"`
+	// update_time is set by the database.
+	// @inject_tag: `gorm:"default:current_timestamp"`
+	UpdateTime *timestamp.Timestamp `protobuf:"bytes,3,opt,name=update_time,json=updateTime,proto3" json:"update_time,omitempty" gorm:"default:current_timestamp"`
+	// name is optional. If set, it must be unique within project_id.
+	// @inject_tag: `gorm:"default:null"`
+	Name string `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty" gorm:"default:null"`
+	// description is optional.
+	// @inject_tag: `gorm:"default:null"`
+	Description string `protobuf:"bytes,5,opt,name=description,proto3" json:"description,omitempty" gorm:"default:null"`
+	// store_id of the owning static credential store.
+	// It must be set.
+	// @inject_tag: `gorm:"not_null"`
+	StoreId string `protobuf:"bytes,6,opt,name=store_id,json=storeId,proto3" json:"store_id,omitempty" gorm:"not_null"`
+	// version allows optimistic locking of the resource.
+	// @inject_tag: `gorm:"default:null"`
+	Version uint32 `protobuf:"varint,7,opt,name=version,proto3" json:"version,omitempty" gorm:"default:null"`
+	// password is the plain-text of the password associated with the credential. We are
+	// not storing this plain-text password in the database.
+	// @inject_tag: `gorm:"-" wrapping:"pt,password_data"`
+	Password []byte `protobuf:"bytes,8,opt,name=password,proto3" json:"password,omitempty" gorm:"-" wrapping:"pt,password_data"`
+	// ct_password is the ciphertext of the password. It
+	// is stored in the database.
+	// @inject_tag: `gorm:"column:password_encrypted;not_null" wrapping:"ct,password_data"`
+	CtPassword []byte `protobuf:"bytes,9,opt,name=ct_password,json=ctPassword,proto3" json:"ct_password,omitempty" gorm:"column:password_encrypted;not_null" wrapping:"ct,password_data"`
+	// password_hmac is a sha256-hmac of the unencrypted password.  It is recalculated
+	// everytime the password is updated.
+	// @inject_tag: `gorm:"not_null"`
+	PasswordHmac []byte `protobuf:"bytes,10,opt,name=password_hmac,json=passwordHmac,proto3" json:"password_hmac,omitempty" gorm:"not_null"`
+	// The key_id of the kms database key used for encrypting this entry.
+	// It must be set.
+	// @inject_tag: `gorm:"not_null"`
+	KeyId         string `protobuf:"bytes,11,opt,name=key_id,json=keyId,proto3" json:"key_id,omitempty" gorm:"not_null"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PasswordCredential) Reset() {
+	*x = PasswordCredential{}
+	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PasswordCredential) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PasswordCredential) ProtoMessage() {}
+
+func (x *PasswordCredential) ProtoReflect() protoreflect.Message {
+	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PasswordCredential.ProtoReflect.Descriptor instead.
+func (*PasswordCredential) Descriptor() ([]byte, []int) {
+	return file_controller_storage_credential_static_store_v1_static_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *PasswordCredential) GetPublicId() string {
+	if x != nil {
+		return x.PublicId
+	}
+	return ""
+}
+
+func (x *PasswordCredential) GetCreateTime() *timestamp.Timestamp {
+	if x != nil {
+		return x.CreateTime
+	}
+	return nil
+}
+
+func (x *PasswordCredential) GetUpdateTime() *timestamp.Timestamp {
+	if x != nil {
+		return x.UpdateTime
+	}
+	return nil
+}
+
+func (x *PasswordCredential) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *PasswordCredential) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *PasswordCredential) GetStoreId() string {
+	if x != nil {
+		return x.StoreId
+	}
+	return ""
+}
+
+func (x *PasswordCredential) GetVersion() uint32 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+func (x *PasswordCredential) GetPassword() []byte {
+	if x != nil {
+		return x.Password
+	}
+	return nil
+}
+
+func (x *PasswordCredential) GetCtPassword() []byte {
+	if x != nil {
+		return x.CtPassword
+	}
+	return nil
+}
+
+func (x *PasswordCredential) GetPasswordHmac() []byte {
+	if x != nil {
+		return x.PasswordHmac
+	}
+	return nil
+}
+
+func (x *PasswordCredential) GetKeyId() string {
+	if x != nil {
+		return x.KeyId
+	}
+	return ""
+}
+
 type UsernamePasswordCredential struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// public_id is a surrogate key suitable for use in a public API.
@@ -186,7 +337,7 @@ type UsernamePasswordCredential struct {
 
 func (x *UsernamePasswordCredential) Reset() {
 	*x = UsernamePasswordCredential{}
-	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[1]
+	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -198,7 +349,7 @@ func (x *UsernamePasswordCredential) String() string {
 func (*UsernamePasswordCredential) ProtoMessage() {}
 
 func (x *UsernamePasswordCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[1]
+	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -211,7 +362,7 @@ func (x *UsernamePasswordCredential) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UsernamePasswordCredential.ProtoReflect.Descriptor instead.
 func (*UsernamePasswordCredential) Descriptor() ([]byte, []int) {
-	return file_controller_storage_credential_static_store_v1_static_proto_rawDescGZIP(), []int{1}
+	return file_controller_storage_credential_static_store_v1_static_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *UsernamePasswordCredential) GetPublicId() string {
@@ -352,7 +503,7 @@ type UsernamePasswordDomainCredential struct {
 
 func (x *UsernamePasswordDomainCredential) Reset() {
 	*x = UsernamePasswordDomainCredential{}
-	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[2]
+	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -364,7 +515,7 @@ func (x *UsernamePasswordDomainCredential) String() string {
 func (*UsernamePasswordDomainCredential) ProtoMessage() {}
 
 func (x *UsernamePasswordDomainCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[2]
+	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -377,7 +528,7 @@ func (x *UsernamePasswordDomainCredential) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UsernamePasswordDomainCredential.ProtoReflect.Descriptor instead.
 func (*UsernamePasswordDomainCredential) Descriptor() ([]byte, []int) {
-	return file_controller_storage_credential_static_store_v1_static_proto_rawDescGZIP(), []int{2}
+	return file_controller_storage_credential_static_store_v1_static_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *UsernamePasswordDomainCredential) GetPublicId() string {
@@ -534,7 +685,7 @@ type SshPrivateKeyCredential struct {
 
 func (x *SshPrivateKeyCredential) Reset() {
 	*x = SshPrivateKeyCredential{}
-	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[3]
+	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -546,7 +697,7 @@ func (x *SshPrivateKeyCredential) String() string {
 func (*SshPrivateKeyCredential) ProtoMessage() {}
 
 func (x *SshPrivateKeyCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[3]
+	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -559,7 +710,7 @@ func (x *SshPrivateKeyCredential) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SshPrivateKeyCredential.ProtoReflect.Descriptor instead.
 func (*SshPrivateKeyCredential) Descriptor() ([]byte, []int) {
-	return file_controller_storage_credential_static_store_v1_static_proto_rawDescGZIP(), []int{3}
+	return file_controller_storage_credential_static_store_v1_static_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *SshPrivateKeyCredential) GetPublicId() string {
@@ -713,7 +864,7 @@ type JsonCredential struct {
 
 func (x *JsonCredential) Reset() {
 	*x = JsonCredential{}
-	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[4]
+	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -725,7 +876,7 @@ func (x *JsonCredential) String() string {
 func (*JsonCredential) ProtoMessage() {}
 
 func (x *JsonCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[4]
+	mi := &file_controller_storage_credential_static_store_v1_static_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -738,7 +889,7 @@ func (x *JsonCredential) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JsonCredential.ProtoReflect.Descriptor instead.
 func (*JsonCredential) Descriptor() ([]byte, []int) {
-	return file_controller_storage_credential_static_store_v1_static_proto_rawDescGZIP(), []int{4}
+	return file_controller_storage_credential_static_store_v1_static_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *JsonCredential) GetPublicId() string {
@@ -835,7 +986,27 @@ const file_controller_storage_credential_static_store_v1_static_proto_rawDesc = 
 	"\vDescription\x12\vdescriptionR\vdescription\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x06 \x01(\tR\tprojectId\x12\x18\n" +
-	"\aversion\x18\a \x01(\rR\aversion\"\xfd\x04\n" +
+	"\aversion\x18\a \x01(\rR\aversion\"\xb4\x04\n" +
+	"\x12PasswordCredential\x12\x1b\n" +
+	"\tpublic_id\x18\x01 \x01(\tR\bpublicId\x12K\n" +
+	"\vcreate_time\x18\x02 \x01(\v2*.controller.storage.timestamp.v1.TimestampR\n" +
+	"createTime\x12K\n" +
+	"\vupdate_time\x18\x03 \x01(\v2*.controller.storage.timestamp.v1.TimestampR\n" +
+	"updateTime\x12$\n" +
+	"\x04name\x18\x04 \x01(\tB\x10\xc2\xdd)\f\n" +
+	"\x04Name\x12\x04nameR\x04name\x12@\n" +
+	"\vdescription\x18\x05 \x01(\tB\x1e\xc2\xdd)\x1a\n" +
+	"\vDescription\x12\vdescriptionR\vdescription\x12\x19\n" +
+	"\bstore_id\x18\x06 \x01(\tR\astoreId\x12\x18\n" +
+	"\aversion\x18\a \x01(\rR\aversion\x12?\n" +
+	"\bpassword\x18\b \x01(\fB#\xc2\xdd)\x1f\n" +
+	"\bPassword\x12\x13attributes.passwordR\bpassword\x12\x1f\n" +
+	"\vct_password\x18\t \x01(\fR\n" +
+	"ctPassword\x12Q\n" +
+	"\rpassword_hmac\x18\n" +
+	" \x01(\fB,\xc2\xdd)(\n" +
+	"\fPasswordHmac\x12\x18attributes.password_hmacR\fpasswordHmac\x12\x15\n" +
+	"\x06key_id\x18\v \x01(\tR\x05keyId\"\xfd\x04\n" +
 	"\x1aUsernamePasswordCredential\x12\x1b\n" +
 	"\tpublic_id\x18\x01 \x01(\tR\bpublicId\x12K\n" +
 	"\vcreate_time\x18\x02 \x01(\v2*.controller.storage.timestamp.v1.TimestampR\n" +
@@ -944,31 +1115,34 @@ func file_controller_storage_credential_static_store_v1_static_proto_rawDescGZIP
 	return file_controller_storage_credential_static_store_v1_static_proto_rawDescData
 }
 
-var file_controller_storage_credential_static_store_v1_static_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_controller_storage_credential_static_store_v1_static_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_controller_storage_credential_static_store_v1_static_proto_goTypes = []any{
 	(*CredentialStore)(nil),                  // 0: controller.storage.credential.static.store.v1.CredentialStore
-	(*UsernamePasswordCredential)(nil),       // 1: controller.storage.credential.static.store.v1.UsernamePasswordCredential
-	(*UsernamePasswordDomainCredential)(nil), // 2: controller.storage.credential.static.store.v1.UsernamePasswordDomainCredential
-	(*SshPrivateKeyCredential)(nil),          // 3: controller.storage.credential.static.store.v1.SshPrivateKeyCredential
-	(*JsonCredential)(nil),                   // 4: controller.storage.credential.static.store.v1.JsonCredential
-	(*timestamp.Timestamp)(nil),              // 5: controller.storage.timestamp.v1.Timestamp
+	(*PasswordCredential)(nil),               // 1: controller.storage.credential.static.store.v1.PasswordCredential
+	(*UsernamePasswordCredential)(nil),       // 2: controller.storage.credential.static.store.v1.UsernamePasswordCredential
+	(*UsernamePasswordDomainCredential)(nil), // 3: controller.storage.credential.static.store.v1.UsernamePasswordDomainCredential
+	(*SshPrivateKeyCredential)(nil),          // 4: controller.storage.credential.static.store.v1.SshPrivateKeyCredential
+	(*JsonCredential)(nil),                   // 5: controller.storage.credential.static.store.v1.JsonCredential
+	(*timestamp.Timestamp)(nil),              // 6: controller.storage.timestamp.v1.Timestamp
 }
 var file_controller_storage_credential_static_store_v1_static_proto_depIdxs = []int32{
-	5,  // 0: controller.storage.credential.static.store.v1.CredentialStore.create_time:type_name -> controller.storage.timestamp.v1.Timestamp
-	5,  // 1: controller.storage.credential.static.store.v1.CredentialStore.update_time:type_name -> controller.storage.timestamp.v1.Timestamp
-	5,  // 2: controller.storage.credential.static.store.v1.UsernamePasswordCredential.create_time:type_name -> controller.storage.timestamp.v1.Timestamp
-	5,  // 3: controller.storage.credential.static.store.v1.UsernamePasswordCredential.update_time:type_name -> controller.storage.timestamp.v1.Timestamp
-	5,  // 4: controller.storage.credential.static.store.v1.UsernamePasswordDomainCredential.create_time:type_name -> controller.storage.timestamp.v1.Timestamp
-	5,  // 5: controller.storage.credential.static.store.v1.UsernamePasswordDomainCredential.update_time:type_name -> controller.storage.timestamp.v1.Timestamp
-	5,  // 6: controller.storage.credential.static.store.v1.SshPrivateKeyCredential.create_time:type_name -> controller.storage.timestamp.v1.Timestamp
-	5,  // 7: controller.storage.credential.static.store.v1.SshPrivateKeyCredential.update_time:type_name -> controller.storage.timestamp.v1.Timestamp
-	5,  // 8: controller.storage.credential.static.store.v1.JsonCredential.create_time:type_name -> controller.storage.timestamp.v1.Timestamp
-	5,  // 9: controller.storage.credential.static.store.v1.JsonCredential.update_time:type_name -> controller.storage.timestamp.v1.Timestamp
-	10, // [10:10] is the sub-list for method output_type
-	10, // [10:10] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	6,  // 0: controller.storage.credential.static.store.v1.CredentialStore.create_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	6,  // 1: controller.storage.credential.static.store.v1.CredentialStore.update_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	6,  // 2: controller.storage.credential.static.store.v1.PasswordCredential.create_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	6,  // 3: controller.storage.credential.static.store.v1.PasswordCredential.update_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	6,  // 4: controller.storage.credential.static.store.v1.UsernamePasswordCredential.create_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	6,  // 5: controller.storage.credential.static.store.v1.UsernamePasswordCredential.update_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	6,  // 6: controller.storage.credential.static.store.v1.UsernamePasswordDomainCredential.create_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	6,  // 7: controller.storage.credential.static.store.v1.UsernamePasswordDomainCredential.update_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	6,  // 8: controller.storage.credential.static.store.v1.SshPrivateKeyCredential.create_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	6,  // 9: controller.storage.credential.static.store.v1.SshPrivateKeyCredential.update_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	6,  // 10: controller.storage.credential.static.store.v1.JsonCredential.create_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	6,  // 11: controller.storage.credential.static.store.v1.JsonCredential.update_time:type_name -> controller.storage.timestamp.v1.Timestamp
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_controller_storage_credential_static_store_v1_static_proto_init() }
@@ -982,7 +1156,7 @@ func file_controller_storage_credential_static_store_v1_static_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_controller_storage_credential_static_store_v1_static_proto_rawDesc), len(file_controller_storage_credential_static_store_v1_static_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/proto/controller/storage/credential/static/store/v1/static.proto
+++ b/internal/proto/controller/storage/credential/static/store/v1/static.proto
@@ -49,6 +49,69 @@ message CredentialStore {
   uint32 version = 7;
 }
 
+message PasswordCredential {
+  // public_id is a surrogate key suitable for use in a public API.
+  // @inject_tag: `gorm:"primary_key"`
+  string public_id = 1;
+
+  // create_time is set by the database.
+  // @inject_tag: `gorm:"default:current_timestamp"`
+  timestamp.v1.Timestamp create_time = 2;
+
+  // update_time is set by the database.
+  // @inject_tag: `gorm:"default:current_timestamp"`
+  timestamp.v1.Timestamp update_time = 3;
+
+  // name is optional. If set, it must be unique within project_id.
+  // @inject_tag: `gorm:"default:null"`
+  string name = 4 [(custom_options.v1.mask_mapping) = {
+    this: "Name"
+    that: "name"
+  }];
+
+  // description is optional.
+  // @inject_tag: `gorm:"default:null"`
+  string description = 5 [(custom_options.v1.mask_mapping) = {
+    this: "Description"
+    that: "description"
+  }];
+
+  // store_id of the owning static credential store.
+  // It must be set.
+  // @inject_tag: `gorm:"not_null"`
+  string store_id = 6;
+
+  // version allows optimistic locking of the resource.
+  // @inject_tag: `gorm:"default:null"`
+  uint32 version = 7;
+
+  // password is the plain-text of the password associated with the credential. We are
+  // not storing this plain-text password in the database.
+  // @inject_tag: `gorm:"-" wrapping:"pt,password_data"`
+  bytes password = 8 [(custom_options.v1.mask_mapping) = {
+    this: "Password"
+    that: "attributes.password"
+  }];
+
+  // ct_password is the ciphertext of the password. It
+  // is stored in the database.
+  // @inject_tag: `gorm:"column:password_encrypted;not_null" wrapping:"ct,password_data"`
+  bytes ct_password = 9;
+
+  // password_hmac is a sha256-hmac of the unencrypted password.  It is recalculated
+  // everytime the password is updated.
+  // @inject_tag: `gorm:"not_null"`
+  bytes password_hmac = 10 [(custom_options.v1.mask_mapping) = {
+    this: "PasswordHmac"
+    that: "attributes.password_hmac"
+  }];
+
+  // The key_id of the kms database key used for encrypting this entry.
+  // It must be set.
+  // @inject_tag: `gorm:"not_null"`
+  string key_id = 11;
+}
+
 message UsernamePasswordCredential {
   // public_id is a surrogate key suitable for use in a public API.
   // @inject_tag: `gorm:"primary_key"`


### PR DESCRIPTION
## Description

This PR implements static password credentials CRUDL repository functionality.

* Added Create and Updated methods 
* Added RewrapQuery SQL
* Added Rewrap function
* Added NewPasswordCredentialId function
* Added password credential handling
* Added password credential support for retrevial 
* Added TestPasswordCredential helper functions

([ICU-17724](https://hashicorp.atlassian.net/browse/ICU-17724))


[ICU-17724]: https://hashicorp.atlassian.net/browse/ICU-17724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ