### PR TITLE
test(bats): Debug for flaky delete target test

### DIFF
--- a/internal/tests/cli/boundary/target.bats
+++ b/internal/tests/cli/boundary/target.bats
@@ -111,6 +111,7 @@ load _target_host_sources
 @test "boundary/target: default user can delete target" {
   local id=$(target_id_from_name $DEFAULT_P_ID $TGT_NAME)
   run delete_target $id
+  echo "output: $output"
   run has_status_code "$output" "204"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Description
Observed another flake in a bats test
```
target.bats
   ...
   boundary/target: default user can delete target222/319 ✗ boundary/target: default user can delete target
   (in test file boundary/target.bats, line 117)
     `[ "$status" -eq 0 ]' failed
   boundary/target: default user can not read deleted target223/319 ✗ boundary/target: default user can not read deleted target
   (in test file boundary/target.bats, line 123)
     `[ "$status" -eq 1 ]' failed
```

There's not enough information to determine what went wrong. This PR adds some debug.

### Testing
Example log when forcing a failure
```
✗ boundary/target: default user can delete target
   (in test file boundary/target.bats, line 116)
     `[ "$status" -eq 0 ]' failed
   output: {"status_code":204}
```

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
