### PR TITLE
fix(cli): Remove connect inactivity timeout defaults expect for darwin+rdp

### DIFF
--- a/api/proxy/option_test.go
+++ b/api/proxy/option_test.go
@@ -108,4 +108,13 @@ func Test_GetOpts(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(client, opts.withApiClient)
 	})
+	t.Run("WithInactivityTimeout", func(t *testing.T) {
+		assert := assert.New(t)
+		opts, err := getOpts()
+		require.NoError(t, err)
+		assert.Empty(opts.withInactivityTimeout)
+		opts, err = getOpts(WithInactivityTimeout(3 * time.Millisecond))
+		require.NoError(t, err)
+		assert.Equal(3*time.Millisecond, opts.withInactivityTimeout)
+	})
 }

--- a/internal/cmd/commands/connect/connect_darwin.go
+++ b/internal/cmd/commands/connect/connect_darwin.go
@@ -1,0 +1,10 @@
+// Copyright IBM Corp. 2020, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+package connect
+
+import "time"
+
+func init() {
+	rdpDefaultTimeout = 30 * time.Second
+}


### PR DESCRIPTION
## Description

After a few complaints around the timeouts triggering, we have decided to move to a less aggressive approach. This PR:
- Removes the 10 minute timeout on sessions before the first connect. Note this was also causing timeouts even if the user explicitly sets `-1`
- Removes all the default timeout values, except for `boundary connect rdp` when using a Mac client
- Increases the default mac+rdp timeout from 5 seconds to 30 seconds
  - For RDP connections the behavior seen is an initial connection is created, this is expected to fail. Then before the second connection is made the user needs to accept a certificate. The default 5 second timeout begins after the first connection fails leaving the user 5 seconds to accept the certificate.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
