### PR TITLE
chore(e2e): Ensure ldap is ready

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -263,7 +263,7 @@ jobs:
           # environment
           # A virtual environment was needed because python environments on
           # self-hosted runners are externally managed.
-          sudo apt install -y python3
+          sudo apt install -y python3-venv
           python3 -m venv "$HOME/cqlsh-venv"
           "$HOME/cqlsh-venv/bin/pip" install --upgrade pip
           "$HOME/cqlsh-venv/bin/pip" install cqlsh

--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -263,7 +263,7 @@ jobs:
           # environment
           # A virtual environment was needed because python environments on
           # self-hosted runners are externally managed.
-          sudo apt install -y python3.12-venv
+          sudo apt install -y python3
           python3 -m venv "$HOME/cqlsh-venv"
           "$HOME/cqlsh-venv/bin/pip" install --upgrade pip
           "$HOME/cqlsh-venv/bin/pip" install cqlsh

--- a/enos/enos-scenario-e2e-docker-base-plus.hcl
+++ b/enos/enos-scenario-e2e-docker-base-plus.hcl
@@ -133,6 +133,8 @@ scenario "e2e_docker_base_plus" {
     module = module.test_e2e_docker
     depends_on = [
       step.create_boundary,
+      step.create_ldap_server,
+      step.create_host,
     ]
     variables {
       is_ci                     = var.is_ci

--- a/enos/enos-scenario-e2e-docker-base-with-vault.hcl
+++ b/enos/enos-scenario-e2e-docker-base-with-vault.hcl
@@ -143,6 +143,7 @@ scenario "e2e_docker_base_with_vault" {
       step.create_boundary,
       step.create_vault,
       step.create_host,
+      step.create_ldap_server,
     ]
     variables {
       is_ci                    = var.is_ci

--- a/enos/modules/docker_ldap/main.tf
+++ b/enos/modules/docker_ldap/main.tf
@@ -98,6 +98,32 @@ resource "enos_local_exec" "create_ldap_group" {
   inline = ["docker exec ${var.container_name} ldapadd -x -H ldap://localhost -D \"${local.admin_dn}\" -w ${local.admin_password} -f /tmp/ldap/group.ldif"]
 }
 
+resource "enos_local_exec" "wait_for_user_entry" {
+  depends_on = [
+    enos_local_exec.create_ldap_user,
+  ]
+
+  inline = [
+    # First verify the user is discoverable the same way Boundary authenticates it.
+    "timeout 20s bash -c 'until docker exec ${var.container_name} ldapsearch -x -H ldap://localhost -D \"${local.admin_dn}\" -w ${local.admin_password} -b \"${local.domain_dn}\" \"(uid=${local.user_name})\" | grep \"numEntries: 1\"; do sleep 2; done'",
+    # Then verify the exact seeded DN exists for Vault static-role operations.
+    "timeout 20s bash -c 'until docker exec ${var.container_name} ldapsearch -x -H ldap://localhost -D \"${local.admin_dn}\" -w ${local.admin_password} -b \"cn=${local.user_name},${local.domain_dn}\" -s base \"(objectClass=*)\" | grep \"numEntries: 1\"; do sleep 2; done'",
+    # Finally verify we can bind as the user using the seeded DN shape.
+    "timeout 20s bash -c 'until docker exec ${var.container_name} ldapwhoami -x -H ldap://localhost -D \"cn=${local.user_name},${local.domain_dn}\" -w ${local.user_password}; do sleep 2; done'"
+  ]
+}
+
+resource "enos_local_exec" "wait_for_group_entry" {
+  depends_on = [
+    enos_local_exec.create_ldap_group,
+  ]
+
+  inline = [
+    # Verify that the group is discoverable
+    "timeout 20s bash -c 'until docker exec ${var.container_name} ldapsearch -x -H ldap://localhost -D \"${local.admin_dn}\" -w ${local.admin_password} -b \"${local.domain_dn}\" \"(cn=${local.group_name})\" | grep \"numEntries: 1\"; do sleep 2; done'"
+  ]
+}
+
 output "address" {
   value = "ldap://${var.container_name}"
 }

--- a/testing/internal/e2e/tests/base_with_vault/credential_library_vault_ldap_test.go
+++ b/testing/internal/e2e/tests/base_with_vault/credential_library_vault_ldap_test.go
@@ -86,10 +86,12 @@ func TestApiVaultLdapCredentialLibrary(t *testing.T) {
 		)
 		require.NoError(t, output.Err, string(output.Stderr))
 
-		output = e2e.RunCommand(ctx, "vault",
-			e2e.WithArgs("policy", "delete", ldapPolicyName),
-		)
-		require.NoError(t, output.Err, string(output.Stderr))
+		if ldapPolicyName != "" {
+			output = e2e.RunCommand(ctx, "vault",
+				e2e.WithArgs("policy", "delete", ldapPolicyName),
+			)
+			require.NoError(t, output.Err, string(output.Stderr))
+		}
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description
This PR addresses some recent flakiness with LDAP e2e tests. On occasion, there are two tests that fail (in different scenarios, both tests execute near the beginning of the run)
```
=== RUN   TestApiVaultLdapCredentialLibrary
│     scope.go:33: Created Org Id: o_zsr1hKTR6x
│     scope.go:53: Created Project Id: p_PYL1cPQA1V
│     target.go:74: Created Target: ttcp_wLnGP7AYHb
│     host.go:43: Created Host Catalog: hcst_tmUIkyVnX8
│     host.go:62: Created Host Set: hsst_sqxlq34S9B
│     host.go:84: Created Host: hst_L5Fc5iFBHc
│     credential_library_vault_ldap_test.go:94: 
│         	Error Trace:	/home/runner/work/boundary/boundary/testing/internal/e2e/tests/base_with_vault/credential_library_vault_ldap_test.go:94
│         	Error:      	Received unexpected error:
│         	            	Error writing data to e2e_ldap/static-role/einstein: Error making API request.
│         	            	
│         	            	URL: PUT http://127.0.0.1:8300/v1/e2e_ldap/static-role/einstein
│         	            	Code: 500. Errors:
│         	            	
│         	            	* 1 error occurred:
│         	            		* failed to search ldap server: LDAP Result Code 32 "No Such Object":
│         	Test:       	TestApiVaultLdapCredentialLibrary
│     credential_library_vault_ldap_test.go:92: 
│         	Error Trace:	/home/runner/work/boundary/boundary/testing/internal/e2e/tests/base_with_vault/credential_library_vault_ldap_test.go:92
│         	            				/opt/hostedtoolcache/go/1.25.7/x64/src/testing/testing.go:1308
│         	            				/opt/hostedtoolcache/go/1.25.7/x64/src/testing/testing.go:1572
│         	            				/opt/hostedtoolcache/go/1.25.7/x64/src/testing/testing.go:1928
│         	            				/opt/hostedtoolcache/go/1.25.7/x64/src/runtime/panic.go:615
│         	            				/opt/hostedtoolcache/go/1.25.7/x64/src/testing/testing.go:1013
│         	            				/home/runner/work/boundary/boundary/testing/internal/e2e/tests/base_with_vault/credential_library_vault_ldap_test.go:94
│         	Error:      	Received unexpected error:
│         	            	exit status 2
│         	Test:       	TestApiVaultLdapCredentialLibrary
│         	Messages:   	Error deleting : Error making API request.
│         	            	
│         	            	URL: DELETE http://127.0.0.1:8300/v1/sys/policies/acl
│         	            	Code: 405. Errors:
│         	            	
│         	            	* 1 error occurred:
│         	            		* unsupported operation
│         	            	
│         	            	
```

```
=== RUN   TestCliLdap
    scope.go:91: Created Org Id: o_dPO9bm6I9v
    auth_method_ldap_test.go:66: Create Auth Method: amldap_OMAu1Hy376
    auth_method_ldap_test.go:83: Created Account: acctldap_z4aaNssHJV
    user.go:71: Created User: u_g1QpxzoSDo
    auth_method_ldap_test.go:130: 
        	Error Trace:	/home/runner/work/boundary/boundary/testing/internal/e2e/tests/base_plus/auth_method_ldap_test.go:130
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestCliLdap
        	Messages:   	Error from controller when performing authentication
        	            	
        	            	Error information:
        	            	  Kind:                Unauthenticated
        	            	  Message:             Unable to authenticate.
        	            	  Status:              401
        	            	  context:             Error from controller when performing authentication
```

Both errors APPEAR to point to the LDAP server not being fully ready before the e2e tests start executing. 

This PR attempts to address this by adding some additional checks after adding an LDAP user and group to ensure that they are available in order to declare that the LDAP container is ready to be used. 

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
