### PR TITLE
feat(query): Create queries for recursive requests of global app token grants

### DIFF
--- a/internal/apptoken/query.go
+++ b/internal/apptoken/query.go
@@ -74,4 +74,43 @@ left join iam_scope_org
           app_token_permission_global.grant_scope,
           app_token_global.public_id;
     `
+
+	// grantsForGlobalTokenProjectResourcesRecursiveQuery gets a global app token's grants for resources
+	// applicable to the project scope.
+	grantsForGlobalTokenProjectResourcesRecursiveQuery = `
+   select app_token_permission_global.private_id                         as permission_id,
+          app_token_permission_global.description,
+          app_token_permission_global.create_time,
+          app_token_permission_global.grant_this_scope,
+          app_token_permission_global.grant_scope,
+          app_token_global.public_id                                     as app_token_id,
+          array_agg(distinct app_token_permission_grant.canonical_grant) as canonical_grants,
+          array_agg(distinct iam_scope_project.scope_id)                 as active_grant_scopes
+     from app_token_global
+     join app_token_permission_global
+       on app_token_global.public_id = app_token_permission_global.app_token_id
+      and app_token_global.public_id = any(@app_token_ids)
+     join app_token_permission_grant
+       on app_token_permission_global.private_id = app_token_permission_grant.permission_id
+     join iam_grant
+       on app_token_permission_grant.canonical_grant = iam_grant.canonical_grant
+      and iam_grant.resource = any(@resources)
+left join app_token_permission_global_individual_project_grant_scope proj_grants
+       on app_token_permission_global.private_id = proj_grants.permission_id
+left join iam_scope_project
+       on proj_grants.scope_id = iam_scope_project.scope_id
+left join app_token_permission_global_individual_org_grant_scope org_grants
+       on app_token_permission_global.private_id = org_grants.permission_id
+    where org_grants.permission_id is null
+       or (
+          app_token_permission_global.grant_scope = 'children' and
+          proj_grants.scope_id is not null
+       )
+ group by app_token_permission_global.private_id,
+          app_token_permission_global.description,
+          app_token_permission_global.create_time,
+          app_token_permission_global.grant_this_scope,
+          app_token_permission_global.grant_scope,
+          app_token_global.public_id;
+    `
 )


### PR DESCRIPTION
- ICU-17909
- ICU-17910
- ICU-17916

## Description

Retrieves grants for App Tokens that live in the Global scope. Queries will be selected based on the scope(s) the requested Resources can live at:
- Resources that can live in any scope (e.g. Groups)
- Resources that can only live in either Global or an Org scope (e.g. Policies, Storage Buckets)
- Resources that can only live in a Project scope (e.g. Hosts, Targets)

Since these queries correspond to recursive requests, there is no `request_scope` to query on.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
