### PR TITLE
Add "pins" as a grant segment

### DIFF
--- a/api/roles/grant_json.gen.go
+++ b/api/roles/grant_json.gen.go
@@ -9,4 +9,5 @@ type GrantJson struct {
 	Ids     []string `json:"ids,omitempty"`
 	Type    string   `json:"type,omitempty"`
 	Actions []string `json:"actions,omitempty"`
+	Pins    []string `json:"pins,omitempty"`
 }

--- a/internal/daemon/controller/handlers/roles/role_service.go
+++ b/internal/daemon/controller/handlers/roles/role_service.go
@@ -1139,6 +1139,7 @@ func toProto(ctx context.Context, in *iam.Role, principals []*iam.PrincipalRole,
 					Json: &pb.GrantJson{
 						Id:      parsed.Id(),
 						Ids:     parsed.Ids(),
+						Pins:    parsed.Pins(),
 						Type:    parsed.Type().String(),
 						Actions: actions,
 					},

--- a/internal/gen/controller.swagger.json
+++ b/internal/gen/controller.swagger.json
@@ -6835,6 +6835,14 @@
           },
           "description": "Output only. The actions.",
           "readOnly": true
+        },
+        "pins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Output only. The pins, if set. Pins constrain the grant to resources\nwithin the given parent resources.",
+          "readOnly": true
         }
       }
     },

--- a/internal/perms/acl.go
+++ b/internal/perms/acl.go
@@ -173,7 +173,7 @@ func NewACL(grants ...Grant) ACL {
 		}
 
 		// Handle explicit pins grants. Pins are stored in AclGrant.Id so
-		// that Case 5 of Allowed() can match them against Resource.Pin.
+		// that Case 5 of acl.Allowed() can match them against Resource.Pin.
 		for _, pin := range grant.pins {
 			addGrant(grant, pin)
 		}

--- a/internal/perms/acl.go
+++ b/internal/perms/acl.go
@@ -147,24 +147,35 @@ func NewACL(grants ...Grant) ACL {
 		descendantsGrants: make([]AclGrant, 0, len(grants)),
 	}
 
+	addGrant := func(grant Grant, id string) {
+		switch grant.grantScopeId {
+		case globals.GrantScopeDescendants:
+			ret.descendantsGrants = append(ret.descendantsGrants, aclGrantFromGrant(grant, id))
+		case globals.GrantScopeChildren:
+			// We use the role's scope here because we're evaluating the
+			// grants themselves, not the resource, so we want to know the
+			// scope of the role that said "children"
+			ret.childrenScopeMap[grant.roleScopeId] = append(ret.childrenScopeMap[grant.roleScopeId], aclGrantFromGrant(grant, id))
+		default:
+			ret.directScopeMap[grant.grantScopeId] = append(ret.directScopeMap[grant.grantScopeId], aclGrantFromGrant(grant, id))
+		}
+	}
+
 	for _, grant := range grants {
+		// Handle id/ids grants
 		ids := grant.ids
 		if len(ids) == 0 {
 			// This handles the no-ID case as well as the deprecated single-ID case
 			ids = []string{grant.id}
 		}
 		for _, id := range ids {
-			switch grant.grantScopeId {
-			case globals.GrantScopeDescendants:
-				ret.descendantsGrants = append(ret.descendantsGrants, aclGrantFromGrant(grant, id))
-			case globals.GrantScopeChildren:
-				// We use the role's scope here because we're evaluating the
-				// grants themselves, not the resource, so we want to know the
-				// scope of the role that said "children"
-				ret.childrenScopeMap[grant.roleScopeId] = append(ret.childrenScopeMap[grant.roleScopeId], aclGrantFromGrant(grant, id))
-			default:
-				ret.directScopeMap[grant.grantScopeId] = append(ret.directScopeMap[grant.grantScopeId], aclGrantFromGrant(grant, id))
-			}
+			addGrant(grant, id)
+		}
+
+		// Handle explicit pins grants. Pins are stored in AclGrant.Id so
+		// that Case 5 of Allowed() can match them against Resource.Pin.
+		for _, pin := range grant.pins {
+			addGrant(grant, pin)
 		}
 	}
 

--- a/internal/perms/acl_test.go
+++ b/internal/perms/acl_test.go
@@ -393,6 +393,153 @@ func Test_ACLAllowed(t *testing.T) {
 				{action: action.CreateWorkerLed, authorized: true},
 			},
 		},
+		// Explicit pin/pins grant tests (Case 5 via pin field)
+		{
+			name: "explicit pins field - matching pin and type",
+			resource: Resource{
+				ParentScopeId: scope.Global.String(),
+				ScopeId:       "o_e",
+				Pin:           "hcst_mypin",
+				Type:          resource.HostSet,
+			},
+			scopeGrants: []scopeGrant{
+				{
+					roleScope:  "o_e",
+					grantScope: "o_e",
+					grants:     []string{"pins=hcst_mypin,hcst_mapins;type=host-set;actions=read,update"},
+				},
+			},
+			actionsAuthorized: []actionAuthorized{
+				{action: action.Read, authorized: true},
+				{action: action.Update, authorized: true},
+				{action: action.Delete},
+				{action: action.List},
+			},
+		},
+		{
+			name: "explicit pins field - matching pin and type on second value",
+			resource: Resource{
+				ParentScopeId: scope.Global.String(),
+				ScopeId:       "o_e",
+				Pin:           "hcst_mapins",
+				Type:          resource.HostSet,
+			},
+			scopeGrants: []scopeGrant{
+				{
+					roleScope:  "o_e",
+					grantScope: "o_e",
+					grants:     []string{"pins=hcst_mypin,hcst_mapins;type=host-set;actions=read,update"},
+				},
+			},
+			actionsAuthorized: []actionAuthorized{
+				{action: action.Read, authorized: true},
+				{action: action.Update, authorized: true},
+				{action: action.Delete},
+				{action: action.List},
+			},
+		},
+		{
+			name: "explicit pins field - wrong pin",
+			resource: Resource{
+				ParentScopeId: scope.Global.String(),
+				ScopeId:       "o_e",
+				Pin:           "hcst_wrongpin",
+				Type:          resource.HostSet,
+			},
+			scopeGrants: []scopeGrant{
+				{
+					roleScope:  "o_e",
+					grantScope: "o_e",
+					grants:     []string{"pins=hcst_mypin;type=host-set;actions=read,update"},
+				},
+			},
+			actionsAuthorized: []actionAuthorized{
+				{action: action.Read},
+				{action: action.Update},
+				{action: action.Delete},
+			},
+		},
+		{
+			name: "explicit pins field - wildcard type",
+			resource: Resource{
+				ParentScopeId: scope.Global.String(),
+				ScopeId:       "o_e",
+				Pin:           "hcst_mypin",
+				Type:          resource.HostSet,
+			},
+			scopeGrants: []scopeGrant{
+				{
+					roleScope:  "o_e",
+					grantScope: "o_e",
+					grants:     []string{"pins=hcst_mypin;type=*;actions=read"},
+				},
+			},
+			actionsAuthorized: []actionAuthorized{
+				{action: action.Read, authorized: true},
+				{action: action.Update},
+				{action: action.Delete},
+			},
+		},
+		{
+			name: "explicit pins field - multiple pins, matching first",
+			resource: Resource{
+				ParentScopeId: scope.Global.String(),
+				ScopeId:       "o_e",
+				Pin:           "hcst_pin1",
+				Type:          resource.HostSet,
+			},
+			scopeGrants: []scopeGrant{
+				{
+					roleScope:  "o_e",
+					grantScope: "o_e",
+					grants:     []string{"pins=hcst_pin1,hcst_pin2;type=host-set;actions=read"},
+				},
+			},
+			actionsAuthorized: []actionAuthorized{
+				{action: action.Read, authorized: true},
+				{action: action.Update},
+			},
+		},
+		{
+			name: "explicit pins field - multiple pins, matching second",
+			resource: Resource{
+				ParentScopeId: scope.Global.String(),
+				ScopeId:       "o_e",
+				Pin:           "hcst_pin2",
+				Type:          resource.HostSet,
+			},
+			scopeGrants: []scopeGrant{
+				{
+					roleScope:  "o_e",
+					grantScope: "o_e",
+					grants:     []string{"pins=hcst_pin1,hcst_pin2;type=host-set;actions=read"},
+				},
+			},
+			actionsAuthorized: []actionAuthorized{
+				{action: action.Read, authorized: true},
+				{action: action.Update},
+			},
+		},
+		{
+			name: "explicit pins field - no matching pin",
+			resource: Resource{
+				ParentScopeId: scope.Global.String(),
+				ScopeId:       "o_e",
+				Pin:           "hcst_other",
+				Type:          resource.HostSet,
+			},
+			scopeGrants: []scopeGrant{
+				{
+					roleScope:  "o_e",
+					grantScope: "o_e",
+					grants:     []string{"pins=hcst_pin1,hcst_pin2;type=host-set;actions=read"},
+				},
+			},
+			actionsAuthorized: []actionAuthorized{
+				{action: action.Read},
+				{action: action.Update},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -669,6 +669,9 @@ func Parse(ctx context.Context, tuple GrantTuple, opt ...Option) (Grant, error) 
 					if grant.typ == resource.Unknown {
 						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains a pin but no resource type", grant.CanonicalString()))
 					}
+					if grant.typ == pinType {
+						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains a type that is the same as the pin type (%s)", grant.CanonicalString(), pinType.String()))
+					}
 					if grant.typ != resource.All && grant.typ.Parent() != pinType {
 						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains type %s that is not a child type of the type (%s) of the specified pin", grant.CanonicalString(), grant.typ.String(), pinType.String()))
 					}

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -440,23 +440,32 @@ func (g *Grant) unmarshalText(ctx context.Context, grantString string) error {
 		switch kv[0] {
 		case "id":
 			g.id = kv[1]
-			if strings.Contains(g.id, ",") {
+			switch {
+			case strings.Contains(g.id, ","):
 				return errors.New(ctx, errors.InvalidParameter, op, "ID cannot contain a comma")
+			case strings.ContainsAny(g.id, ",;="):
+				return errors.New(ctx, errors.InvalidParameter, op, "ID cannot contain a comma, semicolon or equals sign")
 			}
 
 		case "ids":
 			g.ids = strings.Split(kv[1], ",")
 			for _, id := range g.ids {
-				if id == "" {
+				switch {
+				case id == "":
 					return errors.New(ctx, errors.InvalidParameter, op, "empty ID provided")
+				case strings.ContainsAny(id, ",;="):
+					return errors.New(ctx, errors.InvalidParameter, op, "ID cannot contain a comma, semicolon or equals sign")
 				}
 			}
 
 		case "pins":
 			g.pins = strings.Split(kv[1], ",")
 			for _, pin := range g.pins {
-				if pin == "" {
+				switch {
+				case pin == "":
 					return errors.New(ctx, errors.InvalidParameter, op, "empty pin provided")
+				case strings.ContainsAny(pin, ",;="):
+					return errors.New(ctx, errors.InvalidParameter, op, "pin cannot contain a comma, semicolon or equals sign")
 				}
 			}
 

--- a/internal/perms/grants.go
+++ b/internal/perms/grants.go
@@ -127,6 +127,11 @@ type Grant struct {
 	// The IDs in the grant, if provided
 	ids []string
 
+	// The pins in the grant, if provided. Pins explicitly constrain a grant to
+	// resources within the given parent resources, making the pinning intent
+	// clear.
+	pins []string
+
 	// The grant scope ID of the grant
 	grantScopeId string
 
@@ -152,6 +157,12 @@ func (g Grant) Id() string {
 // Ids returns the IDs the grant refers to, if any
 func (g Grant) Ids() []string {
 	return g.ids
+}
+
+// Pins returns the pins the grant refers to, if any. Pins constrain the grant
+// to resources within the given parent resources.
+func (g Grant) Pins() []string {
+	return g.pins
 }
 
 // GrantScopeId returns the grant scope ID the grant refers to, if any
@@ -190,12 +201,17 @@ func (g Grant) clone() *Grant {
 		roleParentScopeId: g.roleParentScopeId,
 		id:                g.id,
 		ids:               g.ids,
+		pins:              g.pins,
 		grantScopeId:      g.grantScopeId,
 		typ:               g.typ,
 	}
 	if g.ids != nil {
 		ret.ids = make([]string, len(g.ids))
 		copy(ret.ids, g.ids)
+	}
+	if g.pins != nil {
+		ret.pins = make([]string, len(g.pins))
+		copy(ret.pins, g.pins)
 	}
 	if g.actionsBeingParsed != nil {
 		ret.actionsBeingParsed = append(ret.actionsBeingParsed, g.actionsBeingParsed...)
@@ -224,6 +240,10 @@ func (g Grant) CanonicalString() string {
 
 	if len(g.ids) > 0 {
 		builder = append(builder, fmt.Sprintf("ids=%s", strings.Join(g.ids, ",")))
+	}
+
+	if len(g.pins) > 0 {
+		builder = append(builder, fmt.Sprintf("pins=%s", strings.Join(g.pins, ",")))
 	}
 
 	if g.typ != resource.Unknown {
@@ -255,6 +275,9 @@ func (g Grant) MarshalJSON() ([]byte, error) {
 	}
 	if len(g.ids) > 0 {
 		res["ids"] = g.ids
+	}
+	if len(g.pins) > 0 {
+		res["pins"] = g.pins
 	}
 	if g.typ != resource.Unknown {
 		res["type"] = g.typ.String()
@@ -315,6 +338,25 @@ func (g *Grant) unmarshalJSON(ctx context.Context, data []byte) error {
 				return errors.New(ctx, errors.InvalidParameter, op, "ID cannot contain a comma, semicolon or equals sign")
 			}
 			g.ids[i] = idStr
+		}
+	}
+	if rawPins, ok := raw["pins"]; ok {
+		pins, ok := rawPins.([]any)
+		if !ok {
+			return errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("unable to interpret %q as array", "pins"))
+		}
+		g.pins = make([]string, len(pins))
+		for i, pin := range pins {
+			pinStr, ok := pin.(string)
+			switch {
+			case !ok:
+				return errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("unable to interpret %q element %q as string", "pins", pin))
+			case pinStr == "":
+				return errors.New(ctx, errors.InvalidParameter, op, "empty pin provided")
+			case strings.ContainsAny(pinStr, ",;="):
+				return errors.New(ctx, errors.InvalidParameter, op, "pin cannot contain a comma, semicolon or equals sign")
+			}
+			g.pins[i] = pinStr
 		}
 	}
 	if rawType, ok := raw["type"]; ok {
@@ -410,6 +452,14 @@ func (g *Grant) unmarshalText(ctx context.Context, grantString string) error {
 				}
 			}
 
+		case "pins":
+			g.pins = strings.Split(kv[1], ",")
+			for _, pin := range g.pins {
+				if pin == "" {
+					return errors.New(ctx, errors.InvalidParameter, op, "empty pin provided")
+				}
+			}
+
 		case "type":
 			typeString := strings.ToLower(kv[1])
 			g.typ = resource.Map[typeString]
@@ -486,11 +536,18 @@ func Parse(ctx context.Context, tuple GrantTuple, opt ...Option) (Grant, error) 
 	if len(grant.ids) > 1 && slices.Contains(grant.ids, "*") {
 		return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("input grant string %q contains both wildcard and non-wildcard values in %q field", tuple.Grant, "ids"))
 	}
+	if len(grant.pins) > 0 && (grant.id != "" || len(grant.ids) > 0) {
+		return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("input grant string %q cannot contain both id/ids and pins fields", tuple.Grant))
+	}
+	if slices.Contains(grant.pins, "*") {
+		return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("input grant string %q contains wildcard value in %q field", tuple.Grant, "pins"))
+	}
 
 	opts := getOpts(opt...)
 
 	var grantIds []string
 	var deprecatedId bool
+	var isPinGrant bool
 	switch {
 	case grant.id != "":
 		grantIds = []string{grant.id}
@@ -508,6 +565,23 @@ func Parse(ctx context.Context, tuple GrantTuple, opt ...Option) (Grant, error) 
 				}
 				if seenType != globals.ResourceInfoFromPrefix(id).Type {
 					return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("input grant string %q contains ids of differently-typed resources", tuple.Grant))
+				}
+			}
+		}
+	case len(grant.pins) > 0:
+		grantIds = grant.pins
+		isPinGrant = true
+		// Ensure we aren't seeing mixed types in pins. We will have already
+		// filtered out the wildcard case above.
+		if len(grant.pins) > 1 {
+			var seenType resource.Type
+			for i, pin := range grantIds {
+				if i == 0 {
+					seenType = globals.ResourceInfoFromPrefix(pin).Type
+					continue
+				}
+				if seenType != globals.ResourceInfoFromPrefix(pin).Type {
+					return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("input grant string %q contains pins of differently-typed resources", tuple.Grant))
 				}
 			}
 		}
@@ -547,8 +621,11 @@ func Parse(ctx context.Context, tuple GrantTuple, opt ...Option) (Grant, error) 
 					}
 				default:
 					fieldName := "ids"
-					if deprecatedId {
+					switch {
+					case deprecatedId:
 						fieldName = "id"
+					case isPinGrant:
+						fieldName = "pins"
 					}
 					return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("unknown template %q in grant %q value", currId, fieldName))
 				}
@@ -578,38 +655,57 @@ func Parse(ctx context.Context, tuple GrantTuple, opt ...Option) (Grant, error) 
 					return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains wildcard id and no specified type", grant.CanonicalString()))
 				}
 			case grantIds[i] != "":
-				// Non-wildcard but specified ID. This can match
-				//   id=foo_bar;actions=foo,bar
-				// or
-				//   id=foo_bar;type=sometype;actions=foo,bar
-				// or
-				//   id=foo_bar;type=*;actions=foo,bar
-				// but notably the specified types have to actually make sense: in
-				// the second example the type corresponding to the ID must have the
-				// specified type as a child type; in the third the ID must be a
-				// type that has child types.
-				idType := globals.ResourceInfoFromPrefix(grantIds[i]).Type
-				if idType == resource.Unknown {
-					return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains an id %q of an unknown resource type", grant.CanonicalString(), grantIds[i]))
-				}
-				switch grant.typ {
-				case resource.Unknown:
-					// This is fine as-is but we do not support collection actions
-					// without a type (either directly specified or wildcard) so
-					// check that
-					if grant.actions[action.Create] ||
-						grant.actions[action.List] {
-						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains create or list action in a format that does not allow these", grant.CanonicalString()))
+				if isPinGrant {
+					// Explicit pin grant: pins=<parent_ids>;type=<child_type>;actions=<action>
+					// The pin must be a resource type that has child types, and a
+					// type must be explicitly specified.
+					pinType := globals.ResourceInfoFromPrefix(grantIds[i]).Type
+					if pinType == resource.Unknown {
+						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains a pin %q of an unknown resource type", grant.CanonicalString(), grantIds[i]))
 					}
-				case resource.All:
-					// Verify that the ID is a type that has child types
-					if !idType.HasChildTypes() {
-						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains an id that does not support child types", grant.CanonicalString()))
+					if !pinType.HasChildTypes() {
+						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains a pin that does not support child types", grant.CanonicalString()))
 					}
-				default:
-					// Specified resource type, verify it's a child
-					if grant.typ.Parent() != idType {
-						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains type %s that is not a child type of the type (%s) of the specified id", grant.CanonicalString(), grant.typ.String(), grant.typ.Parent()))
+					if grant.typ == resource.Unknown {
+						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains a pin but no resource type", grant.CanonicalString()))
+					}
+					if grant.typ != resource.All && grant.typ.Parent() != pinType {
+						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains type %s that is not a child type of the type (%s) of the specified pin", grant.CanonicalString(), grant.typ.String(), pinType.String()))
+					}
+				} else {
+					// Non-wildcard but specified ID. This can match
+					//   id=foo_bar;actions=foo,bar
+					// or
+					//   id=foo_bar;type=sometype;actions=foo,bar
+					// or
+					//   id=foo_bar;type=*;actions=foo,bar
+					// but notably the specified types have to actually make sense: in
+					// the second example the type corresponding to the ID must have the
+					// specified type as a child type; in the third the ID must be a
+					// type that has child types.
+					idType := globals.ResourceInfoFromPrefix(grantIds[i]).Type
+					if idType == resource.Unknown {
+						return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains an id %q of an unknown resource type", grant.CanonicalString(), grantIds[i]))
+					}
+					switch grant.typ {
+					case resource.Unknown:
+						// This is fine as-is but we do not support collection actions
+						// without a type (either directly specified or wildcard) so
+						// check that
+						if grant.actions[action.Create] ||
+							grant.actions[action.List] {
+							return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains create or list action in a format that does not allow these", grant.CanonicalString()))
+						}
+					case resource.All:
+						// Verify that the ID is a type that has child types
+						if !idType.HasChildTypes() {
+							return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains an id that does not support child types", grant.CanonicalString()))
+						}
+					default:
+						// Specified resource type, verify it's a child
+						if grant.typ.Parent() != idType {
+							return Grant{}, errors.New(ctx, errors.InvalidParameter, op, fmt.Sprintf("parsed grant string %q contains type %s that is not a child type of the type (%s) of the specified id", grant.CanonicalString(), grant.typ.String(), grant.typ.Parent()))
+						}
 					}
 				}
 			default: // no specified id
@@ -653,7 +749,16 @@ func Parse(ctx context.Context, tuple GrantTuple, opt ...Option) (Grant, error) 
 				// ensure that we get allowed. We need to use the templated
 				// grant, if any, so we send in a clone with an updated ID.
 				grantForValidation := grant.clone()
-				grantForValidation.id = grantIds[i]
+				if isPinGrant {
+					// For pin grants, the grantIds[i] is the pin (parent
+					// resource ID), not the resource's own ID. Expose it via
+					// the id field so that aclGrantFromGrant puts it in
+					// AclGrant.Id, which is what Case 5 of Allowed() checks.
+					grantForValidation.pins = nil
+					grantForValidation.id = grantIds[i]
+				} else {
+					grantForValidation.id = grantIds[i]
+				}
 				acl := NewACL(*grantForValidation)
 				// For special scope names we aren't sure where the resource
 				// might be, so check possible scopes and see if any are valid
@@ -681,7 +786,7 @@ func Parse(ctx context.Context, tuple GrantTuple, opt ...Option) (Grant, error) 
 						Type:          grant.typ,
 						ParentScopeId: parentScopeId,
 					}
-					if !grant.typ.TopLevelType() {
+					if isPinGrant || !grant.typ.TopLevelType() {
 						r.Pin = grantIds[i]
 					}
 					for k := range grant.actions {
@@ -707,14 +812,16 @@ func Parse(ctx context.Context, tuple GrantTuple, opt ...Option) (Grant, error) 
 		}
 	}
 
-	// See if we need to move grantIds back for the deprecated case. grantIds
-	// will always be at least size 1 since we add the empty string if no IDs
-	// were provided, so we can check to see if that was the case first.
+	// See if we need to move grantIds back for the deprecated/pin case.
+	// grantIds will always be at least size 1 since we add the empty string
+	// if no IDs were provided, so we can check to see if that was the case first.
 	switch {
 	case grantIds[0] == "":
 		// Nothing to do
 	case deprecatedId:
 		grant.id = grantIds[0]
+	case isPinGrant:
+		grant.pins = grantIds
 	default:
 		grant.ids = grantIds
 	}

--- a/internal/perms/grants_schema.go
+++ b/internal/perms/grants_schema.go
@@ -38,6 +38,12 @@ type ResourceTypeSchema struct {
 
 	// The parent resource type, if any, omitted if no parent
 	ParentType string `json:"parent_type,omitempty"`
+
+	// The ID prefixes that are valid as pins for this resource type.
+	// Populated only for resource types that have a parent (e.g. host-set,
+	// account). These are the ID prefixes of the parent resource, so a
+	// "pins=" grant value must begin with one of these prefixes.
+	PinPrefixes []string `json:"pin_prefixes,omitempty"`
 }
 
 // BuildGrantSchema constructs the full grant schema from the registered
@@ -92,8 +98,10 @@ func BuildGrantSchema(ctx context.Context) (*GrantSchema, error) {
 		// Parent type is the resource's parent if one exists,
 		// otherwise this will be an empty string.
 		var parentType string
+		var pinPrefixes []string
 		if parent := typ.Parent(); parent != typ {
 			parentType = parent.String()
+			pinPrefixes = globals.ResourcePrefixesFromType(parent)
 		}
 
 		schema.ResourceTypes = append(schema.ResourceTypes, ResourceTypeSchema{
@@ -103,6 +111,7 @@ func BuildGrantSchema(ctx context.Context) (*GrantSchema, error) {
 			Scopes:            scopeStrs,
 			IdPrefixes:        globals.ResourcePrefixesFromType(typ),
 			ParentType:        parentType,
+			PinPrefixes:       pinPrefixes,
 		})
 	}
 

--- a/internal/perms/grants_schema_test.go
+++ b/internal/perms/grants_schema_test.go
@@ -49,3 +49,49 @@ func TestBuildGrantSchema(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, json.Valid(data), "output should be valid JSON")
 }
+
+func TestBuildGrantSchema_PinPrefixes(t *testing.T) {
+	ctx := context.Background()
+	schema, err := perms.BuildGrantSchema(ctx)
+	require.NoError(t, err)
+
+	// Build a lookup by type name for easy assertions
+	byType := make(map[string]perms.ResourceTypeSchema, len(schema.ResourceTypes))
+	for _, rt := range schema.ResourceTypes {
+		byType[rt.Type] = rt
+	}
+
+	// Child types must have PinPrefixes set to the parent's ID prefixes
+	hostSet, ok := byType["host-set"]
+	require.True(t, ok, "host-set should be in the schema")
+	assert.Equal(t, "host-catalog", hostSet.ParentType)
+	assert.NotEmpty(t, hostSet.PinPrefixes, "host-set should have pin prefixes")
+
+	host, ok := byType["host"]
+	require.True(t, ok, "host should be in the schema")
+	assert.Equal(t, "host-catalog", host.ParentType)
+	assert.NotEmpty(t, host.PinPrefixes, "host should have pin prefixes")
+
+	account, ok := byType["account"]
+	require.True(t, ok, "account should be in the schema")
+	assert.Equal(t, "auth-method", account.ParentType)
+	assert.NotEmpty(t, account.PinPrefixes, "account should have pin prefixes")
+
+	credLib, ok := byType["credential-library"]
+	require.True(t, ok, "credential-library should be in the schema")
+	assert.Equal(t, "credential-store", credLib.ParentType)
+	assert.NotEmpty(t, credLib.PinPrefixes, "credential-library should have pin prefixes")
+
+	// Top-level types must not have PinPrefixes
+	hostCatalog, ok := byType["host-catalog"]
+	require.True(t, ok, "host-catalog should be in the schema")
+	assert.Empty(t, hostCatalog.PinPrefixes, "host-catalog is a top-level type and should have no pin prefixes")
+
+	authMethod, ok := byType["auth-method"]
+	require.True(t, ok, "auth-method should be in the schema")
+	assert.Empty(t, authMethod.PinPrefixes, "auth-method is a top-level type and should have no pin prefixes")
+
+	// PinPrefixes for host-set should match host-catalog's IdPrefixes
+	assert.ElementsMatch(t, hostCatalog.IdPrefixes, hostSet.PinPrefixes,
+		"host-set's pin prefixes should match host-catalog's id prefixes")
+}

--- a/internal/perms/grants_test.go
+++ b/internal/perms/grants_test.go
@@ -245,6 +245,15 @@ func Test_MarshalingAndCloning(t *testing.T) {
 			jsonOutput:      `{"actions":["create","read"],"ids":["baz","bop"],"output_fields":["ids","name","version"],"type":"group"}`,
 			canonicalString: `ids=baz,bop;type=group;actions=create,read;output_fields=ids,name,version`,
 		},
+		{
+			name: "type and pins single pin",
+			input: Grant{
+				pins: []string{"hcst_foobar"},
+				typ:  resource.HostSet,
+			},
+			jsonOutput:      `{"pins":["hcst_foobar"],"type":"host-set"}`,
+			canonicalString: `pins=hcst_foobar;type=host-set`,
+		},
 	}
 
 	for _, test := range tests {
@@ -409,6 +418,60 @@ func Test_Unmarshaling(t *testing.T) {
 			},
 			jsonInput: `{"ids":["foobar"]}`,
 			textInput: `ids=foobar`,
+		},
+		{
+			name: "good pins",
+			expected: Grant{
+				pins: []string{"hcst_foobar", "hcst_foobaz"},
+			},
+			jsonInput: `{"pins":["hcst_foobar","hcst_foobaz"]}`,
+			textInput: `pins=hcst_foobar,hcst_foobaz`,
+		},
+		{
+			name:      "bad pin type",
+			jsonInput: `{"pins":true}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: unable to interpret "pins" as array: parameter violation: error #100`,
+			textInput: `pins=`,
+			textErr:   `perms.(Grant).unmarshalText: segment "pins=" not formatted correctly, missing value: parameter violation: error #100`,
+		},
+		{
+			name:      "bad pins empty",
+			jsonInput: `{"pins":""}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: unable to interpret "pins" as array: parameter violation: error #100`,
+		},
+		{
+			name:      "bad pins comma",
+			jsonInput: `{"pins":[","]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: pin cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+			textInput: `pins=,something`,
+			textErr:   `perms.(Grant).unmarshalText: empty pin provided: parameter violation: error #100`,
+		},
+		{
+			name:      "bad pins type",
+			jsonInput: `{"pins":true}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: unable to interpret "pins" as array: parameter violation: error #100`,
+		},
+		{
+			name:      "bad pins empty element",
+			jsonInput: `{"pins":[""]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: empty pin provided: parameter violation: error #100`,
+			textInput: `pins=hcst_foobar,`,
+			textErr:   `perms.(Grant).unmarshalText: empty pin provided: parameter violation: error #100`,
+		},
+		{
+			name:      "bad pins comma in element",
+			jsonInput: `{"pins":[","]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: pin cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "bad pins semicolon in element",
+			jsonInput: `{"pins":[";"]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: pin cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
+		},
+		{
+			name:      "bad pins equals in element",
+			jsonInput: `{"pins":["="]}`,
+			jsonErr:   `perms.(Grant).unmarshalJSON: pin cannot contain a comma, semicolon or equals sign: parameter violation: error #100`,
 		},
 		{
 			name:      "bad id",
@@ -1000,6 +1063,97 @@ func Test_Parse(t *testing.T) {
 				},
 			},
 		},
+		// pins grant tests
+		{
+			name:  "good text pins single",
+			input: `pins=hcst_foobar;type=host-set;actions=read`,
+			expected: Grant{
+				roleScopeId:  "o_scope",
+				grantScopeId: "o_scope",
+				pins:         []string{"hcst_foobar"},
+				typ:          resource.HostSet,
+				actions: map[action.Type]bool{
+					action.Read: true,
+				},
+			},
+		},
+		{
+			name:  "good json pins single",
+			input: `{"pins":["hcst_foobar"],"type":"host-set","actions":["read"]}`,
+			expected: Grant{
+				roleScopeId:  "o_scope",
+				grantScopeId: "o_scope",
+				pins:         []string{"hcst_foobar"},
+				typ:          resource.HostSet,
+				actions: map[action.Type]bool{
+					action.Read: true,
+				},
+			},
+		},
+		{
+			name:  "good text pins multiple",
+			input: `pins=hcst_foobar,hcst_foobaz;type=host-set;actions=read`,
+			expected: Grant{
+				roleScopeId:  "o_scope",
+				grantScopeId: "o_scope",
+				pins:         []string{"hcst_foobar", "hcst_foobaz"},
+				typ:          resource.HostSet,
+				actions: map[action.Type]bool{
+					action.Read: true,
+				},
+			},
+		},
+		{
+			name:  "good json pins multiple",
+			input: `{"pins":["hcst_foobar","hcst_foobaz"],"type":"host-set","actions":["read"]}`,
+			expected: Grant{
+				roleScopeId:  "o_scope",
+				grantScopeId: "o_scope",
+				pins:         []string{"hcst_foobar", "hcst_foobaz"},
+				typ:          resource.HostSet,
+				actions: map[action.Type]bool{
+					action.Read: true,
+				},
+			},
+		},
+		{
+			name:  "good text pins wildcard type",
+			input: `pins=hcst_foobar;type=*;actions=read`,
+			expected: Grant{
+				roleScopeId:  "o_scope",
+				grantScopeId: "o_scope",
+				pins:         []string{"hcst_foobar"},
+				typ:          resource.All,
+				actions: map[action.Type]bool{
+					action.Read: true,
+				},
+			},
+		},
+		{
+			name:  "bad pins and ids conflict",
+			input: `{"pins":["hcst_foobar"],"ids":["hcst_foobaz"],"type":"host-set","actions":["read"]}`,
+			err:   `perms.Parse: input grant string "{\"pins\":[\"hcst_foobar\"],\"ids\":[\"hcst_foobaz\"],\"type\":\"host-set\",\"actions\":[\"read\"]}" cannot contain both id/ids and pins fields: parameter violation: error #100`,
+		},
+		{
+			name:  "bad pins - not a parent type",
+			input: `{"pins":["hsst_foobar"],"type":"host","actions":["read"]}`,
+			err:   `perms.Parse: parsed grant string "pins=hsst_foobar;type=host;actions=read" contains a pin that does not support child types: parameter violation: error #100`,
+		},
+		{
+			name:  "bad pins - no type specified",
+			input: `{"pins":["hcst_foobar"],"actions":["read"]}`,
+			err:   `perms.Parse: parsed grant string "pins=hcst_foobar;actions=read" contains a pin but no resource type: parameter violation: error #100`,
+		},
+		{
+			name:  "bad pins - wrong child type",
+			input: `{"pins":["hcst_foobar"],"type":"credential","actions":["read"]}`,
+			err:   `perms.Parse: parsed grant string "pins=hcst_foobar;type=credential;actions=read" contains type credential that is not a child type of the type (host-catalog) of the specified pin: parameter violation: error #100`,
+		},
+		{
+			name:  "bad pins - mixed types",
+			input: `{"pins":["hcst_foobar","csst_foobaz"],"type":"host-set","actions":["read"]}`,
+			err:   `perms.Parse: input grant string "{\"pins\":[\"hcst_foobar\",\"csst_foobaz\"],\"type\":\"host-set\",\"actions\":[\"read\"]}" contains pins of differently-typed resources: parameter violation: error #100`,
+		},
 	}
 
 	_, err := Parse(ctx, GrantTuple{RoleScopeId: "", GrantScopeId: "", Grant: ""})
@@ -1124,6 +1278,12 @@ func FuzzParse(f *testing.F) {
 		`{"id":"foobar","type":"host-catalog","actions":["create"]}`,
 		`{"ids":["foobar"],"type":"host-catalog","actions":["create"]}`,
 		`{"ids":["\""]}`,
+		// pins seed cases
+		`pins=hcst_foobar;type=host-set;actions=read`,
+		`pins=hcst_foobar,hcst_foobaz;type=host-set;actions=read`,
+		`{"pins":["hcst_foobar"],"type":"host-set","actions":["read"]}`,
+		`{"pins":["hcst_foobar","hcst_foobaz"],"type":"host-set","actions":["read"]}`,
+		`pins=hcst_foobar;type=*;actions=read`,
 	}
 	for _, tc := range tc {
 		f.Add(tc)

--- a/internal/perms/grants_test.go
+++ b/internal/perms/grants_test.go
@@ -1154,6 +1154,16 @@ func Test_Parse(t *testing.T) {
 			input: `{"pins":["hcst_foobar","csst_foobaz"],"type":"host-set","actions":["read"]}`,
 			err:   `perms.Parse: input grant string "{\"pins\":[\"hcst_foobar\",\"csst_foobaz\"],\"type\":\"host-set\",\"actions\":[\"read\"]}" contains pins of differently-typed resources: parameter violation: error #100`,
 		},
+		{
+			name:  "bad text pins - same type as pin",
+			input: `pins=hcst_foobar;type=host-catalog;actions=read`,
+			err:   `perms.Parse: parsed grant string "pins=hcst_foobar;type=host-catalog;actions=read" contains a type that is the same as the pin type (host-catalog): parameter violation: error #100`,
+		},
+		{
+			name:  "bad json pins - same type as pin",
+			input: `{"pins":["hcst_foobar"],"type":"host-catalog","actions":["read"]}`,
+			err:   `perms.Parse: parsed grant string "pins=hcst_foobar;type=host-catalog;actions=read" contains a type that is the same as the pin type (host-catalog): parameter violation: error #100`,
+		},
 	}
 
 	_, err := Parse(ctx, GrantTuple{RoleScopeId: "", GrantScopeId: "", Grant: ""})

--- a/internal/proto/controller/api/resources/roles/v1/role.proto
+++ b/internal/proto/controller/api/resources/roles/v1/role.proto
@@ -36,6 +36,10 @@ message GrantJson {
 
   // Output only. The actions.
   repeated string actions = 3; // @gotags: `class:"public"`
+
+  // Output only. The pins, if set. Pins constrain the grant to resources
+  // within the given parent resources.
+  repeated string pins = 5; // @gotags: `class:"public"`
 }
 
 message Grant {

--- a/sdk/pbs/controller/api/resources/roles/role.pb.go
+++ b/sdk/pbs/controller/api/resources/roles/role.pb.go
@@ -103,7 +103,10 @@ type GrantJson struct {
 	// Output only. The type, if set.
 	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty" class:"public"` // @gotags: `class:"public"`
 	// Output only. The actions.
-	Actions       []string `protobuf:"bytes,3,rep,name=actions,proto3" json:"actions,omitempty" class:"public"` // @gotags: `class:"public"`
+	Actions []string `protobuf:"bytes,3,rep,name=actions,proto3" json:"actions,omitempty" class:"public"` // @gotags: `class:"public"`
+	// Output only. The pins, if set. Pins constrain the grant to resources
+	// within the given parent resources.
+	Pins          []string `protobuf:"bytes,5,rep,name=pins,proto3" json:"pins,omitempty" class:"public"` // @gotags: `class:"public"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -163,6 +166,13 @@ func (x *GrantJson) GetType() string {
 func (x *GrantJson) GetActions() []string {
 	if x != nil {
 		return x.Actions
+	}
+	return nil
+}
+
+func (x *GrantJson) GetPins() []string {
+	if x != nil {
+		return x.Pins
 	}
 	return nil
 }
@@ -408,12 +418,13 @@ const file_controller_api_resources_roles_v1_role_proto_rawDesc = "" +
 	"\tPrincipal\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1a\n" +
-	"\bscope_id\x18\x03 \x01(\tR\bscope_id\"_\n" +
+	"\bscope_id\x18\x03 \x01(\tR\bscope_id\"s\n" +
 	"\tGrantJson\x12\x12\n" +
 	"\x02id\x18\x01 \x01(\tB\x02\x18\x01R\x02id\x12\x10\n" +
 	"\x03ids\x18\x04 \x03(\tR\x03ids\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x18\n" +
-	"\aactions\x18\x03 \x03(\tR\aactions\"y\n" +
+	"\aactions\x18\x03 \x03(\tR\aactions\x12\x12\n" +
+	"\x04pins\x18\x05 \x03(\tR\x04pins\"y\n" +
 	"\x05Grant\x12\x10\n" +
 	"\x03raw\x18\x01 \x01(\tR\x03raw\x12\x1c\n" +
 	"\tcanonical\x18\x02 \x01(\tR\tcanonical\x12@\n" +


### PR DESCRIPTION
## Description

The ability to pin grants to a specific collection has been supported for a long time, but the syntax is confusing. It reuses `ids` (originally `id`) with the thinking that you are granting, e.g., `read` on `host sets` within the collection with id `foobar`. Or, from another standpoint, in `foobar` allow `read` on `host sets`. Look, it made sense at the time.

However, it means there are different potential meanings for what can go into `ids`, and that in turn makes it confusing to explain pins and can lead to subtle misunderstandings due to e.g. mismatched types.

This change allows `pins` to be used instead, which makes it very explicit what the intention is. Internally, for backwards compatibility, the behavior is very similar to pinning with `ids` with a few extra guardrails -- something we could consider changing in the future if we want, although we'd have to do it at the API level to ensure existing grants work -- but lets the user be more specific and expressive as to intent.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [X] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
