### PR TITLE
docs: Explain storage capacity in concept topic

### DIFF
--- a/website/content/docs/session-recording/index.mdx
+++ b/website/content/docs/session-recording/index.mdx
@@ -68,7 +68,7 @@ Determining how much storage you need to allocate on workers and the external st
 
 When you estimate worker storage requirements, consider the number of concurrent sessions that will be recorded on that worker. Boundary writes the BSR to the worker's local storage while the session is active, and then moves it to the remote storage bucket when the session is closed.
 
-You use the `recording_storage_minimum_available_capacity` setting to configure how much local disk storage space is available on the worker for the cache.
+You use the `recording_storage_minimum_available_capacity` setting to configure the minimum amount of storage space that is required for workers to perform session recording operations. If a worker is at or below the storage threshold, Boundary does not use the worker to record sessions or play back recordings.
 Boundary determines the worker's local storage state based on the capacity you configure.
 If the worker falls below the storage threshold, or if it runs out of local disk space, it may impact your ability to record sessions.
 Refer to [Local storage](/boundary/docs/session-recording/configuration/configure-worker-storage#local-storage) for more information about configuring storage capacity and the possible storage states.


### PR DESCRIPTION
## Description

From an internal Slack conversation: https://ibm-hashicorp.slack.com/archives/C09KVLZF1LM/p1761239420751909

We mention the `recording_storage_minimum_available_capacity` setting in the worker configuration topics, but it might be helpful for users if we also call out that setting as something they should think about before they configure session recording. This PR adds additional information about that setting to the Session recording concepts page in the same place where we recommend users consider how much storage space to allocate. It also adds a link to the section where we describe the storage states and how that setting impacts recording capabilities when the storage threshold is met.

[View the update in the preview deployment](https://boundary-gqjobj7qs-hashicorp.vercel.app/boundary/docs/session-recording#storage-considerations)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
