### PR TITLE
feat(clientcache): pass WithSort to searchTargets

### DIFF
--- a/internal/clientcache/internal/cache/repository_targets.go
+++ b/internal/clientcache/internal/cache/repository_targets.go
@@ -373,8 +373,18 @@ func (r *Repository) searchTargets(ctx context.Context, condition string, search
 		searchArgs = append(searchArgs, opts.withUserId)
 	}
 
+	dbOpts := []db.Option{db.WithLimit(opts.withMaxResultSetSize + 1)}
+	if opts.withSortBy != "" {
+		sd := opts.withSortDirection
+		if sd != Ascending && sd != Descending {
+			sd = Ascending
+		}
+		orderClause := fmt.Sprintf("%s %s", opts.withSortBy, sd)
+		dbOpts = append(dbOpts, db.WithOrder(orderClause))
+	}
+
 	var cachedTargets []*Target
-	if err := r.rw.SearchWhere(ctx, &cachedTargets, condition, searchArgs, db.WithLimit(opts.withMaxResultSetSize+1)); err != nil {
+	if err := r.rw.SearchWhere(ctx, &cachedTargets, condition, searchArgs, dbOpts...); err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
 

--- a/internal/clientcache/internal/cache/repository_targets_test.go
+++ b/internal/clientcache/internal/cache/repository_targets_test.go
@@ -358,6 +358,27 @@ func TestRepository_ListTargets(t *testing.T) {
 		assert.Len(t, l.Targets, len(ts))
 		assert.ElementsMatch(t, l.Targets, ts)
 	})
+
+	t.Run("withSortBy sorts targets", func(t *testing.T) {
+		l, err := r.ListTargets(ctx, kt1.AuthTokenId, WithSort(SortByName, Descending, []SortBy{SortByName}))
+		assert.NoError(t, err)
+		assert.Equal(t, ts[2].Name, l.Targets[0].Name)
+		assert.Equal(t, ts[1].Name, l.Targets[1].Name)
+		assert.Equal(t, ts[0].Name, l.Targets[2].Name)
+	})
+
+	t.Run("withSortBy bad SortBy errors", func(t *testing.T) {
+		_, err := r.ListTargets(ctx, kt1.AuthTokenId, WithSort(SortByCreatedAt, Descending, []SortBy{SortByName}))
+		assert.Error(t, err)
+	})
+
+	t.Run("withSortBy bad SortDirection defaults to Ascending", func(t *testing.T) {
+		l, err := r.ListTargets(ctx, kt1.AuthTokenId, WithSort(SortByName, "Something else", []SortBy{SortByName}))
+		assert.NoError(t, err)
+		assert.Equal(t, ts[0].Name, l.Targets[0].Name)
+		assert.Equal(t, ts[1].Name, l.Targets[1].Name)
+		assert.Equal(t, ts[2].Name, l.Targets[2].Name)
+	})
 }
 
 func TestRepository_ListTargetsLimiting(t *testing.T) {
@@ -524,6 +545,25 @@ func TestRepository_QueryTargets(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, l.Targets, 2)
 		assert.ElementsMatch(t, l.Targets, ts[0:2])
+	})
+
+	t.Run("withSortBy sorts targets", func(t *testing.T) {
+		l, err := r.QueryTargets(ctx, kt1.AuthTokenId, query, WithSort(SortByName, Descending, []SortBy{SortByName}))
+		assert.NoError(t, err)
+		assert.Equal(t, ts[1].Name, l.Targets[0].Name)
+		assert.Equal(t, ts[0].Name, l.Targets[1].Name)
+	})
+
+	t.Run("withSortBy bad SortBy errors", func(t *testing.T) {
+		_, err := r.QueryTargets(ctx, kt1.AuthTokenId, query, WithSort(SortByCreatedAt, Descending, []SortBy{SortByName}))
+		assert.Error(t, err)
+	})
+
+	t.Run("withSortBy bad SortDirection defaults to Ascending", func(t *testing.T) {
+		l, err := r.QueryTargets(ctx, kt1.AuthTokenId, query, WithSort(SortByName, "Something else", []SortBy{SortByName}))
+		assert.NoError(t, err)
+		assert.Equal(t, ts[0].Name, l.Targets[0].Name)
+		assert.Equal(t, ts[1].Name, l.Targets[1].Name)
 	})
 }
 


### PR DESCRIPTION
## Description
This PR implements passing the validated sorting options through the repository layer into the db query

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
