### PR TITLE
feat(repository): LookupAppToken() queries and repository function

### DIFF
--- a/internal/apptoken/apptoken.go
+++ b/internal/apptoken/apptoken.go
@@ -156,8 +156,8 @@ type AppTokenPermission struct {
 
 // DeletedScope represents a scope which has been deleted from an AppTokenPermission.
 type DeletedScope struct {
-	ScopeId   string
-	TimeStamp *timestamp.Timestamp
+	ScopeId   string               `json:"scope_id"`
+	TimeStamp *timestamp.Timestamp `json:"delete_time"`
 }
 
 // newToken generates a new in-memory token for the app token.

--- a/internal/apptoken/options.go
+++ b/internal/apptoken/options.go
@@ -15,6 +15,8 @@ type Option func(*options)
 type options struct {
 	withRecursive          bool
 	withLimit              int
+	withReader             db.Reader
+	withWriter             db.Writer
 	withStartPageAfterItem pagination.Item
 }
 
@@ -51,6 +53,19 @@ func WithLimit(limit int) Option {
 		} else {
 			o.withLimit = db.DefaultLimit
 		}
+	}
+}
+
+// WithReaderWriter allows the caller to pass an inflight transaction to be used
+// for all database operations. If WithReaderWriter(...) is used, then the
+// caller is responsible for managing the transaction.
+//
+// This option allows the caller to create or look up an
+// app token and any related rows within the same transaction.
+func WithReaderWriter(r db.Reader, w db.Writer) Option {
+	return func(o *options) {
+		o.withReader = r
+		o.withWriter = w
 	}
 }
 

--- a/internal/apptoken/query.go
+++ b/internal/apptoken/query.go
@@ -574,7 +574,7 @@ with token_permissions as (
          app_token_project.scope_id                            as grant_scope,
          array_agg(app_token_permission_grant.canonical_grant) as canonical_grants,
          app_token_project.public_id                           as app_token_id,
-         array_agg(app_token_project.scope_id)                 as active_grant_scope_ids,
+         '{}'::text[]                                          as active_grant_scope_ids,
          '{}'::text[]                                          as deleted_grant_scope_ids,
          jsonb '[]'                                            as deleted_scope_details
        from app_token_project
@@ -584,9 +584,6 @@ with token_permissions as (
          on app_token_permission_project.private_id = app_token_permission_grant.permission_id
       where app_token_project.public_id = @app_token_id
    group by app_token_permission_project.private_id,
-            app_token_permission_project.description,
-            app_token_permission_project.grant_this_scope,
-            app_token_project.scope_id,
             app_token_project.public_id
 )
    select app_token_project.public_id,

--- a/internal/apptoken/query.go
+++ b/internal/apptoken/query.go
@@ -380,22 +380,6 @@ left join iam_scope_project
              app_token_org.public_id;
     `
 
-	// TODO: This will be properly implemented with the Create method
-	// getAppTokenByIdQuery retrieves an AppToken by its public ID
-	getAppTokenByIdQuery = `
-	 select public_id, scope_id
-	   from app_token_global
-	  where public_id = $1
-	  union all
-	 select public_id, scope_id
-	   from app_token_org
-	  where public_id = $1
-	  union all
-	 select public_id, scope_id
-	   from app_token_project
-	  where public_id = $1
-	`
-
 	// estimateCountAppTokens estimates the total number of app tokens in the three app token tables
 	estimateCountAppTokens = `
    select sum(reltuples::bigint) as estimate 

--- a/internal/apptoken/query.go
+++ b/internal/apptoken/query.go
@@ -402,4 +402,9 @@ left join iam_scope_project
      from pg_class 
     where oid in ('app_token_global'::regclass, 'app_token_org'::regclass, 'app_token_project'::regclass)
 `
+
+	scopeIdFromAppTokenIdQuery = `
+    select scope_id
+      from app_token
+     where public_id = @public_id;`
 )

--- a/internal/apptoken/query.go
+++ b/internal/apptoken/query.go
@@ -390,7 +390,8 @@ left join iam_scope_project
 	scopeIdFromAppTokenIdQuery = `
     select scope_id
       from app_token
-     where public_id = @public_id;
+     where public_id = @public_id
+     limit 1;
 `
 
 	getAppTokenGlobalQuery = `

--- a/internal/apptoken/query.go
+++ b/internal/apptoken/query.go
@@ -395,7 +395,26 @@ left join iam_scope_project
 `
 
 	getAppTokenGlobalQuery = `
-with token_permissions as (
+with scope_hst as (
+   select iam_scope_hst.public_id       as scope_id,
+          upper(valid_range)::timestamp as delete_time
+     from iam_scope_hst
+left join app_token_permission_global
+       on app_token_permission_global.app_token_id = @app_token_id
+left join app_token_permission_global_individual_org_grant_scope org_grants
+       on app_token_permission_global.private_id = org_grants.permission_id
+      and org_grants.scope_id = iam_scope_hst.public_id
+left join app_token_permission_global_individual_project_grant_scope project_grants
+       on app_token_permission_global.private_id = project_grants.permission_id
+      and project_grants.scope_id = iam_scope_hst.public_id
+left join iam_scope org_scope
+       on org_grants.scope_id = org_scope.public_id
+left join iam_scope project_scope
+       on project_grants.scope_id = project_scope.public_id
+    where iam_scope_hst.public_id = coalesce(org_grants.scope_id, project_grants.scope_id)
+  and not upper_inf(valid_range)
+ order by upper(valid_range) desc
+), token_permissions as (
   select app_token_permission_global.private_id                         as permission_id,
          app_token_permission_global.description                        as description,
          app_token_permission_global.grant_this_scope                   as grant_this_scope,
@@ -418,17 +437,10 @@ with token_permissions as (
          -- deleted_scope_details -> details about deleted scopes
          jsonb_agg(distinct 
            jsonb_build_object(
-             'scope_id', coalesce(org_grants.scope_id, project_grants.scope_id),
-             'delete_time', (
-               select upper(valid_range) as delete_time
-                 from iam_scope_hst
-                where public_id = coalesce(org_grants.scope_id, project_grants.scope_id)
-                order by upper(valid_range) desc
-                limit 1
-             )
+             'scope_id',    scope_hst.scope_id,
+             'delete_time', scope_hst.delete_time 
            )
-         ) filter (where (org_grants.scope_id is not null and org_scope.public_id is null) or 
-                         (project_grants.scope_id is not null and project_scope.public_id is null)) 
+         ) filter (where scope_hst.scope_id is not null and scope_hst.delete_time is not null)
            as deleted_scope_details
        from app_token_global
   left join app_token_permission_global
@@ -443,11 +455,11 @@ with token_permissions as (
          on project_grants.scope_id = project_scope.public_id
   left join app_token_permission_grant
          on app_token_permission_global.private_id = app_token_permission_grant.permission_id
+  left join scope_hst
+         on org_grants.scope_id = scope_hst.scope_id
+         or project_grants.scope_id = scope_hst.scope_id
       where app_token_global.public_id = @app_token_id
    group by app_token_permission_global.private_id,
-            app_token_permission_global.description,
-            app_token_permission_global.grant_this_scope,
-            app_token_permission_global.grant_scope,
             app_token_global.public_id
 )
    select app_token_global.public_id,

--- a/internal/apptoken/query.go
+++ b/internal/apptoken/query.go
@@ -396,8 +396,8 @@ left join iam_scope_project
 
 	getAppTokenGlobalQuery = `
 with scope_hst as (
-   select iam_scope_hst.public_id       as scope_id,
-          upper(valid_range)::timestamp as delete_time
+   select iam_scope_hst.public_id                     as scope_id,
+          upper(iam_scope_hst.valid_range)::timestamp as delete_time
      from iam_scope_hst
 left join app_token_permission_global
        on app_token_permission_global.app_token_id = @app_token_id
@@ -412,8 +412,8 @@ left join iam_scope org_scope
 left join iam_scope project_scope
        on project_grants.scope_id = project_scope.public_id
     where iam_scope_hst.public_id = coalesce(org_grants.scope_id, project_grants.scope_id)
-  and not upper_inf(valid_range)
- order by upper(valid_range) desc
+  and not upper_inf(iam_scope_hst.valid_range)
+ order by upper(iam_scope_hst.valid_range) desc
 ), token_permissions as (
   select app_token_permission_global.private_id                         as permission_id,
          app_token_permission_global.description                        as description,
@@ -496,7 +496,21 @@ left join app_token_cipher
 	`
 
 	getAppTokenOrgQuery = `
-with token_permissions as (
+with scope_hst as (
+   select iam_scope_hst.public_id                     as scope_id,
+          upper(iam_scope_hst.valid_range)::timestamp as delete_time
+     from iam_scope_hst
+left join app_token_permission_org
+       on app_token_permission_org.app_token_id = @app_token_id
+left join app_token_permission_org_individual_grant_scope project_grants
+       on app_token_permission_org.private_id = project_grants.permission_id
+      and project_grants.scope_id = iam_scope_hst.public_id
+left join iam_scope project_scope
+       on project_grants.scope_id = project_scope.public_id
+    where iam_scope_hst.public_id = project_grants.scope_id
+  and not upper_inf(iam_scope_hst.valid_range)
+ order by upper(iam_scope_hst.valid_range) desc
+), token_permissions as (
   select app_token_permission_org.private_id                            as permission_id,
          app_token_permission_org.description                           as description,
          app_token_permission_org.grant_this_scope                      as grant_this_scope,
@@ -517,18 +531,11 @@ with token_permissions as (
          -- deleted_scope_details -> details about deleted scopes
          jsonb_agg(distinct
            jsonb_build_object(
-             'scope_id', project_grants.scope_id,
-             'delete_time', (
-               select upper(valid_range) as delete_time
-                 from iam_scope_hst
-                where public_id = project_grants.scope_id
-                order by upper(valid_range) desc
-                limit 1
-             )
+             'scope_id',    scope_hst.scope_id,
+             'delete_time', scope_hst.delete_time
            )
-         ) filter (
-           where project_grants.scope_id is not null and project_scope.public_id is null
-         ) as deleted_scope_details
+         ) filter (where scope_hst.scope_id is not null and scope_hst.delete_time is not null) 
+           as deleted_scope_details
        from app_token_org
   left join app_token_permission_org
          on app_token_org.public_id = app_token_permission_org.app_token_id
@@ -538,11 +545,10 @@ with token_permissions as (
          on project_grants.scope_id = project_scope.public_id
   left join app_token_permission_grant
          on app_token_permission_org.private_id = app_token_permission_grant.permission_id
+  left join scope_hst
+         on project_grants.scope_id = scope_hst.scope_id
       where app_token_org.public_id = @app_token_id
    group by app_token_permission_org.private_id,
-            app_token_permission_org.description,
-            app_token_permission_org.grant_this_scope,
-            app_token_permission_org.grant_scope,
             app_token_org.public_id
 )
    select app_token_org.public_id,

--- a/internal/apptoken/repository.go
+++ b/internal/apptoken/repository.go
@@ -420,35 +420,6 @@ func createAppTokenProject(ctx context.Context, token *AppToken) (*appTokenProje
 	return tokenToCreate, projectInserts, nil
 }
 
-// TODO: Implement additional fields in AppToken and complete this method
-// getAppTokenById retrieves an AppToken by its public ID
-func (r *Repository) getAppTokenById(ctx context.Context, id string) (*AppToken, error) {
-	const op = "apptoken.(Repository).getAppTokenById"
-	if id == "" {
-		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing id")
-	}
-
-	rows, err := r.reader.Query(ctx, getAppTokenByIdQuery, []any{id})
-	if err != nil {
-		return nil, errors.Wrap(ctx, err, op)
-	}
-	defer rows.Close()
-
-	var at AppToken
-	if rows.Next() {
-		if err := rows.Scan(&at.PublicId, &at.ScopeId); err != nil {
-			return nil, errors.Wrap(ctx, err, op)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, errors.Wrap(ctx, err, op)
-	}
-	if at.PublicId == "" {
-		return nil, errors.New(ctx, errors.NotFound, op, "app token not found")
-	}
-	return &at, nil
-}
-
 // processPermissionGrants validates grants and creates grant objects for insertion
 func processPermissionGrants(ctx context.Context, permId string, grants []string) ([]*appTokenPermissionGrant, error) {
 	const op = "apptoken.processPermissionGrants"

--- a/internal/apptoken/repository.go
+++ b/internal/apptoken/repository.go
@@ -16,8 +16,10 @@ import (
 	"github.com/hashicorp/boundary/internal/db"
 	"github.com/hashicorp/boundary/internal/db/timestamp"
 	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/boundary/internal/iam"
 	"github.com/hashicorp/boundary/internal/kms"
 	"github.com/hashicorp/boundary/internal/perms"
+	"github.com/hashicorp/boundary/internal/types/scope"
 )
 
 // Repository is the apptoken database repository
@@ -622,4 +624,89 @@ func (r *Repository) estimatedCount(ctx context.Context) (int, error) {
 		return 0, errors.Wrap(ctx, err, op, errors.WithMsg("failed to query total app tokens"))
 	}
 	return count, nil
+}
+
+// getAppTokenScopeType returns the [scope.Type] of an App Token by reading it from the base type app_token table.
+// Use this to get scope ID to determine which of the app token subtype tables to operate on.
+func getAppTokenScopeType(ctx context.Context, reader db.Reader, id string) (scope.Type, error) {
+	const op = "apptoken.getAppTokenScopeType"
+	if id == "" {
+		return scope.Unknown, errors.New(ctx, errors.InvalidParameter, op, "missing app token id")
+	}
+	if reader == nil {
+		return scope.Unknown, errors.New(ctx, errors.InvalidParameter, op, "missing db.Reader")
+	}
+	rows, err := reader.Query(ctx, scopeIdFromAppTokenIdQuery, []any{sql.Named("public_id", id)})
+	if err != nil {
+		return scope.Unknown, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("failed to lookup app token scope for id: %s", id)))
+	}
+	defer rows.Close()
+
+	var scopeIds []string
+	for rows.Next() {
+		if err := reader.ScanRows(ctx, rows, &scopeIds); err != nil {
+			return scope.Unknown, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("failed scan results from querying app token scope for id: %s", id)))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return scope.Unknown, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("unexpected error scanning results from querying app token scope for id: %s", id)))
+	}
+	if len(scopeIds) == 0 {
+		return scope.Unknown, errors.New(ctx, errors.RecordNotFound, op, fmt.Sprintf("app token %s not found", id))
+	}
+	if len(scopeIds) > 1 {
+		return scope.Unknown, errors.New(ctx, errors.MultipleRecords, op, fmt.Sprintf("expected 1 row but got: %d", len(scopeIds)))
+	}
+	scopeId := scopeIds[0]
+	switch {
+	case strings.HasPrefix(scopeId, globals.GlobalPrefix):
+		return scope.Global, nil
+	case strings.HasPrefix(scopeId, globals.OrgPrefix):
+		return scope.Org, nil
+	case strings.HasPrefix(scopeId, globals.ProjectPrefix):
+		return scope.Project, nil
+	default:
+		return scope.Unknown, fmt.Errorf("unknown scope type for app token %s", id)
+	}
+}
+
+// getAppTokenScope returns the scope of the app token
+func getAppTokenScope(ctx context.Context, r db.Reader, id string) (*iam.Scope, error) {
+	const op = "apptoken.getAppTokenScope"
+	if id == "" {
+		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing app token id")
+	}
+	if r == nil {
+		return nil, errors.New(ctx, errors.InvalidParameter, op, "missing db.Reader")
+	}
+	rows, err := r.Query(ctx, scopeIdFromAppTokenIdQuery, []any{sql.Named("public_id", id)})
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("failed to lookup app token scope for :%s", id)))
+	}
+	defer rows.Close()
+
+	var scopeIds []string
+	for rows.Next() {
+		if err := r.ScanRows(ctx, rows, &scopeIds); err != nil {
+			return nil, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("failed scan results from querying app token scope for :%s", id)))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(ctx, err, op, errors.WithMsg(fmt.Sprintf("unexpected error scanning results from querying app token scope for :%s", id)))
+	}
+
+	if len(scopeIds) == 0 {
+		return nil, errors.New(ctx, errors.RecordNotFound, op, fmt.Sprintf("app token %s not found", id))
+	}
+	if len(scopeIds) > 1 {
+		return nil, errors.New(ctx, errors.MultipleRecords, op, fmt.Sprintf("expected 1 row but got: %d", len(scopeIds)))
+	}
+
+	scp := iam.AllocScope()
+	scp.PublicId = scopeIds[0]
+	err = r.LookupByPublicId(ctx, &scp)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, op, errors.WithMsg("failed to lookup app token scope"))
+	}
+	return &scp, nil
 }

--- a/internal/apptoken/repository.go
+++ b/internal/apptoken/repository.go
@@ -203,7 +203,9 @@ func createAppTokenGlobal(ctx context.Context, token *AppToken) (*appTokenGlobal
 		}
 		permissionGrantInserts = append(permissionGrantInserts, grantInserts...)
 
-		trimmedScopes := slices.DeleteFunc(perm.GrantedScopes, func(s string) bool {
+		// Create a copy of GrantedScopes before filtering to avoid mutating it
+		grantedScopes := slices.Clone(perm.GrantedScopes)
+		trimmedScopes := slices.DeleteFunc(grantedScopes, func(s string) bool {
 			return s == globals.GrantScopeThis ||
 				s == globals.GrantScopeChildren ||
 				s == globals.GrantScopeDescendants ||
@@ -315,8 +317,11 @@ func createAppTokenOrg(ctx context.Context, token *AppToken) (*appTokenOrg, []in
 		}
 		permissionGrantInserts = append(permissionGrantInserts, grantInserts...)
 
+		// Create a copy of GrantedScopes before filtering to avoid mutating it
+		grantedScopes := slices.Clone(perm.GrantedScopes)
+
 		// remove GrantScopeThis and GrantScopeChildren from perm.GrantedScopes as they've already been processed
-		trimmedScopes := slices.DeleteFunc(perm.GrantedScopes, func(s string) bool {
+		trimmedScopes := slices.DeleteFunc(grantedScopes, func(s string) bool {
 			return s == globals.GrantScopeThis || s == globals.GrantScopeChildren || s == token.GetScopeId()
 		})
 

--- a/internal/apptoken/repository.go
+++ b/internal/apptoken/repository.go
@@ -764,13 +764,6 @@ func (r *Repository) DeleteAppToken(ctx context.Context, publicId string) (int, 
 		return 0, errors.New(ctx, errors.InvalidParameter, op, "missing public ID")
 	}
 
-	// eventually change this to a lookup to confirm existence before delete
-	tokenToDelete := &appToken{
-		AppToken: &store.AppToken{
-			PublicId: publicId,
-		},
-	}
-
 	var rowsDeleted int
 	var err error
 	_, err = r.writer.DoTx(
@@ -778,9 +771,19 @@ func (r *Repository) DeleteAppToken(ctx context.Context, publicId string) (int, 
 		db.StdRetryCnt,
 		db.ExpBackoff{},
 		func(_ db.Reader, w db.Writer) error {
+			// confirm existence before delete
+			_, err := getAppTokenScopeId(ctx, r.reader, publicId)
+			if err != nil {
+				return errors.Wrap(ctx, err, op)
+			}
+
 			rowsDeleted, err = w.Delete(
 				ctx,
-				tokenToDelete,
+				&appToken{
+					AppToken: &store.AppToken{
+						PublicId: publicId,
+					},
+				},
 			)
 			if err != nil {
 				return errors.Wrap(ctx, err, op)

--- a/internal/apptoken/repository.go
+++ b/internal/apptoken/repository.go
@@ -143,7 +143,7 @@ func (r *Repository) LookupAppToken(ctx context.Context, id string, opt ...Optio
 				return errors.Wrap(ctx, err, op)
 			}
 			if res.publicId == "" {
-				return errors.New(ctx, errors.NotFound, op, "app token not found")
+				return errors.New(ctx, errors.RecordNotFound, op, "app token not found")
 			}
 
 			// Unpack permissions JSON from query results

--- a/internal/apptoken/repository_test.go
+++ b/internal/apptoken/repository_test.go
@@ -1054,6 +1054,13 @@ func TestRepository_LookupAppToken(t *testing.T) {
 			assert.WithinDuration(want.ExpirationTime.AsTime(), got.ExpirationTime.AsTime(), time.Second)
 		})
 	}
+
+	// Lookup a random token ID and assert not found error
+	t.Run("no token found", func(t *testing.T) {
+		token, err := repo.LookupAppToken(ctx, "appt_12345")
+		assert.NoError(t, err)
+		assert.Nil(t, token)
+	})
 }
 
 func TestRepository_queryAppTokens(t *testing.T) {

--- a/internal/apptoken/repository_test.go
+++ b/internal/apptoken/repository_test.go
@@ -168,14 +168,14 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list", "type=session;actions=list"},
-						GrantedScopes: []string{"this", "descendants"},
+						GrantedScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
 				},
 			},
 			wantPerms: []testPermission{
 				{
 					GrantThis:   true,
-					GrantScope:  "descendants",
+					GrantScope:  globals.GrantScopeDescendants,
 					Description: "test",
 					Grants:      []string{"type=host-catalog;actions=list", "type=session;actions=list"},
 					Scopes:      []string{},
@@ -192,26 +192,26 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list", "type=session;actions=list"},
-						GrantedScopes: []string{"this", "descendants"},
+						GrantedScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
 					{
 						Label:         "test-2",
 						Grants:        []string{"type=target;actions=list"},
-						GrantedScopes: []string{"children"},
+						GrantedScopes: []string{globals.GrantScopeChildren},
 					},
 				},
 			},
 			wantErr: false,
 			wantPerms: []testPermission{
 				{
-					GrantScope:  "descendants",
+					GrantScope:  globals.GrantScopeDescendants,
 					GrantThis:   true,
 					Description: "test",
 					Grants:      []string{"type=host-catalog;actions=list", "type=session;actions=list"},
 					Scopes:      []string{},
 				},
 				{
-					GrantScope:  "children",
+					GrantScope:  globals.GrantScopeChildren,
 					GrantThis:   false,
 					Description: "test-2",
 					Grants:      []string{"type=target;actions=list"},
@@ -252,7 +252,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list", "type=session;actions=list"},
-						GrantedScopes: []string{"this", proj.GetPublicId()},
+						GrantedScopes: []string{globals.GrantScopeThis, proj.GetPublicId()},
 					},
 				},
 			},
@@ -281,22 +281,22 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test2",
 						Grants:        []string{"type=target;actions=list"},
-						GrantedScopes: []string{"this", proj.GetPublicId(), proj2.GetPublicId()},
+						GrantedScopes: []string{globals.GrantScopeThis, proj.GetPublicId(), proj2.GetPublicId()},
 					},
 					{
 						Label:         "test3",
 						Grants:        []string{"type=session;actions=list"},
-						GrantedScopes: []string{"this", proj2.GetPublicId(), "children"},
+						GrantedScopes: []string{globals.GrantScopeThis, proj2.GetPublicId(), globals.GrantScopeChildren},
 					},
 					{
 						Label:         "test4",
 						Grants:        []string{"type=role;actions=list", "type=user;actions=list"},
-						GrantedScopes: []string{"descendants"},
+						GrantedScopes: []string{globals.GrantScopeDescendants},
 					},
 					{
 						Label:         "test5",
 						Grants:        []string{"type=group;actions=list", "type=scope;actions=list"},
-						GrantedScopes: []string{"this", org2.GetPublicId()},
+						GrantedScopes: []string{globals.GrantScopeThis, org2.GetPublicId()},
 					},
 				},
 			},
@@ -317,14 +317,14 @@ func TestRepository_CreateAppToken(t *testing.T) {
 				},
 				{
 					Description: "test3",
-					GrantScope:  "children",
+					GrantScope:  globals.GrantScopeChildren,
 					GrantThis:   true,
 					Grants:      []string{"type=session;actions=list"},
 					Scopes:      []string{proj2.GetPublicId()},
 				},
 				{
 					Description: "test4",
-					GrantScope:  "descendants",
+					GrantScope:  globals.GrantScopeDescendants,
 					GrantThis:   false,
 					Grants:      []string{"type=role;actions=list", "type=user;actions=list"},
 					Scopes:      []string{},
@@ -348,7 +348,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list", "type=session;actions=list"},
-						GrantedScopes: []string{"this", org.GetPublicId(), proj.GetPublicId()},
+						GrantedScopes: []string{globals.GrantScopeThis, org.GetPublicId(), proj.GetPublicId()},
 					},
 				},
 			},
@@ -381,14 +381,14 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list", "type=session;actions=list"},
-						GrantedScopes: []string{"this", "children"},
+						GrantedScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
 				},
 			},
 			wantPerms: []testPermission{
 				{
 					GrantThis:   true,
-					GrantScope:  "children",
+					GrantScope:  globals.GrantScopeChildren,
 					Description: "test",
 					Grants:      []string{"type=host-catalog;actions=list", "type=session;actions=list"},
 					Scopes:      []string{},
@@ -405,26 +405,26 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list", "type=session;actions=list"},
-						GrantedScopes: []string{"this", "children"},
+						GrantedScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
 					{
 						Label:         "test-2",
 						Grants:        []string{"type=target;actions=list"},
-						GrantedScopes: []string{"children"},
+						GrantedScopes: []string{globals.GrantScopeChildren},
 					},
 				},
 			},
 			wantErr: false,
 			wantPerms: []testPermission{
 				{
-					GrantScope:  "children",
+					GrantScope:  globals.GrantScopeChildren,
 					GrantThis:   true,
 					Description: "test",
 					Grants:      []string{"type=host-catalog;actions=list", "type=session;actions=list"},
 					Scopes:      []string{},
 				},
 				{
-					GrantScope:  "children",
+					GrantScope:  globals.GrantScopeChildren,
 					GrantThis:   false,
 					Description: "test-2",
 					Grants:      []string{"type=target;actions=list"},
@@ -465,7 +465,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list", "type=session;actions=list"},
-						GrantedScopes: []string{"this", proj.GetPublicId()},
+						GrantedScopes: []string{globals.GrantScopeThis, proj.GetPublicId()},
 					},
 				},
 			},
@@ -489,24 +489,24 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list"},
-						GrantedScopes: []string{"children"},
+						GrantedScopes: []string{globals.GrantScopeChildren},
 					},
 					{
 						Label:         "test2",
 						Grants:        []string{"type=target;actions=list"},
-						GrantedScopes: []string{"this", proj.GetPublicId()},
+						GrantedScopes: []string{globals.GrantScopeThis, proj.GetPublicId()},
 					},
 					{
 						Label:         "test3",
 						Grants:        []string{"type=session;actions=list", "type=role;actions=list"},
-						GrantedScopes: []string{"this", "children"},
+						GrantedScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren},
 					},
 				},
 			},
 			wantPerms: []testPermission{
 				{
 					GrantThis:   false,
-					GrantScope:  "children",
+					GrantScope:  globals.GrantScopeChildren,
 					Description: "test",
 					Grants:      []string{"type=host-catalog;actions=list"},
 					Scopes:      []string{},
@@ -520,7 +520,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 				},
 				{
 					GrantThis:   true,
-					GrantScope:  "children",
+					GrantScope:  globals.GrantScopeChildren,
 					Description: "test3",
 					Grants:      []string{"type=session;actions=list", "type=role;actions=list"},
 					Scopes:      []string{},
@@ -546,7 +546,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list", "type=session;actions=list"},
-						GrantedScopes: []string{"this", proj.GetPublicId()},
+						GrantedScopes: []string{globals.GrantScopeThis, proj.GetPublicId()},
 					},
 				},
 			},
@@ -568,7 +568,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list", "type=session;actions=list"},
-						GrantedScopes: []string{"this", proj.GetPublicId()},
+						GrantedScopes: []string{globals.GrantScopeThis, proj.GetPublicId()},
 					},
 					{
 						Label:         "test-2",
@@ -601,7 +601,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"oops_broken", "type=session;actions=list"},
-						GrantedScopes: []string{"this", "descendants"},
+						GrantedScopes: []string{globals.GrantScopeThis, globals.GrantScopeDescendants},
 					},
 				},
 			},
@@ -633,7 +633,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=session;actions=list"},
-						GrantedScopes: []string{"children", "descendants"},
+						GrantedScopes: []string{globals.GrantScopeChildren, globals.GrantScopeDescendants},
 					},
 				},
 			},
@@ -655,7 +655,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test2",
 						Grants:        []string{"type=target;actions=list"},
-						GrantedScopes: []string{"this", proj2.GetPublicId()},
+						GrantedScopes: []string{globals.GrantScopeThis, proj2.GetPublicId()},
 					},
 				},
 			},
@@ -689,7 +689,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list"},
-						GrantedScopes: []string{proj.GetPublicId(), "children"},
+						GrantedScopes: []string{proj.GetPublicId(), globals.GrantScopeChildren},
 					},
 				},
 			},
@@ -706,7 +706,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list"},
-						GrantedScopes: []string{"descendants"},
+						GrantedScopes: []string{globals.GrantScopeDescendants},
 					},
 				},
 			},
@@ -723,7 +723,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list"},
-						GrantedScopes: []string{proj.GetPublicId(), "children"},
+						GrantedScopes: []string{proj.GetPublicId(), globals.GrantScopeChildren},
 					},
 				},
 			},
@@ -740,7 +740,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list"},
-						GrantedScopes: []string{"descendants"},
+						GrantedScopes: []string{globals.GrantScopeDescendants},
 					},
 				},
 			},
@@ -757,7 +757,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list"},
-						GrantedScopes: []string{"children"},
+						GrantedScopes: []string{globals.GrantScopeChildren},
 					},
 				},
 			},
@@ -808,7 +808,7 @@ func TestRepository_CreateAppToken(t *testing.T) {
 					{
 						Label:         "test",
 						Grants:        []string{"type=host-catalog;actions=list", "type=host-catalog;actions=list"},
-						GrantedScopes: []string{"descendants"},
+						GrantedScopes: []string{globals.GrantScopeDescendants},
 					},
 				},
 			},

--- a/internal/apptoken/repository_test.go
+++ b/internal/apptoken/repository_test.go
@@ -856,10 +856,11 @@ func TestRepository_CreateAppToken(t *testing.T) {
 				return
 			}
 			assert.NoError(err)
-			assert.NotNil(at.PublicId)
+			assert.NotNil(at)
+			assert.NotEmpty(at.PublicId)
+			assert.NotEmpty(at.Token)
 			assert.NotNil(at.CreateTime)
 			assert.NotNil(at.ApproximateLastAccessTime)
-			assert.NotNil(at.Token)
 			assert.Equal(at.CreateTime, at.ApproximateLastAccessTime)
 			assert.GreaterOrEqual(at.ExpirationTime.AsTime().Unix(), at.CreateTime.AsTime().Unix())
 

--- a/internal/apptoken/repository_test.go
+++ b/internal/apptoken/repository_test.go
@@ -1808,51 +1808,49 @@ func TestRepository_DeleteAppToken(t *testing.T) {
 		assert.True(errors.IsNotFoundError(err))
 	})
 
-	// re-enable after Lookup is implemented
-	// t.Run("invalid-id", func(t *testing.T) {
-	// 	require := require.New(t)
-	// 	idToDelete := "invalid-id"
+	t.Run("invalid-id", func(t *testing.T) {
+		require := require.New(t)
+		idToDelete := "invalid-id"
 
-	// 	d, err := repo.DeleteAppToken(ctx, idToDelete)
-	// 	require.Equal(0, d)
-	// 	require.Error(err)
-	// })
+		d, err := repo.DeleteAppToken(ctx, idToDelete)
+		require.Equal(0, d)
+		require.Error(err)
+	})
 
-	// re-enable after Lookup is implemented
-	// t.Run("invalid-double-delete", func(t *testing.T) {
-	// 	assert, require := assert.New(t), require.New(t)
-	// 	at := &AppToken{
-	// 		ScopeId:         proj.PublicId,
-	// 		CreatedByUserId: u.PublicId,
-	// 		Permissions: []AppTokenPermission{
-	// 			{
-	// 				Label:         "test",
-	// 				Grants:        []string{"type=host-catalog;actions=list", "type=session;actions=list"},
-	// 				GrantedScopes: []string{"this"},
-	// 			},
-	// 		},
-	// 	}
-	// 	createdAt, err := repo.CreateAppToken(ctx, at)
-	// 	require.NoError(err)
-	// 	require.NotNil(createdAt)
-	// 	idToDelete := createdAt.PublicId
+	t.Run("invalid-double-delete", func(t *testing.T) {
+		assert, require := assert.New(t), require.New(t)
+		at := &AppToken{
+			ScopeId:         proj.PublicId,
+			CreatedByUserId: u.PublicId,
+			Permissions: []AppTokenPermission{
+				{
+					Label:         "test",
+					Grants:        []string{"type=host-catalog;actions=list", "type=session;actions=list"},
+					GrantedScopes: []string{"this"},
+				},
+			},
+		}
+		createdAt, err := repo.CreateAppToken(ctx, at)
+		require.NoError(err)
+		require.NotNil(createdAt)
+		idToDelete := createdAt.PublicId
 
-	// 	d, err := repo.DeleteAppToken(ctx, idToDelete)
-	// 	require.Equal(1, d)
-	// 	assert.NoError(err)
+		d, err := repo.DeleteAppToken(ctx, idToDelete)
+		require.Equal(1, d)
+		assert.NoError(err)
 
-	// 	// verify it's gone
-	// 	atCheck := allocProjectAppToken()
-	// 	atCheck.PublicId = idToDelete
-	// 	err = repo.reader.LookupByPublicId(ctx, &atCheck)
-	// 	assert.Error(err)
-	// 	assert.True(errors.IsNotFoundError(err))
+		// verify it's gone
+		atCheck := allocProjectAppToken()
+		atCheck.PublicId = idToDelete
+		err = repo.reader.LookupByPublicId(ctx, &atCheck)
+		assert.Error(err)
+		assert.True(errors.IsNotFoundError(err))
 
-	// 	// try it again, it should fail
-	// 	d, err = repo.DeleteAppToken(ctx, idToDelete)
-	// 	require.Equal(0, d)
-	// 	require.Error(err)
-	// })
+		// try it again, it should fail
+		d, err = repo.DeleteAppToken(ctx, idToDelete)
+		require.Equal(0, d)
+		require.Error(err)
+	})
 }
 
 func TestRepository_listDeletedIds(t *testing.T) {

--- a/internal/apptoken/repository_test.go
+++ b/internal/apptoken/repository_test.go
@@ -889,6 +889,7 @@ type labeler interface {
 func (p AppTokenPermission) label() string {
 	return p.Label
 }
+
 func (p DeletedScope) label() string {
 	return p.ScopeId
 }
@@ -904,81 +905,26 @@ func TestRepository_LookupAppToken(t *testing.T) {
 	conn, _ := db.TestSetup(t, "postgres")
 	wrap := db.TestWrapper(t)
 	repo := TestRepo(t, conn, wrap)
+
+	// Lookup a random token ID and assert not found error
+	t.Run("no token found", func(t *testing.T) {
+		token, err := repo.LookupAppToken(ctx, "appt_12345")
+		assert.NoError(t, err)
+		assert.Nil(t, token)
+	})
+
+	// Test various scenarios for valid app tokens with different grant scopes and permissions
 	iamRepo := iam.TestRepo(t, conn, wrap)
 	u := iam.TestUser(t, iamRepo, globals.GlobalPrefix)
 
-	// TODO: Lookup a global token with deleted grant scopes
-	// t.Run("global token with deleted grant scopes", func(t *testing.T) {
-	// 	org1, proj1 := iam.TestScopes(t, iamRepo)
-	// 	org2, proj2 := iam.TestScopes(t, iamRepo)
+	org1, proj1a := iam.TestScopes(t, iamRepo)
+	proj1b := iam.TestProject(t, iamRepo, org1.PublicId)
+	org2, proj2 := iam.TestScopes(t, iamRepo)
 
-	// 	token := &AppToken{
-	// 		ScopeId:            globals.GlobalPrefix,
-	// 		CreatedByUserId:    u.PublicId,
-	// 		TimeToStaleSeconds: 100,
-	// 		ExpirationTime:     timestamp.New(time.Now().Add(time.Hour)),
-	// 		Permissions: []AppTokenPermission{
-	// 			{
-	// 				Label:         "test",
-	// 				Grants:        []string{"ids=*;type=scope;actions=list", "ids=*;type=group;actions=create"},
-	// 				GrantedScopes: []string{globals.GrantScopeThis, org1.PublicId, org2.PublicId, proj1.PublicId, proj2.PublicId},
-	// 			},
-	// 		},
-	// 	}
-	// 	wantToken := TestCreateAppToken(t, repo, token)
-
-	// 	orgsDeleted, err := iamRepo.DeleteScope(ctx, org1.PublicId)
-	// 	assert.NoError(t, err)
-	// 	assert.Equal(t, 1, orgsDeleted)
-	// 	projectsDeleted, err := iamRepo.DeleteScope(ctx, proj2.PublicId)
-	// 	assert.NoError(t, err)
-	// 	assert.Equal(t, 1, projectsDeleted)
-
-	// 	gotToken, err := repo.LookupAppToken(ctx, wantToken.PublicId)
-	// 	assert.NoError(t, err)
-	// })
-
-	// TODO: Lookup an org token with deleted grant scopes
-	// TODO: Lookup a project token with deleted grant scopes
-
-	// TODO: delete me!
-	// type testPermission struct {
-	// 	AppTokenPermission
-	// 	scopesToDelete []string
-	// }
-
-	// General tests for various token scopes & grant scope combinations
-
-	var org1, proj1a, proj1b, org2, proj2 *iam.Scope
-	shouldCreateScopes := func() {
-		if org1 == nil {
-			org1, proj1a = iam.TestScopes(t, iamRepo)
-			proj1b = iam.TestProject(t, iamRepo, org1.PublicId)
-		}
-		if proj1a == nil {
-			proj1a = iam.TestProject(t, iamRepo, org1.PublicId)
-		}
-		if proj1b == nil {
-			proj1b = iam.TestProject(t, iamRepo, org1.PublicId)
-		}
-		if org2 == nil {
-			org2, proj2 = iam.TestScopes(t, iamRepo)
-		}
-		if proj2 == nil {
-			proj2 = iam.TestProject(t, iamRepo, org2.PublicId)
-		}
-	}
-
-	shouldCreateScopes()
 	tests := []struct {
-		name      string
-		wantToken func() *AppToken
-
-		scopeId        string               // TODO: delete me!
-		expirationTime *timestamp.Timestamp // TODO: delete me!
-
-		tokenCreateFn  func(individualGrantScopesToKeep, individualGrantScopesToDelete []string) *AppToken
-		scopesToDelete map[string]struct{}
+		name           string
+		wantToken      func() *AppToken
+		scopesToDelete func() []string
 		wantErrMsg     string
 	}{
 		{
@@ -1017,28 +963,34 @@ func TestRepository_LookupAppToken(t *testing.T) {
 				}
 			},
 		},
-		// TODO: Uncomment me
-		// {
-		// 	name: "global token: multiple grants, children grant scope with individual project grant scopes",
-		// 	wantToken: func() *AppToken {
-		// 		return &AppToken{
-		// 			ScopeId:            globals.GlobalPrefix,
-		// 			CreatedByUserId:    u.PublicId,
-		// 			TimeToStaleSeconds: 10,
-		// 			ExpirationTime:     timestamp.New(time.Now().Add(time.Hour)),
-		// 			Permissions: []AppTokenPermission{
-		// 				{
-		// 					Label:         "test",
-		// 					Grants:        []string{"ids=*;type=alias;actions=create", "ids=*;type=group;actions=list"},
-		// 					GrantedScopes: []string{globals.GrantScopeThis, globals.GrantScopeChildren, proj1a.PublicId, proj2.PublicId},
-		// 				},
-		// 			},
-		// 		}
-		// 	},
-		// 	scopesToDelete: map[*string]struct{}{&proj2.PublicId: {}},
-		// },
 		{
-			name: "global token: multiple grants, descendants grant scope",
+			name: "global token: multiple permissions with individual org and project grant scopes",
+			wantToken: func() *AppToken {
+				return &AppToken{
+					ScopeId:            globals.GlobalPrefix,
+					CreatedByUserId:    u.PublicId,
+					TimeToStaleSeconds: 10,
+					ExpirationTime:     timestamp.New(time.Now().Add(time.Hour)),
+					Permissions: []AppTokenPermission{
+						{
+							Label:         "test perm 1",
+							Grants:        []string{"ids=*;type=alias;actions=create"},
+							GrantedScopes: []string{proj1a.PublicId, proj2.PublicId},
+						},
+						{
+							Label:         "test perm 2",
+							Grants:        []string{"ids=*;type=alias;actions=create"},
+							GrantedScopes: []string{org1.PublicId, proj2.PublicId},
+						},
+					},
+				}
+			},
+			scopesToDelete: func() []string {
+				return []string{proj2.PublicId}
+			},
+		},
+		{
+			name: "global token: multiple grants with descendants grant scope",
 			wantToken: func() *AppToken {
 				return &AppToken{
 					ScopeId:            globals.GlobalPrefix,
@@ -1072,24 +1024,12 @@ func TestRepository_LookupAppToken(t *testing.T) {
 					},
 				}
 			},
-			scopesToDelete: map[string]struct{}{org1.PublicId: {}, proj2.PublicId: {}},
-			// tokenCreateFn: func(individualGrantScopesToKeep, individualGrantScopesToDelete []string) *AppToken {
-			// 	return &AppToken{
-			// 	ScopeId:            globals.GlobalPrefix,
-			// 	CreatedByUserId:    u.PublicId,
-			// 	TimeToStaleSeconds: 100,
-			// 	ExpirationTime:     timestamp.New(time.Now().Add(time.Hour)),
-			// 	Permissions: []AppTokenPermission{
-			// 		{
-			// 			Label:         "test",
-			// 			Grants:        []string{"ids=*;type=scope;actions=list", "ids=*;type=group;actions=create"},
-			// 			GrantedScopes: []string{org1.PublicId, org2.PublicId, proj1a.PublicId, proj1b.PublicId, proj2.PublicId},
-			// 		},
-			// 	},
-			// }
+			scopesToDelete: func() []string {
+				return []string{proj2.PublicId, org1.PublicId}
+			},
 		},
 		{
-			name: "org token: multiple grants, individual project grant scopes",
+			name: "org token: multiple grants with individual project grant scopes",
 			wantToken: func() *AppToken {
 				return &AppToken{
 					ScopeId:            org1.PublicId,
@@ -1105,9 +1045,12 @@ func TestRepository_LookupAppToken(t *testing.T) {
 					},
 				}
 			},
+			scopesToDelete: func() []string {
+				return []string{proj1b.PublicId}
+			},
 		},
 		{
-			name: "org token: multiple grants, children grant scope",
+			name: "org token: multiple grants with children grant scope",
 			wantToken: func() *AppToken {
 				return &AppToken{
 					ScopeId:            org1.PublicId,
@@ -1145,6 +1088,34 @@ func TestRepository_LookupAppToken(t *testing.T) {
 						},
 					},
 				}
+			},
+		},
+		{
+			name: "org token: multiple permissions with a deleted scope from each",
+			wantToken: func() *AppToken {
+				proj3 := iam.TestProject(t, iamRepo, org1.PublicId)
+
+				return &AppToken{
+					ScopeId:            org1.PublicId,
+					CreatedByUserId:    u.PublicId,
+					TimeToStaleSeconds: 100,
+					ExpirationTime:     timestamp.New(time.Now().Add(time.Hour)),
+					Permissions: []AppTokenPermission{
+						{
+							Label:         "test perm 1",
+							Grants:        []string{"ids=*;type=user;actions=create"},
+							GrantedScopes: []string{proj1a.PublicId, proj3.PublicId},
+						},
+						{
+							Label:         "test perm 2",
+							Grants:        []string{"ids=*;type=group;actions=read"},
+							GrantedScopes: []string{proj1a.PublicId, proj1b.PublicId, proj3.PublicId},
+						},
+					},
+				}
+			},
+			scopesToDelete: func() []string {
+				return []string{proj1a.PublicId}
 			},
 		},
 		{
@@ -1194,58 +1165,37 @@ func TestRepository_LookupAppToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			// Re-create any scopes deleted in a prior test
-			// shouldCreateScopes()
-
 			// Create the token
-			// if len(tt.scopesToDelete) > 0 {
-			// 	for i := range tt.wantToken.Permissions {
-			// 		tt.wantToken.Permissions[i].GrantedScopes = append(tt.wantToken.Permissions[i].GrantedScopes, tt.scopesToDelete...)
-			// 	}
-			// }
-
 			wantToken := tt.wantToken()
 			want := TestCreateAppToken(t, repo, wantToken)
 
-			// Delete scopes (if applicable)
+			var scopesToDelete []string
+			if tt.scopesToDelete != nil {
+				scopesToDelete = tt.scopesToDelete()
+			}
 			deletedScopes := make(map[string]struct{})
-			// deleteScopes := func(scopesToDelete []string) {
-			// Add child project scopes if deleting an org
-			if _, ok := tt.scopesToDelete[org1.PublicId]; ok {
-				tt.scopesToDelete[proj1a.PublicId] = struct{}{}
-				tt.scopesToDelete[proj1b.PublicId] = struct{}{}
+
+			// If deleting an org, add its child project scopes
+			if slices.Contains(scopesToDelete, org1.PublicId) {
+				scopesToDelete = append(scopesToDelete, proj1a.PublicId, proj1b.PublicId)
 			}
-			if _, ok := tt.scopesToDelete[org2.PublicId]; ok {
-				tt.scopesToDelete[proj2.PublicId] = struct{}{}
+			if slices.Contains(scopesToDelete, org2.PublicId) {
+				scopesToDelete = append(scopesToDelete, proj2.PublicId)
 			}
+			slices.Sort(scopesToDelete)
 
-			for scopeId := range tt.scopesToDelete {
-
-				// if _, alreadyDeleted := deletedScopes[*scopeId]; alreadyDeleted {
-				// 	continue
-				// }
-
+			// Delete the scope referenced by the current App Token, and then re-create it so it can be used for the other tests
+			for _, scopeId := range scopesToDelete {
 				_, err := iamRepo.DeleteScope(ctx, scopeId)
-				assert.NoError(err)
-				deletedScopes[scopeId] = struct{}{}
-				// deletedScopes[scopeId] = struct{}{}
+				require.NoError(t, err)
 
-				// If the deleted scope is an org, also delete its projects to ensure the token's permissions are properly updated to reflect the deleted scopes
+				deletedScopes[scopeId] = struct{}{}
+
 				switch scopeId {
 				case org1.PublicId:
-					// org1, proj1a = iam.TestScopes(t, iamRepo)
 					org1 = iam.TestOrg(t, iamRepo)
-					// proj1b = iam.TestProject(t, iamRepo, org1.PublicId)
-
-					// tt.scopesToDelete[&proj1a.PublicId] = struct{}{}
-					// tt.scopesToDelete[&proj1b.PublicId] = struct{}{}
-
-					// deleteScopes([]string{proj1a.PublicId, proj1b.PublicId})
 				case org2.PublicId:
 					org2 = iam.TestOrg(t, iamRepo)
-
-					// tt.scopesToDelete[&proj2.PublicId] = struct{}{}
-					// org2, proj2 = iam.TestScopes(t, iamRepo)
 				case proj1a.PublicId:
 					proj1a = iam.TestProject(t, iamRepo, org1.PublicId)
 				case proj1b.PublicId:
@@ -1254,12 +1204,11 @@ func TestRepository_LookupAppToken(t *testing.T) {
 					proj2 = iam.TestProject(t, iamRepo, org2.PublicId)
 				}
 			}
-			// }
 
 			// Lookup the token
 			got, err := repo.LookupAppToken(ctx, want.PublicId)
-			assert.NoError(err)
-			assert.NotNil(got)
+			require.NoError(t, err)
+			require.NotNil(t, got)
 			assert.Equal(want.PublicId, got.PublicId)
 			assert.Equal(wantToken.ScopeId, got.ScopeId)
 			assert.Equal(wantToken.Name, got.Name)
@@ -1283,9 +1232,6 @@ func TestRepository_LookupAppToken(t *testing.T) {
 			for i := range wantToken.Permissions {
 				assert.Equal(wantToken.Permissions[i].Label, got.Permissions[i].Label)
 				assert.ElementsMatch(wantToken.Permissions[i].Grants, got.Permissions[i].Grants)
-
-				// slices.Sort(tt.wantToken.Permissions[i].GrantedScopes) // TODO: Unnecessary
-				// sortByLabel(tt.wantToken.Permissions[i].DeletedScopes)
 
 				wantGrantedScopes := make([]string, 0)
 
@@ -1326,60 +1272,9 @@ func TestRepository_LookupAppToken(t *testing.T) {
 					_, deleted := deletedScopes[ds.ScopeId]
 					assert.True(deleted, "unexpected deleted scope %s found in permission %s", ds.ScopeId, got.Permissions[i].Label)
 				}
-
-				// Remove any DeletedScopes from wantGrantScopes
-				// wantGrantScopes := tt.wantToken.Permissions[i].GrantedScopes
-				// for _, ds := range tt.wantToken.Permissions[i].DeletedScopes {
-				// idx := slices.Index(wantGrantScopes, ds.ScopeId)
-
-				// for scopeId := range tt.scopesToDelete {
-				//
-				// 	// Ensure each scope that we wanted to delete exists in []DeletedScopes and not in []GrantedScopes
-				// 	scopeDeleted := false
-				// 	for _, ds := range got.Permissions[i].DeletedScopes {
-				// 		if ds.ScopeId == scopeId {
-				// 			scopeDeleted = true
-				// 			break
-				// 		}
-				// 	}
-				// 	assert.True(scopeDeleted, "expected scope %s to be in DeletedScopes, but it was not", scopeId)
-
-				// 	idx := slices.Index(wantGrantScopes, scopeId)
-				// 	if idx != -1 {
-				// 		wantGrantScopes = slices.Delete(wantGrantScopes, idx, idx+1)
-
-				// 		// If the deleted scope is an org, also remove any project grant scopes for that org
-				// 		switch scopeId {
-				// 		case org1.PublicId:
-				// 			for _, ps := range []string{proj1a.PublicId, proj1b.PublicId} {
-				// 				idx := slices.Index(wantGrantScopes, ps)
-				// 				if idx != -1 {
-				// 					wantGrantScopes = slices.Delete(wantGrantScopes, idx, idx+1)
-				// 				}
-				// 			}
-				// 		case org2.PublicId:
-				// 			idx := slices.Index(wantGrantScopes, proj2.PublicId)
-				// 			if idx != -1 {
-				// 				wantGrantScopes = slices.Delete(wantGrantScopes, idx, idx+1)
-				// 			}
-				// 		}
-				// 	}
-				// }
-
-				// gotGrantScopes := got.Permissions[i].GrantedScopes
-				// assert.ElementsMatch(wantGrantScopes, gotGrantScopes)
-
-				// assert.Equal(tt.wantToken.Permissions[i].GrantedScopes, got.Permissions[i].GrantedScopes)
 			}
 		})
 	}
-
-	// Lookup a random token ID and assert not found error TODO: Hoist me!
-	t.Run("no token found", func(t *testing.T) {
-		token, err := repo.LookupAppToken(ctx, "appt_12345")
-		assert.NoError(t, err)
-		assert.Nil(t, token)
-	})
 }
 
 func TestRepository_queryAppTokens(t *testing.T) {

--- a/internal/apptoken/repository_token_grant.go
+++ b/internal/apptoken/repository_token_grant.go
@@ -69,11 +69,10 @@ func (r *Repository) GrantsForToken(ctx context.Context, tokenId string, res []r
 
 	opts := getOpts(opt...)
 
-	scope, err := getAppTokenScope(ctx, r.reader, tokenId)
+	scopeId, err := getAppTokenScopeId(ctx, r.reader, tokenId)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
-	scopeId := scope.GetPublicId()
 
 	// find the correct query to use
 	query, err := r.resolveAppTokenQuery(ctx, scopeId, res, reqScopeId, opts.withRecursive)

--- a/internal/apptoken/repository_token_grant.go
+++ b/internal/apptoken/repository_token_grant.go
@@ -69,14 +69,14 @@ func (r *Repository) GrantsForToken(ctx context.Context, tokenId string, res []r
 
 	opts := getOpts(opt...)
 
-	// get AppToken to get scope
-	appToken, err := r.getAppTokenById(ctx, tokenId)
+	scope, err := getAppTokenScope(ctx, r.reader, tokenId)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
+	scopeId := scope.GetPublicId()
 
 	// find the correct query to use
-	query, err := r.resolveAppTokenQuery(ctx, appToken.ScopeId, res, reqScopeId, opts.withRecursive)
+	query, err := r.resolveAppTokenQuery(ctx, scopeId, res, reqScopeId, opts.withRecursive)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, op)
 	}
@@ -135,7 +135,7 @@ func (r *Repository) GrantsForToken(ctx context.Context, tokenId string, res []r
 	for _, grant := range grants {
 		resp = append(resp, tempGrantTuple{
 			AppTokenId:            grant.AppTokenId,
-			AppTokenScopeId:       appToken.ScopeId,
+			AppTokenScopeId:       scopeId,
 			AppTokenParentScopeId: grant.AppTokenParentScopeId,
 			GrantScopeId:          grant.GrantScope,
 			Grant:                 strings.Join(grant.CanonicalGrants, ","),

--- a/internal/apptoken/repository_token_grant.go
+++ b/internal/apptoken/repository_token_grant.go
@@ -193,17 +193,21 @@ func (r *Repository) selectRecursiveQuery(ctx context.Context, isGlobal, isOrg, 
 	case isGlobal:
 		if slices.Equal(resourceAllowedIn, []scope.Type{scope.Global, scope.Org, scope.Project}) {
 			return grantsForGlobalTokenGlobalOrgProjectResourcesRecursiveQuery, nil
-		} else if slices.Equal(resourceAllowedIn, []scope.Type{scope.Global, scope.Org}) {
+		}
+		if slices.Equal(resourceAllowedIn, []scope.Type{scope.Global, scope.Org}) {
 			return grantsForGlobalTokenGlobalOrgResourcesRecursiveQuery, nil
-		} else if slices.Equal(resourceAllowedIn, []scope.Type{scope.Project}) {
+		}
+		if slices.Equal(resourceAllowedIn, []scope.Type{scope.Project}) {
 			return grantsForGlobalTokenProjectResourcesRecursiveQuery, nil
 		}
 	case isOrg:
 		if slices.Equal(resourceAllowedIn, []scope.Type{scope.Global, scope.Org, scope.Project}) {
 			return grantsForOrgTokenGlobalOrgProjectResourcesRecursiveQuery, nil
-		} else if slices.Equal(resourceAllowedIn, []scope.Type{scope.Global, scope.Org}) {
+		}
+		if slices.Equal(resourceAllowedIn, []scope.Type{scope.Global, scope.Org}) {
 			return grantsForOrgTokenGlobalOrgResourcesRecursiveQuery, nil
-		} else if slices.Equal(resourceAllowedIn, []scope.Type{scope.Project}) {
+		}
+		if slices.Equal(resourceAllowedIn, []scope.Type{scope.Project}) {
 			return grantsForOrgTokenProjectResourcesRecursiveQuery, nil
 		}
 	case isProject:

--- a/internal/apptoken/testing.go
+++ b/internal/apptoken/testing.go
@@ -79,7 +79,6 @@ func TestCreateAppToken(t *testing.T, repo *Repository, token *AppToken) *AppTok
 	return createdToken
 }
 
-// these will eventually expand to cover org and proj
 func testCheckPermission(t *testing.T, repo *Repository, appTokenId string, scopeId string, wantPerms []testPermission) error {
 	assert := assert.New(t)
 

--- a/internal/apptoken/testing.go
+++ b/internal/apptoken/testing.go
@@ -57,6 +57,10 @@ func TestRepo(t testing.TB, conn *db.DB, rootWrapper wrapping.Wrapper, opt ...Op
 func TestCreateAppToken(t *testing.T, repo *Repository, token *AppToken) *AppToken {
 	t.Helper()
 
+	if token == nil {
+		return nil
+	}
+
 	// Assign a name and description if not set
 	if token.Name == "" {
 		token.Name = fmt.Sprintf("Test App Token %s", time.Now().Format("0405.000000"))

--- a/internal/apptoken/testing.go
+++ b/internal/apptoken/testing.go
@@ -57,9 +57,9 @@ func TestRepo(t testing.TB, conn *db.DB, rootWrapper wrapping.Wrapper, opt ...Op
 func TestCreateAppToken(t *testing.T, repo *Repository, token *AppToken) *AppToken {
 	t.Helper()
 
-	if token == nil {
-		return nil
-	}
+	require := require.New(t)
+	require.NotNil(repo)
+	require.NotNil(token)
 
 	// Assign a name and description if not set
 	if token.Name == "" {
@@ -75,7 +75,7 @@ func TestCreateAppToken(t *testing.T, repo *Repository, token *AppToken) *AppTok
 	}
 
 	createdToken, err := repo.CreateAppToken(t.Context(), token)
-	require.NoError(t, err)
+	require.NoError(err)
 	return createdToken
 }
 

--- a/internal/iam/query.go
+++ b/internal/iam/query.go
@@ -581,9 +581,9 @@ const (
 	`
 
 	scopeIdFromRoleIdQuery = `
-	   select scope_id
-		 from iam_role
-		where public_id = @public_id;`
+    select scope_id
+      from iam_role
+     where public_id = @public_id;`
 
 	listRolesQuery = `
 with

--- a/internal/iam/role.go
+++ b/internal/iam/role.go
@@ -492,7 +492,6 @@ type projectRole struct {
 
 func (p *projectRole) removeGrantScope() {
 	// no-op since hierarchical isn't supported by project roles
-	return
 }
 
 func (p *projectRole) setGrantScope(ctx context.Context, specialGrant string) error {


### PR DESCRIPTION
ICU-17931

## Description
- Global, Org, and Project queries to fetch core App Token data alongside its permission data
- `LookupAppToken()` repository method utilizes these queries (based on token subtype) to fetch full app token information, including token cipher and permission data

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
