### PR TITLE
chore(rdp): expose worker ip and ssh key for debugging

### DIFF
--- a/enos/enos-scenario-e2e-aws-rdp-base.hcl
+++ b/enos/enos-scenario-e2e-aws-rdp-base.hcl
@@ -308,10 +308,12 @@ scenario "e2e_aws_rdp_base" {
       aws_region                               = var.aws_region
       max_page_size                            = step.create_boundary_cluster.max_page_size
       worker_tag_collocated                    = local.collocated_tag
+      worker_address                           = step.create_windows_worker.public_ip
       target_rdp_domain_controller_addr        = step.create_rdp_domain_controller.private_ip
       target_rdp_domain_controller_addr_ipv6   = local.ip_version == "4" ? "" : step.create_rdp_domain_controller.ipv6[0]
       target_rdp_domain_controller_user        = step.create_rdp_domain_controller.admin_username
       target_rdp_domain_controller_password    = step.create_rdp_domain_controller.password
+      target_rdp_domain_controller_ssh_key     = step.create_rdp_domain_controller.ssh_private_key
       target_rdp_member_server_addr            = step.create_rdp_member_server.private_ip
       target_rdp_member_server_domain_hostname = step.create_rdp_member_server.domain_hostname
       target_rdp_member_server_user            = step.create_rdp_member_server.admin_username

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -176,6 +176,11 @@ variable "target_rdp_domain_controller_password" {
   type        = string
   default     = ""
 }
+variable "target_rdp_domain_controller_ssh_key" {
+  description = "Path to the ssh key for the windows domain controller and worker"
+  type        = string
+  default     = ""
+}
 variable "target_rdp_member_server_addr" {
   description = "Address of RDP member server"
   type        = string
@@ -295,6 +300,7 @@ resource "enos_local_exec" "run_e2e_test" {
     E2E_TARGET_RDP_DOMAIN_CONTROLLER_ADDR_IPV6   = var.target_rdp_domain_controller_addr_ipv6
     E2E_TARGET_RDP_DOMAIN_CONTROLLER_USER        = var.target_rdp_domain_controller_user
     E2E_TARGET_RDP_DOMAIN_CONTROLLER_PASSWORD    = var.target_rdp_domain_controller_password
+    E2E_TARGET_RDP_DOMAIN_CONTROLLER_SSH_KEY     = var.target_rdp_domain_controller_ssh_key
     E2E_TARGET_RDP_MEMBER_SERVER_ADDR            = var.target_rdp_member_server_addr
     E2E_TARGET_RDP_MEMBER_SERVER_DOMAIN_HOSTNAME = var.target_rdp_member_server_domain_hostname
     E2E_TARGET_RDP_MEMBER_SERVER_USER            = var.target_rdp_member_server_user


### PR DESCRIPTION
## Description
To enable extracting windows logs I first need to expose the worker IP and ssh key to enosvars

Jira: https://hashicorp.atlassian.net/browse/ICU-18367

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
