### PR TITLE
feat(daemon): csp nonce handling

### DIFF
--- a/internal/daemon/controller/handler.go
+++ b/internal/daemon/controller/handler.go
@@ -801,17 +801,11 @@ func wrapHandlerWithCsp(h http.Handler, props HandlerProperties, isUiRequest fun
 		nonceToken := fmt.Sprintf("'nonce-%s'", nonce)
 
 		csp := defaultCsp
-		switch {
-		// In the case there is style-src present in the csp then we will inject nonce
-		case strings.Contains(csp, "style-src "):
+
+		if strings.Contains(csp, "style-src ") {
 			csp = strings.Replace(csp, "style-src ", fmt.Sprintf("style-src %s ", nonceToken), 1)
-		default:
-			// If default-src exists, append a style-src directive
-			// using the same source list.
-			if _, after, ok := strings.Cut(csp, "default-src "); ok {
-				sources, _, _ := strings.Cut(after, ";")
-				csp = fmt.Sprintf("%s; style-src %s %s", csp, nonceToken, strings.TrimSpace(sources))
-			}
+		} else {
+			csp = fmt.Sprintf("%s; style-src %s 'self'", csp, nonceToken)
 		}
 
 		w.Header().Set(cspKey, csp)

--- a/internal/daemon/controller/handler.go
+++ b/internal/daemon/controller/handler.go
@@ -797,9 +797,22 @@ func wrapHandlerWithCsp(h http.Handler, props HandlerProperties, isUiRequest fun
 		}
 		nonce := base64.StdEncoding.EncodeToString(b)
 
-		// Inject nonce
+		// Inject nonce into the style-src directive of the CSP.
 		nonceToken := fmt.Sprintf("'nonce-%s'", nonce)
-		csp := strings.Replace(defaultCsp, "style-src 'self'", fmt.Sprintf("style-src %s 'self'", nonceToken), 1)
+
+		csp := defaultCsp
+		switch {
+		// In the case there is style-src present in the csp then we will inject nonce
+		case strings.Contains(csp, "style-src "):
+			csp = strings.Replace(csp, "style-src ", fmt.Sprintf("style-src %s ", nonceToken), 1)
+		default:
+			// If default-src exists, append a style-src directive
+			// using the same source list.
+			if _, after, ok := strings.Cut(csp, "default-src "); ok {
+				sources, _, _ := strings.Cut(after, ";")
+				csp = fmt.Sprintf("%s; style-src %s %s", csp, nonceToken, strings.TrimSpace(sources))
+			}
+		}
 
 		w.Header().Set(cspKey, csp)
 		// Creating a custom key so we can pull it when serving UI page

--- a/internal/daemon/controller/handler.go
+++ b/internal/daemon/controller/handler.go
@@ -6,6 +6,8 @@ package controller
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -98,7 +100,8 @@ func (c *Controller) apiHandler(props HandlerProperties) (http.Handler, error) {
 		return nil, err
 	}
 
-	corsWrappedHandler := wrapHandlerWithCors(mux, props)
+	cspWrappedHandler := wrapHandlerWithCsp(mux, props, isUiRequest)
+	corsWrappedHandler := wrapHandlerWithCors(cspWrappedHandler, props)
 	commonWrappedHandler := wrapHandlerWithCommonFuncs(corsWrappedHandler, c, props)
 	callbackInterceptingHandler := wrapHandlerWithCallbackInterceptor(commonWrappedHandler, c)
 	printablePathCheckHandler := cleanhttp.PrintablePathCheckHandler(callbackInterceptingHandler, nil)
@@ -758,4 +761,47 @@ func getActions(urlPath string) []string {
 
 	// Split the rest on ":", returning all actions and sub-actions
 	return strings.Split(rest, ":")
+}
+
+func wrapHandlerWithCsp(h http.Handler, props HandlerProperties, isUiRequest func(*http.Request) bool) http.Handler {
+	cspKey := "Content-Security-Policy"
+	defaultCsp := ""
+	if headers, ok := props.ListenerConfig.CustomUiResponseHeaders[0]; ok {
+		if vals := headers[cspKey]; len(vals) > 0 {
+			defaultCsp = vals[0]
+		}
+		// Remove CSP from the map so WrapCustomHeadersHandler does not
+		// overwrite the nonce injected value.
+		delete(headers, cspKey)
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if defaultCsp == "" || !isUiRequest(req) {
+			h.ServeHTTP(w, req)
+			return
+		}
+
+		// Static assets get the default CSP without a nonce.
+		if strings.LastIndex(req.URL.Path, ".") != -1 {
+			w.Header().Set(cspKey, defaultCsp)
+			h.ServeHTTP(w, req)
+			return
+		}
+
+		// Generate nonce.
+		b := make([]byte, 16)
+		if _, err := rand.Read(b); err != nil {
+			w.Header().Set(cspKey, defaultCsp)
+			h.ServeHTTP(w, req)
+			return
+		}
+		nonce := base64.StdEncoding.EncodeToString(b)
+
+		// Inject nonce
+		nonceToken := "'nonce-" + nonce + "'"
+		csp := strings.Replace(defaultCsp, "style-src 'self'", "style-src "+nonceToken+" 'self'", 1)
+
+		w.Header().Set(cspKey, csp)
+		h.ServeHTTP(w, req)
+	})
 }

--- a/internal/daemon/controller/handler.go
+++ b/internal/daemon/controller/handler.go
@@ -798,10 +798,12 @@ func wrapHandlerWithCsp(h http.Handler, props HandlerProperties, isUiRequest fun
 		nonce := base64.StdEncoding.EncodeToString(b)
 
 		// Inject nonce
-		nonceToken := "'nonce-" + nonce + "'"
-		csp := strings.Replace(defaultCsp, "style-src 'self'", "style-src "+nonceToken+" 'self'", 1)
+		nonceToken := fmt.Sprintf("'nonce-%s'", nonce)
+		csp := strings.Replace(defaultCsp, "style-src 'self'", fmt.Sprintf("style-src %s 'self'", nonceToken), 1)
 
 		w.Header().Set(cspKey, csp)
+		// Creating a custom key so we can pull it when serving UI page
+		w.Header().Set("X-Boundary-Csp-Nonce", nonce)
 		h.ServeHTTP(w, req)
 	})
 }

--- a/internal/daemon/controller/handler_test.go
+++ b/internal/daemon/controller/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -19,6 +20,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/hashicorp/boundary/internal/daemon/controller/handlers"
 	"github.com/hashicorp/boundary/internal/errors"
+	"github.com/hashicorp/go-secure-stdlib/listenerutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/api/httpbody"
@@ -464,6 +466,81 @@ func TestGetActions(t *testing.T) {
 			actions := getActions(tc.url)
 			fmt.Println("actions", len(actions))
 			require.Equal(tc.expected, actions)
+		})
+	}
+}
+
+func TestWrapHandlerWithCsp(t *testing.T) {
+	defaultCsp := "default-src 'none'; script-src 'self' 'wasm-unsafe-eval'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"
+
+	newProps := func() HandlerProperties {
+		headers := http.Header{}
+		headers.Set("Content-Security-Policy", defaultCsp)
+		return HandlerProperties{
+			ListenerConfig: &listenerutil.ListenerConfig{
+				CustomUiResponseHeaders: map[int]http.Header{
+					0: headers,
+				},
+			},
+		}
+	}
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	testCases := []struct {
+		name           string
+		path           string
+		isUi           bool
+		wantNonce      bool
+		wantDefaultCsp bool
+	}{
+		{
+			name:      "document request gets nonce",
+			path:      "/",
+			isUi:      true,
+			wantNonce: true,
+		},
+		{
+			name:           "static asset gets default CSP without nonce",
+			path:           "/assets/app.js",
+			isUi:           true,
+			wantDefaultCsp: true,
+			wantNonce:      false,
+		},
+		{
+			name:      "non UI request gets no CSP header",
+			path:      "/",
+			isUi:      false,
+			wantNonce: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
+			isUiFunc := func(*http.Request) bool { return tc.isUi }
+			handler := wrapHandlerWithCsp(inner, newProps(), isUiFunc)
+			req := httptest.NewRequest("GET", tc.path, nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			csp := rec.Header().Get("Content-Security-Policy")
+
+			switch {
+			case tc.wantNonce:
+				require.NotEmpty(csp)
+				assert.Contains(csp, "'nonce-")
+			case tc.wantDefaultCsp:
+				require.NotEmpty(csp)
+				assert.NotContains(csp, "'nonce-")
+				require.Equal(defaultCsp, csp)
+			default:
+				require.Empty(csp)
+			}
 		})
 	}
 }

--- a/internal/daemon/controller/handler_test.go
+++ b/internal/daemon/controller/handler_test.go
@@ -473,9 +473,12 @@ func TestGetActions(t *testing.T) {
 func TestWrapHandlerWithCsp(t *testing.T) {
 	defaultCsp := "default-src 'none'; script-src 'self' 'wasm-unsafe-eval'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"
 
-	newProps := func() HandlerProperties {
+	newProps := func(csp string) HandlerProperties {
+		if csp == "" {
+			csp = defaultCsp
+		}
 		headers := http.Header{}
-		headers.Set("Content-Security-Policy", defaultCsp)
+		headers.Set("Content-Security-Policy", csp)
 		return HandlerProperties{
 			ListenerConfig: &listenerutil.ListenerConfig{
 				CustomUiResponseHeaders: map[int]http.Header{
@@ -493,8 +496,10 @@ func TestWrapHandlerWithCsp(t *testing.T) {
 		name           string
 		path           string
 		isUi           bool
+		customCsp      string
 		wantNonce      bool
 		wantDefaultCsp bool
+		wantContains   []string
 	}{
 		{
 			name:      "document request gets nonce",
@@ -515,6 +520,13 @@ func TestWrapHandlerWithCsp(t *testing.T) {
 			isUi:      false,
 			wantNonce: false,
 		},
+		{
+			name:         "custom CSP without style-src gets style-src created",
+			path:         "/",
+			isUi:         true,
+			customCsp:    "default-src 'none'; script-src 'self'",
+			wantContains: []string{"default-src 'none'", "script-src 'self'", "; style-src 'nonce-", "'self'"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -523,12 +535,20 @@ func TestWrapHandlerWithCsp(t *testing.T) {
 			assert := assert.New(t)
 
 			isUiFunc := func(*http.Request) bool { return tc.isUi }
-			handler := wrapHandlerWithCsp(inner, newProps(), isUiFunc)
+			handler := wrapHandlerWithCsp(inner, newProps(tc.customCsp), isUiFunc)
 			req := httptest.NewRequest("GET", tc.path, nil)
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, req)
 
 			csp := rec.Header().Get("Content-Security-Policy")
+
+			if len(tc.wantContains) > 0 {
+				require.NotEmpty(csp)
+				for _, want := range tc.wantContains {
+					assert.Contains(csp, want)
+				}
+				return
+			}
 
 			switch {
 			case tc.wantNonce:

--- a/internal/daemon/controller/handler_ui.go
+++ b/internal/daemon/controller/handler_ui.go
@@ -6,6 +6,7 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"strings"
@@ -33,6 +34,24 @@ var serveGrantSchema = func(ctx context.Context, w http.ResponseWriter) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data)
+}
+
+const cspPlaceholder = "__BOUNDARY_CSP_NONCE__"
+
+// cspWriter wraps an http.ResponseWriter to replace the CSP nonce placeholder
+// in index.html with the actual Content-Security-Policy value.
+type cspWriter struct {
+	http.ResponseWriter
+	csp  string
+	done bool
+}
+
+func (w *cspWriter) Write(b []byte) (int, error) {
+	if !w.done {
+		w.done = true
+		b = bytes.Replace(b, []byte(cspPlaceholder), []byte(w.csp), 1)
+	}
+	return w.ResponseWriter.Write(b)
 }
 
 func handleUiWithAssets(c *Controller) http.Handler {
@@ -80,7 +99,13 @@ func handleUiWithAssets(c *Controller) http.Handler {
 			}
 		}
 
-		// Fall through to the next handler
+		// For document requests, replace the CSP placeholder inside <head>.
+		if r.URL.Path == "/" {
+			if csp := w.Header().Get("Content-Security-Policy"); csp != "" {
+				nextHandler.ServeHTTP(&cspWriter{ResponseWriter: w, csp: csp}, r)
+				return
+			}
+		}
 		nextHandler.ServeHTTP(w, r)
 	})
 }

--- a/internal/daemon/controller/handler_ui.go
+++ b/internal/daemon/controller/handler_ui.go
@@ -55,11 +55,20 @@ func (w *cspWriter) WriteHeader(statusCode int) {
 }
 
 func (w *cspWriter) Write(b []byte) (int, error) {
+	originalLen := len(b)
 	if !w.done {
 		w.done = true
 		b = bytes.Replace(b, []byte(cspPlaceholder), []byte(w.nonce), 1)
 	}
-	return w.ResponseWriter.Write(b)
+	_, err := w.ResponseWriter.Write(b)
+	if err != nil {
+		return 0, err
+	}
+	// We return the original length to maintain the io.Writer contract.
+	// Per io.Writer: "Write must return a non-nil error if it returns n < len(p)."
+	// Since we successfully consumed all input bytes, we must return len(p) with nil error.
+	// Returning the modified length would violate this and break the caller's buffer tracking.
+	return originalLen, nil
 }
 
 func handleUiWithAssets(c *Controller) http.Handler {

--- a/internal/daemon/controller/handler_ui.go
+++ b/internal/daemon/controller/handler_ui.go
@@ -49,7 +49,7 @@ type cspWriter struct {
 // WriteHeader removes the stale Content-Length since the body replacement
 // changes the size.
 func (w *cspWriter) WriteHeader(statusCode int) {
-	//We need to force recalculation to avoid content length mismatch
+	// We need to force recalculation to avoid content length mismatch
 	w.ResponseWriter.Header().Del("Content-Length")
 	w.ResponseWriter.WriteHeader(statusCode)
 }
@@ -72,7 +72,7 @@ func handleUiWithAssets(c *Controller) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
-			//Lets remove nonce in case we return here
+			// Lets remove nonce in case we return here
 			w.Header().Del("X-Boundary-Csp-Nonce")
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return

--- a/internal/daemon/controller/handler_ui.go
+++ b/internal/daemon/controller/handler_ui.go
@@ -39,17 +39,25 @@ var serveGrantSchema = func(ctx context.Context, w http.ResponseWriter) {
 const cspPlaceholder = "__BOUNDARY_CSP_NONCE__"
 
 // cspWriter wraps an http.ResponseWriter to replace the CSP nonce placeholder
-// in index.html with the actual Content-Security-Policy value.
+// in index.html with the actual nonce value.
 type cspWriter struct {
 	http.ResponseWriter
-	csp  string
-	done bool
+	nonce string
+	done  bool
+}
+
+// WriteHeader removes the stale Content-Length since the body replacement
+// changes the size.
+func (w *cspWriter) WriteHeader(statusCode int) {
+	//We need to force recalculation to avoid content length mismatch
+	w.ResponseWriter.Header().Del("Content-Length")
+	w.ResponseWriter.WriteHeader(statusCode)
 }
 
 func (w *cspWriter) Write(b []byte) (int, error) {
 	if !w.done {
 		w.done = true
-		b = bytes.Replace(b, []byte(cspPlaceholder), []byte(w.csp), 1)
+		b = bytes.Replace(b, []byte(cspPlaceholder), []byte(w.nonce), 1)
 	}
 	return w.ResponseWriter.Write(b)
 }
@@ -64,6 +72,8 @@ func handleUiWithAssets(c *Controller) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
+			//Lets remove nonce in case we return here
+			w.Header().Del("X-Boundary-Csp-Nonce")
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
@@ -101,11 +111,16 @@ func handleUiWithAssets(c *Controller) http.Handler {
 
 		// For document requests, replace the CSP placeholder inside <head>.
 		if r.URL.Path == "/" {
-			if csp := w.Header().Get("Content-Security-Policy"); csp != "" {
-				nextHandler.ServeHTTP(&cspWriter{ResponseWriter: w, csp: csp}, r)
+			if nonce := w.Header().Get("X-Boundary-Csp-Nonce"); nonce != "" {
+				// Remove nonce once we have injected it in the Write() call
+				w.Header().Del("X-Boundary-Csp-Nonce")
+				nextHandler.ServeHTTP(&cspWriter{ResponseWriter: w, nonce: nonce}, r)
 				return
 			}
 		}
+
+		// Strip internal nonce header for non document requests
+		w.Header().Del("X-Boundary-Csp-Nonce")
 		nextHandler.ServeHTTP(w, r)
 	})
 }

--- a/internal/daemon/controller/handler_ui_test.go
+++ b/internal/daemon/controller/handler_ui_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,6 +18,41 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCspWriter_Write(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		nonce    string
+		wantBody string
+	}{
+		{
+			name:     "replaces placeholder with nonce",
+			input:    "foo __BOUNDARY_CSP_NONCE__ bar",
+			nonce:    "'nonce-abc123'",
+			wantBody: "foo 'nonce-abc123' bar",
+		},
+		{
+			name:     "no placeholder returns original unchanged",
+			input:    "no placeholder here",
+			nonce:    "'nonce-abc123'",
+			wantBody: "no placeholder here",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			w := &cspWriter{
+				ResponseWriter: rec,
+				nonce:          tc.nonce,
+			}
+			n, err := w.Write([]byte(tc.input))
+			require.NoError(t, err)
+			assert.Equal(t, len(tc.input), n, "must return original input length to conform to the io.Writer contract")
+			assert.Equal(t, tc.wantBody, rec.Body.String())
+		})
+	}
+}
 
 func TestUiRouting(t *testing.T) {
 	// Create a temporary directory


### PR DESCRIPTION
## Description

This PR adds nonce handling to support UI features. The changes include a new wrapper to apply CSP with a crypto nonce value and adjust injection of the nonce into returned HTML. This change will take place in tandem with a [UI PR](https://github.com/hashicorp/boundary-ui/pull/3230)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
