### PR TITLE
test(bats): Fix flaky connect helper... AGAIN

### DIFF
--- a/internal/tests/cli/boundary/_connect.bash
+++ b/internal/tests/cli/boundary/_connect.bash
@@ -4,18 +4,48 @@
 function connect_nc() {
   local id=$1
   # Note: When this command returns, the session immediately goes into a "canceling" state
-  echo "SSH-2.0-Test" | boundary connect -exec nc -target-id $id -- -v -w 5 {{boundary.ip}} {{boundary.port}}
+  # Capture output and check for success message since nc may return non-zero on pipe close
+  local output
+  output=$(echo "SSH-2.0-Test" | boundary connect -exec nc -target-id $id -- -v -w 5 {{boundary.ip}} {{boundary.port}} 2>&1)
+  local status=$?
+  echo "$output"
+
+  # If connection succeeded, return 0 regardless of nc's exit status
+  if echo "$output" | grep -q "succeeded"; then
+    return 0
+  fi
+  return $status
 }
 
 function connect_alias() {
   local alias=$1
   # Note: When this command returns, the session immediately goes into a "canceling" state
-  echo "SSH-2.0-Test" | boundary connect $alias -exec nc -- -v -w 5 {{boundary.ip}} {{boundary.port}}
+  # Capture output and check for success message since nc may return non-zero on pipe close
+  local output
+  output=$(echo "SSH-2.0-Test" | boundary connect $alias -exec nc -- -v -w 5 {{boundary.ip}} {{boundary.port}} 2>&1)
+  local status=$?
+  echo "$output"
+
+  # If connection succeeded, return 0 regardless of nc's exit status
+  if echo "$output" | grep -q "succeeded"; then
+    return 0
+  fi
+  return $status
 }
 
 function connect_alias_with_host_id() {
   local alias=$1
   local hostid=$2
   # Note: When this command returns, the session immediately goes into a "canceling" state
-  echo "SSH-2.0-Test" | boundary connect $alias -host-id $hostid -exec nc -- -v -w 5 {{boundary.ip}} {{boundary.port}}
+  # Capture output and check for success message since nc may return non-zero on pipe close
+  local output
+  output=$(echo "SSH-2.0-Test" | boundary connect $alias -host-id $hostid -exec nc -- -v -w 5 {{boundary.ip}} {{boundary.port}} 2>&1)
+  local status=$?
+  echo "$output"
+
+  # If connection succeeded, return 0 regardless of nc's exit status
+  if echo "$output" | grep -q "succeeded"; then
+    return 0
+  fi
+  return $status
 }


### PR DESCRIPTION
## Description
Just after https://github.com/hashicorp/boundary/pull/6535 was merged, we saw this test fail again...

```
boundary/target/connect: admin user can connect to default target249/361 ✗ boundary/target/connect: admin user can connect to default target
   (in test file boundary/target.bats, line 19)
     `[ "$status" -eq 0 ]' failed
   connecting:
   Proxy listening information:
     Address:             127.0.0.1
     Connection Limit:    -1
     Expiration:          Fri, 10 Apr 2026 00:56:34 UTC
     Port:                37869
     Protocol:            tcp
     Session ID:          s_JHH2tsP6LC
   Connection to 127.0.0.1 37869 port [tcp/*] succeeded!
   status: 255
```

Now, we're going to check if we see the `succeeded` line and make it pass if it does.

According to AI
> The exit status 255 typically indicates:
> 
> SIGPIPE or broken pipe: When echo closes the pipe and nc tries to read from it
Connection closed: After the timeout, when the connection is terminated
General error: Some versions of nc use 255 as a generic error code for various non-fatal issues
The key insight is that the connection itself succeeds (as evidenced by the "Connection succeeded!" message), but nc still returns a non-zero exit status because of how the pipe closes or the timeout behavior.
> 
> This is a common issue with netcat in test scenarios where you're just verifying connectivity rather than maintaining a long-lived connection. The fix checks for the success message in the output rather than relying solely on the exit code, which is the correct approach for this use case.

https://hashicorp.atlassian.net/browse/ICU-18860

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
