### PR TITLE
fix(e2e): Increase number of checks for bytes up down data

### DIFF
--- a/testing/internal/e2e/tests/base_connect/bytes_up_down_test.go
+++ b/testing/internal/e2e/tests/base_connect/bytes_up_down_test.go
@@ -68,7 +68,7 @@ func TestCliBytesUpDownTransferData(t *testing.T) {
 				"-o", "IdentitiesOnly=yes", // forces the use of the provided key
 				"-p", "{{boundary.port}}", // this is provided by boundary
 				"{{boundary.ip}}",
-				"for i in {1..30}; do pwd; sleep 1s; done",
+				"for i in {1..120}; do pwd; sleep 1s; done",
 			),
 		)
 	}()
@@ -112,7 +112,7 @@ func TestCliBytesUpDownTransferData(t *testing.T) {
 			t.Logf("bytes_up: %d, bytes_down: %d", bytesUp, bytesDown)
 			return nil
 		},
-		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 20),
 		func(err error, td time.Duration) {
 			t.Logf("%s. Retrying...", err.Error())
 		},
@@ -154,7 +154,7 @@ func TestCliBytesUpDownTransferData(t *testing.T) {
 			t.Logf("bytes_up: %d, bytes_down: %d", newBytesUp, newBytesDown)
 			return nil
 		},
-		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 6),
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 20),
 		func(err error, td time.Duration) {
 			t.Logf("%s. Retrying...", err.Error())
 		},


### PR DESCRIPTION
## Description
This PR attempts to address a flaky e2e test `TestCliBytesUpDownTransferData`
```
=== RUN   TestCliBytesUpDownTransferData
│     scope.go:91: Created Org Id: o_HPvAXeYRFg
│     scope.go:130: Created Project Id: p_OOjVWEioqo
│     target.go:182: Created Target: ttcp_tDRQJKuLWD
│     session.go:25: Waiting for session to appear...
│     bytes_up_down_test.go:58: Starting session...
│     session.go:60: No items are appearing in the session list. Retrying...
│     session.go:48: Found 1 session(s)
│     session.go:55: Created Session: s_vrOvmONNky
│     session.go:71: Waiting for session to be active...
│     bytes_up_down_test.go:81: Waiting for bytes_up/bytes_down to be greater than 0...
│     bytes_up_down_test.go:117: bytes_up: 0, bytes_down: 0, bytes_up or bytes_down is not greater than 0. Retrying...
│     bytes_up_down_test.go:117: bytes_up: 0, bytes_down: 0, bytes_up or bytes_down is not greater than 0. Retrying...
│     bytes_up_down_test.go:117: bytes_up: 0, bytes_down: 0, bytes_up or bytes_down is not greater than 0. Retrying...
│     bytes_up_down_test.go:117: bytes_up: 0, bytes_down: 0, bytes_up or bytes_down is not greater than 0. Retrying...
│     bytes_up_down_test.go:117: bytes_up: 0, bytes_down: 0, bytes_up or bytes_down is not greater than 0. Retrying...
│     bytes_up_down_test.go:120: 
│         	Error Trace:	/src/boundary/testing/internal/e2e/tests/base/bytes_up_down_test.go:120
│         	Error:      	Received unexpected error:
│         	            	bytes_up: 0, bytes_down: 0, bytes_up or bytes_down is not greater than 0
│         	Test:       	TestCliBytesUpDownTransferData
│ --- FAIL: TestCliBytesUpDownTransferData (38.08s)
```

The theory is that the fields for `bytes_up` and `bytes_down` can take some time to get updated. The test will now retry more times before considering it a failure.

https://hashicorp.atlassian.net/browse/ICU-18230

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
