### PR TITLE
test(e2e): Fixed failing database migration test

### DIFF
--- a/testing/internal/e2e/infra/docker.go
+++ b/testing/internal/e2e/infra/docker.go
@@ -183,10 +183,10 @@ func StartBoundary(t testing.TB, pool *dockertest.Pool, network *dockertest.Netw
 		Networks:     []*dockertest.Network{network},
 		ExposedPorts: []string{"9200/tcp", "9201/tcp", "9202/tcp", "9203/tcp"},
 		PortBindings: map[docker.Port][]docker.PortBinding{
-			"9200/tcp": {{HostIP: "localhost", HostPort: "9200/tcp"}},
-			"9201/tcp": {{HostIP: "localhost", HostPort: "9201/tcp"}},
-			"9202/tcp": {{HostIP: "localhost", HostPort: "9202/tcp"}},
-			"9203/tcp": {{HostIP: "localhost", HostPort: "9203/tcp"}},
+			"9200/tcp": {{HostIP: "127.0.0.1", HostPort: "9200"}},
+			"9201/tcp": {{HostIP: "127.0.0.1", HostPort: "9201"}},
+			"9202/tcp": {{HostIP: "127.0.0.1", HostPort: "9202"}},
+			"9203/tcp": {{HostIP: "127.0.0.1", HostPort: "9203"}},
 		},
 		CapAdd: []string{"IPC_LOCK"},
 	})
@@ -194,7 +194,7 @@ func StartBoundary(t testing.TB, pool *dockertest.Pool, network *dockertest.Netw
 
 	return &Container{
 		Resource:     resource,
-		UriLocalhost: "http://localhost:9200",
+		UriLocalhost: "http://127.0.0.1:9200",
 		UriNetwork:   "http://boundary:9200",
 	}
 }
@@ -223,13 +223,13 @@ func StartVault(t testing.TB, pool *dockertest.Pool, network *dockertest.Network
 		Networks:     []*dockertest.Network{network},
 		ExposedPorts: []string{"8200/tcp"},
 		PortBindings: map[docker.Port][]docker.PortBinding{
-			"8200/tcp": {{HostIP: "localhost", HostPort: "8210/tcp"}},
+			"8200/tcp": {{HostIP: "127.0.0.1", HostPort: "8210"}},
 		},
 		CapAdd: []string{"IPC_LOCK"},
 	})
 	require.NoError(t, err)
 
-	uriLocalhost := "http://localhost:8210"
+	uriLocalhost := "http://127.0.0.1:8210"
 
 	return &Container{
 			Resource:     resource,


### PR DESCRIPTION
## Description
Fixed failing database migration e2e test by changing some url bindings for local docker boundary deployment. 

https://hashicorp.atlassian.net/browse/ICU-18287

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
