### PR TITLE
fix(dep): Update nodeenrollment dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/hashicorp/go-version v1.8.0
 	github.com/hashicorp/hcl v1.0.1-vault-7
 	github.com/hashicorp/mql v0.1.5
-	github.com/hashicorp/nodeenrollment v0.2.14
+	github.com/hashicorp/nodeenrollment v0.2.15
 	github.com/hashicorp/vault/api v1.22.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/jackc/pgx/v5 v5.8.0

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/hashicorp/hcl v1.0.1-vault-7 h1:ag5OxFVy3QYTFTJODRzTKVZ6xvdfLLCA1cy/Y
 github.com/hashicorp/hcl v1.0.1-vault-7/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/mql v0.1.5 h1:oy7DfoabOP05ZjUwx7ZidwtMqVIEZnUYBkJaxHvBHo4=
 github.com/hashicorp/mql v0.1.5/go.mod h1:pRgMF50e0ItqpgRkjCPyNyt4tmlpx4Xz5Z4BEdyUYU4=
-github.com/hashicorp/nodeenrollment v0.2.14 h1:/feF2MdMotgbG7E84wKd6d21r84b+9Mqfjt7viBkXwk=
-github.com/hashicorp/nodeenrollment v0.2.14/go.mod h1:9wAx3p2SmSQ1vqUNCjGMt6Qr7xs8KcBxYzOOtVQJvcs=
+github.com/hashicorp/nodeenrollment v0.2.15 h1:rX5OyWiefouqU0Q/Io/ke5bjzHqpUblEc1nB7fsONVU=
+github.com/hashicorp/nodeenrollment v0.2.15/go.mod h1:bgNNmIdBkiNut//AhYp37LJ08/z/xaE5LgxtGC2epxg=
 github.com/hashicorp/vault/api v1.22.0 h1:+HYFquE35/B74fHoIeXlZIP2YADVboaPjaSicHEZiH0=
 github.com/hashicorp/vault/api v1.22.0/go.mod h1:IUZA2cDvr4Ok3+NtK2Oq/r+lJeXkeCrHRmqdyWfpmGM=
 github.com/hashicorp/vault/sdk v0.11.0 h1:KP/tBUywaVcvOebAfMPNCCiXKeCNEbm3JauYmrZd7RI=


### PR DESCRIPTION
## Overview
Update the `nodeenrollment` dependency to the latest `0.2.15` [release](https://github.com/hashicorp/nodeenrollment/commit/02205d391eae7b7100f4cde331ec8c7fe21fcfc2) to resolve workers blocking during tls handshake when client certs are delayed or not provided. 


## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
