### PR TITLE
chore(security): Add CVE-2026-41989 to the list of suppressed vulnerabilities

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -35,6 +35,12 @@ container {
 				#
 				# Boundary does not utilize ping in iputils.
 				"CVE-2025-48964"
+				
+				# libgcrypt@1.10.3-r1 https://nvd.nist.gov/vuln/detail/CVE-2026-41989
+				# 
+				# Boundary currently uses this indirectly via the alpine base image for docker. 
+				# Currently there is no base image fix available. 
+				"CVE-2026-41989"
 			]
 		}
 	}


### PR DESCRIPTION
## Description
Currently suppressing [CVE-2026-41989](https://nvd.nist.gov/vuln/detail/CVE-2026-41989) as there is no released apline linux base image to fix this vulnerability currently. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
