### PR TITLE
chore(e2e): Add helper func ConnectCliStdoutPipe

### DIFF
--- a/testing/internal/e2e/boundary/connect.go
+++ b/testing/internal/e2e/boundary/connect.go
@@ -43,3 +43,46 @@ func ConnectCli(t testing.TB, ctx context.Context, targetId string) ConnectCliOu
 
 	return connectCliOutput
 }
+
+// ConnectCliStdoutPipe uses the boundary CLI to establish connection to the target.
+// It captures stdout via a pipe, parses proxy details from the command output, and returns them.
+// The connection must be closed separately via the `boundary sessions cancel` command
+// This implementation works on cross platforms (Windows, Unix, Linux, macOS) - unlike the pty-based version above (Unix, Linux, macOS).
+// StdoutPipe only captures stdout, as opposed to pty which is an interactive pseudo-terminal
+func ConnectCliStdoutPipe(t testing.TB, ctx context.Context, targetId string) ConnectCliOutput {
+	cmd := exec.CommandContext(ctx,
+		"boundary", "connect",
+		"-target-id", targetId,
+		"-format", "json",
+	)
+
+	// Capture stdout
+	stdoutPipe, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+
+	// Start the command
+	err = cmd.Start()
+	require.NoError(t, err)
+
+	// Register cleanup to kill the process
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+
+	// Read the first line of output (JSON with connection info)
+	scanner := bufio.NewScanner(stdoutPipe)
+	var outputLine string
+	if scanner.Scan() {
+		outputLine = scanner.Text()
+	}
+	require.NoError(t, scanner.Err())
+
+	// Parse the JSON output
+	var connectOutput ConnectCliOutput
+	err = json.Unmarshal([]byte(outputLine), &connectOutput)
+	require.NoError(t, err)
+
+	return connectOutput
+}


### PR DESCRIPTION
## Description
This PR adds a helper function `ConnectCliStdoutPipe`.

This function is similar to `ConnectCli` except it uses StdoutPipe instead of pty. The current use case for this function is for the e2e rdp tests which are executed on a Windows client. pty only works on unix-based platforms (not Windows).

Note, StdoutPipe do behave differently to pty, which is documented in the file.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
