### PR TITLE
test(e2e): Add worker version check (backport to `release/0.19.x`)

### DIFF
--- a/testing/internal/e2e/boundary/version.go
+++ b/testing/internal/e2e/boundary/version.go
@@ -1,0 +1,49 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package boundary
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	gvers "github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/boundary/testing/internal/e2e"
+	"github.com/hashicorp/boundary/version"
+)
+
+// IsVersionAtLeast checks if the Boundary version running in the specified container is at least the given minimum version.
+func IsVersionAtLeast(t testing.TB, ctx context.Context, containerName string, minVersion string) {
+	output := e2e.RunCommand(
+		ctx,
+		"docker",
+		e2e.WithArgs(
+			"exec", containerName,
+			"boundary", "version",
+			"-format", "json",
+		),
+	)
+	require.NoError(t, output.Err, "failed to get version from container %q: %s", containerName, string(output.Stderr))
+
+	var versionResult version.Info
+	err := json.Unmarshal(output.Stdout, &versionResult)
+	require.NoError(t, err)
+
+	minSemVersion, err := gvers.NewSemver(minVersion)
+	require.NoError(t, err)
+
+	containerVersion := versionResult.Semver()
+	require.NotNil(t, containerVersion, "failed to parse version %q from container %q", versionResult.VersionNumber(), containerName)
+
+	if !containerVersion.GreaterThanOrEqual(minSemVersion) {
+		t.Skipf(
+			"Skipping test because container %q is running %q, but this test requires >= %q",
+			containerName,
+			versionResult.VersionNumber(),
+			minVersion,
+		)
+	}
+}


### PR DESCRIPTION
## Description
This PR adds a version check method that will be used in some tests. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
