### PR TITLE
chore: disable HashiCorp copywrite check for new IBM headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ tools: golangci-lint
 	go generate -tags tools tools/tools.go
 	go install github.com/bufbuild/buf/cmd/buf@v1.27.2
 	go install github.com/mfridman/tparse@v0.13.1
-	go install github.com/hashicorp/copywrite@v0.16.6
 
 # golangci-lint recommends installing the binary directly, instead of using go get
 # See the note: https://golangci-lint.run/usage/install/#install-from-source
@@ -140,7 +139,7 @@ perms-table:
 	@go run internal/website/permstable/permstable.go
 
 .PHONY: gen
-gen: cleangen proto api cli perms-table fmt copywrite
+gen: cleangen proto api cli perms-table fmt #copywrite - Removing copywrite; we will need to switch to IBM's tooling, when available
 
 ### oplog requires protoc-gen-go v1.20.0 or later
 # GO111MODULE=on go get -u github.com/golang/protobuf/protoc-gen-go@v1.40
@@ -285,15 +284,16 @@ protolint:
 	cd internal/proto && buf breaking --against 'https://github.com/hashicorp/boundary.git#branch=stable-website,subdir=internal/proto' \
 		--config buf.breaking.wire.yaml
 
-.PHONY: copywrite
-copywrite:
-	copywrite headers
+# Removing copywrite; we will need to switch to IBM's tooling, when available
+#.PHONY: copywrite
+#copywrite:
+#	copywrite headers
 	# In the protobuf API directories, remove the BUSL headers
 	# and rerun copywrite with the directory specific configuration.
-	cd internal/proto/controller/api && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + &&  copywrite headers
-	cd internal/proto/controller/custom_options && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + &&  copywrite headers
-	cd internal/proto/plugin && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + && copywrite headers
-	cd internal/proto/worker/proxy/v1 && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + && copywrite headers
+#	cd internal/proto/controller/api && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + &&  copywrite headers
+#	cd internal/proto/controller/custom_options && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + &&  copywrite headers
+#	cd internal/proto/plugin && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + && copywrite headers
+#	cd internal/proto/worker/proxy/v1 && find . -type f -name '*.proto' -exec sed -i '1,3d' {} + && copywrite headers
 
 .PHONY: website
 # must have nodejs and npm installed


### PR DESCRIPTION
## Description
We're switching to IBM copywrite headers. Our make-gen test runs copywrite and will fail as it uses HashiCorp's copywrite. This PR disables copywrite (until IBM tooling is available)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
