### PR TITLE
Clean up loop captures in tests

### DIFF
--- a/internal/alias/target/repository_alias_test.go
+++ b/internal/alias/target/repository_alias_test.go
@@ -165,7 +165,6 @@ func TestRepository_CreateAlias(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			repo, err := target.NewRepository(ctx, rw, rw, kmsCache)
@@ -683,7 +682,6 @@ func TestRepository_UpdateAlias(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.orig.ScopeId = "global"
 			orig, err := repo.CreateAlias(ctx, tt.orig)
@@ -806,7 +804,6 @@ func TestRepository_LookupAlias(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			kms := kms.TestKms(t, conn, wrapper)
@@ -875,7 +872,6 @@ func TestRepository_DeleteAlias(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got, err := repo.DeleteAlias(ctx, tt.id)

--- a/internal/alias/target/repository_test.go
+++ b/internal/alias/target/repository_test.go
@@ -106,7 +106,6 @@ func TestRepository_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewRepository(ctx, tt.args.r, tt.args.w, tt.args.kms, tt.args.opts...)

--- a/internal/auth/ldap/deref_aliases_test.go
+++ b/internal/auth/ldap/deref_aliases_test.go
@@ -66,7 +66,6 @@ func TestNewDerefAliases(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewDerefAliases(tc.ctx, tc.authMethodId, tc.derefAliases)

--- a/internal/auth/oidc/immutable_fields_test.go
+++ b/internal/auth/oidc/immutable_fields_test.go
@@ -67,7 +67,6 @@ func TestAuthMethod_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -144,7 +143,6 @@ func TestAudClaim_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -225,7 +223,6 @@ func TestCertificate_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -302,7 +299,6 @@ func TestSigningAlg_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -407,7 +403,6 @@ func TestAccount_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -484,7 +479,6 @@ func TestPrompt_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 

--- a/internal/auth/oidc/repository_account_test.go
+++ b/internal/auth/oidc/repository_account_test.go
@@ -200,7 +200,6 @@ func TestRepository_CreateAccount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
@@ -526,7 +525,6 @@ func TestRepository_LookupAccount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
@@ -602,7 +600,6 @@ func TestRepository_DeleteAccount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
@@ -691,7 +688,6 @@ func TestRepository_ListAccounts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
@@ -787,7 +783,6 @@ func TestRepository_ListAccounts_Limits(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache, tt.repoOpts...)
@@ -1137,7 +1132,6 @@ func TestRepository_UpdateAccount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)

--- a/internal/auth/oidc/repository_auth_method_read_test.go
+++ b/internal/auth/oidc/repository_auth_method_read_test.go
@@ -92,7 +92,6 @@ func TestRepository_LookupAuthMethod(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)

--- a/internal/auth/oidc/repository_managed_group_members_test.go
+++ b/internal/auth/oidc/repository_managed_group_members_test.go
@@ -199,7 +199,6 @@ func Test_ManagedGroupMemberships(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 

--- a/internal/auth/oidc/repository_managed_group_test.go
+++ b/internal/auth/oidc/repository_managed_group_test.go
@@ -186,7 +186,6 @@ func TestRepository_CreateManagedGroup(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
@@ -265,7 +264,6 @@ func TestRepository_LookupManagedGroup(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
@@ -341,7 +339,6 @@ func TestRepository_DeleteManagedGroup(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
@@ -458,7 +455,6 @@ func TestRepository_ListManagedGroups(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, ttime, err := repo.ListManagedGroups(context.Background(), tt.in, tt.opts...)
 			if tt.wantIsErr != 0 {
@@ -575,7 +571,6 @@ func TestRepository_ListManagedGroups_Limits(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache, tt.repoOpts...)
@@ -1081,7 +1076,6 @@ func TestRepository_UpdateManagedGroup(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)

--- a/internal/auth/password/account_test.go
+++ b/internal/auth/password/account_test.go
@@ -99,7 +99,6 @@ func TestAccount_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewAccount(context.Background(), tt.args.authMethodId, tt.args.opts...)

--- a/internal/auth/password/argon2_test.go
+++ b/internal/auth/password/argon2_test.go
@@ -149,7 +149,6 @@ func TestArgon2Configuration_Readonly(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			var confs []*Argon2Configuration
@@ -283,7 +282,6 @@ func TestArgon2Configuration_Validate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got := tt.in.validate(context.Background())
@@ -429,7 +427,6 @@ func TestArgon2Credential_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := newArgon2Credential(context.Background(), tt.args.accountId, tt.args.password, tt.args.conf, rand.Reader)

--- a/internal/auth/password/auth_method_test.go
+++ b/internal/auth/password/auth_method_test.go
@@ -74,7 +74,6 @@ func TestAuthMethod_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			org, _ := iam.TestScopes(t, iam.TestRepo(t, conn, wrapper))

--- a/internal/auth/password/repository_account_test.go
+++ b/internal/auth/password/repository_account_test.go
@@ -40,7 +40,6 @@ func TestCheckLoginName(t *testing.T) {
 		{"validloginname", true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.in, func(t *testing.T) {
 			assert.Equal(t, tt.want, validLoginName(tt.in))
 		})
@@ -236,7 +235,6 @@ func TestRepository_CreateAccount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(context.Background(), rw, rw, kms)
@@ -387,7 +385,6 @@ func TestRepository_LookupAccount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -445,7 +442,6 @@ func TestRepository_DeleteAccount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -504,7 +500,6 @@ func TestRepository_ListAccounts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(context.Background(), rw, rw, kms)
@@ -584,7 +579,6 @@ func TestRepository_ListAccounts_Limits(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(context.Background(), rw, rw, kms, tt.repoOpts...)
@@ -926,7 +920,6 @@ func TestRepository_UpdateAccount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(context.Background(), rw, rw, kms)

--- a/internal/auth/password/repository_authmethod_test.go
+++ b/internal/auth/password/repository_authmethod_test.go
@@ -143,7 +143,6 @@ func TestRepository_CreateAuthMethod(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -321,7 +320,6 @@ func TestRepository_LookupAuthMethod(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -376,7 +374,6 @@ func TestRepository_DeleteAuthMethod(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)

--- a/internal/auth/password/repository_configuration_test.go
+++ b/internal/auth/password/repository_configuration_test.go
@@ -162,7 +162,6 @@ func TestRepository_GetConfiguration(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := repo.GetConfiguration(ctx, tt.authMethodId)
@@ -289,7 +288,6 @@ func TestRepository_SetConfiguration(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := repo.SetConfiguration(context.Background(), o.GetPublicId(), tt.in)

--- a/internal/auth/password/repository_password_test.go
+++ b/internal/auth/password/repository_password_test.go
@@ -106,7 +106,6 @@ func TestRepository_Authenticate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			authAcct, err := repo.Authenticate(context.Background(), o.GetPublicId(), tt.args.authMethodId, tt.args.loginName, tt.args.password)
@@ -373,7 +372,6 @@ func TestRepository_ChangePassword(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -493,7 +491,6 @@ func TestRepository_SetPassword(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			acct := tt.createAcct(tt.oldPw)

--- a/internal/auth/password/repository_test.go
+++ b/internal/auth/password/repository_test.go
@@ -118,7 +118,6 @@ func TestRepository_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewRepository(context.Background(), tt.args.r, tt.args.w, tt.args.kms, tt.args.opts...)

--- a/internal/authtoken/authtoken_test.go
+++ b/internal/authtoken/authtoken_test.go
@@ -103,7 +103,6 @@ func TestAuthToken_DbUpdate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			w := db.New(conn)
@@ -173,7 +172,6 @@ func TestAuthToken_DbCreate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			at := &AuthToken{AuthToken: tt.in}
@@ -234,7 +232,6 @@ func TestAuthToken_DbDelete(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			cnt, err := db.New(conn).Delete(ctx, tt.at)

--- a/internal/authtoken/immutable_fields_test.go
+++ b/internal/authtoken/immutable_fields_test.go
@@ -63,7 +63,6 @@ func TestAuthToken_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := new.clone()

--- a/internal/authtoken/repository_test.go
+++ b/internal/authtoken/repository_test.go
@@ -167,7 +167,6 @@ func TestRepository_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got, err := NewRepository(context.Background(), tt.args.r, tt.args.w, tt.args.kms, tt.args.opts...)
@@ -341,7 +340,6 @@ func TestRepository_LookupAuthToken(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -443,7 +441,6 @@ func TestRepository_ValidateToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := repo.ValidateToken(ctx, tt.id, tt.token)
@@ -536,7 +533,6 @@ func TestRepository_ValidateToken_expired(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -606,7 +602,6 @@ func TestRepository_DeleteAuthToken(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -676,7 +671,6 @@ func TestRepository_ListAuthTokens(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)

--- a/internal/billing/repository_test.go
+++ b/internal/billing/repository_test.go
@@ -51,7 +51,6 @@ func TestRepository_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got, err := NewRepository(context.Background(), tt.args.r)

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -1030,7 +1030,6 @@ controller {
 		},
 	}
 	for _, tt := range cases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			out, err := Parse(tt.config)
 			if tt.wantErr {

--- a/internal/credential/static/credential_store_test.go
+++ b/internal/credential/static/credential_store_test.go
@@ -84,7 +84,6 @@ func TestCredentialStore_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewCredentialStore(tt.args.projectId, tt.args.opts...)

--- a/internal/credential/static/json_credential_test.go
+++ b/internal/credential/static/json_credential_test.go
@@ -99,7 +99,6 @@ func TestJsonCredential_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/credential/static/password_credential_test.go
+++ b/internal/credential/static/password_credential_test.go
@@ -103,7 +103,6 @@ func TestPasswordCredential_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/credential/static/repository_credential_store_test.go
+++ b/internal/credential/static/repository_credential_store_test.go
@@ -100,7 +100,6 @@ func TestRepository_CreateCredentialStore(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -195,7 +194,6 @@ func TestRepository_LookupCredentialStore(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -479,7 +477,6 @@ func TestRepository_UpdateCredentialStore(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -667,7 +664,6 @@ func TestRepository_DeleteCredentialStore(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(context.Background(), rw, rw, kms)

--- a/internal/credential/static/repository_credential_test.go
+++ b/internal/credential/static/repository_credential_test.go
@@ -115,7 +115,6 @@ func TestRepository_CreateUsernamePasswordCredential(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -306,7 +305,6 @@ func TestRepository_CreateUsernamePasswordDomainCredential(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -463,7 +461,6 @@ func TestRepository_CreatePasswordCredential(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -658,7 +655,6 @@ func TestRepository_CreateSshPrivateKeyCredential(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -828,7 +824,6 @@ func TestRepository_CreateJsonCredential(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -979,7 +974,6 @@ func TestRepository_LookupCredential(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -1322,7 +1316,6 @@ func TestRepository_DeleteCredential(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(context.Background(), rw, rw, kms)
@@ -1776,7 +1769,6 @@ func TestRepository_UpdateUsernamePasswordCredential(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -2389,7 +2381,6 @@ func TestRepository_UpdateUsernamePasswordDomainCredential(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -2815,7 +2806,6 @@ func TestRepository_UpdatePasswordCredential(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -3406,7 +3396,6 @@ Hdtbe1Kk0rHxN0yIKqXNAAAACWplZmZAYXJjaAECAwQ=
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -3533,7 +3522,6 @@ func TestSshPrivateKeyConstraints(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			c := cred.clone()
 			if tt.nilEncrypted {
@@ -3917,7 +3905,6 @@ func TestRepository_UpdateJsonCredential(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/credential/static/repository_credentials_test.go
+++ b/internal/credential/static/repository_credentials_test.go
@@ -199,7 +199,6 @@ func TestRepository_Retrieve(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			gotCreds, err := repo.Retrieve(context.Background(), tt.args.projectId, tt.args.credIds)
 			if tt.wantErr {

--- a/internal/credential/static/repository_test.go
+++ b/internal/credential/static/repository_test.go
@@ -105,7 +105,6 @@ func TestRepository_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewRepository(context.Background(), tt.args.r, tt.args.w, tt.args.kms, tt.args.opts...)

--- a/internal/credential/static/ssh_private_key_credential_test.go
+++ b/internal/credential/static/ssh_private_key_credential_test.go
@@ -165,7 +165,6 @@ func TestSshPrivateKeyCredential_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/credential/static/usernamepassword_credential_test.go
+++ b/internal/credential/static/usernamepassword_credential_test.go
@@ -122,7 +122,6 @@ func TestUsernamePasswordCredential_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/credential/static/usernamepassworddomain_credential_test.go
+++ b/internal/credential/static/usernamepassworddomain_credential_test.go
@@ -169,7 +169,6 @@ func TestUsernamePasswordDomainCredential_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/credential/vault/client_certificate_test.go
+++ b/internal/credential/vault/client_certificate_test.go
@@ -97,7 +97,6 @@ func TestClientCertificate_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/credential/vault/credential_library_test.go
+++ b/internal/credential/vault/credential_library_test.go
@@ -280,7 +280,6 @@ func TestCredentialLibrary_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/credential/vault/credential_store_test.go
+++ b/internal/credential/vault/credential_store_test.go
@@ -238,7 +238,6 @@ func TestCredentialStore_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewCredentialStore(tt.args.projectId, tt.args.vaultAddress, tt.args.token, tt.args.opts...)

--- a/internal/credential/vault/credential_test.go
+++ b/internal/credential/vault/credential_test.go
@@ -133,7 +133,6 @@ func TestCredential_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/credential/vault/internal/sshprivatekey/sshprivatekey_test.go
+++ b/internal/credential/vault/internal/sshprivatekey/sshprivatekey_test.go
@@ -276,7 +276,6 @@ func TestExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			user, privateKey, passphrase := Extract(tt.given.s, tt.given.uAttr, tt.given.pkAttr, tt.given.pAttr)

--- a/internal/credential/vault/internal/usernamepassword/usernamepassword_test.go
+++ b/internal/credential/vault/internal/usernamepassword/usernamepassword_test.go
@@ -234,7 +234,6 @@ func TestBaseToUsrPass(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			user, pass := Extract(tt.given.s, tt.given.uAttr, tt.given.pAttr)

--- a/internal/credential/vault/internal/usernamepassworddomain/usernamepassworddomain_test.go
+++ b/internal/credential/vault/internal/usernamepassworddomain/usernamepassworddomain_test.go
@@ -313,7 +313,6 @@ func TestBaseToUsrPassDomain(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			user, pass, domain := Extract(tt.given.s, tt.given.uAttr, tt.given.pAttr, tt.given.dAttr)

--- a/internal/credential/vault/mapping_overriders_test.go
+++ b/internal/credential/vault/mapping_overriders_test.go
@@ -112,7 +112,6 @@ func TestValidMappingOverrides(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("%T-%s", tt.m, tt.ct), func(t *testing.T) {
 			got := validMappingOverride(tt.m, tt.ct)
 			assert.Equal(t, tt.want, got)

--- a/internal/credential/vault/private_library_test.go
+++ b/internal/credential/vault/private_library_test.go
@@ -47,7 +47,6 @@ func TestRepository_getPrivateLibraries(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -584,7 +583,6 @@ func TestRequestMap(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			mapper, err := newMapper(ctx, tt.args.requests)
@@ -948,7 +946,6 @@ func TestBaseToUsrPass(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := baseToUsrPass(context.Background(), tt.given)
@@ -1440,7 +1437,6 @@ func TestBaseToUsrPassDomain(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := baseToUsrPassDomain(context.Background(), tt.given)
@@ -2100,7 +2096,6 @@ func TestBaseToSshPriKey(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := baseToSshPriKey(context.Background(), tt.given)
@@ -2397,7 +2392,6 @@ func TestRepository_sshCertIssuingCredentialLibrary_retrieveCredential(t *testin
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			// create ssh library

--- a/internal/credential/vault/private_store_test.go
+++ b/internal/credential/vault/private_store_test.go
@@ -39,7 +39,6 @@ func TestRepository_lookupPrivateStore(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/credential/vault/repository_credential_library_test.go
+++ b/internal/credential/vault/repository_credential_library_test.go
@@ -515,7 +515,6 @@ func TestRepository_CreateCredentialLibrary(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -1637,7 +1636,6 @@ func TestRepository_UpdateCredentialLibrary(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -2068,7 +2066,6 @@ func TestRepository_LookupCredentialLibrary(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				// setup
 				assert, require := assert.New(t), require.New(t)
@@ -2189,7 +2186,6 @@ func TestRepository_DeleteCredentialLibrary(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				assert, require := assert.New(t), require.New(t)
 				kms := kms.TestKms(t, conn, wrapper)
@@ -2389,7 +2385,6 @@ func TestRepository_ListCredentialLibraries_Limits(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/credential/vault/repository_credential_store_test.go
+++ b/internal/credential/vault/repository_credential_store_test.go
@@ -172,7 +172,6 @@ func TestRepository_CreateCredentialStoreNonResource(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -298,7 +297,6 @@ func TestRepository_LookupCredentialStore(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			kms := kms.TestKms(t, conn, wrapper)
@@ -737,7 +735,6 @@ func TestRepository_UpdateCredentialStore_Attributes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -1085,7 +1082,6 @@ func TestRepository_UpdateCredentialStore_VaultToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -1223,7 +1219,6 @@ func TestRepository_UpdateCredentialStore_ClientCert(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -1502,7 +1497,6 @@ group by store_id, status;
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert, require := assert.New(t), require.New(t)

--- a/internal/credential/vault/repository_credentials_test.go
+++ b/internal/credential/vault/repository_credentials_test.go
@@ -451,7 +451,6 @@ func TestRepository_IssueCredentials(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			sess := session.TestSession(t, conn, wrapper, session.ComposedOf{

--- a/internal/credential/vault/repository_ssh_certificate_credential_library_test.go
+++ b/internal/credential/vault/repository_ssh_certificate_credential_library_test.go
@@ -580,7 +580,6 @@ func TestRepository_CreateSSHCertificateCredentialLibrary(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -752,7 +751,6 @@ func TestRepository_LookupSSHCertificateCredentialLibrary(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				// setup
 				assert, require := assert.New(t), require.New(t)
@@ -1488,7 +1486,6 @@ func TestRepository_UpdateSSHCertificateCredentialLibrary(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -1853,7 +1850,6 @@ func TestRepository_DeleteSSHCertificateCredentialLibrary(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				assert, require := assert.New(t), require.New(t)
 				kms := kms.TestKms(t, conn, wrapper)

--- a/internal/credential/vault/repository_test.go
+++ b/internal/credential/vault/repository_test.go
@@ -135,7 +135,6 @@ func TestRepository_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewRepository(context.Background(), tt.args.r, tt.args.w, tt.args.kms, tt.args.scheduler, tt.args.opts...)

--- a/internal/credential/vault/testing_test.go
+++ b/internal/credential/vault/testing_test.go
@@ -195,7 +195,6 @@ func TestTestVaultServer_CreateToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			v := NewTestVaultServer(t)

--- a/internal/credential/vault/vault_capabilities_test.go
+++ b/internal/credential/vault/vault_capabilities_test.go
@@ -204,7 +204,6 @@ func TestPathCapabilities_has(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got := newPathCapabilities(tt.given)
@@ -288,7 +287,6 @@ func TestPathCapabilities_get(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			pc := newPathCapabilities(tt.given)
@@ -369,7 +367,6 @@ path "two" {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.given.vaultPolicy()
 			t.Log(got)
@@ -455,7 +452,6 @@ func TestPathCapabilities_union(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// test the union method is commutative
 			check(t, tt.x, tt.y, tt.z)
@@ -518,7 +514,6 @@ func TestPathCapabilities_missing(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got := tt.have.missing(tt.require)
@@ -563,7 +558,6 @@ func TestPathCapabilities_String(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got := tt.pc.String()
@@ -604,7 +598,6 @@ func TestCapabilities_missing(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		name := fmt.Sprintf("{%s} - {%s} = {%s}", tt.require, tt.have, tt.want)
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
@@ -625,7 +618,6 @@ func TestCapabilities_String(t *testing.T) {
 		{"two", createCapability | updateCapability, `["create", "update"]`},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.given.String()
 			if got != tt.want {

--- a/internal/credential/vault/vault_test.go
+++ b/internal/credential/vault/vault_test.go
@@ -77,7 +77,6 @@ func Test_newClient(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			client, err := newClient(tt.ctx, tt.clientConfig)
@@ -276,7 +275,6 @@ func TestClient_capabilities(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		if tt.name == "" {
 			tt.name = fmt.Sprintf("%v", tt.polices)
 		}

--- a/internal/credential/vault/vault_token_test.go
+++ b/internal/credential/vault/vault_token_test.go
@@ -112,7 +112,6 @@ func TestToken_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 

--- a/internal/daemon/controller/handlers/accounts/validate_test.go
+++ b/internal/daemon/controller/handlers/accounts/validate_test.go
@@ -219,7 +219,6 @@ func TestValidateCreateRequest(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			req := &pbs.CreateAccountRequest{Item: tc.item}
@@ -283,7 +282,6 @@ func TestValidateUpdateRequest(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateUpdateRequest(context.Background(), tc.req)

--- a/internal/daemon/controller/handlers/authmethods/authmethod_test.go
+++ b/internal/daemon/controller/handlers/authmethods/authmethod_test.go
@@ -193,7 +193,6 @@ func TestTransformAuthenticateRequestAttributes(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			in := proto.Clone(c.input)
@@ -418,7 +417,6 @@ func TestTransformAuthenticateResponseAttributes(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			in := proto.Clone(c.input)

--- a/internal/daemon/controller/handlers/managed_groups/validate_test.go
+++ b/internal/daemon/controller/handlers/managed_groups/validate_test.go
@@ -124,7 +124,6 @@ func TestValidateCreateRequest(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			req := &pbs.CreateManagedGroupRequest{Item: tc.item}
@@ -198,7 +197,6 @@ func TestValidateUpdateRequest(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateUpdateRequest(context.Background(), tc.req)

--- a/internal/daemon/worker/session/manager_test.go
+++ b/internal/daemon/worker/session/manager_test.go
@@ -450,7 +450,6 @@ func TestWorkerSetCloseTimeForResponse(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			manager := &manager{sessionMap: new(sync.Map)}

--- a/internal/db/domains_test.go
+++ b/internal/db/domains_test.go
@@ -634,7 +634,6 @@ set id = null;
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			_, err = db.Exec(tt.stmt)
@@ -970,7 +969,6 @@ returning id;
 		{"empty string", "", true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			t.Logf("insert value: %q", tt.value)
@@ -1014,7 +1012,6 @@ select wt_is_sentinel($1);
 		{"empty string", "", false},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			t.Logf("query value: %q", tt.value)
@@ -1088,7 +1085,6 @@ insert on test_not_null_columns
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 

--- a/internal/db/read_writer_test.go
+++ b/internal/db/read_writer_test.go
@@ -2611,7 +2611,6 @@ func TestDb_WriteOplogEntryWith(t *testing.T) {
 // 		},
 // 	}
 // 	for _, tt := range tests {
-// 		tt := tt
 // 		t.Run(tt.name, func(t *testing.T) {
 // 			assert, require := assert.New(t), require.New(t)
 // 			input := tt.args.v
@@ -2891,7 +2890,6 @@ func TestDb_WriteOplogEntryWith(t *testing.T) {
 // 		},
 // 	}
 // 	for _, tt := range tests {
-// 		tt := tt
 // 		t.Run(tt.name, func(t *testing.T) {
 // 			assert, require := assert.New(t), require.New(t)
 // 			input := tt.args.v
@@ -2992,7 +2990,6 @@ func TestDb_WriteOplogEntryWith(t *testing.T) {
 // 		},
 // 	}
 // 	for _, tt := range tests {
-// 		tt := tt
 // 		t.Run(tt.name, func(t *testing.T) {
 // 			assert, require := assert.New(t), require.New(t)
 // 			input := tt.args.v

--- a/internal/errors/is_test.go
+++ b/internal/errors/is_test.go
@@ -68,7 +68,6 @@ func TestError_IsUnique(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			err := tt.in
@@ -130,7 +129,6 @@ func TestError_IsCheckConstraint(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			err := tt.in
@@ -199,7 +197,6 @@ func TestError_IsNotNullError(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			err := tt.in
@@ -243,7 +240,6 @@ func TestError_IsMissingTableError(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			err := tt.in
@@ -289,7 +285,6 @@ func TestError_IsNotFoundError(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			err := tt.in

--- a/internal/event/event_type_test.go
+++ b/internal/event/event_type_test.go
@@ -49,7 +49,6 @@ func TestType_Validate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 

--- a/internal/host/plugin/host_address_test.go
+++ b/internal/host/plugin/host_address_test.go
@@ -114,7 +114,6 @@ func TestHostDnsName_Create(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			var got *host.DnsName
@@ -311,7 +310,6 @@ func TestHostIpAddress_Create(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			var got *host.IpAddress
@@ -386,7 +384,6 @@ func TestHostDnsName_Delete(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := &host.DnsName{
 				DnsName: &store.DnsName{
@@ -453,7 +450,6 @@ func TestHostIpAddress_Delete(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := &host.IpAddress{
 				IpAddress: &store.IpAddress{

--- a/internal/host/plugin/host_catalog_secret_test.go
+++ b/internal/host/plugin/host_catalog_secret_test.go
@@ -90,7 +90,6 @@ func TestHostCatalogSecret_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 

--- a/internal/host/plugin/host_catalog_test.go
+++ b/internal/host/plugin/host_catalog_test.go
@@ -165,7 +165,6 @@ func TestHostCatalog_Create(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewHostCatalog(ctx, tt.args.projectId, tt.args.pluginId, tt.args.opts...)
 			require.NoError(t, err)

--- a/internal/host/plugin/host_set_member_test.go
+++ b/internal/host/plugin/host_set_member_test.go
@@ -112,7 +112,6 @@ func TestHostSetMember_InsertDelete(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			var hostIds []string

--- a/internal/host/plugin/host_set_test.go
+++ b/internal/host/plugin/host_set_test.go
@@ -162,7 +162,6 @@ func TestHostSet_Create(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			got, err := NewHostSet(ctx, tt.args.catalogId, tt.args.opts...)

--- a/internal/host/plugin/host_test.go
+++ b/internal/host/plugin/host_test.go
@@ -201,7 +201,6 @@ func TestHost_Create(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			got := NewHost(ctx, tt.args.catalogId, tt.args.externalId, tt.args.opts...)

--- a/internal/host/plugin/immutable_fields_test.go
+++ b/internal/host/plugin/immutable_fields_test.go
@@ -76,7 +76,6 @@ func TestPluginCatalog_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := new.clone()
@@ -146,7 +145,6 @@ func TestPluginSet_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := new.testCloneHostSet()

--- a/internal/host/plugin/repository_host_catalog_test.go
+++ b/internal/host/plugin/repository_host_catalog_test.go
@@ -293,7 +293,6 @@ func TestRepository_CreateCatalog(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 			kmsCache := kms.TestKms(t, conn, wrapper)
@@ -1268,7 +1267,6 @@ func TestRepository_UpdateCatalog(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			assert := assert.New(t)
@@ -1355,7 +1353,6 @@ func TestRepository_LookupCatalog(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			kms := kms.TestKms(t, conn, wrapper)
@@ -1451,7 +1448,6 @@ func TestRepository_DeleteCatalog(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			pluginInstance.OnDeleteCatalogFn = func(_ context.Context, request *plgpb.OnDeleteCatalogRequest) (*plgpb.OnDeleteCatalogResponse, error) {
 				require.NotNil(t, request.GetCatalog().GetPlugin())
@@ -1509,7 +1505,6 @@ func TestRepository_DeleteCatalogX(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			kms := kms.TestKms(t, conn, wrapper)

--- a/internal/host/plugin/repository_host_set_test.go
+++ b/internal/host/plugin/repository_host_set_test.go
@@ -277,7 +277,6 @@ func TestRepository_CreateSet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			var origPluginAttrs, pluginReceivedAttrs *structpb.Struct
@@ -1198,7 +1197,6 @@ func TestRepository_UpdateSet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			assert := assert.New(t)
@@ -1403,7 +1401,6 @@ func TestRepository_LookupSet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms, sched, plgm)
@@ -1520,7 +1517,6 @@ func TestRepository_Endpoints(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms, sched, plgm)
@@ -1608,7 +1604,6 @@ func TestRepository_listSets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms, sched, plgm)
@@ -1691,7 +1686,6 @@ func TestRepository_listSets_Limits(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms, sched, plgm, tt.repoOpts...)
@@ -1961,7 +1955,6 @@ func TestRepository_DeleteSet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms, sched, plgm)

--- a/internal/host/plugin/repository_host_test.go
+++ b/internal/host/plugin/repository_host_test.go
@@ -190,7 +190,6 @@ func TestJob_UpsertHosts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			job, err := newSetSyncJob(ctx, rw, rw, kms, plgm)

--- a/internal/host/plugin/repository_host_util_test.go
+++ b/internal/host/plugin/repository_host_util_test.go
@@ -247,7 +247,6 @@ func TestUtilFunctions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 			var hi *hostInfo

--- a/internal/host/plugin/repository_test.go
+++ b/internal/host/plugin/repository_test.go
@@ -154,7 +154,6 @@ func TestRepository_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewRepository(context.Background(), tt.args.r, tt.args.w, tt.args.kms, tt.args.scheduler, tt.args.plugins, tt.args.opts...)

--- a/internal/host/static/host_catalog_test.go
+++ b/internal/host/static/host_catalog_test.go
@@ -84,7 +84,6 @@ func TestHostCatalog_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got, err := NewHostCatalog(ctx, tt.args.projectId, tt.args.opts...)

--- a/internal/host/static/host_set_member_test.go
+++ b/internal/host/static/host_set_member_test.go
@@ -48,7 +48,6 @@ func TestHostSetMember_Insert(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewHostSetMember(ctx, tt.set.PublicId, tt.host.PublicId)

--- a/internal/host/static/host_set_test.go
+++ b/internal/host/static/host_set_test.go
@@ -83,7 +83,6 @@ func TestHostSet_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got, err := NewHostSet(ctx, tt.args.catalogId, tt.args.opts...)

--- a/internal/host/static/host_test.go
+++ b/internal/host/static/host_test.go
@@ -129,7 +129,6 @@ func TestHost_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 			got, err := NewHost(ctx, tt.args.catalogId, tt.args.opts...)

--- a/internal/host/static/immutable_fields_test.go
+++ b/internal/host/static/immutable_fields_test.go
@@ -60,7 +60,6 @@ func TestHostCatalog_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := new.clone()
@@ -127,7 +126,6 @@ func TestStaticHost_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := new.testCloneHost()
@@ -201,7 +199,6 @@ func TestStaticHostSet_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := new.testCloneHostSet()
@@ -270,7 +267,6 @@ func TestStaticHostSetMember_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := new.testCloneHostSetMember()

--- a/internal/host/static/repository_host_catalog_test.go
+++ b/internal/host/static/repository_host_catalog_test.go
@@ -78,7 +78,6 @@ func TestRepository_CreateCatalog(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			kms := kms.TestKms(t, conn, wrapper)
@@ -437,7 +436,6 @@ func TestRepository_UpdateCatalog(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			kms := kms.TestKms(t, conn, wrapper)
@@ -610,7 +608,6 @@ func TestRepository_LookupCatalog(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			kms := kms.TestKms(t, conn, wrapper)
@@ -673,7 +670,6 @@ func TestRepository_DeleteCatalog(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			kms := kms.TestKms(t, conn, wrapper)

--- a/internal/host/static/repository_host_set_member_test.go
+++ b/internal/host/static/repository_host_set_member_test.go
@@ -113,7 +113,6 @@ func TestRepository_AddSetMembers_Parameters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -307,7 +306,6 @@ func TestRepository_DeleteSetMembers_Parameters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -498,7 +496,6 @@ func TestRepository_SetSetMembers_Parameters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)

--- a/internal/host/static/repository_host_set_test.go
+++ b/internal/host/static/repository_host_set_test.go
@@ -112,7 +112,6 @@ func TestRepository_CreateSet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -465,7 +464,6 @@ func TestRepository_UpdateSet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -692,7 +690,6 @@ func TestRepository_UpdateSet_Limits(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms, tt.repoOpts...)
@@ -759,7 +756,6 @@ func TestRepository_LookupSet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -843,7 +839,6 @@ func TestRepository_LookupSet_Limits(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms, tt.repoOpts...)
@@ -895,7 +890,6 @@ func TestRepository_listSets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -978,7 +972,6 @@ func TestRepository_listSets_Limits(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms, tt.repoOpts...)
@@ -1114,7 +1107,6 @@ func TestRepository_DeleteSet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)

--- a/internal/host/static/repository_host_test.go
+++ b/internal/host/static/repository_host_test.go
@@ -236,7 +236,6 @@ func TestRepository_CreateHost(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -752,7 +751,6 @@ func TestRepository_UpdateHost(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -949,7 +947,6 @@ func TestRepository_LookupHost(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -1015,7 +1012,6 @@ func TestRepository_LookupHost_HostSets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -1073,7 +1069,6 @@ func TestRepository_ListHosts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -1150,7 +1145,6 @@ func TestRepository_ListHosts_HostSets(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -1224,7 +1218,6 @@ func TestRepository_ListHosts_Limits(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms, tt.repoOpts...)
@@ -1437,7 +1430,6 @@ func TestRepository_DeleteHost(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)

--- a/internal/host/static/repository_test.go
+++ b/internal/host/static/repository_test.go
@@ -106,7 +106,6 @@ func TestRepository_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewRepository(ctx, tt.args.r, tt.args.w, tt.args.kms, tt.args.opts...)

--- a/internal/libs/patchstruct/patchstruct_test.go
+++ b/internal/libs/patchstruct/patchstruct_test.go
@@ -149,7 +149,6 @@ var testCases = []testCase{
 
 func TestPatchStruct(t *testing.T) {
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			dst, src := mustStruct(tc.dst), mustStruct(tc.src)
@@ -177,7 +176,6 @@ func TestPatchStruct(t *testing.T) {
 
 func TestPatchBytes(t *testing.T) {
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			dst, src := mustMarshal(tc.dst), mustMarshal(tc.src)

--- a/internal/listtoken/list_token_test.go
+++ b/internal/listtoken/list_token_test.go
@@ -101,7 +101,6 @@ func Test_NewPaginationToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := listtoken.NewPagination(context.Background(), tt.createdTime, tt.typ, tt.grantsHash, tt.lastItemId, tt.lastItemCreateTime)
@@ -199,7 +198,6 @@ func Test_NewStartRefreshToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := listtoken.NewStartRefresh(context.Background(), tt.createdTime, tt.typ, tt.grantsHash, tt.previousDeletedIdsTime, tt.previousPhaseUpperBound)
@@ -349,7 +347,6 @@ func Test_NewRefreshToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := listtoken.NewRefresh(
@@ -453,7 +450,6 @@ func Test_ValidateListToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := tt.token.Validate(context.Background(), tt.resourceType, tt.grantsHash)
@@ -526,7 +522,6 @@ func Test_ValidatePaginationToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := tt.token.Validate(context.Background(), tt.resourceType, tt.grantsHash)
@@ -599,7 +594,6 @@ func Test_ValidateStartRefreshToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := tt.token.Validate(context.Background(), tt.resourceType, tt.grantsHash)
@@ -738,7 +732,6 @@ func Test_ValidateRefreshToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := tt.token.Validate(context.Background(), tt.resourceType, tt.grantsHash)
@@ -828,7 +821,6 @@ func TestToken_LastItem(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			item, err := tt.token.LastItem(context.Background())

--- a/internal/oplog/immutable_fields_test.go
+++ b/internal/oplog/immutable_fields_test.go
@@ -118,7 +118,6 @@ func Test_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := testCloneEntry(new)

--- a/internal/pagination/purge/purge_test.go
+++ b/internal/pagination/purge/purge_test.go
@@ -111,7 +111,6 @@ func TestNewPurgeJob(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := newPurgeJob(ctx, tt.args.w, tt.args.table)

--- a/internal/plugin/immutable_fields_test.go
+++ b/internal/plugin/immutable_fields_test.go
@@ -51,7 +51,6 @@ func TestHostPlugin_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := newPlugin.testClonePlugin()

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -68,7 +68,6 @@ func TestPlugin_Create(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewPlugin(tt.opts...)
 			require.NotNil(t, got)

--- a/internal/plugin/repository_plugin_test.go
+++ b/internal/plugin/repository_plugin_test.go
@@ -107,7 +107,6 @@ func TestRepository_CreatePlugin(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got, err := repo.CreatePlugin(context.Background(), tt.in, tt.opts...)
@@ -200,7 +199,6 @@ func TestRepository_LookupPlugin(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			kms := kms.TestKms(t, conn, wrapper)
@@ -257,7 +255,6 @@ func TestRepository_LookupPluginByName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			kms := kms.TestKms(t, conn, wrapper)
@@ -329,7 +326,6 @@ func TestRepository_AddSupportFlag(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)

--- a/internal/plugin/repository_test.go
+++ b/internal/plugin/repository_test.go
@@ -104,7 +104,6 @@ func TestRepository_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()

--- a/internal/scheduler/batch/batch_test.go
+++ b/internal/scheduler/batch/batch_test.go
@@ -72,7 +72,6 @@ func TestConfig(t *testing.T) {
 		{0, 0, DefaultMax + 1, DefaultMax},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("min-max-size_%d-%d-%d", tt.min, tt.max, tt.size), func(t *testing.T) {
 			t.Parallel()
 			assert := assert.New(t)
@@ -119,7 +118,6 @@ func TestConfig_setSize(t *testing.T) {
 		{15, 15, true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("newSize_%d", tt.newSize), func(t *testing.T) {
 			t.Parallel()
 			assert, require := assert.New(t), require.New(t)
@@ -159,7 +157,6 @@ func TestConfig_targetRange(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("target_%d", tt.target), func(t *testing.T) {
 			t.Parallel()
 			assert := assert.New(t)
@@ -198,7 +195,6 @@ func TestConfig_exponentialDecrease(t *testing.T) {
 		{500, 2, 125},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("batchSize=%d/attempt=%d", tt.batchSize, tt.attempt), func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			ctx := context.Background()
@@ -239,7 +235,6 @@ func Test_linearDecrease(t *testing.T) {
 		{100, 2, 80},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("batchSize=%d/attempt=%d", tt.batchSize, tt.attempt), func(t *testing.T) {
 			t.Parallel()
 			assert, require := assert.New(t), require.New(t)
@@ -281,7 +276,6 @@ func Test_linearIncrease(t *testing.T) {
 		{10, 2, 12},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("batchSize=%d/attempt=%d", tt.batchSize, tt.attempt), func(t *testing.T) {
 			t.Parallel()
 			assert, require := assert.New(t), require.New(t)
@@ -537,7 +531,6 @@ func TestRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert := assert.New(t)

--- a/internal/scheduler/job/immutable_fields_test.go
+++ b/internal/scheduler/job/immutable_fields_test.go
@@ -73,7 +73,6 @@ func TestJobRun_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := oriRun.clone()

--- a/internal/scheduler/job/repository_job_test.go
+++ b/internal/scheduler/job/repository_job_test.go
@@ -75,7 +75,6 @@ func TestRepository_UpsertJob(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -155,7 +154,6 @@ func TestRepository_LookupJob(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -220,7 +218,6 @@ func TestRepository_deleteJob(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -285,7 +282,6 @@ func TestRepository_ListJobs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -362,7 +358,6 @@ func TestRepository_ListJobs_Limits(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms, tt.repoOpts...)

--- a/internal/scheduler/job/repository_run_test.go
+++ b/internal/scheduler/job/repository_run_test.go
@@ -306,7 +306,6 @@ func TestRepository_UpdateProgress(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
@@ -442,7 +441,6 @@ func TestRepository_CompleteRun(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
@@ -590,7 +588,6 @@ func TestRepository_FailRun(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
@@ -701,7 +698,6 @@ func TestRepository_InterruptRuns(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
@@ -832,7 +828,6 @@ func TestRepository_InterruptServerRuns(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			repo, err := NewRepository(ctx, rw, rw, kmsCache)
 			require.NoError(err)
@@ -941,7 +936,6 @@ func TestRepository_LookupJobRun(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)
@@ -1004,7 +998,6 @@ func TestRepository_deleteJobRun(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			repo, err := NewRepository(ctx, rw, rw, kms)

--- a/internal/scheduler/job/repository_test.go
+++ b/internal/scheduler/job/repository_test.go
@@ -117,7 +117,6 @@ func TestRepository_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := NewRepository(context.Background(), tt.args.r, tt.args.w, tt.args.kms, tt.opts...)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -148,7 +148,6 @@ func TestScheduler_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := New(ctx, tt.args.serverId, tt.args.jobRepo, tt.opts...)
@@ -219,7 +218,6 @@ func TestScheduler_RegisterJob(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			err := sched.RegisterJob(context.Background(), tt.job)

--- a/internal/server/worker_tags_test.go
+++ b/internal/server/worker_tags_test.go
@@ -72,7 +72,6 @@ func TestWorkerTags_Create(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := rw.Create(context.Background(), tt.want)
 			if tt.wantCreateErr {
@@ -245,7 +244,6 @@ func TestRepository_AddWorkerTags(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := repo.AddWorkerTags(context.Background(), tt.args.publicId, tt.args.version, tt.args.tags)
 			if tt.wantErrContains != "" {
@@ -401,7 +399,6 @@ func TestRepository_SetWorkerTags(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := repo.SetWorkerTags(context.Background(), tt.args.publicId, tt.args.version, tt.args.tags)
 			if tt.wantErrContains != "" {
@@ -555,7 +552,6 @@ func TestRepository_DeleteWorkerTags(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := repo.DeleteWorkerTags(context.Background(), tt.args.publicId, tt.args.version, tt.args.tags)
 			if tt.wantErrContains != "" {

--- a/internal/server/worker_test.go
+++ b/internal/server/worker_test.go
@@ -929,7 +929,6 @@ func TestWorker_New(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got := NewWorker(tt.args.scopeId, tt.args.opts...)

--- a/internal/server/workerauth_store_test.go
+++ b/internal/server/workerauth_store_test.go
@@ -197,7 +197,6 @@ func TestRootCertStore(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -385,7 +384,6 @@ func TestWorkerAuthStore(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -502,7 +500,6 @@ func TestWorkerCertBundle(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 

--- a/internal/session/immutable_fields_test.go
+++ b/internal/session/immutable_fields_test.go
@@ -71,7 +71,6 @@ func TestSession_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := new.Clone()
@@ -153,7 +152,6 @@ select session_id,
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			assert, require := assert.New(t), require.New(t)
@@ -218,7 +216,6 @@ func TestConnection_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := new.Clone()

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -492,7 +492,6 @@ func TestProxyCertificate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 

--- a/internal/storage/plugin/repository_test.go
+++ b/internal/storage/plugin/repository_test.go
@@ -71,7 +71,6 @@ func TestRepository_NewRepository(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 			ctx := context.Background()

--- a/internal/storage/storagebucketcredential/environmental/storage_bucket_credential_test.go
+++ b/internal/storage/storagebucketcredential/environmental/storage_bucket_credential_test.go
@@ -92,7 +92,6 @@ func Test_NewStorageBucketCredential(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 			sbc := sbcHooks{}

--- a/internal/storage/storagebucketcredential/managedsecret/storage_bucket_credential_test.go
+++ b/internal/storage/storagebucketcredential/managedsecret/storage_bucket_credential_test.go
@@ -72,7 +72,6 @@ func Test_HmacSecrets(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 
@@ -144,7 +143,6 @@ func Test_Encrypt(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 
@@ -236,7 +234,6 @@ func Test_Decrypt(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 
@@ -288,7 +285,6 @@ func Test_ToPersisted(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 
@@ -370,7 +366,6 @@ func Test_NewStorageBucketCredential(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 			sbc := sbcHooks{}

--- a/internal/target/address_ext_test.go
+++ b/internal/target/address_ext_test.go
@@ -190,7 +190,6 @@ func TestAddress_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := target.NewAddress(context.Background(), tt.args.targetId, tt.args.address)

--- a/internal/target/credential_ext_test.go
+++ b/internal/target/credential_ext_test.go
@@ -56,7 +56,6 @@ func TestStaticCredential_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := target.NewStaticCredential(context.Background(), tt.args.targetId, tt.args.credId, credential.BrokeredPurpose)

--- a/internal/target/credential_library_ext_test.go
+++ b/internal/target/credential_library_ext_test.go
@@ -57,7 +57,6 @@ func TestCredentialLibrary_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			got, err := target.NewCredentialLibrary(context.Background(), tt.args.targetId, tt.args.libraryId, credential.BrokeredPurpose, "test")

--- a/internal/target/repository_proxy_server_certificate_test.go
+++ b/internal/target/repository_proxy_server_certificate_test.go
@@ -126,7 +126,6 @@ func TestFetchTargetProxyServerCertificate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -286,7 +285,6 @@ func TestFetchTargetAliasProxyServerCertificate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 

--- a/internal/target/target_certificate_test.go
+++ b/internal/target/target_certificate_test.go
@@ -81,7 +81,6 @@ func TestGenerateTargetCert(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -135,7 +134,6 @@ func TestTargetProxyCertificate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -284,7 +282,6 @@ func TestTargetAliasProxyCertificate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 

--- a/internal/target/tcp/immutable_fields_test.go
+++ b/internal/target/tcp/immutable_fields_test.go
@@ -66,7 +66,6 @@ func TestTarget_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
@@ -136,7 +135,6 @@ func TestTcpTarget_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := new.Clone()
@@ -219,7 +217,6 @@ func TestTargetHostSet_ImmutableFields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			orig := new.Clone()

--- a/internal/util/net_test.go
+++ b/internal/util/net_test.go
@@ -170,7 +170,6 @@ func Test_JoinHostPort(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			actualAddress := JoinHostPort(tt.host, tt.port)
@@ -267,7 +266,6 @@ func Test_SplitHostPort(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			actualHost, actualPort, err := SplitHostPort(tt.hostport)
 			if tt.expectedErr != nil {
@@ -370,7 +368,6 @@ func Test_ParseAddress(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)
 			actualAddress, err := ParseAddress(context.Background(), tt.address)

--- a/testing/dbtest/session_list_benchmarks_dump_generation_test.go
+++ b/testing/dbtest/session_list_benchmarks_dump_generation_test.go
@@ -108,7 +108,6 @@ func TestGenerateSessionBenchmarkTemplateDumps(t *testing.T) {
 	// across all tests.
 	semaphore := make(chan struct{}, runtime.NumCPU())
 	for _, scenario := range scenarios {
-		scenario := scenario // Parallel test closures act as goroutines, copy iteration variable
 		t.Run(fmt.Sprintf("Generate-%d-sessions-%d-conns-per-session-%d-users-dump", scenario.sessions, scenario.connsPerSession, scenario.users), func(t *testing.T) {
 			t.Parallel() // Lets speed things up a bit
 			ctx := context.Background()
@@ -140,7 +139,6 @@ func TestGenerateSessionBenchmarkTemplateDumps(t *testing.T) {
 			users := make([]*user, scenario.users)
 			eg, gCtx := errgroup.WithContext(ctx)
 			for i := 0; i < scenario.users; i++ {
-				i := i
 				// Parallelize user creation
 				eg.Go(func() error {
 					select {
@@ -165,7 +163,6 @@ func TestGenerateSessionBenchmarkTemplateDumps(t *testing.T) {
 			t.Logf("Populating %d sessions", scenario.sessions)
 			eg, gCtx = errgroup.WithContext(ctx)
 			for i := 0; i < scenario.sessions; i++ {
-				i := i
 				userIndex := i % len(users)
 				// Parallelize session creation
 				eg.Go(func() error {


### PR DESCRIPTION
## Description

The `tt := tt` pattern is no longer needed [since Go 1.22](https://go.dev/blog/loopvar-preview).

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
