### PR TITLE
test(e2e): update resource reference for rdp domain controller module

### DIFF
--- a/enos/modules/aws_rdp_domain_controller/main.tf
+++ b/enos/modules/aws_rdp_domain_controller/main.tf
@@ -471,7 +471,7 @@ resource "time_sleep" "wait_for_reboot" {
 }
 
 data "aws_instance" "instance_password" {
-  depends_on        = [time_sleep.wait_10_minutes]
+  depends_on        = [time_sleep.wait_for_reboot]
   instance_id       = aws_instance.domain_controller.id
   get_password_data = true
 }


### PR DESCRIPTION
## Description
The `time_sleep` resource referenced needs to be updated as it was updated in another PR

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
