### PR TITLE
chore(e2e): Make e2e test artifacts zip files

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -327,7 +327,6 @@ jobs:
           name: test-${{ steps.split.outputs.fragment }}
           path: enos/*.log
           retention-days: 5
-          archive: false
       - name: Get logs from controller container
         # Retrieve logs from the worker container on a failed
         # run to help diagnose a deadlock issue


### PR DESCRIPTION
## Description
This PR reverts one change made in https://github.com/hashicorp/boundary/pull/6523.

This change resulted in e2e test artifacts not being zipped, which I thought wasn't really necessary for these small log files, but it seems like it's causing an impact to CRT workflows. 

CRT workflows were sometimes failing due to 
```
2026-05-19T19:43:37.953Z [DEBUG] bob: extracted: org=hashicorp repo=boundary metrics="{\"last_extraction_error\":\"cannot create zip reader: zip: not a valid zip file\",\"extracted_dirs\":0,\"extraction_duration\":82262,\"extraction_errors\":1,\"extracted_files\":0,\"extraction_size\":0,\"extracted_symlinks\":0,\"extracted_type\":\"zip\",\"input_size\":26473,\"pattern_mismatches\":0,\"unsupported_files\":0,\"last_unsupported_file\":\"\"}"
Error: -19T19:43:37.954Z [ERROR] bob: Failed to download workflow artifact: org=hashicorp repo=boundary error="extract: failed to unpack: cannot create zip reader: zip: not a valid zip file"
Error: Process completed with exit code 1.
```

This PR reverts the change so that artifacts are zipped again.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
