### PR TITLE
fix(credential/vault): add case for upd creds in injected creds switch

### DIFF
--- a/internal/daemon/controller/handlers/targets/credentials.go
+++ b/internal/daemon/controller/handlers/targets/credentials.go
@@ -27,6 +27,16 @@ func dynamicToWorkerCredential(ctx context.Context, cred credential.Dynamic) (se
 	const op = "targets.dynamicToWorkerCredential"
 	var workerCred *serverpb.Credential
 	switch c := cred.(type) {
+	case credential.UsernamePasswordDomain:
+		workerCred = &serverpb.Credential{
+			Credential: &serverpb.Credential_UsernamePasswordDomain{
+				UsernamePasswordDomain: &serverpb.UsernamePasswordDomain{
+					Username: c.Username(),
+					Password: string(c.Password()),
+					Domain:   c.Domain(),
+				},
+			},
+		}
 	case credential.UsernamePassword:
 		workerCred = &serverpb.Credential{
 			Credential: &serverpb.Credential_UsernamePassword{


### PR DESCRIPTION
## Description
fixes an error in injected application credentials where vault creds weren't checked as upd creds

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
