### PR TITLE
chore(e2e): Update URL to avoid 502 Bad Gateway

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -182,9 +182,9 @@ jobs:
         # NOTE: if you update the password store version make sure to update the dep cache key
         run: |
           mkdir -p /tmp/test-deps/pass
-          wget https://git.zx2c4.com/password-store/snapshot/password-store-1.7.4.tar.xz -O /tmp/test-deps/pass/pass.tar.xz
+          wget https://github.com/zx2c4/password-store/archive/refs/tags/1.7.4.tar.gz -O /tmp/test-deps/pass/pass.tar.gz
           cd /tmp/test-deps/pass
-          tar -xvf pass.tar.xz
+          tar -xvf pass.tar.gz
       - name: Install pass for Boundary keyring
         run: |
           cd /tmp/test-deps/pass/password-store-1.7.4

--- a/.github/workflows/test-cli-ui_oss.yml
+++ b/.github/workflows/test-cli-ui_oss.yml
@@ -57,9 +57,9 @@ jobs:
         # NOTE: if you update the password store version make sure to update the dep cache key
         run: |
           mkdir -p /tmp/bats-cli-ui-deps/pass
-          wget https://git.zx2c4.com/password-store/snapshot/password-store-1.7.4.tar.xz -O /tmp/bats-cli-ui-deps/pass/pass.tar.xz
+          wget https://github.com/zx2c4/password-store/archive/refs/tags/1.7.4.tar.gz -O /tmp/bats-cli-ui-deps/pass/pass.tar.gz
           cd /tmp/bats-cli-ui-deps/pass
-          tar -xvf pass.tar.xz
+          tar -xvf pass.tar.gz
       - name: Install pass for Boundary keyring
         run: |
           cd /tmp/bats-cli-ui-deps/pass/password-store-1.7.4


### PR DESCRIPTION
## Description
This PR addresses an issue when workflows are trying to download `password-store`. Workflows (e2e tests, bats tests) can sometimes hit a `502 Bad Gateway` when it tries to access this URL
```
--2025-11-06 16:35:25--  https://git.zx2c4.com/password-store/snapshot/password-store-1.7.4.tar.xz
Resolving git.zx2c4.com (git.zx2c4.com)... 86.109.7.149, 2604:1380:45f1:e200::3
Connecting to git.zx2c4.com (git.zx2c4.com)|86.109.7.149|:443... connected.
HTTP request sent, awaiting response... 502 Bad Gateway
2025-11-06 16:35:25 ERROR 502: Bad Gateway.
```

This PR changes to use a github mirror, which is hopefully more reliable. There will be a follow-up to modify boundary-enterprise.

Test: https://github.com/hashicorp/boundary/actions/runs/19143232258/job/54718898023?pr=6225

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
