### PR TITLE
test(e2e): Address issue when password starts with @

### DIFF
--- a/testing/internal/e2e/vault/vault.go
+++ b/testing/internal/e2e/vault/vault.go
@@ -294,14 +294,17 @@ func CreateKvPasswordCredential(t testing.TB, secretPath string, user string, pr
 		require.NoError(t, err)
 	}
 
+	// Escape '@' in the password. Vault CLI interprets '@' as a file
+	escapedPassword := strings.ReplaceAll(password, "@", "\\@")
+
 	// Create secret
 	output := e2e.RunCommand(context.Background(), "vault",
 		e2e.WithArgs(
 			"kv", "put",
 			"-mount", secretPath,
 			secretName,
-			"username="+user,
-			"password="+password,
+			fmt.Sprintf("username=%s", user),
+			fmt.Sprintf("password=%s", escapedPassword),
 		),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
@@ -338,15 +341,18 @@ func CreateKvPasswordDomainCredential(t testing.TB, secretPath string, user stri
 		require.NoError(t, err)
 	}
 
+	// Escape '@' in the password. Vault CLI interprets '@' as a file
+	escapedPassword := strings.ReplaceAll(password, "@", "\\@")
+
 	// Create secret
 	output := e2e.RunCommand(context.Background(), "vault",
 		e2e.WithArgs(
 			"kv", "put",
 			"-mount", secretPath,
 			secretName,
-			"username="+user,
-			"password="+password,
-			"domain="+domain,
+			fmt.Sprintf("username=%s", user),
+			fmt.Sprintf("password=%s", escapedPassword),
+			fmt.Sprintf("domain=%s", domain),
 		),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))


### PR DESCRIPTION
## Description
This PR addresses an RDP e2e test failure that failed for the following reason
```
vault.go:352:
Error Trace: C:/Test/boundary-src/testing/internal/e2e/vault/vault.go:352
C:/Test/boundary-src/testing/internal/e2e/tests/rdp/win11_to_2019_connect_rdp_kerberos_vault_generic_upd_ent_test.go:91
Error: Received unexpected error:
exit status 1
Test: TestWin11to2019ConnectRdpKerberosVaultGenericUpd
Messages: Failed to parse K=V data: invalid key/value pair "***": error reading file: open @=jRMcnAqlk-8fh6ejRhE4S@!bS-Z2w: The system cannot find the file specified.
```

When AWS generates an admin password for a Windows ec2 instance, there's a chance that the password starts with `@`. However, the Vault CLI interprets strings that start with a `@` as a file, resulting in this error.

This PR modifies the Vault command to escape any `@`s in the string. 

Here is a run from boundary-enterprise: https://github.com/hashicorp/boundary-enterprise/actions/runs/21228411856

https://hashicorp.atlassian.net/browse/ICU-18399

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
