### PR TITLE
test(rdp): pass through server and client version to e2e output

### DIFF
--- a/enos/enos-scenario-e2e-aws-rdp-base.hcl
+++ b/enos/enos-scenario-e2e-aws-rdp-base.hcl
@@ -310,6 +310,7 @@ scenario "e2e_aws_rdp_base" {
       target_rdp_member_server_user            = step.create_rdp_member_server.admin_username
       target_rdp_member_server_password        = step.create_rdp_member_server.password
       target_rdp_domain_name                   = step.create_rdp_domain_controller.domain_name
+      target_rdp_server_version                = matrix.rdp_server
       client_ip_public                         = step.create_windows_client.public_ip
       client_username                          = step.create_windows_client.test_username
       client_password                          = step.create_windows_client.test_password
@@ -317,7 +318,6 @@ scenario "e2e_aws_rdp_base" {
       vault_addr_public                        = step.create_vault_cluster.instance_public_ips_ipv4[0]
       vault_addr_private                       = step.create_vault_cluster.instance_private_ips[0]
       vault_root_token                         = step.create_vault_cluster.vault_root_token
-      server_version                           = matrix.rdp_server
       client_version                           = matrix.client
     }
   }

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -196,7 +196,7 @@ variable "target_rdp_domain_name" {
   type        = string
   default     = ""
 }
-variable "server_version" {
+variable "target_rdp_server_version" {
   description = "Server version of rdp target"
   type        = string
   default     = ""
@@ -285,7 +285,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_TARGET_RDP_MEMBER_SERVER_USER            = var.target_rdp_member_server_user
     E2E_TARGET_RDP_MEMBER_SERVER_PASSWORD        = var.target_rdp_member_server_password
     E2E_TARGET_RDP_DOMAIN_NAME                   = var.target_rdp_domain_name
-    E2E_TARGET_RDP_SERVER_VERSION                = var.server_version
+    E2E_TARGET_RDP_SERVER_VERSION                = var.target_rdp_server_version
     E2E_CLIENT_IP_PUBLIC                         = var.client_ip_public
     E2E_CLIENT_USERNAME                          = var.client_username
     E2E_CLIENT_PASSWORD                          = var.client_password


### PR DESCRIPTION
## Description
Server and client version are needed for RDP automation tests. This change passes these values through to the enos e2e variable output. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
