### PR TITLE
test(e2e): Updated testing helper functions for rdp tests

### DIFF
--- a/testing/internal/e2e/boundary/account.go
+++ b/testing/internal/e2e/boundary/account.go
@@ -45,15 +45,18 @@ func CreateAccountApi(t testing.TB, ctx context.Context, client *api.Client, aut
 
 // CreateAccountCli creates a new account using the cli.
 // Returns the id of the new account as well as the password that was generated
-func CreateAccountCli(t testing.TB, ctx context.Context, authMethodId string, loginName string) (string, string, error) {
+func CreateAccountCli(t testing.TB, ctx context.Context, authMethodId string, loginName string, opt ...e2e.Option) (string, string, error) {
 	name, err := base62.Random(16)
 	if err != nil {
 		return "", "", err
 	}
 
+	var options []e2e.Option
+
 	password, err := base62.Random(16)
 	require.NoError(t, err)
-	output := e2e.RunCommand(ctx, "boundary",
+
+	options = append(options,
 		e2e.WithArgs(
 			"accounts", "create", "password",
 			"-auth-method-id", authMethodId,
@@ -64,6 +67,11 @@ func CreateAccountCli(t testing.TB, ctx context.Context, authMethodId string, lo
 			"-format", "json",
 		),
 		e2e.WithEnv("E2E_TEST_ACCOUNT_PASSWORD", password),
+	)
+	options = append(options, opt...)
+
+	output := e2e.RunCommand(ctx, "boundary",
+		options...,
 	)
 	if output.Err != nil {
 		return "", "", fmt.Errorf("%w: %s", output.Err, string(output.Stderr))

--- a/testing/internal/e2e/boundary/user.go
+++ b/testing/internal/e2e/boundary/user.go
@@ -36,13 +36,14 @@ func CreateUserApi(t testing.TB, ctx context.Context, client *api.Client, scopeI
 
 // CreateUserCli creates a new user using the cli.
 // Returns the id of the new user
-func CreateUserCli(t testing.TB, ctx context.Context, scopeId string) (string, error) {
+func CreateUserCli(t testing.TB, ctx context.Context, scopeId string, opt ...e2e.Option) (string, error) {
 	name, err := base62.Random(16)
 	if err != nil {
 		return "", err
 	}
 
-	output := e2e.RunCommand(ctx, "boundary",
+	var options []e2e.Option
+	options = append(options,
 		e2e.WithArgs(
 			"users", "create",
 			"-scope-id", scopeId,
@@ -50,6 +51,11 @@ func CreateUserCli(t testing.TB, ctx context.Context, scopeId string) (string, e
 			"-description", "e2e",
 			"-format", "json",
 		),
+	)
+	options = append(options, opt...)
+
+	output := e2e.RunCommand(ctx, "boundary",
+		options...,
 	)
 	if output.Err != nil {
 		return "", fmt.Errorf("%w: %s", output.Err, string(output.Stderr))
@@ -67,13 +73,20 @@ func CreateUserCli(t testing.TB, ctx context.Context, scopeId string) (string, e
 }
 
 // SetAccountToUserCli sets an account to a the specified user using the cli.
-func SetAccountToUserCli(t testing.TB, ctx context.Context, userId string, accountId string) error {
-	output := e2e.RunCommand(ctx, "boundary",
+func SetAccountToUserCli(t testing.TB, ctx context.Context, userId string, accountId string, opt ...e2e.Option) error {
+
+	var options []e2e.Option
+	options = append(options,
 		e2e.WithArgs(
 			"users", "set-accounts",
 			"-id", userId,
 			"-account", accountId,
 		),
+	)
+	options = append(options, opt...)
+
+	output := e2e.RunCommand(ctx, "boundary",
+		options...,
 	)
 	if output.Err != nil {
 		return fmt.Errorf("%w: %s", output.Err, string(output.Stderr))

--- a/testing/internal/e2e/boundary/user.go
+++ b/testing/internal/e2e/boundary/user.go
@@ -74,7 +74,6 @@ func CreateUserCli(t testing.TB, ctx context.Context, scopeId string, opt ...e2e
 
 // SetAccountToUserCli sets an account to a the specified user using the cli.
 func SetAccountToUserCli(t testing.TB, ctx context.Context, userId string, accountId string, opt ...e2e.Option) error {
-
 	var options []e2e.Option
 	options = append(options,
 		e2e.WithArgs(


### PR DESCRIPTION
## Description
RDP tests require tokens for cli commands. These changes to these functions allow the token to be passed in through the e2e.option. Shouldn't change any functionality of the functions other than that. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
