### PR TITLE
chore(e2e): Download modules if cache not found

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -109,6 +109,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
           cache: false
       - name: Set up Go modules cache
+        id: go-mod-cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
@@ -119,6 +120,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go
           fail-on-cache-miss: false
+      - name: Downloads Go modules if cache miss
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        run: |
+          go mod download
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd    # TSCCR: loading action configs: failed to query HEAD reference: failed to get advertised references: authorization failed
         with:


### PR DESCRIPTION
## Description
This PR attempts to address some issues when e2e tests fail due to a github action cache being removed.
```
docker: Error response from daemon: invalid mount config for type "bind":
bind source path does not exist: /home/runner/go/pkg/mod

Run 'docker run --help' for more information
```
Example: https://github.com/hashicorp/boundary/actions/runs/21184215529/job/61204666780?pr=6349

The e2e test workflow expects a go modules cache to be available, however, due to stricter enforcement of github actions cache limits, we've been seeing an increase in the above failures due to removal of older caches.

This PR adds some mitigation steps in the event of that happening (if the cache isn't available, make sure to download go modules). 

https://hashicorp.atlassian.net/browse/ICU-18398

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
