### PR TITLE
fix(kms): Duplicate KMS startup metadata labels across multiple KMS blocks

### DIFF
--- a/internal/cmd/base/server_test.go
+++ b/internal/cmd/base/server_test.go
@@ -884,9 +884,8 @@ func TestSetupWorkerPublicAddress(t *testing.T) {
 	}
 }
 
-func TestMergeKmsInfoEntries(t *testing.T) {
+func TestMergeKmsInfoEntriesIntoInfoMap(t *testing.T) {
 	t.Parallel()
-
 	t.Run("duplicate labels are qualified by purpose", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
@@ -938,5 +937,51 @@ func TestMergeKmsInfoEntries(t *testing.T) {
 		}, infoKeys)
 		assert.Equal("us-east-1", info["[downstream-worker-auth 1] AWS KMS Region"])
 		assert.Equal("us-west-2", info["[downstream-worker-auth 2] AWS KMS Region"])
+	})
+
+	t.Run("skipping for KMS AEAD type", func(t *testing.T) {
+		t.Parallel()
+		assert := assert.New(t)
+
+		infoKeys := []string{}
+		info := map[string]string{}
+		mergeKmsInfoEntries(&infoKeys, info, []kmsInfoEntry{
+			{kmsType: wrapping.WrapperTypeAead.String(), key: "[root] Aead Type", value: "aes-gcm", purpose: globals.KmsPurposeRoot, purposeOrdinal: 1},
+			{kmsType: wrapping.WrapperTypeAead.String(), key: "[worker-auth] Aead Type", value: "aes-gcm", purpose: globals.KmsPurposeRecovery, purposeOrdinal: 1},
+		}, map[string]uint{
+			globals.KmsPurposeRoot:     1,
+			globals.KmsPurposeRecovery: 1,
+		})
+
+		assert.ElementsMatch([]string{
+			"[root] Aead Type",
+			"[worker-auth] Aead Type",
+		}, infoKeys)
+		assert.Equal("aes-gcm", info["[root] Aead Type"])
+		assert.Equal("aes-gcm", info["[worker-auth] Aead Type"])
+	})
+
+	t.Run("preserve all existing info keys", func(t *testing.T) {
+		t.Parallel()
+		assert := assert.New(t)
+
+		infoKeys := []string{
+			"log level",
+		}
+		info := map[string]string{
+			"log level": "debug",
+		}
+		mergeKmsInfoEntries(&infoKeys, info, []kmsInfoEntry{
+			{key: "Azure Key Name", value: "boundary-root", purpose: globals.KmsPurposeRoot, purposeOrdinal: 1},
+		}, map[string]uint{
+			globals.KmsPurposeRoot: 1,
+		})
+
+		assert.ElementsMatch([]string{
+			"[root] Azure Key Name",
+			"log level",
+		}, infoKeys)
+		assert.Equal("boundary-root", info["[root] Azure Key Name"])
+		assert.Equal("debug", info["log level"])
 	})
 }

--- a/internal/cmd/base/server_test.go
+++ b/internal/cmd/base/server_test.go
@@ -883,3 +883,60 @@ func TestSetupWorkerPublicAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeKmsInfoEntries(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate labels are qualified by purpose", func(t *testing.T) {
+		t.Parallel()
+		assert := assert.New(t)
+
+		infoKeys := []string{}
+		info := map[string]string{}
+		mergeKmsInfoEntries(&infoKeys, info, []kmsInfoEntry{
+			{key: "Azure Environment", value: "AzurePublicCloud", purpose: globals.KmsPurposeRoot, purposeOrdinal: 1},
+			{key: "Azure Key Name", value: "boundary-root", purpose: globals.KmsPurposeRoot, purposeOrdinal: 1},
+			{key: "Azure Environment", value: "AzurePublicCloud", purpose: globals.KmsPurposeWorkerAuth, purposeOrdinal: 1},
+			{key: "Azure Key Name", value: "boundary-worker", purpose: globals.KmsPurposeWorkerAuth, purposeOrdinal: 1},
+			{key: "Azure Environment", value: "AzurePublicCloud", purpose: globals.KmsPurposeRecovery, purposeOrdinal: 1},
+			{key: "Azure Key Name", value: "boundary-recovery", purpose: globals.KmsPurposeRecovery, purposeOrdinal: 1},
+		}, map[string]uint{
+			globals.KmsPurposeRoot:       1,
+			globals.KmsPurposeWorkerAuth: 1,
+			globals.KmsPurposeRecovery:   1,
+		})
+
+		assert.ElementsMatch([]string{
+			"[root] Azure Environment",
+			"[root] Azure Key Name",
+			"[worker-auth] Azure Environment",
+			"[worker-auth] Azure Key Name",
+			"[recovery] Azure Environment",
+			"[recovery] Azure Key Name",
+		}, infoKeys)
+		assert.Equal("boundary-root", info["[root] Azure Key Name"])
+		assert.Equal("boundary-worker", info["[worker-auth] Azure Key Name"])
+		assert.Equal("boundary-recovery", info["[recovery] Azure Key Name"])
+	})
+
+	t.Run("multiple purpose includes in single block", func(t *testing.T) {
+		t.Parallel()
+		assert := assert.New(t)
+
+		infoKeys := []string{}
+		info := map[string]string{}
+		mergeKmsInfoEntries(&infoKeys, info, []kmsInfoEntry{
+			{key: "AWS KMS Region", value: "us-east-1", purpose: globals.KmsPurposeDownstreamWorkerAuth, purposeOrdinal: 1},
+			{key: "AWS KMS Region", value: "us-west-2", purpose: globals.KmsPurposeDownstreamWorkerAuth, purposeOrdinal: 2},
+		}, map[string]uint{
+			globals.KmsPurposeDownstreamWorkerAuth: 2,
+		})
+
+		assert.ElementsMatch([]string{
+			"[downstream-worker-auth 1] AWS KMS Region",
+			"[downstream-worker-auth 2] AWS KMS Region",
+		}, infoKeys)
+		assert.Equal("us-east-1", info["[downstream-worker-auth 1] AWS KMS Region"])
+		assert.Equal("us-west-2", info["[downstream-worker-auth 2] AWS KMS Region"])
+	})
+}

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -146,6 +146,14 @@ type Server struct {
 	Database *db.DB
 }
 
+type kmsInfoEntry struct {
+	kmsType        string
+	key            string
+	value          string
+	purpose        string
+	purposeOrdinal uint
+}
+
 // NewServer creates a new Server.
 func NewServer(cmd *Command) *Server {
 	return &Server{
@@ -562,6 +570,7 @@ func (b *Server) SetupKMSes(ctx context.Context, ui cli.Ui, config *config.Confi
 	var err error
 	var previousRootKms wrapping.Wrapper
 	purposeCount := map[string]uint{}
+	kmsInfoEntries := make([]kmsInfoEntry, 0, len(sharedConfig.Seals)*3)
 	for _, kms := range sharedConfig.Seals {
 		for _, purpose := range kms.Purpose {
 			purpose = strings.ToLower(purpose)
@@ -594,12 +603,14 @@ func (b *Server) SetupKMSes(ctx context.Context, ui cli.Ui, config *config.Confi
 			// This can be modified by configutil so store the original value
 			origPurpose := kms.Purpose
 			kms.Purpose = []string{purpose}
+			kmsInfoKeys := make([]string, 0, 4)
+			kmsInfo := make(map[string]string)
 
 			wrapper, cleanupFunc, wrapperConfigError := configutil.ConfigureWrapper(
 				ctx,
 				kms,
-				&b.InfoKeys,
-				&b.Info,
+				&kmsInfoKeys,
+				&kmsInfo,
 				configutil.WithPluginOptions(
 					pluginutil.WithPluginsMap(kms_plugin_assets.BuiltinKmsPlugins()),
 					pluginutil.WithPluginsFilesystem(kms_plugin_assets.KmsPluginPrefix, kms_plugin_assets.FileSystem()),
@@ -614,6 +625,15 @@ func (b *Server) SetupKMSes(ctx context.Context, ui cli.Ui, config *config.Confi
 			if wrapper == nil {
 				return fmt.Errorf(
 					"After configuration nil KMS returned, KMS type was %s", kms.Type)
+			}
+			for _, key := range kmsInfoKeys {
+				kmsInfoEntries = append(kmsInfoEntries, kmsInfoEntry{
+					kmsType:        kms.Type,
+					key:            key,
+					value:          kmsInfo[key],
+					purpose:        purpose,
+					purposeOrdinal: purposeCount[purpose],
+				})
 			}
 			if ifWrapper, ok := wrapper.(wrapping.InitFinalizer); ok {
 				if err := ifWrapper.Init(ctx); err != nil && !errors.Is(err, wrapping.ErrFunctionNotImplemented) {
@@ -689,6 +709,7 @@ func (b *Server) SetupKMSes(ctx context.Context, ui cli.Ui, config *config.Confi
 			}
 		}
 	}
+	mergeKmsInfoEntries(&b.InfoKeys, b.Info, kmsInfoEntries, purposeCount)
 
 	// Handle previous root KMS
 	if previousRootKms != nil {
@@ -881,4 +902,29 @@ func MakeSighupCh() chan struct{} {
 		}
 	}()
 	return resultCh
+}
+
+// modifying the displayKey to include purpose information.
+func mergeKmsInfoEntries(infoKeys *[]string, info map[string]string, entries []kmsInfoEntry, purposeTotals map[string]uint) {
+	if infoKeys == nil || info == nil {
+		return
+	}
+
+	for _, entry := range entries {
+		displayKey := entry.key
+		// Skipping KMS "aead" type as its purpose is already represented in the display key.
+		if entry.kmsType != wrapping.WrapperTypeAead.String() {
+			displayKey = fmt.Sprintf("[%s] %s", formatKmsInfoPurpose(entry.purpose, entry.purposeOrdinal, purposeTotals), entry.key)
+		}
+		*infoKeys = append(*infoKeys, displayKey)
+		info[displayKey] = entry.value
+	}
+}
+
+// If there are multiple KMSes with the same purpose (like downstream-worker-auth), it appends an ordinal to differentiate them.
+func formatKmsInfoPurpose(purpose string, ordinal uint, purposeTotals map[string]uint) string {
+	if purposeTotals[purpose] > 1 {
+		return fmt.Sprintf("%s %d", purpose, ordinal)
+	}
+	return purpose
 }

--- a/internal/cmd/base/servers.go
+++ b/internal/cmd/base/servers.go
@@ -904,7 +904,8 @@ func MakeSighupCh() chan struct{} {
 	return resultCh
 }
 
-// modifying the displayKey to include purpose information.
+// mergeKmsInfoEntries builds display keys for each KMS info entry, qualifying them with purpose when needed,
+// and merges them into the provided infoKeys slice and info map.
 func mergeKmsInfoEntries(infoKeys *[]string, info map[string]string, entries []kmsInfoEntry, purposeTotals map[string]uint) {
 	if infoKeys == nil || info == nil {
 		return
@@ -923,7 +924,7 @@ func mergeKmsInfoEntries(infoKeys *[]string, info map[string]string, entries []k
 
 // If there are multiple KMSes with the same purpose (like downstream-worker-auth), it appends an ordinal to differentiate them.
 func formatKmsInfoPurpose(purpose string, ordinal uint, purposeTotals map[string]uint) string {
-	if purposeTotals[purpose] > 1 {
+	if purposeTotals != nil && purposeTotals[purpose] > 1 {
 		return fmt.Sprintf("%s %d", purpose, ordinal)
 	}
 	return purpose


### PR DESCRIPTION
**Summary:**
Fixes incorrect duplicate KMS metadata in Boundary server startup output when multiple KMS blocks of the same provider are configured (for example, Azure Key Vault root, worker-auth, and recovery blocks).

Address Issue: https://github.com/hashicorp/boundary/issues/4236

**Description:** 
During startup, the Boundary controllers and workers write a few log lines which include the names of the keys that are in use. When using more than one block of the same provider (expect AEAD) with different purpose. There is a bug that will only output the name of the last configured key, instead of all names.

For controller config: 
run `boundary server -config controller.hcl`
```
disable_mlock = true

controller {
   ...
}

listener "tcp" {
  ...
}

listener "tcp" {
  ...
}

kms "azurekeyvault" {
  purpose = "root"
  key_name = "boundary-root"
}

kms "azurekeyvault" {
  purpose = "worker-auth"
  key_name = "boundary-worker"
}

kms "azurekeyvault" {
  purpose = "recovery"
  key_name = "boundary-recovery"
}
````
**Example output from my controller:**

<img width="1725" height="414" alt="Screenshot 2026-04-23 at 3 20 51 PM" src="https://github.com/user-attachments/assets/c0e5419f-a7af-46a2-86bb-716c24ce6cd2" /> <br>

**Root-Cause:**
Boundary passed shared startup info containers (b.InfoKeys and b.Info) directly into [configutil.ConfigureWrapper() ](https://github.com/hashicorp/boundary/blob/1684f729cbc506ce8b6099ebe97e1232bb6a1688/internal/cmd/base/servers.go#L598) for every configured KMS block.

For providers like Azure Key Vault, multiple KMS blocks emit the same display labels, such as: Azure Environment, Azure Vault Name, Azure Key Name. [go-secure-stdlib/configutil/kms.go](https://github.com/hashicorp/go-secure-stdlib/blob/2f652a33c02df3e74e4ca6fff6af1110cbefadda/configutil/kms.go#L410)

Because `b.Info` is a map, later KMS blocks overwrote earlier values for the same label, while b.InfoKeys continued appending duplicate keys. This caused startup output to print the same label multiple times, all resolving to the last configured value.

This was a startup info rendering bug only. It did not affect KMS purpose assignment or runtime wrapper usage. 

**Solution:** 
Collect KMS metadata per wrapper in temporary local structures, then merge it into b.InfoKeys / b.Info after all KMS blocks have been processed.

When duplicate display labels are detected, qualify them with KMS purpose (and ordinal when the same purpose appears multiple times ex: downstream-worker-auth), so the printed keys remain unique. 

For example:
[Root] Azure Key Name
[Worker-Auth] Azure Key Name
[Recovery] Azure Key Name

This keeps startup output accurate without changing runtime KMS behavior. <br>
<img width="1342" height="380" alt="Screenshot 2026-04-24 at 1 22 21 PM" src="https://github.com/user-attachments/assets/034f51a4-babf-406b-99e8-c37e49f32c9d" />

<br>

**Scope:**
This fix is provider-agnostic and applies to any KMS wrapper type that emits repeated display labels across multiple configured KMS blocks.

**Why not fix upstream in configutil?**
This was fixed in Boundary rather than configutil because duplicate resolution is a cross-block display concern. configutil only has per-wrapper context, while Boundary has the full set of configured KMS blocks, purposes, and repeated-purpose counts needed to generate stable, unique startup labels.

**Tests**
Added regression coverage for:
- duplicate KMS metadata labels across different purposes.
- duplicate metadata labels for repeated instances of the same purpose.
- skipping purpose for KMS AEAD type as its already done in upstream. 
- preserve all existing info keys