### PR TITLE
chore(e2e): Set disk space for minio container

### DIFF
--- a/enos/modules/docker_minio/main.tf
+++ b/enos/modules/docker_minio/main.tf
@@ -101,6 +101,9 @@ resource "docker_container" "minio_server" {
     "MINIO_ROOT_PASSWORD=minioadmin",
     "MINIO_REGION=${var.region}",
   ]
+  tmpfs = {
+    "/data" = "size=2G"
+  }
   ports {
     internal = 9000
     external = 9000


### PR DESCRIPTION
## Description
In an Admin UI e2e test, we observed the following error
```
Error information:
      Kind:                Internal
      Message:             targets.(Service).AuthorizeSession:
      recording.(Repository).StartSessionRecording:
      recording.(client).StartSessionRecording:
      routing.(CommandClientProducer).IssueCommand: unknown, unknown: error #0: rpc
      error: code = FailedPrecondition desc = from worker w_XlCX8bOWs2: Error
      issuing command: Error encountered when creating session recorder:
      bsr.persistBsrSessionKeys: failed syncing bsr key pubKeyBsrSignature.sign:
      bsr.(container).syncBsrKey: checksum.(File).Close:
      checksum.(Sha256SumWriter).Close: journal.(File).Close:
      storage.(syncingFile).close: storage.(syncingFile).sync: plugin error,
      external system issue: error #3001: rpc error: code = Internal desc = failed
      to put object into minio: Storage backend has reached its minimum free drive
      threshold. Please delete a few objects to proceed.
      bsr.NewSession: could not persist BSR keys
      Status:              500
      context:             Error from controller when performing authorize-session
      action against given target
```

Not sure how it got into that state, but one potential mitigation step is to define storage in the container to be a set size. Reading some github issues, it seems like minio has a free drive threshold of 900MiB (requires that much disk space to be free). 

## Testing
Ran backend e2e tests against this change: https://github.com/hashicorp/boundary-enterprise/actions/runs/19469621190

Ran Admin UI e2e tests against this change: https://github.com/hashicorp/boundary-ui/actions/runs/19469727886

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
