### PR TITLE
chore: add set/remove alias suffix API definitions

### DIFF
--- a/api/scopes/custom.go
+++ b/api/scopes/custom.go
@@ -353,3 +353,140 @@ func (c *Client) DetachStoragePolicy(ctx context.Context, scopeId string, versio
 	s.Response = resp
 	return s, nil
 }
+
+type (
+	SetAliasSuffixResult    = ScopeReadResult
+	RemoveAliasSuffixResult = ScopeReadResult
+)
+
+// SetAliasSuffix sets the alias suffix on the provided scopeId.
+func (c *Client) SetAliasSuffix(ctx context.Context, scopeId string, version uint32, aliasSuffix string, opt ...Option) (*SetAliasSuffixResult, error) {
+	if scopeId == "" {
+		return nil, errors.New("empty scopeId value passed into SetAliasSuffix request")
+	}
+	if aliasSuffix == "" {
+		return nil, errors.New("empty aliasSuffix value passed into SetAliasSuffix request")
+	}
+	if c.client == nil {
+		return nil, errors.New("nil client")
+	}
+
+	opts, apiOpts := getOpts(opt...)
+
+	if version == 0 {
+		if !opts.withAutomaticVersioning {
+			return nil, errors.New("zero version number passed into SetAliasSuffix request")
+		}
+		existingScope, existingErr := c.Read(ctx, scopeId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
+		if existingErr != nil {
+			if api.AsServerError(existingErr) != nil {
+				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
+			}
+			return nil, fmt.Errorf("error performing initial check-and-set read: %w", existingErr)
+		}
+		if existingScope == nil {
+			return nil, errors.New("nil resource response found when performing initial check-and-set read")
+		}
+		if existingScope.Item == nil {
+			return nil, errors.New("nil resource found when performing initial check-and-set read")
+		}
+		version = existingScope.Item.Version
+	}
+
+	opts.postMap["version"] = version
+	opts.postMap["alias_suffix"] = aliasSuffix
+
+	req, err := c.client.NewRequest(ctx, "POST", fmt.Sprintf("scopes/%s:set-alias-suffix", url.PathEscape(scopeId)), opts.postMap, apiOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SetAliasSuffix request: %w", err)
+	}
+
+	if len(opts.queryMap) > 0 {
+		q := url.Values{}
+		for k, v := range opts.queryMap {
+			q.Add(k, v)
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error performing client request during SetAliasSuffix call: %w", err)
+	}
+
+	s := new(SetAliasSuffixResult)
+	s.Item = new(Scope)
+	apiErr, err := resp.Decode(s.Item)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding SetAliasSuffixResult response: %w", err)
+	}
+	if apiErr != nil {
+		return nil, apiErr
+	}
+	s.Response = resp
+	return s, nil
+}
+
+// RemoveAliasSuffix removes the alias suffix from the provided scopeId if one is set.
+func (c *Client) RemoveAliasSuffix(ctx context.Context, scopeId string, version uint32, opt ...Option) (*RemoveAliasSuffixResult, error) {
+	if scopeId == "" {
+		return nil, errors.New("empty scopeId value passed into RemoveAliasSuffix request")
+	}
+	if c.client == nil {
+		return nil, errors.New("nil client")
+	}
+
+	opts, apiOpts := getOpts(opt...)
+
+	if version == 0 {
+		if !opts.withAutomaticVersioning {
+			return nil, errors.New("zero version number passed into RemoveAliasSuffix request")
+		}
+		existingScope, existingErr := c.Read(ctx, scopeId, append([]Option{WithSkipCurlOutput(true)}, opt...)...)
+		if existingErr != nil {
+			if api.AsServerError(existingErr) != nil {
+				return nil, fmt.Errorf("error from controller when performing initial check-and-set read: %w", existingErr)
+			}
+			return nil, fmt.Errorf("error performing initial check-and-set read: %w", existingErr)
+		}
+		if existingScope == nil {
+			return nil, errors.New("nil resource response found when performing initial check-and-set read")
+		}
+		if existingScope.Item == nil {
+			return nil, errors.New("nil resource found when performing initial check-and-set read")
+		}
+		version = existingScope.Item.Version
+	}
+
+	opts.postMap["version"] = version
+
+	req, err := c.client.NewRequest(ctx, "POST", fmt.Sprintf("scopes/%s:remove-alias-suffix", url.PathEscape(scopeId)), opts.postMap, apiOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RemoveAliasSuffix request: %w", err)
+	}
+
+	if len(opts.queryMap) > 0 {
+		q := url.Values{}
+		for k, v := range opts.queryMap {
+			q.Add(k, v)
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error performing client request during RemoveAliasSuffix call: %w", err)
+	}
+
+	s := new(RemoveAliasSuffixResult)
+	s.Item = new(Scope)
+	apiErr, err := resp.Decode(s.Item)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding RemoveAliasSuffixResult response: %w", err)
+	}
+	if apiErr != nil {
+		return nil, apiErr
+	}
+	s.Response = resp
+	return s, nil
+}

--- a/internal/alias/target/alias_test.go
+++ b/internal/alias/target/alias_test.go
@@ -117,16 +117,16 @@ func TestCreate(t *testing.T) {
 			errContains: `destination_id_set_when_host_id_is_set constraint failed`,
 		},
 		{
-			name:        "unsupported project scope",
+			name:        "supported project scope",
 			scope:       proj.GetPublicId(),
-			value:       "unsupported.project.scope",
-			errContains: `alias_must_be_in_global_scope constraint failed`,
+			value:       "supported.project.scope",
+			errContains: "alias_must_be_in_global_scope constraint failed",
 		},
 		{
-			name:        "unsupported org scope",
+			name:        "supported org scope",
 			scope:       proj.GetParentId(),
-			value:       "unsupported.org.scope",
-			errContains: `alias_must_be_in_global_scope constraint failed`,
+			value:       "supported.org.scope",
+			errContains: "check constraint violated",
 		},
 		{
 			name:        "invalid scope",
@@ -161,7 +161,7 @@ func TestCreate(t *testing.T) {
 
 			err = rw.Create(ctx, a)
 			if c.errContains != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), c.errContains)
 			} else {
 				require.NoError(t, err)

--- a/internal/alias/target/alias_test.go
+++ b/internal/alias/target/alias_test.go
@@ -117,9 +117,9 @@ func TestCreate(t *testing.T) {
 			errContains: `destination_id_set_when_host_id_is_set constraint failed`,
 		},
 		{
-			name:        "supported project scope",
+			name:        "unsupported project scope",
 			scope:       proj.GetPublicId(),
-			value:       "supported.project.scope",
+			value:       "unsupported.project.scope",
 			errContains: "alias_must_be_in_global_scope constraint failed",
 		},
 		{

--- a/internal/alias/target/alias_test.go
+++ b/internal/alias/target/alias_test.go
@@ -120,13 +120,13 @@ func TestCreate(t *testing.T) {
 			name:        "unsupported project scope",
 			scope:       proj.GetPublicId(),
 			value:       "unsupported.project.scope",
-			errContains: "alias_must_be_in_global_scope constraint failed",
+			errContains: `alias_must_be_in_global_scope constraint failed`,
 		},
 		{
-			name:        "supported org scope",
+			name:        "unsupported org scope",
 			scope:       proj.GetParentId(),
-			value:       "supported.org.scope",
-			errContains: "check constraint violated",
+			value:       "unsupported.org.scope",
+			errContains: `alias_must_be_in_global_scope constraint failed`,
 		},
 		{
 			name:        "invalid scope",
@@ -161,7 +161,7 @@ func TestCreate(t *testing.T) {
 
 			err = rw.Create(ctx, a)
 			if c.errContains != "" {
-				require.Error(t, err)
+				assert.Error(t, err)
 				assert.Contains(t, err.Error(), c.errContains)
 			} else {
 				require.NoError(t, err)

--- a/internal/daemon/controller/handlers/scopes/scope_service.go
+++ b/internal/daemon/controller/handlers/scopes/scope_service.go
@@ -645,6 +645,16 @@ func (s *Service) DetachStoragePolicy(ctx context.Context, req *pbs.DetachStorag
 	return nil, status.Errorf(codes.Unimplemented, "Policies are an Enterprise-only feature")
 }
 
+// SetAliasSuffix implements the interface pbs.ScopeServiceServer.
+func (s *Service) SetAliasSuffix(ctx context.Context, req *pbs.SetAliasSuffixRequest) (*pbs.SetAliasSuffixResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "Alias suffixes are an Enterprise-only feature")
+}
+
+// RemoveAliasSuffix implements the interface pbs.ScopeServiceServer.
+func (s *Service) RemoveAliasSuffix(ctx context.Context, req *pbs.RemoveAliasSuffixRequest) (*pbs.RemoveAliasSuffixResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "Alias suffixes are an Enterprise-only feature")
+}
+
 func (s *Service) getFromRepo(ctx context.Context, id string) (*iam.Scope, error) {
 	repo, err := s.repoFn()
 	if err != nil {

--- a/internal/daemon/controller/handlers/scopes/scope_service_test.go
+++ b/internal/daemon/controller/handlers/scopes/scope_service_test.go
@@ -3188,3 +3188,27 @@ func TestDetachStoragePolicy(t *testing.T) {
 		assert.Equal(t, gotStatus.Message(), "Policies are an Enterprise-only feature")
 	})
 }
+
+func TestSetAliasSuffix(t *testing.T) {
+	t.Run("unimplemented", func(t *testing.T) {
+		service := &scopes.Service{}
+		_, err := service.SetAliasSuffix(context.Background(), &pbs.SetAliasSuffixRequest{})
+		require.Error(t, err)
+		gotStatus, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, gotStatus.Code(), codes.Unimplemented)
+		assert.Equal(t, gotStatus.Message(), "Alias suffixes are an Enterprise-only feature")
+	})
+}
+
+func TestRemoveAliasSuffix(t *testing.T) {
+	t.Run("unimplemented", func(t *testing.T) {
+		service := &scopes.Service{}
+		_, err := service.RemoveAliasSuffix(context.Background(), &pbs.RemoveAliasSuffixRequest{})
+		require.Error(t, err)
+		gotStatus, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, gotStatus.Code(), codes.Unimplemented)
+		assert.Equal(t, gotStatus.Message(), "Alias suffixes are an Enterprise-only feature")
+	})
+}

--- a/internal/gen/controller.swagger.json
+++ b/internal/gen/controller.swagger.json
@@ -3891,6 +3891,86 @@
         ]
       }
     },
+    "/v1/scopes/{id}:remove-alias-suffix": {
+      "post": {
+        "summary": "Removes the alias suffix from a Scope.",
+        "operationId": "ScopeService_RemoveAliasSuffix",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/controller.api.resources.scopes.v1.Scope"
+            }
+          },
+          "default": {
+            "description": "Returned when there is an error processing the request.",
+            "schema": {
+              "$ref": "#/definitions/controller.api.v1.Error"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "description": "",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/controller.api.services.v1.ScopeService.RemoveAliasSuffixBody"
+            }
+          }
+        ],
+        "tags": [
+          "Scope service"
+        ]
+      }
+    },
+    "/v1/scopes/{id}:set-alias-suffix": {
+      "post": {
+        "summary": "Sets the alias suffix on a Scope.",
+        "operationId": "ScopeService_SetAliasSuffix",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/controller.api.resources.scopes.v1.Scope"
+            }
+          },
+          "default": {
+            "description": "Returned when there is an error processing the request.",
+            "schema": {
+              "$ref": "#/definitions/controller.api.v1.Error"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "description": "",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/controller.api.services.v1.ScopeService.SetAliasSuffixBody"
+            }
+          }
+        ],
+        "tags": [
+          "Scope service"
+        ]
+      }
+    },
     "/v1/scopes/{scope_id}:list-key-version-destruction-jobs": {
       "get": {
         "summary": "Lists all pending key version destruction jobs in a Scope.",
@@ -10720,6 +10800,14 @@
         }
       }
     },
+    "controller.api.services.v1.RemoveAliasSuffixResponse": {
+      "type": "object",
+      "properties": {
+        "item": {
+          "$ref": "#/definitions/controller.api.resources.scopes.v1.Scope"
+        }
+      }
+    },
     "controller.api.services.v1.RemoveGroupMembersResponse": {
       "type": "object",
       "properties": {
@@ -10985,6 +11073,30 @@
         }
       }
     },
+    "controller.api.services.v1.ScopeService.RemoveAliasSuffixBody": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Version is used to ensure this resource has not changed.\nThe mutation will fail if the version does not match the latest known good version."
+        }
+      }
+    },
+    "controller.api.services.v1.ScopeService.SetAliasSuffixBody": {
+      "type": "object",
+      "properties": {
+        "alias_suffix": {
+          "type": "string",
+          "title": ""
+        },
+        "version": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Version is used to ensure this resource has not changed.\nThe mutation will fail if the version does not match the latest known good version."
+        }
+      }
+    },
     "controller.api.services.v1.SessionRecordingService.CreateExportBody": {
       "type": "object",
       "properties": {
@@ -11001,6 +11113,14 @@
           "type": "integer",
           "format": "int64",
           "title": ""
+        }
+      }
+    },
+    "controller.api.services.v1.SetAliasSuffixResponse": {
+      "type": "object",
+      "properties": {
+        "item": {
+          "$ref": "#/definitions/controller.api.resources.scopes.v1.Scope"
         }
       }
     },

--- a/internal/gen/controller/api/services/scope_service.pb.go
+++ b/internal/gen/controller/api/services/scope_service.pb.go
@@ -1171,6 +1171,210 @@ func (x *DetachStoragePolicyResponse) GetItem() *scopes.Scope {
 	return nil
 }
 
+type SetAliasSuffixRequest struct {
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	Id          string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"`                                      // @gotags: `class:"public" eventstream:"observation"`
+	AliasSuffix string                 `protobuf:"bytes,2,opt,name=alias_suffix,json=aliasSuffix,proto3" json:"alias_suffix,omitempty" class:"public"` // @gotags: `class:"public"`
+	// Version is used to ensure this resource has not changed.
+	// The mutation will fail if the version does not match the latest known good version.
+	Version       uint32 `protobuf:"varint,3,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetAliasSuffixRequest) Reset() {
+	*x = SetAliasSuffixRequest{}
+	mi := &file_controller_api_services_v1_scope_service_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetAliasSuffixRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetAliasSuffixRequest) ProtoMessage() {}
+
+func (x *SetAliasSuffixRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_controller_api_services_v1_scope_service_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetAliasSuffixRequest.ProtoReflect.Descriptor instead.
+func (*SetAliasSuffixRequest) Descriptor() ([]byte, []int) {
+	return file_controller_api_services_v1_scope_service_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *SetAliasSuffixRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *SetAliasSuffixRequest) GetAliasSuffix() string {
+	if x != nil {
+		return x.AliasSuffix
+	}
+	return ""
+}
+
+func (x *SetAliasSuffixRequest) GetVersion() uint32 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+type SetAliasSuffixResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Item          *scopes.Scope          `protobuf:"bytes,1,opt,name=item,proto3" json:"item,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetAliasSuffixResponse) Reset() {
+	*x = SetAliasSuffixResponse{}
+	mi := &file_controller_api_services_v1_scope_service_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetAliasSuffixResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetAliasSuffixResponse) ProtoMessage() {}
+
+func (x *SetAliasSuffixResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_controller_api_services_v1_scope_service_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetAliasSuffixResponse.ProtoReflect.Descriptor instead.
+func (*SetAliasSuffixResponse) Descriptor() ([]byte, []int) {
+	return file_controller_api_services_v1_scope_service_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *SetAliasSuffixResponse) GetItem() *scopes.Scope {
+	if x != nil {
+		return x.Item
+	}
+	return nil
+}
+
+type RemoveAliasSuffixRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" class:"public" eventstream:"observation"` // @gotags: `class:"public" eventstream:"observation"`
+	// Version is used to ensure this resource has not changed.
+	// The mutation will fail if the version does not match the latest known good version.
+	Version       uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty" class:"public"` // @gotags: `class:"public"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveAliasSuffixRequest) Reset() {
+	*x = RemoveAliasSuffixRequest{}
+	mi := &file_controller_api_services_v1_scope_service_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveAliasSuffixRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveAliasSuffixRequest) ProtoMessage() {}
+
+func (x *RemoveAliasSuffixRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_controller_api_services_v1_scope_service_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveAliasSuffixRequest.ProtoReflect.Descriptor instead.
+func (*RemoveAliasSuffixRequest) Descriptor() ([]byte, []int) {
+	return file_controller_api_services_v1_scope_service_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *RemoveAliasSuffixRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *RemoveAliasSuffixRequest) GetVersion() uint32 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+type RemoveAliasSuffixResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Item          *scopes.Scope          `protobuf:"bytes,1,opt,name=item,proto3" json:"item,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveAliasSuffixResponse) Reset() {
+	*x = RemoveAliasSuffixResponse{}
+	mi := &file_controller_api_services_v1_scope_service_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveAliasSuffixResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveAliasSuffixResponse) ProtoMessage() {}
+
+func (x *RemoveAliasSuffixResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_controller_api_services_v1_scope_service_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveAliasSuffixResponse.ProtoReflect.Descriptor instead.
+func (*RemoveAliasSuffixResponse) Descriptor() ([]byte, []int) {
+	return file_controller_api_services_v1_scope_service_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *RemoveAliasSuffixResponse) GetItem() *scopes.Scope {
+	if x != nil {
+		return x.Item
+	}
+	return nil
+}
+
 var File_controller_api_services_v1_scope_service_proto protoreflect.FileDescriptor
 
 const file_controller_api_services_v1_scope_service_proto_rawDesc = "" +
@@ -1241,7 +1445,18 @@ const file_controller_api_services_v1_scope_service_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\rR\aversion\"\\\n" +
 	"\x1bDetachStoragePolicyResponse\x12=\n" +
-	"\x04item\x18\x01 \x01(\v2).controller.api.resources.scopes.v1.ScopeR\x04item2\xae\x16\n" +
+	"\x04item\x18\x01 \x01(\v2).controller.api.resources.scopes.v1.ScopeR\x04item\"d\n" +
+	"\x15SetAliasSuffixRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12!\n" +
+	"\falias_suffix\x18\x02 \x01(\tR\valiasSuffix\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\rR\aversion\"W\n" +
+	"\x16SetAliasSuffixResponse\x12=\n" +
+	"\x04item\x18\x01 \x01(\v2).controller.api.resources.scopes.v1.ScopeR\x04item\"D\n" +
+	"\x18RemoveAliasSuffixRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\rR\aversion\"Z\n" +
+	"\x19RemoveAliasSuffixResponse\x12=\n" +
+	"\x04item\x18\x01 \x01(\v2).controller.api.resources.scopes.v1.ScopeR\x04item2\xe5\x19\n" +
 	"\fScopeService\x12\x9d\x01\n" +
 	"\bGetScope\x12+.controller.api.services.v1.GetScopeRequest\x1a,.controller.api.services.v1.GetScopeResponse\"6\x92A\x16\x12\x14Gets a single Scope.\x82\xd3\xe4\x93\x02\x17b\x04item\x12\x0f/v1/scopes/{id}\x12\xbe\x01\n" +
 	"\n" +
@@ -1257,7 +1472,9 @@ const file_controller_api_services_v1_scope_service_proto_rawDesc = "" +
 	"\x1dListKeyVersionDestructionJobs\x12@.controller.api.services.v1.ListKeyVersionDestructionJobsRequest\x1aA.controller.api.services.v1.ListKeyVersionDestructionJobsResponse\"~\x92A<\x12:Lists all pending key version destruction jobs in a Scope.\x82\xd3\xe4\x93\x029\x127/v1/scopes/{scope_id}:list-key-version-destruction-jobs\x12\xaa\x03\n" +
 	"\x11DestroyKeyVersion\x124.controller.api.services.v1.DestroyKeyVersionRequest\x1a5.controller.api.services.v1.DestroyKeyVersionResponse\"\xa7\x02\x92A\xfa\x01\x12\xf7\x01Destroy the specified key version in a Scope. This may start an asynchronous job that re-encrypts all data encrypted by the specified key version. Use GET /v1/scopes/{scope_id}:list-key-version-destruction-jobs to monitor pending destruction jobs.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/scopes:destroy-key-version\x12\xf6\x01\n" +
 	"\x13AttachStoragePolicy\x126.controller.api.services.v1.AttachStoragePolicyRequest\x1a7.controller.api.services.v1.AttachStoragePolicyResponse\"n\x92A5\x123Attaches the specified Storage Policy to the Scope.\x82\xd3\xe4\x93\x020:\x01*b\x04item\"%/v1/scopes/{id}:attach-storage-policy\x12\xf8\x01\n" +
-	"\x13DetachStoragePolicy\x126.controller.api.services.v1.DetachStoragePolicyRequest\x1a7.controller.api.services.v1.DetachStoragePolicyResponse\"p\x92A7\x125Detaches the specified Storage Policy from the Scope.\x82\xd3\xe4\x93\x020:\x01*b\x04item\"%/v1/scopes/{id}:detach-storage-policy\x1a\xa3\x03\x92A\x9f\x03\n" +
+	"\x13DetachStoragePolicy\x126.controller.api.services.v1.DetachStoragePolicyRequest\x1a7.controller.api.services.v1.DetachStoragePolicyResponse\"p\x92A7\x125Detaches the specified Storage Policy from the Scope.\x82\xd3\xe4\x93\x020:\x01*b\x04item\"%/v1/scopes/{id}:detach-storage-policy\x12\xd0\x01\n" +
+	"\x0eSetAliasSuffix\x121.controller.api.services.v1.SetAliasSuffixRequest\x1a2.controller.api.services.v1.SetAliasSuffixResponse\"W\x92A#\x12!Sets the alias suffix on a Scope.\x82\xd3\xe4\x93\x02+:\x01*b\x04item\" /v1/scopes/{id}:set-alias-suffix\x12\xe1\x01\n" +
+	"\x11RemoveAliasSuffix\x124.controller.api.services.v1.RemoveAliasSuffixRequest\x1a5.controller.api.services.v1.RemoveAliasSuffixResponse\"_\x92A(\x12&Removes the alias suffix from a Scope.\x82\xd3\xe4\x93\x02.:\x01*b\x04item\"#/v1/scopes/{id}:remove-alias-suffix\x1a\xa3\x03\x92A\x9f\x03\n" +
 	"\rScope service\x12\x8f\x02A scope acts as a permission Boundary modeled using the concept of a container. It creates a hierarchical structure that lets you organize your resources and manage access control within Boundary. The scope service provides endpoints to let you manage scopes in Boundary.\x1a|\n" +
 	".Read about scopes in the Boundary domain model\x12Jhttps://developer.hashicorp.com/boundary/docs/concepts/domain-model/scopesBMZKgithub.com/hashicorp/boundary/internal/gen/controller/api/services;servicesb\x06proto3"
 
@@ -1273,7 +1490,7 @@ func file_controller_api_services_v1_scope_service_proto_rawDescGZIP() []byte {
 	return file_controller_api_services_v1_scope_service_proto_rawDescData
 }
 
-var file_controller_api_services_v1_scope_service_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_controller_api_services_v1_scope_service_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_controller_api_services_v1_scope_service_proto_goTypes = []any{
 	(*GetScopeRequest)(nil),                       // 0: controller.api.services.v1.GetScopeRequest
 	(*GetScopeResponse)(nil),                      // 1: controller.api.services.v1.GetScopeResponse
@@ -1297,50 +1514,60 @@ var file_controller_api_services_v1_scope_service_proto_goTypes = []any{
 	(*AttachStoragePolicyResponse)(nil),           // 19: controller.api.services.v1.AttachStoragePolicyResponse
 	(*DetachStoragePolicyRequest)(nil),            // 20: controller.api.services.v1.DetachStoragePolicyRequest
 	(*DetachStoragePolicyResponse)(nil),           // 21: controller.api.services.v1.DetachStoragePolicyResponse
-	(*scopes.Scope)(nil),                          // 22: controller.api.resources.scopes.v1.Scope
-	(*fieldmaskpb.FieldMask)(nil),                 // 23: google.protobuf.FieldMask
-	(*scopes.Key)(nil),                            // 24: controller.api.resources.scopes.v1.Key
-	(*scopes.KeyVersionDestructionJob)(nil),       // 25: controller.api.resources.scopes.v1.KeyVersionDestructionJob
+	(*SetAliasSuffixRequest)(nil),                 // 22: controller.api.services.v1.SetAliasSuffixRequest
+	(*SetAliasSuffixResponse)(nil),                // 23: controller.api.services.v1.SetAliasSuffixResponse
+	(*RemoveAliasSuffixRequest)(nil),              // 24: controller.api.services.v1.RemoveAliasSuffixRequest
+	(*RemoveAliasSuffixResponse)(nil),             // 25: controller.api.services.v1.RemoveAliasSuffixResponse
+	(*scopes.Scope)(nil),                          // 26: controller.api.resources.scopes.v1.Scope
+	(*fieldmaskpb.FieldMask)(nil),                 // 27: google.protobuf.FieldMask
+	(*scopes.Key)(nil),                            // 28: controller.api.resources.scopes.v1.Key
+	(*scopes.KeyVersionDestructionJob)(nil),       // 29: controller.api.resources.scopes.v1.KeyVersionDestructionJob
 }
 var file_controller_api_services_v1_scope_service_proto_depIdxs = []int32{
-	22, // 0: controller.api.services.v1.GetScopeResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
-	22, // 1: controller.api.services.v1.ListScopesResponse.items:type_name -> controller.api.resources.scopes.v1.Scope
-	22, // 2: controller.api.services.v1.CreateScopeRequest.item:type_name -> controller.api.resources.scopes.v1.Scope
-	22, // 3: controller.api.services.v1.CreateScopeResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
-	22, // 4: controller.api.services.v1.UpdateScopeRequest.item:type_name -> controller.api.resources.scopes.v1.Scope
-	23, // 5: controller.api.services.v1.UpdateScopeRequest.update_mask:type_name -> google.protobuf.FieldMask
-	22, // 6: controller.api.services.v1.UpdateScopeResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
-	24, // 7: controller.api.services.v1.ListKeysResponse.items:type_name -> controller.api.resources.scopes.v1.Key
-	25, // 8: controller.api.services.v1.ListKeyVersionDestructionJobsResponse.items:type_name -> controller.api.resources.scopes.v1.KeyVersionDestructionJob
-	22, // 9: controller.api.services.v1.AttachStoragePolicyResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
-	22, // 10: controller.api.services.v1.DetachStoragePolicyResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
-	0,  // 11: controller.api.services.v1.ScopeService.GetScope:input_type -> controller.api.services.v1.GetScopeRequest
-	2,  // 12: controller.api.services.v1.ScopeService.ListScopes:input_type -> controller.api.services.v1.ListScopesRequest
-	4,  // 13: controller.api.services.v1.ScopeService.CreateScope:input_type -> controller.api.services.v1.CreateScopeRequest
-	6,  // 14: controller.api.services.v1.ScopeService.UpdateScope:input_type -> controller.api.services.v1.UpdateScopeRequest
-	8,  // 15: controller.api.services.v1.ScopeService.DeleteScope:input_type -> controller.api.services.v1.DeleteScopeRequest
-	10, // 16: controller.api.services.v1.ScopeService.ListKeys:input_type -> controller.api.services.v1.ListKeysRequest
-	12, // 17: controller.api.services.v1.ScopeService.RotateKeys:input_type -> controller.api.services.v1.RotateKeysRequest
-	14, // 18: controller.api.services.v1.ScopeService.ListKeyVersionDestructionJobs:input_type -> controller.api.services.v1.ListKeyVersionDestructionJobsRequest
-	16, // 19: controller.api.services.v1.ScopeService.DestroyKeyVersion:input_type -> controller.api.services.v1.DestroyKeyVersionRequest
-	18, // 20: controller.api.services.v1.ScopeService.AttachStoragePolicy:input_type -> controller.api.services.v1.AttachStoragePolicyRequest
-	20, // 21: controller.api.services.v1.ScopeService.DetachStoragePolicy:input_type -> controller.api.services.v1.DetachStoragePolicyRequest
-	1,  // 22: controller.api.services.v1.ScopeService.GetScope:output_type -> controller.api.services.v1.GetScopeResponse
-	3,  // 23: controller.api.services.v1.ScopeService.ListScopes:output_type -> controller.api.services.v1.ListScopesResponse
-	5,  // 24: controller.api.services.v1.ScopeService.CreateScope:output_type -> controller.api.services.v1.CreateScopeResponse
-	7,  // 25: controller.api.services.v1.ScopeService.UpdateScope:output_type -> controller.api.services.v1.UpdateScopeResponse
-	9,  // 26: controller.api.services.v1.ScopeService.DeleteScope:output_type -> controller.api.services.v1.DeleteScopeResponse
-	11, // 27: controller.api.services.v1.ScopeService.ListKeys:output_type -> controller.api.services.v1.ListKeysResponse
-	13, // 28: controller.api.services.v1.ScopeService.RotateKeys:output_type -> controller.api.services.v1.RotateKeysResponse
-	15, // 29: controller.api.services.v1.ScopeService.ListKeyVersionDestructionJobs:output_type -> controller.api.services.v1.ListKeyVersionDestructionJobsResponse
-	17, // 30: controller.api.services.v1.ScopeService.DestroyKeyVersion:output_type -> controller.api.services.v1.DestroyKeyVersionResponse
-	19, // 31: controller.api.services.v1.ScopeService.AttachStoragePolicy:output_type -> controller.api.services.v1.AttachStoragePolicyResponse
-	21, // 32: controller.api.services.v1.ScopeService.DetachStoragePolicy:output_type -> controller.api.services.v1.DetachStoragePolicyResponse
-	22, // [22:33] is the sub-list for method output_type
-	11, // [11:22] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	26, // 0: controller.api.services.v1.GetScopeResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
+	26, // 1: controller.api.services.v1.ListScopesResponse.items:type_name -> controller.api.resources.scopes.v1.Scope
+	26, // 2: controller.api.services.v1.CreateScopeRequest.item:type_name -> controller.api.resources.scopes.v1.Scope
+	26, // 3: controller.api.services.v1.CreateScopeResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
+	26, // 4: controller.api.services.v1.UpdateScopeRequest.item:type_name -> controller.api.resources.scopes.v1.Scope
+	27, // 5: controller.api.services.v1.UpdateScopeRequest.update_mask:type_name -> google.protobuf.FieldMask
+	26, // 6: controller.api.services.v1.UpdateScopeResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
+	28, // 7: controller.api.services.v1.ListKeysResponse.items:type_name -> controller.api.resources.scopes.v1.Key
+	29, // 8: controller.api.services.v1.ListKeyVersionDestructionJobsResponse.items:type_name -> controller.api.resources.scopes.v1.KeyVersionDestructionJob
+	26, // 9: controller.api.services.v1.AttachStoragePolicyResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
+	26, // 10: controller.api.services.v1.DetachStoragePolicyResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
+	26, // 11: controller.api.services.v1.SetAliasSuffixResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
+	26, // 12: controller.api.services.v1.RemoveAliasSuffixResponse.item:type_name -> controller.api.resources.scopes.v1.Scope
+	0,  // 13: controller.api.services.v1.ScopeService.GetScope:input_type -> controller.api.services.v1.GetScopeRequest
+	2,  // 14: controller.api.services.v1.ScopeService.ListScopes:input_type -> controller.api.services.v1.ListScopesRequest
+	4,  // 15: controller.api.services.v1.ScopeService.CreateScope:input_type -> controller.api.services.v1.CreateScopeRequest
+	6,  // 16: controller.api.services.v1.ScopeService.UpdateScope:input_type -> controller.api.services.v1.UpdateScopeRequest
+	8,  // 17: controller.api.services.v1.ScopeService.DeleteScope:input_type -> controller.api.services.v1.DeleteScopeRequest
+	10, // 18: controller.api.services.v1.ScopeService.ListKeys:input_type -> controller.api.services.v1.ListKeysRequest
+	12, // 19: controller.api.services.v1.ScopeService.RotateKeys:input_type -> controller.api.services.v1.RotateKeysRequest
+	14, // 20: controller.api.services.v1.ScopeService.ListKeyVersionDestructionJobs:input_type -> controller.api.services.v1.ListKeyVersionDestructionJobsRequest
+	16, // 21: controller.api.services.v1.ScopeService.DestroyKeyVersion:input_type -> controller.api.services.v1.DestroyKeyVersionRequest
+	18, // 22: controller.api.services.v1.ScopeService.AttachStoragePolicy:input_type -> controller.api.services.v1.AttachStoragePolicyRequest
+	20, // 23: controller.api.services.v1.ScopeService.DetachStoragePolicy:input_type -> controller.api.services.v1.DetachStoragePolicyRequest
+	22, // 24: controller.api.services.v1.ScopeService.SetAliasSuffix:input_type -> controller.api.services.v1.SetAliasSuffixRequest
+	24, // 25: controller.api.services.v1.ScopeService.RemoveAliasSuffix:input_type -> controller.api.services.v1.RemoveAliasSuffixRequest
+	1,  // 26: controller.api.services.v1.ScopeService.GetScope:output_type -> controller.api.services.v1.GetScopeResponse
+	3,  // 27: controller.api.services.v1.ScopeService.ListScopes:output_type -> controller.api.services.v1.ListScopesResponse
+	5,  // 28: controller.api.services.v1.ScopeService.CreateScope:output_type -> controller.api.services.v1.CreateScopeResponse
+	7,  // 29: controller.api.services.v1.ScopeService.UpdateScope:output_type -> controller.api.services.v1.UpdateScopeResponse
+	9,  // 30: controller.api.services.v1.ScopeService.DeleteScope:output_type -> controller.api.services.v1.DeleteScopeResponse
+	11, // 31: controller.api.services.v1.ScopeService.ListKeys:output_type -> controller.api.services.v1.ListKeysResponse
+	13, // 32: controller.api.services.v1.ScopeService.RotateKeys:output_type -> controller.api.services.v1.RotateKeysResponse
+	15, // 33: controller.api.services.v1.ScopeService.ListKeyVersionDestructionJobs:output_type -> controller.api.services.v1.ListKeyVersionDestructionJobsResponse
+	17, // 34: controller.api.services.v1.ScopeService.DestroyKeyVersion:output_type -> controller.api.services.v1.DestroyKeyVersionResponse
+	19, // 35: controller.api.services.v1.ScopeService.AttachStoragePolicy:output_type -> controller.api.services.v1.AttachStoragePolicyResponse
+	21, // 36: controller.api.services.v1.ScopeService.DetachStoragePolicy:output_type -> controller.api.services.v1.DetachStoragePolicyResponse
+	23, // 37: controller.api.services.v1.ScopeService.SetAliasSuffix:output_type -> controller.api.services.v1.SetAliasSuffixResponse
+	25, // 38: controller.api.services.v1.ScopeService.RemoveAliasSuffix:output_type -> controller.api.services.v1.RemoveAliasSuffixResponse
+	26, // [26:39] is the sub-list for method output_type
+	13, // [13:26] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_controller_api_services_v1_scope_service_proto_init() }
@@ -1354,7 +1581,7 @@ func file_controller_api_services_v1_scope_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_controller_api_services_v1_scope_service_proto_rawDesc), len(file_controller_api_services_v1_scope_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   22,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/gen/controller/api/services/scope_service.pb.gw.go
+++ b/internal/gen/controller/api/services/scope_service.pb.gw.go
@@ -492,6 +492,96 @@ func local_request_ScopeService_DetachStoragePolicy_0(ctx context.Context, marsh
 	return msg, metadata, err
 }
 
+func request_ScopeService_SetAliasSuffix_0(ctx context.Context, marshaler runtime.Marshaler, client ScopeServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetAliasSuffixRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := client.SetAliasSuffix(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ScopeService_SetAliasSuffix_0(ctx context.Context, marshaler runtime.Marshaler, server ScopeServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetAliasSuffixRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := server.SetAliasSuffix(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ScopeService_RemoveAliasSuffix_0(ctx context.Context, marshaler runtime.Marshaler, client ScopeServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RemoveAliasSuffixRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := client.RemoveAliasSuffix(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ScopeService_RemoveAliasSuffix_0(ctx context.Context, marshaler runtime.Marshaler, server ScopeServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RemoveAliasSuffixRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := server.RemoveAliasSuffix(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterScopeServiceHandlerServer registers the http handlers for service ScopeService to "mux".
 // UnaryRPC     :call ScopeServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -717,6 +807,46 @@ func RegisterScopeServiceHandlerServer(ctx context.Context, mux *runtime.ServeMu
 			return
 		}
 		forward_ScopeService_DetachStoragePolicy_0(annotatedContext, mux, outboundMarshaler, w, req, response_ScopeService_DetachStoragePolicy_0{resp.(*DetachStoragePolicyResponse)}, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ScopeService_SetAliasSuffix_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/controller.api.services.v1.ScopeService/SetAliasSuffix", runtime.WithHTTPPathPattern("/v1/scopes/{id}:set-alias-suffix"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ScopeService_SetAliasSuffix_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ScopeService_SetAliasSuffix_0(annotatedContext, mux, outboundMarshaler, w, req, response_ScopeService_SetAliasSuffix_0{resp.(*SetAliasSuffixResponse)}, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ScopeService_RemoveAliasSuffix_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/controller.api.services.v1.ScopeService/RemoveAliasSuffix", runtime.WithHTTPPathPattern("/v1/scopes/{id}:remove-alias-suffix"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ScopeService_RemoveAliasSuffix_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ScopeService_RemoveAliasSuffix_0(annotatedContext, mux, outboundMarshaler, w, req, response_ScopeService_RemoveAliasSuffix_0{resp.(*RemoveAliasSuffixResponse)}, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -945,6 +1075,40 @@ func RegisterScopeServiceHandlerClient(ctx context.Context, mux *runtime.ServeMu
 		}
 		forward_ScopeService_DetachStoragePolicy_0(annotatedContext, mux, outboundMarshaler, w, req, response_ScopeService_DetachStoragePolicy_0{resp.(*DetachStoragePolicyResponse)}, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ScopeService_SetAliasSuffix_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/controller.api.services.v1.ScopeService/SetAliasSuffix", runtime.WithHTTPPathPattern("/v1/scopes/{id}:set-alias-suffix"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ScopeService_SetAliasSuffix_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ScopeService_SetAliasSuffix_0(annotatedContext, mux, outboundMarshaler, w, req, response_ScopeService_SetAliasSuffix_0{resp.(*SetAliasSuffixResponse)}, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ScopeService_RemoveAliasSuffix_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/controller.api.services.v1.ScopeService/RemoveAliasSuffix", runtime.WithHTTPPathPattern("/v1/scopes/{id}:remove-alias-suffix"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ScopeService_RemoveAliasSuffix_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ScopeService_RemoveAliasSuffix_0(annotatedContext, mux, outboundMarshaler, w, req, response_ScopeService_RemoveAliasSuffix_0{resp.(*RemoveAliasSuffixResponse)}, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -993,6 +1157,24 @@ func (m response_ScopeService_DetachStoragePolicy_0) XXX_ResponseBody() interfac
 	return response.Item
 }
 
+type response_ScopeService_SetAliasSuffix_0 struct {
+	*SetAliasSuffixResponse
+}
+
+func (m response_ScopeService_SetAliasSuffix_0) XXX_ResponseBody() interface{} {
+	response := m.SetAliasSuffixResponse
+	return response.Item
+}
+
+type response_ScopeService_RemoveAliasSuffix_0 struct {
+	*RemoveAliasSuffixResponse
+}
+
+func (m response_ScopeService_RemoveAliasSuffix_0) XXX_ResponseBody() interface{} {
+	response := m.RemoveAliasSuffixResponse
+	return response.Item
+}
+
 var (
 	pattern_ScopeService_GetScope_0                      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "scopes", "id"}, ""))
 	pattern_ScopeService_ListScopes_0                    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "scopes"}, ""))
@@ -1005,6 +1187,8 @@ var (
 	pattern_ScopeService_DestroyKeyVersion_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "scopes"}, "destroy-key-version"))
 	pattern_ScopeService_AttachStoragePolicy_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "scopes", "id"}, "attach-storage-policy"))
 	pattern_ScopeService_DetachStoragePolicy_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "scopes", "id"}, "detach-storage-policy"))
+	pattern_ScopeService_SetAliasSuffix_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "scopes", "id"}, "set-alias-suffix"))
+	pattern_ScopeService_RemoveAliasSuffix_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "scopes", "id"}, "remove-alias-suffix"))
 )
 
 var (
@@ -1019,4 +1203,6 @@ var (
 	forward_ScopeService_DestroyKeyVersion_0             = runtime.ForwardResponseMessage
 	forward_ScopeService_AttachStoragePolicy_0           = runtime.ForwardResponseMessage
 	forward_ScopeService_DetachStoragePolicy_0           = runtime.ForwardResponseMessage
+	forward_ScopeService_SetAliasSuffix_0                = runtime.ForwardResponseMessage
+	forward_ScopeService_RemoveAliasSuffix_0             = runtime.ForwardResponseMessage
 )

--- a/internal/gen/controller/api/services/scope_service_grpc.pb.go
+++ b/internal/gen/controller/api/services/scope_service_grpc.pb.go
@@ -33,6 +33,8 @@ const (
 	ScopeService_DestroyKeyVersion_FullMethodName             = "/controller.api.services.v1.ScopeService/DestroyKeyVersion"
 	ScopeService_AttachStoragePolicy_FullMethodName           = "/controller.api.services.v1.ScopeService/AttachStoragePolicy"
 	ScopeService_DetachStoragePolicy_FullMethodName           = "/controller.api.services.v1.ScopeService/DetachStoragePolicy"
+	ScopeService_SetAliasSuffix_FullMethodName                = "/controller.api.services.v1.ScopeService/SetAliasSuffix"
+	ScopeService_RemoveAliasSuffix_FullMethodName             = "/controller.api.services.v1.ScopeService/RemoveAliasSuffix"
 )
 
 // ScopeServiceClient is the client API for ScopeService service.
@@ -93,6 +95,16 @@ type ScopeServiceClient interface {
 	// if a Storage Policy is attempted to be removed from the Scope when the Scope
 	// does not have the Storage Policy attached to it.
 	DetachStoragePolicy(ctx context.Context, in *DetachStoragePolicyRequest, opts ...grpc.CallOption) (*DetachStoragePolicyResponse, error)
+	// SetAliasSuffix sets the alias suffix on a scope (org or project).
+	// The suffix is a single DNS label that project-scoped aliases must
+	// include as part of their value.
+	SetAliasSuffix(ctx context.Context, in *SetAliasSuffixRequest, opts ...grpc.CallOption) (*SetAliasSuffixResponse, error)
+	// RemoveAliasSuffix removes the alias suffix from the specified scope.
+	// The provided request must include the Scope ID for the scope from which
+	// the alias suffix will be removed. If the ID is missing, malformed, or
+	// references a non-existing scope, an error is returned. An error is returned
+	// if aliases exist under the scope (or its child projects for an org scope).
+	RemoveAliasSuffix(ctx context.Context, in *RemoveAliasSuffixRequest, opts ...grpc.CallOption) (*RemoveAliasSuffixResponse, error)
 }
 
 type scopeServiceClient struct {
@@ -213,6 +225,26 @@ func (c *scopeServiceClient) DetachStoragePolicy(ctx context.Context, in *Detach
 	return out, nil
 }
 
+func (c *scopeServiceClient) SetAliasSuffix(ctx context.Context, in *SetAliasSuffixRequest, opts ...grpc.CallOption) (*SetAliasSuffixResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetAliasSuffixResponse)
+	err := c.cc.Invoke(ctx, ScopeService_SetAliasSuffix_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *scopeServiceClient) RemoveAliasSuffix(ctx context.Context, in *RemoveAliasSuffixRequest, opts ...grpc.CallOption) (*RemoveAliasSuffixResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RemoveAliasSuffixResponse)
+	err := c.cc.Invoke(ctx, ScopeService_RemoveAliasSuffix_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ScopeServiceServer is the server API for ScopeService service.
 // All implementations must embed UnimplementedScopeServiceServer
 // for forward compatibility.
@@ -271,6 +303,16 @@ type ScopeServiceServer interface {
 	// if a Storage Policy is attempted to be removed from the Scope when the Scope
 	// does not have the Storage Policy attached to it.
 	DetachStoragePolicy(context.Context, *DetachStoragePolicyRequest) (*DetachStoragePolicyResponse, error)
+	// SetAliasSuffix sets the alias suffix on a scope (org or project).
+	// The suffix is a single DNS label that project-scoped aliases must
+	// include as part of their value.
+	SetAliasSuffix(context.Context, *SetAliasSuffixRequest) (*SetAliasSuffixResponse, error)
+	// RemoveAliasSuffix removes the alias suffix from the specified scope.
+	// The provided request must include the Scope ID for the scope from which
+	// the alias suffix will be removed. If the ID is missing, malformed, or
+	// references a non-existing scope, an error is returned. An error is returned
+	// if aliases exist under the scope (or its child projects for an org scope).
+	RemoveAliasSuffix(context.Context, *RemoveAliasSuffixRequest) (*RemoveAliasSuffixResponse, error)
 	mustEmbedUnimplementedScopeServiceServer()
 }
 
@@ -313,6 +355,12 @@ func (UnimplementedScopeServiceServer) AttachStoragePolicy(context.Context, *Att
 }
 func (UnimplementedScopeServiceServer) DetachStoragePolicy(context.Context, *DetachStoragePolicyRequest) (*DetachStoragePolicyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DetachStoragePolicy not implemented")
+}
+func (UnimplementedScopeServiceServer) SetAliasSuffix(context.Context, *SetAliasSuffixRequest) (*SetAliasSuffixResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetAliasSuffix not implemented")
+}
+func (UnimplementedScopeServiceServer) RemoveAliasSuffix(context.Context, *RemoveAliasSuffixRequest) (*RemoveAliasSuffixResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RemoveAliasSuffix not implemented")
 }
 func (UnimplementedScopeServiceServer) mustEmbedUnimplementedScopeServiceServer() {}
 func (UnimplementedScopeServiceServer) testEmbeddedByValue()                      {}
@@ -533,6 +581,42 @@ func _ScopeService_DetachStoragePolicy_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ScopeService_SetAliasSuffix_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetAliasSuffixRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ScopeServiceServer).SetAliasSuffix(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ScopeService_SetAliasSuffix_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ScopeServiceServer).SetAliasSuffix(ctx, req.(*SetAliasSuffixRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ScopeService_RemoveAliasSuffix_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RemoveAliasSuffixRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ScopeServiceServer).RemoveAliasSuffix(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ScopeService_RemoveAliasSuffix_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ScopeServiceServer).RemoveAliasSuffix(ctx, req.(*RemoveAliasSuffixRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ScopeService_ServiceDesc is the grpc.ServiceDesc for ScopeService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -583,6 +667,14 @@ var ScopeService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DetachStoragePolicy",
 			Handler:    _ScopeService_DetachStoragePolicy_Handler,
+		},
+		{
+			MethodName: "SetAliasSuffix",
+			Handler:    _ScopeService_SetAliasSuffix_Handler,
+		},
+		{
+			MethodName: "RemoveAliasSuffix",
+			Handler:    _ScopeService_RemoveAliasSuffix_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/proto/controller/api/services/v1/scope_service.proto
+++ b/internal/proto/controller/api/services/v1/scope_service.proto
@@ -147,6 +147,32 @@ service ScopeService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {summary: "Detaches the specified Storage Policy from the Scope."};
   }
+
+  // SetAliasSuffix sets the alias suffix on a scope (org or project).
+  // The suffix is a single DNS label that project-scoped aliases must
+  // include as part of their value.
+  rpc SetAliasSuffix(SetAliasSuffixRequest) returns (SetAliasSuffixResponse) {
+    option (google.api.http) = {
+      post: "/v1/scopes/{id}:set-alias-suffix"
+      body: "*"
+      response_body: "item"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {summary: "Sets the alias suffix on a Scope."};
+  }
+
+  // RemoveAliasSuffix removes the alias suffix from the specified scope.
+  // The provided request must include the Scope ID for the scope from which
+  // the alias suffix will be removed. If the ID is missing, malformed, or
+  // references a non-existing scope, an error is returned. An error is returned
+  // if aliases exist under the scope (or its child projects for an org scope).
+  rpc RemoveAliasSuffix(RemoveAliasSuffixRequest) returns (RemoveAliasSuffixResponse) {
+    option (google.api.http) = {
+      post: "/v1/scopes/{id}:remove-alias-suffix"
+      body: "*"
+      response_body: "item"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {summary: "Removes the alias suffix from a Scope."};
+  }
 }
 
 message GetScopeRequest {
@@ -281,5 +307,28 @@ message DetachStoragePolicyRequest {
 }
 
 message DetachStoragePolicyResponse {
+  api.resources.scopes.v1.Scope item = 1;
+}
+
+message SetAliasSuffixRequest {
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
+  string alias_suffix = 2; // @gotags: `class:"public"`
+  // Version is used to ensure this resource has not changed.
+  // The mutation will fail if the version does not match the latest known good version.
+  uint32 version = 3; // @gotags: `class:"public"`
+}
+
+message SetAliasSuffixResponse {
+  api.resources.scopes.v1.Scope item = 1;
+}
+
+message RemoveAliasSuffixRequest {
+  string id = 1; // @gotags: `class:"public" eventstream:"observation"`
+  // Version is used to ensure this resource has not changed.
+  // The mutation will fail if the version does not match the latest known good version.
+  uint32 version = 2; // @gotags: `class:"public"`
+}
+
+message RemoveAliasSuffixResponse {
   api.resources.scopes.v1.Scope item = 1;
 }


### PR DESCRIPTION
## Description
Define  set/remove alias suffix  RPC, so that it is available in API module.
## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
