### PR TITLE
update changelog for 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,16 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
   connection being actively proxied. This behavior can be modified via the
   `-inactive-timeout=<duration>` command-line argument ([PR](https://github.com/hashicorp/boundary/pull/6232))
 * cli: `boundary connect redis` can now consume password credentials ([PR](https://github.com/hashicorp/boundary/pull/6213))
-* AWS KMS credential handling now allows the use of shared credential files. Additionally, the `default` profile is now included in the credential chain by default if it exists. ([PR](https://github.com/hashicorp/boundary/pull/6286))
+* AWS KMS credential handling now allows the use of shared credential files.
+  Additionally, the `default` profile is now included in the credential chain
+  by default if it exists. ([PR](https://github.com/hashicorp/boundary/pull/6286))
 
 ### Bug fixes
 
 * ui: Show username for OIDC auth method in user menu ([PR](https://github.com/hashicorp/boundary-ui/pull/2930))
-* `boundary connect rdp` no longer opens a new window for each call on mac.
+* `boundary connect rdp` no longer opens a new window for each call on mac. ([PR](https://github.com/hashicorp/boundary/pull/6232))
 * Removed the error log during RDP basic settings exchange: When you connect to
-  an RDP target using the built-in Windows Remote Desktop Connection app.
+  an RDP target using the built-in Windows Remote Desktop Connection app. ([PR](https://github.com/hashicorp/boundary/pull/6136))
 
 ## 0.20.0 (2025/09/25)
 


### PR DESCRIPTION
## Description

### New and Improved

* Vault LDAP has been added as a credential provider ([PR](https://github.com/hashicorp/boundary/pull/6222))
* Added support for host key verification when connecting to an SSH target by providing a `known_hosts` file. ([PR](https://github.com/hashicorp/boundary/pull/6263))
* Added new credential type for password. ([PR](https://github.com/hashicorp/boundary/pull/6207))
* ui: Optimized loading of table filters and improved table search support ([PR](https://github.com/hashicorp/boundary-ui/pull/3053))
* cli: `boundary connect` will close unused sessions when there is no longer a connection being actively proxied. This behavior can be modified via the `-inactive-timeout=<duration>` command-line argument ([PR](https://github.com/hashicorp/boundary/pull/6232))
* cli: `boundary connect redis` can now consume password credentials ([PR](https://github.com/hashicorp/boundary/pull/6213))
* AWS KMS credential handling now allows the use of shared credential files. Additionally, the `default` profile is now included in the credential chain by default if it exists. ([PR](https://github.com/hashicorp/boundary/pull/6286))

### Bug fixes

* ui: Show username for OIDC auth method in user menu ([PR](https://github.com/hashicorp/boundary-ui/pull/2930))
* `boundary connect rdp` no longer opens a new window for each call on mac. ([PR](https://github.com/hashicorp/boundary/pull/6232))
* Removed the error log during RDP basic settings exchange: When you connect to an RDP target using the built-in Windows Remote Desktop Connection app. ([PR](https://github.com/hashicorp/boundary/pull/6136))

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
