### PR TITLE
api/proxy: preserve active connections after auth failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Canonical reference for changes, improvements, and bugfixes for Boundary.
 
+## vNext
+
+### Bug Fixes
+
+* api/proxy: Preserve active session connections when a new connection fails authorization.
+
 ## 0.21.3 (2026/04/28)
 
 ### New and Improved

--- a/api/proxy/proxy.go
+++ b/api/proxy/proxy.go
@@ -280,10 +280,12 @@ func (p *ClientProxy) Start(opt ...Option) (retErr error) {
 				}
 				if err := p.runTcpProxyV1(wsConn, listeningConn); err != nil {
 					fin <- fmt.Errorf("error from runTcpProxyV1: %w", err)
-					// No reason to think we can successfully handle the next
-					// connection that comes our way, so cancel the proxy
+					// Close the listener because future connections cannot succeed.
+					// Preserve active connections after an authorization rejection.
 					listenerCloseFunc()
-					p.cancel()
+					if !errors.Is(err, errUnableToAuthorizeConnection) {
+						p.cancel()
+					}
 					return
 				}
 

--- a/api/proxy/proxy_test.go
+++ b/api/proxy/proxy_test.go
@@ -8,15 +8,22 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/x509"
+	"io"
 	"math/big"
 	mathrand "math/rand"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
+	"github.com/hashicorp/boundary/api/consts"
 	"github.com/hashicorp/boundary/api/scopes"
 	"github.com/hashicorp/boundary/api/targets"
+	pb "github.com/hashicorp/boundary/sdk/pbs/proxy"
+	"github.com/hashicorp/boundary/sdk/wspb"
 	"github.com/mitchellh/copystructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -147,6 +154,79 @@ func TestListenerAddr(t *testing.T) {
 	})
 	assert.Equal(expAddr, p.ListenerAddress(context.Background()))
 	assert.WithinDuration(start.Add(3*time.Second), time.Now(), 500*time.Millisecond)
+}
+
+func TestStartAuthorizationFailureKeepsExistingConnections(t *testing.T) {
+	var connectionCount atomic.Int32
+	active := make(chan struct{})
+	rejected := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{Subprotocols: []string{consts.WebsocketProtocolTcpProxyV1}})
+		if !assert.NoError(t, err) {
+			return
+		}
+		defer conn.CloseNow()
+
+		var handshake pb.ClientHandshake
+		if !assert.NoError(t, wspb.Read(r.Context(), conn, &handshake)) {
+			return
+		}
+		if connectionCount.Add(1) == 1 {
+			if !assert.NoError(t, wspb.Write(r.Context(), conn, &pb.HandshakeResult{ConnectionsLeft: -1})) {
+				return
+			}
+			close(active)
+			netConn := websocket.NetConn(r.Context(), conn, websocket.MessageBinary)
+			defer netConn.Close()
+			_, _ = io.Copy(io.Discard, netConn)
+			return
+		}
+
+		close(rejected)
+		_ = conn.Close(websocket.StatusInternalError, "unable to authorize connection")
+	}))
+	defer server.Close()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	proxy, err := New(context.Background(), "", WithSessionAuthorizationData(testSessionAuth(t)), WithListener(listener))
+	require.NoError(t, err)
+	proxy.workerAddr = server.Listener.Addr().String()
+	proxy.transport = http.DefaultTransport.(*http.Transport).Clone()
+
+	startErr := make(chan error, 1)
+	go func() { startErr <- proxy.Start() }()
+
+	first, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer first.Close()
+	require.Eventually(t, func() bool {
+		select {
+		case <-active:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	second, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer second.Close()
+	require.Eventually(t, func() bool {
+		select {
+		case <-rejected:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.NoError(t, second.SetReadDeadline(time.Now().Add(time.Second)))
+	_, err = second.Read(make([]byte, 1))
+	require.Error(t, err)
+	assert.NoError(t, proxy.ctx.Err())
+
+	require.NoError(t, first.Close())
+	require.ErrorContains(t, <-startErr, "unable to authorize connection")
 }
 
 func testSessionAuth(t *testing.T) *targets.SessionAuthorizationData {

--- a/api/proxy/websocket.go
+++ b/api/proxy/websocket.go
@@ -19,6 +19,8 @@ import (
 	"github.com/hashicorp/boundary/sdk/wspb"
 )
 
+var errUnableToAuthorizeConnection = errors.New("unable to authorize connection")
+
 func (p *ClientProxy) getWsConn(ctx context.Context) (*websocket.Conn, error) {
 	conn, resp, err := websocket.Dial(
 		ctx,
@@ -84,7 +86,7 @@ func (p *ClientProxy) runTcpProxyV1(wsConn *websocket.Conn, listeningConn net.Co
 			// connections after the first has failed. We don't cancel the
 			// context here as existing connections may be fine.
 			p.connsLeftCh <- 0
-			return errors.New("unable to authorize connection")
+			return errUnableToAuthorizeConnection
 		}
 		switch {
 		case strings.Contains(err.Error(), "tofu token not allowed"):


### PR DESCRIPTION
## Description

Preserve active proxy connections when a new connection fails authorization. The authorization failure still closes the listener so no further connections can start, but it no longer cancels the shared context used by already-active connections.

Security-control impact: none. Authorization behavior remains unchanged; rejected connections still fail and stop the listener.

Closes #6774

## Testing

- go test ./proxy -run ^TestStartAuthorizationFailureKeepsExistingConnections$ -count=20
- go test -race ./proxy -run ^TestStartAuthorizationFailureKeepsExistingConnections$ -count=1
- go test ./... -count=1 (from api/)
- go vet ./... (from api/)
- LINT_DIFF_BRANCH=origin/main make lint-diff

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I have documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I have documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.