### PR TITLE
test(e2e): Fix cassandra e2e test

### DIFF
--- a/.github/workflows/enos-run.yml
+++ b/.github/workflows/enos-run.yml
@@ -247,18 +247,27 @@ jobs:
       - name: Install other test dependencies
         if: contains(matrix.filter, 'e2e_docker_base_plus')
         run: |
-          # mongosh
-          wget -q https://github.com/mongodb-js/mongosh/releases/download/v2.7.0/mongosh-2.7.0-linux-x64.tgz -O /tmp/mongosh.tgz
+          # Download dependencies in parallel
+          wget -q https://github.com/mongodb-js/mongosh/releases/download/v2.7.0/mongosh-2.7.0-linux-x64.tgz -O /tmp/mongosh.tgz &
+          wget -q https://archive.apache.org/dist/cassandra/4.1.10/apache-cassandra-4.1.10-bin.tar.gz -O /tmp/cassandra.tar.gz &
+          wait
+
+          # Install redis and mysql
+          sudo apt update && sudo apt install -y redis-tools mysql-client
+
+          # Install mongosh
           tar -xzf /tmp/mongosh.tgz -C "$HOME"
           echo "$HOME/mongosh-2.7.0-linux-x64/bin" >> "$GITHUB_PATH"
 
-          # cqlsh (cassandra CLI)
-          wget -q https://archive.apache.org/dist/cassandra/4.1.10/apache-cassandra-4.1.10-bin.tar.gz -O /tmp/cassandra.tar.gz
-          tar -xzf /tmp/cassandra.tar.gz -C "$HOME"
-          echo "$HOME/apache-cassandra-4.1.10/bin" >> "$GITHUB_PATH"
-
-          # redis
-          sudo apt update && sudo apt install -y redis-tools mysql-client
+          # Install cassandra and update it to use the python virtual
+          # environment
+          # A virtual environment was needed because python environments on
+          # self-hosted runners are externally managed.
+          sudo apt install -y python3.12-venv
+          python3 -m venv "$HOME/cqlsh-venv"
+          "$HOME/cqlsh-venv/bin/pip" install --upgrade pip
+          "$HOME/cqlsh-venv/bin/pip" install cqlsh
+          echo "$HOME/cqlsh-venv/bin" >> "$GITHUB_PATH"
       - name: Determine boundary version to test against previous worker version
         # Resolve the worker version from the previous release line.
         if: contains(matrix.filter, 'e2e_docker_base_with_worker_version')

--- a/testing/internal/e2e/tests/base_plus/target_tcp_connect_cassandra_test.go
+++ b/testing/internal/e2e/tests/base_plus/target_tcp_connect_cassandra_test.go
@@ -120,8 +120,11 @@ func TestCliTcpTargetConnectCassandra(t *testing.T) {
 	output := buf.String()
 	t.Logf("Cassandra session output: %s", output)
 
-	require.Contains(t, output, "keyspace_name")
-	require.Contains(t, output, keyspace)
+	// Note: Additional assertions can be tricky due to output containing \r\n
+	// and \b characters. The following assertions should be sufficient to prove
+	// that commands were executed successfully
+	require.Contains(t, output, "system_schema") // output of DESCRIBE KEYSPACES
+	require.Contains(t, output, "(1 rows)")      // output of SELECT query
 
 	t.Log("Successfully connected to Cassandra target")
 }


### PR DESCRIPTION
## Description
This PR makes a fix to the `connect cassandra` e2e test.

The e2e test has been passing even though it's been throwing this error
```
│     target_tcp_connect_cassandra_test.go:121: Cassandra session output: DESCRIBE KEYSPACES;
│         SELECT keyspace_name FROM system_schema.keyspaces WHERE keyspace_name = 'e2eboundarykeyspace';
│         exit
│         Traceback (most recent call last):
│           File "/home/runner/apache-cassandra-4.1.10/bin/cqlsh.py", line 134, in <module>
│             from cassandra.cluster import Cluster
│           File "/home/runner/apache-cassandra-4.1.10/bin/../lib/cassandra-driver-internal-only-3.25.0.zip/cassandra-driver-3.25.0/cassandra/cluster.py", line 33, in <module>
│         ModuleNotFoundError: No module named 'six.moves'
│     target_tcp_connect_cassandra_test.go:126: Successfully connected to Cassandra target
```

This error started occurring after I moved away from using a separate docker container to run tests in order to reduce complexity. 

This PR does the following
- updates the github action workflow to install the needed dependencies
- parallelizes the installation steps in the github action workflow to improve speeds
- updates the assertions in the e2e test to ensure that the output is correct

```
❯ go test -v -count=1 github.com/hashicorp/boundary/testing/internal/e2e/tests/base_plus -run TestCliTcpTargetConnectCassandra
=== RUN   TestCliTcpTargetConnectCassandra
    docker.go:419: Starting Cassandra database...
    docker.go:461: Configuring Cassandra authentication and user permissions...
    docker.go:461: Initializing Cassandra keyspace: e2eboundarykeyspace...
    docker.go:461: Waiting for Cassandra container to restart and apply authentication settings...
    docker.go:461: Creating Cassandra user and granting permissions...
    target_tcp_connect_cassandra_test.go:50: cassandra://e2eboundary:e2eboundary@e2ecassandra:9042/e2eboundarykeyspace
    target_tcp_connect_cassandra_test.go:56: Cassandra info: user=e2eboundary, keyspace=e2eboundarykeyspace, host=e2ecassandra, port=9042, password-set:true
    scope.go:91: Created Org Id: o_hmVDu9fgPq
    scope.go:130: Created Project Id: p_TEEcLeXmzl
    target.go:182: Created Target: ttcp_wdRQUMkQDE
    credential.go:143: Created Credential Store: csst_4sWrDjNyuG
    credential.go:261: Created Username/Password Credentials: credup_wTd7lK5469
    target_tcp_connect_cassandra_test.go:121: Cassandra session output: DESCRIBE KEYSPACES;
        SELECT keyspace_name FROM system_schema.keyspaces WHERE keyspace_name = 'e2eboundarykeyspace';
        exit
        
        ATTENTION: All commands will be saved to history file: /Users/mycow/.cassandra/cqlsh_history
        This may include sensitive information such as passwords.
        To disable history, use --disable-history or set 'disabled = true' in the [history] section of cqlshrc.
        See https://cassandra.apache.org/doc/latest/tools/cqlsh.html for more information.
        
        Connected to e2e-boundary-cluster at 127.0.0.1:54440
        [cqlsh 6.2.0 | Cassandra 5.0.8 | CQL spec 3.4.7 | Native protocol v5]
        Use HELP for help.
        e2eboundary@cqlsh:e2eboundarykeyspace> DESCRIBE KEYSPACES;
        
        e2eboundarykeyspace  system_auth         system_schema  system_views         
        system               system_distributed  system_traces  system_virtual_schema
        
        e2eboundary@cqlsh:e2eboundarykeyspace> SELECT keyspace_name FROM system_schema.keyspaces WHERE keyspace_name = 'e2eboundarykeyspace';
        
         keyspace_name
        ---------------------
         e2eboundarykeyspace
        
        (1 rows)
        e2eboundary@cqlsh:e2eboundarykeyspace> exit
    target_tcp_connect_cassandra_test.go:130: Successfully connected to Cassandra target
--- PASS: TestCliTcpTargetConnectCassandra (179.89s)
```

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
