### PR TITLE
chore: Remove docker dev artifacts

### DIFF
--- a/.release/boundary-artifacts.hcl
+++ b/.release/boundary-artifacts.hcl
@@ -36,13 +36,9 @@ artifacts {
     "boundary_${version_linux}-1_i386.deb",
   ]
   container = [
-    "boundary_default_linux_386_${version}_${commit_sha}.docker.dev.tar",
     "boundary_default_linux_386_${version}_${commit_sha}.docker.tar",
-    "boundary_default_linux_amd64_${version}_${commit_sha}.docker.dev.tar",
     "boundary_default_linux_amd64_${version}_${commit_sha}.docker.tar",
-    "boundary_default_linux_arm64_${version}_${commit_sha}.docker.dev.tar",
     "boundary_default_linux_arm64_${version}_${commit_sha}.docker.tar",
-    "boundary_default_linux_arm_${version}_${commit_sha}.docker.dev.tar",
     "boundary_default_linux_arm_${version}_${commit_sha}.docker.tar",
   ]
 }


### PR DESCRIPTION
## Description
This PR addresses an issue caused by https://github.com/hashicorp/boundary/pull/6606.

After removing the use of the `hashicorppreview` docker hub organization, we started noticing some messages in the proj-boundary-release-engineering slack channel
```
The following artifacts are missing from the build:
 boundary_default_linux_amd64_0.19.6_c3e0571f84a484359510ffae39bcfe74c6ec400b.docker.dev.tar,
 boundary_default_linux_arm64_0.19.6_c3e0571f84a484359510ffae39bcfe74c6ec400b.docker.dev.tar,
 boundary_default_linux_386_0.19.6_c3e0571f84a484359510ffae39bcfe74c6ec400b.docker.dev.tar,
 boundary_default_linux_arm_0.19.6_c3e0571f84a484359510ffae39bcfe74c6ec400b.docker.dev.tar

This means that your build workflow is missing build instructions for these missing artifacts. This is a release blocker. The prepare workflow will not run.
To resolve this, check the build and ensure you are producing the correct artifacts.
```

We needed to also update `./release/boundary-artifacts.hcl` to remove the artifacts we are no longer promoting.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
