### PR TITLE
chore(e2e): update vault create credential funcs

### DIFF
--- a/testing/internal/e2e/vault/vault.go
+++ b/testing/internal/e2e/vault/vault.go
@@ -295,7 +295,6 @@ func CreateKvPasswordCredential(t testing.TB, secretPath string, user string, pr
 	}
 
 	// Create secret
-	require.NoError(t, err)
 	output := e2e.RunCommand(context.Background(), "vault",
 		e2e.WithArgs(
 			"kv", "put",
@@ -340,7 +339,6 @@ func CreateKvPasswordDomainCredential(t testing.TB, secretPath string, user stri
 	}
 
 	// Create secret
-	require.NoError(t, err)
 	output := e2e.RunCommand(context.Background(), "vault",
 		e2e.WithArgs(
 			"kv", "put",


### PR DESCRIPTION
## Description
This PR is to update the e2e test helper functions `CreateKvPasswordCredential` and `CreateKvPasswordDomainCredential` to allow a password parameter to be passed in.

If a password is provided, it will be used to create the credential in vault (new behavior)
If not password is not provided, it will generate a random password to be used (old behavior)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
