### PR TITLE
chore(e2e): Update mongodb-mongosh version

### DIFF
--- a/enos/modules/test_e2e_docker/test.sh
+++ b/enos/modules/test_e2e_docker/test.sh
@@ -121,8 +121,8 @@ apt install docker-ce-cli -y
 
 # Install MongoDB client (mongosh)
 # Reference: https://www.mongodb.com/docs/mongodb-shell/install/#debian
-curl -fsSL https://pgp.mongodb.com/server-7.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-7.0.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+wget -qO- https://www.mongodb.org/static/pgp/server-8.0.asc | tee /etc/apt/trusted.gpg.d/server-8.0.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/trusted.gpg.d/server-8.0.asc] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list
 apt update
 apt install -y mongodb-mongosh
 


### PR DESCRIPTION
## Description
This PR attempts to address an error showing up in e2e tests
```
│ Err:6 https://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 InRelease
│   Sub-process /usr/bin/sqv returned an error code (1), error message is: Signing key on E58830201F7DD82CD808AA84160D26BB1785BA38 is not bound:            No binding signature at time 2026-01-29T19:40:13Z   because: Policy rejected non-revocation signature (PositiveCertification) requiring second pre-image resistance   because: SHA1 is not considered secure since 2026-02-01T00:00:00Z
│ Hit:7 https://apache.jfrog.io/artifactory/cassandra-deb 41x InRelease
│ Reading package lists...
│ Warning: OpenPGP signature verification failed:
│ https://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 InRelease:
│ Sub-process /usr/bin/sqv returned an error code (1), error message is:
│ Signing key on E58830201F7DD82CD808AA84160D26BB1785BA38 is not bound:
│ No binding signature at time 2026-01-29T19:40:13Z   because: Policy rejected
│ non-revocation signature (PositiveCertification) requiring second pre-image
│ resistance   because: SHA1 is not considered secure since
│ 2026-02-01T00:00:00Z
│ Error: The repository 'https://repo.mongodb.org/apt/debian
│ bookworm/mongodb-org/7.0 InRelease' is not signed.
```

This PR updates the version of mongodb used by the docker test runner. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
