### PR TITLE
App Token recursive query improvements

### DIFF
--- a/internal/apptoken/query.go
+++ b/internal/apptoken/query.go
@@ -16,6 +16,7 @@ const (
           app_token_permission_global.grant_this_scope,
           app_token_permission_global.grant_scope,
           app_token_global.public_id                                                                   as app_token_id,
+          ''                                                                                           as app_token_parent_scope_id,
           array_agg(distinct app_token_permission_grant.canonical_grant)                               as canonical_grants,
           array_agg(distinct coalesce(iam_scope_org.scope_id, iam_scope_project.scope_id))
             filter (where    coalesce(iam_scope_org.scope_id, iam_scope_project.scope_id) is not null) as active_grant_scopes
@@ -53,6 +54,7 @@ left join iam_scope_project
           app_token_permission_global.grant_this_scope,
           app_token_permission_global.grant_scope,
           app_token_global.public_id                                     as app_token_id,
+          ''                                                             as app_token_parent_scope_id,
           array_agg(distinct app_token_permission_grant.canonical_grant) as canonical_grants,
           array_agg(distinct iam_scope_org.scope_id)                     as active_grant_scopes
      from app_token_global
@@ -85,6 +87,7 @@ left join iam_scope_org
           app_token_permission_global.grant_this_scope,
           app_token_permission_global.grant_scope,
           app_token_global.public_id                                     as app_token_id,
+          ''                                                             as app_token_parent_scope_id,
           array_agg(distinct app_token_permission_grant.canonical_grant) as canonical_grants,
           array_agg(distinct iam_scope_project.scope_id)                 as active_grant_scopes
      from app_token_global
@@ -119,6 +122,7 @@ left join iam_scope_project
           app_token_permission_org.grant_this_scope,
           app_token_permission_org.grant_scope,
           app_token_org.public_id                                        as app_token_id,
+          'global'                                                       as app_token_parent_scope_id,
           array_agg(distinct app_token_permission_grant.canonical_grant) as canonical_grants,
           array_agg(distinct iam_scope_project.scope_id)                 as active_grant_scopes
      from app_token_org
@@ -151,6 +155,7 @@ left join iam_scope_project
           app_token_permission_org.grant_this_scope,
           app_token_permission_org.grant_scope,
           app_token_org.public_id                                        as app_token_id,
+          'global'                                                       as app_token_parent_scope_id,
           array_agg(distinct app_token_permission_grant.canonical_grant) as canonical_grants,
           array_agg(distinct app_token_org.scope_id)                     as active_grant_scopes
      from app_token_org
@@ -180,6 +185,7 @@ left join iam_scope_project
           app_token_permission_org.grant_this_scope,
           app_token_permission_org.grant_scope,
           app_token_org.public_id                                        as app_token_id,
+          'global'                                                       as app_token_parent_scope_id,
           array_agg(distinct app_token_permission_grant.canonical_grant) as canonical_grants,
           array_agg(distinct iam_scope_project.scope_id)                 as active_grant_scopes
      from app_token_org


### PR DESCRIPTION
## Description

- Adding a `filter` to filter out null `active_grant_scopes` values
- Use `'descendants'` ✅  for global->project relationship instead of `'children'` ❌ 
- Remove joins to org tables from `grantsForGlobalTokenProjectResourcesRecursiveQuery`
- Remove `coalesce()` function calls with only one argument
- Improve alias naming & query spacing
- Only check `grant_this_role_scope = true` for `grantsForOrgTokenGlobalOrgResourcesRecursiveQuery` [[ICU-17918]](https://hashicorp.atlassian.net/browse/ICU-17918?focusedCommentId=907949)
- Add `app_token_parent_scope_id` to query results

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[ICU-17918]: https://hashicorp.atlassian.net/browse/ICU-17918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ