### PR TITLE
test(rdp): update rdp scenario enos vars

### DIFF
--- a/enos/enos-scenario-e2e-aws-rdp-base.hcl
+++ b/enos/enos-scenario-e2e-aws-rdp-base.hcl
@@ -233,6 +233,7 @@ scenario "e2e_aws_rdp_base" {
       alb_sg_additional_ips       = step.create_windows_client.public_ip_list
       aws_ssh_keypair_name        = step.generate_ssh_key.key_pair_name
       aws_ssh_private_key_path    = step.generate_ssh_key.private_key_path
+      db_class                    = var.database_instance_type
     }
   }
 
@@ -293,6 +294,7 @@ scenario "e2e_aws_rdp_base" {
       domain_controller_sec_group_id_list = step.create_rdp_domain_controller.security_group_id_list
       aws_region                          = var.aws_region
       ip_version                          = local.ip_version
+      instance_type                       = var.windows_worker_instance_type
     }
   }
 
@@ -314,6 +316,7 @@ scenario "e2e_aws_rdp_base" {
       domain_controller_private_key       = step.create_rdp_domain_controller.ssh_private_key
       domain_controller_sec_group_id_list = step.create_rdp_domain_controller.security_group_id_list
       ip_version                          = local.ip_version
+      instance_type                       = var.rdp_target_instance_type
     }
   }
 

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -34,6 +34,12 @@ variable "boundary_docker_image_file" {
   default     = ""
 }
 
+variable "windows_worker_instance_type" {
+  description = "EC2 Instance type"
+  type        = string
+  default     = "m7i-flex.xlarge"
+}
+
 variable "worker_instance_type" {
   description = "EC2 Instance type"
   type        = string
@@ -273,4 +279,16 @@ variable "extra_windows_users" {
   description = "number of extra windows users to create on the ec2 windows client"
   type        = number
   default     = 0
+}
+
+variable "database_instance_type" {
+  description = "AWS RDS DB instance type for database"
+  type        = string
+  default     = "db.t4g.small"
+}
+
+variable "rdp_target_instance_type" {
+  description = "Instance type for rdp member server"
+  type        = string
+  default     = "m7i-flex.xlarge"
 }


### PR DESCRIPTION
## Description
This PR updates the `enos-variables.hcl` and passing the instance type variables into the `e2e_aws_rdp_base` enos scenario.

This is needed for testing in the enterprise repo:
https://github.com/hashicorp/boundary-enterprise/pull/2452/changes

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
