### PR TITLE
test(rdp): Changed enos setup to fix logout issue with tests

### DIFF
--- a/enos/modules/aws_rdp_member_server/main.tf
+++ b/enos/modules/aws_rdp_member_server/main.tf
@@ -248,7 +248,7 @@ ${var.domain_admin_password}
                     Set-ItemProperty  -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0"  -Name RestrictReceivingNTLMTraffic -Value 2
                   %{endif~}
 
-                  # Disable some logout functionality that causes tests to hang
+                  # Disables safe-mode verification steps that were stopping loggouts on some tests
                   Disable-ScheduledTask -TaskName "VerifyWinRE" -TaskPath "\Microsoft\Windows\RecoveryEnvironment\"
 
                   # Enable audio


### PR DESCRIPTION
## Description
Added a line in the enos setup for the target instance for RDP testing scenarios. This should solve the issue of being unable to logout during the tests. 

Jira: https://hashicorp.atlassian.net/browse/ICU-18353


## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
