### PR TITLE
chore(e2e): fix flakiness with ConnectCliStdoutPipe

### DIFF
--- a/testing/internal/e2e/boundary/connect.go
+++ b/testing/internal/e2e/boundary/connect.go
@@ -71,12 +71,23 @@ func ConnectCliStdoutPipe(t testing.TB, ctx context.Context, targetId string) Co
 		}
 	})
 
+	// TODO: this doesnt work, need to revist
 	// Read lines until we find valid JSON
 	scanner := bufio.NewScanner(stdoutPipe)
 	var connectOutput ConnectCliOutput
 	linesRead := 0
 	maxLines := 50
 
+	// Potential issue: trying to scan before session is fully established, and output is written
+	// May need a time buffer, instead of loop
+	// 1st scanner.Scan() returns true for first line, when session is created
+	// 2nd scanner.Scan() - hangs here, cause its waiting for more output, but session is just opended, and not writing any data
+
+	// Example log output:
+	// connect.go:83: scan result: true
+	// connect.go:85: line 1
+	// connect.go:86: outputLine: {"address":"...","port":...,"protocol":"rdp","expiration":"...","connection_limit":-1,"session_id":"..."}
+	// hangs on 2nd scan, because no more output is written
 	for scanner.Scan() && linesRead < maxLines {
 		linesRead++
 		outputLine := scanner.Text()


### PR DESCRIPTION
## Description
This PR is to address some flakiness with tests that utilizes this function. There's a possibility that it is trying to read the session proxy output before it is fully setup. 

The solution is to continuously loop and read the StdoutPipe until we get the expected output (at a max of 50 tries).

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
