### PR TITLE
chore(e2e): Update vault installation (`release/0.21.x`)

### DIFF
--- a/enos/modules/test_e2e_docker/test.sh
+++ b/enos/modules/test_e2e_docker/test.sh
@@ -93,22 +93,12 @@ echo "trusted-key $KEY_ID" >> ~/.gnupg/gpg.conf
 pass init $KEY_ID &>/dev/null
 
 # Install the vault cli
-wget -O- https://apt.releases.hashicorp.com/gpg | gpg --batch --yes --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-export lines=$(gpg --no-default-keyring --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg --fingerprint --with-colons)
-while read -r line
-do
-  if [[ $line =~ "fpr"* ]]; then
-    if [[ "$(echo $line | sed -r 's/fpr|://g')" != "798AEC654E5C15428C8E42EEAA16FCBCA621E701" ]]; then
-      echo "HashiCorp key fingerprint does not match expected"
-      exit 1
-    else
-      break
-    fi
-  fi
-done <<< $lines
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
-apt update
-apt install vault -y
+export vault_version="1.17.6"
+export vault_arch=$(dpkg --print-architecture)
+wget "https://releases.hashicorp.com/vault/${vault_version}/vault_${vault_version}_linux_${vault_arch}.zip" -O /tmp/vault.zip
+unzip -o /tmp/vault.zip -d /usr/local/bin/
+rm /tmp/vault.zip
+
 
 # Install the docker cli
 wget -O- https://download.docker.com/linux/debian/gpg | gpg --batch --yes --dearmor -o /etc/apt/keyrings/docker.gpg
@@ -127,6 +117,6 @@ apt update
 apt install -y mongodb-mongosh
 
 # Run Tests
-unzip /boundary.zip -d /usr/local/bin/
+unzip -o /boundary.zip -d /usr/local/bin/
 cd /src/boundary
 go test -v -count=1 $TEST_PACKAGE -timeout $TEST_TIMEOUT | tee /testlogs/test-e2e-${TEST_PACKAGE##*/}.log


### PR DESCRIPTION
## Description
On release branches, we started to notice issues with installing the vault cli
```
[5](https://github.com/hashicorp/boundary/actions/runs/25918503878/job/76182481134?pr=6726#step:35:7456)
│ + apt install vault -y
│
│ WARNING: apt does not have a stable CLI interface. Use with caution in
│ scripts.
│
│ Reading package lists...
│ Building dependency tree...
│ Reading state information...
│ Error: Unable to locate package vault
```

This PR updates how the vault cli is installed in the docker test runner. 

On `main`, we've removed the need for a docker test runner, but it may take some time to sort out the backport changes. I will work on that. This is a stop gap solution for now.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
