### PR TITLE
test(e2e): Address flake in bytes up down test

### DIFF
--- a/testing/internal/e2e/tests/base_connect/bytes_up_down_test.go
+++ b/testing/internal/e2e/tests/base_connect/bytes_up_down_test.go
@@ -68,7 +68,7 @@ func TestCliBytesUpDownTransferData(t *testing.T) {
 				"-o", "IdentitiesOnly=yes", // forces the use of the provided key
 				"-p", "{{boundary.port}}", // this is provided by boundary
 				"{{boundary.ip}}",
-				"for i in {1..120}; do pwd; sleep 1s; done",
+				"sh -c 'i=0; while [ \"$i\" -lt 120 ]; do pwd; sleep 1; i=$((i+1)); done'",
 			),
 		)
 	}()


### PR DESCRIPTION
## Description
This PR attempts to address a flake in the Bytes Up/Down e2e test
```
=== RUN   TestCliBytesUpDownTransferData
    scope.go:91: Created Org Id: o_igM4epuBA5
    scope.go:130: Created Project Id: p_vQEn7pM5Rh
    target.go:182: Created Target: ttcp_FpOarjnajB
    session.go:32: Waiting for session to appear...
    bytes_up_down_test.go:58: Starting session...
    session.go:57: Found 1 session(s)
    session.go:64: Created Session: s_aexoa6ejT5
    session.go:80: Waiting for session to be active...
    bytes_up_down_test.go:81: Waiting for bytes_up/bytes_down to be greater than 0...
    bytes_up_down_test.go:107: Connection - bytes_up: 0, bytes_down: 0, closed_reason: "system error", client: 172.18.0.1:49968, endpoint: 172.18.0.3:2222, session status: active
    bytes_up_down_test.go:145: 
        	Error Trace:	/home/runner/actions-runner/_work/boundary-enterprise/boundary-enterprise/testing/internal/e2e/tests/base_connect/bytes_up_down_test.go:145
        	Error:      	Received unexpected error:
        	            	connection closed before data transmission: system error
        	Test:       	TestCliBytesUpDownTransferData
```

The theory is that 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
