### PR TITLE
fix(db): Delete legacy credential_vault_library_deleted purge job

### DIFF
--- a/internal/db/schema/migrations/oss/postgres/102/01_credential_vault_library_deleted_purge_job.sql
+++ b/internal/db/schema/migrations/oss/postgres/102/01_credential_vault_library_deleted_purge_job.sql
@@ -1,0 +1,12 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+begin;
+  -- The credential_vault_library_deleted table was renamed to
+  -- credential_vault_generic_library_deleted in
+  -- 99/01_credential_vault_library_refactor.up.sql, but the corresponding
+  -- legacy purge job was not deleted. This migration deletes that legacy job.
+  -- The new job that takes over the legacy one is
+  -- credential_vault_generic_library_deleted_items_table_purge.
+  delete from job where name = 'credential_vault_library_deleted_items_table_purge';
+commit;


### PR DESCRIPTION
## Description
With the refactor in version 99, the credential_vault_library_deleted table was renamed to credential_vault_generic_library_deleted, but its corresponding purge job was not removed from the job table, leading to an error: "job credential_vault_library_deleted_items_table_purge not registered on scheduler".

This commit deletes the legacy job entry. The new job that takes over the legacy one is
credential_vault_generic_library_deleted_items_table_purge.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
