### PR TITLE
feat(clientcache): make default order for created_time to desc

### DIFF
--- a/internal/clientcache/cmd/search/search_test.go
+++ b/internal/clientcache/cmd/search/search_test.go
@@ -384,7 +384,7 @@ func TestSearch(t *testing.T) {
 		assert.Less(t, r.Sessions[1].CreatedTime, r.Sessions[0].CreatedTime)
 	})
 
-	t.Run("sorted sessions ascending by default", func(t *testing.T) {
+	t.Run("sorted sessions descending by default", func(t *testing.T) {
 		resp, r, apiErr, err := search(ctx, srv.BaseDotDir(), filterBy{
 			authTokenId: at.Id,
 			resource:    "sessions",
@@ -394,7 +394,7 @@ func TestSearch(t *testing.T) {
 		assert.Nil(t, apiErr)
 		assert.NotNil(t, resp)
 		assert.NotNil(t, r)
-		assert.Less(t, r.Sessions[0].CreatedTime, r.Sessions[1].CreatedTime)
+		assert.Less(t, r.Sessions[1].CreatedTime, r.Sessions[0].CreatedTime)
 	})
 
 	t.Run("sorted and filtered", func(t *testing.T) {

--- a/internal/clientcache/internal/cache/repository_sessions.go
+++ b/internal/clientcache/internal/cache/repository_sessions.go
@@ -385,9 +385,10 @@ func (r *Repository) searchSessions(ctx context.Context, condition string, searc
 	if opts.withSortBy != SortByDefault {
 		var direction string
 		switch opts.withSortDirection {
-		case Descending:
+		// default to descending
+		case Descending, SortDirectionDefault:
 			direction = "desc"
-		case Ascending, SortDirectionDefault:
+		case Ascending:
 			direction = "asc"
 		default:
 			return nil, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("unsupported sort direction: %v", opts.withSortDirection))

--- a/internal/clientcache/internal/cache/repository_sessions_test.go
+++ b/internal/clientcache/internal/cache/repository_sessions_test.go
@@ -741,7 +741,7 @@ func TestRepository_SearchSessionsSorting(t *testing.T) {
 		assert.Equal(t, "ttcp_1", result.Sessions[2].Id)
 	})
 
-	t.Run("sort by created_time with default direction defaults to ascending", func(t *testing.T) {
+	t.Run("sort by created_time with default direction defaults to desc", func(t *testing.T) {
 		params := SearchParams{
 			Resource:      Sessions,
 			AuthTokenId:   kt.AuthTokenId,
@@ -751,9 +751,9 @@ func TestRepository_SearchSessionsSorting(t *testing.T) {
 		result, err := searchService.Search(ctx, params)
 		require.NoError(t, err)
 		require.Len(t, result.Sessions, 3)
-		assert.Equal(t, "ttcp_1", result.Sessions[0].Id)
+		assert.Equal(t, "ttcp_3", result.Sessions[0].Id)
 		assert.Equal(t, "ttcp_2", result.Sessions[1].Id)
-		assert.Equal(t, "ttcp_3", result.Sessions[2].Id)
+		assert.Equal(t, "ttcp_1", result.Sessions[2].Id)
 	})
 
 	t.Run("no sort specified returns results", func(t *testing.T) {
@@ -1361,7 +1361,7 @@ func TestRepository_searchSessions_sortingEdgeCases(t *testing.T) {
 		assert.Contains(t, err.Error(), "unsupported sort direction")
 	})
 
-	t.Run("valid sort with SortDirectionDefault - should default to ascending", func(t *testing.T) {
+	t.Run("valid sort with SortDirectionDefault - should default to descending", func(t *testing.T) {
 		// SortDirectionDefault should be treated as ascending
 		result, err := r.searchSessions(ctx, "true", nil,
 			withAuthTokenId(at.Id),
@@ -1370,9 +1370,9 @@ func TestRepository_searchSessions_sortingEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Len(t, result.Sessions, 2)
-		// Should be in ascending order (oldest first)
-		assert.Equal(t, "ttcp_1", result.Sessions[0].Id)
-		assert.Equal(t, "ttcp_2", result.Sessions[1].Id)
+		// Should be in descending order (newest first)
+		assert.Equal(t, "ttcp_2", result.Sessions[0].Id)
+		assert.Equal(t, "ttcp_1", result.Sessions[1].Id)
 	})
 
 	t.Run("sort with limit 1 - verify incomplete flag", func(t *testing.T) {


### PR DESCRIPTION
## Description
This PR make the default sorting for sessions and created_time to `desc`
## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
