### PR TITLE
e2e(chore): fixed enos variable with null value

### DIFF
--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -281,5 +281,5 @@ variable "ui_build_override" {
 variable "github_token" {
   description = "github token needed to run automated tests (requires read access to hashicorp repos)"
   type        = string
-  default     = null
+  default     = ""
 }


### PR DESCRIPTION
## Description
github_token var being null would cause issues, changed the default value to empty string. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
