### PR TITLE
fix: Add CVE-2026-41989 to the list of suppressed vulnerabilities in security scan

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -40,6 +40,11 @@ container {
                 #
                 # There's no base image fix for this yet.
                 "CVE-2026-27171"
+
+				# libgcrypt@1.10.3-r1 https://nvd.nist.gov/vuln/detail/CVE-2026-41989
+				#
+				# There is no fix available in the Alpine Docker image yet.
+				"CVE-2026-41989"
 			]
 		}
 	}

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -36,11 +36,6 @@ container {
 				# Boundary does not utilize ping in iputils.
 				"CVE-2025-48964",
 
-                # zlib@1.3.1-r2 https://nvd.nist.gov/vuln/detail/CVE-2026-27171
-                #
-                # There's no base image fix for this yet.
-                "CVE-2026-27171"
-
 				# libgcrypt@1.10.3-r1 https://nvd.nist.gov/vuln/detail/CVE-2026-41989
 				#
 				# There is no fix available in the Alpine Docker image yet.


### PR DESCRIPTION
## Description

This PR will suppress [CVE-2026-41989](https://nvd.nist.gov/vuln/detail/CVE-2026-41989) in the security scan. This is coming from the Alpine image Boundary uses in our Docker image. There is no official Alpine release to resolve this yet, so we will suppress for now. 

Previously suppressed [CVE-2026-27171](https://nvd.nist.gov/vuln/detail/CVE-2026-27171) appears to be resolved, so it will be removed from the suppression list.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
