### PR TITLE
chore(e2e): Remove aws_ssh_keypair requirement

### DIFF
--- a/enos/ci/hcp-resources/main.tf
+++ b/enos/ci/hcp-resources/main.tf
@@ -27,11 +27,22 @@ provider "aws" {
   region = var.aws_region
 }
 
+locals {
+  aws_ssh_private_key_path = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
+}
+
+module "generate_ssh_key" {
+  source = "../../modules/aws_ssh_keypair"
+
+  local_key_path         = local.aws_ssh_private_key_path
+  local_aws_keypair_name = var.aws_ssh_keypair_name != null ? var.aws_ssh_keypair_name : null
+}
+
 provider "enos" {
   transport = {
     ssh = {
       user             = "ubuntu"
-      private_key_path = abspath(var.aws_ssh_private_key_path)
+      private_key_path = module.generate_ssh_key.private_key_path
     }
   }
 }
@@ -85,28 +96,29 @@ module "base_infra" {
 }
 
 module "worker" {
-  depends_on = [module.base_infra]
+  depends_on = [module.base_infra, module.generate_ssh_key]
   source     = "../../modules/aws_boundary"
 
-  controller_count        = 0
-  worker_count            = var.worker_count
-  db_create               = false
-  aws_region              = var.aws_region
-  hcp_boundary_cluster_id = var.hcp_boundary_cluster_id
-  ssh_aws_keypair         = var.aws_ssh_keypair_name
-  boundary_license        = module.license.license
-  kms_key_arn             = module.base_infra.kms_key_arn
-  ubuntu_ami_id           = module.base_infra.ami_ids["ubuntu"]["amd64"]
-  vpc_id                  = module.base_infra.vpc_id
-  vpc_tag_module          = module.base_infra.vpc_tag_module
-  worker_instance_type    = local.worker_instance_type
-  worker_type_tags        = [local.egress_tag]
-  worker_config_file_path = "templates/worker_hcp_bsr.hcl"
-  recording_storage_path  = "/recordings"
-  local_artifact_path     = local.boundary_zip_path
-  environment             = local.environment_tag
-  project_name            = local.project_tag
-  common_tags             = local.tags
+  controller_count         = 0
+  worker_count             = var.worker_count
+  db_create                = false
+  aws_region               = var.aws_region
+  hcp_boundary_cluster_id  = var.hcp_boundary_cluster_id
+  aws_ssh_keypair_name     = module.generate_ssh_key.key_pair_name
+  aws_ssh_private_key_path = module.generate_ssh_key.private_key_path
+  boundary_license         = module.license.license
+  kms_key_arn              = module.base_infra.kms_key_arn
+  ubuntu_ami_id            = module.base_infra.ami_ids["ubuntu"]["amd64"]
+  vpc_id                   = module.base_infra.vpc_id
+  vpc_tag_module           = module.base_infra.vpc_tag_module
+  worker_instance_type     = local.worker_instance_type
+  worker_type_tags         = [local.egress_tag]
+  worker_config_file_path  = "templates/worker_hcp_bsr.hcl"
+  recording_storage_path   = "/recordings"
+  local_artifact_path      = local.boundary_zip_path
+  environment              = local.environment_tag
+  project_name             = local.project_tag
+  common_tags              = local.tags
 }
 
 module "storage_bucket" {
@@ -128,14 +140,15 @@ module "target_tags" {
 module "target" {
   source = "../../modules/aws_target"
 
-  target_count         = var.target_count
-  aws_ssh_keypair_name = var.aws_ssh_keypair_name
-  instance_type        = local.target_instance_type
-  enos_user            = local.cluster_tag
-  environment          = local.environment_tag
-  project_name         = local.project_tag
-  ami_id               = module.base_infra.ami_ids["ubuntu"]["amd64"]
-  vpc_id               = module.base_infra.vpc_id
-  subnet_ids           = module.worker.subnet_ids
-  additional_tags      = module.target_tags.tag_map
+  target_count             = var.target_count
+  aws_ssh_keypair_name     = module.generate_ssh_key.key_pair_name
+  aws_ssh_private_key_path = module.generate_ssh_key.private_key_path
+  instance_type            = local.target_instance_type
+  enos_user                = local.cluster_tag
+  environment              = local.environment_tag
+  project_name             = local.project_tag
+  ami_id                   = module.base_infra.ami_ids["ubuntu"]["amd64"]
+  vpc_id                   = module.base_infra.vpc_id
+  subnet_ids               = module.worker.subnet_ids
+  additional_tags          = module.target_tags.tag_map
 }

--- a/enos/enos-modules.hcl
+++ b/enos/enos-modules.hcl
@@ -23,7 +23,6 @@ module "aws_boundary" {
 
   alb_listener_api_port = var.alb_listener_api_port
   boundary_binary_name  = var.boundary_binary_name
-  ssh_aws_keypair       = var.aws_ssh_keypair_name
 }
 
 module "aws_worker" {
@@ -35,8 +34,6 @@ module "aws_worker" {
     "Enos User" : var.enos_user,
     "Environment" : var.environment
   }
-
-  ssh_aws_keypair = var.aws_ssh_keypair_name
 }
 
 module "aws_bucket" {
@@ -114,6 +111,14 @@ module "map2list" {
   source = "./modules/map2list"
 }
 
+module "aws_ssh_keypair" {
+  source = "./modules/aws_ssh_keypair"
+}
+
+module "ssh_keypair" {
+  source = "./modules/ssh_keypair"
+}
+
 module "aws_target" {
   source       = "./modules/aws_target"
   target_count = var.target_count
@@ -142,8 +147,6 @@ module "vault" {
     "Enos User" : var.enos_user,
     "Environment" : var.environment
   }
-
-  ssh_aws_keypair = var.aws_ssh_keypair_name
 }
 
 module "test_e2e" {

--- a/enos/enos-scenario-e2e-aws-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-aws-base-with-vault.hcl
@@ -6,7 +6,6 @@ scenario "e2e_aws_base_with_vault" {
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.default
   ]
 
   matrix {
@@ -14,7 +13,7 @@ scenario "e2e_aws_base_with_vault" {
   }
 
   locals {
-    aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     boundary_install_dir     = abspath(var.boundary_install_dir)
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
@@ -77,6 +76,15 @@ scenario "e2e_aws_base_with_vault" {
     }
   }
 
+  step "generate_ssh_key" {
+    module = module.aws_ssh_keypair
+
+    variables {
+      local_key_path         = local.aws_ssh_private_key_path
+      local_aws_keypair_name = var.aws_ssh_keypair_name != null ? var.aws_ssh_keypair_name : null
+    }
+  }
+
   step "create_boundary_cluster" {
     module = module.aws_boundary
     depends_on = [
@@ -101,6 +109,8 @@ scenario "e2e_aws_base_with_vault" {
       worker_count             = var.worker_count
       worker_instance_type     = var.worker_instance_type
       aws_region               = var.aws_region
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -123,7 +133,9 @@ scenario "e2e_aws_base_with_vault" {
         version = var.vault_version
         edition = "oss"
       }
-      vpc_id = step.create_base_infra.vpc_id
+      vpc_id                   = step.create_base_infra.vpc_id
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -132,13 +144,14 @@ scenario "e2e_aws_base_with_vault" {
     depends_on = [step.create_base_infra]
 
     variables {
-      ami_id               = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      aws_ssh_keypair_name = var.aws_ssh_keypair_name
-      enos_user            = var.enos_user
-      instance_type        = var.target_instance_type
-      vpc_id               = step.create_base_infra.vpc_id
-      target_count         = var.target_count
-      subnet_ids           = step.create_boundary_cluster.subnet_ids
+      ami_id                   = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
+      enos_user                = var.enos_user
+      instance_type            = var.target_instance_type
+      vpc_id                   = step.create_base_infra.vpc_id
+      target_count             = var.target_count
+      subnet_ids               = step.create_boundary_cluster.subnet_ids
     }
   }
 
@@ -158,7 +171,7 @@ scenario "e2e_aws_base_with_vault" {
       auth_login_name          = step.create_boundary_cluster.auth_login_name
       auth_password            = step.create_boundary_cluster.auth_password
       local_boundary_dir       = local.local_boundary_dir
-      aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
       target_address           = step.create_target.target_private_ips[0]
       target_user              = "ubuntu"
       target_port              = "22"
@@ -188,5 +201,9 @@ scenario "e2e_aws_base_with_vault" {
 
   output "vault_ips" {
     value = step.create_vault_cluster.instance_public_ips
+  }
+
+  output "aws_ssh_key_path" {
+    value = step.generate_ssh_key.private_key_path
   }
 }

--- a/enos/enos-scenario-e2e-aws-base.hcl
+++ b/enos/enos-scenario-e2e-aws-base.hcl
@@ -6,7 +6,6 @@ scenario "e2e_aws_base" {
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.default
   ]
 
   matrix {
@@ -14,7 +13,7 @@ scenario "e2e_aws_base" {
   }
 
   locals {
-    aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     boundary_install_dir     = abspath(var.boundary_install_dir)
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
@@ -76,12 +75,22 @@ scenario "e2e_aws_base" {
     }
   }
 
+  step "generate_ssh_key" {
+    module = module.aws_ssh_keypair
+
+    variables {
+      local_key_path         = local.aws_ssh_private_key_path
+      local_aws_keypair_name = var.aws_ssh_keypair_name != null ? var.aws_ssh_keypair_name : null
+    }
+  }
+
   step "create_boundary_cluster" {
     module = module.aws_boundary
     depends_on = [
       step.create_base_infra,
       step.create_db_password,
-      step.build_boundary
+      step.build_boundary,
+      step.generate_ssh_key
     ]
 
     variables {
@@ -100,21 +109,27 @@ scenario "e2e_aws_base" {
       worker_count             = var.worker_count
       worker_instance_type     = var.worker_instance_type
       aws_region               = var.aws_region
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
     }
   }
 
   step "create_target" {
-    module     = module.aws_target
-    depends_on = [step.create_base_infra]
+    module = module.aws_target
+    depends_on = [
+      step.create_base_infra,
+      step.generate_ssh_key
+    ]
 
     variables {
-      ami_id               = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      aws_ssh_keypair_name = var.aws_ssh_keypair_name
-      enos_user            = var.enos_user
-      instance_type        = var.target_instance_type
-      vpc_id               = step.create_base_infra.vpc_id
-      target_count         = var.target_count
-      subnet_ids           = step.create_boundary_cluster.subnet_ids
+      ami_id                   = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
+      enos_user                = var.enos_user
+      instance_type            = var.target_instance_type
+      vpc_id                   = step.create_base_infra.vpc_id
+      target_count             = var.target_count
+      subnet_ids               = step.create_boundary_cluster.subnet_ids
     }
   }
 
@@ -122,7 +137,8 @@ scenario "e2e_aws_base" {
     module = module.test_e2e
     depends_on = [
       step.create_boundary_cluster,
-      step.create_target
+      step.create_target,
+      step.generate_ssh_key
     ]
 
     variables {
@@ -133,7 +149,7 @@ scenario "e2e_aws_base" {
       auth_login_name          = step.create_boundary_cluster.auth_login_name
       auth_password            = step.create_boundary_cluster.auth_password
       local_boundary_dir       = local.local_boundary_dir
-      aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
       target_address           = step.create_target.target_private_ips[0]
       target_user              = "ubuntu"
       target_port              = "22"
@@ -156,5 +172,9 @@ scenario "e2e_aws_base" {
 
   output "target_ips" {
     value = step.create_target.target_public_ips
+  }
+
+  output "aws_ssh_key_path" {
+    value = step.generate_ssh_key.private_key_path
   }
 }

--- a/enos/enos-scenario-e2e-aws-rdp-base.hcl
+++ b/enos/enos-scenario-e2e-aws-rdp-base.hcl
@@ -10,7 +10,6 @@ scenario "e2e_aws_rdp_base" {
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.default
   ]
 
   matrix {
@@ -24,7 +23,7 @@ scenario "e2e_aws_rdp_base" {
   }
 
   locals {
-    aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     boundary_install_dir     = abspath(var.boundary_install_dir)
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_src_dir   = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
@@ -71,6 +70,15 @@ scenario "e2e_aws_rdp_base" {
     variables {
       availability_zones = step.find_azs.availability_zones
       common_tags        = local.tags
+    }
+  }
+
+  step "generate_ssh_key" {
+    module = module.aws_ssh_keypair
+
+    variables {
+      local_key_path         = local.aws_ssh_private_key_path
+      local_aws_keypair_name = var.aws_ssh_keypair_name != null ? var.aws_ssh_keypair_name : null
     }
   }
 
@@ -131,6 +139,7 @@ scenario "e2e_aws_rdp_base" {
     module = module.vault
     depends_on = [
       step.create_base_infra,
+      step.generate_ssh_key
     ]
 
     variables {
@@ -146,7 +155,9 @@ scenario "e2e_aws_rdp_base" {
         version = var.vault_version
         edition = "oss"
       }
-      vpc_id = step.create_base_infra.vpc_id
+      vpc_id                   = step.create_base_infra.vpc_id
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -175,7 +186,8 @@ scenario "e2e_aws_rdp_base" {
       step.build_boundary_linux,
       step.create_windows_client,
       step.create_vault_cluster,
-      step.read_boundary_license
+      step.read_boundary_license,
+      step.generate_ssh_key
     ]
 
     variables {
@@ -200,6 +212,8 @@ scenario "e2e_aws_rdp_base" {
       ip_version                  = local.ip_version
       recording_storage_path      = "/recording"
       alb_sg_additional_ips       = step.create_windows_client.public_ip_list
+      aws_ssh_keypair_name        = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path    = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -302,7 +316,7 @@ scenario "e2e_aws_rdp_base" {
       auth_login_name                          = step.create_boundary_cluster.auth_login_name
       auth_password                            = step.create_boundary_cluster.auth_password
       local_boundary_dir                       = local.local_boundary_dir
-      aws_ssh_private_key_path                 = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path                 = step.generate_ssh_key.private_key_path
       target_user                              = "ubuntu"
       target_port                              = "22"
       aws_bucket_name                          = step.create_bucket.bucket_name
@@ -432,5 +446,9 @@ scenario "e2e_aws_rdp_base" {
 
   output "vault_root_token" {
     value = step.create_vault_cluster.vault_root_token
+  }
+
+  output "aws_ssh_key_path" {
+    value = step.generate_ssh_key.private_key_path
   }
 }

--- a/enos/enos-scenario-e2e-aws-rdp-target.hcl
+++ b/enos/enos-scenario-e2e-aws-rdp-target.hcl
@@ -8,7 +8,6 @@ scenario "e2e_aws_rdp_target" {
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.default
   ]
 
   matrix {

--- a/enos/enos-scenario-e2e-aws.hcl
+++ b/enos/enos-scenario-e2e-aws.hcl
@@ -7,7 +7,6 @@ scenario "e2e_aws" {
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.default
   ]
 
   matrix {
@@ -16,7 +15,7 @@ scenario "e2e_aws" {
   }
 
   locals {
-    aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     boundary_install_dir     = abspath(var.boundary_install_dir)
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     boundary_license_path    = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
@@ -82,10 +81,20 @@ scenario "e2e_aws" {
     }
   }
 
+  step "generate_ssh_key" {
+    module = module.aws_ssh_keypair
+
+    variables {
+      local_key_path         = local.aws_ssh_private_key_path
+      local_aws_keypair_name = var.aws_ssh_keypair_name != null ? var.aws_ssh_keypair_name : null
+    }
+  }
+
   step "create_vault_cluster" {
     module = module.vault
     depends_on = [
       step.create_base_infra,
+      step.generate_ssh_key
     ]
 
     variables {
@@ -101,7 +110,9 @@ scenario "e2e_aws" {
         version = var.vault_version
         edition = "oss"
       }
-      vpc_id = step.create_base_infra.vpc_id
+      vpc_id                   = step.create_base_infra.vpc_id
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -135,6 +146,8 @@ scenario "e2e_aws" {
       worker_config_file_path     = matrix.ip_version == "4" ? "templates/worker.hcl" : "templates/worker_vault_kms.hcl"
       vault_address               = matrix.ip_version == "4" ? "" : step.create_vault_cluster.instance_public_ips[0]
       vault_transit_token         = matrix.ip_version == "4" ? "" : step.create_vault_cluster.vault_transit_token
+      aws_ssh_keypair_name        = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path    = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -154,20 +167,21 @@ scenario "e2e_aws" {
 
   step "create_targets_with_tag1" {
     module     = module.aws_target
-    depends_on = [step.create_base_infra]
+    depends_on = [step.create_base_infra, step.generate_ssh_key]
 
     variables {
-      ami_id               = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      aws_ssh_keypair_name = var.aws_ssh_keypair_name
-      enos_user            = var.enos_user
-      instance_type        = var.target_instance_type
-      vpc_id               = step.create_base_infra.vpc_id
-      target_count         = var.target_count <= 1 ? 2 : var.target_count
-      additional_tags      = step.create_tag1_inputs.tag_map
-      subnet_ids           = step.create_boundary_cluster.subnet_ids
-      ingress_cidr         = matrix.ip_version == "4" ? ["10.0.0.0/8"] : []
-      ingress_ipv6_cidr    = step.create_boundary_cluster.worker_ipv6_cidr
-      ip_version           = matrix.ip_version
+      ami_id                   = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
+      enos_user                = var.enos_user
+      instance_type            = var.target_instance_type
+      vpc_id                   = step.create_base_infra.vpc_id
+      target_count             = var.target_count <= 1 ? 2 : var.target_count
+      additional_tags          = step.create_tag1_inputs.tag_map
+      subnet_ids               = step.create_boundary_cluster.subnet_ids
+      ingress_cidr             = matrix.ip_version == "4" ? ["10.0.0.0/8"] : []
+      ingress_ipv6_cidr        = step.create_boundary_cluster.worker_ipv6_cidr
+      ip_version               = matrix.ip_version
     }
   }
 
@@ -197,24 +211,26 @@ scenario "e2e_aws" {
 
   step "create_isolated_worker" {
     module     = module.aws_worker
-    depends_on = [step.create_boundary_cluster]
+    depends_on = [step.create_boundary_cluster, step.generate_ssh_key]
     variables {
-      vpc_id               = step.create_base_infra.vpc_id
-      availability_zones   = step.create_base_infra.availability_zone_names
-      kms_key_arn          = step.create_base_infra.kms_key_arn
-      ubuntu_ami_id        = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      vpc_cidr             = step.create_base_infra.vpc_cidr
-      vpc_cidr_ipv6        = matrix.ip_version == "4" ? "" : step.create_base_infra.vpc_cidr_ipv6
-      local_artifact_path  = step.build_boundary.artifact_path
-      boundary_install_dir = local.boundary_install_dir
-      name_prefix          = step.create_boundary_cluster.name_prefix
-      cluster_tag          = step.create_boundary_cluster.cluster_tag
-      upstream_ips         = step.create_boundary_cluster.public_controller_addresses
-      controller_sg_id     = step.create_boundary_cluster.controller_aux_sg_id
-      create_subnet        = true
-      worker_type_tags     = [local.isolated_tag]
-      ip_version           = matrix.ip_version
-      config_file_path     = "templates/worker.hcl"
+      vpc_id                   = step.create_base_infra.vpc_id
+      availability_zones       = step.create_base_infra.availability_zone_names
+      kms_key_arn              = step.create_base_infra.kms_key_arn
+      ubuntu_ami_id            = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      vpc_cidr                 = step.create_base_infra.vpc_cidr
+      vpc_cidr_ipv6            = matrix.ip_version == "4" ? "" : step.create_base_infra.vpc_cidr_ipv6
+      local_artifact_path      = step.build_boundary.artifact_path
+      boundary_install_dir     = local.boundary_install_dir
+      name_prefix              = step.create_boundary_cluster.name_prefix
+      cluster_tag              = step.create_boundary_cluster.cluster_tag
+      upstream_ips             = step.create_boundary_cluster.public_controller_addresses
+      controller_sg_id         = step.create_boundary_cluster.controller_aux_sg_id
+      create_subnet            = true
+      worker_type_tags         = [local.isolated_tag]
+      ip_version               = matrix.ip_version
+      config_file_path         = "templates/worker.hcl"
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -236,21 +252,23 @@ scenario "e2e_aws" {
     module = module.aws_target
     depends_on = [
       step.create_base_infra,
-      step.create_isolated_worker
+      step.create_isolated_worker,
+      step.generate_ssh_key
     ]
 
     variables {
-      ami_id               = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      aws_ssh_keypair_name = var.aws_ssh_keypair_name
-      enos_user            = var.enos_user
-      instance_type        = var.target_instance_type
-      vpc_id               = step.create_base_infra.vpc_id
-      target_count         = 1
-      subnet_ids           = step.create_isolated_worker.subnet_ids
-      ingress_cidr         = matrix.ip_version == "4" ? ["10.13.9.0/24"] : []
-      ingress_ipv6_cidr    = step.create_isolated_worker.worker_ipv6_cidr
-      additional_tags      = step.create_tag2_inputs.tag_map
-      ip_version           = matrix.ip_version
+      ami_id                   = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
+      enos_user                = var.enos_user
+      instance_type            = var.target_instance_type
+      vpc_id                   = step.create_base_infra.vpc_id
+      target_count             = 1
+      subnet_ids               = step.create_isolated_worker.subnet_ids
+      ingress_cidr             = matrix.ip_version == "4" ? ["10.13.9.0/24"] : []
+      ingress_ipv6_cidr        = step.create_isolated_worker.worker_ipv6_cidr
+      additional_tags          = step.create_tag2_inputs.tag_map
+      ip_version               = matrix.ip_version
     }
   }
 
@@ -261,7 +279,8 @@ scenario "e2e_aws" {
       step.create_targets_with_tag1,
       step.iam_setup,
       step.create_isolated_worker,
-      step.create_isolated_target
+      step.create_isolated_target,
+      step.generate_ssh_key
     ]
 
     variables {
@@ -272,9 +291,9 @@ scenario "e2e_aws" {
       auth_login_name          = step.create_boundary_cluster.auth_login_name
       auth_password            = step.create_boundary_cluster.auth_password
       local_boundary_dir       = local.local_boundary_dir
-      aws_ssh_private_key_path = local.aws_ssh_private_key_path
       target_user              = "ubuntu"
       target_port              = "22"
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
       aws_access_key_id        = step.iam_setup.access_key_id
       aws_secret_access_key    = step.iam_setup.secret_access_key
       aws_host_set_filter1     = step.create_tag1_inputs.tag_string
@@ -303,5 +322,9 @@ scenario "e2e_aws" {
 
   output "target_ips" {
     value = step.create_targets_with_tag1.target_public_ips
+  }
+
+  output "aws_ssh_key_path" {
+    value = step.generate_ssh_key.private_key_path
   }
 }

--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -6,11 +6,10 @@ scenario "e2e_database" {
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.default
   ]
 
   locals {
-    aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
 
@@ -31,6 +30,14 @@ scenario "e2e_database" {
     }
   }
 
+  step "generate_ssh_key" {
+    module = module.aws_ssh_keypair
+
+    variables {
+      local_key_path         = local.aws_ssh_private_key_path
+      local_aws_keypair_name = var.aws_ssh_keypair_name != null ? var.aws_ssh_keypair_name : null
+    }
+  }
   step "find_azs" {
     module = module.aws_az_finder
 
@@ -76,17 +83,18 @@ scenario "e2e_database" {
 
   step "create_targets_with_tag" {
     module     = module.aws_target
-    depends_on = [step.create_base_infra]
+    depends_on = [step.create_base_infra, step.generate_ssh_key]
 
     variables {
-      ami_id               = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      aws_ssh_keypair_name = var.aws_ssh_keypair_name
-      enos_user            = var.enos_user
-      instance_type        = var.target_instance_type
-      vpc_id               = step.create_base_infra.vpc_id
-      target_count         = 1
-      additional_tags      = step.create_tag_inputs.tag_map
-      subnet_ids           = step.get_subnets.list
+      ami_id                   = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
+      enos_user                = var.enos_user
+      instance_type            = var.target_instance_type
+      vpc_id                   = step.create_base_infra.vpc_id
+      target_count             = 1
+      additional_tags          = step.create_tag_inputs.tag_map
+      subnet_ids               = step.get_subnets.list
     }
   }
 
@@ -114,7 +122,8 @@ scenario "e2e_database" {
     module = module.test_e2e
     depends_on = [
       step.create_targets_with_tag,
-      step.iam_setup
+      step.iam_setup,
+      step.generate_ssh_key
     ]
 
     variables {
@@ -123,7 +132,7 @@ scenario "e2e_database" {
       boundary_license         = var.boundary_edition != "oss" ? step.read_license.license : ""
       local_boundary_dir       = local.local_boundary_dir
       target_user              = "ubuntu"
-      aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
       aws_access_key_id        = step.iam_setup.access_key_id
       aws_secret_access_key    = step.iam_setup.secret_access_key
       aws_host_set_filter1     = step.create_tag_inputs.tag_string

--- a/enos/enos-scenario-e2e-docker-base-connect.hcl
+++ b/enos/enos-scenario-e2e-docker-base-connect.hcl
@@ -4,16 +4,13 @@
 scenario "e2e_docker_base_connect" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
-  providers = [
-    provider.enos.default
-  ]
 
   matrix {
     builder = ["local", "crt"]
   }
 
   locals {
-    aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path   = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
@@ -39,6 +36,14 @@ scenario "e2e_docker_base_connect" {
       path           = matrix.builder == "crt" ? local.boundary_docker_image_file : ""
       cli_build_path = local.build_path[matrix.builder]
       edition        = var.boundary_edition
+    }
+  }
+
+  step "generate_ssh_key" {
+    module = module.ssh_keypair
+
+    variables {
+      local_key_path = local.aws_ssh_private_key_path
     }
   }
 
@@ -94,7 +99,7 @@ scenario "e2e_docker_base_connect" {
     variables {
       image_name            = "${var.docker_mirror}/linuxserver/openssh-server:latest"
       network_name          = [local.network_cluster]
-      private_key_file_path = local.aws_ssh_private_key_path
+      private_key_file_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -114,7 +119,7 @@ scenario "e2e_docker_base_connect" {
       auth_password            = step.create_boundary.password
       local_boundary_dir       = local.local_boundary_dir
       local_boundary_src_dir   = local.local_boundary_src_dir
-      aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
       target_address           = step.create_host.address
       target_port              = step.create_host.port
       target_user              = "ubuntu"

--- a/enos/enos-scenario-e2e-docker-base-plus.hcl
+++ b/enos/enos-scenario-e2e-docker-base-plus.hcl
@@ -5,16 +5,13 @@
 scenario "e2e_docker_base_plus" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
-  providers = [
-    provider.enos.default
-  ]
 
   matrix {
     builder = ["local", "crt"]
   }
 
   locals {
-    aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path   = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
@@ -40,6 +37,14 @@ scenario "e2e_docker_base_plus" {
       path           = matrix.builder == "crt" ? local.boundary_docker_image_file : ""
       cli_build_path = local.build_path[matrix.builder]
       edition        = var.boundary_edition
+    }
+  }
+
+  step "generate_ssh_key" {
+    module = module.ssh_keypair
+
+    variables {
+      local_key_path = local.aws_ssh_private_key_path
     }
   }
 
@@ -108,7 +113,7 @@ scenario "e2e_docker_base_plus" {
     variables {
       image_name            = "${var.docker_mirror}/linuxserver/openssh-server:latest"
       network_name          = [local.network_cluster]
-      private_key_file_path = local.aws_ssh_private_key_path
+      private_key_file_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -128,7 +133,7 @@ scenario "e2e_docker_base_plus" {
       auth_password             = step.create_boundary.password
       local_boundary_dir        = local.local_boundary_dir
       local_boundary_src_dir    = local.local_boundary_src_dir
-      aws_ssh_private_key_path  = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path  = step.generate_ssh_key.private_key_path
       target_address            = step.create_host.address
       target_port               = step.create_host.port
       target_user               = "ubuntu"

--- a/enos/enos-scenario-e2e-docker-base-with-gcp.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-gcp.hcl
@@ -5,7 +5,6 @@ scenario "e2e_docker_base_with_gcp" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
-    provider.enos.default,
     provider.google.default
   ]
 

--- a/enos/enos-scenario-e2e-docker-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-vault.hcl
@@ -4,16 +4,13 @@
 scenario "e2e_docker_base_with_vault" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
-  providers = [
-    provider.enos.default
-  ]
 
   matrix {
     builder = ["local", "crt"]
   }
 
   locals {
-    aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path   = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
@@ -39,6 +36,14 @@ scenario "e2e_docker_base_with_vault" {
       path           = matrix.builder == "crt" ? local.boundary_docker_image_file : ""
       cli_build_path = local.build_path[matrix.builder]
       edition        = var.boundary_edition
+    }
+  }
+
+  step "generate_ssh_key" {
+    module = module.ssh_keypair
+
+    variables {
+      local_key_path = local.aws_ssh_private_key_path
     }
   }
 
@@ -105,7 +110,7 @@ scenario "e2e_docker_base_with_vault" {
     variables {
       image_name            = "${var.docker_mirror}/linuxserver/openssh-server:latest"
       network_name          = [local.network_cluster]
-      private_key_file_path = local.aws_ssh_private_key_path
+      private_key_file_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -137,7 +142,7 @@ scenario "e2e_docker_base_with_vault" {
       auth_password            = step.create_boundary.password
       local_boundary_dir       = local.local_boundary_dir
       local_boundary_src_dir   = local.local_boundary_src_dir
-      aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
       target_address           = step.create_host.address
       target_port              = step.create_host.port
       target_user              = "ubuntu"

--- a/enos/enos-scenario-e2e-docker-base-with-worker-version.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-worker-version.hcl
@@ -4,16 +4,13 @@
 scenario "e2e_docker_base_with_worker_version" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
-  providers = [
-    provider.enos.default
-  ]
 
   matrix {
     builder = ["local", "crt"]
   }
 
   locals {
-    aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path   = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
@@ -43,6 +40,14 @@ scenario "e2e_docker_base_with_worker_version" {
       path           = matrix.builder == "crt" ? local.boundary_docker_image_file : ""
       cli_build_path = local.build_path[matrix.builder]
       edition        = var.boundary_edition
+    }
+  }
+
+  step "generate_ssh_key" {
+    module = module.ssh_keypair
+
+    variables {
+      local_key_path = local.aws_ssh_private_key_path
     }
   }
 
@@ -124,7 +129,7 @@ scenario "e2e_docker_base_with_worker_version" {
     variables {
       image_name            = "${var.docker_mirror}/linuxserver/openssh-server:latest"
       network_name          = [local.network_host]
-      private_key_file_path = local.aws_ssh_private_key_path
+      private_key_file_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -173,7 +178,7 @@ scenario "e2e_docker_base_with_worker_version" {
       auth_password            = step.create_boundary.password
       local_boundary_dir       = local.local_boundary_dir
       local_boundary_src_dir   = local.local_boundary_src_dir
-      aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
       target_address           = step.create_host.address
       target_port              = step.create_host.port
       target_user              = "ubuntu"

--- a/enos/enos-scenario-e2e-docker-base-with-worker.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-worker.hcl
@@ -4,16 +4,13 @@
 scenario "e2e_docker_base_with_worker" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
-  providers = [
-    provider.enos.default
-  ]
 
   matrix {
     builder = ["local", "crt"]
   }
 
   locals {
-    aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path   = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
@@ -41,6 +38,14 @@ scenario "e2e_docker_base_with_worker" {
       path           = matrix.builder == "crt" ? local.boundary_docker_image_file : ""
       cli_build_path = local.build_path[matrix.builder]
       edition        = var.boundary_edition
+    }
+  }
+
+  step "generate_ssh_key" {
+    module = module.ssh_keypair
+
+    variables {
+      local_key_path = local.aws_ssh_private_key_path
     }
   }
 
@@ -122,7 +127,7 @@ scenario "e2e_docker_base_with_worker" {
     variables {
       image_name            = "${var.docker_mirror}/linuxserver/openssh-server:latest"
       network_name          = [local.network_host]
-      private_key_file_path = local.aws_ssh_private_key_path
+      private_key_file_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -168,7 +173,7 @@ scenario "e2e_docker_base_with_worker" {
       auth_password            = step.create_boundary.password
       local_boundary_dir       = local.local_boundary_dir
       local_boundary_src_dir   = local.local_boundary_src_dir
-      aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
       target_address           = step.create_host.address
       target_port              = step.create_host.port
       target_user              = "ubuntu"

--- a/enos/enos-scenario-e2e-docker-base.hcl
+++ b/enos/enos-scenario-e2e-docker-base.hcl
@@ -4,16 +4,13 @@
 scenario "e2e_docker_base" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
-  providers = [
-    provider.enos.default
-  ]
 
   matrix {
     builder = ["local", "crt"]
   }
 
   locals {
-    aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path   = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
@@ -39,6 +36,14 @@ scenario "e2e_docker_base" {
       path           = matrix.builder == "crt" ? local.boundary_docker_image_file : ""
       cli_build_path = local.build_path[matrix.builder]
       edition        = var.boundary_edition
+    }
+  }
+
+  step "generate_ssh_key" {
+    module = module.ssh_keypair
+
+    variables {
+      local_key_path = local.aws_ssh_private_key_path
     }
   }
 
@@ -94,7 +99,7 @@ scenario "e2e_docker_base" {
     variables {
       image_name            = "${var.docker_mirror}/linuxserver/openssh-server:latest"
       network_name          = [local.network_cluster]
-      private_key_file_path = local.aws_ssh_private_key_path
+      private_key_file_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -114,7 +119,7 @@ scenario "e2e_docker_base" {
       auth_password            = step.create_boundary.password
       local_boundary_dir       = local.local_boundary_dir
       local_boundary_src_dir   = local.local_boundary_src_dir
-      aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
       target_address           = step.create_host.address
       target_port              = step.create_host.port
       target_user              = "ubuntu"

--- a/enos/enos-scenario-e2e-docker-worker-registration-controller-led.hcl
+++ b/enos/enos-scenario-e2e-docker-worker-registration-controller-led.hcl
@@ -4,16 +4,13 @@
 scenario "e2e_docker_worker_registration_controller_led" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
-  providers = [
-    provider.enos.default
-  ]
 
   matrix {
     builder = ["local", "crt"]
   }
 
   locals {
-    aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path   = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
@@ -41,6 +38,14 @@ scenario "e2e_docker_worker_registration_controller_led" {
       path           = matrix.builder == "crt" ? local.boundary_docker_image_file : ""
       cli_build_path = local.build_path[matrix.builder]
       edition        = var.boundary_edition
+    }
+  }
+
+  step "generate_ssh_key" {
+    module = module.ssh_keypair
+
+    variables {
+      local_key_path = local.aws_ssh_private_key_path
     }
   }
 
@@ -136,7 +141,7 @@ scenario "e2e_docker_worker_registration_controller_led" {
     variables {
       image_name            = "${var.docker_mirror}/linuxserver/openssh-server:latest"
       network_name          = [local.network_host]
-      private_key_file_path = local.aws_ssh_private_key_path
+      private_key_file_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -183,7 +188,7 @@ scenario "e2e_docker_worker_registration_controller_led" {
       auth_password            = step.create_boundary.password
       local_boundary_dir       = local.local_boundary_dir
       local_boundary_src_dir   = local.local_boundary_src_dir
-      aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
       target_address           = step.create_host.address
       target_port              = step.create_host.port
       target_user              = "ubuntu"

--- a/enos/enos-scenario-e2e-docker-worker-registration-worker-led.hcl
+++ b/enos/enos-scenario-e2e-docker-worker-registration-worker-led.hcl
@@ -4,16 +4,13 @@
 scenario "e2e_docker_worker_registration_worker_led" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
-  providers = [
-    provider.enos.default
-  ]
 
   matrix {
     builder = ["local", "crt"]
   }
 
   locals {
-    aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path   = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_src_dir     = var.local_boundary_src_dir != null ? abspath(var.local_boundary_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
@@ -43,6 +40,15 @@ scenario "e2e_docker_worker_registration_worker_led" {
       edition        = var.boundary_edition
     }
   }
+
+  step "generate_ssh_key" {
+    module = module.ssh_keypair
+
+    variables {
+      local_key_path = local.aws_ssh_private_key_path
+    }
+  }
+
 
   step "create_docker_network_database" {
     module = module.docker_network
@@ -123,7 +129,7 @@ scenario "e2e_docker_worker_registration_worker_led" {
     variables {
       image_name            = "${var.docker_mirror}/linuxserver/openssh-server:latest"
       network_name          = [local.network_host]
-      private_key_file_path = local.aws_ssh_private_key_path
+      private_key_file_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -198,7 +204,7 @@ scenario "e2e_docker_worker_registration_worker_led" {
       auth_password            = step.create_boundary.password
       local_boundary_dir       = local.local_boundary_dir
       local_boundary_src_dir   = local.local_boundary_src_dir
-      aws_ssh_private_key_path = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
       target_address           = step.create_host.address
       target_port              = step.create_host.port
       target_user              = "ubuntu"

--- a/enos/enos-scenario-e2e-ui-aws.hcl
+++ b/enos/enos-scenario-e2e-ui-aws.hcl
@@ -6,7 +6,6 @@ scenario "e2e_ui_aws" {
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.default
   ]
 
   matrix {
@@ -15,7 +14,7 @@ scenario "e2e_ui_aws" {
   }
 
   locals {
-    aws_ssh_private_key_path  = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path  = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     boundary_install_dir      = abspath(var.boundary_install_dir)
     license_path              = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
     local_boundary_dir        = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
@@ -78,6 +77,15 @@ scenario "e2e_ui_aws" {
     }
   }
 
+  step "generate_ssh_key" {
+    module = module.aws_ssh_keypair
+
+    variables {
+      local_key_path         = local.aws_ssh_private_key_path
+      local_aws_keypair_name = var.aws_ssh_keypair_name != null ? var.aws_ssh_keypair_name : null
+    }
+  }
+
   locals {
     egress_tag = "egress"
   }
@@ -108,6 +116,8 @@ scenario "e2e_ui_aws" {
       worker_type_tags         = [local.egress_tag]
       aws_region               = var.aws_region
       protocol                 = matrix.protocol
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -130,7 +140,9 @@ scenario "e2e_ui_aws" {
         version = var.vault_version
         edition = "oss"
       }
-      vpc_id = step.create_base_infra.vpc_id
+      vpc_id                   = step.create_base_infra.vpc_id
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -153,14 +165,15 @@ scenario "e2e_ui_aws" {
     depends_on = [step.create_base_infra]
 
     variables {
-      ami_id               = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      aws_ssh_keypair_name = var.aws_ssh_keypair_name
-      enos_user            = var.enos_user
-      instance_type        = var.target_instance_type
-      vpc_id               = step.create_base_infra.vpc_id
-      target_count         = var.target_count <= 1 ? 2 : var.target_count
-      additional_tags      = step.create_tag_inputs.tag_map
-      subnet_ids           = step.create_boundary_cluster.subnet_ids
+      ami_id                   = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      enos_user                = var.enos_user
+      instance_type            = var.target_instance_type
+      vpc_id                   = step.create_base_infra.vpc_id
+      target_count             = var.target_count <= 1 ? 2 : var.target_count
+      additional_tags          = step.create_tag_inputs.tag_map
+      subnet_ids               = step.create_boundary_cluster.subnet_ids
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -201,7 +214,7 @@ scenario "e2e_ui_aws" {
       auth_password             = step.create_boundary_cluster.auth_password
       local_boundary_dir        = local.local_boundary_dir
       local_boundary_ui_src_dir = local.local_boundary_ui_src_dir
-      aws_ssh_private_key_path  = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path  = step.generate_ssh_key.private_key_path
       target_address            = step.create_targets_with_tag.target_private_ips[0]
       target_user               = "ubuntu"
       target_port               = "22"
@@ -224,5 +237,9 @@ scenario "e2e_ui_aws" {
 
   output "worker_ips" {
     value = step.create_boundary_cluster.worker_ips
+  }
+
+  output "aws_ssh_key_path" {
+    value = step.generate_ssh_key.private_key_path
   }
 }

--- a/enos/enos-scenario-e2e-ui-docker.hcl
+++ b/enos/enos-scenario-e2e-ui-docker.hcl
@@ -4,16 +4,13 @@
 scenario "e2e_ui_docker" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
-  providers = [
-    provider.enos.default
-  ]
 
   matrix {
     builder = ["local", "crt"]
   }
 
   locals {
-    aws_ssh_private_key_path   = abspath(var.aws_ssh_private_key_path)
+    aws_ssh_private_key_path   = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     local_boundary_dir         = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
     local_boundary_ui_src_dir  = var.local_boundary_ui_src_dir != null ? abspath(var.local_boundary_ui_src_dir) : null
     boundary_docker_image_file = abspath(var.boundary_docker_image_file)
@@ -47,6 +44,14 @@ scenario "e2e_ui_docker" {
     module = module.docker_network
     variables {
       network_name = local.network_cluster
+    }
+  }
+
+  step "generate_ssh_key" {
+    module = module.ssh_keypair
+
+    variables {
+      local_key_path = local.aws_ssh_private_key_path
     }
   }
 
@@ -106,7 +111,7 @@ scenario "e2e_ui_docker" {
     variables {
       image_name            = "${var.docker_mirror}/linuxserver/openssh-server:latest"
       network_name          = [local.network_cluster]
-      private_key_file_path = local.aws_ssh_private_key_path
+      private_key_file_path = step.generate_ssh_key.private_key_path
     }
   }
 
@@ -161,7 +166,7 @@ scenario "e2e_ui_docker" {
       auth_password             = step.create_boundary.password
       local_boundary_dir        = local.local_boundary_dir
       local_boundary_ui_src_dir = local.local_boundary_ui_src_dir
-      aws_ssh_private_key_path  = local.aws_ssh_private_key_path
+      aws_ssh_private_key_path  = step.generate_ssh_key.private_key_path
       target_address            = step.create_host.address
       target_port               = step.create_host.port
       target_user               = "ubuntu"

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -5,11 +5,13 @@
 variable "aws_ssh_keypair_name" {
   description = "Name of the AWS keypair Enos will use to connect"
   type        = string
+  default     = null
 }
 
 variable "aws_ssh_private_key_path" {
   description = "Path to the SSH key Enos will use to connect"
   type        = string
+  default     = null
 }
 
 # Tagging
@@ -20,8 +22,9 @@ variable "environment" {
 }
 
 variable "enos_user" {
-  description = "The user running the tests, this is by default your OS user or Github User"
+  description = "The user running the tests, used for tagging purposes"
   type        = string
+  default     = "enos"
 }
 
 # Test configs

--- a/enos/enos.hcl
+++ b/enos/enos.hcl
@@ -29,15 +29,6 @@ provider "aws" "default" {
   region = var.aws_region
 }
 
-provider "enos" "default" {
-  transport = {
-    ssh = {
-      user             = "ubuntu"
-      private_key_path = abspath(var.aws_ssh_private_key_path)
-    }
-  }
-}
-
 provider "google" "default" {
   region  = var.gcp_region
   project = var.gcp_project_id

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -19,29 +19,6 @@
 // Recommend setting this to true unless running in CI.
 // e2e_debug_no_run = true
 
-// The AWS region you want to create the resources in. Make sure you choose a
-// region where you've got an AWS keypair. Applies to AWS scenarios only.
-// aws_region = "us-east-1"
-
-// The name of the AWS keypair in EC2 -> Key Pairs. Ensure this key pair is
-// available in the selected region. Applies to AWS scenarios only.
-// aws_ssh_keypair_name = "mykeypair"
-
-// The path to the local copy of the private key associated with your keypair.
-// Applies to AWS scenarios only.
-// aws_ssh_private_key_path = "/Users/<user>/.ssh/mykeypair.pem
-
-// Name of user. This is used to tag resources in AWS to more easily identify
-// your resources. Can be set to any string.
-/// Applies to AWS scenarios only.
-// enos_user = "enos"
-
-// ENTERPRISE ONLY
-// Path to a license file
-// boundary_license_path = "./support/boundary.hclic"
-// Directly set the boundary license. Overrides boundary license file.
-// boundary_license = ""
-
 // ==============================================================================
 // OPTIONAL VARIABLES
 // ==============================================================================
@@ -51,7 +28,10 @@
 // variant. If you execute variants with the local builder this does not need
 // to be set. In CI we use this to point to the artifacts generated as part
 // of the build workflow.
-// crt_bundle_path = "./boundary_linux_amd64.zip"
+// crt_bundle_path = "~/Downloads/boundary_linux_amd64.zip"
+
+// Docker image file for boundary. This is used for docker scenarios
+// boundary_docker_image_file = "~/Downloads/boundary-docker-image.tar"
 
 // Number of controller instances to create. Applies to AWS scenarios only.
 // controller_count = 1
@@ -100,3 +80,30 @@
 // The boundary version for the worker in scenarios with a worker and controller version
 // mismatch. Will pull the official boundary docker image for given version.
 // worker_version = "0.21"
+
+// If you want to use your own ssh key instead of terraform generating one for
+// you, use this variable.
+// The name of the AWS keypair in EC2 -> Key Pairs. Ensure this key pair is
+// available in the selected region. Applies to AWS scenarios only.
+// aws_ssh_keypair_name = "mykeypair"
+
+// If you want to use your own ssh key instead of terraform generating one for
+// you, use this variable.
+// The path to the local copy of the private key associated with your keypair.
+// aws_ssh_private_key_path = "/Users/<user>/.ssh/mykeypair.pem"
+
+// Name of user. This is used to tag resources in AWS to more easily identify
+// your resources. Can be set to any string.
+/// Applies to AWS scenarios only.
+// enos_user = "enos"
+
+// The AWS region you want to create the resources in. Make sure you choose a
+// region where you've got an AWS keypair. Applies to AWS scenarios only.
+// aws_region = "us-east-1"
+
+// ENTERPRISE ONLY
+// Path to a license file
+// boundary_license_path = "./support/boundary.hclic"
+// Directly set the boundary license. Overrides boundary license file.
+// This can also be set by an environment variable ENOS_VAR_boundary_license
+// boundary_license = ""

--- a/enos/modules/aws_boundary/boundary-instances.tf
+++ b/enos/modules/aws_boundary/boundary-instances.tf
@@ -12,7 +12,7 @@ resource "aws_instance" "controller" {
     aws_security_group.boundary_aux_sg.id,
   ]
   subnet_id            = tolist(data.aws_subnets.infra.ids)[count.index % length(data.aws_subnets.infra.ids)]
-  key_name             = var.ssh_aws_keypair
+  key_name             = var.aws_ssh_keypair_name
   iam_instance_profile = aws_iam_instance_profile.boundary_profile.name
   monitoring           = var.controller_monitoring
   ipv6_address_count   = local.network_stack[var.ip_version].ipv6_address_count
@@ -45,7 +45,7 @@ resource "aws_instance" "worker" {
   instance_type          = var.worker_instance_type
   vpc_security_group_ids = [aws_security_group.boundary_sg.id]
   subnet_id              = tolist(data.aws_subnets.infra.ids)[count.index % length(data.aws_subnets.infra.ids)]
-  key_name               = var.ssh_aws_keypair
+  key_name               = var.aws_ssh_keypair_name
   iam_instance_profile   = aws_iam_instance_profile.boundary_profile.name
   monitoring             = var.worker_monitoring
   ipv6_address_count     = local.network_stack[var.ip_version].ipv6_address_count
@@ -83,7 +83,9 @@ resource "enos_bundle_install" "controller" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.controller[tonumber(each.value)].ipv6_addresses[0] : aws_instance.controller[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.controller[tonumber(each.value)].ipv6_addresses[0] : aws_instance.controller[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -100,7 +102,9 @@ resource "enos_remote_exec" "update_path_controller" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.controller[tonumber(each.value)].ipv6_addresses[0] : aws_instance.controller[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.controller[tonumber(each.value)].ipv6_addresses[0] : aws_instance.controller[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -138,7 +142,9 @@ resource "enos_file" "controller_config" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.controller[tonumber(each.value)].ipv6_addresses[0] : aws_instance.controller[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.controller[tonumber(each.value)].ipv6_addresses[0] : aws_instance.controller[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -153,7 +159,9 @@ resource "enos_boundary_init" "controller" {
 
   transport = {
     ssh = {
-      host = try(var.ip_version == "6" ? aws_instance.controller[0].ipv6_addresses[0] : aws_instance.controller[0].public_ip, null)
+      host             = try(var.ip_version == "6" ? aws_instance.controller[0].ipv6_addresses[0] : aws_instance.controller[0].public_ip, null)
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 
@@ -170,7 +178,9 @@ resource "enos_boundary_start" "controller_start" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.controller[tonumber(each.value)].ipv6_addresses[0] : aws_instance.controller[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.controller[tonumber(each.value)].ipv6_addresses[0] : aws_instance.controller[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 
@@ -195,7 +205,9 @@ resource "enos_remote_exec" "create_controller_audit_log_dir" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.controller[tonumber(each.value)].ipv6_addresses[0] : aws_instance.controller[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.controller[tonumber(each.value)].ipv6_addresses[0] : aws_instance.controller[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -212,7 +224,9 @@ resource "enos_bundle_install" "worker" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -229,7 +243,9 @@ resource "enos_remote_exec" "update_path_worker" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -257,7 +273,9 @@ resource "enos_file" "worker_config" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -274,7 +292,9 @@ resource "enos_boundary_start" "worker_start" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -294,7 +314,9 @@ resource "enos_remote_exec" "create_worker_audit_log_dir" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -314,7 +336,9 @@ resource "enos_remote_exec" "create_worker_auth_storage_dir" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -326,7 +350,9 @@ resource "enos_remote_exec" "get_worker_token" {
   inline = ["timeout 10s bash -c 'set -eo pipefail; until journalctl -u boundary.service | cat | grep \"Worker Auth Registration Request: .*\" | rev | cut -d \" \" -f 1 | rev | xargs; do sleep 2; done'"]
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker[tonumber(each.value)].ipv6_addresses[0] : aws_instance.worker[tonumber(each.value)].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }

--- a/enos/modules/aws_boundary/variables.tf
+++ b/enos/modules/aws_boundary/variables.tf
@@ -104,12 +104,6 @@ variable "controller_monitoring" {
   default     = false
 }
 
-variable "ssh_user" {
-  description = "SSH user to authenticate as"
-  type        = string
-  default     = "ubuntu"
-}
-
 variable "aws_ssh_keypair_name" {
   description = "SSH keypair used to connect to EC2 instances"
   type        = string

--- a/enos/modules/aws_boundary/variables.tf
+++ b/enos/modules/aws_boundary/variables.tf
@@ -110,8 +110,13 @@ variable "ssh_user" {
   default     = "ubuntu"
 }
 
-variable "ssh_aws_keypair" {
+variable "aws_ssh_keypair_name" {
   description = "SSH keypair used to connect to EC2 instances"
+  type        = string
+}
+
+variable "aws_ssh_private_key_path" {
+  description = "SSH private key path for connecting to instances"
   type        = string
 }
 

--- a/enos/modules/aws_ssh_keypair/main.tf
+++ b/enos/modules/aws_ssh_keypair/main.tf
@@ -34,6 +34,15 @@ check "local_key_path_requires_local_aws_keypair_name" {
   }
 }
 
+check "local_aws_keypair_name_requires_local_key_path" {
+  assert {
+    condition     = var.local_aws_keypair_name == null || var.local_key_path != null
+    error_message = "local_key_path must be provided when local_aws_keypair_name is set."
+  }
+}
+
+resource "random_pet" "default" {}
+
 resource "tls_private_key" "ssh" {
   count     = var.local_key_path == null ? 1 : 0
   algorithm = "RSA"
@@ -42,7 +51,7 @@ resource "tls_private_key" "ssh" {
 
 resource "aws_key_pair" "generated" {
   count      = var.local_key_path == null ? 1 : 0
-  key_name   = "ssh-key-enos-aws"
+  key_name   = "ssh-key-enos-aws-${random_pet.default.id}"
   public_key = tls_private_key.ssh[0].public_key_openssh
 }
 

--- a/enos/modules/aws_ssh_keypair/main.tf
+++ b/enos/modules/aws_ssh_keypair/main.tf
@@ -1,0 +1,62 @@
+# Copyright IBM Corp. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+}
+
+variable "local_key_path" {
+  type        = string
+  description = "Path to a local key. If provided, this key will be used instead of generating a new one."
+  default     = null
+}
+
+variable "local_aws_keypair_name" {
+  type        = string
+  description = "Name of the key pair in AWS of the uploaded key from local_key_path."
+  default     = null
+}
+
+check "local_key_path_requires_local_aws_keypair_name" {
+  assert {
+    condition     = var.local_key_path == null || var.local_aws_keypair_name != null
+    error_message = "local_aws_keypair_name must be provided when local_key_path is set."
+  }
+}
+
+resource "tls_private_key" "ssh" {
+  count     = var.local_key_path == null ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "generated" {
+  count      = var.local_key_path == null ? 1 : 0
+  key_name   = "ssh-key-enos-aws"
+  public_key = tls_private_key.ssh[0].public_key_openssh
+}
+
+resource "local_sensitive_file" "private_key" {
+  count           = var.local_key_path == null ? 1 : 0
+  content         = tls_private_key.ssh[0].private_key_pem
+  filename        = "${path.root}/.terraform/tmp/${aws_key_pair.generated[0].key_name}"
+  file_permission = "0400"
+}
+
+output "key_pair_name" {
+  value = var.local_key_path != null ? var.local_aws_keypair_name : aws_key_pair.generated[0].key_name
+}
+
+output "private_key_path" {
+  value = var.local_key_path != null ? abspath(var.local_key_path) : abspath(local_sensitive_file.private_key[0].filename)
+}

--- a/enos/modules/aws_target/main.tf
+++ b/enos/modules/aws_target/main.tf
@@ -17,6 +17,7 @@ variable "environment" {}
 variable "project_name" {}
 variable "instance_type" {}
 variable "aws_ssh_keypair_name" {}
+variable "aws_ssh_private_key_path" {}
 variable "enos_user" {}
 variable "additional_tags" {
   default = {}
@@ -149,7 +150,9 @@ resource "enos_remote_exec" "wait" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.target[each.key].ipv6_addresses[0] : aws_instance.target[each.key].public_ip
+      host             = var.ip_version == "6" ? aws_instance.target[each.key].ipv6_addresses[0] : aws_instance.target[each.key].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }

--- a/enos/modules/aws_vault/variables.tf
+++ b/enos/modules/aws_vault/variables.tf
@@ -118,8 +118,13 @@ variable "sg_additional_ipv6_ips" {
   default     = []
 }
 
-variable "ssh_aws_keypair" {
+variable "aws_ssh_keypair_name" {
   description = "SSH keypair used to connect to EC2 instances"
+  type        = string
+}
+
+variable "aws_ssh_private_key_path" {
+  description = "SSH private key path for connecting to instances"
   type        = string
 }
 

--- a/enos/modules/aws_vault/vault-instances.tf
+++ b/enos/modules/aws_vault/vault-instances.tf
@@ -7,7 +7,7 @@ resource "aws_instance" "vault_instance" {
   instance_type          = var.instance_type
   vpc_security_group_ids = [aws_security_group.enos_vault_sg[0].id]
   subnet_id              = tolist(data.aws_subnets.infra.ids)[each.key % length(data.aws_subnets.infra.ids)]
-  key_name               = var.ssh_aws_keypair
+  key_name               = var.aws_ssh_keypair_name
   iam_instance_profile   = aws_iam_instance_profile.vault_profile[0].name
   ipv6_address_count     = local.network_stack[var.ip_version].ipv6_address_count
   tags = merge(
@@ -41,7 +41,9 @@ resource "enos_remote_exec" "install_dependencies" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[each.value].ipv6_addresses[0] : aws_instance.vault_instance[each.value].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[each.value].ipv6_addresses[0] : aws_instance.vault_instance[each.value].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -57,7 +59,9 @@ resource "enos_bundle_install" "consul" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? each.value.ipv6_addresses[0] : each.value.public_ip
+      host             = var.ip_version == "6" ? each.value.ipv6_addresses[0] : each.value.public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -72,7 +76,9 @@ resource "enos_bundle_install" "vault" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? each.value.ipv6_addresses[0] : each.value.public_ip
+      host             = var.ip_version == "6" ? each.value.ipv6_addresses[0] : each.value.public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -98,7 +104,9 @@ resource "enos_consul_start" "consul" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[each.key].ipv6_addresses[0] : aws_instance.vault_instance[each.key].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[each.key].ipv6_addresses[0] : aws_instance.vault_instance[each.key].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -140,7 +148,9 @@ resource "enos_vault_start" "leader" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[each.key].ipv6_addresses[0] : aws_instance.vault_instance[each.key].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[each.key].ipv6_addresses[0] : aws_instance.vault_instance[each.key].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -181,7 +191,9 @@ resource "enos_vault_start" "followers" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[each.key].ipv6_addresses[0] : aws_instance.vault_instance[each.key].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[each.key].ipv6_addresses[0] : aws_instance.vault_instance[each.key].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -204,7 +216,9 @@ resource "enos_vault_init" "leader" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[0].ipv6_addresses[0] : aws_instance.vault_instance[0].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[0].ipv6_addresses[0] : aws_instance.vault_instance[0].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -222,7 +236,9 @@ resource "enos_vault_unseal" "leader" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[0].ipv6_addresses[0] : aws_instance.vault_instance[0].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[0].ipv6_addresses[0] : aws_instance.vault_instance[0].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -247,7 +263,9 @@ resource "enos_remote_exec" "create_audit_log_dir" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[each.value].ipv6_addresses[0] : aws_instance.vault_instance[each.value].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[each.value].ipv6_addresses[0] : aws_instance.vault_instance[each.value].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -276,7 +294,9 @@ resource "enos_remote_exec" "init_audit_device" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[each.key].ipv6_addresses[0] : aws_instance.vault_instance[each.key].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[each.key].ipv6_addresses[0] : aws_instance.vault_instance[each.key].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -299,7 +319,9 @@ resource "enos_vault_unseal" "followers" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[0].ipv6_addresses[0] : aws_instance.vault_instance[0].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[0].ipv6_addresses[0] : aws_instance.vault_instance[0].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -325,7 +347,9 @@ resource "enos_vault_unseal" "when_vault_unseal_when_no_init_is_set" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[each.key].ipv6_addresses[0] : aws_instance.vault_instance[each.key].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[each.key].ipv6_addresses[0] : aws_instance.vault_instance[each.key].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -345,7 +369,9 @@ resource "enos_remote_exec" "vault_write_license" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[0].ipv6_addresses[0] : aws_instance.vault_instance[0].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[0].ipv6_addresses[0] : aws_instance.vault_instance[0].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -364,7 +390,9 @@ resource "enos_remote_exec" "vault_kms_policy" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.vault_instance[0].ipv6_addresses[0] : aws_instance.vault_instance[0].public_ip
+      host             = var.ip_version == "6" ? aws_instance.vault_instance[0].ipv6_addresses[0] : aws_instance.vault_instance[0].public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }

--- a/enos/modules/aws_worker/main.tf
+++ b/enos/modules/aws_worker/main.tf
@@ -150,7 +150,7 @@ resource "aws_instance" "worker" {
   instance_type          = var.worker_instance_type
   vpc_security_group_ids = [aws_security_group.default.id]
   subnet_id              = var.create_subnet ? aws_subnet.default[0].id : var.subnet_ids[0]
-  key_name               = var.ssh_aws_keypair
+  key_name               = var.aws_ssh_keypair_name
   iam_instance_profile   = aws_iam_instance_profile.boundary_profile.name
   monitoring             = var.worker_monitoring
 
@@ -188,7 +188,9 @@ resource "enos_bundle_install" "worker" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker.ipv6_addresses[0] : aws_instance.worker.public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker.ipv6_addresses[0] : aws_instance.worker.public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -204,7 +206,9 @@ resource "enos_remote_exec" "update_path_worker" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker.ipv6_addresses[0] : aws_instance.worker.public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker.ipv6_addresses[0] : aws_instance.worker.public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -234,7 +238,9 @@ resource "enos_file" "worker_config" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker.ipv6_addresses[0] : aws_instance.worker.public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker.ipv6_addresses[0] : aws_instance.worker.public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -250,7 +256,9 @@ resource "enos_boundary_start" "worker_start" {
   recording_storage_path = var.recording_storage_path != "" ? var.recording_storage_path : null
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker.ipv6_addresses[0] : aws_instance.worker.public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker.ipv6_addresses[0] : aws_instance.worker.public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }
@@ -269,7 +277,9 @@ resource "enos_remote_exec" "create_worker_audit_log_dir" {
 
   transport = {
     ssh = {
-      host = var.ip_version == "6" ? aws_instance.worker.ipv6_addresses[0] : aws_instance.worker.public_ip
+      host             = var.ip_version == "6" ? aws_instance.worker.ipv6_addresses[0] : aws_instance.worker.public_ip
+      user             = "ubuntu"
+      private_key_path = abspath(var.aws_ssh_private_key_path)
     }
   }
 }

--- a/enos/modules/aws_worker/variables.tf
+++ b/enos/modules/aws_worker/variables.tf
@@ -34,9 +34,15 @@ variable "worker_instance_type" {
   default     = "t2.small"
 }
 
-variable "ssh_aws_keypair" {
-  description = "The name of the SSH keypair used to connect to EC2 instances"
+variable "aws_ssh_keypair_name" {
+  description = "SSH keypair used to connect to EC2 instances"
   type        = string
+}
+
+variable "aws_ssh_private_key_path" {
+  description = "SSH private key path for connecting to instances"
+  type        = string
+  sensitive   = true
 }
 
 variable "worker_monitoring" {

--- a/enos/modules/ssh_keypair/main.tf
+++ b/enos/modules/ssh_keypair/main.tf
@@ -1,0 +1,36 @@
+# Copyright IBM Corp. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+terraform {
+  required_providers {
+    tls = {
+      source = "hashicorp/tls"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+}
+
+variable "local_key_path" {
+  type        = string
+  description = "Path to a local key. If provided, this key will be used instead of generating a new one."
+  default     = null
+}
+
+resource "tls_private_key" "ssh" {
+  count     = var.local_key_path == null ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "local_sensitive_file" "private_key" {
+  count           = var.local_key_path == null ? 1 : 0
+  content         = tls_private_key.ssh[0].private_key_pem
+  filename        = "${path.root}/.terraform/tmp/ssh-key-enos"
+  file_permission = "0400"
+}
+
+output "private_key_path" {
+  value = var.local_key_path != null ? abspath(var.local_key_path) : abspath(local_sensitive_file.private_key[0].filename)
+}

--- a/enos/modules/ssh_keypair/main.tf
+++ b/enos/modules/ssh_keypair/main.tf
@@ -18,6 +18,8 @@ variable "local_key_path" {
   default     = null
 }
 
+resource "random_pet" "default" {}
+
 resource "tls_private_key" "ssh" {
   count     = var.local_key_path == null ? 1 : 0
   algorithm = "RSA"
@@ -27,7 +29,7 @@ resource "tls_private_key" "ssh" {
 resource "local_sensitive_file" "private_key" {
   count           = var.local_key_path == null ? 1 : 0
   content         = tls_private_key.ssh[0].private_key_pem
-  filename        = "${path.root}/.terraform/tmp/ssh-key-enos"
+  filename        = "${path.root}/.terraform/tmp/ssh-key-enos-${random_pet.default.id}"
   file_permission = "0400"
 }
 

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -259,10 +259,10 @@ variable "ip_version" {
 }
 
 locals {
+  aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
   aws_host_set_ips1        = jsonencode(var.aws_host_set_ips1)
   aws_host_set_ips2        = jsonencode(var.aws_host_set_ips2)
   package_name             = reverse(split("/", var.test_package))[0]
-  aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
 }
 
 resource "enos_local_exec" "run_e2e_test" {

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -51,11 +51,12 @@ variable "target_user" {
   type        = string
   default     = ""
 }
+
 variable "aws_ssh_private_key_path" {
-  description = "Local Path to key used to SSH onto created hosts"
+  description = "Path to the private key used to SSH into AWS instances"
   type        = string
-  default     = ""
 }
+
 variable "target_address" {
   description = "Address of target"
   type        = string
@@ -258,10 +259,10 @@ variable "ip_version" {
 }
 
 locals {
-  aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
   aws_host_set_ips1        = jsonencode(var.aws_host_set_ips1)
   aws_host_set_ips2        = jsonencode(var.aws_host_set_ips2)
   package_name             = reverse(split("/", var.test_package))[0]
+  aws_ssh_private_key_path = abspath(var.aws_ssh_private_key_path)
 }
 
 resource "enos_local_exec" "run_e2e_test" {


### PR DESCRIPTION
## Description
This PR updates the e2e test infra to remove the requirement for creating an ssh key and passing that to a variable when setting up enos. This ssh key is the one used to authenticate with an ssh target as well as logging into aws ec2 instances. If you don't pass that variable in, the scenario will generate a key for you and create a local copy in a temp folder.

Enterprise changes were tested in this PR: https://github.com/hashicorp/boundary-enterprise/pull/2348 and will get added to the ce -> ent merge PR. 

This continues the path towards minimizing the amount of setup needed when setting up enos for the first time. 

https://hashicorp.atlassian.net/browse/ICU-17258

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
