### PR TITLE
Add support for Red Hat openshift compatible image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 !dist/**
 !.release/docker/**
 !.release/ibm-pao/**
+!LICENSE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,6 +395,33 @@ jobs:
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.minor-version }}-dev-${{ github.sha }}
 
+  build-redhat:
+    name: Red Hat UBI ${{ matrix.arch }} build
+    needs:
+      - product-metadata
+      - set-product-version
+      - build-linux
+    runs-on: ${{ fromJSON(vars.BUILDER_LINUX) }}
+    strategy:
+      matrix:
+        arch: ["amd64", "arm64"]
+    env:
+      version: ${{ needs.set-product-version.outputs.product-version }}
+      revision: ${{ needs.set-product-version.outputs.product-version }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Docker Build (Red Hat UBI)
+        uses: hashicorp/actions-docker-build@v2  # TSCCR: loading action configs: failed to query HEAD reference: failed to get advertised references: authorization failed
+        with:
+          version: ${{ env.version }}
+          target: ubi
+          arch: ${{ matrix.arch }}
+          dockerfile: Dockerfile
+          # redhat_tag instructs actions-docker-build to push to the Red Hat
+          # Quay registry via CRT. The ospid below is the Boundary project ID
+          # from the Red Hat Connect portal.
+          redhat_tag: quay.io/redhat-isv-containers/69efb41d8ba3d570793cb151:${{ env.version }}-ubi
+
   e2e:
     name: e2e
     # Only run the Enos workflow on pull requests that have been originated from

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -409,7 +409,7 @@ jobs:
       version: ${{ needs.set-product-version.outputs.product-version }}
       revision: ${{ needs.set-product-version.outputs.product-version }}
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Docker Build (Red Hat UBI)
         uses: hashicorp/actions-docker-build@v2  # TSCCR: loading action configs: failed to query HEAD reference: failed to get advertised references: authorization failed
         with:

--- a/.release/boundary-artifacts.hcl
+++ b/.release/boundary-artifacts.hcl
@@ -44,5 +44,9 @@ artifacts {
     "boundary_default_linux_arm64_${version}_${commit_sha}.docker.tar",
     "boundary_default_linux_arm_${version}_${commit_sha}.docker.dev.tar",
     "boundary_default_linux_arm_${version}_${commit_sha}.docker.tar",
+    # UBI (Red Hat) container images — pushed to registry.connect.redhat.com
+    # via the CRT release pipeline (update-ironbank event in ci.hcl).
+    "boundary_ubi_linux_amd64_${version}_${commit_sha}.docker.redhat.tar",
+    "boundary_ubi_linux_arm64_${version}_${commit_sha}.docker.redhat.tar",
   ]
 }

--- a/.release/docker/docker-entrypoint.sh
+++ b/.release/docker/docker-entrypoint.sh
@@ -14,19 +14,9 @@ ulimit -c 0
 
 # If the user is trying to run Boundary directly with some arguments, then
 # pass them to Boundary.
-if [ "${1:0:1}" = '-' ]; then
-    set -- boundary "$@"
-fi
-
-if [ "$1" = 'server' ]; then
-    shift
-    set -- boundary server \
-        "$@"
-elif boundary --help "$1" 2>&1 | grep -q "boundary $1"; then
-    # We can't use the return code to check for the existence of a subcommand, so
-    # we have to use grep to look for a pattern in the help output.
-    set -- boundary "$@"
-fi
+# Look for Boundary subcommands.
+# shellcheck source=.release/docker/entrypoint-common.sh
+. /usr/local/bin/entrypoint-common.sh
 
 # If we are running Boundary, make sure it executes as the proper user.
 if [ "$1" = 'boundary' ]; then

--- a/.release/docker/entrypoint-common.sh
+++ b/.release/docker/entrypoint-common.sh
@@ -1,0 +1,20 @@
+# Copyright IBM Corp. 2020, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Common entrypoint logic shared between docker-entrypoint.sh and ubi-docker-entrypoint.sh.
+# This file is intended to be sourced, not executed directly.
+
+# If the user is trying to run Boundary directly with some arguments, then
+# pass them to Boundary.
+if [ "${1:0:1}" = '-' ]; then
+    set -- boundary "$@"
+fi
+
+# Look for Boundary subcommands.
+if [ "$1" = 'server' ]; then
+    set -- boundary "$@"
+elif boundary --help "$1" 2>&1 | grep -q "boundary $1"; then
+    # We can't use the return code to check for the existence of a subcommand,
+    # so we have to use grep to look for a pattern in the help output.
+    set -- boundary "$@"
+fi

--- a/.release/docker/ubi-docker-entrypoint.sh
+++ b/.release/docker/ubi-docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright IBM Corp. 2020, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+# Prevent core dumps
+ulimit -c 0
+
+# Due to OpenShift environment compatibility, we have to allow group write
+# access to the Boundary configuration. This requires us to disable the
+# stricter file permissions checks.
+export BOUNDARY_DISABLE_FILE_PERMISSIONS_CHECK=true
+
+# shellcheck source=.release/docker/entrypoint-common.sh
+. /usr/local/bin/entrypoint-common.sh
+
+# If we are running Boundary and the container user is root, re-execute as
+# the boundary user.
+if [ "$1" = 'boundary' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        export SKIP_CHOWN="true"
+        exec su boundary -p -- "$0" "$@"
+    fi
+fi
+
+exec "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ VOLUME /boundary/
 
 LABEL org.opencontainers.image.licenses="BUSL-1.1"
 
+COPY .release/docker/entrypoint-common.sh /usr/local/bin/entrypoint-common.sh
 COPY .release/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY bin/LICENSE.txt /usr/share/doc/boundary/LICENSE.txt
 
@@ -89,6 +90,7 @@ RUN chmod -R 640 /boundary/*
 EXPOSE 9200 9201 9202
 VOLUME /boundary/
 
+COPY .release/docker/entrypoint-common.sh /usr/local/bin/entrypoint-common.sh
 COPY .release/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 USER boundary
@@ -138,8 +140,85 @@ RUN chmod -R 640 /boundary/*
 EXPOSE 9200 9201 9202
 VOLUME /boundary/
 
+COPY .release/docker/entrypoint-common.sh /usr/local/bin/entrypoint-common.sh
 COPY .release/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 USER ${NAME}
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["server", "-config", "/boundary/config.hcl"]
+
+
+## UBI DOCKERFILE ##
+FROM registry.access.redhat.com/ubi9/ubi-minimal AS ubi
+
+ARG BIN_NAME
+# NAME and PRODUCT_VERSION are the name of the software in releases.hashicorp.com
+# and the version to download. Example: NAME=boundary PRODUCT_VERSION=0.18.0
+ARG NAME=boundary
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
+# TARGETARCH and TARGETOS are set automatically when --platform is provided.
+ARG TARGETOS TARGETARCH
+# LICENSE_SOURCE is the path to the license file in the build context.
+ARG LICENSE_SOURCE=LICENSE
+# LICENSE_DEST is the path where the license file is installed in the container.
+ARG LICENSE_DEST=/usr/share/doc/boundary
+
+# Additional metadata labels used by container registries, platforms
+# and certification scanners.
+LABEL name="Boundary" \
+      maintainer="Boundary Team <boundary@hashicorp.com>" \
+      vendor="HashiCorp" \
+      version=${PRODUCT_VERSION} \
+      release=${PRODUCT_REVISION} \
+      revision=${PRODUCT_REVISION} \
+      summary="Boundary enables practitioners to apply fine-grained authorization policies to infrastructure." \
+      description="Boundary enables practitioners to apply fine-grained authorization policies to infrastructure access, with a focus on identity-based access controls and usage visibility across dynamic infrastructure."
+
+# Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
+ENV NAME=$NAME
+
+# Copy the license file as per Legal requirement
+COPY ${LICENSE_SOURCE} ${LICENSE_DEST}/
+
+# Copy license to /licenses/ directory to comply with Red Hat Container Certification HasLicense requirement.
+# Note: The requirement checks for plain files, not directories.
+COPY ${LICENSE_SOURCE} /licenses/
+
+# Set up certificates and base tools.
+RUN set -eux; \
+    microdnf install -y ca-certificates gnupg openssl libcap tzdata procps shadow-utils util-linux tar && \
+    microdnf clean all && \
+    rm -rf /var/cache/dnf /var/cache/yum
+
+# Create a non-root user to run the software.
+RUN groupadd --gid 1000 ${NAME} && \
+    adduser --uid 1001 --system -g ${NAME} ${NAME} && \
+    usermod -a -G root ${NAME}
+
+# Copy in the new Boundary from CRT pipeline, rather than fetching it from our public releases.
+COPY dist/${TARGETOS}/${TARGETARCH}/${BIN_NAME} /usr/local/bin/${BIN_NAME}
+
+# Set IPC_LOCK at build time because the container runs as an unprivileged user
+RUN setcap cap_ipc_lock=+ep /usr/local/bin/${BIN_NAME}
+
+ENV HOME=/home/${NAME}
+RUN mkdir -p /opt/boundary $HOME /usr/share/doc/boundary && \
+    chown -R ${NAME} /opt/boundary $HOME && \
+    chgrp -R 0 /opt/boundary $HOME /usr/local/bin/${BIN_NAME} /usr/share/doc/boundary && \
+    chmod -R g+rwX /opt/boundary $HOME /usr/local/bin/${BIN_NAME} /usr/share/doc/boundary
+
+COPY ./.release/docker/config.hcl /opt/boundary/config.hcl
+
+EXPOSE 9200 9201 9202
+VOLUME /opt/boundary/
+
+COPY .release/docker/entrypoint-common.sh /usr/local/bin/entrypoint-common.sh
+COPY .release/docker/ubi-docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /opt/boundary
+
+USER ${NAME}
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["server", "-config", "/opt/boundary/config.hcl"]


### PR DESCRIPTION
## Description

This PR adds native Red Hat UBI/OpenShift image support to Boundary by consolidating the previous Dockerfile.openshift setup into the main Dockerfile as a dedicated ubi stage and integrating it with the standard CI/CD release pipeline.

## Changes
Added a ubi stage based on ubi9/ubi-minimal
Added Red Hat certification labels, license files, non-root user, and OpenShift-compatible permissions
Introduced a new OpenShift entrypoint handling arbitrary UID support and permission checks
Added CI workflow to build and push multi-arch (amd64/arm64) UBI images to the Red Hat Connect registry
Registered UBI image tarballs as release artifacts
Updated .dockerignore to include LICENSE in build context

## Testing
Validated successfully using a temporary build-redhat-test.yml workflow before merge.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
