### PR TITLE
ICU-18284-testcase parameter removed from ICU-18284-changes

### DIFF
--- a/internal/cmd/commands/server/listener_reload_test.go
+++ b/internal/cmd/commands/server/listener_reload_test.go
@@ -12,7 +12,6 @@
 package server
 
 import (
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -93,9 +92,9 @@ func TestServer_ReloadListener(t *testing.T) {
 
 	td := t.TempDir()
 
-	controllerKey := config.DevKeyGeneration(config.WithRandomReader(rand.Reader))
-	workerAuthKey := config.DevKeyGeneration(config.WithRandomReader(rand.Reader))
-	recoveryKey := config.DevKeyGeneration(config.WithRandomReader(rand.Reader))
+	controllerKey := config.DevKeyGeneration()
+	workerAuthKey := config.DevKeyGeneration()
+	recoveryKey := config.DevKeyGeneration()
 
 	cmd := testServerCommand(t, testServerCommandOpts{
 		CreateDevDatabase: true,


### PR DESCRIPTION
## Description
Removed unnecessary  parameter passing to `listener_reload_test.go -> TestServer_ReloadListener.config.DevKeyGeneration()`
linked : refactor : ICU-18284-Unify SecureRandomReader #6303
 
File changed:
internal/cmd/commands/server/listener_reload_test.go

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
