### PR TITLE
chore(e2e): Add network check before setting up SSH service in windows instances

### DIFF
--- a/enos/modules/aws_windows_client/main.tf
+++ b/enos/modules/aws_windows_client/main.tf
@@ -155,6 +155,25 @@ resource "aws_instance" "client" {
 
   user_data = <<EOF
                 <powershell>
+                  # Wait for network to be available
+                  $networkTimeout = 120
+                  $networkElapsed = 0
+                  do {
+                    $network = Test-NetConnection -ComputerName "169.254.169.254" -Port 80 -WarningAction SilentlyContinue
+                    if ($network.TcpTestSucceeded) {
+                      Write-Host "Network is available"
+                      break
+                    }
+                    Write-Host "Waiting for network..."
+                    Start-Sleep -Seconds 10
+                    $networkElapsed += 10
+                  } while ($networkElapsed -lt $networkTimeout)
+
+                  if ($networkElapsed -ge $networkTimeout) {
+                    Write-Host "Network not available after timeout. Exiting."
+                    exit 1
+                  }
+
                   # set variables for retry loops
                   $timeout = 300
                   $interval = 30


### PR DESCRIPTION
## Description
This PR attempts to address some flakiness in RDP automated tests. On occasion, e2e tests will fail when setting up test infrastructure due to the following
```
Error: Execution Error
  with module.create_rdp_domain_controller.enos_local_exec.wait_for_ssh[0],
  on ../../modules/aws_rdp_domain_controller/main.tf line 458, in resource "enos_local_exec" "wait_for_ssh":
 458: resource "enos_local_exec" "wait_for_ssh" {
failed to execute commands due to: running inline command failed, due to:
failed to execute command due to: exit status 124
output:
ssh: connect to host 34.201.103.152 port 22: Connection timed out
ssh: connect to host 34.201.103.152 port 22: Connection timed out
ssh: connect to host 34.201.103.152 port 22: Connection timed out
ssh: connect to host 34.201.103.152 port 22: Connection timed out
```

This can occur on any of the windows instances we are setting up. We try to set up SSH services on these instances and we have a step to verify that we can successfully SSH to them, but sometimes, it times out on this verification step.

The current theory is that this is caused by something timing related when setting up the SSH service, so this PR attempts to mitigate this by adding some additional wait times
- for instances that require a reboot (setting up the windows domain, adding a computer to a domain), the SSH service is set up as a scheduled task upon the next reboot. The scheduled task is set up to run 2 minutes after boot to ensure that networking services are available (trigger.delay)
- the SSH setup script also performs a check to ensure that networking is available

Here are some runs against a branch in boundary-enterprise for testing purposes: https://github.com/hashicorp/boundary-enterprise/actions/runs/21082332766. I have not seen a failure in 10 attempts, but I think it's worth getting this in to get more of a sample size in CI. 

https://hashicorp.atlassian.net/browse/ICU-18364

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
