### PR TITLE
chore(e2e): Run tests in CI

### DIFF
--- a/enos/enos-scenario-e2e-docker-base-plus.hcl
+++ b/enos/enos-scenario-e2e-docker-base-plus.hcl
@@ -135,6 +135,7 @@ scenario "e2e_docker_base_plus" {
       step.create_boundary,
     ]
     variables {
+      is_ci                     = var.is_ci
       test_package              = "github.com/hashicorp/boundary/testing/internal/e2e/tests/base_plus"
       controller_container_name = step.create_boundary.container_name
       network_name              = step.create_docker_network.network_name


### PR DESCRIPTION
## Description
This makes a fix after merging this PR: https://github.com/hashicorp/boundary/pull/6591

One e2e scenario was missed when introducing a new `is_ci` variable. This now ensures that this scenario runs in CI.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
