### PR TITLE
chore(e2e): Add steps to wait for worker registration

### DIFF
--- a/enos/enos-scenario-e2e-docker-base-with-worker-version.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-worker-version.hcl
@@ -177,6 +177,34 @@ scenario "e2e_docker_base_with_worker_version" {
     }
   }
 
+  step "get_worker_id" {
+    module = module.docker_boundary_cmd
+    depends_on = [
+      step.create_worker
+    ]
+    variables {
+      address      = step.create_boundary.container_address
+      image_name   = step.build_boundary_docker_image.image_name
+      network_name = local.network_cluster
+      login_name   = step.create_boundary.login_name
+      password     = step.create_boundary.password
+      script       = "get_worker_id.sh"
+      worker_name  = step.create_worker.worker_name
+    }
+  }
+
+  step "wait_for_worker_registration" {
+    module = module.docker_check_worker_log
+    depends_on = [
+      step.create_worker,
+      step.get_worker_id
+    ]
+    variables {
+      container_name = step.create_boundary.container_name
+      worker_id      = step.get_worker_id.output["items"][0]["id"]
+    }
+  }
+
   step "run_e2e_test" {
     module = module.test_e2e_docker
     depends_on = [

--- a/enos/enos-scenario-e2e-docker-base-with-worker.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-worker.hcl
@@ -168,6 +168,34 @@ scenario "e2e_docker_base_with_worker" {
     }
   }
 
+  step "get_worker_id" {
+    module = module.docker_boundary_cmd
+    depends_on = [
+      step.create_worker
+    ]
+    variables {
+      address      = step.create_boundary.container_address
+      image_name   = step.build_boundary_docker_image.image_name
+      network_name = local.network_cluster
+      login_name   = step.create_boundary.login_name
+      password     = step.create_boundary.password
+      script       = "get_worker_id.sh"
+      worker_name  = step.create_worker.worker_name
+    }
+  }
+
+  step "wait_for_worker_registration" {
+    module = module.docker_check_worker_log
+    depends_on = [
+      step.create_worker,
+      step.get_worker_id
+    ]
+    variables {
+      container_name = step.create_boundary.container_name
+      worker_id      = step.get_worker_id.output["items"][0]["id"]
+    }
+  }
+
   step "run_e2e_test" {
     module = module.test_e2e_docker
     depends_on = [

--- a/enos/enos-scenario-e2e-ui-docker.hcl
+++ b/enos/enos-scenario-e2e-ui-docker.hcl
@@ -140,6 +140,34 @@ scenario "e2e_ui_docker" {
     }
   }
 
+  step "get_worker_id" {
+    module = module.docker_boundary_cmd
+    depends_on = [
+      step.create_worker
+    ]
+    variables {
+      address      = step.create_boundary.container_address
+      image_name   = step.build_boundary_docker_image.image_name
+      network_name = local.network_cluster
+      login_name   = step.create_boundary.login_name
+      password     = step.create_boundary.password
+      script       = "get_worker_id.sh"
+      worker_name  = step.create_worker.worker_name
+    }
+  }
+
+  step "wait_for_worker_registration" {
+    module = module.docker_check_worker_log
+    depends_on = [
+      step.create_worker,
+      step.get_worker_id
+    ]
+    variables {
+      container_name = step.create_boundary.container_name
+      worker_id      = step.get_worker_id.output["items"][0]["id"]
+    }
+  }
+
   step "create_ldap_server" {
     module = module.docker_ldap
     depends_on = [


### PR DESCRIPTION
## Description
This PR updates some e2e scenarios to ensure the worker has registered before tests start executing. This is to prevent any race conditions causing e2e test failures. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
