### PR TITLE
chore(e2e): Address docker image naming

### DIFF
--- a/enos/modules/docker_boundary/main.tf
+++ b/enos/modules/docker_boundary/main.tf
@@ -61,13 +61,13 @@ variable "max_page_size" {
 }
 
 resource "docker_image" "boundary" {
-  name         = var.image_name
+  name         = local.image_name
   keep_locally = false
 }
 
 resource "enos_local_exec" "init_database" {
   environment = {
-    TEST_BOUNDARY_IMAGE   = var.image_name
+    TEST_BOUNDARY_IMAGE   = local.image_name
     TEST_DATABASE_ADDRESS = var.postgres_address
     TEST_DATABASE_NETWORK = var.database_network
     TEST_BOUNDARY_LICENSE = var.boundary_license
@@ -77,6 +77,7 @@ resource "enos_local_exec" "init_database" {
 }
 
 locals {
+  image_name     = replace(var.image_name, "+", "-")
   db_init_info   = jsondecode(enos_local_exec.init_database.stdout)
   auth_method_id = local.db_init_info["auth_method"]["auth_method_id"]
   login_name     = local.db_init_info["auth_method"]["login_name"]

--- a/enos/modules/docker_boundary_cmd/main.tf
+++ b/enos/modules/docker_boundary_cmd/main.tf
@@ -41,7 +41,7 @@ variable "worker_token" {
 
 resource "enos_local_exec" "get_auth_token" {
   environment = {
-    TEST_BOUNDARY_IMAGE           = var.image_name
+    TEST_BOUNDARY_IMAGE           = local.image_name
     BOUNDARY_ADDR                 = var.address
     TEST_NETWORK_NAME             = var.network_name
     E2E_PASSWORD_ADMIN_LOGIN_NAME = var.login_name
@@ -53,6 +53,7 @@ resource "enos_local_exec" "get_auth_token" {
 }
 
 locals {
+  image_name = replace(var.image_name, "+", "-")
   auth_info  = jsondecode(enos_local_exec.get_auth_token.stdout)
   auth_token = local.auth_info["item"]["attributes"]["token"]
 }
@@ -60,7 +61,7 @@ locals {
 resource "enos_local_exec" "run_script" {
   depends_on = [enos_local_exec.get_auth_token]
   environment = {
-    TEST_BOUNDARY_IMAGE           = var.image_name
+    TEST_BOUNDARY_IMAGE           = local.image_name
     BOUNDARY_ADDR                 = var.address
     TEST_NETWORK_NAME             = var.network_name
     E2E_PASSWORD_ADMIN_LOGIN_NAME = var.login_name

--- a/enos/modules/docker_worker/main.tf
+++ b/enos/modules/docker_worker/main.tf
@@ -67,11 +67,12 @@ variable "worker_led_registration" {
 }
 
 resource "docker_image" "boundary" {
-  name         = var.image_name
+  name         = local.image_name
   keep_locally = true
 }
 
 locals {
+  image_name             = replace(var.image_name, "+", "-")
   recording_storage_path = "/boundary/recordings"
   port_ops               = var.port + 1
 }


### PR DESCRIPTION
## Description
In `release/0.19.x`, we are still passing in the docker image name into the e2e test tooling. With the change to remove the use of the `hashicorppreview` docker hub organization (https://github.com/hashicorp/boundary/pull/6670), there was an issue in the enterprise repo when trying to load the enterprise docker image due to some naming differences. 

This PR makes a quick fix in this release branch to address the naming changes. This isn't a problem in newer release branches.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
