### PR TITLE
Backport of Mark expired Vault token as expired when Vault is unreachable into release/0.21.x

### DIFF
--- a/internal/credential/vault/private_store.go
+++ b/internal/credential/vault/private_store.go
@@ -43,25 +43,26 @@ func (r *Repository) lookupClientStore(ctx context.Context, publicId string) (*c
 // a Vault client. If the Vault token for the store is expired all token data will be null
 // other than the status of expired.
 type clientStore struct {
-	PublicId         string `gorm:"primary_key"`
-	ProjectId        string
-	DeleteTime       *timestamp.Timestamp
-	VaultAddress     string
-	Namespace        string
-	CaCert           []byte
-	TlsServerName    string
-	TlsSkipVerify    bool
-	WorkerFilter     string
-	TokenHmac        []byte
-	Token            TokenSecret
-	CtToken          []byte
-	TokenRenewalTime *timestamp.Timestamp
-	TokenKeyId       string
-	TokenStatus      string
-	ClientCert       []byte
-	ClientKeyId      string
-	ClientKey        KeySecret
-	CtClientKey      []byte
+	PublicId            string `gorm:"primary_key"`
+	ProjectId           string
+	DeleteTime          *timestamp.Timestamp
+	VaultAddress        string
+	Namespace           string
+	CaCert              []byte
+	TlsServerName       string
+	TlsSkipVerify       bool
+	WorkerFilter        string
+	TokenHmac           []byte
+	Token               TokenSecret
+	CtToken             []byte
+	TokenRenewalTime    *timestamp.Timestamp
+	TokenKeyId          string
+	TokenStatus         string
+	TokenExpirationTime *timestamp.Timestamp
+	ClientCert          []byte
+	ClientKeyId         string
+	ClientKey           KeySecret
+	CtClientKey         []byte
 }
 
 func allocClientStore() *clientStore {
@@ -98,7 +99,7 @@ func (ps *clientStore) token() *Token {
 		tk.Status = ps.TokenStatus
 		tk.CtToken = ps.CtToken
 		tk.KeyId = ps.TokenKeyId
-
+		tk.ExpirationTime = ps.TokenExpirationTime
 		return tk
 	}
 

--- a/internal/credential/vault/supported.go
+++ b/internal/credential/vault/supported.go
@@ -50,8 +50,6 @@ func init() {
 	}
 }
 
-func gotDocker(t testing.TB) {}
-
 func gotNewServer(t testing.TB, opt ...TestOption) *TestVaultServer {
 	const (
 		serverTlsTemplate = `{
@@ -189,9 +187,17 @@ func gotNewServer(t testing.TB, opt ...TestOption) *TestVaultServer {
 
 	resource, err := pool.RunWithOptions(dockerOptions)
 	require.NoError(err)
+
+	server.Shutdown = func(t *testing.T) {
+		cleanupResource(t, pool, resource)
+		server.stopped = true
+	}
+
 	if !opts.skipCleanup {
 		t.Cleanup(func() {
-			cleanupResource(t, pool, resource)
+			if !server.stopped {
+				cleanupResource(t, pool, resource)
+			}
 		})
 	}
 	server.vaultContainer = resource

--- a/internal/credential/vault/supported.go
+++ b/internal/credential/vault/supported.go
@@ -190,12 +190,12 @@ func gotNewServer(t testing.TB, opt ...TestOption) *TestVaultServer {
 
 	server.Shutdown = func(t *testing.T) {
 		cleanupResource(t, pool, resource)
-		server.stopped = true
+		server.stopped.Store(true)
 	}
 
 	if !opts.skipCleanup {
 		t.Cleanup(func() {
-			if !server.stopped {
+			if !server.stopped.Load() {
 				cleanupResource(t, pool, resource)
 			}
 		})

--- a/internal/credential/vault/testing.go
+++ b/internal/credential/vault/testing.go
@@ -1196,6 +1196,9 @@ type TestVaultServer struct {
 	vaultContainer    any
 	ldapContainer     any
 	postgresContainer any
+
+	stopped  bool
+	Shutdown func(t *testing.T)
 }
 
 // NewTestVaultServer creates and returns a TestVaultServer. Some Vault

--- a/internal/credential/vault/testing.go
+++ b/internal/credential/vault/testing.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1197,7 +1198,7 @@ type TestVaultServer struct {
 	ldapContainer     any
 	postgresContainer any
 
-	stopped  bool
+	stopped  atomic.Bool
 	Shutdown func(t *testing.T)
 }
 

--- a/internal/db/schema/migrations/oss/postgres/103/01_credential_vault_token_renewal_revocation_view.up.sql
+++ b/internal/db/schema/migrations/oss/postgres/103/01_credential_vault_token_renewal_revocation_view.up.sql
@@ -1,0 +1,52 @@
+-- Copyright (c) HashiCorp, Inc.
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- public.credential_vault_token_renewal_revocation source
+
+begin;
+
+  drop view credential_vault_token_renewal_revocation;
+
+  create view credential_vault_token_renewal_revocation as
+  with
+    tokens as (
+      select token, -- encrypted
+             token_hmac,
+             store_id,
+             -- renewal time is the midpoint between the last renewal time and the expiration time
+             last_renewal_time + (expiration_time - last_renewal_time) / 2 as renewal_time,
+             key_id,
+             status,
+             expiration_time
+        from credential_vault_token
+       where status in ('current', 'maintaining', 'revoke')
+    )
+    select store.public_id        as public_id,
+           store.project_id       as project_id,
+           store.vault_address    as vault_address,
+           store.namespace        as namespace,
+           store.ca_cert          as ca_cert,
+           store.tls_server_name  as tls_server_name,
+           store.tls_skip_verify  as tls_skip_verify,
+           store.worker_filter    as worker_filter,
+           store.delete_time      as delete_time,
+           token.token            as ct_token, -- encrypted
+           token.token_hmac       as token_hmac,
+           token.renewal_time     as token_renewal_time,
+           token.key_id           as token_key_id,
+           token.status           as token_status,
+           token.expiration_time  as token_expiration_time,
+           cert.certificate       as client_cert,
+           cert.certificate_key   as ct_client_key, -- encrypted
+           cert.key_id            as client_key_id
+      from credential_vault_store store
+      join tokens token
+        on store.public_id = token.store_id
+      left join credential_vault_client_certificate cert
+        on store.public_id = cert.store_id;
+   comment on view credential_vault_token_renewal_revocation is
+      'credential_vault_token_renewal_revocation is a view where each row contains a credential store and the credential store''s data needed to connect to Vault. '
+      'The view returns a separate row for each active token in Vault (current, maintaining and revoke tokens); this view should only be used for token renewal and revocation. '
+      'Each row may contain encrypted data. This view should not be used to retrieve data which will be returned external to boundary.';
+
+commit;


### PR DESCRIPTION
## Description
Manual backport [PR](https://github.com/hashicorp/boundary/pull/6235) to release 0.21.x

Vault credential stores have an internal job that periodically renews Vault tokens. If the renewal call returns a 403 error, the system assumes the token is no longer valid and marks it as expired.

When Vault is unreachable, the system logs an error and continues trying to renew the token past its expiration time since Vault never returns a 403 error. This change checks if the token has already expired; if so, it will mark the token as expired even when communication with Vault returns an error.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
