### PR TITLE
chore(e2e): Use updated opencv artifact name

### DIFF
--- a/enos/modules/aws_windows_client/scripts/setup.ps1
+++ b/enos/modules/aws_windows_client/scripts/setup.ps1
@@ -59,7 +59,7 @@ if ("${github_token}" -ne "") {
     $repo = "hashicorp/boundary-enterprise"
     $workflow = "build-opencv-ent.yml"
     $branch = "main"
-    $artifactName = "opencv"
+    $artifactName = "opencv-windows"
 
     $run = gh run list --repo $repo --workflow=$workflow --branch=$branch --status success --limit 1 --json databaseId | ConvertFrom-Json
     if (-not $run -or -not $run[0].databaseId) {


### PR DESCRIPTION
## Description
This PR updates the e2e test infrastructure to use the updated opencv windows artifact name done from this PR: https://github.com/hashicorp/boundary-enterprise/pull/1833.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

https://hashicorp.atlassian.net/browse/ICU-18083