### PR TITLE
docs: Adds HCSEC-2026-11 to Community changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### Security
 
+* Resolved a vulnerability (CVE-2026-776) that could lead to a denial-of-service condition during TLS handshakes. For more information, refer to [Boundary Workers Vulnerable to Denial of Service During TLS Handshake](https://discuss.hashicorp.com/t/hcsec-2026-11-boundary-workers-vulnerable-to-denial-of-service-during-tls-handshake/77403).
 * Updated jackc/pgx/v5 dependency to v5.9.2 to address GHSA-j88v-2chj-qfwx, GO-2026-4771, GO-2026-4772, and GHSA-9jj7-4m8r-rfcm ([PR](https://github.com/hashicorp/boundary/pull/6607), [PR](https://github.com/hashicorp/boundary/pull/6617))
 * Updated Azure/go-ntlmssp dependency to v0.1.1 to address GHSA-pjcq-xvwq-hhpj ([PR](https://github.com/hashicorp/boundary/pull/6625))
 
@@ -56,11 +57,12 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ## 0.20.3 (2026/04/30)
 
-### New and Improved 
+### New and Improved
 * Added support for new `debug` flag to expose pprof endpoints for debugging purposes. ([PR](https://github.com/hashicorp/boundary/pull/6644))
 
 ### Security
 
+* Resolved a vulnerability (CVE-2026-776) that could lead to a denial-of-service condition during TLS handshakes. For more information, refer to [Boundary Workers Vulnerable to Denial of Service During TLS Handshake](https://discuss.hashicorp.com/t/hcsec-2026-11-boundary-workers-vulnerable-to-denial-of-service-during-tls-handshake/77403).
 * Updated jackc/pgx/v5 dependency to v5.9.2 to address GHSA-j88v-2chj-qfwx, GO-2026-4771, GO-2026-4772, and GHSA-9jj7-4m8r-rfcm ([PR](https://github.com/hashicorp/boundary/pull/6607), [PR](https://github.com/hashicorp/boundary/pull/6617))
 * Updated Azure/go-ntlmssp dependency to v0.1.1 to address GHSA-pjcq-xvwq-hhpj ([PR](https://github.com/hashicorp/boundary/pull/6625))
 
@@ -128,6 +130,7 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### Security
 
+* Resolved a vulnerability (CVE-2026-776) that could lead to a denial-of-service condition during TLS handshakes. For more information, refer to [Boundary Workers Vulnerable to Denial of Service During TLS Handshake](https://discuss.hashicorp.com/t/hcsec-2026-11-boundary-workers-vulnerable-to-denial-of-service-during-tls-handshake/77403).
 * Updated jackc/pgx/v5 dependency to v5.9.2 to address GHSA-j88v-2chj-qfwx, GO-2026-4771, GO-2026-4772, and GHSA-9jj7-4m8r-rfcm ([PR](https://github.com/hashicorp/boundary/pull/6607), [PR](https://github.com/hashicorp/boundary/pull/6617))
 * Updated Azure/go-ntlmssp dependency to v0.1.1 to address GHSA-pjcq-xvwq-hhpj ([PR](https://github.com/hashicorp/boundary/pull/6625))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### Security
 
-* Resolved a vulnerability (CVE-2026-776) that could lead to a denial-of-service condition during TLS handshakes. For more information, refer to [Boundary Workers Vulnerable to Denial of Service During TLS Handshake](https://discuss.hashicorp.com/t/hcsec-2026-11-boundary-workers-vulnerable-to-denial-of-service-during-tls-handshake/77403).
+* Resolved a vulnerability (CVE-2026-7776) that could lead to a denial-of-service condition during TLS handshakes. For more information, refer to [Boundary Workers Vulnerable to Denial of Service During TLS Handshake](https://discuss.hashicorp.com/t/hcsec-2026-11-boundary-workers-vulnerable-to-denial-of-service-during-tls-handshake/77403).
 * Updated jackc/pgx/v5 dependency to v5.9.2 to address GHSA-j88v-2chj-qfwx, GO-2026-4771, GO-2026-4772, and GHSA-9jj7-4m8r-rfcm ([PR](https://github.com/hashicorp/boundary/pull/6607), [PR](https://github.com/hashicorp/boundary/pull/6617))
 * Updated Azure/go-ntlmssp dependency to v0.1.1 to address GHSA-pjcq-xvwq-hhpj ([PR](https://github.com/hashicorp/boundary/pull/6625))
 
@@ -62,7 +62,7 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### Security
 
-* Resolved a vulnerability (CVE-2026-776) that could lead to a denial-of-service condition during TLS handshakes. For more information, refer to [Boundary Workers Vulnerable to Denial of Service During TLS Handshake](https://discuss.hashicorp.com/t/hcsec-2026-11-boundary-workers-vulnerable-to-denial-of-service-during-tls-handshake/77403).
+* Resolved a vulnerability (CVE-2026-7776) that could lead to a denial-of-service condition during TLS handshakes. For more information, refer to [Boundary Workers Vulnerable to Denial of Service During TLS Handshake](https://discuss.hashicorp.com/t/hcsec-2026-11-boundary-workers-vulnerable-to-denial-of-service-during-tls-handshake/77403).
 * Updated jackc/pgx/v5 dependency to v5.9.2 to address GHSA-j88v-2chj-qfwx, GO-2026-4771, GO-2026-4772, and GHSA-9jj7-4m8r-rfcm ([PR](https://github.com/hashicorp/boundary/pull/6607), [PR](https://github.com/hashicorp/boundary/pull/6617))
 * Updated Azure/go-ntlmssp dependency to v0.1.1 to address GHSA-pjcq-xvwq-hhpj ([PR](https://github.com/hashicorp/boundary/pull/6625))
 
@@ -130,7 +130,7 @@ Canonical reference for changes, improvements, and bugfixes for Boundary.
 
 ### Security
 
-* Resolved a vulnerability (CVE-2026-776) that could lead to a denial-of-service condition during TLS handshakes. For more information, refer to [Boundary Workers Vulnerable to Denial of Service During TLS Handshake](https://discuss.hashicorp.com/t/hcsec-2026-11-boundary-workers-vulnerable-to-denial-of-service-during-tls-handshake/77403).
+* Resolved a vulnerability (CVE-2026-7776) that could lead to a denial-of-service condition during TLS handshakes. For more information, refer to [Boundary Workers Vulnerable to Denial of Service During TLS Handshake](https://discuss.hashicorp.com/t/hcsec-2026-11-boundary-workers-vulnerable-to-denial-of-service-during-tls-handshake/77403).
 * Updated jackc/pgx/v5 dependency to v5.9.2 to address GHSA-j88v-2chj-qfwx, GO-2026-4771, GO-2026-4772, and GHSA-9jj7-4m8r-rfcm ([PR](https://github.com/hashicorp/boundary/pull/6607), [PR](https://github.com/hashicorp/boundary/pull/6617))
 * Updated Azure/go-ntlmssp dependency to v0.1.1 to address GHSA-pjcq-xvwq-hhpj ([PR](https://github.com/hashicorp/boundary/pull/6625))
 


### PR DESCRIPTION
## Description

This PR adds a short description of CVE-2026-776 to the CHANGELOG for versions 0.21.3, 0.20.3, and 0.19.5. It includes a link to the HCSEC-2026-11 security bulletin.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
