### PR TITLE
docs: Update macOS client phrasing

### DIFF
--- a/website/content/docs/credentials/rdp-testing-and-compatibility-matrix.mdx
+++ b/website/content/docs/credentials/rdp-testing-and-compatibility-matrix.mdx
@@ -194,9 +194,9 @@ A: This is a known issue. The client currently does not support more than one co
 
 A: No. At this time, only servers using traditional Kerberos or NTLMv2 authentication are supported.
 
-**Q: The macOS Windows app is asking for a password. Is injection not working?**
+**Q: The macOS Windows App is asking for a password. Is injection not working?**
 
-A: This is a known behavior of the macOS Windows app. You can leave the password field blank and proceed; Boundary will still inject the correct credentials in the background.
+A: This is a known behavior of the macOS Windows App. You can leave the password field blank and proceed; Boundary will still inject the correct credentials in the background.
 
 ## More information
 


### PR DESCRIPTION
## Description

An internal review brought up some feedback that our description of the mac client could be vague. This PR updates the reference to the macOS client to be more specifically the macOS Windows app.

[View the update in the preview deployment](https://boundary-m2src9jnm-hashicorp.vercel.app/boundary/docs/credentials/rdp-testing-and-compatibility-matrix)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [X] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
