### PR TITLE
fix(sqltest): Remove deprecated docker --link usage 

### DIFF
--- a/internal/db/sqltest/Makefile
+++ b/internal/db/sqltest/Makefile
@@ -56,14 +56,18 @@ ifeq ($(DB_LOGS), 1)
 	log_cmd = docker logs $(SQL_TEST_CONTAINER_NAME)
 endif
 
+SQL_TEST_NETWORK_NAME ?= boundary-sql-tests-net
+
 # re-write paths for docker
 dockerized_tests = $(patsubst tests/%,/test/%,$(TESTS))
 
 test:
 	@echo Using $(POSTGRES_DOCKER_IMAGE)
 	@echo Using $(PG_TAP_DOCKER_IMAGE)
+	@docker network create $(SQL_TEST_NETWORK_NAME) 2>/dev/null || true
 	@docker run -d \
 		--name $(SQL_TEST_CONTAINER_NAME) \
+		--network $(SQL_TEST_NETWORK_NAME) \
 		$(DOCKER_ARGS) \
 		-e POSTGRES_PASSWORD=boundary \
 		-e POSTGRES_USER=boundary \
@@ -73,16 +77,16 @@ test:
 		$(POSTGRES_DOCKER_IMAGE)
 	@docker run --rm \
 		--name test \
-		--link $(SQL_TEST_CONTAINER_NAME):db \
+		--network $(SQL_TEST_NETWORK_NAME) \
 		-e DATABASE=boundary \
-		-e HOST=db \
+		-e HOST=$(SQL_TEST_CONTAINER_NAME) \
 		-e PORT=5432 \
 		-e USER=boundary \
 		-e PASSWORD=boundary \
 		-e TESTS="$(PROVE_OPTS) $(dockerized_tests)" \
 		-v "$(CWD)/tests":/test \
 		$(PG_TAP_DOCKER_IMAGE); \
-		(ret=$$?; docker stop $(SQL_TEST_CONTAINER_NAME) > /dev/null 2>&1 && $(log_cmd) && docker rm -f -v $(SQL_TEST_CONTAINER_NAME) > /dev/null 2>&1 && exit $$ret)
+		(ret=$$?; docker stop $(SQL_TEST_CONTAINER_NAME) > /dev/null 2>&1 && $(log_cmd) && docker rm -f -v $(SQL_TEST_CONTAINER_NAME) > /dev/null 2>&1 && docker network rm $(SQL_TEST_NETWORK_NAME) > /dev/null 2>&1 && exit $$ret)
 
 database-up:
 	@echo Using $(POSTGRES_DOCKER_IMAGE)


### PR DESCRIPTION
## Overview
This replaces the deprecated Docker [--link](https://docs.docker.com/engine/network/links/) flag with an explicit user-defined bridge network in the sqltest Makefile. The `--link` flag is a legacy feature that Docker recommends against and that [Podman does not implemented](https://docs.podman.io/en/latest/markdown/podman-run.1.html).
## Notes
- There should be no functional change to test behavior. Containers instead now resolve each other by name via DNS on a shared network instead of through link aliases.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
