### PR TITLE
feat(cli): Add token authentication support for connect kube helper

### DIFF
--- a/internal/cmd/commands/connect/connect.go
+++ b/internal/cmd/commands/connect/connect.go
@@ -796,13 +796,14 @@ func (c *Command) handleExec(clientProxy *apiproxy.ClientProxy, passthroughArgs 
 		creds = sshCreds
 
 	case "kube":
-		kubeArgs, err := c.kubeFlags.buildArgs(c, port, host, addr)
+		kubeArgs, kubeCreds, err := c.kubeFlags.buildArgs(c, port, host, addr, creds)
 		if err != nil {
 			c.PrintCliError(fmt.Errorf("Error parsing session args: %w", err))
 			c.execCmdReturnValue.Store(int32(3))
 			return
 		}
 		args = append(args, kubeArgs...)
+		creds = kubeCreds
 	}
 
 	if argsErr != nil {


### PR DESCRIPTION
## Description

Adds support for consuming password-type credentials when connecting to Kubernetes targets using `boundary connect kube` helper command. 

When a password credential is brokered through Boundary, the command will now pass it as a bearer token to `kubectl` using the `--token` flag.

Tested with both Static and Vault credential stores against an actual Kubernetes cluster.


## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

**Reason for change:** Enable connect kube helper to authenticate to Kubernetes clusters using credentials brokered.

**Revert plan:** Can be fully reverted by reverting this PR.

**Security control impact:** No changes to security controls. Follows existing pattern from other connect commands (SSH, Postgres, Redis). 
