### PR TITLE
Revert "chore(e2e): Stop running builds with new pushes"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 env:
   PKG_NAME: "boundary"
 


### PR DESCRIPTION
Reverts hashicorp/boundary#6309

I think this is causing some leftover resources, which then results in hitting VPC limits in the AWS account. When there are new pushes, existing runs of `build` will get cancelled. This also seems to include the e2e tests that were kicked off by `build`.