### PR TITLE
chore: Fix backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,57 +14,14 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ${{ fromJSON(vars.RUNNER) }}
-    container: hashicorpdev/backport-assistant:0.5.1
+    container: hashicorpdev/backport-assistant:v0.6.3
     steps:
-      # Note: actions/checkout v5 breaks the backport assistant, so we pin to v4.2.2 for now.
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # Fetch all branches and tags
-      - name: Check if any migrations have changed
-        run: |
-          if git diff --exit-code --name-only "origin/${{ github.event.pull_request.base.ref }}"...HEAD -- internal/db/schema/migrations; then
-            echo "No migrations have changed, continuing with backport"
-          else
-            # Post comment on PR.
-            echo "Posting new backport-failure GitHub comment under PR #${{ github.event.pull_request.number }}"
-            curl -sX POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              -d '{"body": "Backport Assistant: you attempted to automatically backport changes in this PR, but because it contained changes to migration files, this was rejected. Please carefully manually backport the changes."}' \
-              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/comments"
-            echo "Migrations have changed, refusing to backport. Please carefully manually backport the changes."
-            exit 1
-          fi
-      - name: Backport changes to stable-website
-        run: |
-          backport-assistant backport -automerge
-        env:
-          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
-          BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
-          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      - name: Backport changes to latest release branch
-        run: |
-          resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/labels?per_page=100")
-          ret="$?"
-          if [[ "$ret" -ne 0 ]]; then
-              echo "The GitHub API returned $ret"
-              exit $ret
-          fi
-
-          # get the latest backport label excluding any website labels, ex: `backport/0.3.x` and not `backport/website`
-          latest_backport_label=$(echo "$resp" | jq -r '.[] | select(.name | (startswith("backport/") and (contains("website") | not))) | .name' | sort -rV | head -n1)
-          echo "Latest backport label: $latest_backport_label"
-
-          # set BACKPORT_TARGET_TEMPLATE for backport-assistant
-          # trims backport/ from the beginning with parameter substitution
-          export BACKPORT_TARGET_TEMPLATE="release/${latest_backport_label#backport/}"
-          backport-assistant backport -automerge
-        env:
-          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
-          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to targeted release branch
         run: |
-          backport-assistant backport -automerge
+          backport-assistant backport
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.\\w+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"


### PR DESCRIPTION
## Description
This PR fixes the backport workflow. It was failing due to the following error
```

Run actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
  with:
    fetch-depth: 0
    repository: hashicorp/boundary
    token: ***
    ssh-strict: true
    ssh-user: git
    persist-credentials: true
    clean: true
    sparse-checkout-cone-mode: true
    fetch-tags: false
    show-progress: true
    lfs: false
    submodules: false
    set-safe-directory: true
/usr/bin/docker exec  e0f899157c02229a9b39d64c8080d4e55e0f0f4578226cfbd0404b1959b7179f sh -c "cat /etc/*release | grep ^ID"
Error relocating /__e/node24_alpine/bin/node: pthread_getname_np: symbol not found

```
https://github.com/hashicorp/boundary/actions/runs/30373612421/job/90323532053

Test: https://github.com/hashicorp/boundary/actions/runs/30381066455/job/90348757335

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
