### PR TITLE
backport: feat(clientproxy): Automatically Close `boundary connect` When Proxy is no Longer in Use

### DIFF
--- a/api/proxy/option.go
+++ b/api/proxy/option.go
@@ -39,6 +39,7 @@ type Options struct {
 	WithSkipSessionTeardown      bool
 	withSessionTeardownTimeout   time.Duration
 	withApiClient                *api.Client
+	withInactivityTimeout        time.Duration
 }
 
 // Option is a function that takes in an options struct and sets values or
@@ -139,6 +140,15 @@ func WithSessionTeardownTimeout(with time.Duration) Option {
 func WithApiClient(with *api.Client) Option {
 	return func(o *Options) error {
 		o.withApiClient = with
+		return nil
+	}
+}
+
+// WithInactivityTimeout provides an optional duration after which a session
+// with no active connections will be cancelled
+func WithInactivityTimeout(with time.Duration) Option {
+	return func(o *Options) error {
+		o.withInactivityTimeout = with
 		return nil
 	}
 }

--- a/internal/cmd/commands/connect/end_process_nonwindows.go
+++ b/internal/cmd/commands/connect/end_process_nonwindows.go
@@ -1,0 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !windows
+
+package connect
+
+import (
+	"os"
+	"syscall"
+)
+
+// endProcess gracefully ends the provided os process
+func endProcess(p *os.Process) error {
+	if p == nil {
+		return nil
+	}
+	return p.Signal(syscall.SIGTERM)
+}

--- a/internal/cmd/commands/connect/end_process_windows.go
+++ b/internal/cmd/commands/connect/end_process_windows.go
@@ -1,0 +1,18 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+
+package connect
+
+import (
+	"os"
+)
+
+// endProcess kills the provided os process
+func endProcess(p *os.Process) error {
+	if p == nil {
+		return nil
+	}
+	return p.Kill()
+}

--- a/internal/cmd/commands/connect/rdp.go
+++ b/internal/cmd/commands/connect/rdp.go
@@ -59,7 +59,7 @@ func (r *rdpFlags) buildArgs(c *Command, port, ip, addr string) []string {
 	case "mstsc.exe":
 		args = append(args, "/v", addr)
 	case "open":
-		args = append(args, "-n", "-W", fmt.Sprintf("rdp://full%saddress=s%s%s", "%20", "%3A", url.QueryEscape(addr)))
+		args = append(args, "-W", fmt.Sprintf("rdp://full%saddress=s%s%s", "%20", "%3A", url.QueryEscape(addr)))
 	}
 	return args
 }

--- a/internal/tests/api/proxy/proxy_test.go
+++ b/internal/tests/api/proxy/proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/boundary/internal/tests/helper"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	_ "github.com/hashicorp/boundary/internal/daemon/controller/handlers/targets/tcp"
 )
@@ -138,5 +139,101 @@ func TestConnectionsLeft(t *testing.T) {
 
 	pxyCancel()
 	// Wait to ensure cleanup and that the second-start logic works
+	wg.Wait()
+}
+
+func TestConnectionTimeout(t *testing.T) {
+	require := require.New(t)
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:  t.Name(),
+		Level: hclog.Trace,
+	})
+
+	// Create controller and worker
+	conf, err := config.DevController()
+	require.NoError(err)
+	c1 := controller.NewTestController(t, &controller.TestControllerOpts{
+		Config:                 conf,
+		InitialResourcesSuffix: "1234567890",
+		Logger:                 logger.Named("c1"),
+		WorkerRPCGracePeriod:   helper.DefaultControllerRPCGracePeriod,
+	})
+	helper.ExpectWorkers(t, c1)
+
+	w1 := worker.NewTestWorker(t, &worker.TestWorkerOpts{
+		WorkerAuthKms:    c1.Config().WorkerAuthKms,
+		InitialUpstreams: c1.ClusterAddrs(),
+		Logger:           logger.Named("w1"),
+		SuccessfulControllerRPCGracePeriodDuration: helper.DefaultControllerRPCGracePeriod,
+		Name: "w1",
+	})
+	helper.ExpectWorkers(t, c1, w1)
+
+	// Connect target
+	client := c1.Client()
+	client.SetToken(c1.Token().Token)
+	tcl := targets.NewClient(client)
+	tgt, err := tcl.Read(c1.Context(), "ttcp_1234567890")
+	require.NoError(err)
+	require.NotNil(tgt)
+
+	// Create test server, update default port on target
+	ts := helper.NewTestTcpServer(t)
+	require.NotNil(t, ts)
+	defer ts.Close()
+	var sessionConnsLimit int32 = 2
+
+	tgt = updateTargetForProxy(t, c1.Context(), tcl, tgt, ts.Port(), sessionConnsLimit, w1.Name())
+
+	// Authorize session to get authorization data
+	sess, err := tcl.AuthorizeSession(c1.Context(), tgt.Item.Id)
+	require.NoError(err)
+	sessAuthz, err := sess.GetSessionAuthorization()
+	require.NoError(err)
+
+	// Create a context we can cancel to stop the proxy, a channel for conns
+	// left, and a waitgroup to ensure cleanup
+	pxyCtx, pxyCancel := context.WithCancel(c1.Context())
+	defer pxyCancel()
+	wg := new(sync.WaitGroup)
+
+	pxy, err := proxy.New(pxyCtx, sessAuthz.AuthorizationToken)
+	require.NoError(err)
+	wg.Add(1)
+	done := atomic.NewBool(false)
+	go func() {
+		defer wg.Done()
+		require.NoError(pxy.Start(proxy.WithInactivityTimeout(time.Second)))
+		done.Store(true)
+	}()
+
+	addr := pxy.ListenerAddress(context.Background())
+	require.NotEmpty(addr)
+	addrPort, err := netip.ParseAddrPort(addr)
+	require.NoError(err)
+
+	echo := []byte("echo")
+	readBuf := make([]byte, len(echo))
+
+	conn, err := net.DialTCP("tcp", nil, net.TCPAddrFromAddrPort(addrPort))
+	require.NoError(err)
+	written, err := conn.Write(echo)
+	require.NoError(err)
+	require.Equal(written, len(echo))
+	read, err := conn.Read(readBuf)
+	require.NoError(err)
+	require.Equal(read, len(echo))
+	require.NoError(conn.Close())
+
+	start := time.Now()
+	for {
+		if done.Load() || time.Since(start) > time.Second*2 {
+			require.True(done.Load(), "proxy did not close itself within the expected time frame (2 seconds)")
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.Equal("Inactivity timeout reached", pxy.CloseReason())
+	pxyCancel()
 	wg.Wait()
 }


### PR DESCRIPTION
## Description
This PR backports a fix for `boundary connect` from https://github.com/hashicorp/boundary/pull/6232 into release/0.20.

> This PR solves an issue where `boundary connect <subcommand>` remains open, even after a client has finished using the proxy tunnel.
> 
> Additionally introduces the `-inactive-timeout=<duration>` command option to `boundary connect` and all subcommands, allowing a user to optionally extend the timeout when necessary

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
