### PR TITLE
feat(query): Create queries for recursive requests of org app token grants

### DIFF
--- a/internal/apptoken/query.go
+++ b/internal/apptoken/query.go
@@ -177,4 +177,38 @@ left join iam_scope_project
           app_token_permission_org.grant_scope,
           app_token_org.public_id;
     `
+
+	// grantsForOrgTokenProjectResourcesRecursiveQuery gets an org app token's grants for resources
+	// applicable to a project scope.
+	grantsForOrgTokenProjectResourcesRecursiveQuery = `
+   select app_token_permission_org.private_id                            as permission_id,
+          app_token_permission_org.description,
+          app_token_permission_org.create_time,
+          app_token_permission_org.grant_this_scope,
+          app_token_permission_org.grant_scope,
+          app_token_org.public_id                                        as app_token_id,
+          array_agg(distinct app_token_permission_grant.canonical_grant) as canonical_grants,
+          array_agg(distinct iam_scope_project.scope_id)                 as active_grant_scopes
+     from app_token_org
+     join app_token_permission_org
+       on app_token_org.public_id = app_token_permission_org.app_token_id
+      and app_token_org.public_id = any(@app_token_ids)
+     join app_token_permission_grant
+       on app_token_permission_org.private_id = app_token_permission_grant.permission_id
+     join iam_grant
+       on app_token_permission_grant.canonical_grant = iam_grant.canonical_grant
+      and iam_grant.resource = any(@resources)
+left join app_token_permission_org_individual_grant_scope individual_project_grants
+       on app_token_permission_org.private_id = individual_project_grants.permission_id
+left join iam_scope_project
+       on individual_project_grants.scope_id = iam_scope_project.scope_id
+    where app_token_permission_org.grant_scope = 'children'
+       or individual_project_grants.scope_id is not null
+ group by app_token_permission_org.private_id,
+          app_token_permission_org.description,
+          app_token_permission_org.create_time,
+          app_token_permission_org.grant_this_scope,
+          app_token_permission_org.grant_scope,
+          app_token_org.public_id;
+    `
 )


### PR DESCRIPTION
- ICU-17917
- ICU-17918
- ICU-17919

## Description

Retrieves grants for App Tokens that live in an Org scope. Queries will be selected based on the scope(s) the requested Resources can live at:

- Resources that can live in any scope (e.g. Groups)
- Resources that can only live in either Global or an Org scope (e.g. Policies, Storage Buckets)
- Resources that can only live in a Project scope (e.g. Hosts, Targets)
Since these queries correspond to recursive requests, there is no request_scope to query on.


## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
