### PR TITLE
refact(e2e): Rename credential methods for clarity

### DIFF
--- a/testing/internal/e2e/boundary/credential.go
+++ b/testing/internal/e2e/boundary/credential.go
@@ -202,10 +202,10 @@ func CreateStaticCredentialPrivateKeyCli(t testing.TB, ctx context.Context, cred
 	return credentialId, nil
 }
 
-// CreateStaticCredentialPasswordCli uses the cli to create a new password credential in the
+// CreateStaticCredentialUsernamePasswordCli uses the cli to create a new password credential in the
 // provided static credential store.
 // Returns the id of the new credential
-func CreateStaticCredentialPasswordCli(t testing.TB, ctx context.Context, credentialStoreId string, user string, password string) (string, error) {
+func CreateStaticCredentialUsernamePasswordCli(t testing.TB, ctx context.Context, credentialStoreId string, user string, password string) (string, error) {
 	name, err := base62.Random(16)
 	if err != nil {
 		return "", err

--- a/testing/internal/e2e/tests/base/credential_store_test.go
+++ b/testing/internal/e2e/tests/base/credential_store_test.go
@@ -77,7 +77,7 @@ func TestCliStaticCredentialStore(t *testing.T) {
 	require.NoError(t, err)
 	privateKeyCredentialsId, err := boundary.CreateStaticCredentialPrivateKeyCli(t, ctx, storeId, c.TargetSshUser, testPemFile)
 	require.NoError(t, err)
-	pwCredentialId, err := boundary.CreateStaticCredentialPasswordCli(t, ctx, storeId, c.TargetSshUser, testPassword)
+	pwCredentialId, err := boundary.CreateStaticCredentialUsernamePasswordCli(t, ctx, storeId, c.TargetSshUser, testPassword)
 	require.NoError(t, err)
 	jsonCredentialId, err := boundary.CreateStaticCredentialJsonCli(t, ctx, storeId, testCredentialsFile)
 	require.NoError(t, err)

--- a/testing/internal/e2e/tests/base/paginate_credential_test.go
+++ b/testing/internal/e2e/tests/base/paginate_credential_test.go
@@ -88,7 +88,7 @@ func TestCliPaginateCredentials(t *testing.T) {
 	assert.Empty(t, initialCredentials.ListToken)
 
 	// Create a new credential and destroy one of the other credentials
-	credentialId, err := boundary.CreateStaticCredentialPasswordCli(t, ctx, storeId, "user", "password")
+	credentialId, err := boundary.CreateStaticCredentialUsernamePasswordCli(t, ctx, storeId, "user", "password")
 	require.NoError(t, err)
 	output = e2e.RunCommand(ctx, "boundary",
 		e2e.WithArgs(

--- a/testing/internal/e2e/tests/base/target_tcp_connect_cassandra_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_cassandra_test.go
@@ -82,7 +82,7 @@ func TestCliTcpTargetConnectCassandra(t *testing.T) {
 	storeId, err := boundary.CreateCredentialStoreStaticCli(t, ctx, projectId)
 	require.NoError(t, err)
 
-	credentialId, err := boundary.CreateStaticCredentialPasswordCli(
+	credentialId, err := boundary.CreateStaticCredentialUsernamePasswordCli(
 		t,
 		ctx,
 		storeId,

--- a/testing/internal/e2e/tests/base/target_tcp_connect_mongo_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_mongo_test.go
@@ -83,7 +83,7 @@ func TestCliTcpTargetConnectMongo(t *testing.T) {
 	storeId, err := boundary.CreateCredentialStoreStaticCli(t, ctx, projectId)
 	require.NoError(t, err)
 
-	credentialId, err := boundary.CreateStaticCredentialPasswordCli(
+	credentialId, err := boundary.CreateStaticCredentialUsernamePasswordCli(
 		t,
 		ctx,
 		storeId,

--- a/testing/internal/e2e/tests/base/target_tcp_connect_mysql_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_mysql_test.go
@@ -82,7 +82,7 @@ func TestCliTcpTargetConnectMysql(t *testing.T) {
 	storeId, err := boundary.CreateCredentialStoreStaticCli(t, ctx, projectId)
 	require.NoError(t, err)
 
-	credentialId, err := boundary.CreateStaticCredentialPasswordCli(
+	credentialId, err := boundary.CreateStaticCredentialUsernamePasswordCli(
 		t,
 		ctx,
 		storeId,

--- a/testing/internal/e2e/tests/base/target_tcp_connect_redis_test.go
+++ b/testing/internal/e2e/tests/base/target_tcp_connect_redis_test.go
@@ -84,7 +84,7 @@ func TestCliTcpTargetConnectRedis(t *testing.T) {
 	storeId, err := boundary.CreateCredentialStoreStaticCli(t, ctx, projectId)
 	require.NoError(t, err)
 
-	credentialId, err := boundary.CreateStaticCredentialPasswordCli(
+	credentialId, err := boundary.CreateStaticCredentialUsernamePasswordCli(
 		t,
 		ctx,
 		storeId,

--- a/testing/internal/e2e/tests/base_plus/target_tcp_connect_postgres_test.go
+++ b/testing/internal/e2e/tests/base_plus/target_tcp_connect_postgres_test.go
@@ -47,7 +47,7 @@ func TestCliTcpTargetConnectPostgres(t *testing.T) {
 	require.NoError(t, err)
 	storeId, err := boundary.CreateCredentialStoreStaticCli(t, ctx, projectId)
 	require.NoError(t, err)
-	credentialId, err := boundary.CreateStaticCredentialPasswordCli(
+	credentialId, err := boundary.CreateStaticCredentialUsernamePasswordCli(
 		t,
 		ctx,
 		storeId,

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -268,7 +268,7 @@ func populateBoundaryDatabase(t testing.TB, ctx context.Context, c *config, te T
 	// Create static credentials
 	storeId, err := boundary.CreateCredentialStoreStaticCli(t, ctx, projectId)
 	require.NoError(t, err)
-	_, err = boundary.CreateStaticCredentialPasswordCli(t, ctx, storeId, c.TargetSshUser, "password")
+	_, err = boundary.CreateStaticCredentialUsernamePasswordCli(t, ctx, storeId, c.TargetSshUser, "password")
 	require.NoError(t, err)
 	_, err = boundary.CreateStaticCredentialJsonCli(t, ctx, storeId, "testdata/credential.json")
 	require.NoError(t, err)


### PR DESCRIPTION
## Description
This PR renames some e2e test methods for clarity. There will be a new "Password" credential type, so the existing methods should specify that it includes a username.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
