### PR TITLE
feat(perms): expose valid output fields per resource in grants schema

### DIFF
--- a/internal/perms/grants_schema.go
+++ b/internal/perms/grants_schema.go
@@ -12,7 +12,70 @@ import (
 	"github.com/hashicorp/boundary/internal/types/action"
 	"github.com/hashicorp/boundary/internal/types/resource"
 	"github.com/hashicorp/boundary/internal/types/scope"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/accounts"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/aliases"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/authmethods"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/authtokens"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/credentiallibraries"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/credentials"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/credentialstores"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/groups"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/hostcatalogs"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/hosts"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/hostsets"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/managedgroups"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/policies"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/roles"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/scopes"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/session_recordings"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/sessions"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/storagebuckets"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/targets"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/users"
+	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/workers"
+	"google.golang.org/protobuf/proto"
 )
+
+// resourceProtoMessages maps a resource type to its proto message,
+// whose fields define the valid output fields for that resource.
+var resourceProtoMessages = map[resource.Type]proto.Message{
+	resource.Account:           (*accounts.Account)(nil),
+	resource.Alias:             (*aliases.Alias)(nil),
+	resource.AuthMethod:        (*authmethods.AuthMethod)(nil),
+	resource.AuthToken:         (*authtokens.AuthToken)(nil),
+	resource.Credential:        (*credentials.Credential)(nil),
+	resource.CredentialLibrary: (*credentiallibraries.CredentialLibrary)(nil),
+	resource.CredentialStore:   (*credentialstores.CredentialStore)(nil),
+	resource.Group:             (*groups.Group)(nil),
+	resource.Host:              (*hosts.Host)(nil),
+	resource.HostCatalog:       (*hostcatalogs.HostCatalog)(nil),
+	resource.HostSet:           (*hostsets.HostSet)(nil),
+	resource.ManagedGroup:      (*managedgroups.ManagedGroup)(nil),
+	resource.Policy:            (*policies.Policy)(nil),
+	resource.Role:              (*roles.Role)(nil),
+	resource.Scope:             (*scopes.Scope)(nil),
+	resource.Session:           (*sessions.Session)(nil),
+	resource.SessionRecording:  (*session_recordings.SessionRecording)(nil),
+	resource.StorageBucket:     (*storagebuckets.StorageBucket)(nil),
+	resource.Target:            (*targets.Target)(nil),
+	resource.User:              (*users.User)(nil),
+	resource.Worker:            (*workers.Worker)(nil),
+}
+
+// outputFieldsForResource returns the valid output fields for the given
+// resource type, derived from its proto definition.
+func outputFieldsForResource(typ resource.Type) []string {
+	msg, ok := resourceProtoMessages[typ]
+	if !ok {
+		return nil
+	}
+	fields := msg.ProtoReflect().Descriptor().Fields()
+	out := make([]string, 0, fields.Len())
+	for i := 0; i < fields.Len(); i++ {
+		out = append(out, string(fields.Get(i).Name()))
+	}
+	return out
+}
 
 // GrantSchema represents the schema of grants in the system,
 // including the resource types and their associated actions, scopes.
@@ -38,6 +101,9 @@ type ResourceTypeSchema struct {
 
 	// The parent resource type, if any, omitted if no parent
 	ParentType string `json:"parent_type,omitempty"`
+
+	// The valid output fields that can be returned for this resource type
+	OutputFields []string `json:"output_fields,omitempty"`
 }
 
 // BuildGrantSchema constructs the full grant schema from the registered
@@ -103,6 +169,7 @@ func BuildGrantSchema(ctx context.Context) (*GrantSchema, error) {
 			Scopes:            scopeStrs,
 			IdPrefixes:        globals.ResourcePrefixesFromType(typ),
 			ParentType:        parentType,
+			OutputFields:      outputFieldsForResource(typ),
 		})
 	}
 


### PR DESCRIPTION
## Description
This PR exposes the valid output fields for each resource type in the grants schema endpoint. The changes include a new mapping from resource types to their proto messages and a helper that derives the field list from each proto descriptor, surfaced as `output_fields` on every resource entry returned by `/grants-schema.json`. 

### Response Schema
```json
{
  "resource_types": [
    {
      "type": "string",
      "collection_actions": ["string"],
      "id_actions": ["string"],
      "scopes": ["string"],
      "id_prefixes": ["string"],
      "parent_type": "string",
      "output_fields": ["string"]  //  NEW
    }
  ]
}
```

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
