### PR TITLE
chore(e2e): create multiple users in windows domain

### DIFF
--- a/enos/enos-scenario-e2e-aws-rdp-base.hcl
+++ b/enos/enos-scenario-e2e-aws-rdp-base.hcl
@@ -1,11 +1,7 @@
 # Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
-# This scenario creates a complete end-to-end test environment for Boundary to
-# test RDP functionality. It includes a Windows client, a Boundary controller
-# and worker, a domain controller, a member server, and another member server
-# with a worker running on it.
-scenario "e2e_aws_rdp_base" {
+scenario "e2e_aws_base" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
@@ -13,43 +9,23 @@ scenario "e2e_aws_rdp_base" {
   ]
 
   matrix {
-    builder       = ["local", "crt"]
-    client        = ["win10", "win11"]
-    kerberos_only = ["true", "false"]
-    # Windows Server 2016 does not support OpenSSH, but it's relied on for some
-    # parts of setup. If 2016 is selected, the member server will be created as
-    # 2016, but the domain controller and worker will be 2019.
-    rdp_server = ["2016", "2019", "2022", "2025"]
+    builder = ["local", "crt"]
   }
 
   locals {
     aws_ssh_private_key_path = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     boundary_install_dir     = abspath(var.boundary_install_dir)
+    license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
-    boundary_license_path    = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
-    ip_version               = "4"
-
-    build_path_linux = {
+    build_path = {
       "local" = "/tmp",
       "crt"   = var.crt_bundle_path == null ? null : abspath(var.crt_bundle_path)
     }
-
-    build_path_windows = {
-      "local" = "/tmp",
-      "crt"   = var.crt_bundle_path_windows == null ? null : abspath(var.crt_bundle_path_windows)
-    }
-
     tags = merge({
       "Project Name" : var.project_name
       "Project" : "Enos",
       "Environment" : "ci"
     }, var.tags)
-
-    collocated_tag = "collocated"
-  }
-
-  step "get_repo_root" {
-    module = module.get_repo_root
   }
 
   step "get_boundary_binary" {
@@ -70,15 +46,38 @@ scenario "e2e_aws_rdp_base" {
 
     variables {
       instance_type = [
+        var.controller_instance_type,
         var.worker_instance_type,
-        var.controller_instance_type
+        var.target_instance_type
       ]
     }
   }
 
-  step "create_base_infra" {
-    module = local.ip_version == "4" ? module.aws_vpc : module.aws_vpc_ipv6
+  step "read_license" {
+    module = module.read_license
 
+    variables {
+      license_path = local.license_path
+      license      = var.boundary_license
+      edition      = step.get_boundary_edition.edition
+    }
+  }
+
+  step "create_db_password" {
+    module = module.random_stringifier
+  }
+
+  step "build_boundary" {
+    module = matrix.builder == "crt" ? module.build_crt : module.build_local
+
+    variables {
+      path    = local.build_path[matrix.builder]
+      edition = step.get_boundary_edition.edition
+    }
+  }
+
+  step "create_base_infra" {
+    module = module.aws_vpc
     depends_on = [
       step.find_azs,
     ]
@@ -98,221 +97,52 @@ scenario "e2e_aws_rdp_base" {
     }
   }
 
-  step "build_boundary_linux" {
-    module = matrix.builder == "crt" ? module.build_crt : module.build_local
-
-    variables {
-      path    = local.build_path_linux[matrix.builder]
-      edition = step.get_boundary_edition.edition
-    }
-  }
-
-  step "build_boundary_windows" {
-    module = matrix.builder == "crt" ? module.build_crt : module.build_local
-
-    depends_on = [
-      step.build_boundary_linux,
-    ]
-
-    variables {
-      path          = local.build_path_windows[matrix.builder]
-      edition       = step.get_boundary_edition.edition
-      goos          = "windows"
-      build_target  = "build"
-      artifact_name = "boundary_windows"
-      binary_name   = "boundary.exe"
-    }
-  }
-
-  step "create_windows_client" {
-    module = module.aws_windows_client
-
-    depends_on = [
-      step.create_base_infra,
-      step.build_boundary_windows,
-    ]
-
-    variables {
-      vpc_id                = step.create_base_infra.vpc_id
-      client_version        = matrix.client
-      boundary_cli_zip_path = step.build_boundary_windows.artifact_path
-      boundary_src_path     = step.get_repo_root.path
-      github_token          = var.github_token
-      ip_version            = local.ip_version
-      vault_version         = var.vault_version
-    }
-  }
-
-  step "read_boundary_license" {
-    module = module.read_license
-
-    variables {
-      license_path = local.boundary_license_path
-      license      = var.boundary_license
-      edition      = step.get_boundary_edition.edition
-    }
-  }
-
-  step "create_vault_cluster" {
-    module = module.vault
-    depends_on = [
-      step.create_base_infra,
-      step.generate_ssh_key
-    ]
-
-    variables {
-      deploy          = true
-      ami_id          = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      instance_type   = var.vault_instance_type
-      instance_count  = 1
-      kms_key_arn     = step.create_base_infra.kms_key_arn
-      storage_backend = "raft"
-      unseal_method   = "shamir"
-      ip_version      = local.ip_version
-      vault_release = {
-        version = var.vault_version
-        edition = "oss"
-      }
-      vpc_id                   = step.create_base_infra.vpc_id
-      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
-      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
-    }
-  }
-
-  step "create_db_password" {
-    module = module.random_stringifier
-  }
-
-  step "create_rdp_domain_controller" {
-    module = module.aws_rdp_domain_controller
-    depends_on = [
-      step.create_base_infra,
-    ]
-
-    variables {
-      vpc_id         = step.create_base_infra.vpc_id
-      server_version = matrix.rdp_server == "2016" ? "2019" : matrix.rdp_server
-      ip_version     = local.ip_version
-    }
-  }
-
   step "create_boundary_cluster" {
     module = module.aws_boundary
     depends_on = [
       step.create_base_infra,
       step.create_db_password,
-      step.build_boundary_linux,
-      step.create_windows_client,
-      step.create_vault_cluster,
-      step.read_boundary_license,
+      step.build_boundary,
       step.generate_ssh_key
     ]
 
     variables {
-      boundary_binary_name        = var.boundary_binary_name
-      boundary_install_dir        = local.boundary_install_dir
-      boundary_license            = step.read_boundary_license.license
-      common_tags                 = local.tags
-      controller_instance_type    = var.controller_instance_type
-      controller_count            = var.controller_count
-      db_pass                     = step.create_db_password.string
-      kms_key_arn                 = step.create_base_infra.kms_key_arn
-      local_artifact_path         = step.build_boundary_linux.artifact_path
-      ubuntu_ami_id               = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      vpc_id                      = step.create_base_infra.vpc_id
-      worker_count                = var.worker_count
-      worker_instance_type        = var.worker_instance_type
-      controller_config_file_path = "templates/controller_bsr.hcl"
-      worker_config_file_path     = "templates/worker_bsr.hcl"
-      vault_address               = step.create_vault_cluster.instance_public_ips[0]
-      vault_transit_token         = step.create_vault_cluster.vault_transit_token
-      aws_region                  = var.aws_region
-      ip_version                  = local.ip_version
-      recording_storage_path      = "/recording"
-      alb_sg_additional_ips       = step.create_windows_client.public_ip_list
-      aws_ssh_keypair_name        = step.generate_ssh_key.key_pair_name
-      aws_ssh_private_key_path    = step.generate_ssh_key.private_key_path
+      boundary_binary_name     = var.boundary_binary_name
+      boundary_install_dir     = local.boundary_install_dir
+      boundary_license         = step.read_license.license
+      common_tags              = local.tags
+      controller_instance_type = var.controller_instance_type
+      controller_count         = var.controller_count
+      db_pass                  = step.create_db_password.string
+      kms_key_arn              = step.create_base_infra.kms_key_arn
+      local_artifact_path      = step.build_boundary.artifact_path
+      ubuntu_ami_id            = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      vpc_id                   = step.create_base_infra.vpc_id
+      vpc_tag_module           = step.create_base_infra.vpc_tag_module
+      worker_count             = var.worker_count
+      worker_instance_type     = var.worker_instance_type
+      aws_region               = var.aws_region
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
     }
   }
 
-  step "create_test_id" {
-    module = module.random_stringifier
-    variables {
-      length = 5
-    }
-  }
-
-  step "iam_setup" {
-    module = module.aws_iam_setup
+  step "create_target" {
+    module = module.aws_target
     depends_on = [
       step.create_base_infra,
-      step.create_test_id
+      step.generate_ssh_key
     ]
 
     variables {
-      test_id    = step.create_test_id.string
-      test_email = var.test_email
-    }
-  }
-
-  step "create_bucket" {
-    module = module.aws_bucket
-    depends_on = [
-      step.create_boundary_cluster,
-    ]
-    variables {
-      cluster_tag = step.create_boundary_cluster.cluster_tag
-      user        = step.iam_setup.user_name
-      is_user     = true
-    }
-  }
-
-  step "create_windows_worker" {
-    module = module.aws_rdp_member_server_with_worker
-    depends_on = [
-      step.create_base_infra,
-      step.create_rdp_domain_controller,
-      step.build_boundary_windows,
-      step.create_boundary_cluster,
-    ]
-
-    variables {
-      vpc_id                              = step.create_base_infra.vpc_id
-      server_version                      = matrix.rdp_server == "2016" ? "2019" : matrix.rdp_server
-      boundary_cli_zip_path               = step.build_boundary_windows.artifact_path
-      kms_key_arn                         = step.create_base_infra.kms_key_arn
-      controller_ip                       = step.create_boundary_cluster.controller_ips_private
-      iam_name                            = step.create_boundary_cluster.iam_instance_profile_name
-      boundary_security_group             = step.create_boundary_cluster.boundary_sg_id
-      active_directory_domain             = step.create_rdp_domain_controller.domain_name
-      domain_controller_aws_keypair_name  = step.create_rdp_domain_controller.keypair_name
-      domain_controller_ip                = step.create_rdp_domain_controller.private_ip
-      domain_admin_password               = step.create_rdp_domain_controller.password
-      domain_controller_private_key       = step.create_rdp_domain_controller.ssh_private_key
-      domain_controller_sec_group_id_list = step.create_rdp_domain_controller.security_group_id_list
-      aws_region                          = var.aws_region
-      ip_version                          = local.ip_version
-    }
-  }
-
-  step "create_rdp_member_server" {
-    module = module.aws_rdp_member_server
-    depends_on = [
-      step.create_base_infra,
-      step.create_rdp_domain_controller,
-    ]
-
-    variables {
-      vpc_id                              = step.create_base_infra.vpc_id
-      server_version                      = matrix.rdp_server
-      kerberos_only                       = matrix.kerberos_only == "true" ? true : false
-      active_directory_domain             = step.create_rdp_domain_controller.domain_name
-      domain_controller_aws_keypair_name  = step.create_rdp_domain_controller.keypair_name
-      domain_controller_ip                = step.create_rdp_domain_controller.private_ip
-      domain_admin_password               = step.create_rdp_domain_controller.password
-      domain_controller_private_key       = step.create_rdp_domain_controller.ssh_private_key
-      domain_controller_sec_group_id_list = step.create_rdp_domain_controller.security_group_id_list
-      ip_version                          = local.ip_version
+      ami_id                   = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
+      enos_user                = var.enos_user
+      instance_type            = var.target_instance_type
+      vpc_id                   = step.create_base_infra.vpc_id
+      target_count             = var.target_count
+      subnet_ids               = step.create_boundary_cluster.subnet_ids
     }
   }
 
@@ -320,49 +150,29 @@ scenario "e2e_aws_rdp_base" {
     module = module.test_e2e
     depends_on = [
       step.create_boundary_cluster,
-      step.create_rdp_domain_controller,
-      step.create_rdp_member_server,
-      step.create_windows_worker,
-      step.create_bucket
+      step.create_target,
+      step.generate_ssh_key
     ]
 
     variables {
-      test_package                             = ""
-      alb_boundary_api_addr                    = step.create_boundary_cluster.alb_boundary_api_addr
-      auth_method_id                           = step.create_boundary_cluster.auth_method_id
-      auth_login_name                          = step.create_boundary_cluster.auth_login_name
-      auth_password                            = step.create_boundary_cluster.auth_password
-      local_boundary_dir                       = local.local_boundary_dir != null ? local.local_boundary_dir : step.get_boundary_binary.path
-      aws_ssh_private_key_path                 = step.generate_ssh_key.private_key_path
-      target_user                              = "ubuntu"
-      target_port                              = "22"
-      aws_bucket_name                          = step.create_bucket.bucket_name
-      aws_region                               = var.aws_region
-      max_page_size                            = step.create_boundary_cluster.max_page_size
-      worker_tag_collocated                    = local.collocated_tag
-      worker_address                           = step.create_windows_worker.public_ip
-      target_rdp_domain_controller_addr        = step.create_rdp_domain_controller.private_ip
-      target_rdp_domain_controller_addr_ipv6   = local.ip_version == "4" ? "" : step.create_rdp_domain_controller.ipv6[0]
-      target_rdp_domain_controller_user        = step.create_rdp_domain_controller.admin_username
-      target_rdp_domain_controller_password    = step.create_rdp_domain_controller.password
-      target_rdp_domain_controller_ssh_key     = step.create_rdp_domain_controller.ssh_private_key
-      target_rdp_member_server_addr            = step.create_rdp_member_server.private_ip
-      target_rdp_member_server_domain_hostname = step.create_rdp_member_server.domain_hostname
-      target_rdp_member_server_user            = step.create_rdp_member_server.admin_username
-      target_rdp_member_server_password        = step.create_rdp_member_server.password
-      target_rdp_domain_name                   = step.create_rdp_domain_controller.domain_name
-      target_rdp_server_version                = matrix.rdp_server
-      controller_ip_public                     = step.create_boundary_cluster.controller_ips[0]
-      client_ip_public                         = step.create_windows_client.public_ip
-      client_username                          = step.create_windows_client.test_username
-      client_password                          = step.create_windows_client.test_password
-      client_test_dir                          = step.create_windows_client.test_dir
-      client_ssh_key                           = step.create_windows_client.ssh_private_key
-      client_version                           = matrix.client
-      vault_addr_public                        = step.create_vault_cluster.instance_addresses[0]
-      vault_addr_private                       = step.create_vault_cluster.instance_addresses_private[0]
-      vault_root_token                         = step.create_vault_cluster.vault_root_token
+      is_ci                    = var.is_ci
+      test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/base"
+      alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
+      auth_method_id           = step.create_boundary_cluster.auth_method_id
+      auth_login_name          = step.create_boundary_cluster.auth_login_name
+      auth_password            = step.create_boundary_cluster.auth_password
+      local_boundary_dir       = local.local_boundary_dir != null ? local.local_boundary_dir : step.get_boundary_binary.path
+      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
+      target_address           = step.create_target.target_private_ips[0]
+      target_user              = "ubuntu"
+      target_port              = "22"
+      max_page_size            = step.create_boundary_cluster.max_page_size
+      aws_region               = var.aws_region
     }
+  }
+
+  output "test_results" {
+    value = step.run_e2e_test.test_results
   }
 
   output "controller_ips" {
@@ -373,96 +183,8 @@ scenario "e2e_aws_rdp_base" {
     value = step.create_boundary_cluster.worker_ips
   }
 
-  output "rdp_domain_ssh_key" {
-    value = step.create_rdp_domain_controller.ssh_private_key
-  }
-
-  output "rdp_domain_controller_public_ip" {
-    value = step.create_rdp_domain_controller.public_ip
-  }
-
-  output "rdp_domain_controller_private_ip" {
-    value = step.create_rdp_domain_controller.private_ip
-  }
-
-  output "rdp_domain_controller_ipv6" {
-    value = step.create_rdp_domain_controller.ipv6
-  }
-
-  output "rdp_domain_controller_admin_username" {
-    value = step.create_rdp_domain_controller.admin_username
-  }
-
-  output "rdp_domain_controller_admin_password" {
-    value = step.create_rdp_domain_controller.password
-  }
-
-  output "rdp_domain" {
-    value = step.create_rdp_domain_controller.domain_name
-  }
-
-  output "rdp_member_server_public_ip" {
-    value = step.create_rdp_member_server.public_ip
-  }
-
-  output "rdp_member_server_private_ip" {
-    value = step.create_rdp_member_server.private_ip
-  }
-
-  output "rdp_member_server_domain_hostname" {
-    value = step.create_rdp_member_server.domain_hostname
-  }
-
-  output "rdp_member_server_admin_password" {
-    value = step.create_rdp_member_server.password
-  }
-
-  output "windows_client_public_ip" {
-    value = step.create_windows_client.public_ip
-  }
-
-  output "windows_client_private_ip" {
-    value = step.create_windows_client.private_ip
-  }
-
-  output "windows_client_admin_password" {
-    value = step.create_windows_client.admin_password
-  }
-
-  output "windows_client_test_user" {
-    value = step.create_windows_client.test_username
-  }
-
-  output "windows_client_test_password" {
-    value = step.create_windows_client.test_password
-  }
-
-  output "windows_client_ssh_key" {
-    value = step.create_windows_client.ssh_private_key
-  }
-
-  output "windows_worker_admin_username" {
-    value = step.create_windows_worker.admin_username
-  }
-
-  output "windows_worker_admin_password" {
-    value = step.create_windows_worker.admin_password
-  }
-
-  output "windows_worker_public_ip" {
-    value = step.create_windows_worker.public_ip
-  }
-
-  output "windows_worker_private_ip" {
-    value = step.create_windows_worker.private_ip
-  }
-
-  output "vault_address_public" {
-    value = step.create_vault_cluster.instance_public_ips_ipv4[0]
-  }
-
-  output "vault_root_token" {
-    value = step.create_vault_cluster.vault_root_token
+  output "target_ips" {
+    value = step.create_target.target_public_ips
   }
 
   output "aws_ssh_key_path" {

--- a/enos/enos-scenario-e2e-aws-rdp-base.hcl
+++ b/enos/enos-scenario-e2e-aws-rdp-base.hcl
@@ -1,7 +1,11 @@
 # Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
-scenario "e2e_aws_base" {
+# This scenario creates a complete end-to-end test environment for Boundary to
+# test RDP functionality. It includes a Windows client, a Boundary controller
+# and worker, a domain controller, a member server, and another member server
+# with a worker running on it.
+scenario "e2e_aws_rdp_base" {
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
@@ -9,23 +13,43 @@ scenario "e2e_aws_base" {
   ]
 
   matrix {
-    builder = ["local", "crt"]
+    builder       = ["local", "crt"]
+    client        = ["win10", "win11"]
+    kerberos_only = ["true", "false"]
+    # Windows Server 2016 does not support OpenSSH, but it's relied on for some
+    # parts of setup. If 2016 is selected, the member server will be created as
+    # 2016, but the domain controller and worker will be 2019.
+    rdp_server = ["2016", "2019", "2022", "2025"]
   }
 
   locals {
     aws_ssh_private_key_path = var.aws_ssh_private_key_path != null ? abspath(var.aws_ssh_private_key_path) : null
     boundary_install_dir     = abspath(var.boundary_install_dir)
-    license_path             = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
     local_boundary_dir       = var.local_boundary_dir != null ? abspath(var.local_boundary_dir) : null
-    build_path = {
+    boundary_license_path    = abspath(var.boundary_license_path != null ? var.boundary_license_path : joinpath(path.root, "./support/boundary.hclic"))
+    ip_version               = "4"
+
+    build_path_linux = {
       "local" = "/tmp",
       "crt"   = var.crt_bundle_path == null ? null : abspath(var.crt_bundle_path)
     }
+
+    build_path_windows = {
+      "local" = "/tmp",
+      "crt"   = var.crt_bundle_path_windows == null ? null : abspath(var.crt_bundle_path_windows)
+    }
+
     tags = merge({
       "Project Name" : var.project_name
       "Project" : "Enos",
       "Environment" : "ci"
     }, var.tags)
+
+    collocated_tag = "collocated"
+  }
+
+  step "get_repo_root" {
+    module = module.get_repo_root
   }
 
   step "get_boundary_binary" {
@@ -46,38 +70,15 @@ scenario "e2e_aws_base" {
 
     variables {
       instance_type = [
-        var.controller_instance_type,
         var.worker_instance_type,
-        var.target_instance_type
+        var.controller_instance_type
       ]
     }
   }
 
-  step "read_license" {
-    module = module.read_license
-
-    variables {
-      license_path = local.license_path
-      license      = var.boundary_license
-      edition      = step.get_boundary_edition.edition
-    }
-  }
-
-  step "create_db_password" {
-    module = module.random_stringifier
-  }
-
-  step "build_boundary" {
-    module = matrix.builder == "crt" ? module.build_crt : module.build_local
-
-    variables {
-      path    = local.build_path[matrix.builder]
-      edition = step.get_boundary_edition.edition
-    }
-  }
-
   step "create_base_infra" {
-    module = module.aws_vpc
+    module = local.ip_version == "4" ? module.aws_vpc : module.aws_vpc_ipv6
+
     depends_on = [
       step.find_azs,
     ]
@@ -97,52 +98,222 @@ scenario "e2e_aws_base" {
     }
   }
 
-  step "create_boundary_cluster" {
-    module = module.aws_boundary
+  step "build_boundary_linux" {
+    module = matrix.builder == "crt" ? module.build_crt : module.build_local
+
+    variables {
+      path    = local.build_path_linux[matrix.builder]
+      edition = step.get_boundary_edition.edition
+    }
+  }
+
+  step "build_boundary_windows" {
+    module = matrix.builder == "crt" ? module.build_crt : module.build_local
+
+    depends_on = [
+      step.build_boundary_linux,
+    ]
+
+    variables {
+      path          = local.build_path_windows[matrix.builder]
+      edition       = step.get_boundary_edition.edition
+      goos          = "windows"
+      build_target  = "build"
+      artifact_name = "boundary_windows"
+      binary_name   = "boundary.exe"
+    }
+  }
+
+  step "create_windows_client" {
+    module = module.aws_windows_client
+
     depends_on = [
       step.create_base_infra,
-      step.create_db_password,
-      step.build_boundary,
+      step.build_boundary_windows,
+    ]
+
+    variables {
+      vpc_id                = step.create_base_infra.vpc_id
+      client_version        = matrix.client
+      boundary_cli_zip_path = step.build_boundary_windows.artifact_path
+      boundary_src_path     = step.get_repo_root.path
+      github_token          = var.github_token
+      ip_version            = local.ip_version
+      vault_version         = var.vault_version
+    }
+  }
+
+  step "read_boundary_license" {
+    module = module.read_license
+
+    variables {
+      license_path = local.boundary_license_path
+      license      = var.boundary_license
+      edition      = step.get_boundary_edition.edition
+    }
+  }
+
+  step "create_vault_cluster" {
+    module = module.vault
+    depends_on = [
+      step.create_base_infra,
       step.generate_ssh_key
     ]
 
     variables {
-      boundary_binary_name     = var.boundary_binary_name
-      boundary_install_dir     = local.boundary_install_dir
-      boundary_license         = step.read_license.license
-      common_tags              = local.tags
-      controller_instance_type = var.controller_instance_type
-      controller_count         = var.controller_count
-      db_pass                  = step.create_db_password.string
-      kms_key_arn              = step.create_base_infra.kms_key_arn
-      local_artifact_path      = step.build_boundary.artifact_path
-      ubuntu_ami_id            = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      deploy          = true
+      ami_id          = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      instance_type   = var.vault_instance_type
+      instance_count  = 1
+      kms_key_arn     = step.create_base_infra.kms_key_arn
+      storage_backend = "raft"
+      unseal_method   = "shamir"
+      ip_version      = local.ip_version
+      vault_release = {
+        version = var.vault_version
+        edition = "oss"
+      }
       vpc_id                   = step.create_base_infra.vpc_id
-      vpc_tag_module           = step.create_base_infra.vpc_tag_module
-      worker_count             = var.worker_count
-      worker_instance_type     = var.worker_instance_type
-      aws_region               = var.aws_region
       aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
       aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
     }
   }
 
-  step "create_target" {
-    module = module.aws_target
+  step "create_db_password" {
+    module = module.random_stringifier
+  }
+
+  step "create_rdp_domain_controller" {
+    module = module.aws_rdp_domain_controller
     depends_on = [
       step.create_base_infra,
+    ]
+
+    variables {
+      vpc_id         = step.create_base_infra.vpc_id
+      server_version = matrix.rdp_server == "2016" ? "2019" : matrix.rdp_server
+      ip_version     = local.ip_version
+      extra_users    = var.extra_windows_users
+    }
+  }
+
+  step "create_boundary_cluster" {
+    module = module.aws_boundary
+    depends_on = [
+      step.create_base_infra,
+      step.create_db_password,
+      step.build_boundary_linux,
+      step.create_windows_client,
+      step.create_vault_cluster,
+      step.read_boundary_license,
       step.generate_ssh_key
     ]
 
     variables {
-      ami_id                   = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
-      aws_ssh_keypair_name     = step.generate_ssh_key.key_pair_name
-      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
-      enos_user                = var.enos_user
-      instance_type            = var.target_instance_type
-      vpc_id                   = step.create_base_infra.vpc_id
-      target_count             = var.target_count
-      subnet_ids               = step.create_boundary_cluster.subnet_ids
+      boundary_binary_name        = var.boundary_binary_name
+      boundary_install_dir        = local.boundary_install_dir
+      boundary_license            = step.read_boundary_license.license
+      common_tags                 = local.tags
+      controller_instance_type    = var.controller_instance_type
+      controller_count            = var.controller_count
+      db_pass                     = step.create_db_password.string
+      kms_key_arn                 = step.create_base_infra.kms_key_arn
+      local_artifact_path         = step.build_boundary_linux.artifact_path
+      ubuntu_ami_id               = step.create_base_infra.ami_ids["ubuntu"]["amd64"]
+      vpc_id                      = step.create_base_infra.vpc_id
+      worker_count                = var.worker_count
+      worker_instance_type        = var.worker_instance_type
+      controller_config_file_path = "templates/controller_bsr.hcl"
+      worker_config_file_path     = "templates/worker_bsr.hcl"
+      vault_address               = step.create_vault_cluster.instance_public_ips[0]
+      vault_transit_token         = step.create_vault_cluster.vault_transit_token
+      aws_region                  = var.aws_region
+      ip_version                  = local.ip_version
+      recording_storage_path      = "/recording"
+      alb_sg_additional_ips       = step.create_windows_client.public_ip_list
+      aws_ssh_keypair_name        = step.generate_ssh_key.key_pair_name
+      aws_ssh_private_key_path    = step.generate_ssh_key.private_key_path
+    }
+  }
+
+  step "create_test_id" {
+    module = module.random_stringifier
+    variables {
+      length = 5
+    }
+  }
+
+  step "iam_setup" {
+    module = module.aws_iam_setup
+    depends_on = [
+      step.create_base_infra,
+      step.create_test_id
+    ]
+
+    variables {
+      test_id    = step.create_test_id.string
+      test_email = var.test_email
+    }
+  }
+
+  step "create_bucket" {
+    module = module.aws_bucket
+    depends_on = [
+      step.create_boundary_cluster,
+    ]
+    variables {
+      cluster_tag = step.create_boundary_cluster.cluster_tag
+      user        = step.iam_setup.user_name
+      is_user     = true
+    }
+  }
+
+  step "create_windows_worker" {
+    module = module.aws_rdp_member_server_with_worker
+    depends_on = [
+      step.create_base_infra,
+      step.create_rdp_domain_controller,
+      step.build_boundary_windows,
+      step.create_boundary_cluster,
+    ]
+
+    variables {
+      vpc_id                              = step.create_base_infra.vpc_id
+      server_version                      = matrix.rdp_server == "2016" ? "2019" : matrix.rdp_server
+      boundary_cli_zip_path               = step.build_boundary_windows.artifact_path
+      kms_key_arn                         = step.create_base_infra.kms_key_arn
+      controller_ip                       = step.create_boundary_cluster.controller_ips_private
+      iam_name                            = step.create_boundary_cluster.iam_instance_profile_name
+      boundary_security_group             = step.create_boundary_cluster.boundary_sg_id
+      active_directory_domain             = step.create_rdp_domain_controller.domain_name
+      domain_controller_aws_keypair_name  = step.create_rdp_domain_controller.keypair_name
+      domain_controller_ip                = step.create_rdp_domain_controller.private_ip
+      domain_admin_password               = step.create_rdp_domain_controller.password
+      domain_controller_private_key       = step.create_rdp_domain_controller.ssh_private_key
+      domain_controller_sec_group_id_list = step.create_rdp_domain_controller.security_group_id_list
+      aws_region                          = var.aws_region
+      ip_version                          = local.ip_version
+    }
+  }
+
+  step "create_rdp_member_server" {
+    module = module.aws_rdp_member_server
+    depends_on = [
+      step.create_base_infra,
+      step.create_rdp_domain_controller,
+    ]
+
+    variables {
+      vpc_id                              = step.create_base_infra.vpc_id
+      server_version                      = matrix.rdp_server
+      kerberos_only                       = matrix.kerberos_only == "true" ? true : false
+      active_directory_domain             = step.create_rdp_domain_controller.domain_name
+      domain_controller_aws_keypair_name  = step.create_rdp_domain_controller.keypair_name
+      domain_controller_ip                = step.create_rdp_domain_controller.private_ip
+      domain_admin_password               = step.create_rdp_domain_controller.password
+      domain_controller_private_key       = step.create_rdp_domain_controller.ssh_private_key
+      domain_controller_sec_group_id_list = step.create_rdp_domain_controller.security_group_id_list
+      ip_version                          = local.ip_version
     }
   }
 
@@ -150,29 +321,49 @@ scenario "e2e_aws_base" {
     module = module.test_e2e
     depends_on = [
       step.create_boundary_cluster,
-      step.create_target,
-      step.generate_ssh_key
+      step.create_rdp_domain_controller,
+      step.create_rdp_member_server,
+      step.create_windows_worker,
+      step.create_bucket
     ]
 
     variables {
-      is_ci                    = var.is_ci
-      test_package             = "github.com/hashicorp/boundary/testing/internal/e2e/tests/base"
-      alb_boundary_api_addr    = step.create_boundary_cluster.alb_boundary_api_addr
-      auth_method_id           = step.create_boundary_cluster.auth_method_id
-      auth_login_name          = step.create_boundary_cluster.auth_login_name
-      auth_password            = step.create_boundary_cluster.auth_password
-      local_boundary_dir       = local.local_boundary_dir != null ? local.local_boundary_dir : step.get_boundary_binary.path
-      aws_ssh_private_key_path = step.generate_ssh_key.private_key_path
-      target_address           = step.create_target.target_private_ips[0]
-      target_user              = "ubuntu"
-      target_port              = "22"
-      max_page_size            = step.create_boundary_cluster.max_page_size
-      aws_region               = var.aws_region
+      test_package                             = ""
+      alb_boundary_api_addr                    = step.create_boundary_cluster.alb_boundary_api_addr
+      auth_method_id                           = step.create_boundary_cluster.auth_method_id
+      auth_login_name                          = step.create_boundary_cluster.auth_login_name
+      auth_password                            = step.create_boundary_cluster.auth_password
+      local_boundary_dir                       = local.local_boundary_dir != null ? local.local_boundary_dir : step.get_boundary_binary.path
+      aws_ssh_private_key_path                 = step.generate_ssh_key.private_key_path
+      target_user                              = "ubuntu"
+      target_port                              = "22"
+      aws_bucket_name                          = step.create_bucket.bucket_name
+      aws_region                               = var.aws_region
+      max_page_size                            = step.create_boundary_cluster.max_page_size
+      worker_tag_collocated                    = local.collocated_tag
+      worker_address                           = step.create_windows_worker.public_ip
+      target_rdp_domain_controller_addr        = step.create_rdp_domain_controller.private_ip
+      target_rdp_domain_controller_addr_ipv6   = local.ip_version == "4" ? "" : step.create_rdp_domain_controller.ipv6[0]
+      target_rdp_domain_controller_user        = step.create_rdp_domain_controller.admin_username
+      target_rdp_domain_controller_password    = step.create_rdp_domain_controller.password
+      target_rdp_domain_controller_ssh_key     = step.create_rdp_domain_controller.ssh_private_key
+      target_rdp_member_server_addr            = step.create_rdp_member_server.private_ip
+      target_rdp_member_server_domain_hostname = step.create_rdp_member_server.domain_hostname
+      target_rdp_member_server_user            = step.create_rdp_member_server.admin_username
+      target_rdp_member_server_password        = step.create_rdp_member_server.password
+      target_rdp_domain_name                   = step.create_rdp_domain_controller.domain_name
+      target_rdp_server_version                = matrix.rdp_server
+      controller_ip_public                     = step.create_boundary_cluster.controller_ips[0]
+      client_ip_public                         = step.create_windows_client.public_ip
+      client_username                          = step.create_windows_client.test_username
+      client_password                          = step.create_windows_client.test_password
+      client_test_dir                          = step.create_windows_client.test_dir
+      client_ssh_key                           = step.create_windows_client.ssh_private_key
+      client_version                           = matrix.client
+      vault_addr_public                        = step.create_vault_cluster.instance_addresses[0]
+      vault_addr_private                       = step.create_vault_cluster.instance_addresses_private[0]
+      vault_root_token                         = step.create_vault_cluster.vault_root_token
     }
-  }
-
-  output "test_results" {
-    value = step.run_e2e_test.test_results
   }
 
   output "controller_ips" {
@@ -183,11 +374,103 @@ scenario "e2e_aws_base" {
     value = step.create_boundary_cluster.worker_ips
   }
 
-  output "target_ips" {
-    value = step.create_target.target_public_ips
+  output "rdp_domain_ssh_key" {
+    value = step.create_rdp_domain_controller.ssh_private_key
+  }
+
+  output "rdp_domain_controller_public_ip" {
+    value = step.create_rdp_domain_controller.public_ip
+  }
+
+  output "rdp_domain_controller_private_ip" {
+    value = step.create_rdp_domain_controller.private_ip
+  }
+
+  output "rdp_domain_controller_ipv6" {
+    value = step.create_rdp_domain_controller.ipv6
+  }
+
+  output "rdp_domain_controller_admin_username" {
+    value = step.create_rdp_domain_controller.admin_username
+  }
+
+  output "rdp_domain_controller_admin_password" {
+    value = step.create_rdp_domain_controller.password
+  }
+
+  output "rdp_domain" {
+    value = step.create_rdp_domain_controller.domain_name
+  }
+
+  output "rdp_member_server_public_ip" {
+    value = step.create_rdp_member_server.public_ip
+  }
+
+  output "rdp_member_server_private_ip" {
+    value = step.create_rdp_member_server.private_ip
+  }
+
+  output "rdp_member_server_domain_hostname" {
+    value = step.create_rdp_member_server.domain_hostname
+  }
+
+  output "rdp_member_server_admin_password" {
+    value = step.create_rdp_member_server.password
+  }
+
+  output "windows_client_public_ip" {
+    value = step.create_windows_client.public_ip
+  }
+
+  output "windows_client_private_ip" {
+    value = step.create_windows_client.private_ip
+  }
+
+  output "windows_client_admin_password" {
+    value = step.create_windows_client.admin_password
+  }
+
+  output "windows_client_test_user" {
+    value = step.create_windows_client.test_username
+  }
+
+  output "windows_client_test_password" {
+    value = step.create_windows_client.test_password
+  }
+
+  output "windows_client_ssh_key" {
+    value = step.create_windows_client.ssh_private_key
+  }
+
+  output "windows_worker_admin_username" {
+    value = step.create_windows_worker.admin_username
+  }
+
+  output "windows_worker_admin_password" {
+    value = step.create_windows_worker.admin_password
+  }
+
+  output "windows_worker_public_ip" {
+    value = step.create_windows_worker.public_ip
+  }
+
+  output "windows_worker_private_ip" {
+    value = step.create_windows_worker.private_ip
+  }
+
+  output "vault_address_public" {
+    value = step.create_vault_cluster.instance_public_ips_ipv4[0]
+  }
+
+  output "vault_root_token" {
+    value = step.create_vault_cluster.vault_root_token
   }
 
   output "aws_ssh_key_path" {
     value = step.generate_ssh_key.private_key_path
+  }
+
+  output "extra_domain_users" {
+    value = step.create_rdp_domain_controller.extra_domain_users
   }
 }

--- a/enos/enos-scenario-e2e-aws-rdp-base.hcl
+++ b/enos/enos-scenario-e2e-aws-rdp-base.hcl
@@ -470,7 +470,7 @@ scenario "e2e_aws_rdp_base" {
     value = step.generate_ssh_key.private_key_path
   }
 
-  output "extra_domain_users" {
-    value = step.create_rdp_domain_controller.extra_domain_users
+  output "rdp_domain_users" {
+    value = step.create_rdp_domain_controller.rdp_domain_users
   }
 }

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -268,3 +268,9 @@ variable "is_ci" {
   type        = bool
   default     = false
 }
+
+variable "extra_windows_users" {
+  description = "number of extra windows users to create"
+  type        = number
+  default     = 0
+}

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -270,7 +270,7 @@ variable "is_ci" {
 }
 
 variable "extra_windows_users" {
-  description = "number of extra windows users to create"
+  description = "number of extra windows users to create on the ec2 windows client"
   type        = number
   default     = 0
 }

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -76,6 +76,10 @@
 // region where you've got an AWS keypair. Applies to AWS scenarios only.
 // aws_region = "us-east-1"
 
+// Number of extra users you want to create in RDP scenarios.
+// Useful for performance testing.
+// extra_windows_users = 0
+
 // ENTERPRISE ONLY
 // Path to a license file
 // boundary_license_path = "./support/boundary.hclic"

--- a/enos/modules/aws_rdp_domain_controller/main.tf
+++ b/enos/modules/aws_rdp_domain_controller/main.tf
@@ -535,3 +535,29 @@ resource "local_file" "ldaps_script_output" {
   content    = enos_local_exec.run_ldaps_script[0].stdout
   filename   = "${path.root}/.terraform/tmp/setup_ldaps.out"
 }
+
+resource "enos_local_exec" "add_create_users_script" {
+  depends_on = [
+    enos_local_exec.make_dir,
+  ]
+  count = var.extra_users > 0 ? 1 : 0
+
+  inline = ["scp -i ${abspath(local_sensitive_file.private_key.filename)} -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${path.module}/scripts/create_users.ps1 Administrator@${aws_instance.domain_controller.public_ip}:${local.test_dir}"]
+}
+
+resource "enos_local_exec" "run_create_users_script" {
+  depends_on = [
+    enos_local_exec.add_create_users_script,
+  ]
+  count = var.extra_users > 0 ? 1 : 0
+
+  inline = ["ssh -i ${abspath(local_sensitive_file.private_key.filename)} -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no Administrator@${aws_instance.domain_controller.public_ip} ${local.test_dir}/create_users.ps1 -Count ${var.extra_users} -PasswordPrefix ${var.extra_users_password_base}"]
+}
+
+resource "local_file" "create_users_script_output" {
+  depends_on = [enos_local_exec.run_create_users_script]
+  count      = var.extra_users > 0 ? 1 : 0
+
+  content  = enos_local_exec.run_create_users_script[0].stdout
+  filename = "${path.root}/.terraform/tmp/create_users.out"
+}

--- a/enos/modules/aws_rdp_domain_controller/main.tf
+++ b/enos/modules/aws_rdp_domain_controller/main.tf
@@ -540,7 +540,7 @@ resource "enos_local_exec" "add_create_users_script" {
   depends_on = [
     enos_local_exec.make_dir,
   ]
-  count = var.extra_users > 0 ? 1 : 0
+  count = (var.extra_users > 0 && var.server_version != "2016") ? 1 : 0
 
   inline = ["scp -i ${abspath(local_sensitive_file.private_key.filename)} -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${path.module}/scripts/create_users.ps1 Administrator@${aws_instance.domain_controller.public_ip}:${local.test_dir}"]
 }
@@ -549,14 +549,14 @@ resource "enos_local_exec" "run_create_users_script" {
   depends_on = [
     enos_local_exec.add_create_users_script,
   ]
-  count = var.extra_users > 0 ? 1 : 0
+  count = (var.extra_users > 0 && var.server_version != "2016") ? 1 : 0
 
   inline = ["ssh -i ${abspath(local_sensitive_file.private_key.filename)} -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no Administrator@${aws_instance.domain_controller.public_ip} ${local.test_dir}/create_users.ps1 -Count ${var.extra_users} -PasswordPrefix ${var.extra_users_password_base}"]
 }
 
 resource "local_file" "create_users_script_output" {
   depends_on = [enos_local_exec.run_create_users_script]
-  count      = var.extra_users > 0 ? 1 : 0
+  count      = (var.extra_users > 0 && var.server_version != "2016") ? 1 : 0
 
   content  = enos_local_exec.run_create_users_script[0].stdout
   filename = "${path.root}/.terraform/tmp/create_users.out"

--- a/enos/modules/aws_rdp_domain_controller/outputs.tf
+++ b/enos/modules/aws_rdp_domain_controller/outputs.tf
@@ -51,3 +51,11 @@ output "vault_ldap_user" {
   description = "User created for Vault LDAP use"
   value       = local.vault_ldap_user
 }
+
+output "extra_domain_users" {
+  description = "Extra domain users created for performance testing"
+  value = [
+    for user_number in range(var.extra_users) :
+    "Username: ${var.extra_users_username_base}${user_number + 1} Password: ${var.extra_users_password_base}${user_number + 1}"
+  ]
+}

--- a/enos/modules/aws_rdp_domain_controller/outputs.tf
+++ b/enos/modules/aws_rdp_domain_controller/outputs.tf
@@ -52,7 +52,7 @@ output "vault_ldap_user" {
   value       = local.vault_ldap_user
 }
 
-output "extra_domain_users" {
+output "rdp_domain_users" {
   description = "Extra domain users created for performance testing"
   value = [
     for user_number in range(var.extra_users) :

--- a/enos/modules/aws_rdp_domain_controller/scripts/create_users.ps1
+++ b/enos/modules/aws_rdp_domain_controller/scripts/create_users.ps1
@@ -1,0 +1,82 @@
+[CmdletBinding()]
+param(
+	[Parameter(Mandatory = $true)]
+	[ValidateRange(1, 10000)]
+	[int]$Count,
+
+	[Parameter(Mandatory = $false)]
+	[ValidateRange(1, 1000000)]
+	[int]$StartAt = 1,
+
+	[Parameter(Mandatory = $false)]
+	[ValidateNotNullOrEmpty()]
+	[string]$UsernamePrefix = "user",
+
+	[Parameter(Mandatory = $false)]
+	[ValidateNotNullOrEmpty()]
+	[string]$PasswordPrefix = "p@ssw0rd00!",
+
+	[Parameter(Mandatory = $false)]
+	[ValidateNotNullOrEmpty()]
+	[string]$AdminGroupName = "Domain Admins"
+)
+
+$ErrorActionPreference = "Stop"
+
+Import-Module ActiveDirectory
+
+$domain = Get-ADDomain
+$dnsRoot = $domain.DNSRoot
+$createdUsers = 0
+
+function Grant-AdminGroupMembership {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$SamAccountName
+	)
+
+	try {
+		Add-ADGroupMember -Identity $AdminGroupName -Members $SamAccountName -ErrorAction Stop
+		Write-Host "Granted domain admin access to user: $SamAccountName"
+	}
+	catch {
+		if ($_.Exception.Message -match "already a member") {
+			Write-Host "User '$SamAccountName' is already in '$AdminGroupName'."
+		}
+		else {
+			throw
+		}
+	}
+}
+
+
+
+
+for ($i = $StartAt; $i -lt ($StartAt + $Count); $i++) {
+	$username = "$UsernamePrefix$i"
+	$plainPassword = "$PasswordPrefix$i"
+	$securePassword = ConvertTo-SecureString $plainPassword -AsPlainText -Force
+
+	$existingUser = Get-ADUser -Filter "SamAccountName -eq '$username'" -ErrorAction SilentlyContinue
+	if ($existingUser) {
+		Write-Warning "User '$username' already exists. Skipping."
+		Grant-AdminGroupMembership -SamAccountName $username
+		continue
+	}
+
+	New-ADUser `
+		-Name $username `
+		-SamAccountName $username `
+		-UserPrincipalName "$username@$dnsRoot" `
+		-AccountPassword $securePassword `
+		-Enabled $true `
+		-PasswordNeverExpires $true
+
+	$createdUsers++
+	Write-Host "Created user: $username"
+
+	Grant-AdminGroupMembership -SamAccountName $username
+
+}
+
+Write-Host "Done. Created $createdUsers user(s)."

--- a/enos/modules/aws_rdp_domain_controller/scripts/create_users.ps1
+++ b/enos/modules/aws_rdp_domain_controller/scripts/create_users.ps1
@@ -49,9 +49,6 @@ function Grant-AdminGroupMembership {
 	}
 }
 
-
-
-
 for ($i = $StartAt; $i -lt ($StartAt + $Count); $i++) {
 	$username = "$UsernamePrefix$i"
 	$plainPassword = "$PasswordPrefix$i"

--- a/enos/modules/aws_rdp_domain_controller/variables.tf
+++ b/enos/modules/aws_rdp_domain_controller/variables.tf
@@ -6,6 +6,24 @@ variable "vpc_id" {
   description = "Id of VPC to add additional infra resources to."
 }
 
+variable "extra_users" {
+  type        = number
+  description = "Number of additional domcain users to be created"
+  default     = 0
+}
+
+variable "extra_users_password_base" {
+  type        = string
+  description = "base of password for the extra users"
+  default     = "p@ssw0rd00!"
+}
+
+variable "extra_users_username_base" {
+  type        = string
+  description = "base of password for the extra users"
+  default     = "user"
+}
+
 # =================================================================
 # ec2 instance configuration
 # =================================================================

--- a/enos/modules/aws_rdp_domain_controller/variables.tf
+++ b/enos/modules/aws_rdp_domain_controller/variables.tf
@@ -8,8 +8,13 @@ variable "vpc_id" {
 
 variable "extra_users" {
   type        = number
-  description = "Number of additional domcain users to be created"
+  description = "Number of additional domain users to be created"
   default     = 0
+
+  validation {
+    condition     = var.extra_users >= 0 && floor(var.extra_users) == var.extra_users
+    error_message = "extra_users must be a whole number greater than or equal to 0."
+  }
 }
 
 variable "extra_users_password_base" {
@@ -20,7 +25,7 @@ variable "extra_users_password_base" {
 
 variable "extra_users_username_base" {
   type        = string
-  description = "base of password for the extra users"
+  description = "base of username for the extra users"
   default     = "user"
 }
 


### PR DESCRIPTION
## Description## Description
We wanted to have the ability to test multiple domain users for RDP testing so that we could test the performance of boundary with multiple rdp connections. This PR adds a new enos variable that will create a number of users in the domain that can then be used for rdp testing. 

https://hashicorp.atlassian.net/browse/ICU-18977
## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
