### PR TITLE
chore(e2e): Fix worker version e2e-docker-base-with-worker-version to account for 1.0 release

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -101,8 +101,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          fetch-depth: ${{ matrix.scenario == 'e2e_docker_base_with_worker_version' && '0' || '1' }}
-          fetch-tags: ${{ matrix.scenario == 'e2e_docker_base_with_worker_version' && 'true' || 'false' }}
+          fetch-depth: ${{ contains(matrix.filter, 'e2e_docker_base_with_worker_version') && '0' || '1' }}
+          fetch-tags: ${{ contains(matrix.filter, 'e2e_docker_base_with_worker_version') && 'true' || 'false' }}
       - name: Determine Go version
         id: get-go-version
         # We use .go-version as our source of truth for current Go

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -100,6 +100,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: '0'
       - name: Determine Go version
         id: get-go-version
         # We use .go-version as our source of truth for current Go
@@ -265,12 +267,39 @@ jobs:
           enos scenario check --chdir ./enos ${{ matrix.filter }} && \
           enos scenario exec --chdir ./enos ${{ matrix.filter }} --cmd "version"
       - name: Determine boundary version to test against previous worker version
-        # Get the Boundary version number and decrement the minor version by 1
+        # Resolve the worker version from the previous release line.
         if: contains(matrix.filter, 'e2e_docker_base_with_worker_version')
         run: |
-          version_num=$(./enos/support/boundary/boundary version | awk -F'[. ]' '/Version Number/ {print $(NF-1)}')
-          export ENOS_VAR_worker_version="$((version_num - 1))"
-          echo "ENOS_VAR_worker_version=0.$ENOS_VAR_worker_version" >> "$GITHUB_ENV"
+          current_version_raw=$(./enos/support/boundary/boundary version | awk '/Version Number/ {print $3}')
+          current_version="${current_version_raw#v}"
+          current_version="${current_version%%[-+]*}"
+
+          if ! [[ "$current_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Unable to parse Boundary version: $current_version_raw" >&2
+            exit 1
+          fi
+
+          IFS='.' read -r current_major current_minor current_patch <<< "$current_version"
+
+          all_semver_tags=$(git tag -l | sed 's/^v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$')
+
+          previous_version=""
+          if [ "$current_minor" -gt 0 ]; then
+            target_minor=$((current_minor - 1))
+            previous_version=$(echo "$all_semver_tags" | grep -E "^${current_major}\.${target_minor}\.[0-9]+$" | sort -V | tail -n1)
+          fi
+
+          if [ -z "$previous_version" ] && [ "$current_major" -gt 0 ]; then
+            target_major=$((current_major - 1))
+            previous_version=$(echo "$all_semver_tags" | grep -E "^${target_major}\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
+          fi
+
+          if [ -z "$previous_version" ]; then
+            echo "No previous release line found for current version $current_version" >&2
+            exit 1
+          fi
+
+          echo "ENOS_VAR_worker_version=$previous_version" >> "$GITHUB_ENV"
       - name: Run Enos scenario
         id: run
         # Continue once and retry

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -279,7 +279,7 @@ jobs:
             exit 1
           fi
 
-          IFS='.' read -r current_major current_minor current_patch <<< "$current_version"
+          IFS='.' read -r current_major current_minor _ <<< "$current_version"
 
           all_semver_tags=$(git tag -l | sed 's/^v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true)
 

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -25,7 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          fetch-depth: '0'
+          fetch-depth: '1'
+          fet-tags: true
       - name: Determine Go version
         id: get-go-version
         # We use .go-version as our source of truth for current Go
@@ -271,7 +272,6 @@ jobs:
         if: contains(matrix.filter, 'e2e_docker_base_with_worker_version')
         run: |
           current_version_raw=$(./enos/support/boundary/boundary version | awk '/Version Number/ {print $3}')
-          current_version="${current_version_raw#v}"
           current_version="${current_version%%[-+]*}"
 
           if ! [[ "$current_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -281,17 +281,16 @@ jobs:
 
           IFS='.' read -r current_major current_minor current_patch <<< "$current_version"
 
-          all_semver_tags=$(git tag -l | sed 's/^v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$')
+          all_semver_tags=$(git tag -l | sed 's/^v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true)
 
           previous_version=""
           if [ "$current_minor" -gt 0 ]; then
             target_minor=$((current_minor - 1))
-            previous_version=$(echo "$all_semver_tags" | grep -E "^${current_major}\.${target_minor}\.[0-9]+$" | sort -V | tail -n1)
+            previous_version=$(echo "$all_semver_tags" | grep -E "^${current_major}\.${target_minor}\.[0-9]+$" | sort -V | tail -n1 || true)
           fi
-
           if [ -z "$previous_version" ] && [ "$current_major" -gt 0 ]; then
             target_major=$((current_major - 1))
-            previous_version=$(echo "$all_semver_tags" | grep -E "^${target_major}\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
+            previous_version=$(echo "$all_semver_tags" | grep -E "^${target_major}\.[0-9]+\.[0-9]+$" | sort -V | tail -n1 || true)
           fi
 
           if [ -z "$previous_version" ]; then

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -25,8 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          fetch-depth: '1'
-          fet-tags: true
+          fetch-depth: '0'
       - name: Determine Go version
         id: get-go-version
         # We use .go-version as our source of truth for current Go
@@ -102,7 +101,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          fetch-depth: '0'
+          fetch-depth: ${{ matrix.scenario == 'e2e_docker_base_with_worker_version' && '0' || '1' }}
+          fetch-tags: ${{ matrix.scenario == 'e2e_docker_base_with_worker_version' && 'true' || 'false' }}
       - name: Determine Go version
         id: get-go-version
         # We use .go-version as our source of truth for current Go
@@ -272,7 +272,7 @@ jobs:
         if: contains(matrix.filter, 'e2e_docker_base_with_worker_version')
         run: |
           current_version_raw=$(./enos/support/boundary/boundary version | awk '/Version Number/ {print $3}')
-          current_version="${current_version%%[-+]*}"
+          current_version="${current_version_raw%%[-+]*}"
 
           if ! [[ "$current_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Unable to parse Boundary version: $current_version_raw" >&2


### PR DESCRIPTION
## Description
Change the logic for getting the version to taking current version - 1 to taking a list of versions and then finding the version before.
examples
0.21.3->0.20.2
1.0.0->0.21.3 (or whatever the last non 1.x.x version is)

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
