### PR TITLE
test(e2e): vault creds escape '@' for password

### DIFF
--- a/testing/internal/e2e/vault/vault.go
+++ b/testing/internal/e2e/vault/vault.go
@@ -295,10 +295,11 @@ func CreateKvPasswordCredential(t testing.TB, secretPath string, user string, pr
 	}
 
 	// Escape '@' when prefixed to password. Vault CLI interprets '@' as a file
+	var passwordArg string
 	if strings.HasPrefix(password, "@") {
-		password = fmt.Sprintf("password=\\%s", password)
+		passwordArg = fmt.Sprintf("\\%s", password)
 	} else {
-		password = fmt.Sprintf("password=%s", password)
+		passwordArg = password
 	}
 
 	// Create secret
@@ -308,7 +309,7 @@ func CreateKvPasswordCredential(t testing.TB, secretPath string, user string, pr
 			"-mount", secretPath,
 			secretName,
 			fmt.Sprintf("username=%s", user),
-			password,
+			fmt.Sprintf("password=%s", passwordArg),
 		),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
@@ -346,10 +347,11 @@ func CreateKvPasswordDomainCredential(t testing.TB, secretPath string, user stri
 	}
 
 	// Escape '@' when prefixed to password. Vault CLI interprets '@' as a file
+	var passwordArg string
 	if strings.HasPrefix(password, "@") {
-		password = fmt.Sprintf("password=\\%s", password)
+		passwordArg = fmt.Sprintf("\\%s", password)
 	} else {
-		password = fmt.Sprintf("password=%s", password)
+		passwordArg = password
 	}
 
 	// Create secret
@@ -359,7 +361,7 @@ func CreateKvPasswordDomainCredential(t testing.TB, secretPath string, user stri
 			"-mount", secretPath,
 			secretName,
 			fmt.Sprintf("username=%s", user),
-			password,
+			fmt.Sprintf("password=%s", passwordArg),
 			fmt.Sprintf("domain=%s", domain),
 		),
 	)

--- a/testing/internal/e2e/vault/vault.go
+++ b/testing/internal/e2e/vault/vault.go
@@ -294,8 +294,13 @@ func CreateKvPasswordCredential(t testing.TB, secretPath string, user string, pr
 		require.NoError(t, err)
 	}
 
-	// Escape '@' in the password. Vault CLI interprets '@' as a file
-	escapedPassword := strings.ReplaceAll(password, "@", "\\@")
+	// Escape '@' when prefixed to password. Vault CLI interprets '@' as a file
+	var passwordArg string
+	if strings.HasPrefix(password, "@") {
+		passwordArg = fmt.Sprintf("password=\\%s", password)
+	} else {
+		passwordArg = fmt.Sprintf("password=%s", password)
+	}
 
 	// Create secret
 	output := e2e.RunCommand(context.Background(), "vault",
@@ -304,7 +309,7 @@ func CreateKvPasswordCredential(t testing.TB, secretPath string, user string, pr
 			"-mount", secretPath,
 			secretName,
 			fmt.Sprintf("username=%s", user),
-			fmt.Sprintf("password=%s", escapedPassword),
+			passwordArg,
 		),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
@@ -341,8 +346,13 @@ func CreateKvPasswordDomainCredential(t testing.TB, secretPath string, user stri
 		require.NoError(t, err)
 	}
 
-	// Escape '@' in the password. Vault CLI interprets '@' as a file
-	escapedPassword := strings.ReplaceAll(password, "@", "\\@")
+	// Escape '@' when prefixed to password. Vault CLI interprets '@' as a file
+	var passwordArg string
+	if strings.HasPrefix(password, "@") {
+		passwordArg = fmt.Sprintf("password=\\%s", password)
+	} else {
+		passwordArg = fmt.Sprintf("password=%s", password)
+	}
 
 	// Create secret
 	output := e2e.RunCommand(context.Background(), "vault",
@@ -351,7 +361,7 @@ func CreateKvPasswordDomainCredential(t testing.TB, secretPath string, user stri
 			"-mount", secretPath,
 			secretName,
 			fmt.Sprintf("username=%s", user),
-			fmt.Sprintf("password=%s", escapedPassword),
+			passwordArg,
 			fmt.Sprintf("domain=%s", domain),
 		),
 	)

--- a/testing/internal/e2e/vault/vault.go
+++ b/testing/internal/e2e/vault/vault.go
@@ -295,11 +295,10 @@ func CreateKvPasswordCredential(t testing.TB, secretPath string, user string, pr
 	}
 
 	// Escape '@' when prefixed to password. Vault CLI interprets '@' as a file
-	var passwordArg string
 	if strings.HasPrefix(password, "@") {
-		passwordArg = fmt.Sprintf("password=\\%s", password)
+		password = fmt.Sprintf("password=\\%s", password)
 	} else {
-		passwordArg = fmt.Sprintf("password=%s", password)
+		password = fmt.Sprintf("password=%s", password)
 	}
 
 	// Create secret
@@ -309,7 +308,7 @@ func CreateKvPasswordCredential(t testing.TB, secretPath string, user string, pr
 			"-mount", secretPath,
 			secretName,
 			fmt.Sprintf("username=%s", user),
-			passwordArg,
+			password,
 		),
 	)
 	require.NoError(t, output.Err, string(output.Stderr))
@@ -347,11 +346,10 @@ func CreateKvPasswordDomainCredential(t testing.TB, secretPath string, user stri
 	}
 
 	// Escape '@' when prefixed to password. Vault CLI interprets '@' as a file
-	var passwordArg string
 	if strings.HasPrefix(password, "@") {
-		passwordArg = fmt.Sprintf("password=\\%s", password)
+		password = fmt.Sprintf("password=\\%s", password)
 	} else {
-		passwordArg = fmt.Sprintf("password=%s", password)
+		password = fmt.Sprintf("password=%s", password)
 	}
 
 	// Create secret
@@ -361,7 +359,7 @@ func CreateKvPasswordDomainCredential(t testing.TB, secretPath string, user stri
 			"-mount", secretPath,
 			secretName,
 			fmt.Sprintf("username=%s", user),
-			passwordArg,
+			password,
 			fmt.Sprintf("domain=%s", domain),
 		),
 	)


### PR DESCRIPTION
## Description
This PR updates the e2e vault functions `CreateKvPasswordCredential` and `CreateKvPasswordDomainCredential` to only escape `'@'` if it is in the beginning of the password.

No need to escape `'@'` if it's elsewhere in the string. It will instead turn it to `'\@'` which is wrong and will cause credential issues.

This is a fix for https://github.com/hashicorp/boundary/pull/6358
## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
