### PR TITLE
chore(e2e): set windows terminal app in registry

### DIFF
--- a/enos/modules/aws_windows_client/scripts/setup.ps1
+++ b/enos/modules/aws_windows_client/scripts/setup.ps1
@@ -111,8 +111,8 @@ if ("${github_token}" -ne "") {
 
 # Setting default terminal app to Windows Terminal (modern terminal)
 # aka Settings > System > For Developers > Terminal to Windows Terminal
-# By defualt, Windows11 has preferred terminal app set as "Let Windows decide"
-# which causes inconsistent terminal experience affecting images use for RDP tests
+# By default, Windows11 has preferred terminal app set as "Let Windows decide"
+# which causes inconsistent terminal experience affecting images used for RDP tests
 # Two properties need to be set in registry to change default terminal app
 # DelegationTerminal determines which terminal UI to use
 # DelegationConsole determines how the data is communicated between the terminal and the operating system


### PR DESCRIPTION
## Description
This PR sets the desired terminal app to Windows Terminal (as opposed to "Let Windows decide) for the autologinuser profile used in e2e tests for RDP.

There were some flakiness in the RDP tests, as it sometimes opened the legacy version of powershell while our tests expected the use of the modern version.

For context this is what the script is updating
<img width="2560" height="1440" alt="Screenshot 2026-01-08 at 2 00 41 PM" src="https://github.com/user-attachments/assets/7270d1fb-4999-4845-a865-f3bb20824f7c" />

Jira Ticket - https://hashicorp.atlassian.net/browse/ICU-18330

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
