### PR TITLE
SemGrep rule to identify direct uses of crypto/rand.Reader and recommend the use of the SecureRandomReader instead

### DIFF
--- a/.semgrep/avoid-crypto-rand.yaml
+++ b/.semgrep/avoid-crypto-rand.yaml
@@ -28,4 +28,6 @@ rules:
           - "worker.go"
           - "repository_scope.go"
           - "keys.go"
+          - "testing_ent.go"
+          - "options_ent.go"
     fix: Use SecureRandomReader instead of crypto/rand.Reader directly.


### PR DESCRIPTION
## Description

SemGrep rule to identify direct uses of crypto/rand.Reader (or math/rand.Reader) and recommend the use of the SecureRandomReader instead

## Reference:
-  [](url)https://hashicorp.atlassian.net/browse/ICU-18349
- [](url)https://docs.google.com/document/d/1j-LIjrjvRtSY8dP0xuMUtJXGf6P74o-f-F-vnvfTqIA/edit?tab=t.0#heading=h.gq0wz3evx7x7

## Files Modified
      
        new file:   .semgrep/avoid-crypto-rand.yaml
  
## SemGrep Playground
[](url)https://semgrep.dev/playground/new?editorMode=advanced

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
