### PR TITLE
Updating sdk and Api with latest tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,8 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3
-	github.com/hashicorp/boundary/api v0.0.54
-	github.com/hashicorp/boundary/sdk v0.0.55
+	github.com/hashicorp/boundary/api v0.0.58
+	github.com/hashicorp/boundary/sdk v0.0.56
 	github.com/hashicorp/cap v0.11.0
 	github.com/hashicorp/cap/ldap v0.0.0-20240206183135-ed8f24513744
 	github.com/hashicorp/dawdle v0.5.0


### PR DESCRIPTION
## Description
Updating SDK and API tags with release of 0.21.0 as per instructions

*Note that the version set in go.mod is not used by Boundary as there is a replace directive in place, but it makes sense to keep these up to date with the latest release anyway.

