### PR TITLE
test(rdp): added public controller ip as an output for github runner rdp tests

### DIFF
--- a/enos/enos-scenario-e2e-aws-rdp-base.hcl
+++ b/enos/enos-scenario-e2e-aws-rdp-base.hcl
@@ -318,6 +318,7 @@ scenario "e2e_aws_rdp_base" {
       target_rdp_member_server_password        = step.create_rdp_member_server.password
       target_rdp_domain_name                   = step.create_rdp_domain_controller.domain_name
       target_rdp_server_version                = matrix.rdp_server
+      controller_ip_public                     = step.create_boundary_cluster.controller_ips[0]
       client_ip_public                         = step.create_windows_client.public_ip
       client_username                          = step.create_windows_client.test_username
       client_password                          = step.create_windows_client.test_password

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -236,6 +236,11 @@ variable "client_ssh_key" {
   type        = string
   default     = ""
 }
+variable "controller_ip_public" {
+  description = "public ip of the controller"
+  type        = string
+  default     = ""
+}
 variable "ip_version" {
   description = "ip version used to setup boundary instance, should be 4, 6, or dual"
   type        = string
@@ -296,6 +301,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_TARGET_RDP_MEMBER_SERVER_PASSWORD        = var.target_rdp_member_server_password
     E2E_TARGET_RDP_DOMAIN_NAME                   = var.target_rdp_domain_name
     E2E_TARGET_RDP_SERVER_VERSION                = var.target_rdp_server_version
+    E2E_CONTROLLER_IP_PUBLIC                     = var.controller_ip_public
     E2E_CLIENT_IP_PUBLIC                         = var.client_ip_public
     E2E_CLIENT_USERNAME                          = var.client_username
     E2E_CLIENT_PASSWORD                          = var.client_password


### PR DESCRIPTION
## Description
Github runner for RDP uses the controller public IP to connect to boundary so we need to expose that through enos

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
