### PR TITLE
chore: add missing changelog for 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 * Removed the error log during RDP basic settings exchange: When you connect to
   an RDP target using the built-in Windows Remote Desktop Connection app. ([PR](https://github.com/hashicorp/boundary/pull/6136))
 
+## 0.20.1 (2025/11/03)
+
+### New and Improved
+
+* Added a complete IBM Key Protect wrapper implementation with configuration options and KMS client integration ([PR](https://github.com/hashicorp/go-kms-wrapping/pull/292))
+
 ## 0.20.0 (2025/09/25)
 
 ### New and Improved


### PR DESCRIPTION
## Description
CHANGELOG was missing for 0.20.1, synced from the release/0.20.x branch to ensure consistency with main

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
