### PR TITLE
chore: update supported postgres versions

### DIFF
--- a/.github/workflows/test-sql.yml
+++ b/.github/workflows/test-sql.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     strategy:
       matrix:
-        postgres-version: [ alpine, 13-alpine, 14-alpine, 15-alpine, 16-alpine, 17-alpine ]
+        postgres-version: [ alpine,15-alpine, 16-alpine, 17-alpine ]
     name: SQL Tests ${{ matrix.postgres-version }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -13,7 +13,7 @@ const (
 	AnonymousUserId        = "u_anon"
 	RecoveryUserId         = "u_recovery"
 
-	MinimumSupportedPostgresVersion = "12"
+	MinimumSupportedPostgresVersion = "15"
 
 	GrantScopeThis        = "this"
 	GrantScopeChildren    = "children"


### PR DESCRIPTION
## Description
We recently stopped supporting versions of Postgres before 15.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
