### PR TITLE
chore: Update changelog for 0.20.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 * Updated jackc/pgx/v5 dependency to v5.9.2 to address GHSA-j88v-2chj-qfwx, GO-2026-4771, GO-2026-4772, and GHSA-9jj7-4m8r-rfcm ([PR](https://github.com/hashicorp/boundary/pull/6607), [PR](https://github.com/hashicorp/boundary/pull/6617))
 * Updated Azure/go-ntlmssp dependency to v0.1.1 to address GHSA-pjcq-xvwq-hhpj ([PR](https://github.com/hashicorp/boundary/pull/6625))
+* Added support for new `debug` flag to expose pprof endpoints for debugging purposes. ([PR](https://github.com/hashicorp/boundary/pull/6644))
 
 ## 0.20.2 (2026/02/10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,11 +50,13 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## 0.20.3 (2026/04/24)
 
+### New and  Improved 
+* Added support for new `debug` flag to expose pprof endpoints for debugging purposes. ([PR](https://github.com/hashicorp/boundary/pull/6644))
+
 ### Security
 
 * Updated jackc/pgx/v5 dependency to v5.9.2 to address GHSA-j88v-2chj-qfwx, GO-2026-4771, GO-2026-4772, and GHSA-9jj7-4m8r-rfcm ([PR](https://github.com/hashicorp/boundary/pull/6607), [PR](https://github.com/hashicorp/boundary/pull/6617))
 * Updated Azure/go-ntlmssp dependency to v0.1.1 to address GHSA-pjcq-xvwq-hhpj ([PR](https://github.com/hashicorp/boundary/pull/6625))
-* Added support for new `debug` flag to expose pprof endpoints for debugging purposes. ([PR](https://github.com/hashicorp/boundary/pull/6644))
 
 ## 0.20.2 (2026/02/10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## 0.20.3 (2026/04/24)
 
-### New and  Improved 
+### New and Improved 
 * Added support for new `debug` flag to expose pprof endpoints for debugging purposes. ([PR](https://github.com/hashicorp/boundary/pull/6644))
 
 ### Security


### PR DESCRIPTION
## Description
This PR updates the `CHANGELOG` to include new `-debug` option from #6644.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
