### PR TITLE
ICU-19016: Improve worker logging

### DIFF
--- a/internal/daemon/worker/controller_connection.go
+++ b/internal/daemon/worker/controller_connection.go
@@ -275,22 +275,74 @@ func (w *Worker) workerConnectionInfo(addr string) (*structpb.Struct, error) {
 	return st, nil
 }
 
-// monitorUpstreamConnectionState listens for new state changes from grpc client
-// connection and updates the state
+// monitorUpstreamConnectionState listens for new state changes from grpc client connection,
+// updates the state, and logs significant state transitions for observability
 func monitorUpstreamConnectionState(ctx context.Context, cc *grpc.ClientConn, connectionState *atomic.Value) {
+	const op = "worker.monitorUpstreamConnectionState"
 	var state connectivity.State
 	if v := connectionState.Load(); !util.IsNil(v) {
 		state = v.(connectivity.State)
 	}
 
 	for cc.WaitForStateChange(ctx, state) {
+		previousState := state
 		state = cc.GetState()
 
 		// if the client is shutdown, exit function
 		if state == connectivity.Shutdown {
+			event.WriteSysEvent(ctx, op, "upstream connection shut down",
+				"upstream_address", cc.Target(),
+				"previous_state", previousState.String(),
+				"current_state", state.String(),
+			)
 			return
 		}
 
 		connectionState.Store(state)
+
+		switch state {
+		case connectivity.TransientFailure:
+			event.WriteError(ctx, op,
+				fmt.Errorf("upstream connection entered transient failure state; worker cannot reach upstream"),
+				event.WithInfo(
+					"upstream_address", cc.Target(),
+					"previous_state", previousState.String(),
+					"current_state", state.String(),
+				),
+			)
+		case connectivity.Connecting:
+			if previousState == connectivity.Ready || previousState == connectivity.TransientFailure {
+				event.WriteSysEvent(ctx, op, "upstream connection is reconnecting",
+					"upstream_address", cc.Target(),
+					"previous_state", previousState.String(),
+					"current_state", state.String(),
+				)
+			}
+		case connectivity.Ready:
+			if previousState != connectivity.Ready {
+				event.WriteSysEvent(ctx, op, "upstream connection is ready",
+					"upstream_address", cc.Target(),
+					"previous_state", previousState.String(),
+					"current_state", state.String(),
+				)
+			}
+		case connectivity.Idle:
+			if previousState == connectivity.Ready {
+				event.WriteSysEvent(ctx, op, "upstream connection has become idle",
+					"upstream_address", cc.Target(),
+					"previous_state", previousState.String(),
+					"current_state", state.String(),
+				)
+			}
+		default:
+			event.WriteError(ctx, op,
+				fmt.Errorf("upstream connection entered unexpected state"),
+				event.WithInfo(
+					"upstream_address", cc.Target(),
+					"previous_state", previousState.String(),
+					"current_state", state.String(),
+				),
+			)
+		}
 	}
 }


### PR DESCRIPTION
## Description

Improve boundary worker logging to identify upstream connectivity failures

Scenario :- worker created in vpc, connects to HCP boundary controller through LB. When LB has issue and worker can't communicate with controller, there are no proper logs to identify. 

Need to add more logs when LB fails, the gRPC state silently transitions READY → CONNECTING → TRANSIENT_FAILURE. There is no log event on this transition.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
