### PR TITLE
fix(e2e): Fix ipv6 address argument

### DIFF
--- a/enos/enos-scenario-e2e-aws-rdp-base.hcl
+++ b/enos/enos-scenario-e2e-aws-rdp-base.hcl
@@ -309,7 +309,7 @@ scenario "e2e_aws_rdp_base" {
       max_page_size                            = step.create_boundary_cluster.max_page_size
       worker_tag_collocated                    = local.collocated_tag
       target_rdp_domain_controller_addr        = step.create_rdp_domain_controller.private_ip
-      target_rdp_domain_controller_addr_ipv6   = step.create_rdp_domain_controller.ipv6[0]
+      target_rdp_domain_controller_addr_ipv6   = local.ip_version == "4" ? "" : step.create_rdp_domain_controller.ipv6[0]
       target_rdp_domain_controller_user        = step.create_rdp_domain_controller.admin_username
       target_rdp_domain_controller_password    = step.create_rdp_domain_controller.password
       target_rdp_member_server_addr            = step.create_rdp_member_server.private_ip


### PR DESCRIPTION
## Description
This PR makes a fix to the RDP scenario to properly pass in an argument only if `ip_version != "4"`.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
