### PR TITLE
Fix ICU-17791: Correct help text for hyphenated resources

### DIFF
--- a/internal/cmd/common/help.go
+++ b/internal/cmd/common/help.go
@@ -30,24 +30,27 @@ func SynopsisFunc(inFunc, resType string) string {
 
 func HelpMap(resType string) map[string]func() string {
 	prefixMap := map[string]string{
-		resource.Scope.String():            "o",
-		resource.AuthToken.String():        "at",
-		resource.AuthMethod.String():       "am",
-		resource.Account.String():          "a",
-		resource.Billing.String():          "b",
-		resource.Role.String():             "r",
-		resource.Group.String():            "g",
-		resource.User.String():             "u",
-		resource.HostCatalog.String():      "hc",
-		resource.HostSet.String():          "hs",
-		resource.Host.String():             "h",
-		resource.Session.String():          "s",
-		resource.Target.String():           "t",
-		resource.Worker.String():           "w",
-		resource.SessionRecording.String(): "sr",
-		resource.StorageBucket.String():    "sb",
-		resource.Policy.String():           "p",
-		resource.Alias.String():            "alt",
+		resource.Scope.String():             "o",
+		resource.AuthToken.String():         "at",
+		resource.AuthMethod.String():        "am",
+		resource.Account.String():           "a",
+		resource.Billing.String():           "b",
+		resource.Role.String():              "r",
+		resource.Group.String():             "g",
+		resource.User.String():              "u",
+		resource.HostCatalog.String():       "hc",
+		resource.HostSet.String():           "hs",
+		resource.Host.String():              "h",
+		resource.Session.String():           "s",
+		resource.Target.String():            "t",
+		resource.Worker.String():            "w",
+		resource.SessionRecording.String():  "sr",
+		resource.StorageBucket.String():     "sb",
+		resource.Policy.String():            "p",
+		resource.Alias.String():             "alt",
+		resource.CredentialStore.String():   "cs",
+		resource.CredentialLibrary.String(): "cl",
+		resource.ManagedGroup.String():      "mg",
 	}
 	return map[string]func() string{
 		"base": func() string {
@@ -136,6 +139,8 @@ func subtype(in []string, resType string, prefixMap map[string]string) []string 
 	default:
 		articleType = fmt.Sprintf("a %s", articleType)
 	}
+	// Normalize resType to use hyphens for map lookup
+	normalizedResType := strings.ReplaceAll(resType, " ", "-")
 	for i, v := range in {
 		in[i] = strings.Replace(
 			strings.Replace(
@@ -147,7 +152,7 @@ func subtype(in []string, resType string, prefixMap map[string]string) []string 
 							"{{type}}", resType, -1),
 						"{{pluraltypes}}", pluralTypes, -1),
 					"{{uppertype}}", textproto.CanonicalMIMEHeaderKey(resType), -1),
-				"{{prefix}}", prefixMap[resType], -1),
+				"{{prefix}}", prefixMap[normalizedResType], -1),
 			"{{articletype}}", articleType, -1)
 	}
 	return in


### PR DESCRIPTION
## Description
https://hashicorp.atlassian.net/browse/ICU-17791

- Add missing prefixMap entries for credential-store, credential-library, and managed-group
- Add normalization to convert space-separated resource names to hyphenated format before map lookup
- Fixes help text showing '_1234567890' instead of 'cs_1234567890', 'cl_1234567890', 'mg_1234567890'

The bug occurred because resType parameter arrives as 'credential store' (with space) but prefixMap keys use 'credential-store' (with hyphen), causing lookup failures.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
