### PR TITLE
chore(rdp): add client ssh key to enos variable output

### DIFF
--- a/enos/enos-scenario-e2e-aws-rdp-base.hcl
+++ b/enos/enos-scenario-e2e-aws-rdp-base.hcl
@@ -320,6 +320,7 @@ scenario "e2e_aws_rdp_base" {
       client_username                          = step.create_windows_client.test_username
       client_password                          = step.create_windows_client.test_password
       client_test_dir                          = step.create_windows_client.test_dir
+      client_ssh_key                           = step.create_windows_client.ssh_private_key
       vault_addr_public                        = step.create_vault_cluster.instance_public_ips_ipv4[0]
       vault_addr_private                       = step.create_vault_cluster.instance_private_ips[0]
       vault_root_token                         = step.create_vault_cluster.vault_root_token

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -226,7 +226,11 @@ variable "client_test_dir" {
   type        = string
   default     = ""
 }
-
+variable "client_ssh_key" {
+  description = "Path to the ssh key for the windows client"
+  type        = string
+  default     = ""
+}
 variable "ip_version" {
   description = "ip version used to setup boundary instance, should be 4, 6, or dual"
   type        = string
@@ -291,6 +295,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_CLIENT_PASSWORD                          = var.client_password
     E2E_CLIENT_TEST_DIR                          = var.client_test_dir
     E2E_CLIENT_VERSION                           = var.client_version
+    E2E_CLIENT_SSH_KEY                           = var.client_ssh_key
   }
 
   inline = var.debug_no_run ? [""] : [


### PR DESCRIPTION
## Description
The client ssh key is required for the github action that runs the rdp e2e tests.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
