### PR TITLE
test(e2e): Use vault version from variable

### DIFF
--- a/enos/enos-scenario-e2e-database.hcl
+++ b/enos/enos-scenario-e2e-database.hcl
@@ -129,6 +129,7 @@ scenario "e2e_database" {
       aws_host_set_filter1     = step.create_tag_inputs.tag_string
       max_page_size            = 10
       aws_region               = var.aws_region
+      vault_version            = var.vault_version
     }
   }
 

--- a/enos/modules/test_e2e/main.tf
+++ b/enos/modules/test_e2e/main.tf
@@ -81,6 +81,11 @@ variable "vault_root_token" {
   type        = string
   default     = ""
 }
+variable "vault_version" {
+  description = "Version of vault being tested, used to determine which tests to run"
+  type        = string
+  default     = ""
+}
 variable "aws_access_key_id" {
   description = "Access Key Id for AWS IAM user used in dynamic host catalogs"
   type        = string
@@ -281,6 +286,7 @@ resource "enos_local_exec" "run_e2e_test" {
     VAULT_TOKEN                                  = var.vault_root_token
     E2E_VAULT_ADDR_PUBLIC                        = var.vault_addr_public
     E2E_VAULT_ADDR_PRIVATE                       = var.vault_addr_private
+    E2E_VAULT_VERSION                            = var.vault_version
     E2E_AWS_ACCESS_KEY_ID                        = var.aws_access_key_id
     E2E_AWS_SECRET_ACCESS_KEY                    = var.aws_secret_access_key
     E2E_AWS_HOST_SET_FILTER                      = var.aws_host_set_filter1

--- a/testing/internal/e2e/tests/database/env_test.go
+++ b/testing/internal/e2e/tests/database/env_test.go
@@ -10,6 +10,7 @@ type config struct {
 	TargetSshKeyPath   string `envconfig:"E2E_SSH_KEY_PATH" required:"true"` // e.g. /Users/username/key.pem
 	TargetPort         string `envconfig:"E2E_TARGET_PORT" default:"22"`
 	VaultSecretPath    string `envconfig:"E2E_VAULT_SECRET_PATH" default:"e2e_secrets"`
+	VaultVersion       string `envconfig:"E2E_VAULT_VERSION" default:"1.17.6"`
 	AwsAccessKeyId     string `envconfig:"E2E_AWS_ACCESS_KEY_ID" required:"true"`
 	AwsSecretAccessKey string `envconfig:"E2E_AWS_SECRET_ACCESS_KEY" required:"true"`
 	AwsHostSetFilter   string `envconfig:"E2E_AWS_HOST_SET_FILTER" required:"true"` // e.g. "tag:testtag=true"

--- a/testing/internal/e2e/tests/database/migration_test.go
+++ b/testing/internal/e2e/tests/database/migration_test.go
@@ -89,7 +89,7 @@ func setupEnvironment(t testing.TB, c *config, boundaryRepo, boundaryTag string)
 	})
 
 	// Start Vault
-	v, vaultToken := infra.StartVault(t, pool, network, "hashicorp/vault", "latest")
+	v, vaultToken := infra.StartVault(t, pool, network, "hashicorp/vault", c.VaultVersion)
 	t.Cleanup(func() {
 		if err := pool.Purge(v.Resource); err != nil {
 			t.Logf("error purging pool: %v", err)


### PR DESCRIPTION
## Description
It seems like there's some issue when using the latest version of the vault docker container. This PR makes the migration test use the vault version defined in the enos variables rather than "latest"

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
