### PR TITLE
test(e2e): Randomized project name in tests

### DIFF
--- a/testing/internal/e2e/tests/base_connect/target_tcp_connect_authz_token_test.go
+++ b/testing/internal/e2e/tests/base_connect/target_tcp_connect_authz_token_test.go
@@ -39,6 +39,7 @@ func TestCliTcpTargetConnectTargetWithAuthzToken(t *testing.T) {
 		require.NoError(t, output.Err, string(output.Stderr))
 	})
 	name, err := base62.Random(16)
+	require.NoError(t, err)
 	testProjectName := fmt.Sprintf("e2e Project %s", name)
 	output := e2e.RunCommand(ctx, "boundary",
 		e2e.WithArgs(

--- a/testing/internal/e2e/tests/base_connect/target_tcp_connect_test.go
+++ b/testing/internal/e2e/tests/base_connect/target_tcp_connect_test.go
@@ -94,6 +94,7 @@ func TestCliTcpTargetConnectTargetViaTargetAndScopeNames(t *testing.T) {
 		require.NoError(t, output.Err, string(output.Stderr))
 	})
 	name, err := base62.Random(16)
+	require.NoError(t, err)
 	testProjectName := fmt.Sprintf("e2e Project %s", name)
 	testTargetName := fmt.Sprintf("e2e target %s", name)
 	projectId, err := boundary.CreateProjectCli(t, ctx, orgId, e2e.WithArgs("-name", testProjectName))


### PR DESCRIPTION
## Description
Added a randomizer to project name in tests that were using a hardcoded project name. 

jira: https://hashicorp.atlassian.net/browse/ICU-18340

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
